### PR TITLE
feat: add claude-never-forgets persistent memory plugin

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -4883,6 +4883,31 @@
         "skills": 13,
         "total": 13
       }
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "memory",
+        "context",
+        "persistent",
+        "preferences",
+        "sessions",
+        "recall"
+      ],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      },
+      "components": {
+        "hooks": 4,
+        "commands": 3,
+        "skills": 1,
+        "total": 8
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4735,6 +4735,25 @@
         "name": "Charles Wiltgen",
         "url": "https://github.com/CharlesWiltgen"
       }
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "memory",
+        "context",
+        "persistent",
+        "preferences",
+        "sessions",
+        "recall"
+      ],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      }
     }
   ]
 }

--- a/plugins/community/claude-never-forgets/.claude-plugin/plugin.json
+++ b/plugins/community/claude-never-forgets/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "claude-never-forgets",
+  "version": "1.0.0",
+  "description": "Persistent memory across sessions. Learns preferences, conventions, and corrections automatically.",
+  "author": {
+    "name": "yldrmahmet",
+    "url": "https://github.com/yldrmahmet"
+  },
+  "repository": "https://github.com/yldrmahmet/claude-never-forgets",
+  "license": "MIT",
+  "keywords": ["memory", "persistence", "learning", "context"]
+}

--- a/plugins/community/claude-never-forgets/LICENSE
+++ b/plugins/community/claude-never-forgets/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 yldrmahmet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/community/claude-never-forgets/README.md
+++ b/plugins/community/claude-never-forgets/README.md
@@ -1,0 +1,81 @@
+# Claude Never Forgets
+
+A Claude Code plugin that provides persistent memory across sessions and context windows.
+
+![Claude Never Forgets](claude_terminal.png)
+
+## Why
+
+Claude Code's context window is limited to 200K tokens. During long coding sessions, earlier parts of your conversation get summarized or dropped. When you start a new session, Claude has no memory of your previous work.
+
+This plugin saves important parts of your conversations to a local file and automatically loads them when you start a new session - so your preferences, decisions, and project context persist.
+
+## Install
+
+```bash
+/plugin install yldrmahmet/claude-never-forgets
+```
+
+## How It Works
+
+**Automatic saving:**
+- Every user message and Claude response is saved
+- Tool rejections (when you decline a suggested action) are captured as corrections
+- Memories are stored in `.claude/memories/project_memory.json`
+
+**Automatic loading:**
+- When you start a new session, saved memories are loaded into context
+- Claude sees your previous preferences and decisions
+
+**Automatic cleanup:**
+- When memories exceed 10 entries, Claude consolidates them
+- Keeps important information (preferences, decisions, corrections)
+- Removes noise (greetings, acknowledgments)
+- The threshold (10) can be changed in `hooks/stop_cleanup.py`
+
+## Commands
+
+```bash
+/remember [text]   # Manually add something to memory
+/forget [text]     # Remove a specific memory
+/memories          # View all stored memories
+```
+
+## Example
+
+```
+Session 1:
+You: "Use pnpm instead of npm for this project"
+Claude: *uses pnpm*
+→ Saved to memory
+
+Session 2 (next day):
+🧠 Loaded 3 memories
+You: "Install axios"
+Claude: *runs pnpm add axios*
+→ Remembered your preference
+```
+
+## Storage
+
+Each project has its own memory file:
+
+```
+your-project/
+└── .claude/
+    └── memories/
+        └── project_memory.json
+```
+
+You can:
+- Commit it to git to share with your team
+- Add it to .gitignore for personal preferences
+- Edit it manually if needed
+
+## Privacy
+
+All memories are stored locally. Nothing is sent to external servers.
+
+## License
+
+MIT

