### PR TITLE
chore(ci): auto-merge Dependabot minors; add 'maintainer-ready' label flow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,16 @@
+name: automerge
+on:
+  pull_request:
+    types: [opened, labeled, synchronize, reopened, ready_for_review]
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  automerge:
+    # Auto-merge Dependabot PRs for minor/patch updates after checks pass
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          target: minor

--- a/.github/workflows/maintainer-ready-automerge.yml
+++ b/.github/workflows/maintainer-ready-automerge.yml
@@ -1,0 +1,19 @@
+name: maintainer-ready-automerge
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, ready_for_review]
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  enable-auto-merge:
+    # Enable auto-merge on PRs explicitly marked by maintainers
+    if: >-
+      contains(join(fromJson(toJson(github.event.pull_request.labels)).*.name, ','), 'maintainer-ready')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
- Dependabot minors auto-merge after checks\n- Maintainer-controlled auto-merge: add 'maintainer-ready' label to enable\n- No change to contributor PRs unless you add the label\n\nThis keeps security fixes on autopilot and preserves human approval for plugins.