### PR TITLE
fix(docs): canonicalize metrics across all documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-Claude Code plugins marketplace and learning hub. 259 plugins across 18 categories with 241 Agent Skills. Live at https://claudecodeplugins.io/
+Claude Code plugins marketplace and learning hub. 258 plugins across 22 categories with 239 Agent Skills. Live at https://claudecodeplugins.io/
 
 **Monorepo structure:** pnpm workspaces (v9.15.9+) with:
 - 7 MCP server plugins in `plugins/mcp/*` (TypeScript/Node.js)
-- 252 instruction-based plugins in `plugins/[category]/*` (Markdown)
+- 251 instruction-based plugins in `plugins/[category]/*` (Markdown)
 - Astro website in `marketplace/` (uses npm, not pnpm)
 - Shared packages in `packages/` (CLI, validator, analytics)
 
@@ -290,7 +290,7 @@ packages:
 - Entry point must be executable: `chmod +x dist/index.js`
 - Set `"type": "module"` in package.json for ES modules
 
-### 3. Agent Skills (241 across 73% of plugins)
+### 3. Agent Skills (239 across plugins)
 - **What they are**: Auto-activating capabilities triggered by conversation context
 - **Location**: `plugins/[category]/[plugin]/skills/[skill-name]/SKILL.md`
 - **How they work**: Claude reads trigger phrases and activates automatically
@@ -358,7 +358,7 @@ author: Name <email>
 - Description must include trigger phrases
 - Validate with: `python3 scripts/validate-skills-schema.py`
 
-**Skill Count:** 241 skills across 18 categories, all 2025-compliant
+**Skill Count:** 239 skills across 22 categories, all 2025-compliant
 
 ## Validation Pipeline (6 Stages)
 
@@ -545,8 +545,8 @@ npm run preview      # Test production build locally
 **Location:** `planned-skills/`
 
 **Goal**: Generate 500 standalone Agent Skills separate from plugins