--- a/plugins/community/claude-never-forgets/commands/forget.md
+++ b/plugins/community/claude-never-forgets/commands/forget.md
@@ -1,0 +1,10 @@
+---
+description: Remove something from project memory
+argument-hint: [what to forget]
+---
+
+Read `.claude/memories/project_memory.json`, find and remove entries matching "$ARGUMENTS" from `manual_memories` or `realtime_memories`.
+
+Confirm: `✓ Forgot: "<matched>"`
+
+If not found: `No memory found matching "$ARGUMENTS". Use /memories to see all.`

--- a/plugins/community/claude-never-forgets/commands/memories.md
+++ b/plugins/community/claude-never-forgets/commands/memories.md
@@ -1,0 +1,19 @@
+---
+description: Show all stored project memories
+---
+
+Read `.claude/memories/project_memory.json` and display:
+
+```
+# Project Memories
+
+## Manual (user added)
+- [content] (added X ago)
+
+## Learned
+- [type] content (added X ago)
+
+Total: X memories
+```
+
+If empty: `📭 No memories yet. Use /remember [text] to add.`

--- a/plugins/community/claude-never-forgets/commands/remember.md
+++ b/plugins/community/claude-never-forgets/commands/remember.md
@@ -1,0 +1,12 @@
+---
+description: Manually add something to project memory
+argument-hint: [what to remember]
+---
+
+Add to `.claude/memories/project_memory.json` in `manual_memories` array:
+
+```json
+{"type": "manual", "content": "$ARGUMENTS", "added_at": "<timestamp>", "source": "user_command"}
+```
+
+Confirm: `✓ Remembered: "$ARGUMENTS"`

