### PR TITLE
feat(ux): Plugin Comparison View

### DIFF
--- a/marketplace/src/components/CompareBar.astro
+++ b/marketplace/src/components/CompareBar.astro
@@ -1,0 +1,378 @@
+---
+// CompareBar - Sticky comparison bar for selecting plugins to compare
+---
+
+<div id="compare-bar" class="compare-bar hidden">
+  <div class="compare-content">
+    <div class="compare-header">
+      <span class="compare-icon">⚖️</span>
+      <span class="compare-title">Compare Plugins</span>
+      <span id="compare-count" class="compare-count">0 selected</span>
+    </div>
+
+    <div id="compare-items" class="compare-items">
+      <!-- Selected items will be inserted here -->
+    </div>
+
+    <div class="compare-actions">
+      <button id="compare-clear" class="compare-btn secondary">Clear All</button>
+      <a id="compare-go" href="/compare/" class="compare-btn primary disabled">
+        Compare Now
+      </a>
+    </div>
+  </div>
+</div>
+
+<style>
+  .compare-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: white;
+    border-top: 2px solid var(--brand-orange);
+    box-shadow: 0 -4px 20px rgba(0,0,0,0.15);
+    z-index: 1000;
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+  }
+
+  .compare-bar.visible {
+    transform: translateY(0);
+  }
+
+  .compare-bar.hidden {
+    display: none;
+  }
+
+  .compare-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .compare-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .compare-icon {
+    font-size: 1.25rem;
+  }
+
+  .compare-title {
+    font-weight: 600;
+    font-family: 'Poppins', Arial, sans-serif;
+  }
+
+  .compare-count {
+    background: var(--brand-light);
+    color: var(--brand-orange);
+    padding: 0.25rem 0.75rem;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .compare-items {
+    display: flex;
+    gap: 0.75rem;
+    flex: 1;
+    overflow-x: auto;
+    padding: 0.25rem 0;
+  }
+
+  .compare-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--brand-light);
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .compare-item-name {
+    font-weight: 500;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .compare-item-type {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    color: var(--brand-mid-gray);
+    padding: 0.15rem 0.4rem;
+    background: white;
+    border-radius: 4px;
+  }
+
+  .compare-item-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    font-size: 1rem;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+  }
+
+  .compare-item-remove:hover {
+    opacity: 1;
+  }
+
+  .compare-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .compare-btn {
+    padding: 0.6rem 1.25rem;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: 'Poppins', Arial, sans-serif;
+  }
+
+  .compare-btn.secondary {
+    background: white;
+    border: 1px solid var(--brand-light-gray);
+    color: var(--brand-dark);
+  }
+
+  .compare-btn.secondary:hover {
+    border-color: var(--brand-orange);
+    color: var(--brand-orange);
+  }
+
+  .compare-btn.primary {
+    background: var(--brand-orange);
+    border: none;
+    color: white;
+  }
+
+  .compare-btn.primary:hover:not(.disabled) {
+    background: var(--brand-orange-dark);
+  }
+
+  .compare-btn.primary.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  @media (max-width: 768px) {
+    .compare-content {
+      padding: 1rem;
+      gap: 1rem;
+    }
+
+    .compare-header {
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    .compare-items {
+      width: 100%;
+    }
+
+    .compare-actions {
+      width: 100%;
+      justify-content: stretch;
+    }
+
+    .compare-btn {
+      flex: 1;
+      justify-content: center;
+    }
+  }
+</style>
+
+<script is:inline>
+  // Comparison state management
+  window.CompareManager = {
+    MAX_ITEMS: 4,
+    items: [],
+
+    init() {
+      // Load from localStorage
+      const saved = localStorage.getItem('compare-items');
+      if (saved) {
+        try {
+          this.items = JSON.parse(saved);
+          this.render();
+        } catch (e) {
+          this.items = [];
+        }
+      }
+
+      // Set up event listeners
+      document.getElementById('compare-clear')?.addEventListener('click', () => {
+        this.clearAll();
+      });
+
+      // Update compare link on changes
+      this.updateCompareLink();
+    },
+
+    add(item) {
+      if (this.items.length >= this.MAX_ITEMS) {
+        this.showToast(`Maximum ${this.MAX_ITEMS} items for comparison`);
+        return false;
+      }
+
+      if (this.items.find(i => i.id === item.id)) {
+        this.showToast('Already added to comparison');
+        return false;
+      }
+
+      this.items.push(item);
+      this.save();
+      this.render();
+      this.showToast(`Added "${item.name}" to comparison`);
+      return true;
+    },
+
+    remove(id) {
+      const index = this.items.findIndex(i => i.id === id);
+      if (index > -1) {
+        const item = this.items[index];
+        this.items.splice(index, 1);
+        this.save();
+        this.render();
+        this.showToast(`Removed "${item.name}" from comparison`);
+      }
+    },
+
+    clearAll() {
+      this.items = [];
+      this.save();
+      this.render();
+      this.showToast('Comparison cleared');
+    },
+
+    has(id) {
+      return this.items.some(i => i.id === id);
+    },
+
+    save() {
+      localStorage.setItem('compare-items', JSON.stringify(this.items));
+    },
+
+    render() {
+      const bar = document.getElementById('compare-bar');
+      const itemsContainer = document.getElementById('compare-items');
+      const countEl = document.getElementById('compare-count');
+
+      if (!bar || !itemsContainer || !countEl) return;
+
+      // Update count
+      countEl.textContent = `${this.items.length} selected`;
+
+      // Show/hide bar
+      if (this.items.length > 0) {
+        bar.classList.remove('hidden');
+        setTimeout(() => bar.classList.add('visible'), 10);
+      } else {
+        bar.classList.remove('visible');
+        setTimeout(() => bar.classList.add('hidden'), 300);
+      }
+
+      // Render items
+      itemsContainer.innerHTML = this.items.map(item => `
+        <div class="compare-item" data-id="${item.id}">
+          <span class="compare-item-type">${item.type}</span>
+          <span class="compare-item-name">${item.name}</span>
+          <button class="compare-item-remove" onclick="CompareManager.remove('${item.id}')" title="Remove">×</button>
+        </div>
+      `).join('');
+
+      this.updateCompareLink();
+      this.updateCardStates();
+    },
+
+    updateCompareLink() {
+      const btn = document.getElementById('compare-go');
+      if (!btn) return;
+
+      if (this.items.length >= 2) {
+        const ids = this.items.map(i => i.id).join(',');
+        btn.href = `/compare/?items=${encodeURIComponent(ids)}`;
+        btn.classList.remove('disabled');
+      } else {
+        btn.href = '/compare/';
+        btn.classList.add('disabled');
+      }
+    },
+
+    updateCardStates() {
+      // Update compare buttons on cards
+      document.querySelectorAll('[data-compare-id]').forEach(btn => {
+        const id = btn.dataset.compareId;
+        if (this.has(id)) {
+          btn.classList.add('active');
+          btn.textContent = '✓ Added';
+        } else {
+          btn.classList.remove('active');
+          btn.textContent = '+ Compare';
+        }
+      });
+    },
+
+    showToast(message) {
+      const existing = document.querySelector('.compare-toast');
+      if (existing) existing.remove();
+
+      const toast = document.createElement('div');
+      toast.className = 'compare-toast';
+      toast.textContent = message;
+      toast.style.cssText = `
+        position: fixed;
+        bottom: 6rem;
+        left: 50%;
+        transform: translateX(-50%);
+        background: #1a1a1a;
+        color: white;
+        padding: 0.75rem 1.25rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        z-index: 1001;
+        animation: fadeInOut 2s ease-in-out forwards;
+      `;
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 2000);
+    }
+  };
+
+  // Initialize on DOM ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => CompareManager.init());
+  } else {
+    CompareManager.init();
+  }
+</script>
+
+<style is:global>
+  @keyframes fadeInOut {
+    0% { opacity: 0; transform: translateX(-50%) translateY(10px); }
+    15% { opacity: 1; transform: translateX(-50%) translateY(0); }
+    85% { opacity: 1; transform: translateX(-50%) translateY(0); }
+    100% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+  }
+</style>