-- Current: 241 skills embedded in plugins
-- Target: 741 total skills (500 standalone + 241 embedded)
+- Current: 239 skills embedded in plugins
+- Target: 739 total skills (500 standalone + 239 embedded)
 
 **Structure:**
 ```
@@ -719,18 +719,19 @@ python3 scripts/audit-skills-quality.py
 
 ## Statistics (Current)
 
-- **Total Plugins**: 259 across 18 categories
-- **Agent Skills**: 241 (73% of plugins have skills)
-- **MCP Plugins**: 7 (2% of marketplace)
-- **AI Instruction Plugins**: 252 (98% of marketplace)
+> **Canonical Source:** `node scripts/metrics-summary.js` or `marketplace/src/data/unified-search-index.json`
+
+- **Total Plugins**: 258 (indexed in search)
+- **Agent Skills**: 239 (indexed in search)
+- **Categories**: 22 (from search index)
+- **MCP Plugins**: 7 (3% of marketplace)
+- **AI Instruction Plugins**: 251 (97% of marketplace)
 - **Plugin Packs**: 4 major packs (devops, security, api-development, ai-ml)
-- **Categories**: 18 total categories
 - **2025 Schema**: Validated with scripts/validate-skills-schema.py
 - **Website**: https://claudecodeplugins.io/ (Astro 5.16.6 + Tailwind 4.1.18)
-- **Monorepo Version**: 4.3.0 (package.json)
-- **Release Version**: 4.0.0 (README.md - includes Learning Lab)
-- **CLI Tool**: @claude-code-plugins/ccp (published to npm)
-- **Last Updated**: 2025-12-24
+- **Monorepo Version**: 4.4.0 (package.json)
+- **CLI Tool**: @intentsolutionsio/ccpi (published to npm)
+- **Last Updated**: 2025-12-26
 
 ## Important Notes
 
@@ -744,4 +745,4 @@ There is currently no monetization mechanism for Claude Code plugins. All plugin
 Claude Code plugins are in **public beta** (October 2025). Features and best practices evolve. This marketplace stays updated with latest changes from Anthropic.
 
 ### Agent Skills Launch
-Agent Skills feature launched October 16, 2025 by Anthropic. This marketplace was first to implement comprehensive skill support across 241 plugins.
+Agent Skills feature launched October 16, 2025 by Anthropic. This marketplace was first to implement comprehensive skill support with 239 indexed skills.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Version](https://img.shields.io/badge/version-4.4.0-brightgreen)](CHANGELOG.md)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
-[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-244%20Skills-orange?logo=sparkles)](CHANGELOG.md)
-[![Plugins](https://img.shields.io/badge/Total%20Plugins-264-blue)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-239%20Skills-orange?logo=sparkles)](CHANGELOG.md)
+[![Plugins](https://img.shields.io/badge/Total%20Plugins-258-blue)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![2025 Schema](https://img.shields.io/badge/2025%20Schema-Compliant-success?logo=checkmarx)](tutorials/skills/05-skill-validation.ipynb)
 [![Tool Permissions](https://img.shields.io/badge/Tool%20Permissions-Secured-blueviolet?logo=shield)](tutorials/skills/02-skill-anatomy.ipynb)
 [![Interactive Tutorials](https://img.shields.io/badge/Tutorials-11%20Notebooks-yellow?logo=jupyter)](tutorials/README.md)
@@ -172,7 +172,7 @@ See [Learning Paths](#-learning-paths) for step-by-step guides
 
 ## 🚀 Agent Skills - The Future of Claude Automation
 
-**244 production-ready Agent Skills** that activate automatically based on your conversations:
+**239 production-ready Agent Skills** that activate automatically based on your conversations:
 
 ### What are Agent Skills?
 Agent Skills are intelligent automation tools that Claude Code can invoke automatically when relevant. Unlike plugins that need manual commands, **Skills detect when they're needed and activate seamlessly**.
@@ -192,10 +192,10 @@ Agent Skills are intelligent automation tools that Claude Code can invoke automa
 - **📝 Documentation Skills:** Auto-documentation, API specs, tutorials
 
 ### Quick Stats
-- **244 Skills** equipped across plugins
+- **239 Skills** indexed for search
 - **2025 Schema:** Validated against Anthropic standards
 - **Average skill size:** 3.2KB of intelligent automation
-- **Categories covered:** 18 specialized domains
+- **Categories covered:** 22 specialized domains
 
 ---
 
@@ -350,7 +350,7 @@ This marketplace contains **two types of plugins** that work differently:
 
 ### 🧠 Agent Skills - A Feature, Not a Type
 
-**244 plugins (92% of marketplace) include Agent Skills** - automatic capabilities that Claude activates based on conversation context.
+**239 Agent Skills across plugins** - automatic capabilities that Claude activates based on conversation context.
 
 - **What they are**: SKILL.md files that teach Claude when and how to use the plugin
 - **How they work**: Claude reads trigger phrases and activates skills automatically
@@ -379,7 +379,7 @@ A comprehensive technical breakdown by **Lee-Han Chung** covering:
 
 This article is the definitive external resource for understanding how Agent Skills work under the hood.
 
-*244 plugins in this marketplace (92%) include Agent Skills based on these principles.*
+*239 Agent Skills in this marketplace follow these principles.*
 
 ---
 

--- a/planned-skills/README.md
+++ b/planned-skills/README.md
@@ -20,13 +20,13 @@
 
 ## Key Decision: Standalone Skills
 
-These 500 skills will be **standalone** in `/skills/`, separate from the 241 plugin-embedded skills.
+These 500 skills will be **standalone** in `/skills/`, separate from the 239 plugin-embedded skills.
 
 | Type | Location | Count |
 |------|----------|-------|
 | **Standalone Skills (NEW)** | `/skills/[category]/[skill]/SKILL.md` | 500 planned |
-| Plugin-Embedded Skills | `/plugins/*/skills/*/SKILL.md` | 241 existing |
-| **Total After Completion** | | **741 skills** |
+| Plugin-Embedded Skills | `/plugins/*/skills/*/SKILL.md` | 239 existing |
+| **Total After Completion** | | **739 skills** |
 
 ---
 
@@ -211,4 +211,4 @@ skills/
 
 **Last Updated**: 2025-12-19
 **Maintained By**: Intent Solutions (Jeremy Longshore)
-**Target**: 500 standalone skills + 241 embedded = 741 total
+**Target**: 500 standalone skills + 239 embedded = 739 total

--- a/scripts/metrics-summary.js
+++ b/scripts/metrics-summary.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Canonical Metrics Summary
+ *
+ * Single source of truth for all marketplace metrics.
+ * All documentation should reference output from this script.
+ *
+ * Usage:
+ *   node scripts/metrics-summary.js          # Human-readable output
+ *   node scripts/metrics-summary.js --json   # JSON output for scripts
+ *   node scripts/metrics-summary.js --md     # Markdown snippet for docs
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = join(__dirname, '..');
+
+// Canonical source: unified-search-index.json (generated at build time)
+const SEARCH_INDEX_PATH = join(ROOT, 'marketplace/src/data/unified-search-index.json');
+const MARKETPLACE_JSON_PATH = join(ROOT, '.claude-plugin/marketplace.json');
+const PLUGINS_DIR = join(ROOT, 'plugins');
+
+function getSearchIndexMetrics() {
+  try {
+    const data = JSON.parse(readFileSync(SEARCH_INDEX_PATH, 'utf-8'));
+    return {
+      source: 'unified-search-index.json',
+      totalPlugins: data.stats.totalPlugins,
+      totalSkills: data.stats.totalSkills,
+      totalItems: data.stats.totalItems,
+      categories: data.stats.categories,
+      categoryCount: data.stats.categories.length,
+      skillToolsCount: data.stats.skillTools?.length || 0,
+    };
+  } catch (e) {
+    return { error: `Failed to read search index: ${e.message}` };
+  }
+}
+
+function getMarketplaceJsonMetrics() {
+  try {
+    const data = JSON.parse(readFileSync(MARKETPLACE_JSON_PATH, 'utf-8'));
+    return {
+      source: 'marketplace.json',
+      catalogPlugins: data.plugins.length,
+    };
+  } catch (e) {
+    return { error: `Failed to read marketplace.json: ${e.message}` };
+  }
+}
+
+function countFilesystem() {
+  let pluginDirs = 0;
+  let skillFiles = 0;
+  const categoryDirs = new Set();
+
+  function walk(dir, depth = 0) {
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === '.claude-plugin') {
+            pluginDirs++;
+          } else if (depth === 0) {
+            categoryDirs.add(entry.name);
+          }
+          if (entry.name !== 'node_modules' && entry.name !== '.git') {
+            walk(fullPath, depth + 1);
+          }
+        } else if (entry.name === 'SKILL.md') {
+          skillFiles++;
+        }
+      }
+    } catch (e) {
+      // Skip inaccessible directories
+    }
+  }
+
+  walk(PLUGINS_DIR);
+  return {
+    source: 'filesystem',
+    pluginDirectories: pluginDirs,
+    skillFiles: skillFiles,
+    categoryDirectories: categoryDirs.size,
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonOutput = args.includes('--json');
+  const mdOutput = args.includes('--md');
+
+  const searchIndex = getSearchIndexMetrics();
+  const marketplace = getMarketplaceJsonMetrics();
+  const filesystem = countFilesystem();
+
+  const metrics = {
+    timestamp: new Date().toISOString(),
+    canonical: {
+      description: 'Use these values in documentation (from unified-search-index.json)',
+      totalPlugins: searchIndex.totalPlugins,
+      totalSkills: searchIndex.totalSkills,
+      totalCategories: searchIndex.categoryCount,
+      totalSearchItems: searchIndex.totalItems,
+    },
+    sources: {
+      searchIndex,
+      marketplace,
+      filesystem,
+    },
+    discrepancies: {
+      pluginsDiff: filesystem.pluginDirectories - searchIndex.totalPlugins,
+      skillsDiff: filesystem.skillFiles - searchIndex.totalSkills,
+      catalogVsIndex: marketplace.catalogPlugins - searchIndex.totalPlugins,
+      notes: [
+        `${filesystem.pluginDirectories - marketplace.catalogPlugins} plugins on disk not in catalog`,
+        `${filesystem.skillFiles - searchIndex.totalSkills} SKILL.md files not indexed (orphaned)`,
+      ],
+    },
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(metrics, null, 2));
+  } else if (mdOutput) {
+    console.log(`## Marketplace Metrics (${new Date().toLocaleDateString()})\n`);
+    console.log(`| Metric | Count | Source |`);
+    console.log(`|--------|-------|--------|`);
+    console.log(`| Plugins | ${metrics.canonical.totalPlugins} | search index |`);
+    console.log(`| Skills | ${metrics.canonical.totalSkills} | search index |`);
+    console.log(`| Categories | ${metrics.canonical.totalCategories} | search index |`);
+    console.log(`| Search Items | ${metrics.canonical.totalSearchItems} | search index |`);
+    console.log(`\n**Definitions:**`);
+    console.log(`- **Plugins**: Entries in unified-search-index.json (excludes orphaned/unlisted)`);
+    console.log(`- **Skills**: Agent Skills indexed for search (excludes orphaned)`);
+    console.log(`- **Categories**: Unique category values in search index`);
+  } else {
+    console.log('='.repeat(60));
+    console.log('CANONICAL MARKETPLACE METRICS');
+    console.log('Generated:', metrics.timestamp);
+    console.log('='.repeat(60));
+    console.log('\n📊 USE THESE VALUES IN DOCUMENTATION:\n');
+    console.log(`  Plugins:     ${metrics.canonical.totalPlugins}`);
+    console.log(`  Skills:      ${metrics.canonical.totalSkills}`);
+    console.log(`  Categories:  ${metrics.canonical.totalCategories}`);
+    console.log(`  Search Items: ${metrics.canonical.totalSearchItems}`);
+    console.log('\n📁 SOURCE BREAKDOWN:\n');
+    console.log(`  Search Index (canonical):`);
+    console.log(`    - Plugins: ${searchIndex.totalPlugins}`);
+    console.log(`    - Skills: ${searchIndex.totalSkills}`);
+    console.log(`    - Categories: ${searchIndex.categoryCount}`);
+    console.log(`\n  Marketplace Catalog:`);
+    console.log(`    - Catalog Entries: ${marketplace.catalogPlugins}`);
+    console.log(`\n  Filesystem:`);
+    console.log(`    - Plugin Dirs: ${filesystem.pluginDirectories}`);
+    console.log(`    - SKILL.md Files: ${filesystem.skillFiles}`);
+    console.log(`    - Category Dirs: ${filesystem.categoryDirectories}`);
+    console.log('\n⚠️  DISCREPANCIES:\n');
+    metrics.discrepancies.notes.forEach(note => console.log(`  - ${note}`));
+    console.log('\n' + '='.repeat(60));
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Created `scripts/metrics-summary.js` as canonical metrics extractor (single source of truth)
- Fixed 15+ metric inconsistencies across CLAUDE.md, README.md, and planned-skills/README.md
- Established `unified-search-index.json` as the canonical source for all marketplace metrics

## Canonical Values

| Metric | Before (Various) | After (Canonical) |
|--------|------------------|-------------------|
| Plugins | 259, 264, 258 | **258** |
| Skills | 239, 241, 244 | **239** |
| Categories | 18, 21, 22 | **22** |
| 500 Skills Target | 500 + 241 = 741 | **500 + 239 = 739** |

## Files Changed

1. `scripts/metrics-summary.js` (NEW) - Canonical metrics extractor
2. `CLAUDE.md` - 8 sections updated
3. `README.md` - 6 locations updated
4. `planned-skills/README.md` - 4 locations updated

## Beads Epic

- **ID:** `claude-code-plugins-u3z`
- **Priority:** P0
- **Status:** in_progress

## Test plan

- [ ] Run `node scripts/metrics-summary.js` and verify output matches unified-search-index.json
- [ ] Verify all badge counts in README match canonical values
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)