--- a/plugins/community/claude-never-forgets/hooks/hooks.json
+++ b/plugins/community/claude-never-forgets/hooks/hooks.json
@@ -1,0 +1,49 @@
+{
+  "description": "Claude Never Forgets - Persistent memory across sessions",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt.py",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/tool_rejected.py",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop_cleanup.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/community/claude-never-forgets/hooks/session_start.py
+++ b/plugins/community/claude-never-forgets/hooks/session_start.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Session Start - Load memories and inject as context."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        cwd = data.get("cwd", ".")
+        memory_file = Path(cwd) / ".claude" / "memories" / "project_memory.json"
+
+        if not memory_file.exists():
+            print(json.dumps({
+                "systemMessage": "\033[1;97m🧠 Claude Never Forgets: Ready to learn.\033[0m"
+            }))
+            sys.exit(0)
+
+        memories = json.load(open(memory_file, "r", encoding="utf-8"))
+
+        manual = memories.get("manual_memories", [])
+        realtime = memories.get("realtime_memories", [])
+
+        if not manual and not realtime:
+            print(json.dumps({
+                "systemMessage": "\033[1;97m🧠 Claude Never Forgets: No memories yet.\033[0m"
+            }))
+            sys.exit(0)
+
+        lines = ["## Project Memory", "", "Apply these in your responses:", ""]
+
+        if manual:
+            lines.append("### User Rules")
+            for m in manual[:10]:
+                lines.append(f"- {m.get('content', '')}")
+            lines.append("")
+
+        if realtime:
+            lines.append("### Learned")
+            for m in realtime[-10:]:
+                lines.append(f"- [{m.get('type', 'info')}] {m.get('content', '')}")
+            lines.append("")
+
+        count = len(manual) + len(realtime)
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": "\n".join(lines)
+            },
+            "systemMessage": f"\033[1;97m🧠 Claude Never Forgets: Loaded {count} memories.\033[0m"
+        }))
+
+    except Exception:
+        print(json.dumps({}))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/community/claude-never-forgets/hooks/stop_cleanup.py
+++ b/plugins/community/claude-never-forgets/hooks/stop_cleanup.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Stop Hook - Trigger cleanup if 10+ memories."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+        cwd = data.get("cwd", ".")
+        memory_file = Path(cwd) / ".claude" / "memories" / "project_memory.json"
+
+        if not memory_file.exists():
+            print(json.dumps({}))
+            sys.exit(0)
+
+        memories = json.load(open(memory_file, "r", encoding="utf-8"))
+        count = len(memories.get("realtime_memories", []))
+
+        if count >= 10:
+            print(json.dumps({
+                "decision": "block",
+                "reason": f"""🧹 Memory cleanup required. You have {count} memories.
+
+Read .claude/memories/project_memory.json and consolidate realtime_memories.
+
+SIGNAL (keep): preferences, decisions, corrections, tech choices, completed features, conventions
+NOISE (remove): greetings, thanks, praise without context, exact duplicates
+
+For each memory ask: "Will this help me serve the user better next session?" If yes, keep it.
+
+Merge related memories into single entries. Target: 5-7 memories. Write back silently."""
+            }))
+        else:
+            print(json.dumps({}))
+
+    except Exception:
+        print(json.dumps({}))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/community/claude-never-forgets/hooks/tool_rejected.py
+++ b/plugins/community/claude-never-forgets/hooks/tool_rejected.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Tool Rejected - Save when user rejects a tool with feedback."""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+        error = data.get("error", "")
+
+        if "rejected" not in error.lower() or len(error) < 10:
+            print(json.dumps({}))
+            sys.exit(0)
+
+        cwd = data.get("cwd", ".")
+        memory_file = Path(cwd) / ".claude" / "memories" / "project_memory.json"
+        memory_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if memory_file.exists():
+            memories = json.load(open(memory_file, "r", encoding="utf-8"))
+        else:
+            memories = {"memories": [], "manual_memories": [], "realtime_memories": []}
+
+        tool_name = data.get("tool_name", "unknown")
+        content = f"[CORRECTION] {tool_name}: {error}"[:300]
+
+        memories.setdefault("realtime_memories", []).append({
+            "type": "correction",
+            "content": content,
+            "added_at": datetime.now().isoformat(),
+            "source": "tool_rejection"
+        })
+
+        memories["updated_at"] = datetime.now().isoformat()
+        json.dump(memories, open(memory_file, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
+
+    except Exception:
+        pass
+
+    print(json.dumps({}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/community/claude-never-forgets/hooks/user_prompt.py
+++ b/plugins/community/claude-never-forgets/hooks/user_prompt.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""User Prompt - Save user message and Claude's last response."""
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def get_memories(cwd: str) -> tuple[Path, dict]:
+    """Load or create memory file."""
+    memory_file = Path(cwd) / ".claude" / "memories" / "project_memory.json"
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if memory_file.exists():
+        try:
+            return memory_file, json.load(open(memory_file, "r", encoding="utf-8"))
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    return memory_file, {
+        "memories": [],
+        "manual_memories": [],
+        "realtime_memories": [],
+        "created_at": datetime.now().isoformat()
+    }
+
+
+def get_last_claude_response(transcript_path: str) -> str | None:
+    """Get Claude's last response from transcript."""
+    if not transcript_path or not os.path.exists(transcript_path):
+        return None
+
+    try:
+        with open(transcript_path, "r", encoding="utf-8") as f:
+            for line in reversed(f.readlines()):
+                msg = json.loads(line.strip())
+                if msg.get("type") == "assistant":
+                    content = msg.get("message", {}).get("content", [])
+                    for block in content if isinstance(content, list) else []:
+                        if block.get("type") == "text" and len(block.get("text", "")) > 10:
+                            return block["text"][:200]
+    except Exception:
+        pass
+    return None
+
+
+def is_duplicate(content: str, memories: list) -> bool:
+    """Check for duplicate."""
+    key = content.lower()[:50]
+    return any(m.get("content", "").lower()[:50] == key for m in memories)
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+        prompt = data.get("prompt", "")
+
+        if len(prompt) < 5 or prompt.startswith("/"):
+            print(json.dumps({}))
+            sys.exit(0)
+
+        cwd = data.get("cwd", os.getcwd())
+        transcript = data.get("transcript_path", "")
+        memory_file, memories = get_memories(cwd)
+
+        if "realtime_memories" not in memories:
+            memories["realtime_memories"] = []
+
+        # Save Claude's last response
+        response = get_last_claude_response(transcript)
+        if response and not is_duplicate(response, memories["realtime_memories"]):
+            memories["realtime_memories"].append({
+                "type": "claude_response",
+                "content": response,
+                "added_at": datetime.now().isoformat(),
+                "source": "realtime_capture"
+            })
+
+        # Save user message
+        clean_prompt = " ".join(prompt.split())[:200]
+        if not is_duplicate(clean_prompt, memories["realtime_memories"]):
+            memories["realtime_memories"].append({
+                "type": "message",
+                "content": clean_prompt,
+                "added_at": datetime.now().isoformat(),
+                "source": "realtime_capture"
+            })
+
+        memories["updated_at"] = datetime.now().isoformat()
+        json.dump(memories, open(memory_file, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
+
+    except Exception:
+        pass
+
+    print(json.dumps({}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/community/claude-never-forgets/skills/memory/SKILL.md
+++ b/plugins/community/claude-never-forgets/skills/memory/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: memory
+description: Access and use project memories from previous sessions. Use this skill when you need to recall past decisions, check project conventions, or understand user preferences that were established in earlier sessions.
+---
+
+# Project Memory
+
+Memories stored in `.claude/memories/project_memory.json`.
+
+## Use When
+- Choosing libraries/tools
+- Making architecture decisions
+- User says "remember when..." or "like before"
+
+## Rules
+- Apply silently, don't announce
+- Current request > old memory if conflict
+
+## Commands
+- `/remember [text]` - Add to manual_memories array
+- `/forget [text]` - Remove matching memory
+- `/memories` - Show all stored memories


### PR DESCRIPTION
## Type of Change

  - [x] 🔌 New plugin submission

  ## Description

  **Summary:**
  A persistent memory plugin that saves user preferences, decisions, and corrections across Claude Code sessions and context
  window limits.

  **Motivation:**
  Claude Code's 200K token context window causes earlier conversation parts to be summarized or lost. This plugin solves that
  by storing important information locally and loading it automatically in new sessions.

  ## Plugin Details

  **Plugin Name:** claude-never-forgets
  **Category:** productivity
  **Version:** 0.1.0
  **Keywords:** memory, context, persistent, preferences, sessions, recall

  **Components Included:**
  - [x] Commands (how many: 3)
  - [x] Hooks (how many: 4)
  - [x] Skills (how many: 1)

  **Dependencies:** Python 3 (standard library only)

  ## Checklist

  ### For All PRs
  - [x] I have read the CONTRIBUTING.md guidelines
  - [x] My code follows the project's style and conventions
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings or errors

  ### For Plugin Submissions/Updates
  - [x] Plugin has valid `.claude-plugin/plugin.json`
  - [x] README.md is comprehensive with installation, usage, and examples
  - [x] LICENSE file is included (MIT)
  - [x] No hardcoded secrets, API keys, or credentials
  - [x] Marketplace.json has been updated with plugin entry

  ## Testing Evidence

  **Test Environment:**
  - OS: Linux (Fedora 43)
  - Claude Code Version: Latest

  **Test Results:**
  Plugin tested locally, memories save and load correctly across sessions.

  ## Breaking Changes
  - [x] No

  ## Security Considerations

  ### Automated Security Scans
  - [x] No hardcoded secrets
  - [x] No destructive commands
  - [x] All data stored locally only

  ### Manual Security Review
  - [x] **Data Privacy**: All memories stored locally in `.claude/memories/`
  - [x] **Permission Audit**: Minimal permissions, only reads/writes local JSON file
  - [x] **Clear Intent**: README clearly explains functionality

  **By submitting this PR, I confirm:**
  - [x] I have the right to submit this code under the project's license
  - [x] I understand my contributions will be publicly available