--- a/marketplace/src/pages/compare.astro
+++ b/marketplace/src/pages/compare.astro
@@ -1,0 +1,686 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import searchIndex from '../data/unified-search-index.json';
+
+// Build lookup map for quick access
+const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, item]));
+---
+
+<BaseLayout
+  title="Compare Plugins | Claude Code Plugins"
+  description="Compare plugins and skills side-by-side. Evaluate features, categories, and capabilities."
+>
+  <style>
+    .compare-page {
+      padding: 6rem 2rem 4rem;
+      max-width: 1400px;
+      margin: 0 auto;
+      min-height: 80vh;
+    }
+
+    .page-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    .page-title {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+      font-weight: 700;
+      margin: 0 0 0.5rem;
+      font-family: 'Poppins', Arial, sans-serif;
+    }
+
+    .page-description {
+      color: var(--brand-mid-gray);
+      font-size: 1rem;
+    }
+
+    /* Empty State */
+    .empty-state {
+      text-align: center;
+      padding: 4rem 2rem;
+      background: var(--brand-light);
+      border-radius: 16px;
+      margin: 2rem 0;
+    }
+
+    .empty-icon {
+      font-size: 4rem;
+      margin-bottom: 1rem;
+    }
+
+    .empty-title {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0 0 0.5rem;
+      font-family: 'Poppins', Arial, sans-serif;
+    }
+
+    .empty-text {
+      color: var(--brand-mid-gray);
+      margin: 0 0 1.5rem;
+    }
+
+    .empty-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      background: var(--brand-orange);
+      color: white;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      font-family: 'Poppins', Arial, sans-serif;
+      transition: background 0.2s;
+    }
+
+    .empty-cta:hover {
+      background: var(--brand-orange-dark);
+    }
+
+    /* Comparison Table */
+    .compare-container {
+      overflow-x: auto;
+      margin: 2rem 0;
+    }
+
+    .compare-table {
+      width: 100%;
+      min-width: 600px;
+      border-collapse: collapse;
+      background: white;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    }
+
+    .compare-table th,
+    .compare-table td {
+      padding: 1rem 1.25rem;
+      text-align: left;
+      border-bottom: 1px solid var(--brand-light-gray);
+    }
+
+    .compare-table th {
+      background: var(--brand-light);
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: var(--brand-mid-gray);
+      font-family: 'Poppins', Arial, sans-serif;
+      white-space: nowrap;
+    }
+
+    .compare-table th:first-child {
+      width: 140px;
+      position: sticky;
+      left: 0;
+      z-index: 1;
+      background: var(--brand-light);
+    }
+
+    .compare-table td:first-child {
+      font-weight: 600;
+      color: var(--brand-dark);
+      position: sticky;
+      left: 0;
+      background: white;
+      z-index: 1;
+    }
+
+    .compare-table tr:last-child td {
+      border-bottom: none;
+    }
+
+    .compare-header-cell {
+      text-align: center;
+      min-width: 200px;
+    }
+
+    .plugin-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .plugin-type-badge {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+
+    .plugin-type-badge.plugin {
+      background: rgba(106, 155, 204, 0.15);
+      color: var(--brand-blue);
+    }
+
+    .plugin-type-badge.skill {
+      background: rgba(217, 119, 87, 0.15);
+      color: var(--brand-orange);
+    }
+
+    .plugin-name {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--brand-dark);
+      text-decoration: none;
+    }
+
+    .plugin-name:hover {
+      color: var(--brand-orange);
+    }
+
+    .remove-btn {
+      background: none;
+      border: 1px solid var(--brand-light-gray);
+      padding: 0.3rem 0.6rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      color: var(--brand-mid-gray);
+      transition: all 0.2s;
+    }
+
+    .remove-btn:hover {
+      border-color: #dc2626;
+      color: #dc2626;
+    }
+
+    /* Cell content styles */
+    .cell-category {
+      display: inline-block;
+      padding: 0.3rem 0.75rem;
+      background: var(--brand-light);
+      border-radius: 20px;
+      font-size: 0.85rem;
+      text-transform: capitalize;
+    }
+
+    .cell-description {
+      font-size: 0.9rem;
+      color: var(--brand-mid-gray);
+      line-height: 1.5;
+      max-width: 250px;
+    }
+
+    .cell-tools {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
+
+    .tool-tag {
+      background: var(--brand-light);
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      font-family: 'Monaco', 'Menlo', monospace;
+    }
+
+    .cell-install {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .install-code {
+      background: #1a1a1a;
+      color: #22c55e;
+      padding: 0.5rem 0.75rem;
+      border-radius: 6px;
+      font-size: 0.8rem;
+      font-family: 'Monaco', 'Menlo', monospace;
+      white-space: nowrap;
+      overflow-x: auto;
+    }
+
+    .copy-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.35rem 0.6rem;
+      background: var(--brand-orange);
+      color: white;
+      border: none;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: background 0.2s;
+      width: fit-content;
+    }
+
+    .copy-btn:hover {
+      background: var(--brand-orange-dark);
+    }
+
+    .cell-na {
+      color: var(--brand-mid-gray);
+      font-style: italic;
+      font-size: 0.85rem;
+    }
+
+    .cell-link {
+      color: var(--brand-orange);
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    .cell-link:hover {
+      text-decoration: underline;
+    }
+
+    /* Add more button */
+    .add-column {
+      text-align: center;
+      min-width: 150px;
+    }
+
+    .add-btn {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 1rem;
+      background: var(--brand-light);
+      border: 2px dashed var(--brand-light-gray);
+      border-radius: 8px;
+      color: var(--brand-mid-gray);
+      text-decoration: none;
+      transition: all 0.2s;
+    }
+
+    .add-btn:hover {
+      border-color: var(--brand-orange);
+      color: var(--brand-orange);
+    }
+
+    .add-icon {
+      font-size: 1.5rem;
+    }
+
+    .add-text {
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    /* Actions row */
+    .compare-actions {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      margin-top: 2rem;
+    }
+
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+      font-family: 'Poppins', Arial, sans-serif;
+    }
+
+    .action-btn.primary {
+      background: var(--brand-orange);
+      border: none;
+      color: white;
+    }
+
+    .action-btn.primary:hover {
+      background: var(--brand-orange-dark);
+    }
+
+    .action-btn.secondary {
+      background: white;
+      border: 1px solid var(--brand-light-gray);
+      color: var(--brand-dark);
+    }
+
+    .action-btn.secondary:hover {
+      border-color: var(--brand-orange);
+      color: var(--brand-orange);
+    }
+
+    @media (max-width: 768px) {
+      .compare-page {
+        padding: 4rem 1rem 2rem;
+      }
+
+      .compare-table th,
+      .compare-table td {
+        padding: 0.75rem 1rem;
+      }
+    }
+  </style>
+
+  <div class="compare-page">
+    <header class="page-header">
+      <h1 class="page-title">Compare Plugins</h1>
+      <p class="page-description">Side-by-side comparison of selected plugins and skills</p>
+    </header>
+
+    <div id="empty-state" class="empty-state">
+      <div class="empty-icon">⚖️</div>
+      <h2 class="empty-title">No plugins selected</h2>
+      <p class="empty-text">Browse the explore page and add plugins to compare them side-by-side.</p>
+      <a href="/explore/" class="empty-cta">
+        <span>Browse Plugins</span>
+        <span>→</span>
+      </a>
+    </div>
+
+    <div id="compare-content" class="compare-container" style="display: none;">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th id="header-1" class="compare-header-cell">—</th>
+            <th id="header-2" class="compare-header-cell">—</th>
+            <th id="header-3" class="compare-header-cell">—</th>
+            <th id="header-4" class="compare-header-cell">—</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Type</td>
+            <td id="type-1">—</td>
+            <td id="type-2">—</td>
+            <td id="type-3">—</td>
+            <td id="type-4">—</td>
+          </tr>
+          <tr>
+            <td>Category</td>
+            <td id="category-1">—</td>
+            <td id="category-2">—</td>
+            <td id="category-3">—</td>
+            <td id="category-4">—</td>
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td id="description-1">—</td>
+            <td id="description-2">—</td>
+            <td id="description-3">—</td>
+            <td id="description-4">—</td>
+          </tr>
+          <tr>
+            <td>Allowed Tools</td>
+            <td id="tools-1">—</td>
+            <td id="tools-2">—</td>
+            <td id="tools-3">—</td>
+            <td id="tools-4">—</td>
+          </tr>
+          <tr>
+            <td>Parent Plugin</td>
+            <td id="parent-1">—</td>
+            <td id="parent-2">—</td>
+            <td id="parent-3">—</td>
+            <td id="parent-4">—</td>
+          </tr>
+          <tr>
+            <td>Install Command</td>
+            <td id="install-1">—</td>
+            <td id="install-2">—</td>
+            <td id="install-3">—</td>
+            <td id="install-4">—</td>
+          </tr>
+          <tr>
+            <td>View Details</td>
+            <td id="link-1">—</td>
+            <td id="link-2">—</td>
+            <td id="link-3">—</td>
+            <td id="link-4">—</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div id="compare-actions" class="compare-actions" style="display: none;">
+      <button id="share-comparison" class="action-btn secondary">
+        <span>📋</span> Copy Share Link
+      </button>
+      <button id="clear-all" class="action-btn secondary">
+        <span>🗑️</span> Clear All
+      </button>
+      <a href="/explore/" class="action-btn primary">
+        <span>+</span> Add More
+      </a>
+    </div>
+  </div>
+
+  <script is:inline define:vars={{ itemsData: JSON.stringify(Object.fromEntries(searchIndex.items.map(item => [item.id || item.name, item]))) }}>
+    const itemsMap = JSON.parse(itemsData);
+
+    function getItemsFromURL() {
+      const params = new URLSearchParams(window.location.search);
+      const itemsParam = params.get('items');
+      if (!itemsParam) return [];
+      return itemsParam.split(',').filter(Boolean);
+    }
+
+    function getItemsFromStorage() {
+      try {
+        const saved = localStorage.getItem('compare-items');
+        if (saved) {
+          return JSON.parse(saved).map(item => item.id);
+        }
+      } catch (e) {}
+      return [];
+    }
+
+    function renderComparison() {
+      let itemIds = getItemsFromURL();
+      if (itemIds.length === 0) {
+        itemIds = getItemsFromStorage();
+      }
+
+      const emptyState = document.getElementById('empty-state');
+      const content = document.getElementById('compare-content');
+      const actions = document.getElementById('compare-actions');
+
+      if (itemIds.length === 0) {
+        emptyState.style.display = 'block';
+        content.style.display = 'none';
+        actions.style.display = 'none';
+        return;
+      }
+
+      emptyState.style.display = 'none';
+      content.style.display = 'block';
+      actions.style.display = 'flex';
+
+      // Render each column
+      for (let i = 1; i <= 4; i++) {
+        const id = itemIds[i - 1];
+        const item = id ? itemsMap[id] : null;
+
+        renderColumn(i, item);
+      }
+
+      // Update URL if loaded from storage
+      if (getItemsFromURL().length === 0 && itemIds.length > 0) {
+        const newUrl = `/compare/?items=${encodeURIComponent(itemIds.join(','))}`;
+        window.history.replaceState({}, '', newUrl);
+      }
+    }
+
+    function renderColumn(index, item) {
+      const headerEl = document.getElementById(`header-${index}`);
+      const typeEl = document.getElementById(`type-${index}`);
+      const categoryEl = document.getElementById(`category-${index}`);
+      const descriptionEl = document.getElementById(`description-${index}`);
+      const toolsEl = document.getElementById(`tools-${index}`);
+      const parentEl = document.getElementById(`parent-${index}`);
+      const installEl = document.getElementById(`install-${index}`);
+      const linkEl = document.getElementById(`link-${index}`);
+
+      if (!item) {
+        // Empty column - show add button
+        headerEl.innerHTML = `
+          <a href="/explore/" class="add-btn">
+            <span class="add-icon">+</span>
+            <span class="add-text">Add Plugin</span>
+          </a>
+        `;
+        typeEl.innerHTML = '<span class="cell-na">—</span>';
+        categoryEl.innerHTML = '<span class="cell-na">—</span>';
+        descriptionEl.innerHTML = '<span class="cell-na">—</span>';
+        toolsEl.innerHTML = '<span class="cell-na">—</span>';
+        parentEl.innerHTML = '<span class="cell-na">—</span>';
+        installEl.innerHTML = '<span class="cell-na">—</span>';
+        linkEl.innerHTML = '<span class="cell-na">—</span>';
+        return;
+      }
+
+      const id = item.id || item.name;
+      const displayName = item.displayName || item.name;
+      const detailUrl = item.type === 'plugin' ? `/plugins/${item.name}/` : `/skills/${item.slug}/`;
+
+      // Header
+      headerEl.innerHTML = `
+        <div class="plugin-header">
+          <span class="plugin-type-badge ${item.type}">${item.type}</span>
+          <a href="${detailUrl}" class="plugin-name">${displayName}</a>
+          <button class="remove-btn" onclick="removeItem('${id}')">Remove</button>
+        </div>
+      `;
+
+      // Type
+      typeEl.innerHTML = `<span class="plugin-type-badge ${item.type}">${item.type}</span>`;
+
+      // Category
+      const categoryName = item.category.replace(/-/g, ' ');
+      categoryEl.innerHTML = `<span class="cell-category">${categoryName}</span>`;
+
+      // Description
+      descriptionEl.innerHTML = `<div class="cell-description">${item.description || 'No description'}</div>`;
+
+      // Tools (skills only)
+      if (item.type === 'skill' && item.allowedTools && item.allowedTools.length > 0) {
+        toolsEl.innerHTML = `
+          <div class="cell-tools">
+            ${item.allowedTools.map(t => `<span class="tool-tag">${t}</span>`).join('')}
+          </div>
+        `;
+      } else if (item.type === 'plugin') {
+        toolsEl.innerHTML = '<span class="cell-na">N/A (plugins)</span>';
+      } else {
+        toolsEl.innerHTML = '<span class="cell-na">None specified</span>';
+      }
+
+      // Parent plugin (skills only)
+      if (item.type === 'skill' && item.parentPlugin) {
+        parentEl.innerHTML = `<a href="/plugins/${item.parentPlugin.name}/" class="cell-link">${item.parentPlugin.name}</a>`;
+      } else if (item.type === 'plugin') {
+        parentEl.innerHTML = '<span class="cell-na">N/A (is a plugin)</span>';
+      } else {
+        parentEl.innerHTML = '<span class="cell-na">Standalone</span>';
+      }
+
+      // Install command
+      const installCmd = `/plugin install ${item.name}@claude-code-plugins-plus`;
+      installEl.innerHTML = `
+        <div class="cell-install">
+          <code class="install-code">${installCmd}</code>
+          <button class="copy-btn" onclick="copyToClipboard('${installCmd}')">
+            <span>📋</span> Copy
+          </button>
+        </div>
+      `;
+
+      // Link
+      linkEl.innerHTML = `<a href="${detailUrl}" class="cell-link">View Details →</a>`;
+    }
+
+    function removeItem(id) {
+      // Update localStorage
+      try {
+        const saved = localStorage.getItem('compare-items');
+        if (saved) {
+          const items = JSON.parse(saved).filter(item => item.id !== id);
+          localStorage.setItem('compare-items', JSON.stringify(items));
+        }
+      } catch (e) {}
+
+      // Update URL and re-render
+      let itemIds = getItemsFromURL();
+      if (itemIds.length === 0) {
+        itemIds = getItemsFromStorage();
+      }
+      itemIds = itemIds.filter(i => i !== id);
+
+      if (itemIds.length > 0) {
+        const newUrl = `/compare/?items=${encodeURIComponent(itemIds.join(','))}`;
+        window.history.replaceState({}, '', newUrl);
+      } else {
+        window.history.replaceState({}, '', '/compare/');
+      }
+
+      renderComparison();
+    }
+
+    function copyToClipboard(text) {
+      navigator.clipboard.writeText(text).then(() => {
+        showToast('Copied to clipboard!');
+      });
+    }
+
+    function showToast(message) {
+      const existing = document.querySelector('.compare-toast');
+      if (existing) existing.remove();
+
+      const toast = document.createElement('div');
+      toast.className = 'compare-toast';
+      toast.textContent = message;
+      toast.style.cssText = `
+        position: fixed;
+        bottom: 2rem;
+        left: 50%;
+        transform: translateX(-50%);
+        background: #1a1a1a;
+        color: white;
+        padding: 0.75rem 1.25rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        z-index: 1001;
+        animation: fadeInOut 2s ease-in-out forwards;
+      `;
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 2000);
+    }
+
+    // Event listeners
+    document.getElementById('share-comparison')?.addEventListener('click', () => {
+      const url = window.location.href;
+      navigator.clipboard.writeText(url).then(() => {
+        showToast('Share link copied!');
+      });
+    });
+
+    document.getElementById('clear-all')?.addEventListener('click', () => {
+      localStorage.removeItem('compare-items');
+      window.history.replaceState({}, '', '/compare/');
+      renderComparison();
+    });
+
+    // Initialize
+    renderComparison();
+  </script>
+
+  <style is:global>
+    @keyframes fadeInOut {
+      0% { opacity: 0; transform: translateX(-50%) translateY(10px); }
+      15% { opacity: 1; transform: translateX(-50%) translateY(0); }
+      85% { opacity: 1; transform: translateX(-50%) translateY(0); }
+      100% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+    }
+  </style>
+</BaseLayout>

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import CompareBar from '../components/CompareBar.astro';
 import searchIndex from '../data/unified-search-index.json';
 
 const pageTitle = 'Explore Plugins & Skills';
@@ -183,12 +184,12 @@ const pageDescription = `Search all ${searchIndex.stats.totalPlugins} plugins an
     }
 
     .result-card {
-      display: block;
+      display: flex;
+      flex-direction: column;
       padding: 1.75rem;
       background: white;
       border-radius: 12px;
       border: 2px solid var(--brand-light-gray);
-      text-decoration: none;
       transition: all 0.3s var(--transition-smooth);
       position: relative;
     }
@@ -197,6 +198,45 @@ const pageDescription = `Search all ${searchIndex.stats.totalPlugins} plugins an
       border-color: var(--brand-orange);
       transform: translateY(-4px);
       box-shadow: 0 8px 24px rgba(217, 119, 87, 0.15);
+    }
+
+    .result-card-link {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+      flex: 1;
+    }
+
+    .compare-toggle-btn {
+      position: absolute;
+      bottom: 1rem;
+      right: 1rem;
+      padding: 0.4rem 0.75rem;
+      background: var(--brand-light);
+      border: 1px solid var(--brand-light-gray);
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--brand-mid-gray);
+      cursor: pointer;
+      transition: all 0.2s;
+      font-family: 'Poppins', Arial, sans-serif;
+    }
+
+    .compare-toggle-btn:hover {
+      border-color: var(--brand-orange);
+      color: var(--brand-orange);
+      background: rgba(217, 119, 87, 0.1);
+    }
+
+    .compare-toggle-btn.active {
+      background: var(--brand-orange);
+      border-color: var(--brand-orange);
+      color: white;
+    }
+
+    .compare-toggle-btn.active:hover {
+      background: var(--brand-orange-dark);
     }
 
     .result-type-badge {
@@ -439,41 +479,57 @@ const pageDescription = `Search all ${searchIndex.stats.totalPlugins} plugins an
   <div class="results-section">
     <div id="results-grid" class="results-grid">
       {searchIndex.items.map(item => (
-        <a
-          href={item.type === 'plugin' ? `/plugins/${item.name}/` : `/skills/${item.slug}/`}
+        <div
           class="result-card"
           data-type={item.type}
           data-category={item.category}
           data-tools={item.type === 'skill' ? JSON.stringify(item.allowedTools) : '[]'}
+          data-item-id={item.id || item.name}
+          data-item-name={item.displayName || item.name}
         >
-          <span class={`result-type-badge ${item.type}`}>
-            {item.type}
-          </span>
+          <a
+            href={item.type === 'plugin' ? `/plugins/${item.name}/` : `/skills/${item.slug}/`}
+            class="result-card-link"
+          >
+            <span class={`result-type-badge ${item.type}`}>
+              {item.type}
+            </span>
 
-          <h3 class="result-name">{item.type === 'plugin' && item.displayName ? item.displayName : item.name}</h3>
-          <p class="result-description">{item.description}</p>
+            <h3 class="result-name">{item.type === 'plugin' && item.displayName ? item.displayName : item.name}</h3>
+            <p class="result-description">{item.description}</p>
 
-          <div class="result-meta">
-            {item.type === 'skill' && item.parentPlugin && (
-              <div class="parent-plugin">
-                <span>📦</span>
-                <span>Provided by {item.parentPlugin.name}</span>
+            <div class="result-meta">
+              {item.type === 'skill' && item.parentPlugin && (
+                <div class="parent-plugin">
+                  <span>📦</span>
+                  <span>Provided by {item.parentPlugin.name}</span>
+                </div>
+              )}
+              <div class="result-category">{item.category.replace(/-/g, ' ')}</div>
+            </div>
+
+            {item.type === 'skill' && item.allowedTools && item.allowedTools.length > 0 && (
+              <div class="result-tools">
+                {item.allowedTools.slice(0, 4).map(tool => (
+                  <span class="tool-tag">{tool}</span>
+                ))}
+                {item.allowedTools.length > 4 && (
+                  <span class="tool-tag">+{item.allowedTools.length - 4} more</span>
+                )}
               </div>
             )}
-            <div class="result-category">{item.category.replace(/-/g, ' ')}</div>
-          </div>
+          </a>
 
-          {item.type === 'skill' && item.allowedTools && item.allowedTools.length > 0 && (
-            <div class="result-tools">
-              {item.allowedTools.slice(0, 4).map(tool => (
-                <span class="tool-tag">{tool}</span>
-              ))}
-              {item.allowedTools.length > 4 && (
-                <span class="tool-tag">+{item.allowedTools.length - 4} more</span>
-              )}
-            </div>
-          )}
-        </a>
+          <button
+            class="compare-toggle-btn"
+            data-compare-id={item.id || item.name}
+            data-compare-name={item.displayName || item.name}
+            data-compare-type={item.type}
+            title="Add to comparison"
+          >
+            + Compare
+          </button>
+        </div>
       ))}
     </div>
   </div>
@@ -716,4 +772,36 @@ const pageDescription = `Search all ${searchIndex.stats.totalPlugins} plugins an
   <script define:vars={{ items: searchIndex.items }}>
     window.__SEARCH_INDEX__ = items;
   </script>
+
+  <!-- Compare button event listeners -->
+  <script is:inline>
+    document.addEventListener('DOMContentLoaded', () => {
+      // Initialize compare button states
+      if (window.CompareManager) {
+        window.CompareManager.updateCardStates();
+      }
+
+      // Add click handlers to compare buttons
+      document.querySelectorAll('.compare-toggle-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+
+          const id = btn.dataset.compareId;
+          const name = btn.dataset.compareName;
+          const type = btn.dataset.compareType;
+
+          if (window.CompareManager) {
+            if (window.CompareManager.has(id)) {
+              window.CompareManager.remove(id);
+            } else {
+              window.CompareManager.add({ id, name, type });
+            }
+          }
+        });
+      });
+    });
+  </script>
+
+  <CompareBar />
 </BaseLayout>


