### PR TITLE
fix(ux): Center content in Learning Hub feature card

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -466,6 +466,7 @@ import searchIndex from '../data/unified-search-index.json';
             transition: all 0.4s var(--transition-smooth);
             position: relative;
             overflow: hidden;
+            text-align: center;
         }
 
         .feature-card::before {


### PR DESCRIPTION
Centers all content within feature cards including the Learning Hub.

Changes:
- Added text-align: center to .feature-card CSS class
- Centers icon, heading, description, and links
- Improves visual consistency across all feature sections

Fixes user-reported issue: Learning Hub content now properly centered in its box.