### PR TITLE
fix(playbooks): escape internal backticks with HTML entities

### DIFF
--- a/marketplace/src/pages/playbooks/02-cost-caps.astro
+++ b/marketplace/src/pages/playbooks/02-cost-caps.astro
@@ -63,7 +63,7 @@ const response = await claude.messages.create({
   max_tokens: 4096,
   messages: [{
     role: &#039;user&#039;,
-    content: `Review this entire codebase: &#36;{fs.readFileSync(&#039;monorepo.txt&#039;)}` // 250K tokens
+    content: &#96;Review this entire codebase: &#36;{fs.readFileSync(&#039;monorepo.txt&#039;)}&#96; // 250K tokens
   }]
 });
 
@@ -146,8 +146,8 @@ messages: [...]
 });
 
 const cost = tracker.track(response.usage, response.model);
-console.log(`Request cost: &#36;&#36;{cost.totalCost.toFixed(4)}`);
-console.log(`Total spent: &#36;&#36;{tracker.getTotalCost().toFixed(2)}`);</code></pre>
+console.log(&#96;Request cost: &#36;&#36;{cost.totalCost.toFixed(4)}&#96;);
+console.log(&#96;Total spent: &#36;&#36;{tracker.getTotalCost().toFixed(2)}&#96;);</code></pre>
 
 <h3>2. Analytics Daemon Integration</h3>
 
@@ -212,7 +212,7 @@ this.lastReset = new Date();
 // Check budget before execution
 if (this.spent &gt;= this.dailyBudget) {
 throw new Error(
-`Daily budget exceeded: &#36;&#36;{this.spent.toFixed(2)} / &#36;&#36;{this.dailyBudget}`
+&#96;Daily budget exceeded: &#36;&#36;{this.spent.toFixed(2)} / &#36;&#36;{this.dailyBudget}&#96;
 );
 }
 
@@ -223,7 +223,7 @@ this.spent += cost;
 // Warn at 80%
 if (this.spent &gt;= this.dailyBudget * 0.8) {
 console.warn(
-`⚠️ 80% of daily budget used: &#36;&#36;{this.spent.toFixed(2)} / &#36;&#36;{this.dailyBudget}`
+&#96;⚠️ 80% of daily budget used: &#36;&#36;{this.spent.toFixed(2)} / &#36;&#36;{this.dailyBudget}&#96;
 );
 }
 
@@ -328,7 +328,7 @@ const spent = this.userSpent.get(userId) || 0;
 
 if (spent &gt;= quota) {
 throw new Error(
-`User &#36;{userId} quota exceeded: &#36;&#36;{spent.toFixed(2)} / &#36;&#36;{quota}`
+&#96;User &#36;{userId} quota exceeded: &#36;&#36;{spent.toFixed(2)} / &#36;&#36;{quota}&#96;
 );
 }
 
@@ -347,7 +347,7 @@ userId,
 quota: &#36;&#36;{quota},
 spent: &#36;&#36;{spent.toFixed(2)},
 remaining: &#36;&#36;{(quota - spent).toFixed(2)},
-percentage: `&#36;{((spent / quota) * 100).toFixed(1)}%`
+percentage: &#96;&#36;{((spent / quota) * 100).toFixed(1)}%&#96;
 };
 }
 }</code></pre>
@@ -402,7 +402,7 @@ async function reviewFile(file: string, codebase: string) {
     model: &#039;claude-3-5-sonnet-20241022&#039;,
     messages: [{
       role: &#039;user&#039;,
-      content: `Codebase context:\n&#36;{codebase}\n\nReview:\n&#36;{file}` // 100K + 5K tokens
+      content: &#96;Codebase context:\n&#36;{codebase}\n\nReview:\n&#36;{file}&#96; // 100K + 5K tokens
     }]
   });
 }
@@ -415,7 +415,7 @@ return await claude.messages.create({
 model: &#039;claude-3-5-sonnet-20241022&#039;,
 messages: [{
 role: &#039;user&#039;,
-content: `Related files:\n&#36;{context}\n\nReview:\n&#36;{file}` // 10K + 5K tokens
+content: &#96;Related files:\n&#36;{context}\n\nReview:\n&#36;{file}&#96; // 10K + 5K tokens
 }]
 });
 }
