### PR TITLE
Add gh-dash plugin: GitHub PR dashboard

### DIFF
--- a/plugins/devops/gh-dash/README.md
+++ b/plugins/devops/gh-dash/README.md
@@ -1,0 +1,40 @@
+# gh-dash
+
+GitHub PR dashboard for Claude Code.
+
+## Features
+
+- `/gh-dash:pr` - View PR status dashboard
+- Visual CI/CD progress bar with live updates
+- Bot comment detection (CodeRabbit, Cursor Bugbot, Coverage)
+- Files changed and lines added/removed stats
+- Merge PRs directly from terminal
+
+## Installation
+
+```bash
+claude --plugin-dir /path/to/claude-code-gh-dash
+```
+
+Or install from marketplace:
+```
+/plugin install gh-dash
+```
+
+## Prerequisites
+
+- GitHub CLI (`gh`) installed and authenticated
+
+## Usage
+
+```
+/gh-dash:pr              # View PR for current branch
+/gh-dash:pr --merge      # Squash merge
+/gh-dash:pr --merge merge    # Merge commit
+/gh-dash:pr --merge rebase   # Rebase
+```
+
+## Links
+
+- [Source Repository](https://github.com/jakozloski/claude-code-gh-dash)
+- [Author](https://github.com/jakozloski)

--- a/plugins/devops/gh-dash/plugin.json
+++ b/plugins/devops/gh-dash/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "gh-dash",
+  "version": "1.0.0",
+  "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+  "author": {
+    "name": "Jake Kozloski",
+    "email": "jakozloski@gmail.com"
+  },
+  "homepage": "https://github.com/jakozloski/claude-code-gh-dash",
+  "repository": "https://github.com/jakozloski/claude-code-gh-dash",
+  "license": "MIT",
+  "keywords": [
+    "github",
+    "pull-request",
+    "ci-cd",
+    "dashboard",
+    "devops",
+    "merge",
+    "code-review"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **gh-dash** to the devops category - a GitHub PR dashboard plugin for Claude Code.

### Features
- `/gh-dash:pr` command to view PR status dashboard
- Visual CI/CD progress bar with live updates
- Bot comment detection (CodeRabbit, Cursor Bugbot, Coverage)
- Files changed and lines added/removed stats
- Merge PRs directly from terminal (squash/merge/rebase)

### Source Repository
https://github.com/jakozloski/claude-code-gh-dash

### Category
`plugins/devops/gh-dash/`