### PR TITLE
fix(ci): Exclude tsconfig*.json from strict JSON validation

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Validate JSON files
         run: |
           echo "Validating JSON files..."
-          find . -name "*.json" -type f -exec sh -c '
+          # Exclude tsconfig*.json files as they use JSONC (JSON with Comments)
+          find . -name "*.json" -not -name "tsconfig*.json" -type f -exec sh -c '
             for file; do
               echo "Checking $file"
               if ! jq empty "$file" 2>/dev/null; then


### PR DESCRIPTION
## Problem
The validation workflow was failing because it was trying to validate  files with , but these files use JSONC (JSON with Comments) which is valid TypeScript configuration but not valid strict JSON.

## Root Cause
-  contains comments like 
- The workflow uses  to validate all  files
-  doesn't support JSON with Comments (JSONC)
- Error: 

## Solution
Exclude  files from the  validation step by adding  to the find command.

## Testing
- [ ] Workflow validation should now pass
- [x] tsconfig.json files remain valid TypeScript configuration
- [x] Other JSON files continue to be validated

Resolves: Validation failure in #188 deployment