@@ -434,7 +434,7 @@ fn: () =&gt; Promise&lt;{ result: T; cost: number }&gt;
 const cached = this.cache.get(cacheKey);
 
 if (cached &amp;&amp; Date.now() - cached.timestamp &lt; this.ttl) {
-console.log(`Cache hit: &#36;&#36;{cached.cost.toFixed(4)} saved`);
+console.log(&#96;Cache hit: &#36;&#36;{cached.cost.toFixed(4)} saved&#96;);
 return { result: cached.response, cost: 0, cached: true };
 }
 
@@ -463,7 +463,7 @@ hitRate: 0 // Track separately
 const cache = new ResponseCache();
 
 const { result, cost, cached } = await cache.execute(
-`code-review-&#36;{fileHash}`,
+&#96;code-review-&#36;{fileHash}&#96;,
 async () =&gt; {
 const response = await claude.messages.create(...);
 return { result: response, cost: calculateCost(response.usage) };
@@ -482,7 +482,7 @@ return { result: response, cost: calculateCost(response.usage) };
 async function reviewFiles(files: string[]) {
   for (const file of files) {
     await claude.messages.create({
-      messages: [{ role: &#039;user&#039;, content: `Review: &#36;{file}` }]
+      messages: [{ role: &#039;user&#039;, content: &#96;Review: &#36;{file}&#96; }]
     });
   }
 }
@@ -496,7 +496,7 @@ for (const batch of batches) {
 await claude.messages.create({
 messages: [{
 role: &#039;user&#039;,
-content: `Review these files:\n&#36;{batch.map((f, i) =&gt; \`&#36;{i+1}. &#36;{f}\`).join(&#039;\n&#039;)}`
+content: &#96;Review these files:\n&#36;{batch.map((f, i) =&gt; \&#96;&#36;{i+1}. &#36;{f}\&#96;).join(&#039;\n&#039;)}&#96;
 }]
 });
 }
@@ -525,7 +525,7 @@ for (const plugin of plugins) {
 try {
 await budget.executeWithBudget(async () =&gt; {
 const { result, cost, cached } = await cache.execute(
-`security-review-&#36;{plugin.id}`,
+&#96;security-review-&#36;{plugin.id}&#96;,
 async () =&gt; {
 const response = await claude.messages.create({
 model: &#039;claude-3-5-haiku-20241022&#039;, // Use cheaper model
@@ -545,7 +545,7 @@ results.push({ plugin: plugin.name, review: result, cached });
 return { result, cost };
 });
 } catch (error) {
-console.error(`Budget exceeded at plugin &#36;{plugin.name}`);
+console.error(&#96;Budget exceeded at plugin &#36;{plugin.name}&#96;);
 break;
 }
 }
@@ -583,14 +583,14 @@ userId: string,
 fn: () =&gt; Promise&lt;{ result: T; cost: number }&gt;
 ): Promise&lt;T&gt; {
 const team = this.teams.get(teamName);
-if (!team) throw new Error(`Unknown team: &#36;{teamName}`);
+if (!team) throw new Error(&#96;Unknown team: &#36;{teamName}&#96;);
 if (!team.members.includes(userId)) {
-throw new Error(`User &#36;{userId} not in team &#36;{teamName}`);
+throw new Error(&#96;User &#36;{userId} not in team &#36;{teamName}&#96;);
 }
 
 const spent = this.teamSpend.get(teamName) || 0;
 if (spent &gt;= team.monthlyBudget) {
-throw new Error(`Team &#36;{teamName} budget exceeded`);
+throw new Error(&#96;Team &#36;{teamName} budget exceeded&#96;);
 }
 
 const { result, cost } = await fn();
@@ -609,7 +609,7 @@ members: team.members.length,
 budget: &#36;&#36;{team.monthlyBudget},
 spent: &#36;&#36;{spent.toFixed(2)},
 remaining: &#36;&#36;{(team.monthlyBudget - spent).toFixed(2)},
-percentageUsed: `&#36;{((spent / team.monthlyBudget) * 100).toFixed(1)}%`,
+percentageUsed: &#96;&#36;{((spent / team.monthlyBudget) * 100).toFixed(1)}%&#96;,
 daysRemaining: 30 - new Date().getDate(),
 projectedOverage: spent / new Date().getDate() * 30 &gt; team.monthlyBudget
 };
@@ -689,7 +689,7 @@ const roi = calculateROI(codeReviewMetrics);
 // totalCost: &#36;0.50
 // ROI: ((&#36;350 - &#36;0.50) / &#36;0.50) × 100 = 69,900%
 
-console.log(`ROI: &#36;{roi.toFixed(0)}%`); // 69,900% ROI</code></pre>
+console.log(&#96;ROI: &#36;{roi.toFixed(0)}%&#96;); // 69,900% ROI</code></pre>
 
 <h3>Break-Even Analysis</h3>
 

--- a/marketplace/src/pages/playbooks/03-mcp-reliability.astro
+++ b/marketplace/src/pages/playbooks/03-mcp-reliability.astro
@@ -212,7 +212,7 @@ stdio: [&#039;pipe&#039;, &#039;pipe&#039;, &#039;pipe&#039;]
 });
 
 this.process.on(&#039;exit&#039;, (code: number) =&gt; {
-console.error(`MCP server exited with code &#36;{code}`);
+console.error(&#96;MCP server exited with code &#36;{code}&#96;);
 this.handleExit();
 });
 
@@ -241,12 +241,12 @@ t =&gt; now - t &lt; this.restartWindow
 
 if (this.restartTimes.length &gt;= this.maxRestarts) {
 console.error(
-`MCP server crashed &#36;{this.maxRestarts} times in &#36;{this.restartWindow}ms. Giving up.`
+&#96;MCP server crashed &#36;{this.maxRestarts} times in &#36;{this.restartWindow}ms. Giving up.&#96;
 );
 process.exit(1);
 }
 
-console.log(`Restarting MCP server (attempt &#36;{this.restartTimes.length}/&#36;{this.maxRestarts})`);
+console.log(&#96;Restarting MCP server (attempt &#36;{this.restartTimes.length}/&#36;{this.maxRestarts})&#96;);
 setTimeout(() =&gt; this.start(this.process.spawnfile), 1000);
 }
 
@@ -356,7 +356,7 @@ pool.release(db);
   ): Promise&lt;T&gt; {
     const timeout = new Promise&lt;never&gt;((_, reject) =&gt; {
       setTimeout(() =&gt; {
-        reject(new Error(`&#36;{operation} timed out after &#36;{timeoutMs}ms`));
+        reject(new Error(&#96;&#36;{operation} timed out after &#36;{timeoutMs}ms&#96;));
       }, timeoutMs);
     });
 
@@ -418,7 +418,7 @@ const result = await fallback();
 return {
 content: [{
 type: &#039;text&#039;,
-text: `⚠️ Primary method failed. Using cached/fallback data:\n\n&#36;{result}`
+text: &#96;⚠️ Primary method failed. Using cached/fallback data:\n\n&#36;{result}&#96;
 }],
 fallback: true
 };
@@ -426,7 +426,7 @@ fallback: true
 return {
 content: [{
 type: &#039;text&#039;,
-text: `Error: Both primary and fallback methods failed.\nPrimary: &#36;{error.message}\nFallback: &#36;{fallbackError.message}`
+text: &#96;Error: Both primary and fallback methods failed.\nPrimary: &#36;{error.message}\nFallback: &#36;{fallbackError.message}&#96;
 }],
 isError: true
 };
@@ -455,7 +455,7 @@ const cached = cache.get(&#039;latest&#039;);
 if (!cached) throw new Error(&#039;No cache available&#039;);
 
 const age = Date.now() - cached.timestamp;
-return `&#36;{JSON.stringify(cached.data)}\n\n(Cached &#36;{Math.floor(age / 1000)}s ago)`;
+return &#96;&#36;{JSON.stringify(cached.data)}\n\n(Cached &#36;{Math.floor(age / 1000)}s ago)&#96;;
 }
 );
 }
@@ -507,7 +507,7 @@ if (this.state === &#039;half-open&#039;) {
 console.log(&#039;Circuit breaker: Re-opening (recovery failed)&#039;);
 this.state = &#039;open&#039;;
 } else if (this.failures &gt;= this.threshold) {
-console.log(`Circuit breaker: Opening (&#36;{this.failures} failures)`);
+console.log(&#96;Circuit breaker: Opening (&#36;{this.failures} failures)&#96;);
 this.state = &#039;open&#039;;
 }
 
@@ -756,7 +756,7 @@ metrics.recordToolCall(&#039;test-api&#039;, latency);
 return {
 content: [{
 type: &#039;text&#039;,
-text: `✓ API Response (&#36;{latency}ms)\n\n&#36;{JSON.stringify(result, null, 2)}`
+text: &#96;✓ API Response (&#36;{latency}ms)\n\n&#36;{JSON.stringify(result, null, 2)}&#96;
 }]
 };
 } catch (error) {
@@ -767,7 +767,7 @@ if (error.message.includes(&#039;Circuit breaker is OPEN&#039;)) {
 return {
 content: [{
 type: &#039;text&#039;,
-text: `⚠️ API temporarily unavailable (circuit breaker triggered)\n\nThe API has failed &#36;{breaker.getState().failures} times. Waiting 30s before retry.`
+text: &#96;⚠️ API temporarily unavailable (circuit breaker triggered)\n\nThe API has failed &#36;{breaker.getState().failures} times. Waiting 30s before retry.&#96;
 }],
 isError: true
 };
@@ -776,7 +776,7 @@ isError: true
 return {
 content: [{
 type: &#039;text&#039;,
-text: `❌ API Error (&#36;{latency}ms)\n\n&#36;{error.message}`
+text: &#96;❌ API Error (&#36;{latency}ms)\n\n&#36;{error.message}&#96;
 }],
 isError: true
 };
@@ -828,7 +828,7 @@ const cached = cache.get(projectPath);
 
 if (cached &amp;&amp; Date.now() - cached.timestamp &lt; 3600000) {
 // Use cache if less than 1 hour old
-return `&#36;{JSON.stringify(cached.data, null, 2)}\n\n(Cached &#36;{Math.floor((Date.now() - cached.timestamp) / 1000)}s ago)`;
+return &#96;&#36;{JSON.stringify(cached.data, null, 2)}\n\n(Cached &#36;{Math.floor((Date.now() - cached.timestamp) / 1000)}s ago)&#96;;
 }
 
 // Simple grep-based scan
@@ -1045,7 +1045,7 @@ pnpm start
 ws.onmessage = (event) =&gt; {
   const data = JSON.parse(event.data);
   if (data.type === &#039;plugin.activation&#039;) {
-    console.log(`MCP server &#36;{data.pluginName} activated`);
+    console.log(&#96;MCP server &#36;{data.pluginName} activated&#96;);
   }
 };</code></pre>
 

--- a/marketplace/src/pages/playbooks/04-ollama-migration.astro
+++ b/marketplace/src/pages/playbooks/04-ollama-migration.astro
@@ -366,14 +366,14 @@ console.log(JSON.stringify(results, null, 2));
 <p><strong>Scenario</strong>: 100,000 requests/month, 500 input + 200 output tokens</p>
 
 <h4>Cloud API Costs (Claude 3.5 Sonnet)</h4>
-<p>\`\`<code></p>
+<p>\&#96;\&#96;<code></p>
 <p>Monthly cost: &#36;450</p>
 <p>Annual cost: &#36;5,400</p>
 <p>3-year cost: &#36;16,200</p>
-<code>\`</code>
+<code>\&#96;</code>
 
 <h4>Self-Hosted Ollama Costs</h4>
-<code>\`</code>
+<code>\&#96;</code>
 <p>Hardware (one-time):</p>
 - NVIDIA RTX 4090 (24GB): &#36;1,600
 - Workstation PC (CPU, RAM, SSD): &#36;2,000
@@ -387,7 +387,7 @@ console.log(JSON.stringify(results, null, 2));
 <p>3-year total: &#36;3,600 + (&#36;600 × 3) = &#36;5,400</p>
 
 <p>Savings vs Claude: &#36;16,200 - &#36;5,400 = &#36;10,800 (67% savings)</p>
-<code>\`</code>
+<code>\&#96;</code>
 
 <p><strong>Break-even point</strong>: 12 months</p>
 
@@ -500,7 +500,7 @@ const response = await anthropic.messages.create({
   model: &#039;claude-3-5-sonnet-20241022&#039;,
   messages: [{
     role: &#039;user&#039;,
-    content: `Analyze patient record: &#36;{patientData}` // ❌ HIPAA violation!
+    content: &#96;Analyze patient record: &#36;{patientData}&#96; // ❌ HIPAA violation!
   }]
 });
 
@@ -509,7 +509,7 @@ const response = await fetch(&#039;http://localhost:11434/api/generate&#039;, {
 method: &#039;POST&#039;,
 body: JSON.stringify({
 model: &#039;llama3.3:70b&#039;,
-prompt: `Analyze patient record: &#36;{patientData}` // ✅ Never leaves network
+prompt: &#96;Analyze patient record: &#36;{patientData}&#96; // ✅ Never leaves network
 })
 });</code></pre>
 
@@ -734,7 +734,7 @@ async generate(prompt: string, model: string): Promise&lt;string&gt; {
 const instance = this.instances[this.currentIndex];
 this.currentIndex = (this.currentIndex + 1) % this.instances.length;
 
-const response = await fetch(`&#36;{instance}/api/generate`, {
+const response = await fetch(&#96;&#36;{instance}/api/generate&#96;, {
 method: &#039;POST&#039;,
 body: JSON.stringify({ model, prompt, stream: false })
 });
@@ -919,7 +919,7 @@ print(response.json()[&#039;response&#039;])</code></pre>
 <ul>
 <li><code>ai-sdk-agents</code> - Supports Ollama for multi-agent workflows</li>
 <li><code>ollama-local-ai</code> - Ollama integration examples</li>
-<li></code>local-llm-wrapper\` - Generic local model wrapper</li>
+<li></code>local-llm-wrapper\&#96; - Generic local model wrapper</li>
 </ul>
 
 <h3>External Resources</h3>

--- a/marketplace/src/pages/playbooks/05-incident-debugging.astro
+++ b/marketplace/src/pages/playbooks/05-incident-debugging.astro
@@ -167,17 +167,17 @@ In 15 minutes or when resolved.</code></pre>
 <h3>1. Rate Limit Exhaustion</h3>
 
 <p><strong>Symptoms</strong>:</p>
-<p>\`\`<code></p>
+<p>\&#96;\&#96;<code></p>
 <p>Error 429: Rate limit exceeded</p>
 <p>anthropic-ratelimit-requests-remaining: 0</p>
 <p>anthropic-ratelimit-requests-reset: 2025-12-24T15:00:00Z</p>
-<code>\`</code>
+<code>\&#96;</code>
 
 <p><strong>Diagnosis</strong>:</p>
 <pre><code class="language-typescript">async function diagnoseRateLimits(): Promise&lt;void&gt; {
   // Check recent API calls
   const recentCalls = await queryLogs(&#039;SELECT COUNT(*) FROM api_calls WHERE timestamp &gt; NOW() - INTERVAL 1 MINUTE&#039;);
-  console.log(`API calls in last minute: &#36;{recentCalls}`);
+  console.log(&#96;API calls in last minute: &#36;{recentCalls}&#96;);
 
 // Check rate limit headers from last successful call
 const lastHeaders = await getLastAPIHeaders();
@@ -212,11 +212,11 @@ this.lastRefill = now;
 <h3>2. Agent Timeout</h3>
 
 <p><strong>Symptoms</strong>:</p>
-<code>\`</code>
+<code>\&#96;</code>
 <p>Error: Agent execution timed out after 300000ms</p>
 <p>Task: code-review</p>
 <p>Conversation: abc-123-def</p>
-<code>\`</code>
+<code>\&#96;</code>
 
 <p><strong>Diagnosis</strong>:</p>
 <pre><code class="language-bash"># Check for hung processes
@@ -239,7 +239,7 @@ class TimeoutManager {
     return Promise.race([
       fn(),
       new Promise&lt;never&gt;((_, reject) =&gt;
-        setTimeout(() =&gt; reject(new Error(`Timeout after &#36;{timeoutMs}ms`)), timeoutMs)
+        setTimeout(() =&gt; reject(new Error(&#96;Timeout after &#36;{timeoutMs}ms&#96;)), timeoutMs)
       )
     ]);
   }
@@ -378,7 +378,7 @@ const byPlugin = groupBy(failures, f =&gt; f.pluginName);
 const suspiciousPlugin = Object.entries(byPlugin)
 .sort((a, b) =&gt; b[1].length - a[1].length)[0];
 
-console.log(`Most failures from plugin: &#36;{suspiciousPlugin[0]} (&#36;{suspiciousPlugin[1].length} errors)`);
+console.log(&#96;Most failures from plugin: &#36;{suspiciousPlugin[0]} (&#36;{suspiciousPlugin[1].length} errors)&#96;);
 }</code></pre>
 
 <h3>3. Distributed Tracing</h3>
@@ -423,7 +423,7 @@ span.end();
 <h3>Parsing Claude Code Logs</h3>
 
 <p><strong>Log Format</strong>:</p>
-<code>\`</code>
+<code>\&#96;</code>
 <p>[2025-12-24T14:35:22.123Z] [ERROR] [agent:code-review] Rate limit exceeded</p>
 <p>conversationId: abc-123-def</p>
 <p>userId: user-456</p>
@@ -431,7 +431,7 @@ span.end();
 <p>retryAfter: 12</p>
 <p>stack: Error: Rate limit exceeded</p>
 <p>at callClaude (/app/src/api.ts:45:11)</p>
-<code>\`</code>
+<code>\&#96;</code>
 
 <p><strong>Analysis Script</strong>:</p>
 <pre><code class="language-typescript">import { readFileSync } from &#039;fs&#039;;
@@ -487,7 +487,7 @@ console.log(&#039;Errors by component:&#039;);
 Object.entries(errorsByComponent)
 .sort((a, b) =&gt; b[1].length - a[1].length)
 .forEach(([component, errors]) =&gt; {
-console.log(`  &#36;{component}: &#36;{errors.length}`);
+console.log(&#96;  &#36;{component}: &#36;{errors.length}&#96;);
 });
 
 // Recent errors (last 5 minutes)
@@ -496,9 +496,9 @@ l.level === &#039;ERROR&#039; &amp;&amp;
 Date.now() - l.timestamp.getTime() &lt; 300000
 );
 
-console.log(`\nRecent errors: &#36;{recentErrors.length}`);
+console.log(&#96;\nRecent errors: &#36;{recentErrors.length}&#96;);
 recentErrors.slice(0, 10).forEach(err =&gt; {
-console.log(`  &#36;{err.timestamp.toISOString()} - &#36;{err.message}`);
+console.log(&#96;  &#36;{err.timestamp.toISOString()} - &#36;{err.message}&#96;);
 });
 }</code></pre>
 
@@ -512,12 +512,12 @@ const data = JSON.parse(event.data);
 
 // Track rate limit warnings
 if (data.type === &#039;rate_limit.warning&#039;) {
-console.warn(`⚠️ Rate limit approaching: &#36;{data.current}/&#36;{data.limit}`);
+console.warn(&#96;⚠️ Rate limit approaching: &#36;{data.current}/&#36;{data.limit}&#96;);
 }
 
 // Track errors
 if (data.type === &#039;llm.call&#039; &amp;&amp; data.error) {
-console.error(`❌ LLM call failed: &#36;{data.error}`);
+console.error(&#96;❌ LLM call failed: &#36;{data.error}&#96;);
 }
 };
 
@@ -526,7 +526,7 @@ const response = await fetch(&#039;http://localhost:3333/api/sessions&#039;);
 const sessions = await response.json();
 const failedSessions = sessions.filter(s =&gt; s.errorCount &gt; 0);
 
-console.log(`Failed sessions: &#36;{failedSessions.length}/&#36;{sessions.length}`);</code></pre>
+console.log(&#96;Failed sessions: &#36;{failedSessions.length}/&#36;{sessions.length}&#96;);</code></pre>
 
 <hr>
 
@@ -644,7 +644,7 @@ const breaker = this.breakers.get(serviceName);
 if (breaker) {
 breaker.state = &#039;closed&#039;;
 breaker.failures = 0;
-console.log(`✓ Reset circuit breaker for &#36;{serviceName}`);
+console.log(&#96;✓ Reset circuit breaker for &#36;{serviceName}&#96;);
 }
 }
 
@@ -772,7 +772,7 @@ console.log(&#039;Error in code-reviewer agent&#039;);</code></pre>
      pagerDuty.trigger({
        severity: &#039;critical&#039;,
        title: &#039;High error rate detected&#039;,
-       details: `Error rate: &#36;{(errorRate * 100).toFixed(1)}%`
+       details: &#96;Error rate: &#36;{(errorRate * 100).toFixed(1)}%&#96;
      });
    }</code></pre>
 
@@ -783,7 +783,7 @@ console.log(&#039;Error in code-reviewer agent&#039;);</code></pre>
 
 1. Check logs: <code>tail -f /var/log/claude-code.log | grep TIMEOUT</code>
 2. Identify pattern: Which agents are timing out?
-3. Check system resources: <code>top, free -m</code>, </code>df -h\`
+3. Check system resources: <code>top, free -m</code>, </code>df -h\&#96;
 4. If rate limits: Implement emergency throttling
 5. If resource exhaustion: Restart services</code></pre>
 

--- a/marketplace/src/pages/playbooks/07-compliance-audit.astro
+++ b/marketplace/src/pages/playbooks/07-compliance-audit.astro
@@ -350,7 +350,7 @@ private async archiveToS3(logs: any[]): Promise&lt;void&gt; {
 const archive = JSON.stringify(logs);
 await s3.putObject({
 Bucket: &#039;audit-logs-archive&#039;,
-Key: `archive-&#36;{Date.now()}.json.gz`,
+Key: &#96;archive-&#36;{Date.now()}.json.gz&#96;,
 Body: gzip(archive)
 });
 }
@@ -380,7 +380,7 @@ await db.preferences.deleteMany({ userId });
 // Anonymize audit logs (can&#039;t delete due to legal requirements)
 await db.auditLogs.updateMany(
 { userId },
-{ &#36;set: { userId: `ANONYMIZED_&#36;{crypto.randomUUID()}` } }
+{ &#36;set: { userId: &#96;ANONYMIZED_&#36;{crypto.randomUUID()}&#96; } }
 );
 
 // Generate confirmation
@@ -465,7 +465,7 @@ outcome: &#039;failure&#039;,
 metadata: { role: user.role }
 });
 
-throw new Error(`Permission denied: &#36;{permission}`);
+throw new Error(&#96;Permission denied: &#36;{permission}&#96;);
 }
 
 await action();
@@ -563,7 +563,7 @@ metadata: { reason: &#039;brute_force_detected&#039; }
 
 private async alertSecurityTeam(userId: string, reason: string): Promise&lt;void&gt; {
 // Send to PagerDuty, Slack, email, etc.
-console.log(`SECURITY ALERT: &#36;{reason} for user &#36;{userId}`);
+console.log(&#96;SECURITY ALERT: &#36;{reason} for user &#36;{userId}&#96;);
 }
 
 private async verifyIdentity(userId: string): Promise&lt;any&gt; {
@@ -706,7 +706,7 @@ return JSON.stringify(data, null, 2);
     // ❌ HIPAA VIOLATION: Sending PHI to cloud
     // const response = await anthropic.messages.create({
     //   model: &#039;claude-3-5-sonnet-20241022&#039;,
-    //   messages: [{ role: &#039;user&#039;, content: `Analyze: &#36;{patientData}` }]
+    //   messages: [{ role: &#039;user&#039;, content: &#96;Analyze: &#36;{patientData}&#96; }]
     // });
 
 // ✅ HIPAA COMPLIANT: Self-hosted Ollama

--- a/marketplace/src/pages/playbooks/08-team-presets.astro
+++ b/marketplace/src/pages/playbooks/08-team-presets.astro
@@ -260,7 +260,7 @@ const meta = {
 <li><strong>Create Hotfix Branch</strong></code></pre>bash</li>
 </ul>
 <p>git checkout -b hotfix/issue-description main</p>
-<p>\`\`<code></p>
+<p>\&#96;\&#96;<code></p>
 
 <ul>
 <li><strong>Implement Fix</strong></li>
@@ -304,7 +304,7 @@ const meta = {
 <li>Monitor for 30 minutes post-deploy</li>
 <li>Auto-rollback if error rate > 5%</li>
 </ul>
-</code>\`<code>
+</code>\&#96;<code>
 
 <h3>Feature Development Workflow</h3>
 
@@ -529,7 +529,7 @@ import inquirer from &#039;inquirer&#039;;
 
 <h3>Centralized Configuration Repository</h3>
 
-</code>\`<code>
+</code>\&#96;<code>
 <p>team-configs/</p>
 <p>├── backend/</p>
 <p>│   ├── config.json</p>
@@ -544,7 +544,7 @@ import inquirer from &#039;inquirer&#039;;
 <p>└── devops/</p>
 <p>├── config.json</p>
 <p>└── ...</p>
-</code>\`<code>
+</code>\&#96;<code>
 
 <h3>Configuration Sync</h3>
 
@@ -557,24 +557,24 @@ import { readFileSync, writeFileSync } from &#039;fs&#039;;
 
 <p>async syncFromCentral(team: string): Promise&lt;void&gt; {</p>
 <p>// Clone/pull config repo</p>
-<p>execSync(`git clone &#36;{this.configRepo} /tmp/team-configs || (cd /tmp/team-configs &amp;&amp; git pull)`);</p>
+<p>execSync(&#96;git clone &#36;{this.configRepo} /tmp/team-configs || (cd /tmp/team-configs &amp;&amp; git pull)&#96;);</p>
 
 <p>// Copy team config</p>
-<p>const teamConfig = readFileSync(`/tmp/team-configs/&#36;{team}/config.json`, &#039;utf-8&#039;);</p>
-<p>writeFileSync(`&#36;{process.env.HOME}/.claude/config.json`, teamConfig);</p>
+<p>const teamConfig = readFileSync(&#96;/tmp/team-configs/&#36;{team}/config.json&#96;, &#039;utf-8&#039;);</p>
+<p>writeFileSync(&#96;&#36;{process.env.HOME}/.claude/config.json&#96;, teamConfig);</p>
 
 <p>// Copy workflows</p>
-<p>execSync(`cp -r /tmp/team-configs/&#36;{team}/workflows/* &#36;{process.env.HOME}/.claude/workflows/`);</p>
+<p>execSync(&#96;cp -r /tmp/team-configs/&#36;{team}/workflows/* &#36;{process.env.HOME}/.claude/workflows/&#96;);</p>
 
 <p>// Copy hooks</p>
-<p>execSync(`cp /tmp/team-configs/&#36;{team}/hooks/* .git/hooks/`);</p>
+<p>execSync(&#96;cp /tmp/team-configs/&#36;{team}/hooks/* .git/hooks/&#96;);</p>
 
-<p>console.log(`✓ Synced configuration for &#36;{team} team`);</p>
+<p>console.log(&#96;✓ Synced configuration for &#36;{team} team&#96;);</p>
 <p>}</p>
 
 <p>async pushLocalChanges(team: string, message: string): Promise&lt;void&gt; {</p>
 <p>// Copy local config back to central repo</p>
-<p>execSync(`cp &#36;{process.env.HOME}/.claude/config.json /tmp/team-configs/&#36;{team}/config.json`);</p>
+<p>execSync(&#96;cp &#36;{process.env.HOME}/.claude/config.json /tmp/team-configs/&#36;{team}/config.json&#96;);</p>
 
 <p>// Commit and push</p>
 <p>execSync(</code></p>
@@ -584,7 +584,7 @@ import { readFileSync, writeFileSync } from &#039;fs&#039;;
 <p>git push origin main</p>
 <p><code>);</p>
 
-<p>console.log(`✓ Pushed changes to central repository`);</p>
+<p>console.log(&#96;✓ Pushed changes to central repository&#96;);</p>
 <p>}</p>
 <p>}</p>
 
@@ -616,9 +616,9 @@ import { readFileSync, writeFileSync } from &#039;fs&#039;;
 <p>startTime: Date.now()</p>
 <p>};</p>
 
-<p>console.log(`🎯 Pair Programming Session Started`);</p>
-<p>console.log(`Task: &#36;{task}`);</p>
-<p>console.log(`Navigator: &#36;{session.navigator}`);</p>
+<p>console.log(&#96;🎯 Pair Programming Session Started&#96;);</p>
+<p>console.log(&#96;Task: &#36;{task}&#96;);</p>
+<p>console.log(&#96;Navigator: &#36;{session.navigator}&#96;);</p>
 <p>console.log(&#039;------------------------------------------\n&#039;);</p>
 
 <p>return session;</p>
@@ -628,7 +628,7 @@ import { readFileSync, writeFileSync } from &#039;fs&#039;;
 <p>// AI agent analyzes code and provides real-time feedback</p>
 <p>const response = await callClaude({</p>
 <p>agent: &#039;code-reviewer&#039;,</p>
-<p>prompt: `As a pair programming navigator, review this code:\n\n&#36;{code}\n\nContext: &#36;{context}\n\nProvide:\n1. Immediate feedback\n2. Suggestions for improvement\n3. Potential bugs\n4. Best practices`</p>
+<p>prompt: &#96;As a pair programming navigator, review this code:\n\n&#36;{code}\n\nContext: &#36;{context}\n\nProvide:\n1. Immediate feedback\n2. Suggestions for improvement\n3. Potential bugs\n4. Best practices&#96;</p>
 <p>});</p>
 
 <p>return response;</p>
@@ -636,8 +636,8 @@ import { readFileSync, writeFileSync } from &#039;fs&#039;;
 
 <p>async endSession(session: PairSession): Promise&lt;void&gt; {</p>
 <p>const duration = Date.now() - session.startTime;</p>
-<p>console.log(`\n✅ Pair Programming Session Complete`);</p>
-<p>console.log(`Duration: &#36;{Math.floor(duration / 60000)} minutes`);</p>
+<p>console.log(&#96;\n✅ Pair Programming Session Complete&#96;);</p>
+<p>console.log(&#96;Duration: &#36;{Math.floor(duration / 60000)} minutes&#96;);</p>
 <p>}</p>
 <p>}</code></pre></p>
 

--- a/marketplace/src/pages/playbooks/09-cost-attribution.astro
+++ b/marketplace/src/pages/playbooks/09-cost-attribution.astro
@@ -308,7 +308,7 @@ const tagger = new CostTagger();
 <p>const budget = await budgetManager.checkBudget(&#039;team&#039;, teamId);</p>
 
 <p>if (!budget.allowed) {</p>
-<p>throw new Error(`Budget exceeded for team &#36;{teamId}. Spent: &#36;&#36;{budget.spent.toFixed(2)}, Limit: &#36;&#36;{budget.limit.toFixed(2)}`);</p>
+<p>throw new Error(&#96;Budget exceeded for team &#36;{teamId}. Spent: &#36;&#36;{budget.spent.toFixed(2)}, Limit: &#36;&#36;{budget.limit.toFixed(2)}&#96;);</p>
 <p>}</p>
 
 <p>return await callClaude(prompt);</p>
@@ -335,8 +335,8 @@ const tagger = new CostTagger();
 <p>const costs = await db.costs.find({</p>
 <p>team: teamId,</p>
 <p>timestamp: {</p>
-<p>&#36;gte: new Date(`&#36;{month}-01`).getTime(),</p>
-<p>&#36;lt: new Date(`&#36;{month}-01`).getTime() + 30 * 86400000</p>
+<p>&#36;gte: new Date(&#96;&#36;{month}-01&#96;).getTime(),</p>
+<p>&#36;lt: new Date(&#96;&#36;{month}-01&#96;).getTime() + 30 * 86400000</p>
 <p>}</p>
 <p>});</p>
 
@@ -448,8 +448,8 @@ const tagger = new CostTagger();
 <p>async generateMonthlyReport(month: string): Promise&lt;UsageMetrics&gt; {</p>
 <p>const costs = await db.costs.find({</p>
 <p>timestamp: {</p>
-<p>&#36;gte: new Date(`&#36;{month}-01`).getTime(),</p>
-<p>&#36;lt: new Date(`&#36;{month}-01`).getTime() + 30 * 86400000</p>
+<p>&#36;gte: new Date(&#96;&#36;{month}-01&#96;).getTime(),</p>
+<p>&#36;lt: new Date(&#96;&#36;{month}-01&#96;).getTime() + 30 * 86400000</p>
 <p>}</p>
 <p>});</p>
 
@@ -567,7 +567,7 @@ const tagger = new CostTagger();
 
 <p>return {</p>
 <p>category: &#039;model-selection&#039;,</p>
-<p>description: `&#36;{simplePrompts.length} simple prompts use Claude 3.5 Sonnet. Switch to Claude 3.5 Haiku for 73% cost reduction.`,</p>
+<p>description: &#96;&#36;{simplePrompts.length} simple prompts use Claude 3.5 Sonnet. Switch to Claude 3.5 Haiku for 73% cost reduction.&#96;,</p>
 <p>potentialSavings: monthlySavings,</p>
 <p>effort: &#039;low&#039;,</p>
 <p>implementation: &#039;Update model parameter in simple workflows to claude-3-5-haiku-20241022&#039;</p>
@@ -596,7 +596,7 @@ const tagger = new CostTagger();
 <p>if (duplicateCost &gt; 10) {</p>
 <p>return {</p>
 <p>category: &#039;caching&#039;,</p>
-<p>description: `&#36;{duplicates.length} prompts are duplicated. Implement caching to avoid redundant API calls.`,</p>
+<p>description: &#96;&#36;{duplicates.length} prompts are duplicated. Implement caching to avoid redundant API calls.&#96;,</p>
 <p>potentialSavings: duplicateCost * 30,</p>
 <p>effort: &#039;medium&#039;,</p>
 <p>implementation: &#039;Add Redis cache for LLM responses with 1-hour TTL&#039;</p>
@@ -623,7 +623,7 @@ const tagger = new CostTagger();
 
 <p>return {</p>
 <p>category: &#039;batching&#039;,</p>
-<p>description: `&#36;{batchableCount} requests could be batched. Combine multiple prompts into single API call.`,</p>
+<p>description: &#96;&#36;{batchableCount} requests could be batched. Combine multiple prompts into single API call.&#96;,</p>
 <p>potentialSavings: savings <em> 30 </em> 0.3,  // 30% reduction from batching</p>
 <p>effort: &#039;high&#039;,</p>
 <p>implementation: &#039;Implement request batching with 100ms window&#039;</p>
@@ -634,7 +634,7 @@ const tagger = new CostTagger();
 <p>}</p>
 
 <p>private hashPrompt(cost: any): string {</p>
-<p>return `&#36;{cost.workflow}-&#36;{cost.inputTokens}-&#36;{cost.outputTokens}`;</p>
+<p>return &#96;&#36;{cost.workflow}-&#36;{cost.inputTokens}-&#36;{cost.outputTokens}&#96;;</p>
 <p>}</p>
 <p>}</code></pre></p>
 
@@ -660,13 +660,13 @@ const tagger = new CostTagger();
 </ul>
 
 <p>&lt;h2&gt;Top Projects by Cost&lt;/h2&gt;</p>
-<p>&#36;{metrics.topProjects.map((p, i) =&gt; `&#36;{i + 1}. &#36;{p.project}: &#36;&#36;{p.cost.toFixed(2)}`).join(&#039;\n&#039;)}</p>
+<p>&#36;{metrics.topProjects.map((p, i) =&gt; &#96;&#36;{i + 1}. &#36;{p.project}: &#36;&#36;{p.cost.toFixed(2)}&#96;).join(&#039;\n&#039;)}</p>
 
 <p>&lt;h2&gt;Top Users by Cost&lt;/h2&gt;</p>
-<p>&#36;{metrics.topUsers.map((u, i) =&gt; `&#36;{i + 1}. &#36;{u.user}: &#36;&#36;{u.cost.toFixed(2)}`).join(&#039;\n&#039;)}</p>
+<p>&#36;{metrics.topUsers.map((u, i) =&gt; &#96;&#36;{i + 1}. &#36;{u.user}: &#36;&#36;{u.cost.toFixed(2)}&#96;).join(&#039;\n&#039;)}</p>
 
 <p>&lt;h2&gt;Daily Cost Trend&lt;/h2&gt;</p>
-<p>&#36;{metrics.costTrend.map(d =&gt; `&#36;{d.date}: &#36;&#36;{d.cost.toFixed(2)}`).join(&#039;\n&#039;)}</p>
+<p>&#36;{metrics.costTrend.map(d =&gt; &#96;&#36;{d.date}: &#36;&#36;{d.cost.toFixed(2)}&#96;).join(&#039;\n&#039;)}</p>
 
 <p>&lt;h2&gt;Optimization Recommendations&lt;/h2&gt;</p>
 <p>&#36;{await this.getOptimizationRecommendations()}</p>
@@ -683,7 +683,7 @@ const tagger = new CostTagger();
 <p>const recommendations = await optimizer.analyzeAndRecommend(&#039;engineering-backend&#039;);</p>
 
 <p>return recommendations</p>
-<p>.map(r =&gt; `- <strong>&#36;{r.category}</strong>: &#36;{r.description} (Savings: &#36;&#36;{r.potentialSavings.toFixed(2)}/month, Effort: &#36;{r.effort})`)</p>
+<p>.map(r =&gt; &#96;- <strong>&#36;{r.category}</strong>: &#36;{r.description} (Savings: &#36;&#36;{r.potentialSavings.toFixed(2)}/month, Effort: &#36;{r.effort})&#96;)</p>
 <p>.join(&#039;\n&#039;);</p>
 <p>}</p>
 <p>}</code></pre></p>


### PR DESCRIPTION
## Summary

Fixes the esbuild parsing error that was breaking playbook page builds:
```
Expected "}" but found ")"
Location: marketplace/src/pages/playbooks/02-cost-caps.astro:36:39
```

**Root Cause**: Code examples inside `set:html={` `...` `}` template literals contained backticks that prematurely terminated the outer template string.

**Fix**: Replaced all internal backticks with `&#96;` HTML entities.

## Files Fixed (7 total, ~180 backticks escaped)

| File | Backticks |
|------|-----------|
| 02-cost-caps.astro | 42 |
| 03-mcp-reliability.astro | 26 |
| 04-ollama-migration.astro | 12 |
| 05-incident-debugging.astro | 30 |
| 07-compliance-audit.astro | 10 |
| 08-team-presets.astro | 33 |
| 09-cost-attribution.astro | 26 |

## Test Plan

- [ ] CI build passes
- [ ] All 11 playbook pages render correctly
- [ ] Code examples display properly with backticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)