### PR TITLE
feat: add cli-power-skills external source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -764,6 +764,35 @@ sources:
       - ".github/**"
 
   # ============================================================
+  # CLI Power Skills (Yuriy Kotik)
+  # https://github.com/ykotik/cli-power-skills
+  # ============================================================
+
+  - name: cli-power-skills
+    description: Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools
+    repo: ykotik/cli-power-skills
+    source_path: .
+    target_path: plugins/productivity/cli-power-skills
+    author:
+      name: Yuriy Kotik
+      github: ykotik
+    license: MIT
+    category: productivity
+    verified: false
+    include:
+      - ".claude-plugin/**"
+      - "skills/**"
+      - "package.json"
+      - "README.md"
+      - "INSTALL.md"
+      - "LICENSE"
+    exclude:
+      - "node_modules/**"
+      - ".git/**"
+      - "*.log"
+      - "docs/**"
+
+  # ============================================================
   # Add more external sources below
   # ============================================================
 


### PR DESCRIPTION
## Summary

Adds **cli-power-skills** ([ykotik/cli-power-skills](https://github.com/ykotik/cli-power-skills)) as an external source for daily sync.

**7 domain-grouped agentic skills covering 26 CLI tools:**

| Skill | Tools |
|-------|-------|
| data-processing | jq, yq, gron, miller, xsv, DuckDB |
| security-scanning | Trivy, ShellCheck, sops |
| api-testing | Hurl, httpx |
| web-crawling | Playwright, Puppeteer, Scrapy, Crawlee, Katana |
| web-research | newspaper4k, yt-dlp, Sherlock |
| python-tooling | uv, Ruff |
| ci-automation | gh, just, act, git-cliff, restic |

**Design:** Skills are agentic (Claude auto-selects based on task context), complementary to built-in tools, with layered recipes (single-tool patterns + multi-tool pipelines).

## Changes

- Added entry to `sources.yaml` with include/exclude paths
- Source repo has `.claude-plugin/plugin.json`, `package.json`, `LICENSE`, and all 7 skills under `skills/`

## Checklist

- [x] Entry follows `sources.yaml` format
- [x] Source repo has `plugin.json` with required fields only
- [x] MIT license included
- [x] Skills use standard SKILL.md frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)