### PR TITLE
fix(playbooks): escape template literals for build

### DIFF
--- a/marketplace/src/pages/playbooks/01-multi-agent-rate-limits.astro
+++ b/marketplace/src/pages/playbooks/01-multi-agent-rate-limits.astro
@@ -144,7 +144,7 @@ const ws = new WebSocket(&#039;ws://localhost:3456&#039;);
 ws.onmessage = (event) =&gt; {
 const data = JSON.parse(event.data);
 if (data.type === &#039;rate_limit.warning&#039;) {
-console.warn(\\`⚠️ Rate limit: \\${data.current}/\\${data.limit}\\`);
+console.warn(&#96;⚠️ Rate limit: &#36;{data.current}/&#36;{data.limit}&#96;);
 // Trigger throttling
 }
 };</code></pre>
@@ -334,7 +334,7 @@ const baseDelay = 1000 * Math.pow(2, attempt);
 const jitter = Math.random() <em> baseDelay </em> 0.3;
 const delay = baseDelay + jitter;
 
-console.log(\\`Rate limited. Retrying in \\${delay}ms (attempt \\${attempt + 1}/\\${maxRetries})\\`);
+console.log(&#96;Rate limited. Retrying in &#36;{delay}ms (attempt &#36;{attempt + 1}/&#36;{maxRetries})&#96;);
 await sleep(delay);
 }
 }


### PR DESCRIPTION
Follow-up to PR #209.

The playbook pages were failing to build because code examples contained template literals (\` and \${) that were being parsed by esbuild inside the set:html directive.

Fix: Replace escaped template characters with HTML entities (&#96; and &#36;)