### PR DESCRIPTION
## Summary
Side-by-side plugin comparison feature allowing users to evaluate up to 4 plugins/skills simultaneously.

## Features

### CompareBar Component
- Sticky bottom bar showing selected items
- Quick add/remove from comparison
- Shows plugin count and names
- "Compare Now" button links to comparison page

### Compare Page (`/compare/`)
- Side-by-side table comparing:
  - Type (plugin/skill)
  - Category
  - Description
  - Allowed Tools (skills)
  - Parent Plugin (skills)
  - Install command with copy button
  - Link to detail page
- Empty state with CTA to explore
- Shareable URLs (`?items=plugin1,plugin2`)
- Remove individual items or clear all

### Explore Page Integration
- "Compare" button on every plugin/skill card
- Toggle active state when added
- Cards maintain full clickability for navigation

## Test Plan
- [ ] Navigate to `/explore/`
- [ ] Click "Compare" on 2+ plugin cards
- [ ] Verify CompareBar appears at bottom
- [ ] Click "Compare Now" to go to `/compare/`
- [ ] Verify side-by-side table shows correct data
- [ ] Click "Copy Share Link" - verify URL copied
- [ ] Reload page - verify items persist from URL
- [ ] Click "Clear All" - verify returns to empty state

Part of Marketplace UX vNext epic (STORY 0o2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)