### PR TITLE
fix(ci): Remove analytics-dashboard from workspace to unblock deployment

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,3 @@ packages:
   - 'marketplace'
   - 'packages/cli'
   - 'packages/analytics-daemon'
-  - 'packages/analytics-dashboard'


### PR DESCRIPTION
Hotfix for failed deployment. analytics-dashboard not yet ready for CI - will add back after lockfile update.