### PR TITLE
feat: Shopify Skill Pack v2.0 — 38 skills with references extraction

### DIFF
--- a/plugins/saas-packs/shopify-pack/README.md
+++ b/plugins/saas-packs/shopify-pack/README.md
@@ -1,6 +1,6 @@
 # Shopify Skill Pack
 
-> 30 production-grade Claude Code skills for building Shopify apps, integrations, and headless storefronts
+> 38 production-grade Claude Code skills for building Shopify apps, integrations, and headless storefronts
 
 ## What Is Shopify?
 
@@ -82,6 +82,19 @@ This skill pack provides real, working guidance for every stage of Shopify devel
 | `shopify-architecture-variants` | Embedded app vs Hydrogen vs backend integration vs theme extension |
 | `shopify-known-pitfalls` | Top 10 Shopify API anti-patterns with real wrong/right code examples |
 
+### v2.0 Skills (N31-N38)
+
+| Skill | Description |
+|-------|-------------|
+| `shopify-metafields-metaobjects` | Custom data modeling with `metafieldDefinitionCreate`, `metafieldsSet`, and `metaobjectCreate` |
+| `shopify-functions` | WASM-sandboxed checkout logic for discounts, payments, and delivery customization |
+| `shopify-storefront-headless` | Headless commerce with Storefront API, Cart API, and Hydrogen framework |
+| `shopify-checkout-extensions` | Checkout UI Extensions replacing checkout.liquid (deprecated Aug 2025) |
+| `shopify-theme-performance` | Core Web Vitals optimization, LCP fixes, Liquid profiling, `image_url` filter |
+| `shopify-graphql-cost-optimizer` | Query cost prediction, reduction strategies, and bulk operation decisions |
+| `shopify-b2b-wholesale` | B2B companies, catalogs, price lists, and wholesale checkout (Shopify Plus) |
+| `shopify-ai-toolkit-wrapper` | MCP integration for GraphQL validation, Liquid linting, and doc search |
+
 ## Quick Start
 
 ### 1. Install the Pack
@@ -116,13 +129,13 @@ npm install @shopify/shopify-api dotenv
 
 ```typescript
 import "@shopify/shopify-api/adapters/node";
-import { shopifyApi } from "@shopify/shopify-api";
+import { shopifyApi, LATEST_API_VERSION } from "@shopify/shopify-api";
 
 const shopify = shopifyApi({
   apiKey: process.env.SHOPIFY_API_KEY!,
   apiSecretKey: process.env.SHOPIFY_API_SECRET!,
   hostName: "localhost",
-  apiVersion: "2024-10",
+  apiVersion: LATEST_API_VERSION,
   isCustomStoreApp: true,
   adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!,
 });

--- a/plugins/saas-packs/shopify-pack/package.json
+++ b/plugins/saas-packs/shopify-pack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@intentsolutionsio/shopify-pack",
-  "version": "1.0.0",
-  "description": "Claude Code skill pack for Shopify - 30 skills covering e-commerce development, storefront APIs, and app integration",
+  "version": "2.0.0",
+  "description": "Claude Code skill pack for Shopify - 38 skills covering e-commerce development, storefront APIs, and app integration",
   "main": "README.md",
   "type": "module",
   "files": [

--- a/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-advanced-troubleshooting
 description: |
   Debug complex Shopify API issues using cost analysis, request tracing,
   webhook delivery inspection, and GraphQL introspection.
+  Use when encountering intermittent failures, throttling mysteries, or webhook delivery gaps.
   Trigger with phrases like "shopify hard bug", "shopify mystery error",
   "shopify deep debug", "difficult shopify issue", "shopify intermittent failure".
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
@@ -29,201 +30,44 @@ Deep debugging for complex Shopify API issues: cost analysis with debug headers,
 
 ### Step 1: GraphQL Cost Analysis
 
-When queries THROTTLE unexpectedly, use the cost debug header:
-
-```bash
-# Get detailed per-field cost breakdown
-curl -X POST "https://$STORE/admin/api/2024-10/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Shopify-GraphQL-Cost-Debug: 1" \
-  -d '{
-    "query": "{ products(first: 50) { edges { node { id title variants(first: 20) { edges { node { id price metafields(first: 5) { edges { node { key value } } } } } } } } } }"
-  }' | jq '.extensions.cost'
-```
-
-Response shows why the cost is high:
-```json
-{
-  "requestedQueryCost": 1552,
-  "actualQueryCost": 234,
-  "throttleStatus": {
-    "maximumAvailable": 1000.0,
-    "currentlyAvailable": 766.0,
-    "restoreRate": 50.0
-  }
-}
-```
+When queries THROTTLE unexpectedly, use the cost debug header by adding `Shopify-GraphQL-Cost-Debug: 1` to your request. The response `extensions.cost` reveals why a query is expensive.
 
 **Key:** `requestedQueryCost` is `first` multiplied through nested connections. `50 products * 20 variants * (1 + 5 metafields)` = high cost even if actual data is small.
 
 ### Step 2: Trace a Specific Request
 
-Every Shopify response includes `X-Request-Id`. Capture it for support:
+Every Shopify response includes `X-Request-Id`. Capture it for support escalation:
 
 ```bash
-# Capture full response headers and body
-curl -v -X POST "https://$STORE/admin/api/2024-10/graphql.json" \
+curl -v -X POST "https://$STORE/admin/api/2025-04/graphql.json" \
   -H "X-Shopify-Access-Token: $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ shop { name } }"}' 2>&1 | tee /tmp/shopify-debug.txt
 
-# Extract the request ID
 grep -i "x-request-id" /tmp/shopify-debug.txt
 ```
 
 ### Step 3: Webhook Delivery Inspection
 
-Inspect webhook delivery status in the Partner Dashboard, or query via API:
+Inspect webhook delivery status in the Partner Dashboard, or query subscription health via API.
 
-```typescript
-// Check webhook subscription health
-const WEBHOOK_STATUS = `{
-  webhookSubscriptions(first: 50) {
-    edges {
-      node {
-        id
-        topic
-        endpoint {
-          ... on WebhookHttpEndpoint {
-            callbackUrl
-          }
-        }
-        format
-        apiVersion
-        createdAt
-        updatedAt
-      }
-    }
-  }
-}`;
-
-// Common webhook delivery issues:
-// 1. Your endpoint returns non-200 — Shopify retries 19 times over 48 hours
-// 2. Response takes > 5 seconds — Shopify considers it failed
-// 3. Endpoint is HTTP (not HTTPS) — Shopify won't deliver
-// 4. SSL certificate invalid — delivery fails silently
-```
+See [Webhook Status Query](references/webhook-status-query.md) for the complete query and common delivery failure patterns.
 
 ### Step 4: GraphQL Introspection for API Version Differences
 
-```bash
-# Check if a specific field exists in your API version
-curl -X POST "https://$STORE/admin/api/2024-10/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "{ __type(name: \"Product\") { fields { name type { name kind } } } }"
-  }' | jq '.data.__type.fields[] | {name, type: .type.name}'
-
-# Check available mutations
-curl -X POST "https://$STORE/admin/api/2024-10/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "{ __schema { mutationType { fields { name description } } } }"
-  }' | jq '.data.__schema.mutationType.fields[] | select(.name | startswith("product"))'
-```
+Use introspection queries to check if specific fields or mutations exist in your API version. Query `__type` for field lists or `__schema` for available mutations filtered by prefix.
 
 ### Step 5: Systematic Isolation
 
-```bash
-#!/bin/bash
-# shopify-layer-test.sh — test each layer independently
-STORE="$SHOPIFY_STORE"
-TOKEN="$SHOPIFY_ACCESS_TOKEN"
-VERSION="2024-10"
+Run a layer-by-layer diagnostic that tests DNS, TCP, TLS, HTTP, GraphQL, and rate limit state independently.
 
-echo "=== Layer-by-Layer Diagnostic ==="
-
-# Layer 1: DNS
-echo -n "1. DNS: "
-dig +short "$STORE" >/dev/null 2>&1 && echo "OK" || echo "FAIL"
-
-# Layer 2: TCP connectivity
-echo -n "2. TCP: "
-timeout 5 bash -c "echo > /dev/tcp/${STORE}/443" 2>/dev/null && echo "OK" || echo "FAIL"
-
-# Layer 3: TLS handshake
-echo -n "3. TLS: "
-echo | openssl s_client -connect "$STORE:443" -servername "$STORE" 2>/dev/null | grep -q "Verify return code: 0" && echo "OK" || echo "FAIL"
-
-# Layer 4: HTTP response
-echo -n "4. HTTP: "
-HTTP=$(curl -sf -o /dev/null -w "%{http_code}" "https://$STORE/admin/api/$VERSION/shop.json" -H "X-Shopify-Access-Token: $TOKEN")
-[ "$HTTP" = "200" ] && echo "OK ($HTTP)" || echo "FAIL ($HTTP)"
-
-# Layer 5: GraphQL
-echo -n "5. GraphQL: "
-GQL=$(curl -sf "https://$STORE/admin/api/$VERSION/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ shop { name } }"}' | jq -r '.data.shop.name')
-[ -n "$GQL" ] && echo "OK ($GQL)" || echo "FAIL"
-
-# Layer 6: Rate limit state
-echo -n "6. Rate limit: "
-curl -sf "https://$STORE/admin/api/$VERSION/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ shop { name } }"}' \
-  | jq -r '.extensions.cost.throttleStatus | "\(.currentlyAvailable)/\(.maximumAvailable) available"'
-```
+See [Layer-by-Layer Diagnostic](references/layer-by-layer-diagnostic.md) for the complete shell script.
 
 ### Step 6: Debug Intermittent Failures
 
-```typescript
-// Capture timing and response details for pattern analysis
-interface DebugEntry {
-  timestamp: string;
-  operation: string;
-  requestId: string;
-  statusCode: number;
-  durationMs: number;
-  queryCost: number;
-  availablePoints: number;
-  error?: string;
-}
+Wrap Shopify calls in a debug logger that captures timing, cost, and error data for pattern analysis.
 
-const debugLog: DebugEntry[] = [];
-
-async function debugShopifyCall<T>(
-  operation: string,
-  fn: () => Promise<T>
-): Promise<T> {
-  const start = Date.now();
-  try {
-    const result = await fn();
-    debugLog.push({
-      timestamp: new Date().toISOString(),
-      operation,
-      requestId: "from-response-headers",
-      statusCode: 200,
-      durationMs: Date.now() - start,
-      queryCost: (result as any).extensions?.cost?.actualQueryCost || 0,
-      availablePoints: (result as any).extensions?.cost?.throttleStatus?.currentlyAvailable || 0,
-    });
-    return result;
-  } catch (error: any) {
-    debugLog.push({
-      timestamp: new Date().toISOString(),
-      operation,
-      requestId: error.response?.headers?.["x-request-id"] || "unknown",
-      statusCode: error.response?.code || 0,
-      durationMs: Date.now() - start,
-      queryCost: 0,
-      availablePoints: 0,
-      error: error.message,
-    });
-    throw error;
-  }
-}
-
-// After running, analyze the debug log for patterns:
-// - Do failures cluster at specific times?
-// - Does availablePoints drop to 0 before failures?
-// - Are specific operations consistently slow?
-```
+See [Debug Intermittent Failures](references/debug-intermittent-failures.md) for the complete TypeScript implementation.
 
 ## Output
 
@@ -245,23 +89,23 @@ async function debugShopifyCall<T>(
 
 ## Examples
 
-### Support Escalation with Evidence
+### Diagnosing Intermittent 502 Errors
 
-```bash
-# Collect everything for a support ticket
-echo "=== Shopify Support Evidence ===" > evidence.txt
-echo "Date: $(date -u)" >> evidence.txt
-echo "Store: $SHOPIFY_STORE" >> evidence.txt
-echo "API Version: 2024-10" >> evidence.txt
-echo "" >> evidence.txt
-echo "Error X-Request-Ids:" >> evidence.txt
-echo "  - abc123def456" >> evidence.txt
-echo "" >> evidence.txt
-echo "Query that fails:" >> evidence.txt
-echo '  { products(first: 50) { edges { node { id title } } } }' >> evidence.txt
-echo "" >> evidence.txt
-echo "Frequency: ~5% of requests between 2pm-4pm UTC" >> evidence.txt
-```
+A store experiences random 502 errors on product sync queries. Use the debug wrapper to capture timing and cost data across 100 requests, then analyze the pattern.
+
+See [Debug Intermittent Failures](references/debug-intermittent-failures.md) for the complete TypeScript implementation.
+
+### Isolating a Webhook Delivery Gap
+
+Orders are created but the fulfillment webhook never fires. Run the webhook status query to check subscription health and delivery success rates.
+
+See [Webhook Status Query](references/webhook-status-query.md) for the complete query and common delivery failure patterns.
+
+### Pinpointing a Network Layer Failure
+
+API calls fail sporadically from a specific server. Run the layer-by-layer diagnostic to test DNS, TCP, TLS, HTTP, and GraphQL independently.
+
+See [Layer-by-Layer Diagnostic](references/layer-by-layer-diagnostic.md) for the complete shell script.
 
 ## Resources
 
@@ -269,7 +113,3 @@ echo "Frequency: ~5% of requests between 2pm-4pm UTC" >> evidence.txt
 - [Webhook Troubleshooting](https://shopify.dev/docs/apps/build/webhooks/troubleshoot)
 - [Shopify Partner Support](https://help.shopify.com/en/partners)
 - [Shopify Community Forums](https://community.shopify.dev)
-
-## Next Steps
-
-For load testing, see `shopify-load-scale`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/debug-intermittent-failures.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/debug-intermittent-failures.md
@@ -1,0 +1,54 @@
+Debug wrapper that captures timing, cost, and error data for pattern analysis of intermittent Shopify API failures.
+
+```typescript
+// Capture timing and response details for pattern analysis
+interface DebugEntry {
+  timestamp: string;
+  operation: string;
+  requestId: string;
+  statusCode: number;
+  durationMs: number;
+  queryCost: number;
+  availablePoints: number;
+  error?: string;
+}
+
+const debugLog: DebugEntry[] = [];
+
+async function debugShopifyCall<T>(
+  operation: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const start = Date.now();
+  try {
+    const result = await fn();
+    debugLog.push({
+      timestamp: new Date().toISOString(),
+      operation,
+      requestId: "from-response-headers",
+      statusCode: 200,
+      durationMs: Date.now() - start,
+      queryCost: (result as any).extensions?.cost?.actualQueryCost || 0,
+      availablePoints: (result as any).extensions?.cost?.throttleStatus?.currentlyAvailable || 0,
+    });
+    return result;
+  } catch (error: any) {
+    debugLog.push({
+      timestamp: new Date().toISOString(),
+      operation,
+      requestId: error.response?.headers?.["x-request-id"] || "unknown",
+      statusCode: error.response?.code || 0,
+      durationMs: Date.now() - start,
+      queryCost: 0,
+      availablePoints: 0,
+      error: error.message,
+    });
+    throw error;
+  }
+}
+
+// After running, analyze the debug log for patterns:
+// - Do failures cluster at specific times?
+// - Does availablePoints drop to 0 before failures?
+// - Are specific operations consistently slow?
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/layer-by-layer-diagnostic.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/layer-by-layer-diagnostic.md
@@ -1,0 +1,44 @@
+Layer-by-layer diagnostic script that tests DNS, TCP, TLS, HTTP, GraphQL, and rate limit state independently.
+
+```bash
+#!/bin/bash
+# shopify-layer-test.sh — test each layer independently
+STORE="$SHOPIFY_STORE"
+TOKEN="$SHOPIFY_ACCESS_TOKEN"
+VERSION="2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+
+echo "=== Layer-by-Layer Diagnostic ==="
+
+# Layer 1: DNS
+echo -n "1. DNS: "
+dig +short "$STORE" >/dev/null 2>&1 && echo "OK" || echo "FAIL"
+
+# Layer 2: TCP connectivity
+echo -n "2. TCP: "
+timeout 5 bash -c "echo > /dev/tcp/${STORE}/443" 2>/dev/null && echo "OK" || echo "FAIL"
+
+# Layer 3: TLS handshake
+echo -n "3. TLS: "
+echo | openssl s_client -connect "$STORE:443" -servername "$STORE" 2>/dev/null | grep -q "Verify return code: 0" && echo "OK" || echo "FAIL"
+
+# Layer 4: HTTP response
+echo -n "4. HTTP: "
+HTTP=$(curl -sf -o /dev/null -w "%{http_code}" "https://$STORE/admin/api/$VERSION/shop.json" -H "X-Shopify-Access-Token: $TOKEN")
+[ "$HTTP" = "200" ] && echo "OK ($HTTP)" || echo "FAIL ($HTTP)"
+
+# Layer 5: GraphQL
+echo -n "5. GraphQL: "
+GQL=$(curl -sf "https://$STORE/admin/api/$VERSION/graphql.json" \
+  -H "X-Shopify-Access-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ shop { name } }"}' | jq -r '.data.shop.name')
+[ -n "$GQL" ] && echo "OK ($GQL)" || echo "FAIL"
+
+# Layer 6: Rate limit state
+echo -n "6. Rate limit: "
+curl -sf "https://$STORE/admin/api/$VERSION/graphql.json" \
+  -H "X-Shopify-Access-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ shop { name } }"}' \
+  | jq -r '.extensions.cost.throttleStatus | "\(.currentlyAvailable)/\(.maximumAvailable) available"'
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/webhook-status-query.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/references/webhook-status-query.md
@@ -1,0 +1,30 @@
+Webhook subscription health check query and common delivery issues.
+
+```typescript
+// Check webhook subscription health
+const WEBHOOK_STATUS = `{
+  webhookSubscriptions(first: 50) {
+    edges {
+      node {
+        id
+        topic
+        endpoint {
+          ... on WebhookHttpEndpoint {
+            callbackUrl
+          }
+        }
+        format
+        apiVersion
+        createdAt
+        updatedAt
+      }
+    }
+  }
+}`;
+
+// Common webhook delivery issues:
+// 1. Your endpoint returns non-200 — Shopify retries 19 times over 48 hours
+// 2. Response takes > 5 seconds — Shopify considers it failed
+// 3. Endpoint is HTTP (not HTTPS) — Shopify won't deliver
+// 4. SSL certificate invalid — delivery fails silently
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: shopify-ai-toolkit-wrapper
+description: |
+  Integrate Shopify's AI Toolkit MCP server with Claude Code for GraphQL validation,
+  Liquid linting, and documentation search.
+  Use when setting up Shopify MCP integration, validating GraphQL queries,
+  or linting Liquid templates.
+  Trigger with phrases like "shopify ai toolkit", "shopify mcp",
+  "shopify claude integration", "shopify graphql validation", "shopify liquid lint".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify AI Toolkit Wrapper
+
+## Overview
+
+Shopify's AI Toolkit provides an official MCP (Model Context Protocol) server for developer workflows. This skill configures it for Claude Code, enabling GraphQL schema validation, Liquid template linting, and real-time Shopify documentation search without leaving your editor.
+
+## Prerequisites
+
+- Node.js 18+ and npm/pnpm installed
+- A Shopify store with a custom app or API access token
+- Access scopes appropriate for your workflow (minimum: `read_products`, `read_themes`)
+- Claude Code with MCP support enabled
+
+## Instructions
+
+### Step 1: MCP Configuration
+
+Create or update `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "shopify": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@shopify/ai-toolkit-mcp"
+      ],
+      "env": {
+        "SHOPIFY_ACCESS_TOKEN": "${SHOPIFY_ACCESS_TOKEN}",
+        "SHOPIFY_STORE_URL": "https://your-store.myshopify.com"
+      }
+    }
+  }
+}
+```
+
+> **Note**: The package name `@shopify/ai-toolkit-mcp` may change. Check [shopify.dev/docs](https://shopify.dev/docs) for the latest official MCP package name and configuration.
+
+Set your environment variables:
+
+```bash
+export SHOPIFY_ACCESS_TOKEN="shpat_xxxxxxxxxxxxxxxxxxxx"
+export SHOPIFY_STORE_URL="https://your-store.myshopify.com"
+```
+
+See [references/mcp-config.md](references/mcp-config.md) for advanced configuration and troubleshooting.
+
+### Step 2: GraphQL Schema Validation
+
+With the MCP server running, validate GraphQL queries against your store's live schema before executing them. The MCP introspects the schema and catches:
+
+- Deprecated fields (e.g., `priceRange` should be `priceRangeV2`)
+- Type mismatches in mutation inputs (e.g., `ProductInput` split into `ProductCreateInput`/`ProductUpdateInput` in 2024-10)
+- Missing required fields and incorrect enum values
+
+See [references/graphql-validation.md](references/graphql-validation.md) for common validation errors and deprecated field mappings.
+
+### Step 3: Liquid Template Linting
+
+The AI Toolkit checks Liquid templates for syntax errors, deprecated filters, and performance anti-patterns:
+
+| Issue | Bad | Fix |
+|-------|-----|-----|
+| Deprecated filter | `img_url: '800x'` | `image_url: width: 800` |
+| Scope leak | `{% include 'card' %}` | `{% render 'card', product: product %}` |
+| Unbounded loop | `collections.all.products` | Add `limit: 50` or use `paginate` |
+
+### Step 4: Documentation Search
+
+Query Shopify's official documentation through the MCP server for up-to-date API information:
+
+```
+# Example MCP queries you can make:
+# - "What fields are available on the Product object?"
+# - "Show me the companyCreate mutation input shape"
+# - "What scopes do I need for B2B operations?"
+# - "What changed in the 2024-10 API version?"
+```
+
+This is especially useful for checking API version changes and deprecated fields without leaving your editor.
+
+See [references/workflow-integration.md](references/workflow-integration.md) for combining MCP tools with other shopify-pack skills.
+
+## Output
+
+- MCP server configured and connected to your Shopify store
+- GraphQL queries validated against live schema before execution
+- Liquid templates linted for deprecated filters and anti-patterns
+- Real-time documentation search available in Claude Code
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `MCP connection refused` | MCP server failed to start | Check Node.js version (18+), run `npx @shopify/ai-toolkit-mcp` manually to see errors |
+| `Invalid access token` | Token expired or wrong format | Regenerate token in Shopify admin (Settings > Apps > Develop apps) |
+| `Schema introspection failed` | Insufficient API scopes | Add `read_products` and `read_themes` scopes to your app |
+| `Rate limited on doc queries` | Too many documentation requests | Space out queries; docs are cached after first fetch |
+| `ENOENT: .mcp.json not found` | Config file missing or wrong location | Must be in project root or `~/.claude/.mcp.json` for global config |
+| `Package not found` | MCP package name changed | Check shopify.dev/docs for the current official package name |
+
+## Examples
+
+### Validating a GraphQL Mutation Before Execution
+
+You need to call `productCreate` but aren't sure which input fields changed in the latest API version. Use the MCP server to validate your query against the live schema.
+
+See [GraphQL Validation](references/graphql-validation.md) for common validation errors and deprecated field mappings.
+
+### Setting Up MCP for a Team Project
+
+Configure the Shopify MCP server at project, user, and global levels so the entire team gets schema validation automatically.
+
+See [MCP Config](references/mcp-config.md) for advanced configuration and troubleshooting.
+
+### Combining MCP Validation with Other Shopify Skills
+
+Chain MCP schema validation before running mutations from other shopify-pack skills like B2B or checkout extensions.
+
+See [Workflow Integration](references/workflow-integration.md) for the combined workflow patterns.
+
+## Resources
+
+- [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai)
+- [MCP Server Protocol](https://modelcontextprotocol.io/docs)
+- [Shopify Admin API Reference](https://shopify.dev/docs/api/admin-graphql)
+- [Shopify Theme Liquid Reference](https://shopify.dev/docs/api/liquid)
+- [Shopify App Scopes](https://shopify.dev/docs/api/usage/access-scopes)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/graphql-validation.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/graphql-validation.md
@@ -1,0 +1,132 @@
+Using the Shopify MCP server to validate GraphQL queries against your store's schema.
+
+## Why Validate Before Executing
+
+Shopify's GraphQL API evolves across API versions. Fields get deprecated, renamed, or restructured. Validating against your store's live schema catches:
+
+- Deprecated fields that will break in upcoming versions
+- Type mismatches in mutation inputs
+- Missing required fields
+- Fields that require higher API scopes
+
+## Common Deprecated Field Mappings
+
+| Deprecated | Current | API Version Changed |
+|-----------|---------|-------------------|
+| `priceRange` | `priceRangeV2` | 2022-10 |
+| `img_url` filter | `image_url` filter | 2023-04 |
+| `ProductInput` (unified) | `ProductCreateInput` / `ProductUpdateInput` | 2024-10 |
+| `inventoryBulkAdjustQuantityAtLocation` | `inventoryAdjustQuantities` | 2023-10 |
+| `collectionPublish` | `publishablePublish` | 2023-04 |
+| `productPublish` | `publishablePublish` | 2023-04 |
+
+## Schema Introspection Query
+
+If using the MCP server's introspection capabilities, it runs queries like:
+
+```graphql
+{
+  __type(name: "ProductCreateInput") {
+    name
+    kind
+    inputFields {
+      name
+      type {
+        name
+        kind
+        ofType { name kind }
+      }
+      defaultValue
+    }
+  }
+}
+```
+
+This reveals the exact shape your store's API version expects.
+
+## Common Validation Errors
+
+### Field Not Found
+
+```
+Error: Cannot query field "priceRange" on type "Product". 
+Did you mean "priceRangeV2"?
+```
+
+**Fix**: Update to the current field name. Check the API changelog for your version.
+
+### Wrong Input Type
+
+```
+Error: Variable "$input" got invalid value. 
+In field "title": Expected type "String!", found null.
+```
+
+**Fix**: Required fields (marked with `!`) must be provided and non-null.
+
+### Scope Insufficient
+
+```
+Error: Access denied for productCreate mutation.
+Requires write_products scope.
+```
+
+**Fix**: Update your app's scopes in the Shopify partner dashboard and reinstall.
+
+### API Version Mismatch
+
+```
+Error: Field "productSet" doesn't exist on type "Mutation".
+```
+
+**Fix**: `productSet` was introduced in 2024-01. Update your API version or use `productCreate` + `productUpdate`.
+
+## Version-Specific Gotchas
+
+### 2024-10: Product Input Split
+
+Before 2024-10:
+```graphql
+mutation productCreate($input: ProductInput!) { ... }
+mutation productUpdate($input: ProductInput!) { ... }
+```
+
+After 2024-10:
+```graphql
+mutation productCreate($input: ProductCreateInput!) { ... }
+mutation productUpdate($input: ProductUpdateInput!) { ... }
+```
+
+The fields differ between create and update. For example, `handle` is only settable on create, not update.
+
+### 2023-10: Inventory Adjustments
+
+Before:
+```graphql
+mutation inventoryBulkAdjustQuantityAtLocation(
+  $inventoryItemAdjustments: [InventoryAdjustItemInput!]!,
+  $locationId: ID!
+) { ... }
+```
+
+After:
+```graphql
+mutation inventoryAdjustQuantities(
+  $input: InventoryAdjustQuantitiesInput!
+) { ... }
+```
+
+The new mutation supports adjusting quantities across multiple locations in a single call.
+
+## Using `LATEST_API_VERSION`
+
+When using `@shopify/shopify-api`, always use the constant instead of hardcoding:
+
+```typescript
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+
+const client = new shopify.clients.Graphql({
+  session,
+  apiVersion: LATEST_API_VERSION, // Always current
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/mcp-config.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/mcp-config.md
@@ -1,0 +1,151 @@
+Complete MCP configuration for Shopify AI Toolkit with troubleshooting.
+
+## Configuration Locations
+
+MCP servers can be configured at three levels:
+
+| Location | Scope | File |
+|----------|-------|------|
+| Project | This project only | `.mcp.json` in project root |
+| User | All projects for this user | `~/.claude/.mcp.json` |
+| Workspace | Shared via version control | `.claude/mcp.json` (committed) |
+
+## Minimal Configuration
+
+```json
+{
+  "mcpServers": {
+    "shopify": {
+      "command": "npx",
+      "args": ["-y", "@shopify/ai-toolkit-mcp"],
+      "env": {
+        "SHOPIFY_ACCESS_TOKEN": "${SHOPIFY_ACCESS_TOKEN}",
+        "SHOPIFY_STORE_URL": "https://your-store.myshopify.com"
+      }
+    }
+  }
+}
+```
+
+> **Package name note**: The package `@shopify/ai-toolkit-mcp` is a placeholder. Check [shopify.dev/docs](https://shopify.dev/docs) for the current official MCP package name. It may also be published as `@shopify/dev-mcp`, `@shopify/cli-mcp`, or similar.
+
+## Environment Variables
+
+Set these before starting Claude Code:
+
+```bash
+# Required
+export SHOPIFY_ACCESS_TOKEN="shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export SHOPIFY_STORE_URL="https://your-store.myshopify.com"
+
+# Optional (if using a Shopify Partner app)
+export SHOPIFY_API_KEY="your-api-key"
+export SHOPIFY_API_SECRET="your-api-secret"
+```
+
+### Generating an Access Token
+
+1. Go to Shopify Admin > Settings > Apps and sales channels > Develop apps
+2. Click "Create an app"
+3. Configure Admin API scopes (minimum: `read_products`, `read_themes`)
+4. Install the app and copy the Admin API access token
+
+Token format: `shpat_` followed by 32 hex characters.
+
+## Advanced Configuration
+
+```json
+{
+  "mcpServers": {
+    "shopify": {
+      "command": "npx",
+      "args": ["-y", "@shopify/ai-toolkit-mcp"],
+      "env": {
+        "SHOPIFY_ACCESS_TOKEN": "${SHOPIFY_ACCESS_TOKEN}",
+        "SHOPIFY_STORE_URL": "${SHOPIFY_STORE_URL}",
+        "SHOPIFY_API_VERSION": "2025-01",
+        "LOG_LEVEL": "debug"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+## Multi-Store Configuration
+
+For agencies or developers working across multiple stores:
+
+```json
+{
+  "mcpServers": {
+    "shopify-production": {
+      "command": "npx",
+      "args": ["-y", "@shopify/ai-toolkit-mcp"],
+      "env": {
+        "SHOPIFY_ACCESS_TOKEN": "${SHOPIFY_PROD_TOKEN}",
+        "SHOPIFY_STORE_URL": "https://production-store.myshopify.com"
+      }
+    },
+    "shopify-staging": {
+      "command": "npx",
+      "args": ["-y", "@shopify/ai-toolkit-mcp"],
+      "env": {
+        "SHOPIFY_ACCESS_TOKEN": "${SHOPIFY_STAGING_TOKEN}",
+        "SHOPIFY_STORE_URL": "https://staging-store.myshopify.com"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### MCP Server Fails to Start
+
+```bash
+# Test the MCP server directly
+npx @shopify/ai-toolkit-mcp
+
+# Common errors:
+# "ENOENT" → Node.js not in PATH, ensure Node 18+
+# "MODULE_NOT_FOUND" → Package name changed, check Shopify docs
+# "EACCES" → Permission issue, try: npm config set prefix ~/.npm-global
+```
+
+### Connection Timeout
+
+```bash
+# Increase timeout in .mcp.json
+# Default is usually 10s, bump to 30s for first-time installs
+"timeout": 30000
+
+# Or pre-install the package
+npm install -g @shopify/ai-toolkit-mcp
+# Then use the global path instead of npx
+```
+
+### Token Validation Errors
+
+```bash
+# Verify token works
+curl -s "https://your-store.myshopify.com/admin/api/2025-01/shop.json" \
+  -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
+  | jq '.shop.name'
+
+# If 401: Token is invalid or expired → regenerate in admin
+# If 403: Token lacks required scopes → update app permissions
+```
+
+### Environment Variable Not Resolving
+
+The `${VAR_NAME}` syntax in `.mcp.json` reads from the shell environment. If variables are not resolving:
+
+```bash
+# Check they are exported (not just set)
+export SHOPIFY_ACCESS_TOKEN="shpat_xxx"  # This works
+SHOPIFY_ACCESS_TOKEN="shpat_xxx"          # This does NOT work with MCP
+
+# Add to shell profile for persistence
+echo 'export SHOPIFY_ACCESS_TOKEN="shpat_xxx"' >> ~/.bashrc
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/workflow-integration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/references/workflow-integration.md
@@ -1,0 +1,115 @@
+Combining the Shopify MCP server with other shopify-pack skills for efficient development workflows.
+
+## Workflow: Validate-Then-Execute
+
+Use the MCP server's schema validation before running any GraphQL mutation from other shopify-pack skills:
+
+```
+1. Write your GraphQL query/mutation
+2. MCP validates against live schema → catches errors before execution
+3. MCP checks query cost → avoid THROTTLED/MAX_COST_EXCEEDED
+4. Execute the validated query via @shopify/shopify-api
+```
+
+### Example: Product Creation Pipeline
+
+```typescript
+// Step 1: Use MCP to verify ProductCreateInput shape for your API version
+// The MCP server introspects the schema and confirms field names
+
+// Step 2: Use shopify-graphql-cost-optimizer to check estimated cost
+// products(first: 10) with 5 fields ≈ 52 points (safe)
+
+// Step 3: Execute using the pattern from shopify-core-workflow-a
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+
+const response = await client.request(CREATE_PRODUCT, {
+  variables: {
+    input: {
+      title: "New Product",
+      status: "DRAFT",
+    },
+  },
+});
+
+// Step 4: Validate response using shopify-common-errors patterns
+if (response.data.productCreate.userErrors.length > 0) {
+  // Handle per shopify-common-errors skill
+}
+```
+
+## Workflow: Theme Development Loop
+
+Combine MCP linting with theme performance optimization:
+
+```
+1. Edit Liquid template
+2. MCP lints for deprecated filters (img_url → image_url)
+3. MCP checks for anti-patterns (include → render)
+4. Apply shopify-theme-performance optimizations
+5. Run Liquid profiler (?profile=true) to verify improvement
+```
+
+### Example: Fix Deprecated Filters
+
+```liquid
+{% comment %} MCP flags this as deprecated {% endcomment %}
+{{ product.featured_image | img_url: '800x' }}
+
+{% comment %} Apply image-optimization.md reference pattern {% endcomment %}
+{{ product.featured_image | image_url: width: 800 | image_tag:
+    loading: 'lazy',
+    sizes: '(max-width: 749px) 100vw, 50vw',
+    widths: '400,600,800' }}
+```
+
+## Workflow: B2B Setup with Validation
+
+When setting up B2B using shopify-b2b-wholesale, validate each step:
+
+```
+1. MCP confirms B2B mutations exist for your API version
+2. MCP verifies required scopes (read_customers, write_customers)
+3. Run companyCreate → MCP validates input shape
+4. Run catalogCreate → MCP checks catalog limit for plan
+5. Run priceListCreate → MCP confirms pricing fields
+```
+
+## Workflow: Cost-Aware Bulk Operations
+
+Decide between paginated queries and bulk operations:
+
+```
+1. Write initial query
+2. MCP predicts requestedQueryCost
+3. If cost > 500: use shopify-graphql-cost-optimizer splitting patterns
+4. If total items > 250: switch to bulk operations (shopify-graphql-cost-optimizer)
+5. MCP validates bulk query syntax (no first/last params allowed)
+```
+
+### Decision Matrix
+
+| Scenario | Approach | Skill Reference |
+|----------|----------|----------------|
+| < 50 items, interactive | Direct query | shopify-core-workflow-a |
+| 50-250 items, background | Paginated with cursor | shopify-graphql-cost-optimizer (query-splitting.md) |
+| > 250 items, export | Bulk operations | shopify-graphql-cost-optimizer (bulk-operations.md) |
+| Real-time sync | Webhooks | shopify-webhooks-events |
+| Rate-limited operation | Throttle-aware client | shopify-rate-limits |
+
+## Combining MCP Tools in Claude Code
+
+When working in Claude Code with the Shopify MCP server configured, you can chain capabilities:
+
+```
+User: "Create a new product collection for summer items"
+
+Claude Code workflow:
+1. [MCP] Search docs for collectionCreate mutation shape
+2. [MCP] Validate the mutation against store's schema
+3. [shopify-core-workflow-a] Use the collection creation pattern
+4. [shopify-graphql-cost-optimizer] Verify query cost is reasonable
+5. Execute the validated, cost-checked mutation
+```
+
+This creates a safety net where queries are validated and cost-checked before hitting the Shopify API, reducing wasted API calls and avoiding throttling.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-architecture-variants
 description: |
   Choose between Shopify app architectures: embedded Remix app, headless storefront with
   Hydrogen, standalone integration, or theme app extension.
+  Use when starting a new Shopify project and deciding which architecture pattern to follow.
   Trigger with phrases like "shopify architecture decision", "shopify embedded vs headless",
   "shopify Hydrogen", "shopify app types", "which shopify architecture".
 allowed-tools: Read, Grep
@@ -29,183 +30,27 @@ Four validated architecture patterns for building on Shopify. Choose based on yo
 
 ### Variant A: Embedded Admin App (Remix)
 
-**Best for:** Admin panel apps, merchant tools, dashboards, order management
+Admin panel apps, merchant tools, dashboards. Uses `@shopify/shopify-app-remix` with OAuth and Polaris UI inside the Shopify admin.
 
-**When to use:** You need to add functionality to the Shopify admin for merchants.
-
-```
-my-shopify-app/
-├── app/
-│   ├── routes/
-│   │   ├── app._index.tsx         # Dashboard (inside Shopify admin)
-│   │   ├── app.products.tsx       # Feature pages
-│   │   ├── auth.$.tsx             # OAuth handler
-│   │   └── webhooks.tsx           # Webhook receiver
-│   ├── shopify.server.ts          # @shopify/shopify-app-remix
-│   └── root.tsx
-├── extensions/                     # Optional extensions
-├── prisma/schema.prisma           # Session + app data
-├── shopify.app.toml
-└── package.json
-```
-
-**Key packages:** `@shopify/shopify-app-remix`, `@shopify/polaris`, `@shopify/app-bridge-react`
-
-**API used:** Admin GraphQL API (server-side via `authenticate.admin()`)
-
-**Auth:** OAuth with session token exchange (handled by the Remix adapter)
-
-```typescript
-// Authenticated loader — runs server-side inside Shopify admin
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { admin } = await authenticate.admin(request);
-  const response = await admin.graphql(`{ shop { name plan { displayName } } }`);
-  return json(await response.json());
-}
-```
-
----
+See [Embedded Remix App](references/embedded-remix-app.md) for the project structure and authenticated loader pattern.
 
 ### Variant B: Headless Storefront (Hydrogen)
 
-**Best for:** Custom storefronts, unique shopping experiences, PWAs
+Custom storefronts and unique shopping experiences. Uses the Storefront GraphQL API, hosted on Shopify Oxygen or any edge platform.
 
-**When to use:** You're building a custom frontend that replaces the Shopify Online Store.
-
-```
-my-hydrogen-store/
-├── app/
-│   ├── routes/
-│   │   ├── ($locale)._index.tsx           # Homepage
-│   │   ├── ($locale).products.$handle.tsx # Product page
-│   │   ├── ($locale).collections._index.tsx
-│   │   ├── ($locale).cart.tsx             # Cart page
-│   │   └── ($locale).account.tsx          # Customer account
-│   ├── components/
-│   │   ├── ProductCard.tsx
-│   │   ├── Cart.tsx
-│   │   └── Header.tsx
-│   ├── lib/
-│   │   └── shopify.ts                     # Storefront API client
-│   └── root.tsx
-├── public/
-└── hydrogen.config.ts
-```
-
-**Key packages:** `@shopify/hydrogen`, `@shopify/hydrogen-react`, `@shopify/remix-oxygen`
-
-**API used:** Storefront GraphQL API (public, no admin tokens needed)
-
-**Hosting:** Shopify Oxygen (recommended) or any edge platform
-
-```typescript
-// Hydrogen product page — uses Storefront API
-export async function loader({ params, context }: LoaderFunctionArgs) {
-  const { storefront } = context;
-  const { product } = await storefront.query(PRODUCT_QUERY, {
-    variables: { handle: params.handle },
-  });
-  return json({ product });
-}
-```
-
----
+See [Hydrogen Storefront](references/hydrogen-storefront.md) for the project structure and Storefront API loader.
 
 ### Variant C: Backend Integration (Standalone)
 
-**Best for:** ERP sync, warehouse management, analytics, multi-channel integration
+ERP sync, warehouse management, analytics. Uses `@shopify/shopify-api` with a custom app access token -- no OAuth or merchant UI needed.
 
-**When to use:** You're connecting Shopify to other systems — no merchant-facing UI needed.
-
-```
-shopify-integration/
-├── src/
-│   ├── shopify/
-│   │   ├── client.ts              # @shopify/shopify-api client
-│   │   ├── webhooks.ts            # Webhook handlers
-│   │   └── sync.ts                # Data sync logic
-│   ├── services/
-│   │   ├── erp-sync.ts            # Sync orders to ERP
-│   │   ├── inventory-sync.ts      # Bi-directional inventory
-│   │   └── customer-export.ts     # Customer data pipeline
-│   ├── jobs/
-│   │   ├── daily-sync.ts          # Scheduled sync job
-│   │   └── webhook-processor.ts   # Queue-based webhook processing
-│   └── index.ts
-├── .env
-└── package.json
-```
-
-**Key packages:** `@shopify/shopify-api`, custom app token
-
-**API used:** Admin GraphQL API (custom app access token, no OAuth)
-
-**Auth:** Custom app access token (`shpat_xxx`) — no OAuth flow needed
-
-```typescript
-// Custom app — direct API access, no merchant UI
-const shopify = shopifyApi({
-  apiKey: process.env.SHOPIFY_API_KEY!,
-  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
-  hostName: "localhost",
-  apiVersion: "2024-10",
-  isCustomStoreApp: true,
-  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!,
-});
-```
-
----
+See [Backend Integration](references/backend-integration.md) for the project structure and client setup.
 
 ### Variant D: Theme App Extension Only
 
-**Best for:** Storefront widgets, product reviews, badges, banners
+Storefront widgets, product reviews, badges. Runs entirely in the merchant's storefront using Liquid templates -- no server needed.
 
-**When to use:** You only need to add UI elements to the merchant's Online Store.
-
-```
-my-theme-extension/
-├── extensions/
-│   └── my-widget/
-│       ├── blocks/
-│       │   ├── product-badge.liquid
-│       │   ├── announcement-bar.liquid
-│       │   └── review-stars.liquid
-│       ├── assets/
-│       │   ├── widget.css
-│       │   └── widget.js
-│       ├── locales/
-│       │   └── en.default.json
-│       └── snippets/
-│           └── shared-styles.liquid
-├── shopify.app.toml
-└── package.json
-```
-
-**Key tech:** Liquid templates, JavaScript, CSS
-
-**API used:** None directly — uses Liquid objects (`product`, `cart`, `customer`)
-
-**No server needed:** Theme app extensions run entirely in the merchant's storefront.
-
-```liquid
-{% comment %} blocks/product-badge.liquid {% endcomment %}
-{% schema %}
-{
-  "name": "Sale Badge",
-  "target": "section",
-  "settings": [
-    { "type": "text", "id": "badge_text", "label": "Badge Text", "default": "SALE" },
-    { "type": "color", "id": "badge_color", "label": "Color", "default": "#FF0000" }
-  ]
-}
-{% endschema %}
-
-{% if product.compare_at_price > product.price %}
-  <span class="sale-badge" style="background: {{ block.settings.badge_color }}">
-    {{ block.settings.badge_text }}
-  </span>
-{% endif %}
-```
+See [Theme App Extension](references/theme-app-extension.md) for the project structure and Liquid block example.
 
 ---
 
@@ -264,7 +109,3 @@ shopify app generate extension --type theme
 - [Hydrogen Framework](https://shopify.dev/docs/storefronts/headless/hydrogen)
 - [Theme App Extensions](https://shopify.dev/docs/apps/build/online-store/theme-app-extensions)
 - [Custom Apps](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/generate-app-access-tokens-admin)
-
-## Next Steps
-
-For common anti-patterns, see `shopify-known-pitfalls`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/backend-integration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/backend-integration.md
@@ -1,0 +1,44 @@
+Variant C: Backend Integration (Standalone) project structure and custom app client setup.
+
+**Best for:** ERP sync, warehouse management, analytics, multi-channel integration
+
+**When to use:** You're connecting Shopify to other systems -- no merchant-facing UI needed.
+
+```
+shopify-integration/
+├── src/
+│   ├── shopify/
+│   │   ├── client.ts              # @shopify/shopify-api client
+│   │   ├── webhooks.ts            # Webhook handlers
+│   │   └── sync.ts                # Data sync logic
+│   ├── services/
+│   │   ├── erp-sync.ts            # Sync orders to ERP
+│   │   ├── inventory-sync.ts      # Bi-directional inventory
+│   │   └── customer-export.ts     # Customer data pipeline
+│   ├── jobs/
+│   │   ├── daily-sync.ts          # Scheduled sync job
+│   │   └── webhook-processor.ts   # Queue-based webhook processing
+│   └── index.ts
+├── .env
+└── package.json
+```
+
+**Key packages:** `@shopify/shopify-api`, custom app token
+
+**API used:** Admin GraphQL API (custom app access token, no OAuth)
+
+**Auth:** Custom app access token (`shpat_xxx`) -- no OAuth flow needed
+
+```typescript
+import { LATEST_API_VERSION, shopifyApi } from "@shopify/shopify-api";
+
+// Custom app — direct API access, no merchant UI
+const shopify = shopifyApi({
+  apiKey: process.env.SHOPIFY_API_KEY!,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
+  hostName: "localhost",
+  apiVersion: LATEST_API_VERSION,
+  isCustomStoreApp: true,
+  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!,
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/embedded-remix-app.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/embedded-remix-app.md
@@ -1,0 +1,36 @@
+Variant A: Embedded Admin App (Remix) project structure and authenticated loader pattern.
+
+**Best for:** Admin panel apps, merchant tools, dashboards, order management
+
+**When to use:** You need to add functionality to the Shopify admin for merchants.
+
+```
+my-shopify-app/
+├── app/
+│   ├── routes/
+│   │   ├── app._index.tsx         # Dashboard (inside Shopify admin)
+│   │   ├── app.products.tsx       # Feature pages
+│   │   ├── auth.$.tsx             # OAuth handler
+│   │   └── webhooks.tsx           # Webhook receiver
+│   ├── shopify.server.ts          # @shopify/shopify-app-remix
+│   └── root.tsx
+├── extensions/                     # Optional extensions
+├── prisma/schema.prisma           # Session + app data
+├── shopify.app.toml
+└── package.json
+```
+
+**Key packages:** `@shopify/shopify-app-remix`, `@shopify/polaris`, `@shopify/app-bridge-react`
+
+**API used:** Admin GraphQL API (server-side via `authenticate.admin()`)
+
+**Auth:** OAuth with session token exchange (handled by the Remix adapter)
+
+```typescript
+// Authenticated loader — runs server-side inside Shopify admin
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { admin } = await authenticate.admin(request);
+  const response = await admin.graphql(`{ shop { name plan { displayName } } }`);
+  return json(await response.json());
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/hydrogen-storefront.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/hydrogen-storefront.md
@@ -1,0 +1,42 @@
+Variant B: Headless Storefront (Hydrogen) project structure and Storefront API loader.
+
+**Best for:** Custom storefronts, unique shopping experiences, PWAs
+
+**When to use:** You're building a custom frontend that replaces the Shopify Online Store.
+
+```
+my-hydrogen-store/
+├── app/
+│   ├── routes/
+│   │   ├── ($locale)._index.tsx           # Homepage
+│   │   ├── ($locale).products.$handle.tsx # Product page
+│   │   ├── ($locale).collections._index.tsx
+│   │   ├── ($locale).cart.tsx             # Cart page
+│   │   └── ($locale).account.tsx          # Customer account
+│   ├── components/
+│   │   ├── ProductCard.tsx
+│   │   ├── Cart.tsx
+│   │   └── Header.tsx
+│   ├── lib/
+│   │   └── shopify.ts                     # Storefront API client
+│   └── root.tsx
+├── public/
+└── hydrogen.config.ts
+```
+
+**Key packages:** `@shopify/hydrogen`, `@shopify/hydrogen-react`, `@shopify/remix-oxygen`
+
+**API used:** Storefront GraphQL API (public, no admin tokens needed)
+
+**Hosting:** Shopify Oxygen (recommended) or any edge platform
+
+```typescript
+// Hydrogen product page — uses Storefront API
+export async function loader({ params, context }: LoaderFunctionArgs) {
+  const { storefront } = context;
+  const { product } = await storefront.query(PRODUCT_QUERY, {
+    variables: { handle: params.handle },
+  });
+  return json({ product });
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/theme-app-extension.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/references/theme-app-extension.md
@@ -1,0 +1,50 @@
+Variant D: Theme App Extension project structure and Liquid block example.
+
+**Best for:** Storefront widgets, product reviews, badges, banners
+
+**When to use:** You only need to add UI elements to the merchant's Online Store.
+
+```
+my-theme-extension/
+├── extensions/
+│   └── my-widget/
+│       ├── blocks/
+│       │   ├── product-badge.liquid
+│       │   ├── announcement-bar.liquid
+│       │   └── review-stars.liquid
+│       ├── assets/
+│       │   ├── widget.css
+│       │   └── widget.js
+│       ├── locales/
+│       │   └── en.default.json
+│       └── snippets/
+│           └── shared-styles.liquid
+├── shopify.app.toml
+└── package.json
+```
+
+**Key tech:** Liquid templates, JavaScript, CSS
+
+**API used:** None directly -- uses Liquid objects (`product`, `cart`, `customer`)
+
+**No server needed:** Theme app extensions run entirely in the merchant's storefront.
+
+```liquid
+{% comment %} blocks/product-badge.liquid {% endcomment %}
+{% schema %}
+{
+  "name": "Sale Badge",
+  "target": "section",
+  "settings": [
+    { "type": "text", "id": "badge_text", "label": "Badge Text", "default": "SALE" },
+    { "type": "color", "id": "badge_color", "label": "Color", "default": "#FF0000" }
+  ]
+}
+{% endschema %}
+
+{% if product.compare_at_price > product.price %}
+  <span class="sale-badge" style="background: {{ block.settings.badge_color }}">
+    {{ block.settings.badge_text }}
+  </span>
+{% endif %}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: shopify-b2b-wholesale
+description: |
+  Build Shopify Plus B2B features with companies, catalogs, and wholesale pricing.
+  Use when setting up wholesale accounts, creating price lists,
+  or configuring B2B checkout with purchase orders.
+  Trigger with phrases like "shopify b2b", "shopify wholesale",
+  "shopify company api", "shopify price lists", "shopify catalog api".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify B2B & Wholesale
+
+## Overview
+
+Shopify Plus B2B features let you create separate wholesale experiences with company accounts, custom catalogs, and tiered pricing. This skill covers the full B2B setup: companies, catalogs, price lists, and checkout configuration using the GraphQL Admin API. Requires a Shopify Plus plan.
+
+## Prerequisites
+
+- Shopify Plus plan (B2B features are Plus-only)
+- Access scopes: `read_customers`, `write_customers`, `read_products`, `write_products`, `read_orders`
+- B2B enabled in Shopify admin (Settings > B2B)
+- API version 2023-10 or later (B2B mutations stabilized)
+
+## Instructions
+
+### Step 1: Create a B2B Company
+
+Use `companyCreate` with `CompanyCreateInput` — requires `company` (name, note), `companyContact` (email, firstName, lastName), and `companyLocation` (name, billingAddress, shippingAddress):
+
+```typescript
+await client.request(COMPANY_CREATE, {
+  variables: {
+    input: {
+      company: { name: "Acme Wholesale Inc", note: "Tier 1 partner" },
+      companyContact: { email: "buyer@acme.com", firstName: "Jane", lastName: "Doe" },
+      companyLocation: {
+        name: "Headquarters",
+        billingAddress: { address1: "123 Commerce St", city: "Austin", provinceCode: "TX", countryCode: "US", zip: "78701" },
+        shippingAddress: { address1: "123 Commerce St", city: "Austin", provinceCode: "TX", countryCode: "US", zip: "78701" },
+      },
+    },
+  },
+});
+// Always check userErrors in response — returns code like COMPANY_NOT_FOUND, INVALID
+```
+
+See [references/company-management.md](references/company-management.md) for the full mutation, additional contacts, locations, and roles.
+
+### Step 2: Create a Catalog
+
+Catalogs link products to specific companies. Use `catalogCreate` with a title, status, and `context.companyLocationIds`:
+
+```typescript
+await client.request(CATALOG_CREATE, {
+  variables: {
+    input: {
+      title: "Wholesale Tier 1",
+      status: "ACTIVE",
+      context: { companyLocationIds: ["gid://shopify/CompanyLocation/123456"] },
+    },
+  },
+});
+```
+
+### Step 3: Set Wholesale Pricing
+
+Create a price list with `priceListCreate`. Use `PERCENTAGE_DECREASE` for blanket discounts or `priceListFixedPricesAdd` for per-variant overrides:
+
+```typescript
+// 30% off all products in this catalog
+await client.request(PRICE_LIST_CREATE, {
+  variables: {
+    input: {
+      name: "Wholesale 30% Off",
+      currency: "USD",
+      parent: { adjustment: { type: "PERCENTAGE_DECREASE", value: 30 } },
+      catalogId: "gid://shopify/Catalog/789",
+    },
+  },
+});
+```
+
+For fixed price overrides, volume pricing, and multi-currency, see [references/catalog-pricing.md](references/catalog-pricing.md).
+
+### Step 4: B2B Checkout Configuration
+
+B2B orders use `draftOrderCreate` with `purchaseOrder` number and `purchasingEntity` linking to the company. Key fields:
+
+```typescript
+await client.request(DRAFT_ORDER_CREATE, {
+  variables: {
+    input: {
+      purchaseOrder: "PO-2026-0042",
+      lineItems: [{ variantId: "gid://shopify/ProductVariant/123", quantity: 100 }],
+      purchasingEntity: {
+        purchasingCompany: {
+          companyId: "gid://shopify/Company/456",
+          companyContactId: "gid://shopify/CompanyContact/789",
+          companyLocationId: "gid://shopify/CompanyLocation/012",
+        },
+      },
+      paymentTerms: { paymentTermsTemplateId: "gid://shopify/PaymentTermsTemplate/1" },
+    },
+  },
+});
+```
+
+Payment terms templates: Due on receipt, Net 15, Net 30, Net 45, Net 60, Net 90. Query available templates with `paymentTermsTemplates`.
+
+See [references/b2b-checkout.md](references/b2b-checkout.md) for the full draft order flow, invoice sending, and vaulted payments.
+
+## Output
+
+- B2B company created with contact and billing/shipping addresses
+- Catalog linked to specific company locations
+- Wholesale price list with percentage or fixed pricing
+- Draft orders with purchase order numbers and payment terms
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `COMPANY_NOT_FOUND` | Invalid company GID | Verify the company ID exists via `companyQuery` |
+| `CATALOG_LIMIT_EXCEEDED` | Max catalogs per context reached | Remove unused catalogs or upgrade plan |
+| `PRICE_LIST_NOT_FOUND` | Price list not linked to catalog | Ensure `catalogId` is set on price list |
+| `B2B_NOT_ENABLED` | B2B feature not activated | Enable B2B in Shopify admin Settings > B2B (requires Plus) |
+| `COMPANY_CONTACT_NOT_FOUND` | Contact not associated with company | Create contact via `companyContactCreate` first |
+| `INVALID_PURCHASING_ENTITY` | Missing company/contact/location in draft order | All three IDs required in `purchasingCompany` |
+
+## Examples
+
+### Onboarding a New Wholesale Partner
+
+Create a B2B company with multiple contacts, locations, and roles for a new wholesale account joining your program.
+
+See [Company Management](references/company-management.md) for the full mutation and multi-contact setup.
+
+### Setting Up Tiered Wholesale Pricing
+
+Configure percentage-based discounts for standard wholesalers and fixed per-variant overrides for VIP partners using price lists.
+
+See [Catalog Pricing](references/catalog-pricing.md) for percentage, fixed price, and volume pricing strategies.
+
+### Processing a B2B Purchase Order
+
+Create a draft order with a PO number, Net 30 payment terms, and company association for a wholesale buyer.
+
+See [B2B Checkout](references/b2b-checkout.md) for the full draft order flow, invoice sending, and vaulted payments.
+
+## Resources
+
+- [B2B on Shopify](https://shopify.dev/docs/apps/build/b2b)
+- [companyCreate Mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/companyCreate)
+- [catalogCreate Mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/catalogCreate)
+- [priceListCreate Mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/priceListCreate)
+- [B2B Checkout](https://shopify.dev/docs/apps/build/b2b/checkout)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/b2b-checkout.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/b2b-checkout.md
@@ -1,0 +1,230 @@
+B2B-specific checkout configuration: draft orders, payment terms, and purchase order numbers.
+
+## Draft Orders for B2B
+
+Draft orders are the primary way to create B2B orders programmatically. They support purchase order numbers, payment terms, and company association:
+
+```typescript
+const DRAFT_ORDER_CREATE = `
+  mutation draftOrderCreate($input: DraftOrderInput!) {
+    draftOrderCreate(input: $input) {
+      draftOrder {
+        id
+        name
+        status
+        invoiceUrl
+        purchaseOrder
+        totalPriceSet {
+          shopMoney { amount currencyCode }
+        }
+        subtotalPriceSet {
+          shopMoney { amount currencyCode }
+        }
+        totalTaxSet {
+          shopMoney { amount currencyCode }
+        }
+        lineItems(first: 50) {
+          edges {
+            node {
+              title
+              quantity
+              originalUnitPriceSet {
+                shopMoney { amount currencyCode }
+              }
+            }
+          }
+        }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(DRAFT_ORDER_CREATE, {
+  variables: {
+    input: {
+      purchaseOrder: "PO-2026-0042",
+      note: "Q1 restock order",
+      tags: ["wholesale", "tier-1"],
+      lineItems: [
+        {
+          variantId: "gid://shopify/ProductVariant/111",
+          quantity: 100,
+        },
+        {
+          variantId: "gid://shopify/ProductVariant/222",
+          quantity: 50,
+        },
+      ],
+      purchasingEntity: {
+        purchasingCompany: {
+          companyId: "gid://shopify/Company/456",
+          companyContactId: "gid://shopify/CompanyContact/789",
+          companyLocationId: "gid://shopify/CompanyLocation/012",
+        },
+      },
+      shippingAddress: {
+        address1: "500 Industrial Blvd",
+        address2: "Dock 3",
+        city: "Dallas",
+        provinceCode: "TX",
+        countryCode: "US",
+        zip: "75201",
+      },
+      paymentTerms: {
+        paymentTermsTemplateId: "gid://shopify/PaymentTermsTemplate/1",
+      },
+    },
+  },
+});
+```
+
+## Payment Terms
+
+Shopify provides built-in payment terms templates for B2B:
+
+| Template | Description |
+|----------|-------------|
+| Due on receipt | Payment required immediately |
+| Net 15 | Payment due 15 days after fulfillment |
+| Net 30 | Payment due 30 days after fulfillment |
+| Net 45 | Payment due 45 days after fulfillment |
+| Net 60 | Payment due 60 days after fulfillment |
+| Net 90 | Payment due 90 days after fulfillment |
+
+Query available payment terms templates:
+
+```typescript
+const PAYMENT_TERMS_TEMPLATES = `
+  query paymentTermsTemplates {
+    paymentTermsTemplates {
+      id
+      name
+      paymentTermsType
+      dueInDays
+      description
+    }
+  }
+`;
+
+const response = await client.request(PAYMENT_TERMS_TEMPLATES);
+// Returns all available templates with their GIDs
+```
+
+## Sending Invoice to B2B Customer
+
+After creating a draft order, send the invoice so the B2B contact can complete payment:
+
+```typescript
+const SEND_INVOICE = `
+  mutation draftOrderInvoiceSend(
+    $id: ID!,
+    $email: DraftOrderInvoiceInput
+  ) {
+    draftOrderInvoiceSend(id: $id, email: $email) {
+      draftOrder {
+        id
+        status
+        invoiceSentAt
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(SEND_INVOICE, {
+  variables: {
+    id: "gid://shopify/DraftOrder/123",
+    email: {
+      to: ["purchasing@acme-dist.com"],
+      subject: "Invoice for PO-2026-0042",
+      customMessage: "Your wholesale order is ready for payment.",
+    },
+  },
+});
+```
+
+## Complete a Draft Order
+
+Convert a draft order to a real order (mark as paid or apply payment terms):
+
+```typescript
+const DRAFT_ORDER_COMPLETE = `
+  mutation draftOrderComplete($id: ID!, $paymentPending: Boolean) {
+    draftOrderComplete(id: $id, paymentPending: $paymentPending) {
+      draftOrder {
+        id
+        status
+        order {
+          id
+          name
+          displayFinancialStatus
+        }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+// paymentPending: true = mark as payment pending (Net 30 etc.)
+// paymentPending: false = mark as paid
+await client.request(DRAFT_ORDER_COMPLETE, {
+  variables: {
+    id: "gid://shopify/DraftOrder/123",
+    paymentPending: true, // B2B orders typically use deferred payment
+  },
+});
+```
+
+## Vaulted Payment Methods
+
+B2B customers can save payment methods for repeat orders:
+
+```typescript
+const CUSTOMER_PAYMENT_METHODS = `
+  query customerPaymentMethods($customerId: ID!) {
+    customer(id: $customerId) {
+      id
+      paymentMethods(first: 10) {
+        edges {
+          node {
+            id
+            instrument {
+              ... on CustomerCreditCard {
+                brand
+                lastDigits
+                expiryMonth
+                expiryYear
+              }
+            }
+            revokedAt
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Send a payment method request to the B2B customer
+const SEND_PAYMENT_REQUEST = `
+  mutation customerPaymentMethodSendUpdateEmail($customerId: ID!) {
+    customerPaymentMethodSendUpdateEmail(customerId: $customerId) {
+      customer { id }
+      userErrors { field message }
+    }
+  }
+`;
+```
+
+## B2B Order Workflow Summary
+
+```
+1. companyCreate → Create B2B company with contact and location
+2. catalogCreate → Link product catalog to company location
+3. priceListCreate → Set wholesale pricing for catalog
+4. draftOrderCreate → Create order with PO number and payment terms
+5. draftOrderInvoiceSend → Email invoice to B2B contact
+6. Customer pays via invoice link (or you mark as paid)
+7. draftOrderComplete → Converts to real order
+8. Fulfill order through normal fulfillment flow
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/catalog-pricing.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/catalog-pricing.md
@@ -1,0 +1,233 @@
+Price list strategies for Shopify B2B: percentage adjustments, fixed prices, and volume pricing.
+
+## Percentage-Based Price List
+
+Apply a blanket discount to all products in a catalog:
+
+```typescript
+const PRICE_LIST_CREATE = `
+  mutation priceListCreate($input: PriceListCreateInput!) {
+    priceListCreate(input: $input) {
+      priceList {
+        id
+        name
+        currency
+        parent {
+          adjustment { type value }
+        }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+// 25% off all products for this catalog
+await client.request(PRICE_LIST_CREATE, {
+  variables: {
+    input: {
+      name: "Silver Tier - 25% Off",
+      currency: "USD",
+      parent: {
+        adjustment: {
+          type: "PERCENTAGE_DECREASE", // PERCENTAGE_DECREASE or PERCENTAGE_INCREASE
+          value: 25,
+        },
+      },
+      catalogId: "gid://shopify/Catalog/123",
+    },
+  },
+});
+```
+
+## Fixed Price Overrides
+
+Set specific prices for individual variants, overriding the percentage adjustment:
+
+```typescript
+const FIXED_PRICES_ADD = `
+  mutation priceListFixedPricesAdd(
+    $priceListId: ID!,
+    $prices: [PriceListPriceInput!]!
+  ) {
+    priceListFixedPricesAdd(priceListId: $priceListId, prices: $prices) {
+      prices {
+        variant { id title }
+        price { amount currencyCode }
+        compareAtPrice { amount currencyCode }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(FIXED_PRICES_ADD, {
+  variables: {
+    priceListId: "gid://shopify/PriceList/456",
+    prices: [
+      {
+        variantId: "gid://shopify/ProductVariant/111",
+        price: {
+          amount: "15.00",
+          currencyCode: "USD",
+        },
+        compareAtPrice: {
+          amount: "29.99", // Shows original price crossed out
+          currencyCode: "USD",
+        },
+      },
+      {
+        variantId: "gid://shopify/ProductVariant/222",
+        price: {
+          amount: "42.50",
+          currencyCode: "USD",
+        },
+      },
+    ],
+  },
+});
+```
+
+## Query Price List Prices
+
+```typescript
+const PRICE_LIST_PRICES = `
+  query priceList($id: ID!, $first: Int!, $after: String) {
+    priceList(id: $id) {
+      id
+      name
+      currency
+      parent {
+        adjustment { type value }
+      }
+      prices(first: $first, after: $after) {
+        edges {
+          node {
+            variant {
+              id
+              title
+              product { title }
+            }
+            price { amount currencyCode }
+            compareAtPrice { amount currencyCode }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`;
+
+await client.request(PRICE_LIST_PRICES, {
+  variables: { id: "gid://shopify/PriceList/456", first: 50 },
+});
+```
+
+## Remove Fixed Prices
+
+Revert specific variants back to the percentage-based price:
+
+```typescript
+const FIXED_PRICES_DELETE = `
+  mutation priceListFixedPricesDelete(
+    $priceListId: ID!,
+    $variantIds: [ID!]!
+  ) {
+    priceListFixedPricesDelete(
+      priceListId: $priceListId,
+      variantIds: $variantIds
+    ) {
+      deletedFixedPriceVariantIds
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(FIXED_PRICES_DELETE, {
+  variables: {
+    priceListId: "gid://shopify/PriceList/456",
+    variantIds: ["gid://shopify/ProductVariant/111"],
+  },
+});
+```
+
+## Volume Pricing (Quantity Rules)
+
+Set minimum, maximum, and increment quantities per variant for B2B:
+
+```typescript
+const QUANTITY_RULES_ADD = `
+  mutation quantityRulesAdd(
+    $priceListId: ID!,
+    $quantityRules: [QuantityRuleInput!]!
+  ) {
+    quantityRulesAdd(
+      priceListId: $priceListId,
+      quantityRules: $quantityRules
+    ) {
+      quantityRules {
+        variant { id title }
+        minimum
+        maximum
+        increment
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(QUANTITY_RULES_ADD, {
+  variables: {
+    priceListId: "gid://shopify/PriceList/456",
+    quantityRules: [
+      {
+        variantId: "gid://shopify/ProductVariant/111",
+        minimum: 12,      // Must order at least 12
+        maximum: 1000,     // Cap at 1000 per order
+        increment: 12,     // Must order in multiples of 12 (case packs)
+      },
+      {
+        variantId: "gid://shopify/ProductVariant/222",
+        minimum: 6,
+        increment: 6,
+        // No maximum = unlimited
+      },
+    ],
+  },
+});
+```
+
+## Multi-Currency Pricing
+
+Create separate price lists per currency for international wholesale:
+
+```typescript
+// EUR price list for European distributors
+await client.request(PRICE_LIST_CREATE, {
+  variables: {
+    input: {
+      name: "EU Wholesale",
+      currency: "EUR",
+      parent: {
+        adjustment: {
+          type: "PERCENTAGE_DECREASE",
+          value: 30,
+        },
+      },
+      catalogId: "gid://shopify/Catalog/123",
+    },
+  },
+});
+
+// Then add EUR-specific fixed prices
+await client.request(FIXED_PRICES_ADD, {
+  variables: {
+    priceListId: "gid://shopify/PriceList/789",
+    prices: [
+      {
+        variantId: "gid://shopify/ProductVariant/111",
+        price: { amount: "13.50", currencyCode: "EUR" },
+      },
+    ],
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/company-management.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/references/company-management.md
@@ -1,0 +1,266 @@
+Full company CRUD operations for Shopify B2B using the GraphQL Admin API.
+
+## Create a Company with Multiple Contacts
+
+```typescript
+const COMPANY_CREATE = `
+  mutation companyCreate($input: CompanyCreateInput!) {
+    companyCreate(input: $input) {
+      company {
+        id
+        name
+        note
+        externalId
+        mainContact {
+          id
+          customer { id email firstName lastName }
+        }
+        locations(first: 10) {
+          edges {
+            node {
+              id
+              name
+              shippingAddress { address1 city provinceCode countryCode zip }
+            }
+          }
+        }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(COMPANY_CREATE, {
+  variables: {
+    input: {
+      company: {
+        name: "Acme Distribution LLC",
+        note: "Gold tier partner since 2024",
+        externalId: "CRM-ACME-001", // Your internal ID for syncing
+      },
+      companyContact: {
+        email: "purchasing@acme-dist.com",
+        firstName: "Sarah",
+        lastName: "Chen",
+        title: "Head of Procurement",
+      },
+      companyLocation: {
+        name: "Main Warehouse",
+        billingAddress: {
+          address1: "500 Industrial Blvd",
+          address2: "Suite 100",
+          city: "Dallas",
+          provinceCode: "TX",
+          countryCode: "US",
+          zip: "75201",
+          phone: "+12145551234",
+        },
+        shippingAddress: {
+          address1: "500 Industrial Blvd",
+          address2: "Dock 3",
+          city: "Dallas",
+          provinceCode: "TX",
+          countryCode: "US",
+          zip: "75201",
+        },
+      },
+    },
+  },
+});
+```
+
+## Add Additional Contacts
+
+```typescript
+const CONTACT_CREATE = `
+  mutation companyContactCreate(
+    $companyId: ID!,
+    $input: CompanyContactInput!
+  ) {
+    companyContactCreate(companyId: $companyId, input: $input) {
+      companyContact {
+        id
+        customer { id email }
+        title
+        isMainContact
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CONTACT_CREATE, {
+  variables: {
+    companyId: "gid://shopify/Company/123",
+    input: {
+      email: "accounts@acme-dist.com",
+      firstName: "Mike",
+      lastName: "Johnson",
+      title: "Accounts Payable",
+    },
+  },
+});
+```
+
+## Add Additional Locations
+
+```typescript
+const LOCATION_CREATE = `
+  mutation companyLocationCreate(
+    $companyId: ID!,
+    $input: CompanyLocationInput!
+  ) {
+    companyLocationCreate(companyId: $companyId, input: $input) {
+      companyLocation {
+        id
+        name
+        shippingAddress { address1 city provinceCode }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(LOCATION_CREATE, {
+  variables: {
+    companyId: "gid://shopify/Company/123",
+    input: {
+      name: "West Coast Warehouse",
+      billingAddress: {
+        address1: "200 Pacific Ave",
+        city: "Los Angeles",
+        provinceCode: "CA",
+        countryCode: "US",
+        zip: "90001",
+      },
+      shippingAddress: {
+        address1: "200 Pacific Ave",
+        city: "Los Angeles",
+        provinceCode: "CA",
+        countryCode: "US",
+        zip: "90001",
+      },
+    },
+  },
+});
+```
+
+## Update a Company
+
+```typescript
+const COMPANY_UPDATE = `
+  mutation companyUpdate($companyId: ID!, $input: CompanyInput!) {
+    companyUpdate(companyId: $companyId, input: $input) {
+      company {
+        id
+        name
+        note
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(COMPANY_UPDATE, {
+  variables: {
+    companyId: "gid://shopify/Company/123",
+    input: {
+      name: "Acme Distribution International",
+      note: "Upgraded to Platinum tier Q1 2026",
+    },
+  },
+});
+```
+
+## Query Companies
+
+```typescript
+const COMPANIES_QUERY = `
+  query companies($first: Int!, $query: String, $after: String) {
+    companies(first: $first, query: $query, after: $after) {
+      edges {
+        node {
+          id
+          name
+          note
+          externalId
+          contactCount
+          locationCount
+          ordersCount
+          mainContact {
+            customer { email }
+          }
+          locations(first: 5) {
+            edges {
+              node {
+                id
+                name
+                catalogs(first: 5) {
+                  edges { node { id title } }
+                }
+              }
+            }
+          }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+// Search by name
+await client.request(COMPANIES_QUERY, {
+  variables: { first: 25, query: "name:Acme*" },
+});
+```
+
+## Delete a Company
+
+```typescript
+const COMPANY_DELETE = `
+  mutation companyDelete($id: ID!) {
+    companyDelete(id: $id) {
+      deletedCompanyId
+      userErrors { field message code }
+    }
+  }
+`;
+
+// WARNING: This also removes all associated contacts, locations, and catalog assignments
+await client.request(COMPANY_DELETE, {
+  variables: { id: "gid://shopify/Company/123" },
+});
+```
+
+## Assign Contact Roles
+
+```typescript
+const ASSIGN_ROLE = `
+  mutation companyContactAssignRole(
+    $companyContactId: ID!,
+    $companyContactRoleAssignment: CompanyContactRoleAssignmentInput!
+  ) {
+    companyContactAssignRole(
+      companyContactId: $companyContactId,
+      companyContactRoleAssignment: $companyContactRoleAssignment
+    ) {
+      companyContactRoleAssignment {
+        id
+        role { id name }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+// Roles: "Order only", "Location admin", "Location manager"
+await client.request(ASSIGN_ROLE, {
+  variables: {
+    companyContactId: "gid://shopify/CompanyContact/456",
+    companyContactRoleAssignment: {
+      companyLocationId: "gid://shopify/CompanyLocation/789",
+      roleId: "gid://shopify/CompanyContactRole/1", // Look up via companyContactRoles query
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: shopify-checkout-extensions
+description: |
+  Build Checkout UI Extensions to customize Shopify checkout with sandboxed React-like components.
+  Use when replacing checkout.liquid (deprecated Aug 2025), adding custom fields to checkout,
+  displaying banners, or reading checkout state with hooks.
+  Trigger with phrases like "shopify checkout extension", "shopify checkout ui",
+  "checkout customization shopify", "checkout.liquid migration", "shopify checkout components".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify Checkout UI Extensions
+
+## Overview
+
+Checkout UI Extensions replace checkout.liquid (deprecated August 2025) with sandboxed, React-like components at specific checkout targets. They run in isolation with no DOM access and a strict 64KB bundle limit, using Shopify's component library for consistent, accessible UIs.
+
+## Prerequisites
+
+- Shopify CLI 3.x+ and a Shopify Partners app
+- Node.js 18+, `@shopify/ui-extensions-react` package
+- Development store with checkout extensibility enabled
+
+## Instructions
+
+### Step 1: Configure the Extension
+
+```toml
+# extensions/checkout-banner/shopify.extension.toml
+api_version = "2025-01"
+type = "ui_extension"
+
+[[extensions.targeting]]
+module = "./src/Checkout.tsx"
+target = "purchase.checkout.block.render"
+
+[extensions.capabilities]
+api_access = true
+network_access = false
+```
+
+### Step 2: Build with UI Components
+
+```tsx
+import {
+  reactExtension, Banner, BlockStack, Text, useSettings,
+} from "@shopify/ui-extensions-react/checkout";
+
+export default reactExtension("purchase.checkout.block.render", () => <CheckoutBanner />);
+
+function CheckoutBanner() {
+  const { banner_text } = useSettings();
+  return (
+    <BlockStack spacing="tight">
+      <Banner status="info">{banner_text || "Free shipping over $50!"}</Banner>
+    </BlockStack>
+  );
+}
+```
+
+### Step 3: Read Checkout Data with Hooks
+
+```tsx
+import {
+  useApplyMetafieldsChange, useTotalAmount, useShippingAddress, TextField,
+} from "@shopify/ui-extensions-react/checkout";
+
+function DeliveryNote() {
+  const applyMetafieldsChange = useApplyMetafieldsChange();
+  return (
+    <TextField
+      label="Delivery instructions"
+      onChange={(value) => applyMetafieldsChange({
+        type: "updateMetafield",
+        namespace: "custom", key: "delivery_note",
+        valueType: "string", value,
+      })}
+    />
+  );
+}
+```
+
+### Step 4: Bundle Size Strategies
+
+```bash
+shopify app build --verbose  # Check output size
+# Import only what you use — each component adds ~1-3KB
+# Avoid lodash, date-fns, zod — use native JS
+# Split into multiple extensions if approaching 64KB
+```
+
+See [extension-targets.md](references/extension-targets.md) for all targets, [ui-components.md](references/ui-components.md) for components, and [bundle-optimization.md](references/bundle-optimization.md) for size strategies.
+
+## Output
+
+- Checkout UI extension rendering at the configured target point
+- Custom data collection via metafield writes from checkout
+- Merchant-configurable settings via the extension editor
+- Sandboxed execution with no impact on checkout performance
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `EXTENSION_LOAD_FAILED` | Bundle exceeds 64KB or invalid code | Tree-shake deps; check size with `--verbose` |
+| Sandbox violation | DOM access, `fetch`, or `window` usage | Use only Shopify components and hooks |
+| `CHECKOUT_COMPLETION_BLOCKED` | Extension error with `block_progress` | Add try/catch; test all edge cases |
+| Target not rendering | Wrong target or not enabled | Verify target in TOML; check admin placement |
+
+## Examples
+
+### Adding a Custom Field to Checkout
+
+Collect delivery instructions or gift messages by rendering a text input at a specific checkout target and saving the value as a cart metafield.
+
+See [Extension Targets](references/extension-targets.md) for all available targets and placement options.
+
+### Building a Reusable Checkout Banner
+
+Create a merchant-configurable promotional banner using Shopify's UI component library with proper accessibility.
+
+See [UI Components](references/ui-components.md) for available components and their key props.
+
+### Optimizing Extension Bundle Size
+
+Your checkout extension is approaching the 64KB limit. Apply tree-shaking, dependency auditing, and extension splitting strategies.
+
+See [Bundle Optimization](references/bundle-optimization.md) for size measurement and reduction techniques.
+
+## Resources
+
+- [Checkout UI Extensions Overview](https://shopify.dev/docs/apps/build/checkout)
+- [Extension Targets Reference](https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview)
+- [UI Component Library](https://shopify.dev/docs/api/checkout-ui-extensions/latest/components)
+- [checkout.liquid Migration Guide](https://shopify.dev/docs/apps/build/checkout/migrate-checkout-liquid)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/bundle-optimization.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/bundle-optimization.md
@@ -1,0 +1,107 @@
+Strategies for staying under the 64KB Checkout UI Extension bundle limit.
+
+## Measuring Bundle Size
+
+```bash
+# Build and check the output size
+shopify app build --verbose
+
+# The built extension is at:
+# extensions/[name]/dist/[target].js
+ls -la extensions/checkout-banner/dist/*.js
+
+# Detailed breakdown (if using esbuild directly)
+npx esbuild extensions/checkout-banner/src/Checkout.tsx \
+  --bundle --analyze --outfile=/dev/null
+```
+
+## Import Strategy
+
+### Import Only What You Use
+
+```tsx
+// BAD: Imports the entire library
+import * as UI from "@shopify/ui-extensions-react/checkout";
+
+// GOOD: Named imports enable tree-shaking
+import {
+  reactExtension,
+  Banner,
+  BlockStack,
+  Text,
+  useSettings,
+} from "@shopify/ui-extensions-react/checkout";
+```
+
+### Avoid Heavy Dependencies
+
+| Dependency | Size Impact | Alternative |
+|-----------|-------------|-------------|
+| `lodash` | ~70KB | Native array/object methods |
+| `date-fns` | ~30KB+ | `Intl.DateTimeFormat` or manual formatting |
+| `zod` | ~14KB | Manual validation (checkout data is typed) |
+| `uuid` | ~3KB | `crypto.randomUUID()` |
+| Any React router | N/A | Not applicable (single component, no routing) |
+
+## Code Splitting Between Extensions
+
+If your app has multiple checkout extensions, share code via a local package:
+
+```
+extensions/
+├── shared/
+│   ├── package.json
+│   └── src/
+│       ├── formatPrice.ts      # Shared utility
+│       └── constants.ts        # Shared config
+├── checkout-banner/
+│   ├── shopify.extension.toml
+│   └── src/Checkout.tsx        # Imports from ../shared/
+└── delivery-note/
+    ├── shopify.extension.toml
+    └── src/Checkout.tsx        # Imports from ../shared/
+```
+
+Each extension is bundled independently, so shared code is duplicated per bundle. Keep shared modules small.
+
+## Reducing Component Count
+
+```tsx
+// BAD: Many small components (each import adds overhead)
+import {
+  BlockStack, InlineStack, View, Grid,
+  Text, Heading, TextBlock,
+  Button, Pressable,
+  Banner, Divider, Image, Icon,
+  TextField, Checkbox, Select, ChoiceList,
+} from "@shopify/ui-extensions-react/checkout";
+
+// GOOD: Only what this extension actually renders
+import {
+  reactExtension,
+  BlockStack,
+  Banner,
+  Text,
+  useSettings,
+} from "@shopify/ui-extensions-react/checkout";
+```
+
+## When Approaching the Limit
+
+1. **Audit imports**: Remove unused components and hooks
+2. **Inline small utilities**: Don't import a library for one function
+3. **Split into multiple extensions**: Two 30KB extensions beat one 60KB extension
+4. **Move logic to metafields**: Pre-compute values in your app backend, store as metafields, read with `useAppMetafields()` — keeps the extension thin
+5. **Use `useSettings()`**: Let merchants configure text/values instead of hardcoding strings in the bundle
+
+## Size Budget Planning
+
+| Component | Approximate Cost |
+|-----------|-----------------|
+| Base extension boilerplate | ~5KB |
+| Each UI component import | ~1-3KB |
+| Each hook import | ~0.5-2KB |
+| Shared utility code | Varies |
+| **Target budget** | **< 50KB** (leave headroom) |
+
+Leave at least 14KB of headroom below the 64KB limit for Shopify's runtime overhead and future component updates.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/extension-targets.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/extension-targets.md
@@ -1,0 +1,77 @@
+All Checkout UI Extension targets with descriptions and common use cases.
+
+## Block Render Targets (Dynamic Placement)
+
+These targets allow merchants to place the extension anywhere in the checkout editor.
+
+| Target | Location | Use Case |
+|--------|----------|----------|
+| `purchase.checkout.block.render` | Merchant-configured block position | General-purpose: banners, upsells, custom fields |
+| `purchase.thank-you.block.render` | Thank you page (merchant-positioned) | Post-purchase surveys, referral prompts |
+| `customer-account.order-status.block.render` | Order status page | Tracking info, return initiation |
+
+## Static Render Targets (Fixed Position)
+
+These render at a specific, fixed location in the checkout flow.
+
+### Information Step
+| Target | Location |
+|--------|----------|
+| `purchase.checkout.header.render-after` | After the checkout header |
+| `purchase.checkout.contact.render-before` | Before email/phone fields |
+| `purchase.checkout.contact.render-after` | After email/phone fields |
+
+### Shipping Step
+| Target | Location |
+|--------|----------|
+| `purchase.checkout.delivery-address.render-before` | Before the shipping address form |
+| `purchase.checkout.delivery-address.render-after` | After the shipping address form |
+| `purchase.checkout.shipping-option-list.render-before` | Before shipping method options |
+| `purchase.checkout.shipping-option-list.render-after` | After shipping method options |
+| `purchase.checkout.shipping-option-item.render-after` | After each individual shipping option |
+| `purchase.checkout.pickup-point-list.render-before` | Before pickup point options |
+| `purchase.checkout.pickup-point-list.render-after` | After pickup point options |
+| `purchase.checkout.pickup-location-list.render-before` | Before local pickup locations |
+| `purchase.checkout.pickup-location-list.render-after` | After local pickup locations |
+
+### Payment Step
+| Target | Location |
+|--------|----------|
+| `purchase.checkout.payment-method-list.render-before` | Before payment methods |
+| `purchase.checkout.payment-method-list.render-after` | After payment methods |
+
+### Review & Completion
+| Target | Location |
+|--------|----------|
+| `purchase.checkout.reductions.render-before` | Before discount code field |
+| `purchase.checkout.reductions.render-after` | After discount code field |
+| `purchase.checkout.cart-line-list.render-after` | After the order summary line items |
+| `purchase.checkout.cart-line-item.render-after` | After each individual cart line item |
+| `purchase.checkout.footer.render-after` | After the checkout footer |
+| `purchase.checkout.actions.render-before` | Before the "Pay now" / "Complete order" button |
+
+### Thank You Page
+| Target | Location |
+|--------|----------|
+| `purchase.thank-you.header.render-after` | After thank you page header |
+| `purchase.thank-you.footer.render-after` | After thank you page footer |
+| `purchase.thank-you.cart-line-list.render-after` | After order summary on thank you |
+| `purchase.thank-you.cart-line-item.render-after` | After each line item on thank you |
+| `purchase.thank-you.customer-information.render-after` | After customer info on thank you |
+
+## Choosing the Right Target
+
+**For custom input fields** (delivery notes, gift messages):
+- `purchase.checkout.delivery-address.render-after` or `purchase.checkout.block.render`
+
+**For upsells/cross-sells**:
+- `purchase.checkout.cart-line-list.render-after` or `purchase.checkout.actions.render-before`
+
+**For trust badges/guarantees**:
+- `purchase.checkout.payment-method-list.render-after` or `purchase.checkout.footer.render-after`
+
+**For delivery date pickers**:
+- `purchase.checkout.shipping-option-list.render-after`
+
+**For post-purchase engagement**:
+- `purchase.thank-you.block.render`

--- a/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/ui-components.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/references/ui-components.md
@@ -1,0 +1,196 @@
+Available Checkout UI Extension components and their key props.
+
+## Layout Components
+
+### BlockStack
+Vertical stack with spacing control.
+```tsx
+<BlockStack spacing="base" padding="base">
+  <Text>Item 1</Text>
+  <Text>Item 2</Text>
+</BlockStack>
+// spacing: "none" | "extraTight" | "tight" | "base" | "loose" | "extraLoose"
+// padding: same values, or ["base", "none"] for [block, inline]
+```
+
+### InlineStack
+Horizontal stack.
+```tsx
+<InlineStack spacing="base" blockAlignment="center">
+  <Icon source="truck" />
+  <Text>Free shipping</Text>
+</InlineStack>
+// blockAlignment: "leading" | "center" | "trailing" | "baseline"
+// inlineAlignment: "leading" | "center" | "trailing"
+```
+
+### Grid
+CSS Grid layout.
+```tsx
+<Grid columns={["fill", "auto"]} spacing="base">
+  <View><Text>Left</Text></View>
+  <View><Text>Right</Text></View>
+</Grid>
+```
+
+### View
+Generic container (like a div).
+```tsx
+<View padding="base" border="base" cornerRadius="base">
+  <Text>Boxed content</Text>
+</View>
+```
+
+### Divider
+Horizontal rule.
+```tsx
+<Divider />
+```
+
+## Content Components
+
+### Text
+```tsx
+<Text size="medium" emphasis="bold" appearance="subdued">
+  Styled text
+</Text>
+// size: "extraSmall" | "small" | "base" | "medium" | "large" | "extraLarge"
+// emphasis: "bold" | "italic"
+// appearance: "accent" | "subdued" | "info" | "success" | "warning" | "critical" | "decorative"
+```
+
+### Heading
+```tsx
+<Heading level={2}>Section Title</Heading>
+// level: 1 | 2 | 3
+```
+
+### TextBlock
+Multi-line text with paragraph spacing.
+```tsx
+<TextBlock>Long paragraph text that wraps naturally.</TextBlock>
+```
+
+### Image
+```tsx
+<Image source="https://cdn.shopify.com/..." accessibilityDescription="Product photo" />
+// cornerRadius, aspectRatio, fit ("cover" | "contain") available
+```
+
+### Icon
+```tsx
+<Icon source="checkCircle" size="small" appearance="accent" />
+// Built-in sources: "arrowLeft", "arrowRight", "cart", "checkCircle", "chevronDown",
+// "chevronUp", "close", "critical", "discount", "email", "errorCircle",
+// "info", "lock", "marker", "mobile", "note", "pen", "plus", "profile",
+// "question", "star", "store", "success", "truck", "warning"
+```
+
+### Banner
+```tsx
+<Banner status="info" title="Optional title">
+  Banner content text.
+</Banner>
+// status: "info" | "success" | "warning" | "critical"
+// collapsible: boolean
+```
+
+## Form Components
+
+### TextField
+```tsx
+<TextField
+  label="Delivery Note"
+  value={note}
+  onChange={setNote}
+  maxLength={250}
+  multiline={3}
+  error="Required field"
+/>
+// type: "text" (default) | "email" | "telephone"
+```
+
+### Checkbox
+```tsx
+<Checkbox checked={agreed} onChange={setAgreed}>
+  I agree to the terms
+</Checkbox>
+```
+
+### Select
+```tsx
+<Select
+  label="Gift wrap style"
+  value={style}
+  onChange={setStyle}
+  options={[
+    { value: "none", label: "No wrapping" },
+    { value: "basic", label: "Basic ($3)" },
+    { value: "premium", label: "Premium ($8)" },
+  ]}
+/>
+```
+
+### ChoiceList
+Radio or checkbox group.
+```tsx
+<ChoiceList
+  name="delivery-speed"
+  value={[selected]}
+  onChange={setSelected}
+  variant="group"
+>
+  <Choice id="standard">Standard (3-5 days)</Choice>
+  <Choice id="express">Express (1-2 days)</Choice>
+</ChoiceList>
+```
+
+### DatePicker
+```tsx
+<DatePicker
+  selected={selectedDate}
+  onChange={setSelectedDate}
+  disabled={["2025-12-25", "2025-12-26"]}
+/>
+```
+
+### Button
+```tsx
+<Button kind="secondary" onPress={handleClick} loading={isLoading}>
+  Add gift wrap
+</Button>
+// kind: "primary" | "secondary" | "plain"
+// appearance: "critical" | "monochrome"
+```
+
+## Interactive Components
+
+### Pressable
+Clickable wrapper (like a button without button styling).
+```tsx
+<Pressable onPress={() => setExpanded(!expanded)}>
+  <InlineStack spacing="tight">
+    <Text>Show details</Text>
+    <Icon source={expanded ? "chevronUp" : "chevronDown"} />
+  </InlineStack>
+</Pressable>
+```
+
+### Disclosure
+Expandable/collapsible section.
+```tsx
+<Disclosure open={isOpen} onToggle={setIsOpen}>
+  <Pressable><Text>Toggle section</Text></Pressable>
+  <View padding="base">
+    <Text>Hidden content revealed on toggle.</Text>
+  </View>
+</Disclosure>
+```
+
+## Important Constraints
+
+- **No custom CSS**: All styling via component props (spacing, padding, appearance)
+- **No raw HTML**: Cannot use `<div>`, `<span>`, or any DOM elements
+- **No external fonts/images**: Must use Shopify CDN URLs or extension assets
+- **No `fetch`**: Use `useApplyMetafieldsChange` to write data; read via hooks
+- **64KB limit**: Every component import adds to bundle size

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-ci-integration
 description: |
   Configure CI/CD pipelines for Shopify apps with GitHub Actions, API version testing,
   and Shopify CLI deployment.
+  Use when setting up automated testing, deployment pipelines, or API version monitoring for Shopify apps.
   Trigger with phrases like "shopify CI", "shopify GitHub Actions",
   "shopify automated tests", "CI shopify", "shopify deploy pipeline".
 allowed-tools: Read, Write, Edit, Bash(gh:*)
@@ -29,91 +30,9 @@ Set up CI/CD pipelines for Shopify apps using GitHub Actions, including API vers
 
 ### Step 1: GitHub Actions Workflow
 
-```yaml
-# .github/workflows/shopify-ci.yml
-name: Shopify App CI
+Create a workflow with lint, test, API version check, and deploy jobs.
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-env:
-  SHOPIFY_API_VERSION: "2024-10"
-
-jobs:
-  lint-and-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run typecheck
-      - run: npm test -- --coverage
-        env:
-          SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
-          SHOPIFY_API_SECRET: ${{ secrets.SHOPIFY_API_SECRET }}
-
-  integration-test:
-    runs-on: ubuntu-latest
-    needs: lint-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-      - run: npm ci
-      - name: Run Shopify integration tests
-        run: npm run test:integration
-        env:
-          SHOPIFY_STORE: ${{ secrets.SHOPIFY_TEST_STORE }}
-          SHOPIFY_ACCESS_TOKEN: ${{ secrets.SHOPIFY_TEST_TOKEN }}
-          SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
-          SHOPIFY_API_SECRET: ${{ secrets.SHOPIFY_API_SECRET }}
-
-  api-version-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for deprecated API version
-        run: |
-          # Ensure we're not using an expired API version
-          VERSION=$(grep -r "apiVersion" src/ --include="*.ts" -h | head -1 | grep -oP '\d{4}-\d{2}')
-          echo "Using API version: $VERSION"
-
-          # Check if version is still supported
-          SUPPORTED=$(curl -sf -H "X-Shopify-Access-Token: ${{ secrets.SHOPIFY_TEST_TOKEN }}" \
-            "https://${{ secrets.SHOPIFY_TEST_STORE }}/admin/api/versions.json" \
-            | jq -r ".supported_versions[] | select(.handle == \"$VERSION\") | .supported")
-
-          if [ "$SUPPORTED" != "true" ]; then
-            echo "::warning::API version $VERSION is no longer supported!"
-            exit 1
-          fi
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [lint-and-test, integration-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - run: npm ci
-      - run: npm run build
-      - name: Deploy with Shopify CLI
-        run: npx shopify app deploy --force
-        env:
-          SHOPIFY_CLI_PARTNERS_TOKEN: ${{ secrets.SHOPIFY_PARTNERS_TOKEN }}
-```
+See [GitHub Actions Workflow](references/github-actions-workflow.md) for the complete `.github/workflows/shopify-ci.yml` file.
 
 ### Step 2: Configure Secrets
 
@@ -128,45 +47,9 @@ gh secret set SHOPIFY_PARTNERS_TOKEN --body "your_partners_cli_token"
 
 ### Step 3: Integration Test Structure
 
-```typescript
-// tests/integration/shopify.test.ts
-import { describe, it, expect, beforeAll } from "vitest";
+Write integration tests that verify store connectivity, required scopes, and rate limit compliance. Tests skip automatically when `SHOPIFY_ACCESS_TOKEN` is not set.
 
-const SKIP = !process.env.SHOPIFY_ACCESS_TOKEN;
-
-describe.skipIf(SKIP)("Shopify Integration", () => {
-  let client: any;
-
-  beforeAll(() => {
-    client = getGraphqlClient(process.env.SHOPIFY_STORE!);
-  });
-
-  it("should connect to store", async () => {
-    const response = await client.request("{ shop { name } }");
-    expect(response.data.shop.name).toBeTruthy();
-  });
-
-  it("should have required scopes", async () => {
-    const response = await client.request(`{
-      app { installation { accessScopes { handle } } }
-    }`);
-    const scopes = response.data.app.installation.accessScopes.map(
-      (s: any) => s.handle
-    );
-    expect(scopes).toContain("read_products");
-    expect(scopes).toContain("read_orders");
-  });
-
-  it("should query products within rate limits", async () => {
-    const response = await client.request(`{
-      products(first: 5) {
-        edges { node { id title } }
-      }
-    }`);
-    expect(response.extensions.cost.actualQueryCost).toBeLessThan(100);
-  });
-});
-```
+See [Integration Test Structure](references/integration-test-structure.md) for the complete Vitest test file.
 
 ## Output
 
@@ -199,7 +82,3 @@ describe.skipIf(SKIP)("Shopify Integration", () => {
 - [Shopify CLI for CI/CD](https://shopify.dev/docs/apps/build/cli-for-apps/ci-cd)
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [Shopify App Deployment](https://shopify.dev/docs/apps/build/cli-for-apps/deploy)
-
-## Next Steps
-
-For deployment patterns, see `shopify-deploy-integration`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/references/github-actions-workflow.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/references/github-actions-workflow.md
@@ -1,0 +1,87 @@
+Complete GitHub Actions workflow for Shopify app CI/CD with lint, test, API version check, and deployment.
+
+```yaml
+# .github/workflows/shopify-ci.yml
+name: Shopify App CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  SHOPIFY_API_VERSION: "2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test -- --coverage
+        env:
+          SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
+          SHOPIFY_API_SECRET: ${{ secrets.SHOPIFY_API_SECRET }}
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - name: Run Shopify integration tests
+        run: npm run test:integration
+        env:
+          SHOPIFY_STORE: ${{ secrets.SHOPIFY_TEST_STORE }}
+          SHOPIFY_ACCESS_TOKEN: ${{ secrets.SHOPIFY_TEST_TOKEN }}
+          SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
+          SHOPIFY_API_SECRET: ${{ secrets.SHOPIFY_API_SECRET }}
+
+  api-version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for deprecated API version
+        run: |
+          # Ensure we're not using an expired API version
+          VERSION=$(grep -r "apiVersion" src/ --include="*.ts" -h | head -1 | grep -oP '\d{4}-\d{2}')
+          echo "Using API version: $VERSION"
+
+          # Check if version is still supported
+          SUPPORTED=$(curl -sf -H "X-Shopify-Access-Token: ${{ secrets.SHOPIFY_TEST_TOKEN }}" \
+            "https://${{ secrets.SHOPIFY_TEST_STORE }}/admin/api/versions.json" \
+            | jq -r ".supported_versions[] | select(.handle == \"$VERSION\") | .supported")
+
+          if [ "$SUPPORTED" != "true" ]; then
+            echo "::warning::API version $VERSION is no longer supported!"
+            exit 1
+          fi
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, integration-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy with Shopify CLI
+        run: npx shopify app deploy --force
+        env:
+          SHOPIFY_CLI_PARTNERS_TOKEN: ${{ secrets.SHOPIFY_PARTNERS_TOKEN }}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/references/integration-test-structure.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/references/integration-test-structure.md
@@ -1,0 +1,41 @@
+Vitest integration test structure for verifying Shopify store connectivity, scopes, and rate limit compliance.
+
+```typescript
+// tests/integration/shopify.test.ts
+import { describe, it, expect, beforeAll } from "vitest";
+
+const SKIP = !process.env.SHOPIFY_ACCESS_TOKEN;
+
+describe.skipIf(SKIP)("Shopify Integration", () => {
+  let client: any;
+
+  beforeAll(() => {
+    client = getGraphqlClient(process.env.SHOPIFY_STORE!);
+  });
+
+  it("should connect to store", async () => {
+    const response = await client.request("{ shop { name } }");
+    expect(response.data.shop.name).toBeTruthy();
+  });
+
+  it("should have required scopes", async () => {
+    const response = await client.request(`{
+      app { installation { accessScopes { handle } } }
+    }`);
+    const scopes = response.data.app.installation.accessScopes.map(
+      (s: any) => s.handle
+    );
+    expect(scopes).toContain("read_products");
+    expect(scopes).toContain("read_orders");
+  });
+
+  it("should query products within rate limits", async () => {
+    const response = await client.request(`{
+      products(first: 5) {
+        edges { node { id title } }
+      }
+    }`);
+    expect(response.extensions.cost.actualQueryCost).toBeLessThan(100);
+  });
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/SKILL.md
@@ -37,104 +37,33 @@ Check whether the error is an HTTP status code error or a GraphQL `userErrors` r
 
 ### 401 Unauthorized
 
-**Actual Shopify Response:**
-```json
-{
-  "errors": "[API] Invalid API key or access token (unrecognized login or wrong password)"
-}
-```
+**Response:** `"[API] Invalid API key or access token (unrecognized login or wrong password)"`
 
-**Causes:**
-- Access token expired (merchant uninstalled and reinstalled)
-- Wrong `X-Shopify-Access-Token` header
-- Using a Storefront API token for Admin API or vice versa
+**Causes:** Access token expired (merchant uninstalled/reinstalled), wrong header, or using Storefront token for Admin API.
 
-**Fix:**
-```bash
-# Verify token format:
-# Admin API token: shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (32 hex chars)
-# Storefront API token: different format, starts with shpat_ too
-curl -s -o /dev/null -w "%{http_code}" \
-  -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://your-store.myshopify.com/admin/api/2024-10/shop.json"
-# Should return 200
-```
+**Fix:** Verify token format (`shpat_` + 32 hex chars) and test with a simple `shop.json` GET request.
 
 ---
 
 ### 403 Forbidden
 
-**Actual Shopify Response:**
-```json
-{
-  "errors": "This action requires merchant approval for read_orders scope."
-}
-```
+**Response:** `"This action requires merchant approval for read_orders scope."`
 
-**Cause:** Your app's access token lacks the required scope.
-
-**Fix:** Add the needed scope to your app config and re-trigger OAuth:
-```toml
-# shopify.app.toml
-[access_scopes]
-scopes = "read_products,write_products,read_orders,write_orders"
-```
+**Fix:** Add the needed scope to `shopify.app.toml` under `[access_scopes]` and re-trigger OAuth.
 
 ---
 
 ### 404 Not Found
 
-**Actual Shopify Response:**
-```json
-{
-  "errors": "Not Found"
-}
-```
+**Causes:** Wrong API version in URL, resource was deleted, or store domain is incorrect.
 
-**Causes:**
-- Wrong API version in URL
-- Resource was deleted
-- Store domain is incorrect
-
-**Fix:**
-```bash
-# Verify the API version exists
-curl -s "https://your-store.myshopify.com/admin/api/2024-10/shop.json" \
-  -H "X-Shopify-Access-Token: $TOKEN"
-
-# Check available API versions
-curl -s "https://your-store.myshopify.com/admin/api/versions.json" \
-  -H "X-Shopify-Access-Token: $TOKEN"
-```
+**Fix:** Verify the API version exists by checking `/admin/api/versions.json`.
 
 ---
 
 ### 422 Unprocessable Entity
 
-**Actual Shopify Responses:**
-```json
-{
-  "errors": {
-    "title": ["can't be blank"],
-    "handle": ["has already been taken"]
-  }
-}
-```
-
-```json
-{
-  "errors": {
-    "base": ["Product cannot be saved: Title is too long (maximum is 255 characters)"]
-  }
-}
-```
-
-**Common 422 triggers:**
-- Missing required fields (title, etc.)
-- Duplicate handle/slug
-- Invalid metafield type
-- Price format issues (must be string like "29.99")
-- Invalid country/province codes
+**Common triggers:** Missing required fields, duplicate handle/slug, invalid metafield type, price format issues (must be string like `"29.99"`), invalid country/province codes.
 
 **Fix:** Check the `errors` object or `userErrors` array for specific field-level messages.
 
@@ -142,37 +71,7 @@ curl -s "https://your-store.myshopify.com/admin/api/versions.json" \
 
 ### 429 Too Many Requests (Rate Limited)
 
-**REST API Response:**
-```
-HTTP/1.1 429 Too Many Requests
-Retry-After: 2.0
-```
-
-**GraphQL Response (in body, returns 200):**
-```json
-{
-  "errors": [
-    {
-      "message": "Throttled",
-      "extensions": {
-        "code": "THROTTLED",
-        "documentation": "https://shopify.dev/api/usage/rate-limits"
-      }
-    }
-  ],
-  "extensions": {
-    "cost": {
-      "requestedQueryCost": 752,
-      "actualQueryCost": null,
-      "throttleStatus": {
-        "maximumAvailable": 2000,
-        "currentlyAvailable": 0,
-        "restoreRate": 100
-      }
-    }
-  }
-}
-```
+REST returns `429` with `Retry-After` header. GraphQL returns `200` with `THROTTLED` error code in the body and zero `currentlyAvailable` points.
 
 **Fix:** See `shopify-rate-limits` skill for complete backoff implementation.
 
@@ -180,32 +79,11 @@ Retry-After: 2.0
 
 ### GraphQL userErrors (200 with Errors)
 
-**Critical: Shopify returns HTTP 200 even when mutations fail.**
+**Critical: Shopify returns HTTP 200 even when mutations fail.** Always check `userErrors` after every mutation:
 
-```json
-{
-  "data": {
-    "productCreate": {
-      "product": null,
-      "userErrors": [
-        {
-          "field": ["title"],
-          "message": "Title can't be blank",
-          "code": "BLANK"
-        }
-      ]
-    }
-  }
-}
-```
-
-**Always check `userErrors` after every mutation:**
 ```typescript
-const response = await client.request(mutation, { variables });
 const result = response.data.productCreate;
-
 if (result.userErrors.length > 0) {
-  // These are validation errors, NOT HTTP errors
   for (const err of result.userErrors) {
     console.error(`Field ${err.field?.join(".")}: ${err.message} (${err.code})`);
   }
@@ -217,21 +95,7 @@ if (result.userErrors.length > 0) {
 
 ### 5xx Server Errors
 
-**Shopify internal errors — not your fault, but you must handle them.**
-
-```json
-{
-  "errors": "Internal Server Error"
-}
-```
-
-**Fix:** Retry with exponential backoff. Include the `X-Request-Id` header value when reporting to Shopify support.
-
-```typescript
-// The X-Request-Id header is in every Shopify response
-const requestId = error.response?.headers?.["x-request-id"];
-console.error(`Shopify 500 error. Request ID: ${requestId}`);
-```
+Shopify internal errors -- not your fault. Retry with exponential backoff and capture the `X-Request-Id` header for support tickets.
 
 ## Output
 
@@ -255,45 +119,12 @@ console.error(`Shopify 500 error. Request ID: ${requestId}`);
 
 ### Quick Diagnostic Script
 
-```bash
-#!/bin/bash
-STORE="your-store.myshopify.com"
-TOKEN="$SHOPIFY_ACCESS_TOKEN"
-VERSION="2024-10"
+Run auth, scope, and API version checks in one pass.
 
-echo "=== Shopify Diagnostic ==="
-
-# 1. Test auth
-echo -n "Auth: "
-curl -s -o /dev/null -w "%{http_code}" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/$VERSION/shop.json"
-echo ""
-
-# 2. Check scopes
-echo "Scopes:"
-curl -s -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/oauth/access_scopes.json" | python3 -m json.tool
-
-# 3. Check API versions
-echo "API Versions:"
-curl -s -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/versions.json" | python3 -c "
-import json, sys
-versions = json.load(sys.stdin)['supported_versions']
-for v in versions[:5]:
-    print(f'  {v[\"handle\"]} {\"(latest)\" if v.get(\"latest\") else \"\"}')"
-
-# 4. Shopify status
-echo "Shopify Status: https://www.shopifystatus.com"
-```
+See [Diagnostic Script](references/diagnostic-script.md) for the complete shell script.
 
 ## Resources
 
 - [Shopify API Response Codes](https://shopify.dev/docs/api/usage/response-codes)
 - [GraphQL Error Handling](https://shopify.dev/docs/apps/build/graphql/basics/queries#error-handling)
 - [Shopify Status Page](https://www.shopifystatus.com)
-
-## Next Steps
-
-For comprehensive debugging, see `shopify-debug-bundle`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/references/diagnostic-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/references/diagnostic-script.md
@@ -1,0 +1,34 @@
+Quick diagnostic script that tests auth, scopes, API versions, and Shopify status in one pass.
+
+```bash
+#!/bin/bash
+STORE="your-store.myshopify.com"
+TOKEN="$SHOPIFY_ACCESS_TOKEN"
+VERSION="2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+
+echo "=== Shopify Diagnostic ==="
+
+# 1. Test auth
+echo -n "Auth: "
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/$VERSION/shop.json"
+echo ""
+
+# 2. Check scopes
+echo "Scopes:"
+curl -s -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/oauth/access_scopes.json" | python3 -m json.tool
+
+# 3. Check API versions
+echo "API Versions:"
+curl -s -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/versions.json" | python3 -c "
+import json, sys
+versions = json.load(sys.stdin)['supported_versions']
+for v in versions[:5]:
+    print(f'  {v[\"handle\"]} {\"(latest)\" if v.get(\"latest\") else \"\"}')"
+
+# 4. Shopify status
+echo "Shopify Status: https://www.shopifystatus.com"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
@@ -30,247 +30,33 @@ Primary workflow for Shopify: manage products, variants, collections, and invent
 
 ### Step 1: Create a Product
 
-```typescript
-// As of 2024-10, productCreate uses ProductCreateInput (not the old ProductInput)
-const CREATE_PRODUCT = `
-  mutation productCreate($input: ProductCreateInput!) {
-    productCreate(product: $input) {
-      product {
-        id
-        title
-        handle
-        status
-        variants(first: 10) {
-          edges {
-            node {
-              id
-              title
-              price
-              sku
-              inventoryQuantity
-            }
-          }
-        }
-      }
-      userErrors {
-        field
-        message
-        code
-      }
-    }
-  }
-`;
+Use `productCreate` with `ProductCreateInput` (as of 2024-10, this replaced the old unified `ProductInput`). Always check `userErrors` -- Shopify returns 200 even on validation failures.
 
-const response = await client.request(CREATE_PRODUCT, {
-  variables: {
-    input: {
-      title: "Premium Cotton T-Shirt",
-      descriptionHtml: "<p>Soft 100% organic cotton tee.</p>",
-      vendor: "My Brand",
-      productType: "Apparel",
-      tags: ["cotton", "organic", "summer"],
-      status: "DRAFT", // ACTIVE, DRAFT, or ARCHIVED
-      productOptions: [
-        {
-          name: "Size",
-          values: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
-        },
-        {
-          name: "Color",
-          values: [{ name: "Black" }, { name: "White" }, { name: "Navy" }],
-        },
-      ],
-    },
-  },
-});
-
-// ALWAYS check userErrors — Shopify returns 200 even on validation failures
-if (response.data.productCreate.userErrors.length > 0) {
-  console.error("Validation errors:", response.data.productCreate.userErrors);
-  // Example: [{ field: ["title"], message: "Title can't be blank", code: "BLANK" }]
-}
-```
+See [Product Create Mutation](references/product-create-mutation.md) for the complete mutation, variables, and error handling.
 
 ### Step 2: Update a Product
 
-```typescript
-// 2024-10+: productUpdate uses ProductUpdateInput (separate from create)
-const UPDATE_PRODUCT = `
-  mutation productUpdate($input: ProductUpdateInput!) {
-    productUpdate(product: $input) {
-      product {
-        id
-        title
-        status
-        updatedAt
-      }
-      userErrors {
-        field
-        message
-      }
-    }
-  }
-`;
+Use `productUpdate` with `ProductUpdateInput` (separate from create as of 2024-10). Supports metafield updates inline.
 
-await client.request(UPDATE_PRODUCT, {
-  variables: {
-    input: {
-      id: "gid://shopify/Product/1234567890",
-      title: "Updated Product Title",
-      status: "ACTIVE",
-      metafields: [
-        {
-          namespace: "custom",
-          key: "care_instructions",
-          value: "Machine wash cold",
-          type: "single_line_text_field",
-        },
-      ],
-    },
-  },
-});
-```
+See [Product Update Mutation](references/product-update-mutation.md) for the complete mutation and variables.
 
 ### Step 3: Query Products with Filtering
 
-```typescript
-// Search products with Shopify's query syntax
-const SEARCH_PRODUCTS = `
-  query products($query: String!, $first: Int!, $after: String) {
-    products(first: $first, after: $after, query: $query) {
-      edges {
-        node {
-          id
-          title
-          handle
-          status
-          productType
-          vendor
-          totalInventory
-          priceRangeV2 {
-            minVariantPrice { amount currencyCode }
-            maxVariantPrice { amount currencyCode }
-          }
-          images(first: 1) {
-            edges {
-              node { url altText }
-            }
-          }
-        }
-        cursor
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-`;
+Search products using Shopify's query syntax (`status:active`, `product_type:Apparel AND vendor:'My Brand'`, `tag:sale`, etc.) with cursor-based pagination.
 
-// Shopify query syntax examples:
-// "status:active"
-// "product_type:Apparel AND vendor:'My Brand'"
-// "inventory_total:>0"
-// "created_at:>2024-01-01"
-// "tag:sale"
-const data = await client.request(SEARCH_PRODUCTS, {
-  variables: {
-    query: "status:active AND product_type:Apparel",
-    first: 25,
-  },
-});
-```
+See [Search Products Query](references/search-products-query.md) for the complete query with pagination and query syntax examples.
 
 ### Step 4: Manage Variants and Pricing
 
-```typescript
-// Create variants in bulk
-const BULK_CREATE_VARIANTS = `
-  mutation productVariantsBulkCreate(
-    $productId: ID!,
-    $variants: [ProductVariantsBulkInput!]!
-  ) {
-    productVariantsBulkCreate(productId: $productId, variants: $variants) {
-      productVariants {
-        id
-        title
-        price
-        sku
-        barcode
-        inventoryQuantity
-        selectedOptions { name value }
-      }
-      userErrors {
-        field
-        message
-        code
-      }
-    }
-  }
-`;
+Create variants in bulk with `productVariantsBulkCreate`, including pricing, SKU, barcode, option values, and inventory quantities per location.
 
-await client.request(BULK_CREATE_VARIANTS, {
-  variables: {
-    productId: "gid://shopify/Product/1234567890",
-    variants: [
-      {
-        price: "29.99",
-        sku: "TSH-BLK-S",
-        barcode: "1234567890123",
-        optionValues: [
-          { optionName: "Color", name: "Black" },
-          { optionName: "Size", name: "S" },
-        ],
-        inventoryQuantities: [
-          {
-            availableQuantity: 100,
-            locationId: "gid://shopify/Location/1234",
-          },
-        ],
-      },
-    ],
-  },
-});
-```
+See [Bulk Create Variants](references/bulk-create-variants.md) for the complete mutation and variables.
 
 ### Step 5: Manage Collections
 
-```typescript
-// Create a smart (automated) collection
-const CREATE_SMART_COLLECTION = `
-  mutation collectionCreate($input: CollectionInput!) {
-    collectionCreate(input: $input) {
-      collection {
-        id
-        title
-        handle
-        productsCount
-        ruleSet {
-          appliedDisjunctively
-          rules { column relation condition }
-        }
-      }
-      userErrors { field message }
-    }
-  }
-`;
+Create smart (automated) collections with rule-based product matching using tag, product type, and other column filters.
 
-await client.request(CREATE_SMART_COLLECTION, {
-  variables: {
-    input: {
-      title: "Summer Sale",
-      descriptionHtml: "<p>All items on summer sale</p>",
-      ruleSet: {
-        appliedDisjunctively: false, // AND logic
-        rules: [
-          { column: "TAG", relation: "EQUALS", condition: "sale" },
-          { column: "PRODUCT_TYPE", relation: "EQUALS", condition: "Apparel" },
-        ],
-      },
-    },
-  },
-});
-```
+See [Smart Collection Create](references/smart-collection-create.md) for the complete mutation and variables.
 
 ## Output
 
@@ -322,7 +108,3 @@ await client.request(PRODUCT_SET, {
 - [productSet Mutation (Upsert)](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productSet)
 - [Product Object](https://shopify.dev/docs/api/admin-graphql/latest/objects/Product)
 - [2024-10 ProductInput Split](https://shopify.dev/docs/api/release-notes/2024-10)
-
-## Next Steps
-
-For order management workflow, see `shopify-core-workflow-b`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
@@ -73,7 +73,7 @@ See [Smart Collection Create](references/smart-collection-create.md) for the com
 | `userErrors: [{code: "BLANK", field: ["title"]}]` | Empty required field | Provide non-empty title |
 | `userErrors: [{code: "INVALID"}]` | Invalid metafield type | Check `type` matches Shopify's metafield types |
 | `Access denied` on `productCreate` | Missing `write_products` scope | Request scope in app config |
-| `Product not found` | Wrong GID format | Must be `gid://shopify/Product/{numeric_id}` |
+| `Product not found` | Wrong GID format | Must be `gid://shopify/Product/1234567890` (numeric ID) |
 
 ## Examples
 

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/bulk-create-variants.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/bulk-create-variants.md
@@ -1,0 +1,51 @@
+Bulk variant creation with pricing, SKU, barcode, option values, and inventory quantities.
+
+```typescript
+// Create variants in bulk
+const BULK_CREATE_VARIANTS = `
+  mutation productVariantsBulkCreate(
+    $productId: ID!,
+    $variants: [ProductVariantsBulkInput!]!
+  ) {
+    productVariantsBulkCreate(productId: $productId, variants: $variants) {
+      productVariants {
+        id
+        title
+        price
+        sku
+        barcode
+        inventoryQuantity
+        selectedOptions { name value }
+      }
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+`;
+
+await client.request(BULK_CREATE_VARIANTS, {
+  variables: {
+    productId: "gid://shopify/Product/1234567890",
+    variants: [
+      {
+        price: "29.99",
+        sku: "TSH-BLK-S",
+        barcode: "1234567890123",
+        optionValues: [
+          { optionName: "Color", name: "Black" },
+          { optionName: "Size", name: "S" },
+        ],
+        inventoryQuantities: [
+          {
+            availableQuantity: 100,
+            locationId: "gid://shopify/Location/1234",
+          },
+        ],
+      },
+    ],
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/product-create-mutation.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/product-create-mutation.md
@@ -1,0 +1,62 @@
+ProductCreate mutation with ProductCreateInput (2024-10+ split from old ProductInput), including options and variants setup.
+
+```typescript
+// As of 2024-10, productCreate uses ProductCreateInput (not the old ProductInput)
+const CREATE_PRODUCT = `
+  mutation productCreate($input: ProductCreateInput!) {
+    productCreate(product: $input) {
+      product {
+        id
+        title
+        handle
+        status
+        variants(first: 10) {
+          edges {
+            node {
+              id
+              title
+              price
+              sku
+              inventoryQuantity
+            }
+          }
+        }
+      }
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+`;
+
+const response = await client.request(CREATE_PRODUCT, {
+  variables: {
+    input: {
+      title: "Premium Cotton T-Shirt",
+      descriptionHtml: "<p>Soft 100% organic cotton tee.</p>",
+      vendor: "My Brand",
+      productType: "Apparel",
+      tags: ["cotton", "organic", "summer"],
+      status: "DRAFT", // ACTIVE, DRAFT, or ARCHIVED
+      productOptions: [
+        {
+          name: "Size",
+          values: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
+        },
+        {
+          name: "Color",
+          values: [{ name: "Black" }, { name: "White" }, { name: "Navy" }],
+        },
+      ],
+    },
+  },
+});
+
+// ALWAYS check userErrors — Shopify returns 200 even on validation failures
+if (response.data.productCreate.userErrors.length > 0) {
+  console.error("Validation errors:", response.data.productCreate.userErrors);
+  // Example: [{ field: ["title"], message: "Title can't be blank", code: "BLANK" }]
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/product-update-mutation.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/product-update-mutation.md
@@ -1,0 +1,39 @@
+ProductUpdate mutation with ProductUpdateInput (separate from create as of 2024-10), including metafield updates.
+
+```typescript
+// 2024-10+: productUpdate uses ProductUpdateInput (separate from create)
+const UPDATE_PRODUCT = `
+  mutation productUpdate($input: ProductUpdateInput!) {
+    productUpdate(product: $input) {
+      product {
+        id
+        title
+        status
+        updatedAt
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+await client.request(UPDATE_PRODUCT, {
+  variables: {
+    input: {
+      id: "gid://shopify/Product/1234567890",
+      title: "Updated Product Title",
+      status: "ACTIVE",
+      metafields: [
+        {
+          namespace: "custom",
+          key: "care_instructions",
+          value: "Machine wash cold",
+          type: "single_line_text_field",
+        },
+      ],
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/search-products-query.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/search-products-query.md
@@ -1,0 +1,49 @@
+Product search query with Shopify query syntax, pagination, and price/image data.
+
+```typescript
+// Search products with Shopify's query syntax
+const SEARCH_PRODUCTS = `
+  query products($query: String!, $first: Int!, $after: String) {
+    products(first: $first, after: $after, query: $query) {
+      edges {
+        node {
+          id
+          title
+          handle
+          status
+          productType
+          vendor
+          totalInventory
+          priceRangeV2 {
+            minVariantPrice { amount currencyCode }
+            maxVariantPrice { amount currencyCode }
+          }
+          images(first: 1) {
+            edges {
+              node { url altText }
+            }
+          }
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+// Shopify query syntax examples:
+// "status:active"
+// "product_type:Apparel AND vendor:'My Brand'"
+// "inventory_total:>0"
+// "created_at:>2024-01-01"
+// "tag:sale"
+const data = await client.request(SEARCH_PRODUCTS, {
+  variables: {
+    query: "status:active AND product_type:Apparel",
+    first: 25,
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/smart-collection-create.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/references/smart-collection-create.md
@@ -1,0 +1,38 @@
+Smart (automated) collection creation with rule-based product matching.
+
+```typescript
+// Create a smart (automated) collection
+const CREATE_SMART_COLLECTION = `
+  mutation collectionCreate($input: CollectionInput!) {
+    collectionCreate(input: $input) {
+      collection {
+        id
+        title
+        handle
+        productsCount
+        ruleSet {
+          appliedDisjunctively
+          rules { column relation condition }
+        }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(CREATE_SMART_COLLECTION, {
+  variables: {
+    input: {
+      title: "Summer Sale",
+      descriptionHtml: "<p>All items on summer sale</p>",
+      ruleSet: {
+        appliedDisjunctively: false, // AND logic
+        rules: [
+          { column: "TAG", relation: "EQUALS", condition: "sale" },
+          { column: "PRODUCT_TYPE", relation: "EQUALS", condition: "Apparel" },
+        ],
+      },
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
@@ -66,7 +66,7 @@ See [Customer Search Query](references/customer-search-query.md) for the complet
 | `Access denied for orders` | Missing `read_orders` scope | Add scope and re-auth |
 | `Fulfillment order not found` | Wrong fulfillment order ID | Query fulfillment orders first |
 | `Cannot fulfill: already fulfilled` | Order already shipped | Check `remainingQuantity > 0` |
-| `Customer not found` | Invalid customer GID | Verify GID format `gid://shopify/Customer/{id}` |
+| `Customer not found` | Invalid customer GID | Verify GID format `gid://shopify/Customer/1234567890` (numeric ID) |
 | `Order is not editable` | Order already archived | Only draft/open orders are editable |
 | `THROTTLED` | Rate limit exceeded | Implement backoff -- see `shopify-rate-limits` |
 

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
@@ -30,252 +30,27 @@ Secondary core workflow: manage orders, customers, and fulfillments. Query order
 
 ### Step 1: Query Orders
 
-```typescript
-const QUERY_ORDERS = `
-  query orders($first: Int!, $query: String, $after: String) {
-    orders(first: $first, query: $query, after: $after, sortKey: CREATED_AT, reverse: true) {
-      edges {
-        node {
-          id
-          name                    # "#1001"
-          createdAt
-          displayFinancialStatus  # PAID, PENDING, REFUNDED, etc.
-          displayFulfillmentStatus # FULFILLED, UNFULFILLED, PARTIALLY_FULFILLED
-          totalPriceSet {
-            shopMoney { amount currencyCode }
-          }
-          customer {
-            id
-            displayName
-            email
-          }
-          lineItems(first: 10) {
-            edges {
-              node {
-                title
-                quantity
-                variant {
-                  id
-                  sku
-                  price
-                }
-                originalTotalSet {
-                  shopMoney { amount currencyCode }
-                }
-              }
-            }
-          }
-          shippingAddress {
-            address1
-            city
-            province
-            country
-            zip
-          }
-        }
-        cursor
-      }
-      pageInfo { hasNextPage endCursor }
-    }
-  }
-`;
+Query orders with financial/fulfillment status filters, line items, customer data, and shipping addresses. Uses Shopify query syntax (`financial_status:paid`, `fulfillment_status:unfulfilled`, `name:#1001`, etc.).
 
-// Shopify order query syntax:
-// "financial_status:paid"
-// "fulfillment_status:unfulfilled"
-// "created_at:>2024-01-01"
-// "name:#1001"
-// "email:customer@example.com"
-// "tag:rush"
-const data = await client.request(QUERY_ORDERS, {
-  variables: {
-    first: 25,
-    query: "financial_status:paid AND fulfillment_status:unfulfilled",
-  },
-});
-```
+See [Query Orders](references/query-orders.md) for the complete query with pagination and query syntax examples.
 
 ### Step 2: Create a Draft Order
 
-```typescript
-const CREATE_DRAFT_ORDER = `
-  mutation draftOrderCreate($input: DraftOrderInput!) {
-    draftOrderCreate(input: $input) {
-      draftOrder {
-        id
-        name
-        totalPriceSet {
-          shopMoney { amount currencyCode }
-        }
-        invoiceUrl
-      }
-      userErrors {
-        field
-        message
-      }
-    }
-  }
-`;
+Create draft orders with variant line items, custom line items, discounts, shipping addresses, and customer assignment.
 
-await client.request(CREATE_DRAFT_ORDER, {
-  variables: {
-    input: {
-      lineItems: [
-        {
-          variantId: "gid://shopify/ProductVariant/12345",
-          quantity: 2,
-        },
-        {
-          title: "Custom Engraving", // Custom line item (no variant)
-          originalUnitPrice: "15.00",
-          quantity: 1,
-        },
-      ],
-      customerId: "gid://shopify/Customer/67890",
-      note: "Rush order — ship priority",
-      tags: ["wholesale", "rush"],
-      shippingAddress: {
-        address1: "123 Main St",
-        city: "Portland",
-        provinceCode: "OR",
-        countryCode: "US",
-        zip: "97201",
-      },
-      appliedDiscount: {
-        title: "Wholesale 10%",
-        value: 10.0,
-        valueType: "PERCENTAGE",
-      },
-    },
-  },
-});
-```
+See [Draft Order Create](references/draft-order-create.md) for the complete mutation and variables.
 
 ### Step 3: Process Fulfillment
 
-```typescript
-// Step 3a: Get fulfillment orders for an order
-const GET_FULFILLMENT_ORDERS = `
-  query fulfillmentOrders($orderId: ID!) {
-    order(id: $orderId) {
-      fulfillmentOrders(first: 10) {
-        edges {
-          node {
-            id
-            status  # OPEN, IN_PROGRESS, CLOSED, CANCELLED
-            assignedLocation {
-              name
-            }
-            lineItems(first: 20) {
-              edges {
-                node {
-                  id
-                  totalQuantity
-                  remainingQuantity
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+Two-step process: first query fulfillment orders for an order to get line item IDs, then create the fulfillment with tracking information and customer notification.
 
-// Step 3b: Create fulfillment with tracking
-const CREATE_FULFILLMENT = `
-  mutation fulfillmentCreate($fulfillment: FulfillmentInput!) {
-    fulfillmentCreate(fulfillment: $fulfillment) {
-      fulfillment {
-        id
-        status
-        trackingInfo {
-          number
-          url
-          company
-        }
-      }
-      userErrors { field message }
-    }
-  }
-`;
-
-await client.request(CREATE_FULFILLMENT, {
-  variables: {
-    fulfillment: {
-      lineItemsByFulfillmentOrder: [
-        {
-          fulfillmentOrderId: "gid://shopify/FulfillmentOrder/99999",
-          fulfillmentOrderLineItems: [
-            {
-              id: "gid://shopify/FulfillmentOrderLineItem/11111",
-              quantity: 2,
-            },
-          ],
-        },
-      ],
-      trackingInfo: {
-        number: "1Z999AA10123456784",
-        url: "https://www.ups.com/track?tracknum=1Z999AA10123456784",
-        company: "UPS",
-      },
-      notifyCustomer: true,
-    },
-  },
-});
-```
+See [Fulfillment Processing](references/fulfillment-processing.md) for both queries and the complete workflow.
 
 ### Step 4: Customer Management
 
-```typescript
-// Query customers
-const SEARCH_CUSTOMERS = `
-  query customers($query: String!, $first: Int!) {
-    customers(first: $first, query: $query) {
-      edges {
-        node {
-          id
-          displayName
-          email
-          phone
-          numberOfOrders
-          amountSpent { amount currencyCode }
-          tags
-          addresses(first: 3) {
-            address1
-            city
-            province
-            country
-          }
-          metafields(first: 5) {
-            edges {
-              node {
-                namespace
-                key
-                value
-                type
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+Search customers by email, order count, total spent, tags, and state. Returns addresses and metafields.
 
-// Customer query examples:
-// "email:john@example.com"
-// "orders_count:>5"
-// "total_spent:>100"
-// "tag:vip"
-// "state:enabled"
-const customers = await client.request(SEARCH_CUSTOMERS, {
-  variables: {
-    query: "orders_count:>5 AND total_spent:>100",
-    first: 20,
-  },
-});
-```
+See [Customer Search Query](references/customer-search-query.md) for the complete query and syntax examples.
 
 ## Output
 
@@ -293,7 +68,7 @@ const customers = await client.request(SEARCH_CUSTOMERS, {
 | `Cannot fulfill: already fulfilled` | Order already shipped | Check `remainingQuantity > 0` |
 | `Customer not found` | Invalid customer GID | Verify GID format `gid://shopify/Customer/{id}` |
 | `Order is not editable` | Order already archived | Only draft/open orders are editable |
-| `THROTTLED` | Rate limit exceeded | Implement backoff — see `shopify-rate-limits` |
+| `THROTTLED` | Rate limit exceeded | Implement backoff -- see `shopify-rate-limits` |
 
 ## Examples
 
@@ -320,36 +95,9 @@ const ORDER_ANALYTICS = `
 
 ### Refund an Order
 
-```typescript
-const REFUND_CREATE = `
-  mutation refundCreate($input: RefundInput!) {
-    refundCreate(input: $input) {
-      refund {
-        id
-        totalRefundedSet { shopMoney { amount currencyCode } }
-      }
-      userErrors { field message }
-    }
-  }
-`;
+Create a refund with line item restock and customer notification.
 
-await client.request(REFUND_CREATE, {
-  variables: {
-    input: {
-      orderId: "gid://shopify/Order/12345",
-      note: "Customer requested return",
-      notify: true,
-      refundLineItems: [
-        {
-          lineItemId: "gid://shopify/LineItem/67890",
-          quantity: 1,
-          restockType: "RETURN",
-        },
-      ],
-    },
-  },
-});
-```
+See [Refund Create](references/refund-create.md) for the complete mutation and variables.
 
 ## Resources
 
@@ -357,7 +105,3 @@ await client.request(REFUND_CREATE, {
 - [FulfillmentCreate Mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentCreate)
 - [Customer Object](https://shopify.dev/docs/api/admin-graphql/latest/objects/Customer)
 - [Draft Orders](https://shopify.dev/docs/api/admin-graphql/latest/mutations/draftOrderCreate)
-
-## Next Steps
-
-For common errors, see `shopify-common-errors`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/customer-search-query.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/customer-search-query.md
@@ -1,0 +1,51 @@
+Customer search query with spending, order count, tags, addresses, and metafields.
+
+```typescript
+// Query customers
+const SEARCH_CUSTOMERS = `
+  query customers($query: String!, $first: Int!) {
+    customers(first: $first, query: $query) {
+      edges {
+        node {
+          id
+          displayName
+          email
+          phone
+          numberOfOrders
+          amountSpent { amount currencyCode }
+          tags
+          addresses(first: 3) {
+            address1
+            city
+            province
+            country
+          }
+          metafields(first: 5) {
+            edges {
+              node {
+                namespace
+                key
+                value
+                type
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Customer query examples:
+// "email:john@example.com"
+// "orders_count:>5"
+// "total_spent:>100"
+// "tag:vip"
+// "state:enabled"
+const customers = await client.request(SEARCH_CUSTOMERS, {
+  variables: {
+    query: "orders_count:>5 AND total_spent:>100",
+    first: 20,
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/draft-order-create.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/draft-order-create.md
@@ -1,0 +1,55 @@
+Draft order creation with line items, custom items, discounts, and shipping address.
+
+```typescript
+const CREATE_DRAFT_ORDER = `
+  mutation draftOrderCreate($input: DraftOrderInput!) {
+    draftOrderCreate(input: $input) {
+      draftOrder {
+        id
+        name
+        totalPriceSet {
+          shopMoney { amount currencyCode }
+        }
+        invoiceUrl
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+await client.request(CREATE_DRAFT_ORDER, {
+  variables: {
+    input: {
+      lineItems: [
+        {
+          variantId: "gid://shopify/ProductVariant/12345",
+          quantity: 2,
+        },
+        {
+          title: "Custom Engraving", // Custom line item (no variant)
+          originalUnitPrice: "15.00",
+          quantity: 1,
+        },
+      ],
+      customerId: "gid://shopify/Customer/67890",
+      note: "Rush order — ship priority",
+      tags: ["wholesale", "rush"],
+      shippingAddress: {
+        address1: "123 Main St",
+        city: "Portland",
+        provinceCode: "OR",
+        countryCode: "US",
+        zip: "97201",
+      },
+      appliedDiscount: {
+        title: "Wholesale 10%",
+        value: 10.0,
+        valueType: "PERCENTAGE",
+      },
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/fulfillment-processing.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/fulfillment-processing.md
@@ -1,0 +1,77 @@
+Two-step fulfillment processing: query fulfillment orders, then create fulfillment with tracking info.
+
+### Step 3a: Get fulfillment orders
+
+```typescript
+const GET_FULFILLMENT_ORDERS = `
+  query fulfillmentOrders($orderId: ID!) {
+    order(id: $orderId) {
+      fulfillmentOrders(first: 10) {
+        edges {
+          node {
+            id
+            status  # OPEN, IN_PROGRESS, CLOSED, CANCELLED
+            assignedLocation {
+              name
+            }
+            lineItems(first: 20) {
+              edges {
+                node {
+                  id
+                  totalQuantity
+                  remainingQuantity
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+```
+
+### Step 3b: Create fulfillment with tracking
+
+```typescript
+const CREATE_FULFILLMENT = `
+  mutation fulfillmentCreate($fulfillment: FulfillmentInput!) {
+    fulfillmentCreate(fulfillment: $fulfillment) {
+      fulfillment {
+        id
+        status
+        trackingInfo {
+          number
+          url
+          company
+        }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(CREATE_FULFILLMENT, {
+  variables: {
+    fulfillment: {
+      lineItemsByFulfillmentOrder: [
+        {
+          fulfillmentOrderId: "gid://shopify/FulfillmentOrder/99999",
+          fulfillmentOrderLineItems: [
+            {
+              id: "gid://shopify/FulfillmentOrderLineItem/11111",
+              quantity: 2,
+            },
+          ],
+        },
+      ],
+      trackingInfo: {
+        number: "1Z999AA10123456784",
+        url: "https://www.ups.com/track?tracknum=1Z999AA10123456784",
+        company: "UPS",
+      },
+      notifyCustomer: true,
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/query-orders.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/query-orders.md
@@ -1,0 +1,66 @@
+Order query with financial/fulfillment status, line items, customer, and shipping data plus pagination.
+
+```typescript
+const QUERY_ORDERS = `
+  query orders($first: Int!, $query: String, $after: String) {
+    orders(first: $first, query: $query, after: $after, sortKey: CREATED_AT, reverse: true) {
+      edges {
+        node {
+          id
+          name                    # "#1001"
+          createdAt
+          displayFinancialStatus  # PAID, PENDING, REFUNDED, etc.
+          displayFulfillmentStatus # FULFILLED, UNFULFILLED, PARTIALLY_FULFILLED
+          totalPriceSet {
+            shopMoney { amount currencyCode }
+          }
+          customer {
+            id
+            displayName
+            email
+          }
+          lineItems(first: 10) {
+            edges {
+              node {
+                title
+                quantity
+                variant {
+                  id
+                  sku
+                  price
+                }
+                originalTotalSet {
+                  shopMoney { amount currencyCode }
+                }
+              }
+            }
+          }
+          shippingAddress {
+            address1
+            city
+            province
+            country
+            zip
+          }
+        }
+        cursor
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+// Shopify order query syntax:
+// "financial_status:paid"
+// "fulfillment_status:unfulfilled"
+// "created_at:>2024-01-01"
+// "name:#1001"
+// "email:customer@example.com"
+// "tag:rush"
+const data = await client.request(QUERY_ORDERS, {
+  variables: {
+    first: 25,
+    query: "financial_status:paid AND fulfillment_status:unfulfilled",
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/refund-create.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/references/refund-create.md
@@ -1,0 +1,32 @@
+Refund creation mutation with line item restock and customer notification.
+
+```typescript
+const REFUND_CREATE = `
+  mutation refundCreate($input: RefundInput!) {
+    refundCreate(input: $input) {
+      refund {
+        id
+        totalRefundedSet { shopMoney { amount currencyCode } }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(REFUND_CREATE, {
+  variables: {
+    input: {
+      orderId: "gid://shopify/Order/12345",
+      note: "Customer requested return",
+      notify: true,
+      refundLineItems: [
+        {
+          lineItemId: "gid://shopify/LineItem/67890",
+          quantity: 1,
+          restockType: "RETURN",
+        },
+      ],
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-cost-tuning
 description: |
   Optimize Shopify app costs through plan selection, API usage monitoring,
   and Shopify Plus upgrade analysis.
+  Use when analyzing API spend, choosing between Shopify plans, or reducing billable API calls.
   Trigger with phrases like "shopify cost", "shopify billing",
   "shopify pricing", "shopify Plus worth it", "shopify API usage", "reduce shopify costs".
 allowed-tools: Read, Grep
@@ -42,148 +43,21 @@ API rate limits are determined by the **merchant's** plan, not your app:
 
 ### Step 2: App Billing API
 
-If your app charges merchants, use the GraphQL App Billing API:
+If your app charges merchants, use the GraphQL `appSubscriptionCreate` mutation to create recurring charges. Set `test: true` in development to avoid real billing.
 
-```typescript
-// Create a recurring charge
-const CREATE_SUBSCRIPTION = `
-  mutation appSubscriptionCreate(
-    $name: String!,
-    $lineItems: [AppSubscriptionLineItemInput!]!,
-    $returnUrl: URL!,
-    $test: Boolean
-  ) {
-    appSubscriptionCreate(
-      name: $name,
-      lineItems: $lineItems,
-      returnUrl: $returnUrl,
-      test: $test
-    ) {
-      appSubscription {
-        id
-        status
-      }
-      confirmationUrl
-      userErrors { field message }
-    }
-  }
-`;
-
-const response = await client.request(CREATE_SUBSCRIPTION, {
-  variables: {
-    name: "Pro Plan",
-    returnUrl: "https://your-app.com/billing/callback",
-    test: process.env.NODE_ENV !== "production", // test charges in dev
-    lineItems: [
-      {
-        plan: {
-          appRecurringPricingDetails: {
-            price: { amount: 9.99, currencyCode: "USD" },
-            interval: "EVERY_30_DAYS",
-          },
-        },
-      },
-    ],
-  },
-});
-
-// Redirect merchant to confirmationUrl to approve the charge
-```
+See [App Billing API](references/app-billing-api.md) for the complete mutation and variable setup.
 
 ### Step 3: Monitor API Usage
 
-```typescript
-class ShopifyUsageTracker {
-  private graphqlCosts: number[] = [];
-  private restCalls: number = 0;
-  private startOfPeriod: Date = new Date();
+Track GraphQL query costs and REST call counts over time to identify optimization opportunities. Log `extensions.cost.actualQueryCost` from every GraphQL response.
 
-  trackGraphqlCost(extensions: any): void {
-    if (extensions?.cost?.actualQueryCost) {
-      this.graphqlCosts.push(extensions.cost.actualQueryCost);
-    }
-  }
-
-  trackRestCall(): void {
-    this.restCalls++;
-  }
-
-  getReport(): UsageReport {
-    const totalGraphqlCost = this.graphqlCosts.reduce((a, b) => a + b, 0);
-    const avgCost = totalGraphqlCost / (this.graphqlCosts.length || 1);
-
-    return {
-      period: {
-        start: this.startOfPeriod,
-        end: new Date(),
-      },
-      graphql: {
-        totalQueries: this.graphqlCosts.length,
-        totalCost: totalGraphqlCost,
-        averageCost: Math.round(avgCost),
-        maxSingleCost: Math.max(...this.graphqlCosts, 0),
-      },
-      rest: {
-        totalCalls: this.restCalls,
-      },
-      recommendation: avgCost > 500
-        ? "High average query cost — optimize field selection"
-        : avgCost > 100
-        ? "Moderate cost — consider bulk operations for large queries"
-        : "Efficient usage",
-    };
-  }
-}
-```
+See [Usage Tracker Class](references/usage-tracker-class.md) for a complete tracking implementation with reporting.
 
 ### Step 4: Cost Reduction Strategies
 
-**Strategy 1: Replace REST with GraphQL** (get only what you need)
+Four key strategies: replace REST with GraphQL for targeted field selection, use bulk operations for exports, cache responses and invalidate via webhooks, and use Storefront API for public data.
 
-```typescript
-// REST returns ALL fields — 5KB+ per product
-// GET /admin/api/2024-10/products/123.json
-// Returns: title, body_html, vendor, product_type, handle, template_suffix,
-//          published_scope, tags, admin_graphql_api_id, variants[], images[],
-//          options[], ... (everything)
-
-// GraphQL returns ONLY requested fields — 200 bytes
-const response = await client.request(`{
-  product(id: "gid://shopify/Product/123") {
-    title
-    status
-    totalInventory
-  }
-}`);
-```
-
-**Strategy 2: Use Bulk Operations for exports**
-
-```typescript
-// Instead of 200 paginated queries (200 * ~100 cost = 20,000 points):
-// Use 1 bulk operation (minimal cost, runs in background)
-await client.request(`
-  mutation { bulkOperationRunQuery(query: """
-    { products { edges { node { id title } } } }
-  """) { bulkOperation { id status } userErrors { message } } }
-`);
-```
-
-**Strategy 3: Cache and invalidate via webhooks**
-
-```typescript
-// Instead of re-querying products every request:
-// Cache products, invalidate only when products/update webhook fires
-// Saves: hundreds of queries per hour for read-heavy apps
-```
-
-**Strategy 4: Use Storefront API for public data**
-
-```typescript
-// Storefront API has separate rate limits
-// Use it for: product listings, collections, search
-// Keep Admin API for: order management, customer data, fulfillments
-```
+See [Cost Reduction Strategies](references/cost-reduction-strategies.md) for code examples of each approach.
 
 ## Output
 
@@ -223,7 +97,3 @@ if (cost) {
 - [App Billing API](https://shopify.dev/docs/apps/build/billing)
 - [Shopify Pricing](https://www.shopify.com/pricing)
 - [Shopify Plus Rate Limits](https://shopify.dev/changelog/increased-admin-api-rate-limits-for-shopify-plus)
-
-## Next Steps
-
-For architecture patterns, see `shopify-reference-architecture`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/app-billing-api.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/app-billing-api.md
@@ -1,0 +1,47 @@
+Complete GraphQL mutation for creating a recurring app subscription charge via the Shopify Billing API.
+
+```typescript
+// Create a recurring charge
+const CREATE_SUBSCRIPTION = `
+  mutation appSubscriptionCreate(
+    $name: String!,
+    $lineItems: [AppSubscriptionLineItemInput!]!,
+    $returnUrl: URL!,
+    $test: Boolean
+  ) {
+    appSubscriptionCreate(
+      name: $name,
+      lineItems: $lineItems,
+      returnUrl: $returnUrl,
+      test: $test
+    ) {
+      appSubscription {
+        id
+        status
+      }
+      confirmationUrl
+      userErrors { field message }
+    }
+  }
+`;
+
+const response = await client.request(CREATE_SUBSCRIPTION, {
+  variables: {
+    name: "Pro Plan",
+    returnUrl: "https://your-app.com/billing/callback",
+    test: process.env.NODE_ENV !== "production", // test charges in dev
+    lineItems: [
+      {
+        plan: {
+          appRecurringPricingDetails: {
+            price: { amount: 9.99, currencyCode: "USD" },
+            interval: "EVERY_30_DAYS",
+          },
+        },
+      },
+    ],
+  },
+});
+
+// Redirect merchant to confirmationUrl to approve the charge
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/cost-reduction-strategies.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/cost-reduction-strategies.md
@@ -1,0 +1,48 @@
+Four strategies for reducing Shopify API costs and improving efficiency.
+
+**Strategy 1: Replace REST with GraphQL** (get only what you need)
+
+```typescript
+// REST returns ALL fields — 5KB+ per product
+// GET /admin/api/{version}/products/123.json
+// Returns: title, body_html, vendor, product_type, handle, template_suffix,
+//          published_scope, tags, admin_graphql_api_id, variants[], images[],
+//          options[], ... (everything)
+
+// GraphQL returns ONLY requested fields — 200 bytes
+const response = await client.request(`{
+  product(id: "gid://shopify/Product/123") {
+    title
+    status
+    totalInventory
+  }
+}`);
+```
+
+**Strategy 2: Use Bulk Operations for exports**
+
+```typescript
+// Instead of 200 paginated queries (200 * ~100 cost = 20,000 points):
+// Use 1 bulk operation (minimal cost, runs in background)
+await client.request(`
+  mutation { bulkOperationRunQuery(query: """
+    { products { edges { node { id title } } } }
+  """) { bulkOperation { id status } userErrors { message } } }
+`);
+```
+
+**Strategy 3: Cache and invalidate via webhooks**
+
+```typescript
+// Instead of re-querying products every request:
+// Cache products, invalidate only when products/update webhook fires
+// Saves: hundreds of queries per hour for read-heavy apps
+```
+
+**Strategy 4: Use Storefront API for public data**
+
+```typescript
+// Storefront API has separate rate limits
+// Use it for: product listings, collections, search
+// Keep Admin API for: order management, customer data, fulfillments
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/usage-tracker-class.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/references/usage-tracker-class.md
@@ -1,0 +1,45 @@
+A class for tracking GraphQL query costs and REST API call counts, with reporting and optimization recommendations.
+
+```typescript
+class ShopifyUsageTracker {
+  private graphqlCosts: number[] = [];
+  private restCalls: number = 0;
+  private startOfPeriod: Date = new Date();
+
+  trackGraphqlCost(extensions: any): void {
+    if (extensions?.cost?.actualQueryCost) {
+      this.graphqlCosts.push(extensions.cost.actualQueryCost);
+    }
+  }
+
+  trackRestCall(): void {
+    this.restCalls++;
+  }
+
+  getReport(): UsageReport {
+    const totalGraphqlCost = this.graphqlCosts.reduce((a, b) => a + b, 0);
+    const avgCost = totalGraphqlCost / (this.graphqlCosts.length || 1);
+
+    return {
+      period: {
+        start: this.startOfPeriod,
+        end: new Date(),
+      },
+      graphql: {
+        totalQueries: this.graphqlCosts.length,
+        totalCost: totalGraphqlCost,
+        averageCost: Math.round(avgCost),
+        maxSingleCost: Math.max(...this.graphqlCosts, 0),
+      },
+      rest: {
+        totalCalls: this.restCalls,
+      },
+      recommendation: avgCost > 500
+        ? "High average query cost — optimize field selection"
+        : avgCost > 100
+        ? "Moderate cost — consider bulk operations for large queries"
+        : "Efficient usage",
+    };
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-data-handling
 description: |
   Handle Shopify customer PII, implement GDPR/CCPA compliance, and manage data retention
   with Shopify's mandatory privacy webhooks.
+  Use when building apps that store customer data, preparing for App Store review, or implementing deletion workflows.
   Trigger with phrases like "shopify data", "shopify PII", "shopify GDPR",
   "shopify customer data", "shopify privacy", "shopify CCPA", "shopify data request".
 allowed-tools: Read, Write, Edit
@@ -41,177 +42,21 @@ When a merchant grants your app access, you may receive:
 
 ### Step 2: Implement Mandatory Privacy Webhooks
 
-Shopify **requires** three GDPR webhooks for App Store apps. Your app will be **rejected** without them.
+Shopify **requires** three GDPR webhooks for App Store apps. Your app will be **rejected** without them: `customers/data_request` (customer wants their data), `customers/redact` (delete a customer's PII), and `shop/redact` (delete all shop data 48h after uninstall).
 
-```typescript
-// 1. customers/data_request — Customer requests their data
-// Shopify sends this when a customer asks the merchant for their data
-async function handleCustomerDataRequest(payload: {
-  shop_domain: string;
-  customer: { id: number; email: string; phone: string };
-  orders_requested: number[];
-  data_request: { id: number };
-}): Promise<void> {
-  // Collect all data you store about this customer
-  const customerData = await db.customerRecords.findMany({
-    where: {
-      shopDomain: payload.shop_domain,
-      shopifyCustomerId: String(payload.customer.id),
-    },
-  });
+See [GDPR Privacy Webhooks](references/gdpr-privacy-webhooks.md) for the complete implementation of all three handlers.
 
-  const orderData = await db.orderRecords.findMany({
-    where: {
-      shopDomain: payload.shop_domain,
-      shopifyOrderId: { in: payload.orders_requested.map(String) },
-    },
-  });
+### Step 3: Data Minimization and PII Detection
 
-  // You have 30 days to respond
-  // Email the data to the merchant (or make it available via your app)
-  await sendDataExport({
-    requestId: payload.data_request.id,
-    shop: payload.shop_domain,
-    customer: customerData,
-    orders: orderData,
-  });
-}
+Only fetch the fields you actually use in GraphQL queries. Add PII redaction middleware to prevent customer data from leaking into logs — detect emails, phone numbers, and credit card patterns.
 
-// 2. customers/redact — Delete specific customer's data
-async function handleCustomerRedact(payload: {
-  shop_domain: string;
-  customer: { id: number; email: string; phone: string };
-  orders_to_redact: number[];
-}): Promise<void> {
-  // Delete ALL personal data for this customer
-  await db.customerRecords.deleteMany({
-    where: {
-      shopDomain: payload.shop_domain,
-      shopifyCustomerId: String(payload.customer.id),
-    },
-  });
+See [Data Minimization and PII Detection](references/data-minimization-and-pii-detection.md) for query examples and redaction middleware.
 
-  // Anonymize order records (keep for accounting, remove PII)
-  for (const orderId of payload.orders_to_redact) {
-    await db.orderRecords.update({
-      where: { shopifyOrderId: String(orderId) },
-      data: {
-        customerEmail: null,
-        customerName: null,
-        shippingAddress: null,
-        // Keep: orderId, total, line items, timestamps
-      },
-    });
-  }
+### Step 4: Data Retention Policy
 
-  // Log the deletion (keep audit record)
-  await db.auditLog.create({
-    data: {
-      action: "CUSTOMER_DATA_REDACTED",
-      shop: payload.shop_domain,
-      customerId: String(payload.customer.id),
-      timestamp: new Date(),
-    },
-  });
-}
+Automate cleanup with a daily cron job: delete API logs after 30 days, webhook logs after 90 days, and keep audit logs for 7 years (regulatory requirement).
 
-// 3. shop/redact — Delete ALL data for a shop (48h after uninstall)
-async function handleShopRedact(payload: {
-  shop_id: number;
-  shop_domain: string;
-}): Promise<void> {
-  // Delete EVERYTHING related to this shop
-  await db.customerRecords.deleteMany({
-    where: { shopDomain: payload.shop_domain },
-  });
-  await db.orderRecords.deleteMany({
-    where: { shopDomain: payload.shop_domain },
-  });
-  await db.sessions.deleteMany({
-    where: { shop: payload.shop_domain },
-  });
-  await db.appSettings.deleteMany({
-    where: { shopDomain: payload.shop_domain },
-  });
-
-  console.log(`All data deleted for ${payload.shop_domain}`);
-}
-```
-
-### Step 3: Data Minimization in API Queries
-
-```typescript
-// BAD: Fetching all customer fields when you only need the name
-const ALL_FIELDS = `{
-  customer(id: $id) {
-    id firstName lastName email phone
-    addresses { address1 city province country zip phone }
-    orders(first: 100) {
-      edges { node { id name totalPrice shippingAddress { ... } } }
-    }
-    metafields(first: 20) { edges { node { key value } } }
-  }
-}`;
-
-// GOOD: Only fetch what you actually use
-const MINIMAL_FIELDS = `{
-  customer(id: $id) {
-    id
-    displayName
-    numberOfOrders
-    amountSpent { amount currencyCode }
-  }
-}`;
-```
-
-### Step 4: PII Detection in Logs
-
-```typescript
-// Prevent customer PII from leaking into logs
-const PII_PATTERNS = [
-  { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
-  { name: "phone", pattern: /\+?\d{10,15}/g },
-  { name: "credit_card", pattern: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g },
-];
-
-function redactPII(text: string): string {
-  let result = text;
-  for (const { name, pattern } of PII_PATTERNS) {
-    result = result.replace(pattern, `[REDACTED:${name}]`);
-  }
-  return result;
-}
-
-// Use in logging middleware
-function safeLog(message: string, data: any): void {
-  const safeData = JSON.parse(redactPII(JSON.stringify(data)));
-  console.log(message, safeData);
-}
-```
-
-### Step 5: Data Retention Policy
-
-```typescript
-// Automatic cleanup — run daily via cron
-async function enforceRetentionPolicy(): Promise<void> {
-  const now = new Date();
-
-  // Delete API request logs older than 30 days
-  await db.apiLogs.deleteMany({
-    where: { createdAt: { lt: new Date(now.getTime() - 30 * 86400000) } },
-  });
-
-  // Delete webhook event logs older than 90 days
-  await db.webhookLogs.deleteMany({
-    where: { createdAt: { lt: new Date(now.getTime() - 90 * 86400000) } },
-  });
-
-  // Keep audit logs for 7 years (regulatory requirement)
-  // Never auto-delete audit records
-
-  console.log("Retention policy enforced");
-}
-```
+See [Data Retention Policy](references/data-retention-policy.md) for the complete implementation.
 
 ## Output
 
@@ -252,7 +97,3 @@ curl -X POST http://localhost:3000/webhooks/gdpr/data-request \
 - [Shopify Privacy Law Compliance](https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance)
 - [GDPR Webhook Requirements](https://shopify.dev/changelog/apps-now-need-to-use-gdpr-webhooks)
 - [Data Protection Best Practices](https://shopify.dev/docs/apps/build/compliance)
-
-## Next Steps
-
-For enterprise access control, see `shopify-enterprise-rbac`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/data-minimization-and-pii-detection.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/data-minimization-and-pii-detection.md
@@ -1,0 +1,52 @@
+GraphQL data minimization patterns and PII detection/redaction middleware for Shopify apps.
+
+### Data Minimization in API Queries
+
+```typescript
+// BAD: Fetching all customer fields when you only need the name
+const ALL_FIELDS = `{
+  customer(id: $id) {
+    id firstName lastName email phone
+    addresses { address1 city province country zip phone }
+    orders(first: 100) {
+      edges { node { id name totalPrice shippingAddress { ... } } }
+    }
+    metafields(first: 20) { edges { node { key value } } }
+  }
+}`;
+
+// GOOD: Only fetch what you actually use
+const MINIMAL_FIELDS = `{
+  customer(id: $id) {
+    id
+    displayName
+    numberOfOrders
+    amountSpent { amount currencyCode }
+  }
+}`;
+```
+
+### PII Detection in Logs
+
+```typescript
+// Prevent customer PII from leaking into logs
+const PII_PATTERNS = [
+  { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
+  { name: "phone", pattern: /\+?\d{10,15}/g },
+  { name: "credit_card", pattern: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g },
+];
+
+function redactPII(text: string): string {
+  let result = text;
+  for (const { name, pattern } of PII_PATTERNS) {
+    result = result.replace(pattern, `[REDACTED:${name}]`);
+  }
+  return result;
+}
+
+// Use in logging middleware
+function safeLog(message: string, data: any): void {
+  const safeData = JSON.parse(redactPII(JSON.stringify(data)));
+  console.log(message, safeData);
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/data-retention-policy.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/data-retention-policy.md
@@ -1,0 +1,23 @@
+Automatic data retention policy enforcement via daily cron job.
+
+```typescript
+// Automatic cleanup — run daily via cron
+async function enforceRetentionPolicy(): Promise<void> {
+  const now = new Date();
+
+  // Delete API request logs older than 30 days
+  await db.apiLogs.deleteMany({
+    where: { createdAt: { lt: new Date(now.getTime() - 30 * 86400000) } },
+  });
+
+  // Delete webhook event logs older than 90 days
+  await db.webhookLogs.deleteMany({
+    where: { createdAt: { lt: new Date(now.getTime() - 90 * 86400000) } },
+  });
+
+  // Keep audit logs for 7 years (regulatory requirement)
+  // Never auto-delete audit records
+
+  console.log("Retention policy enforced");
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/gdpr-privacy-webhooks.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/references/gdpr-privacy-webhooks.md
@@ -1,0 +1,96 @@
+Complete implementation of the three mandatory GDPR webhooks required for Shopify App Store submission.
+
+```typescript
+// 1. customers/data_request — Customer requests their data
+// Shopify sends this when a customer asks the merchant for their data
+async function handleCustomerDataRequest(payload: {
+  shop_domain: string;
+  customer: { id: number; email: string; phone: string };
+  orders_requested: number[];
+  data_request: { id: number };
+}): Promise<void> {
+  // Collect all data you store about this customer
+  const customerData = await db.customerRecords.findMany({
+    where: {
+      shopDomain: payload.shop_domain,
+      shopifyCustomerId: String(payload.customer.id),
+    },
+  });
+
+  const orderData = await db.orderRecords.findMany({
+    where: {
+      shopDomain: payload.shop_domain,
+      shopifyOrderId: { in: payload.orders_requested.map(String) },
+    },
+  });
+
+  // You have 30 days to respond
+  // Email the data to the merchant (or make it available via your app)
+  await sendDataExport({
+    requestId: payload.data_request.id,
+    shop: payload.shop_domain,
+    customer: customerData,
+    orders: orderData,
+  });
+}
+
+// 2. customers/redact — Delete specific customer's data
+async function handleCustomerRedact(payload: {
+  shop_domain: string;
+  customer: { id: number; email: string; phone: string };
+  orders_to_redact: number[];
+}): Promise<void> {
+  // Delete ALL personal data for this customer
+  await db.customerRecords.deleteMany({
+    where: {
+      shopDomain: payload.shop_domain,
+      shopifyCustomerId: String(payload.customer.id),
+    },
+  });
+
+  // Anonymize order records (keep for accounting, remove PII)
+  for (const orderId of payload.orders_to_redact) {
+    await db.orderRecords.update({
+      where: { shopifyOrderId: String(orderId) },
+      data: {
+        customerEmail: null,
+        customerName: null,
+        shippingAddress: null,
+        // Keep: orderId, total, line items, timestamps
+      },
+    });
+  }
+
+  // Log the deletion (keep audit record)
+  await db.auditLog.create({
+    data: {
+      action: "CUSTOMER_DATA_REDACTED",
+      shop: payload.shop_domain,
+      customerId: String(payload.customer.id),
+      timestamp: new Date(),
+    },
+  });
+}
+
+// 3. shop/redact — Delete ALL data for a shop (48h after uninstall)
+async function handleShopRedact(payload: {
+  shop_id: number;
+  shop_domain: string;
+}): Promise<void> {
+  // Delete EVERYTHING related to this shop
+  await db.customerRecords.deleteMany({
+    where: { shopDomain: payload.shop_domain },
+  });
+  await db.orderRecords.deleteMany({
+    where: { shopDomain: payload.shop_domain },
+  });
+  await db.sessions.deleteMany({
+    where: { shop: payload.shop_domain },
+  });
+  await db.appSettings.deleteMany({
+    where: { shopDomain: payload.shop_domain },
+  });
+
+  console.log(`All data deleted for ${payload.shop_domain}`);
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/SKILL.md
@@ -28,105 +28,18 @@ Collect all diagnostic information needed for Shopify support tickets: API versi
 
 ## Instructions
 
-### Step 1: Create Debug Bundle Script
+### Step 1: Create and Run Debug Bundle
+
+The debug bundle script collects shop info, access scopes, supported API versions, GraphQL and REST rate limit state, environment details (Node/npm versions, SDK version, env vars), then packages everything into a tarball with tokens automatically redacted.
+
+See [Debug Bundle Script](references/debug-bundle-script.md) for the complete bash script.
+
+Set these environment variables before running:
 
 ```bash
-#!/bin/bash
-# shopify-debug-bundle.sh
-set -euo pipefail
-
-STORE="${SHOPIFY_STORE:-your-store.myshopify.com}"
-TOKEN="${SHOPIFY_ACCESS_TOKEN}"
-VERSION="${SHOPIFY_API_VERSION:-2024-10}"
-BUNDLE_DIR="shopify-debug-$(date +%Y%m%d-%H%M%S)"
-
-mkdir -p "$BUNDLE_DIR"
-
-echo "=== Shopify Debug Bundle ===" | tee "$BUNDLE_DIR/summary.txt"
-echo "Store: $STORE" | tee -a "$BUNDLE_DIR/summary.txt"
-echo "API Version: $VERSION" | tee -a "$BUNDLE_DIR/summary.txt"
-echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "$BUNDLE_DIR/summary.txt"
-echo "---" | tee -a "$BUNDLE_DIR/summary.txt"
-```
-
-### Step 2: Collect API State
-
-```bash
-# Shop info and plan
-echo "--- Shop Info ---" >> "$BUNDLE_DIR/summary.txt"
-curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/$VERSION/shop.json" \
-  | jq '{name: .shop.name, plan: .shop.plan_name, domain: .shop.domain, timezone: .shop.iana_timezone}' \
-  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: shop.json" >> "$BUNDLE_DIR/summary.txt"
-
-# Granted access scopes
-echo "--- Access Scopes ---" >> "$BUNDLE_DIR/summary.txt"
-curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/oauth/access_scopes.json" \
-  | jq '.access_scopes[].handle' \
-  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: scopes" >> "$BUNDLE_DIR/summary.txt"
-
-# Supported API versions
-echo "--- API Versions ---" >> "$BUNDLE_DIR/summary.txt"
-curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/versions.json" \
-  | jq '.supported_versions[] | {handle, display_name, latest, supported}' \
-  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: versions" >> "$BUNDLE_DIR/summary.txt"
-```
-
-### Step 3: Test Rate Limit State
-
-```bash
-# GraphQL rate limit check — inspects cost headers
-echo "--- Rate Limit State ---" >> "$BUNDLE_DIR/summary.txt"
-curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ shop { name } }"}' \
-  "https://$STORE/admin/api/$VERSION/graphql.json" \
-  | jq '.extensions.cost' \
-  >> "$BUNDLE_DIR/summary.txt" 2>&1
-
-# REST rate limit check — inspect response headers
-echo "--- REST Rate Limit Headers ---" >> "$BUNDLE_DIR/summary.txt"
-curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/$VERSION/shop.json" \
-  | grep -iE "(x-shopify-shop-api-call-limit|retry-after|x-request-id)" \
-  >> "$BUNDLE_DIR/summary.txt" 2>&1
-```
-
-### Step 4: Collect Environment Info
-
-```bash
-echo "--- Environment ---" >> "$BUNDLE_DIR/summary.txt"
-echo "Node: $(node --version 2>/dev/null || echo 'not installed')" >> "$BUNDLE_DIR/summary.txt"
-echo "npm: $(npm --version 2>/dev/null || echo 'not installed')" >> "$BUNDLE_DIR/summary.txt"
-
-# SDK version
-echo "--- @shopify/shopify-api ---" >> "$BUNDLE_DIR/summary.txt"
-npm list @shopify/shopify-api 2>/dev/null >> "$BUNDLE_DIR/summary.txt" || echo "not installed" >> "$BUNDLE_DIR/summary.txt"
-
-# Environment variables (redacted)
-echo "--- Env Vars (redacted) ---" >> "$BUNDLE_DIR/summary.txt"
-echo "SHOPIFY_API_KEY: ${SHOPIFY_API_KEY:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
-echo "SHOPIFY_API_SECRET: ${SHOPIFY_API_SECRET:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
-echo "SHOPIFY_ACCESS_TOKEN: ${SHOPIFY_ACCESS_TOKEN:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
-echo "SHOPIFY_SCOPES: ${SHOPIFY_SCOPES:-[NOT SET]}" >> "$BUNDLE_DIR/summary.txt"
-echo "SHOPIFY_API_VERSION: ${SHOPIFY_API_VERSION:-[NOT SET]}" >> "$BUNDLE_DIR/summary.txt"
-```
-
-### Step 5: Package and Report
-
-```bash
-# Redact any leaked tokens from the bundle
-find "$BUNDLE_DIR" -type f -exec sed -i 's/shpat_[a-f0-9]\{32\}/shpat_[REDACTED]/g' {} +
-
-tar -czf "$BUNDLE_DIR.tar.gz" "$BUNDLE_DIR"
-echo ""
-echo "Bundle created: $BUNDLE_DIR.tar.gz"
-echo "Contents:"
-ls -la "$BUNDLE_DIR/"
-echo ""
-echo "Review before sharing — check for sensitive data!"
+export SHOPIFY_STORE="your-store.myshopify.com"
+export SHOPIFY_ACCESS_TOKEN="shpat_xxx"
+export SHOPIFY_API_VERSION="2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
 ```
 
 ## Output
@@ -166,7 +79,7 @@ echo "Review before sharing — check for sensitive data!"
 
 ```bash
 curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/shop.json" \
+  "https://$SHOPIFY_STORE/admin/api/2025-04/shop.json" \
   | jq '{name: .shop.name, plan: .shop.plan_name}' \
   && echo "HEALTHY" || echo "UNHEALTHY"
 ```
@@ -176,7 +89,3 @@ curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
 - [Shopify API Response Codes](https://shopify.dev/docs/api/usage/response-codes)
 - [Shopify Partner Support](https://help.shopify.com/en/partners)
 - [Shopify Status Page](https://www.shopifystatus.com)
-
-## Next Steps
-
-For rate limit issues, see `shopify-rate-limits`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/references/debug-bundle-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/references/debug-bundle-script.md
@@ -1,0 +1,83 @@
+Complete bash script that collects Shopify diagnostic information into a shareable bundle.
+
+```bash
+#!/bin/bash
+# shopify-debug-bundle.sh
+set -euo pipefail
+
+STORE="${SHOPIFY_STORE:-your-store.myshopify.com}"
+TOKEN="${SHOPIFY_ACCESS_TOKEN}"
+VERSION="${SHOPIFY_API_VERSION:-2025-04}"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+BUNDLE_DIR="shopify-debug-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$BUNDLE_DIR"
+
+echo "=== Shopify Debug Bundle ===" | tee "$BUNDLE_DIR/summary.txt"
+echo "Store: $STORE" | tee -a "$BUNDLE_DIR/summary.txt"
+echo "API Version: $VERSION" | tee -a "$BUNDLE_DIR/summary.txt"
+echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "$BUNDLE_DIR/summary.txt"
+echo "---" | tee -a "$BUNDLE_DIR/summary.txt"
+
+# --- Shop Info and Plan ---
+echo "--- Shop Info ---" >> "$BUNDLE_DIR/summary.txt"
+curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/$VERSION/shop.json" \
+  | jq '{name: .shop.name, plan: .shop.plan_name, domain: .shop.domain, timezone: .shop.iana_timezone}' \
+  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: shop.json" >> "$BUNDLE_DIR/summary.txt"
+
+# --- Granted Access Scopes ---
+echo "--- Access Scopes ---" >> "$BUNDLE_DIR/summary.txt"
+curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/oauth/access_scopes.json" \
+  | jq '.access_scopes[].handle' \
+  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: scopes" >> "$BUNDLE_DIR/summary.txt"
+
+# --- Supported API Versions ---
+echo "--- API Versions ---" >> "$BUNDLE_DIR/summary.txt"
+curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/versions.json" \
+  | jq '.supported_versions[] | {handle, display_name, latest, supported}' \
+  >> "$BUNDLE_DIR/summary.txt" 2>&1 || echo "FAILED: versions" >> "$BUNDLE_DIR/summary.txt"
+
+# --- GraphQL Rate Limit Check ---
+echo "--- Rate Limit State ---" >> "$BUNDLE_DIR/summary.txt"
+curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ shop { name } }"}' \
+  "https://$STORE/admin/api/$VERSION/graphql.json" \
+  | jq '.extensions.cost' \
+  >> "$BUNDLE_DIR/summary.txt" 2>&1
+
+# --- REST Rate Limit Headers ---
+echo "--- REST Rate Limit Headers ---" >> "$BUNDLE_DIR/summary.txt"
+curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/$VERSION/shop.json" \
+  | grep -iE "(x-shopify-shop-api-call-limit|retry-after|x-request-id)" \
+  >> "$BUNDLE_DIR/summary.txt" 2>&1
+
+# --- Environment ---
+echo "--- Environment ---" >> "$BUNDLE_DIR/summary.txt"
+echo "Node: $(node --version 2>/dev/null || echo 'not installed')" >> "$BUNDLE_DIR/summary.txt"
+echo "npm: $(npm --version 2>/dev/null || echo 'not installed')" >> "$BUNDLE_DIR/summary.txt"
+
+echo "--- @shopify/shopify-api ---" >> "$BUNDLE_DIR/summary.txt"
+npm list @shopify/shopify-api 2>/dev/null >> "$BUNDLE_DIR/summary.txt" || echo "not installed" >> "$BUNDLE_DIR/summary.txt"
+
+echo "--- Env Vars (redacted) ---" >> "$BUNDLE_DIR/summary.txt"
+echo "SHOPIFY_API_KEY: ${SHOPIFY_API_KEY:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
+echo "SHOPIFY_API_SECRET: ${SHOPIFY_API_SECRET:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
+echo "SHOPIFY_ACCESS_TOKEN: ${SHOPIFY_ACCESS_TOKEN:+[SET]}" >> "$BUNDLE_DIR/summary.txt"
+echo "SHOPIFY_SCOPES: ${SHOPIFY_SCOPES:-[NOT SET]}" >> "$BUNDLE_DIR/summary.txt"
+echo "SHOPIFY_API_VERSION: ${SHOPIFY_API_VERSION:-[NOT SET]}" >> "$BUNDLE_DIR/summary.txt"
+
+# --- Package and Redact ---
+find "$BUNDLE_DIR" -type f -exec sed -i 's/shpat_[a-f0-9]\{32\}/shpat_[REDACTED]/g' {} +
+
+tar -czf "$BUNDLE_DIR.tar.gz" "$BUNDLE_DIR"
+echo ""
+echo "Bundle created: $BUNDLE_DIR.tar.gz"
+echo "Contents:"
+ls -la "$BUNDLE_DIR/"
+echo ""
+echo "Review before sharing — check for sensitive data!"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/SKILL.md
@@ -44,156 +44,27 @@ shopify app deploy
 
 ### Step 2: Vercel Deployment
 
-```bash
-# Set environment variables
-vercel env add SHOPIFY_API_KEY production
-vercel env add SHOPIFY_API_SECRET production
-vercel env add SHOPIFY_SCOPES production
-vercel env add SHOPIFY_APP_URL production
+Set environment variables, configure `vercel.json` for webhooks and function timeouts, and update `shopify.app.toml` with the Vercel URL.
 
-# Deploy
-vercel --prod
-```
-
-```json
-// vercel.json
-{
-  "framework": "remix",
-  "env": {
-    "SHOPIFY_API_KEY": "@shopify-api-key",
-    "SHOPIFY_API_SECRET": "@shopify-api-secret"
-  },
-  "headers": [
-    {
-      "source": "/webhooks(.*)",
-      "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" }
-      ]
-    }
-  ],
-  "functions": {
-    "app/**/*.ts": { "maxDuration": 25 }
-  }
-}
-```
-
-Update `shopify.app.toml` with your Vercel URL:
-
-```toml
-[auth]
-redirect_urls = [
-  "https://your-app.vercel.app/auth/callback"
-]
-
-application_url = "https://your-app.vercel.app"
-```
+See [Vercel Deployment](references/vercel-deployment.md) for the complete configuration.
 
 ### Step 3: Fly.io Deployment
 
-```toml
-# fly.toml
-app = "my-shopify-app"
-primary_region = "iad"
+Configure `fly.toml` with health checks and min-machines, set secrets via `fly secrets set`, and deploy.
 
-[env]
-  NODE_ENV = "production"
-  SHOPIFY_API_VERSION = "2024-10"
-
-[http_service]
-  internal_port = 3000
-  force_https = true
-  auto_stop_machines = "stop"
-  auto_start_machines = true
-  min_machines_running = 1
-
-[checks]
-  [checks.health]
-    port = 3000
-    type = "http"
-    interval = "15s"
-    timeout = "2s"
-    path = "/health"
-```
-
-```bash
-# Set secrets (never in fly.toml)
-fly secrets set \
-  SHOPIFY_API_KEY="your_key" \
-  SHOPIFY_API_SECRET="your_secret" \
-  SHOPIFY_ACCESS_TOKEN="shpat_xxx"
-
-# Deploy
-fly deploy
-
-# Check health
-fly status
-curl https://my-shopify-app.fly.dev/health
-```
+See [Fly.io Deployment](references/flyio-deployment.md) for the complete configuration.
 
 ### Step 4: Google Cloud Run Deployment
 
-```dockerfile
-# Dockerfile
-FROM node:20-slim AS builder
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
+Use a multi-stage Dockerfile for minimal image size, deploy with `gcloud run deploy`, and configure secrets via Secret Manager.
 
-FROM node:20-slim
-WORKDIR /app
-COPY --from=builder /app/package*.json ./
-RUN npm ci --production
-COPY --from=builder /app/build ./build
-EXPOSE 3000
-CMD ["npm", "start"]
-```
-
-```bash
-# Build and deploy
-gcloud builds submit --tag gcr.io/$PROJECT_ID/shopify-app
-
-gcloud run deploy shopify-app \
-  --image gcr.io/$PROJECT_ID/shopify-app \
-  --region us-central1 \
-  --platform managed \
-  --allow-unauthenticated \
-  --port 3000 \
-  --set-secrets="SHOPIFY_API_KEY=shopify-api-key:latest,SHOPIFY_API_SECRET=shopify-api-secret:latest" \
-  --min-instances=1 \
-  --max-instances=10
-
-# Update app URL in Shopify
-# Use the Cloud Run service URL in shopify.app.toml
-```
+See [Cloud Run Deployment](references/cloud-run-deployment.md) for Dockerfile and deploy commands.
 
 ### Step 5: Post-Deploy Verification
 
-```bash
-#!/bin/bash
-APP_URL="https://your-app.example.com"
+Run health checks, verify webhook endpoints return 401 (no HMAC), test OAuth start, and sync app config.
 
-echo "=== Post-Deploy Verification ==="
-
-# Health check
-echo -n "Health: "
-curl -sf "$APP_URL/health" | jq '.status'
-
-# Webhook endpoint reachable
-echo -n "Webhook endpoint: "
-curl -sf -o /dev/null -w "%{http_code}" -X POST "$APP_URL/webhooks"
-echo " (expected 401 — no HMAC)"
-
-# OAuth start
-echo -n "OAuth: "
-curl -sf -o /dev/null -w "%{http_code}" "$APP_URL/auth?shop=test.myshopify.com"
-echo ""
-
-# Run shopify app config sync
-echo "Syncing app config..."
-shopify app deploy --force
-```
+See [Post-Deploy Verification](references/post-deploy-verification.md) for the complete verification script.
 
 ## Output
 
@@ -228,7 +99,7 @@ SHOPIFY_APP_URL=           # Your deployed app URL
 SHOPIFY_ACCESS_TOKEN=      # shpat_xxx
 
 # Optional:
-SHOPIFY_API_VERSION=       # Default: latest stable
+SHOPIFY_API_VERSION=       # Default: latest stable. Update quarterly — see shopify.dev/docs/api/usage/versioning
 SESSION_SECRET=            # For cookie signing
 DATABASE_URL=              # Session storage
 ```
@@ -239,7 +110,3 @@ DATABASE_URL=              # Session storage
 - [Vercel Remix Deployment](https://vercel.com/guides/deploying-remix-with-vercel)
 - [Fly.io Node.js](https://fly.io/docs/languages-and-frameworks/node/)
 - [Cloud Run Quickstart](https://cloud.google.com/run/docs/quickstarts)
-
-## Next Steps
-
-For webhook handling, see `shopify-webhooks-events`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/cloud-run-deployment.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/cloud-run-deployment.md
@@ -1,0 +1,37 @@
+Google Cloud Run deployment for Shopify apps, including multi-stage Dockerfile and gcloud commands.
+
+```dockerfile
+# Dockerfile
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-slim
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm ci --production
+COPY --from=builder /app/build ./build
+EXPOSE 3000
+CMD ["npm", "start"]
+```
+
+```bash
+# Build and deploy
+gcloud builds submit --tag gcr.io/$PROJECT_ID/shopify-app
+
+gcloud run deploy shopify-app \
+  --image gcr.io/$PROJECT_ID/shopify-app \
+  --region us-central1 \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 3000 \
+  --set-secrets="SHOPIFY_API_KEY=shopify-api-key:latest,SHOPIFY_API_SECRET=shopify-api-secret:latest" \
+  --min-instances=1 \
+  --max-instances=10
+
+# Update app URL in Shopify
+# Use the Cloud Run service URL in shopify.app.toml
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/flyio-deployment.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/flyio-deployment.md
@@ -1,0 +1,41 @@
+Fly.io deployment configuration for Shopify apps, including fly.toml and secrets management.
+
+```toml
+# fly.toml
+app = "my-shopify-app"
+primary_region = "iad"
+
+[env]
+  NODE_ENV = "production"
+  SHOPIFY_API_VERSION = "2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[checks]
+  [checks.health]
+    port = 3000
+    type = "http"
+    interval = "15s"
+    timeout = "2s"
+    path = "/health"
+```
+
+```bash
+# Set secrets (never in fly.toml)
+fly secrets set \
+  SHOPIFY_API_KEY="your_key" \
+  SHOPIFY_API_SECRET="your_secret" \
+  SHOPIFY_ACCESS_TOKEN="shpat_xxx"
+
+# Deploy
+fly deploy
+
+# Check health
+fly status
+curl https://my-shopify-app.fly.dev/health
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/post-deploy-verification.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/post-deploy-verification.md
@@ -1,0 +1,26 @@
+Post-deployment verification script that checks health, webhooks, and OAuth endpoints.
+
+```bash
+#!/bin/bash
+APP_URL="https://your-app.example.com"
+
+echo "=== Post-Deploy Verification ==="
+
+# Health check
+echo -n "Health: "
+curl -sf "$APP_URL/health" | jq '.status'
+
+# Webhook endpoint reachable
+echo -n "Webhook endpoint: "
+curl -sf -o /dev/null -w "%{http_code}" -X POST "$APP_URL/webhooks"
+echo " (expected 401 — no HMAC)"
+
+# OAuth start
+echo -n "OAuth: "
+curl -sf -o /dev/null -w "%{http_code}" "$APP_URL/auth?shop=test.myshopify.com"
+echo ""
+
+# Run shopify app config sync
+echo "Syncing app config..."
+shopify app deploy --force
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/vercel-deployment.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/references/vercel-deployment.md
@@ -1,0 +1,45 @@
+Vercel deployment configuration for Shopify Remix apps, including environment variables and vercel.json setup.
+
+```bash
+# Set environment variables
+vercel env add SHOPIFY_API_KEY production
+vercel env add SHOPIFY_API_SECRET production
+vercel env add SHOPIFY_SCOPES production
+vercel env add SHOPIFY_APP_URL production
+
+# Deploy
+vercel --prod
+```
+
+```json
+// vercel.json
+{
+  "framework": "remix",
+  "env": {
+    "SHOPIFY_API_KEY": "@shopify-api-key",
+    "SHOPIFY_API_SECRET": "@shopify-api-secret"
+  },
+  "headers": [
+    {
+      "source": "/webhooks(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ],
+  "functions": {
+    "app/**/*.ts": { "maxDuration": 25 }
+  }
+}
+```
+
+Update `shopify.app.toml` with your Vercel URL:
+
+```toml
+[auth]
+redirect_urls = [
+  "https://your-app.vercel.app/auth/callback"
+]
+
+application_url = "https://your-app.vercel.app"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-enterprise-rbac
 description: |
   Implement Shopify Plus access control patterns with staff permissions,
   multi-location management, and Shopify Organization features.
+  Use when building apps for Shopify Plus merchants, implementing per-staff permissions, or managing multi-store organizations.
   Trigger with phrases like "shopify permissions", "shopify staff",
   "shopify Plus organization", "shopify roles", "shopify multi-location".
 allowed-tools: Read, Write, Edit
@@ -27,234 +28,23 @@ Implement role-based access control for Shopify Plus apps using Shopify's staff 
 
 ## Instructions
 
-### Step 1: Query Staff Member Permissions
+### Step 1: Query Staff Permissions and Map to App Roles
 
-```typescript
-// Query staff members and their permissions via GraphQL
-const STAFF_QUERY = `{
-  staffMembers(first: 50) {
-    edges {
-      node {
-        id
-        email
-        firstName
-        lastName
-        isShopOwner
-        active
-        locale
-        permissions: accessScopes {
-          handle
-          description
-        }
-      }
-    }
-  }
-}`;
+Query staff members via GraphQL to get their access scopes, then map those scopes to app-level roles (admin, manager, fulfillment, viewer). Staff permissions mirror app scopes like `read_products`, `write_orders`, etc.
 
-// Staff permissions match app access scopes:
-// "read_products", "write_products", "read_orders", etc.
-// A staff member can only use app features matching their store permissions
-```
+See [Staff Query and Role Mapping](references/staff-query-and-role-mapping.md) for the complete GraphQL query, role definitions, and matching logic.
 
-### Step 2: App-Level Role Mapping
+### Step 2: Permission Middleware and Multi-Location Access
 
-Map Shopify staff permissions to your app's roles:
+In embedded apps, use online access tokens to get per-staff permissions from `session.onlineAccessInfo`. For Shopify Plus stores with multiple locations, restrict fulfillment and inventory operations to authorized locations per user.
 
-```typescript
-type AppRole = "admin" | "manager" | "viewer" | "fulfillment";
+See [Permission Middleware and Location Access](references/permission-middleware-and-location-access.md) for Remix loader examples and location access control.
 
-interface RoleMapping {
-  role: AppRole;
-  requiredScopes: string[];
-  allowedActions: string[];
-}
+### Step 3: Organization API and Audit Trail
 
-const ROLE_MAPPINGS: RoleMapping[] = [
-  {
-    role: "admin",
-    requiredScopes: ["write_products", "write_orders", "write_customers"],
-    allowedActions: ["*"],
-  },
-  {
-    role: "manager",
-    requiredScopes: ["write_products", "read_orders"],
-    allowedActions: ["manage_products", "view_orders", "view_analytics"],
-  },
-  {
-    role: "fulfillment",
-    requiredScopes: ["read_orders", "write_fulfillments"],
-    allowedActions: ["view_orders", "create_fulfillment", "update_tracking"],
-  },
-  {
-    role: "viewer",
-    requiredScopes: ["read_products"],
-    allowedActions: ["view_products", "view_analytics"],
-  },
-];
+Shopify Plus Organization API enables multi-store management with organization-level, store-level admin, and store-level staff roles. Log all access decisions (allowed and denied) for compliance auditing.
 
-function determineRole(staffScopes: string[]): AppRole {
-  // Find the highest-privilege role the staff member qualifies for
-  for (const mapping of ROLE_MAPPINGS) {
-    if (mapping.requiredScopes.every((s) => staffScopes.includes(s))) {
-      return mapping.role;
-    }
-  }
-  return "viewer"; // fallback
-}
-
-function canPerformAction(role: AppRole, action: string): boolean {
-  const mapping = ROLE_MAPPINGS.find((m) => m.role === role);
-  if (!mapping) return false;
-  return mapping.allowedActions.includes("*") || mapping.allowedActions.includes(action);
-}
-```
-
-### Step 3: Embedded App Permission Middleware
-
-```typescript
-// In an embedded Shopify app, the session token contains the staff member info
-import { authenticate } from "../shopify.server";
-
-// Remix loader with permission check
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { admin, session } = await authenticate.admin(request);
-
-  // session.onlineAccessInfo contains staff permissions for online tokens
-  const staffInfo = session.onlineAccessInfo;
-  if (!staffInfo) {
-    // Offline token — no per-user permissions available
-    return json({ role: "admin" });
-  }
-
-  const scopes = staffInfo.associated_user_scope.split(",");
-  const role = determineRole(scopes);
-
-  // Check permission for this specific page
-  if (!canPerformAction(role, "view_orders")) {
-    throw new Response("Forbidden", { status: 403 });
-  }
-
-  return json({ role, user: staffInfo.associated_user });
-}
-```
-
-### Step 4: Multi-Location Access Control
-
-```typescript
-// Shopify Plus stores can have multiple locations
-// Control which locations a staff member can access
-
-const LOCATIONS_QUERY = `{
-  locations(first: 50) {
-    edges {
-      node {
-        id
-        name
-        isActive
-        address {
-          city
-          province
-          country
-        }
-        fulfillmentService {
-          serviceName
-        }
-      }
-    }
-  }
-}`;
-
-// Restrict operations to authorized locations
-interface LocationPermission {
-  locationId: string;
-  canFulfill: boolean;
-  canAdjustInventory: boolean;
-  canViewOrders: boolean;
-}
-
-async function checkLocationAccess(
-  userId: string,
-  locationId: string,
-  action: "fulfill" | "adjust_inventory" | "view_orders"
-): Promise<boolean> {
-  const permissions = await db.locationPermissions.findFirst({
-    where: { userId, locationId },
-  });
-
-  if (!permissions) return false;
-
-  switch (action) {
-    case "fulfill": return permissions.canFulfill;
-    case "adjust_inventory": return permissions.canAdjustInventory;
-    case "view_orders": return permissions.canViewOrders;
-    default: return false;
-  }
-}
-```
-
-### Step 5: Shopify Plus Organization API
-
-```typescript
-// Shopify Plus Organization features (multi-store management)
-// Access via the Organization API
-
-const ORG_STORES_QUERY = `{
-  organizationStores(first: 50) {
-    edges {
-      node {
-        id
-        name
-        shopDomain
-        plan {
-          displayName
-        }
-        staff(first: 10) {
-          edges {
-            node {
-              email
-              role
-            }
-          }
-        }
-      }
-    }
-  }
-}`;
-
-// Organization-level roles:
-// - Organization admin: full access to all stores
-// - Store-level admin: full access to assigned stores
-// - Store-level staff: permission-based access
-```
-
-### Step 6: Audit Trail for Access
-
-```typescript
-interface AccessAuditEntry {
-  timestamp: Date;
-  userId: string;
-  userEmail: string;
-  role: AppRole;
-  action: string;
-  resource: string;
-  shopDomain: string;
-  locationId?: string;
-  allowed: boolean;
-  ipAddress?: string;
-}
-
-async function auditAccess(entry: AccessAuditEntry): Promise<void> {
-  await db.accessAudit.create({ data: entry });
-
-  // Alert on denied access attempts
-  if (!entry.allowed) {
-    console.warn(
-      `[ACCESS DENIED] ${entry.userEmail} attempted ${entry.action} ` +
-      `on ${entry.resource} in ${entry.shopDomain}`
-    );
-  }
-}
-```
+See [Organization API and Audit Trail](references/organization-api-and-audit-trail.md) for the Organization query and audit implementation.
 
 ## Output
 
@@ -299,7 +89,3 @@ export async function action({ request }: ActionFunctionArgs) {
 - [Online vs Offline Tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens)
 - [Shopify Plus Organization](https://help.shopify.com/en/manual/shopify-plus/organization)
 - [Multi-Location Inventory](https://shopify.dev/docs/apps/build/orders-fulfillment/inventory-management-apps)
-
-## Next Steps
-
-For major migrations, see `shopify-migration-deep-dive`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/organization-api-and-audit-trail.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/organization-api-and-audit-trail.md
@@ -1,0 +1,65 @@
+Shopify Plus Organization API for multi-store management and access audit trail implementation.
+
+### Organization API
+
+```typescript
+// Shopify Plus Organization features (multi-store management)
+// Access via the Organization API
+
+const ORG_STORES_QUERY = `{
+  organizationStores(first: 50) {
+    edges {
+      node {
+        id
+        name
+        shopDomain
+        plan {
+          displayName
+        }
+        staff(first: 10) {
+          edges {
+            node {
+              email
+              role
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// Organization-level roles:
+// - Organization admin: full access to all stores
+// - Store-level admin: full access to assigned stores
+// - Store-level staff: permission-based access
+```
+
+### Audit Trail for Access
+
+```typescript
+interface AccessAuditEntry {
+  timestamp: Date;
+  userId: string;
+  userEmail: string;
+  role: AppRole;
+  action: string;
+  resource: string;
+  shopDomain: string;
+  locationId?: string;
+  allowed: boolean;
+  ipAddress?: string;
+}
+
+async function auditAccess(entry: AccessAuditEntry): Promise<void> {
+  await db.accessAudit.create({ data: entry });
+
+  // Alert on denied access attempts
+  if (!entry.allowed) {
+    console.warn(
+      `[ACCESS DENIED] ${entry.userEmail} attempted ${entry.action} ` +
+      `on ${entry.resource} in ${entry.shopDomain}`
+    );
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/permission-middleware-and-location-access.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/permission-middleware-and-location-access.md
@@ -1,0 +1,84 @@
+Embedded app permission middleware for Remix loaders and multi-location access control for Shopify Plus stores.
+
+### Embedded App Permission Middleware
+
+```typescript
+// In an embedded Shopify app, the session token contains the staff member info
+import { authenticate } from "../shopify.server";
+
+// Remix loader with permission check
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { admin, session } = await authenticate.admin(request);
+
+  // session.onlineAccessInfo contains staff permissions for online tokens
+  const staffInfo = session.onlineAccessInfo;
+  if (!staffInfo) {
+    // Offline token — no per-user permissions available
+    return json({ role: "admin" });
+  }
+
+  const scopes = staffInfo.associated_user_scope.split(",");
+  const role = determineRole(scopes);
+
+  // Check permission for this specific page
+  if (!canPerformAction(role, "view_orders")) {
+    throw new Response("Forbidden", { status: 403 });
+  }
+
+  return json({ role, user: staffInfo.associated_user });
+}
+```
+
+### Multi-Location Access Control
+
+```typescript
+// Shopify Plus stores can have multiple locations
+// Control which locations a staff member can access
+
+const LOCATIONS_QUERY = `{
+  locations(first: 50) {
+    edges {
+      node {
+        id
+        name
+        isActive
+        address {
+          city
+          province
+          country
+        }
+        fulfillmentService {
+          serviceName
+        }
+      }
+    }
+  }
+}`;
+
+// Restrict operations to authorized locations
+interface LocationPermission {
+  locationId: string;
+  canFulfill: boolean;
+  canAdjustInventory: boolean;
+  canViewOrders: boolean;
+}
+
+async function checkLocationAccess(
+  userId: string,
+  locationId: string,
+  action: "fulfill" | "adjust_inventory" | "view_orders"
+): Promise<boolean> {
+  const permissions = await db.locationPermissions.findFirst({
+    where: { userId, locationId },
+  });
+
+  if (!permissions) return false;
+
+  switch (action) {
+    case "fulfill": return permissions.canFulfill;
+    case "adjust_inventory": return permissions.canAdjustInventory;
+    case "view_orders": return permissions.canViewOrders;
+    default: return false;
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/staff-query-and-role-mapping.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/references/staff-query-and-role-mapping.md
@@ -1,0 +1,81 @@
+Query staff member permissions via GraphQL and map them to application-level roles.
+
+### Staff Member Query
+
+```typescript
+// Query staff members and their permissions via GraphQL
+const STAFF_QUERY = `{
+  staffMembers(first: 50) {
+    edges {
+      node {
+        id
+        email
+        firstName
+        lastName
+        isShopOwner
+        active
+        locale
+        permissions: accessScopes {
+          handle
+          description
+        }
+      }
+    }
+  }
+}`;
+
+// Staff permissions match app access scopes:
+// "read_products", "write_products", "read_orders", etc.
+// A staff member can only use app features matching their store permissions
+```
+
+### App-Level Role Mapping
+
+```typescript
+type AppRole = "admin" | "manager" | "viewer" | "fulfillment";
+
+interface RoleMapping {
+  role: AppRole;
+  requiredScopes: string[];
+  allowedActions: string[];
+}
+
+const ROLE_MAPPINGS: RoleMapping[] = [
+  {
+    role: "admin",
+    requiredScopes: ["write_products", "write_orders", "write_customers"],
+    allowedActions: ["*"],
+  },
+  {
+    role: "manager",
+    requiredScopes: ["write_products", "read_orders"],
+    allowedActions: ["manage_products", "view_orders", "view_analytics"],
+  },
+  {
+    role: "fulfillment",
+    requiredScopes: ["read_orders", "write_fulfillments"],
+    allowedActions: ["view_orders", "create_fulfillment", "update_tracking"],
+  },
+  {
+    role: "viewer",
+    requiredScopes: ["read_products"],
+    allowedActions: ["view_products", "view_analytics"],
+  },
+];
+
+function determineRole(staffScopes: string[]): AppRole {
+  // Find the highest-privilege role the staff member qualifies for
+  for (const mapping of ROLE_MAPPINGS) {
+    if (mapping.requiredScopes.every((s) => staffScopes.includes(s))) {
+      return mapping.role;
+    }
+  }
+  return "viewer"; // fallback
+}
+
+function canPerformAction(role: AppRole, action: string): boolean {
+  const mapping = ROLE_MAPPINGS.find((m) => m.role === role);
+  if (!mapping) return false;
+  return mapping.allowedActions.includes("*") || mapping.allowedActions.includes(action);
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-functions/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-functions/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: shopify-functions
+description: |
+  Build Shopify Functions for custom discount, payment, and delivery logic in a WASM sandbox.
+  Use when creating custom discount rules, payment customizations, delivery options,
+  or cart transformations that run server-side at checkout.
+  Trigger with phrases like "shopify functions", "shopify discounts",
+  "shopify wasm", "custom discount function", "shopify checkout customization".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify Functions
+
+## Overview
+
+Shopify Functions execute custom business logic in a WebAssembly sandbox at checkout: discounts, payment filtering, delivery customization, and cart transforms. They run server-side with strict constraints (11ms execution, 1MB memory, no network access) and replace Shopify Scripts.
+
+## Prerequisites
+
+- Shopify CLI 3.x+ installed (`npm install -g @shopify/cli`)
+- Shopify Partners account with a development store
+- App configured for the target function API type
+
+## Instructions
+
+### Step 1: Configure the Function Extension
+
+```toml
+# extensions/product-discount/shopify.extension.toml
+api_version = "2025-01"
+type = "product_discounts"
+
+[[targeting]]
+target = "purchase.product-discount.run"
+input_query = "extensions/product-discount/input.graphql"
+export = "run"
+```
+
+### Step 2: Define the Input Query
+
+The input query declares what data your function receives at runtime:
+
+```graphql
+# extensions/product-discount/input.graphql
+query Input {
+  cart {
+    lines {
+      quantity
+      merchandise {
+        ... on ProductVariant {
+          id
+          product { hasAnyTag(tags: ["VIP-DISCOUNT"]) }
+        }
+      }
+    }
+  }
+  discountNode {
+    metafield(namespace: "$app:discount-config", key: "percentage") { value }
+  }
+}
+```
+
+### Step 3: Implement the Function
+
+```typescript
+// extensions/product-discount/src/run.ts
+import type { Input, FunctionRunResult } from "../generated/api";
+
+export function run(input: Input): FunctionRunResult {
+  const percentage = parseFloat(input.discountNode?.metafield?.value ?? "0");
+  if (percentage === 0) return { discounts: [], discountApplicationStrategy: "FIRST" };
+
+  const targets = input.cart.lines
+    .filter((line) => line.merchandise.product.hasAnyTag)
+    .map((line) => ({ productVariant: { id: line.merchandise.id } }));
+
+  return {
+    discounts: [{
+      targets,
+      value: { percentage: { value: percentage.toString() } },
+      message: `${percentage}% VIP Discount`,
+    }],
+    discountApplicationStrategy: "FIRST",
+  };
+}
+```
+
+### Step 4: Test and Deploy
+
+```bash
+shopify app function typegen          # Generate types from input query
+shopify app function build            # Build to WASM
+shopify app function run --input test-input.json  # Test locally
+shopify app deploy                    # Deploy with app
+```
+
+See [function-types.md](references/function-types.md) for all function types, [input-output-schemas.md](references/input-output-schemas.md) for I/O shapes, and [wasm-constraints.md](references/wasm-constraints.md) for sandbox limitations.
+
+## Output
+
+- WASM binary deployed as a Shopify Function extension
+- Custom discount/payment/delivery logic running server-side at checkout
+- Type-safe input/output via generated TypeScript types
+- Configurable via metafields (merchant-editable without code changes)
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `FunctionError` | Runtime panic or unhandled exception in WASM | Add error handling; check optional fields for null |
+| `FUNCTION_TOO_LARGE` | WASM binary exceeds 256KB | Tree-shake deps; use Rust for smaller binaries |
+| Input query validation | Query references unavailable fields | Match `api_version` to available schema fields |
+| Timeout (>11ms) | Function exceeds execution limit | Reduce iterations; pre-compute in metafields |
+
+## Examples
+
+### Creating a VIP Discount Function
+
+Build a product discount function that applies a configurable percentage off for items tagged "VIP-DISCOUNT" using metafield-driven configuration.
+
+See [Function Types](references/function-types.md) for all available function types and their targeting.
+
+### Defining Input Queries and Output Schemas
+
+Design the GraphQL input query that declares what cart data your function receives, and return the correctly shaped `FunctionRunResult`.
+
+See [Input/Output Schemas](references/input-output-schemas.md) for I/O shapes per function type.
+
+### Working Within WASM Sandbox Limits
+
+Your function hits the 11ms execution timeout or 256KB binary size limit. Apply optimization strategies for the constrained WASM environment.
+
+See [WASM Constraints](references/wasm-constraints.md) for sandbox limitations and workarounds.
+
+## Resources
+
+- [Shopify Functions Overview](https://shopify.dev/docs/apps/build/functions)
+- [Product Discount Tutorial](https://shopify.dev/docs/apps/build/discounts/build-discount-function)
+- [Function APIs Reference](https://shopify.dev/docs/api/functions)
+- [WASM Limitations](https://shopify.dev/docs/apps/build/functions/input-output#limitations)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/function-types.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/function-types.md
@@ -1,0 +1,81 @@
+All Shopify Function types with their targeting, use cases, and API extensions.
+
+## Function Types
+
+| Type | TOML `type` | Target | Use Case |
+|------|------------|--------|----------|
+| Product Discounts | `product_discounts` | `purchase.product-discount.run` | Percentage/fixed discounts on line items |
+| Order Discounts | `order_discounts` | `purchase.order-discount.run` | Discounts on the entire order (e.g., spend $100 get $10 off) |
+| Shipping Discounts | `delivery_discounts` | `purchase.delivery-discount.run` | Free or discounted shipping based on conditions |
+| Payment Customization | `payment_customization` | `purchase.payment-customization.run` | Hide/reorder/rename payment methods at checkout |
+| Delivery Customization | `delivery_customization` | `purchase.delivery-customization.run` | Hide/reorder/rename delivery options at checkout |
+| Cart Transform | `cart_transform` | `purchase.cart-transform.run` | Merge lines, expand bundles, modify cart before checkout |
+| Fulfillment Constraints | `fulfillment_constraints` | `purchase.fulfillment-constraint.run` | Restrict which locations can fulfill which items |
+| Order Routing | `order_routing_location_rule` | `purchase.order-routing-location-rule.run` | Custom logic for location-based order routing |
+| Cart & Checkout Validation | `cart_checkout_validation` | `purchase.validation.run` | Block checkout based on custom rules (e.g., max 3 items) |
+
+## Discount Function Subtypes
+
+### Product Discount
+```toml
+type = "product_discounts"
+[[targeting]]
+target = "purchase.product-discount.run"
+```
+- Applies to individual cart lines
+- Returns `targets` array with `productVariant` IDs
+- Value: `percentage` or `fixedAmount`
+
+### Order Discount
+```toml
+type = "order_discounts"
+[[targeting]]
+target = "purchase.order-discount.run"
+```
+- Applies to the whole order
+- Does NOT use line-level targets
+- Value: `percentage` or `fixedAmount` on order subtotal
+
+### Shipping Discount
+```toml
+type = "delivery_discounts"
+[[targeting]]
+target = "purchase.delivery-discount.run"
+```
+- Targets delivery groups
+- Can make specific shipping options free or discounted
+
+## Non-Discount Functions
+
+### Payment Customization
+```toml
+type = "payment_customization"
+[[targeting]]
+target = "purchase.payment-customization.run"
+```
+Returns `operations` array:
+```typescript
+{
+  operations: [
+    { hide: { paymentMethodId: "gid://shopify/PaymentMethod/1" } },
+    { rename: { paymentMethodId: "gid://shopify/PaymentMethod/2", name: "Pay Later" } },
+    { move: { paymentMethodId: "gid://shopify/PaymentMethod/3", index: 0 } },
+  ]
+}
+```
+
+### Delivery Customization
+```toml
+type = "delivery_customization"
+[[targeting]]
+target = "purchase.delivery-customization.run"
+```
+Same `operations` shape as payment: `hide`, `rename`, `move` on delivery options.
+
+### Cart Transform
+```toml
+type = "cart_transform"
+[[targeting]]
+target = "purchase.cart-transform.run"
+```
+Operations: `merge` (combine lines), `expand` (split bundles into components), `update` (modify line properties).

--- a/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/input-output-schemas.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/input-output-schemas.md
@@ -1,0 +1,154 @@
+Input query examples and FunctionRunResult shapes for each Shopify Function type.
+
+## Product Discount Input/Output
+
+### Input Query
+```graphql
+query Input {
+  cart {
+    lines {
+      quantity
+      cost {
+        amountPerQuantity { amount currencyCode }
+        totalAmount { amount currencyCode }
+      }
+      merchandise {
+        ... on ProductVariant {
+          id
+          product {
+            id
+            hasAnyTag(tags: ["sale"])
+            inAnyCollection(ids: ["gid://shopify/Collection/123"])
+          }
+        }
+      }
+    }
+    buyerIdentity {
+      customer { id hasAnyTag(tags: ["VIP"]) }
+    }
+  }
+  discountNode {
+    metafield(namespace: "$app:config", key: "settings") { value }
+  }
+}
+```
+
+### FunctionRunResult
+```typescript
+interface FunctionRunResult {
+  discountApplicationStrategy: "FIRST" | "MAXIMUM";
+  discounts: Array<{
+    targets: Array<{
+      productVariant: { id: string };
+    }>;
+    value:
+      | { percentage: { value: string } }       // "10.0" for 10%
+      | { fixedAmount: { amount: string } };     // "5.00" for $5 off
+    message?: string;                            // Shown to customer
+    conditions?: Array<{
+      productMinimumQuantity?: { ids: string[]; minimumQuantity: string };
+      productMinimumSubtotal?: { ids: string[]; minimumAmount: { amount: string } };
+      orderMinimumSubtotal?: { minimumAmount: { amount: string } };
+    }>;
+  }>;
+}
+```
+
+## Order Discount Input/Output
+
+### FunctionRunResult
+```typescript
+interface FunctionRunResult {
+  discountApplicationStrategy: "FIRST" | "MAXIMUM";
+  discounts: Array<{
+    value:
+      | { percentage: { value: string } }
+      | { fixedAmount: { amount: string } };
+    message?: string;
+    conditions?: Array<{
+      orderMinimumSubtotal?: { minimumAmount: { amount: string } };
+    }>;
+  }>;
+  // Note: no "targets" — applies to whole order
+}
+```
+
+## Payment Customization Input/Output
+
+### Input Query
+```graphql
+query Input {
+  cart {
+    cost { totalAmount { amount currencyCode } }
+    buyerIdentity {
+      customer { hasAnyTag(tags: ["wholesale"]) }
+    }
+  }
+  paymentMethods {
+    id
+    name
+  }
+  paymentCustomization {
+    metafield(namespace: "$app:config", key: "rules") { value }
+  }
+}
+```
+
+### FunctionRunResult
+```typescript
+interface FunctionRunResult {
+  operations: Array<
+    | { hide: { paymentMethodId: string } }
+    | { rename: { paymentMethodId: string; name: string } }
+    | { move: { paymentMethodId: string; index: number } }
+  >;
+}
+```
+
+## Delivery Customization Input/Output
+
+### Input Query
+```graphql
+query Input {
+  cart {
+    deliveryGroups {
+      deliveryOptions {
+        handle
+        title
+        cost { amount }
+      }
+      deliveryAddress {
+        countryCode
+        provinceCode
+      }
+    }
+  }
+  deliveryCustomization {
+    metafield(namespace: "$app:config", key: "rules") { value }
+  }
+}
+```
+
+### FunctionRunResult
+```typescript
+interface FunctionRunResult {
+  operations: Array<
+    | { hide: { deliveryOptionHandle: string } }
+    | { rename: { deliveryOptionHandle: string; name: string } }
+    | { move: { deliveryOptionHandle: string; index: number } }
+  >;
+}
+```
+
+## Cart Transform Input/Output
+
+### FunctionRunResult
+```typescript
+interface FunctionRunResult {
+  operations: Array<
+    | { merge: { parentVariantId: string; title: string; cartLines: Array<{ cartLineId: string; quantity: number }> } }
+    | { expand: { cartLineId: string; expandedCartItems: Array<{ merchandiseId: string; quantity: number }> } }
+    | { update: { cartLineId: string; title?: string; image?: { url: string } } }
+  >;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/wasm-constraints.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-functions/references/wasm-constraints.md
@@ -1,0 +1,91 @@
+Shopify Functions WASM sandbox constraints and workarounds.
+
+## Hard Limits
+
+| Constraint | Limit | Notes |
+|-----------|-------|-------|
+| Execution time | 11ms | Wall-clock time per invocation |
+| Memory | 1MB | Linear memory available to WASM module |
+| Binary size | 256KB | Compiled `.wasm` file maximum |
+| Network access | None | No HTTP, no fetch, no external calls |
+| File system | None | No disk reads or writes |
+| Standard library | Limited | No threads, no async, no random |
+| Input size | 64KB | Serialized input from the input query |
+| Output size | 64KB | Serialized FunctionRunResult |
+
+## What This Means in Practice
+
+### No Network Calls
+Functions cannot call external APIs at runtime. All configuration must be pre-loaded via:
+- **Metafields** on the discount/customization node (set by app, read in input query)
+- **Input query data** from the cart, customer, and product graph
+
+### No Large Dependencies
+Libraries like `lodash`, `moment`, or `date-fns` will blow the 256KB limit. Alternatives:
+- Write vanilla TypeScript/JavaScript utilities
+- Use Rust for smaller binary sizes (~50-100KB typical vs ~150-200KB for JS via Javy)
+- Tree-shake aggressively: import only what you need
+
+### Memory Constraints
+```typescript
+// BAD: Allocating large arrays
+const allVariants = input.cart.lines.flatMap(l => /* ... */);  // Could exceed 1MB
+
+// GOOD: Process line by line
+for (const line of input.cart.lines) {
+  // Process each line individually
+}
+```
+
+## Language Comparison
+
+| Factor | TypeScript (Javy) | Rust |
+|--------|-------------------|------|
+| Binary size | 150-200KB typical | 50-100KB typical |
+| Compile speed | Fast | Slower |
+| Ecosystem | Familiar to most devs | Smaller community |
+| Performance | Good | Better (native WASM) |
+| Debugging | Source maps available | WASM debug info |
+| Shopify CLI support | Full (`shopify app function build`) | Full (Cargo-based) |
+
+## Workarounds for Common Patterns
+
+### Dynamic Configuration
+```typescript
+// Store config in metafields, read via input query
+// input.graphql:
+// discountNode { metafield(namespace: "$app:config", key: "rules") { value } }
+
+const config = JSON.parse(input.discountNode?.metafield?.value ?? "{}");
+// { "min_quantity": 3, "percentage": "15.0", "excluded_tags": ["final-sale"] }
+```
+
+### Complex Logic That Exceeds Limits
+If your logic is too complex for the WASM sandbox:
+1. Pre-compute results in your app backend on a schedule
+2. Store computed values as metafields on products/variants
+3. Function reads pre-computed metafields via input query (simple lookup, fast execution)
+
+### Testing Locally
+```bash
+# Generate test input matching your input query
+shopify app function run --input test-input.json
+
+# Run with verbose output
+shopify app function run --input test-input.json --export run
+
+# Profile execution time
+time shopify app function run --input test-input.json
+```
+
+### Debugging Size Issues
+```bash
+# Check WASM binary size after build
+ls -la dist/function.wasm
+
+# If using Rust, check what's contributing to size
+cargo bloat --release --wasm
+
+# If using TypeScript, check bundled dependencies
+npx source-map-explorer dist/function.js
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: shopify-graphql-cost-optimizer
+description: |
+  Master Shopify's calculated query cost system to avoid throttling.
+  Use when hitting THROTTLED errors, optimizing GraphQL queries,
+  or deciding when to use bulk operations instead.
+  Trigger with phrases like "shopify query cost", "shopify graphql cost",
+  "shopify rate limit graphql", "shopify throttled", "shopify bulk operations".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify GraphQL Cost Optimizer
+
+## Overview
+
+Every Shopify GraphQL query has a calculated cost. The API uses a token bucket (1,000 points max, refills at 50/second for standard plans) and throttles once depleted. The key insight: `requestedQueryCost` is the worst-case estimate, while `actualQueryCost` is what you really paid. Understanding the gap between them is how you avoid throttling.
+
+## Prerequisites
+
+- Shopify app with GraphQL Admin API access
+- `@shopify/shopify-api` package installed
+- Understanding of GraphQL connections (edges/node pattern)
+
+## Instructions
+
+### Step 1: Read Cost Headers
+
+Every GraphQL response includes cost data in `extensions.cost`:
+
+```json
+{
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 252,
+      "actualQueryCost": 12,
+      "throttleStatus": {
+        "maximumAvailable": 1000.0,
+        "currentlyAvailable": 988.0,
+        "restoreRate": 50.0
+      }
+    }
+  }
+}
+```
+
+Add the `X-GraphQL-Cost-Include-Fields: true` request header for a per-field cost breakdown.
+
+### Step 2: Predict Query Cost
+
+Cost rules for calculation:
+
+- **Single object field**: 1 point (e.g., `shop { name }` = 1)
+- **Connection**: `first` or `last` param multiplied by child cost, plus 2 for the connection itself
+- **Nested connections**: costs multiply
+
+```graphql
+# Example: products(first: 10) { edges { node { title variants(first: 5) { edges { node { price } } } } } }
+# Cost = 2 (products connection) + 10 * (1 (title) + 2 (variants connection) + 5 * 1 (price))
+# = 2 + 10 * (1 + 2 + 5) = 2 + 80 = 82 requestedQueryCost
+```
+
+See [references/cost-calculation-rules.md](references/cost-calculation-rules.md) for the full calculation rules.
+
+### Step 3: Cost Reduction Techniques
+
+**Reduce `first` parameter** — the single biggest lever:
+
+```graphql
+# BAD: 250 * nested cost = massive
+products(first: 250) { ... }
+
+# GOOD: paginate with smaller pages
+products(first: 25, after: $cursor) { ... }
+```
+
+**Select only needed fields** — every field costs 1 point per connection node:
+
+```graphql
+# BAD: 10 fields * 50 products = 500+ points
+products(first: 50) { edges { node { id title description vendor tags status productType totalInventory createdAt updatedAt } } }
+
+# GOOD: 3 fields * 50 products = ~152 points
+products(first: 50) { edges { node { id title status } } }
+```
+
+**Avoid deep nesting** — flatten or split queries. See [references/query-splitting.md](references/query-splitting.md) for patterns.
+
+### Step 4: Use Bulk Operations for Large Data Sets
+
+When you need 250+ items, switch to `bulkOperationRunQuery`. It bypasses the cost system entirely — no `first`/`last` params, no cursors, returns all items as JSONL.
+
+See [references/bulk-operations.md](references/bulk-operations.md) for the complete `bulkOperationRunQuery` mutation, polling, and JSONL download flow.
+
+## Output
+
+- Query cost visible in every response via `extensions.cost`
+- Queries optimized below 200 points each
+- Bulk operations configured for large data exports
+- Per-field cost breakdown available for debugging
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `THROTTLED` | Bucket depleted (0 points available) | Wait for `restoreRate` to refill, then retry |
+| `MAX_COST_EXCEEDED` | Single query exceeds 1,000 points | Reduce `first` params or split into multiple queries |
+| `QUERY_TOO_COMPLEX` | Too many nested connections (depth > 3) | Flatten query, fetch nested data separately |
+| `BULK_OPERATION_FAILED` | Bulk query syntax error or timeout | Check `errorCode` on the bulk operation object |
+| `BULK_OPERATION_ALREADY_RUNNING` | Only one bulk op per app per store | Poll current operation status before starting new one |
+
+## Examples
+
+### Calculating Cost for a Nested Product Query
+
+Predict the cost of a query that fetches products with variants and metafields before running it, to avoid unexpected THROTTLED errors.
+
+See [Cost Calculation Rules](references/cost-calculation-rules.md) for the full calculation formula and worked examples.
+
+### Splitting an Expensive Query
+
+A single query exceeds 1,000 points due to deep nesting. Break it into multiple cheaper queries that stay well under the limit.
+
+See [Query Splitting](references/query-splitting.md) for patterns to flatten and separate expensive queries.
+
+### Exporting a Full Product Catalog
+
+You need all 10,000+ products with variants. Switch from paginated queries to a bulk operation that bypasses the cost system entirely.
+
+See [Bulk Operations](references/bulk-operations.md) for the complete mutation, polling, and JSONL download flow.
+
+## Resources
+
+- [GraphQL Rate Limits](https://shopify.dev/docs/api/usage/rate-limits#graphql-admin-api-rate-limits)
+- [Calculated Query Cost](https://shopify.dev/docs/api/usage/rate-limits#calculated-query-cost)
+- [Bulk Operations](https://shopify.dev/docs/api/usage/bulk-operations/queries)
+- [Query Cost Debugging](https://shopify.dev/docs/api/usage/rate-limits#debugging-query-cost)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/bulk-operations.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/bulk-operations.md
@@ -1,0 +1,236 @@
+Complete guide to Shopify's bulk operation API for large data exports that bypass the query cost system.
+
+## When to Use Bulk Operations
+
+- Exporting more than 250 items of any resource type
+- Syncing entire product catalogs to external systems
+- Generating reports across all orders/customers
+- Any operation where cursor-based pagination would require 10+ API calls
+
+## Starting a Bulk Query
+
+```typescript
+const BULK_OPERATION_RUN = `
+  mutation bulkOperationRunQuery($query: String!) {
+    bulkOperationRunQuery(query: $query) {
+      bulkOperation {
+        id
+        status
+        url
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const response = await client.request(BULK_OPERATION_RUN, {
+  variables: {
+    query: `{
+      products {
+        edges {
+          node {
+            id
+            title
+            handle
+            status
+            vendor
+            productType
+            tags
+            variants {
+              edges {
+                node {
+                  id
+                  title
+                  sku
+                  price
+                  inventoryQuantity
+                  barcode
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+  },
+});
+
+const bulkOperationId = response.data.bulkOperationRunQuery.bulkOperation.id;
+```
+
+**Important**: Bulk query syntax differs from normal queries:
+- No `first`/`last` pagination arguments
+- No `after`/`before` cursors
+- Connections return ALL items automatically
+- Only one bulk operation can run per app per store at a time
+
+## Polling for Completion
+
+```typescript
+const POLL_OPERATION = `
+  query currentBulkOperation {
+    currentBulkOperation {
+      id
+      status
+      errorCode
+      objectCount
+      fileSize
+      url
+      createdAt
+      completedAt
+    }
+  }
+`;
+
+async function waitForBulkOperation(client: any): Promise<string | null> {
+  while (true) {
+    const response = await client.request(POLL_OPERATION);
+    const operation = response.data.currentBulkOperation;
+
+    switch (operation.status) {
+      case "COMPLETED":
+        console.log(
+          `Bulk operation complete: ${operation.objectCount} objects, ` +
+          `${(operation.fileSize / 1024 / 1024).toFixed(1)}MB`
+        );
+        return operation.url; // JSONL download URL
+
+      case "FAILED":
+        console.error(`Bulk operation failed: ${operation.errorCode}`);
+        return null;
+
+      case "CANCELED":
+        console.warn("Bulk operation was canceled");
+        return null;
+
+      case "RUNNING":
+      case "CREATED":
+        console.log(`Status: ${operation.status}, objects so far: ${operation.objectCount}`);
+        await new Promise((r) => setTimeout(r, 3000)); // Poll every 3 seconds
+        break;
+
+      default:
+        throw new Error(`Unknown status: ${operation.status}`);
+    }
+  }
+}
+```
+
+## Downloading and Parsing JSONL
+
+The result is a JSONL (JSON Lines) file where each line is an object. Parent-child relationships use `__parentId`:
+
+```typescript
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
+
+async function parseBulkResults(url: string) {
+  const response = await fetch(url);
+  const text = await response.text();
+  const lines = text.trim().split("\n");
+
+  const products: Map<string, any> = new Map();
+  const variants: any[] = [];
+
+  for (const line of lines) {
+    const obj = JSON.parse(line);
+
+    if (obj.id.includes("Product") && !obj.id.includes("Variant")) {
+      products.set(obj.id, { ...obj, variants: [] });
+    } else if (obj.id.includes("ProductVariant")) {
+      variants.push(obj);
+    }
+  }
+
+  // Link variants to products via __parentId
+  for (const variant of variants) {
+    const product = products.get(variant.__parentId);
+    if (product) {
+      product.variants.push(variant);
+    }
+  }
+
+  return Array.from(products.values());
+}
+```
+
+### Example JSONL Output
+
+```jsonl
+{"id":"gid://shopify/Product/123","title":"T-Shirt","handle":"t-shirt","status":"ACTIVE"}
+{"id":"gid://shopify/ProductVariant/456","title":"Small","sku":"TSH-S","price":"29.99","__parentId":"gid://shopify/Product/123"}
+{"id":"gid://shopify/ProductVariant/789","title":"Medium","sku":"TSH-M","price":"29.99","__parentId":"gid://shopify/Product/123"}
+{"id":"gid://shopify/Product/234","title":"Hoodie","handle":"hoodie","status":"ACTIVE"}
+{"id":"gid://shopify/ProductVariant/567","title":"Large","sku":"HOO-L","price":"59.99","__parentId":"gid://shopify/Product/234"}
+```
+
+## Using Webhooks Instead of Polling
+
+For production, subscribe to the `BULK_OPERATIONS_FINISH` webhook:
+
+```typescript
+const WEBHOOK_CREATE = `
+  mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: WebhookSubscriptionInput!) {
+    webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
+      webhookSubscription { id }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(WEBHOOK_CREATE, {
+  variables: {
+    topic: "BULK_OPERATIONS_FINISH",
+    webhookSubscription: {
+      callbackUrl: "https://your-app.com/webhooks/bulk-complete",
+      format: "JSON",
+    },
+  },
+});
+```
+
+The webhook payload includes the download URL:
+
+```json
+{
+  "admin_graphql_api_id": "gid://shopify/BulkOperation/123",
+  "completed_at": "2026-01-15T10:30:00Z",
+  "status": "completed",
+  "type": "query",
+  "url": "https://storage.googleapis.com/shopify-tiers-assets-prod/bulk-operation/..."
+}
+```
+
+## Error States
+
+| `errorCode` | Meaning | Recovery |
+|-------------|---------|----------|
+| `ACCESS_DENIED` | App lacks required scopes | Check app scopes in partner dashboard |
+| `INTERNAL_SERVER_ERROR` | Shopify-side failure | Retry after 60 seconds |
+| `TIMEOUT` | Query took too long (>24 hours) | Simplify query, reduce fields |
+
+## Bulk Mutations
+
+For writing data in bulk (e.g., updating thousands of products), use `bulkOperationRunMutation`:
+
+```typescript
+const BULK_MUTATION = `
+  mutation bulkOperationRunMutation(
+    $mutation: String!,
+    $stagedUploadPath: String!
+  ) {
+    bulkOperationRunMutation(
+      mutation: $mutation,
+      stagedUploadPath: $stagedUploadPath
+    ) {
+      bulkOperation { id status }
+      userErrors { field message }
+    }
+  }
+`;
+```
+
+This requires first uploading a JSONL file via staged uploads, then running the mutation against it.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/cost-calculation-rules.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/cost-calculation-rules.md
@@ -1,0 +1,147 @@
+Detailed breakdown of how Shopify calculates GraphQL query cost.
+
+## Cost Formula
+
+```
+Total Cost = sum of all field costs at each level
+```
+
+**Rules:**
+
+1. **Scalar fields on a root query**: 1 point each
+2. **Object fields**: 1 point for the object + cost of its children
+3. **Connection fields**: 2 points for the connection + (`first` or `last` param * cost of each node)
+4. **Nested connections**: costs multiply — this is where queries explode
+
+## Examples with Calculations
+
+### Simple Query (Low Cost)
+
+```graphql
+{
+  shop {          # 1 point (object)
+    name          # 1 point (scalar)
+    email         # 1 point (scalar)
+  }
+}
+# Total requestedQueryCost: 3
+```
+
+### Single Connection
+
+```graphql
+{
+  products(first: 10) {   # 2 points (connection overhead)
+    edges {
+      node {
+        id               # 1 point per node
+        title            # 1 point per node
+      }
+    }
+  }
+}
+# Cost: 2 + (10 * 2) = 22 requestedQueryCost
+```
+
+### Nested Connection
+
+```graphql
+{
+  products(first: 10) {           # 2 (connection)
+    edges {
+      node {
+        id                        # 1 per product
+        title                     # 1 per product
+        variants(first: 5) {      # 2 (connection) per product
+          edges {
+            node {
+              id                  # 1 per variant
+              price               # 1 per variant
+            }
+          }
+        }
+      }
+    }
+  }
+}
+# Per variant: 2 fields = 2
+# Per product variants connection: 2 + (5 * 2) = 12
+# Per product: 2 fields + 12 (variants) = 14
+# Total: 2 (products connection) + (10 * 14) = 142 requestedQueryCost
+```
+
+### Triple Nesting (Dangerous)
+
+```graphql
+{
+  products(first: 50) {
+    edges {
+      node {
+        variants(first: 20) {
+          edges {
+            node {
+              metafields(first: 10) {
+                edges {
+                  node { key value }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+# Per metafield: 2 fields = 2
+# Per variant metafields: 2 + (10 * 2) = 22
+# Per variant total: 22
+# Per product variants: 2 + (20 * 22) = 442
+# Total: 2 + (50 * 442) = 22,102 requestedQueryCost
+# This EXCEEDS the 1,000 point maximum — will return MAX_COST_EXCEEDED
+```
+
+## requestedQueryCost vs actualQueryCost
+
+The `requestedQueryCost` assumes all connections return the maximum `first` items. The `actualQueryCost` is calculated after execution based on how many items actually existed.
+
+```json
+{
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 142,
+      "actualQueryCost": 38
+    }
+  }
+}
+```
+
+In this example, the query requested `products(first: 10)` but only 3 products existed, so the actual cost was much lower. **Shopify deducts `actualQueryCost` from your bucket, not `requestedQueryCost`.** However, Shopify uses `requestedQueryCost` to decide whether to reject the query upfront with `MAX_COST_EXCEEDED`.
+
+## Inline Fragments
+
+Inline fragments (`... on Type`) add the cost of their fields to each node:
+
+```graphql
+{
+  nodes(ids: ["gid://shopify/Product/1", "gid://shopify/Collection/2"]) {
+    ... on Product {
+      title          # 1 per Product node
+      description    # 1 per Product node
+    }
+    ... on Collection {
+      title          # 1 per Collection node
+      productsCount  # 1 per Collection node
+    }
+  }
+}
+# Cost: sum of all possible fragment fields per node (worst case)
+```
+
+## Cost Budget Strategy
+
+| Query Type | Target Cost | Reasoning |
+|-----------|-------------|-----------|
+| Interactive (user-facing) | < 100 | Leave room for concurrent queries |
+| Background sync | < 500 | Single query at a time, can wait for restore |
+| One-time migration | Use bulk operations | Bypass cost system entirely |
+| Dashboard polling | < 50 | Runs frequently, must not accumulate |

--- a/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/query-splitting.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/references/query-splitting.md
@@ -1,0 +1,193 @@
+Patterns for splitting expensive Shopify GraphQL queries into cheaper ones.
+
+## When to Split
+
+Split a query when:
+- `requestedQueryCost` exceeds 500 points
+- You have nested connections deeper than 2 levels
+- You need data from multiple unrelated resource types
+
+## Pattern 1: Flatten Nested Connections
+
+Instead of fetching products with nested variants and metafields in one query:
+
+```graphql
+# BAD: Triple nesting = cost explosion
+{
+  products(first: 50) {
+    edges {
+      node {
+        id
+        title
+        variants(first: 20) {
+          edges {
+            node {
+              id
+              price
+              metafields(first: 5) {
+                edges { node { key value } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+# requestedQueryCost: ~6,052
+```
+
+Split into two queries:
+
+```graphql
+# Query 1: Get products and variant IDs (cost: ~222)
+{
+  products(first: 50) {
+    edges {
+      node {
+        id
+        title
+        variants(first: 20) {
+          edges {
+            node {
+              id
+              price
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# Query 2: Get metafields for specific variants you care about (cost: ~52)
+{
+  nodes(ids: ["gid://shopify/ProductVariant/111", "gid://shopify/ProductVariant/222"]) {
+    ... on ProductVariant {
+      id
+      metafields(first: 5) {
+        edges { node { key value namespace type } }
+      }
+    }
+  }
+}
+```
+
+## Pattern 2: Paginate Aggressively
+
+```graphql
+# BAD: 250 items at once
+{
+  products(first: 250) {
+    edges { node { id title status } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+# requestedQueryCost: ~502
+
+# GOOD: Small pages, paginate with cursor
+{
+  products(first: 25, after: $cursor) {
+    edges { node { id title status } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+# requestedQueryCost: ~52
+```
+
+Implementation for cursor-based pagination:
+
+```typescript
+async function paginateAll(client: any, query: string, variables: any = {}) {
+  const allItems: any[] = [];
+  let cursor: string | null = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const response = await client.request(query, {
+      variables: { ...variables, after: cursor, first: 25 },
+    });
+
+    // Extract the connection (works for any top-level connection)
+    const connectionKey = Object.keys(response.data).find(
+      (k) => response.data[k]?.edges
+    );
+    const connection = response.data[connectionKey!];
+
+    allItems.push(...connection.edges.map((e: any) => e.node));
+    hasNextPage = connection.pageInfo.hasNextPage;
+    cursor = connection.pageInfo.endCursor;
+
+    // Respect rate limits
+    const available = response.extensions?.cost?.throttleStatus?.currentlyAvailable;
+    if (available && available < 100) {
+      const waitMs = ((100 - available) / 50) * 1000;
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+  }
+
+  return allItems;
+}
+```
+
+## Pattern 3: Use `nodes` Query for Known IDs
+
+When you already have IDs, the `nodes` query is cheaper than filtering:
+
+```graphql
+# BAD: Query with filter to find specific products
+{
+  products(first: 100, query: "id:123 OR id:456 OR id:789") {
+    edges { node { id title variants(first: 10) { edges { node { id price } } } } }
+  }
+}
+# requestedQueryCost: ~1,202 (100 * (1 + 12))
+
+# GOOD: Direct lookup by GID
+{
+  nodes(ids: [
+    "gid://shopify/Product/123",
+    "gid://shopify/Product/456",
+    "gid://shopify/Product/789"
+  ]) {
+    ... on Product {
+      id
+      title
+      variants(first: 10) {
+        edges { node { id price } }
+      }
+    }
+  }
+}
+# requestedQueryCost: ~39 (3 * (1 + 12))
+```
+
+## Pattern 4: Separate Reads from Writes
+
+Never combine mutations with expensive queries:
+
+```typescript
+// BAD: Mutation + expensive re-fetch in one request
+const UPDATE_AND_FETCH = `
+  mutation {
+    productUpdate(input: { id: "gid://shopify/Product/123", title: "New" }) {
+      product {
+        id title
+        variants(first: 100) { edges { node { id price sku inventoryQuantity } } }
+        images(first: 50) { edges { node { url altText } } }
+      }
+    }
+  }
+`;
+
+// GOOD: Mutation returns minimal data, separate query if needed
+const UPDATE = `
+  mutation productUpdate($input: ProductUpdateInput!) {
+    productUpdate(product: $input) {
+      product { id title updatedAt }
+      userErrors { field message }
+    }
+  }
+`;
+// Then fetch only if needed, with targeted fields
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/SKILL.md
@@ -48,83 +48,9 @@ SHOPIFY_API_SECRET=your_api_secret
 
 ### Step 3: Write the Hello World Script
 
-```typescript
-// hello-shopify.ts
-import "@shopify/shopify-api/adapters/node";
-import { shopifyApi } from "@shopify/shopify-api";
-import "dotenv/config";
+Initialize the Shopify API client with `LATEST_API_VERSION` (imported from `@shopify/shopify-api`), create a custom app session, then query shop info and products via GraphQL.
 
-const shopify = shopifyApi({
-  apiKey: process.env.SHOPIFY_API_KEY!,
-  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
-  hostName: "localhost",
-  apiVersion: "2024-10",
-  isCustomStoreApp: true,
-  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!,
-});
-
-async function main() {
-  const session = shopify.session.customAppSession(
-    process.env.SHOPIFY_STORE!
-  );
-
-  const client = new shopify.clients.Graphql({ session });
-
-  // Query shop info
-  const shopInfo = await client.request(`{
-    shop {
-      name
-      currencyCode
-      primaryDomain { url }
-    }
-  }`);
-  console.log("Store:", shopInfo.data.shop.name);
-  console.log("Currency:", shopInfo.data.shop.currencyCode);
-
-  // Query first 5 products
-  const products = await client.request(`{
-    products(first: 5) {
-      edges {
-        node {
-          id
-          title
-          status
-          totalInventory
-          variants(first: 3) {
-            edges {
-              node {
-                title
-                price
-                sku
-                inventoryQuantity
-              }
-            }
-          }
-        }
-      }
-    }
-  }`);
-
-  console.log("\nProducts:");
-  for (const edge of products.data.products.edges) {
-    const p = edge.node;
-    console.log(`  - ${p.title} (${p.status}, ${p.totalInventory} in stock)`);
-    for (const v of p.variants.edges) {
-      console.log(`      Variant: ${v.node.title} — $${v.node.price} (SKU: ${v.node.sku})`);
-    }
-  }
-
-  console.log("\nSuccess! Your Shopify connection is working.");
-}
-
-main().catch((err) => {
-  console.error("Failed:", err.message);
-  if (err.response) {
-    console.error("Response:", JSON.stringify(err.response.body, null, 2));
-  }
-  process.exit(1);
-});
-```
+See [Hello World Script](references/hello-world-script.md) for the complete implementation.
 
 ### Step 4: Run It
 
@@ -166,55 +92,9 @@ Success! Your Shopify connection is working.
 
 ## Examples
 
-### Create a Product via GraphQL Mutation
+### Create a Product and Query via REST
 
-```typescript
-const response = await client.request(`
-  mutation productCreate($input: ProductCreateInput!) {
-    productCreate(product: $input) {
-      product {
-        id
-        title
-        handle
-      }
-      userErrors {
-        field
-        message
-      }
-    }
-  }
-`, {
-  variables: {
-    input: {
-      title: "Hello World Product",
-      descriptionHtml: "<p>Created via Shopify API</p>",
-      vendor: "My App",
-      productType: "Test",
-      tags: ["api-created", "hello-world"],
-    },
-  },
-});
-
-if (response.data.productCreate.userErrors.length > 0) {
-  console.error("Errors:", response.data.productCreate.userErrors);
-} else {
-  console.log("Created:", response.data.productCreate.product.title);
-}
-```
-
-### REST Admin API (Legacy but Still Supported)
-
-```typescript
-const restClient = new shopify.clients.Rest({ session });
-
-// GET /admin/api/2024-10/products.json
-const { body } = await restClient.get({
-  path: "products",
-  query: { limit: 5, status: "active" },
-});
-
-console.log("Products:", body.products.map((p: any) => p.title));
-```
+See [GraphQL Mutation and REST Examples](references/graphql-mutation-and-rest-examples.md) for a `productCreate` mutation and legacy REST API usage.
 
 ## Resources
 
@@ -222,7 +102,3 @@ console.log("Products:", body.products.map((p: any) => p.title));
 - [Getting Started with GraphQL](https://shopify.dev/docs/apps/build/graphql/basics/queries)
 - [REST Admin API Reference](https://shopify.dev/docs/api/admin-rest)
 - [Shopify API Versioning](https://shopify.dev/docs/api/usage/versioning)
-
-## Next Steps
-
-Proceed to `shopify-local-dev-loop` for development workflow setup.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/references/graphql-mutation-and-rest-examples.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/references/graphql-mutation-and-rest-examples.md
@@ -1,0 +1,51 @@
+Examples of creating a product via GraphQL mutation and querying products via the REST Admin API.
+
+### Create a Product via GraphQL Mutation
+
+```typescript
+const response = await client.request(`
+  mutation productCreate($input: ProductCreateInput!) {
+    productCreate(product: $input) {
+      product {
+        id
+        title
+        handle
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`, {
+  variables: {
+    input: {
+      title: "Hello World Product",
+      descriptionHtml: "<p>Created via Shopify API</p>",
+      vendor: "My App",
+      productType: "Test",
+      tags: ["api-created", "hello-world"],
+    },
+  },
+});
+
+if (response.data.productCreate.userErrors.length > 0) {
+  console.error("Errors:", response.data.productCreate.userErrors);
+} else {
+  console.log("Created:", response.data.productCreate.product.title);
+}
+```
+
+### REST Admin API (Legacy but Still Supported)
+
+```typescript
+const restClient = new shopify.clients.Rest({ session });
+
+// GET /admin/api/{version}/products.json
+const { body } = await restClient.get({
+  path: "products",
+  query: { limit: 5, status: "active" },
+});
+
+console.log("Products:", body.products.map((p: any) => p.title));
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/references/hello-world-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/references/hello-world-script.md
@@ -1,0 +1,79 @@
+Complete hello world script that connects to a Shopify store and queries shop info and products via the GraphQL Admin API.
+
+```typescript
+// hello-shopify.ts
+import "@shopify/shopify-api/adapters/node";
+import { shopifyApi, LATEST_API_VERSION } from "@shopify/shopify-api";
+import "dotenv/config";
+
+const shopify = shopifyApi({
+  apiKey: process.env.SHOPIFY_API_KEY!,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
+  hostName: "localhost",
+  apiVersion: LATEST_API_VERSION,
+  isCustomStoreApp: true,
+  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!,
+});
+
+async function main() {
+  const session = shopify.session.customAppSession(
+    process.env.SHOPIFY_STORE!
+  );
+
+  const client = new shopify.clients.Graphql({ session });
+
+  // Query shop info
+  const shopInfo = await client.request(`{
+    shop {
+      name
+      currencyCode
+      primaryDomain { url }
+    }
+  }`);
+  console.log("Store:", shopInfo.data.shop.name);
+  console.log("Currency:", shopInfo.data.shop.currencyCode);
+
+  // Query first 5 products
+  const products = await client.request(`{
+    products(first: 5) {
+      edges {
+        node {
+          id
+          title
+          status
+          totalInventory
+          variants(first: 3) {
+            edges {
+              node {
+                title
+                price
+                sku
+                inventoryQuantity
+              }
+            }
+          }
+        }
+      }
+    }
+  }`);
+
+  console.log("\nProducts:");
+  for (const edge of products.data.products.edges) {
+    const p = edge.node;
+    console.log(`  - ${p.title} (${p.status}, ${p.totalInventory} in stock)`);
+    for (const v of p.variants.edges) {
+      console.log(`      Variant: ${v.node.title} — $${v.node.price} (SKU: ${v.node.sku})`);
+    }
+  }
+
+  console.log("\nSuccess! Your Shopify connection is working.");
+}
+
+main().catch((err) => {
+  console.error("Failed:", err.message);
+  if (err.response) {
+    console.error("Response:", JSON.stringify(err.response.body, null, 2));
+  }
+  process.exit(1);
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-incident-runbook
 description: |
   Execute Shopify incident response with triage using Shopify status page,
   API health checks, and rate limit diagnosis.
+  Use when a Shopify integration is down, returning errors, or behaving unexpectedly in production.
   Trigger with phrases like "shopify incident", "shopify outage",
   "shopify down", "shopify on-call", "shopify emergency", "shopify not responding".
 allowed-tools: Read, Grep, Bash(curl:*)
@@ -29,51 +30,9 @@ Rapid incident response for Shopify API outages, authentication failures, and ra
 
 ### Step 1: Quick Triage (First 5 Minutes)
 
-```bash
-#!/bin/bash
-echo "=== SHOPIFY INCIDENT TRIAGE ==="
-echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+Run the triage script to check Shopify status, API connectivity, REST rate limits, and GraphQL throttle state in one pass.
 
-# 1. Is Shopify itself down?
-echo ""
-echo "--- Shopify Status ---"
-echo "Check: https://www.shopifystatus.com"
-echo "API Status: https://www.shopifystatus.com/api/v2/status.json"
-curl -sf "https://www.shopifystatus.com/api/v2/status.json" 2>/dev/null \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'Overall: {d[\"status\"][\"description\"]}')" \
-  2>/dev/null || echo "Could not reach status page"
-
-# 2. Can we reach the Shopify API?
-echo ""
-echo "--- API Connectivity ---"
-echo -n "Admin API: "
-HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
-  -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/shop.json" 2>/dev/null)
-echo "$HTTP_CODE"
-
-# 3. Rate limit state
-echo ""
-echo "--- Rate Limit State ---"
-curl -sI -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/shop.json" 2>/dev/null \
-  | grep -i "x-shopify-shop-api-call-limit"
-
-# 4. GraphQL rate limit
-echo ""
-echo "--- GraphQL Throttle ---"
-curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ shop { name } }"}' \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/graphql.json" 2>/dev/null \
-  | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-t=d.get('extensions',{}).get('cost',{}).get('throttleStatus',{})
-print(f'Available: {t.get(\"currentlyAvailable\",\"?\")}/{t.get(\"maximumAvailable\",\"?\")}')
-print(f'Restore rate: {t.get(\"restoreRate\",\"?\")}/sec')
-" 2>/dev/null || echo "Could not query"
-```
+See [Triage Script](references/triage-script.md) for the complete diagnostic script.
 
 ### Step 2: Decision Tree
 
@@ -99,40 +58,9 @@ Is Shopifystatus.com showing an incident?
 
 ### Step 3: Immediate Actions by Error Type
 
-**401 — Token Expired/Revoked:**
-```bash
-# Verify the token is still valid
-curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/shop.json" | jq '.shop.name'
+Diagnostic commands and remediation for 401 (token expired), 429 (rate limited), and 5xx (Shopify internal errors). Always capture `X-Request-Id` headers for Shopify support.
 
-# If 401: merchant may have uninstalled and reinstalled
-# → Trigger re-authentication flow
-# → Check APP_UNINSTALLED webhook logs
-```
-
-**429 — Rate Limited:**
-```bash
-# Check if you have a runaway loop
-# Look for rapid sequential API calls in your logs
-
-# Immediate mitigation: pause all non-critical API calls
-# Check GraphQL query costs — are any queries > 500 points?
-
-# For REST: check the bucket header
-curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/2024-10/shop.json" \
-  | grep "x-shopify-shop-api-call-limit"
-# If "40/40" — bucket is full, wait 20 seconds (40 / 2 per second)
-```
-
-**5xx — Shopify Internal Error:**
-```bash
-# Capture the X-Request-Id for support
-curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/2024-10/shop.json" \
-  | grep -i "x-request-id"
-# Include this ID when contacting Shopify Partner Support
-```
+See [Error Type Actions](references/error-type-actions.md) for complete commands per error type.
 
 ### Step 4: Communication Templates
 
@@ -179,7 +107,7 @@ All data is safe — no orders or products have been lost.
 
 ```bash
 curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
-  "https://$SHOPIFY_STORE/admin/api/2024-10/shop.json" \
+  "https://$SHOPIFY_STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" \
   | jq '{name: .shop.name, plan: .shop.plan_name}' \
   && echo "SHOPIFY: HEALTHY" || echo "SHOPIFY: UNREACHABLE"
 ```
@@ -198,7 +126,3 @@ curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
 - [Shopify Status Page](https://www.shopifystatus.com)
 - [Shopify Partner Support](https://help.shopify.com/en/partners)
 - [Shopify Community Forums](https://community.shopify.dev)
-
-## Next Steps
-
-For data handling and GDPR, see `shopify-data-handling`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/references/error-type-actions.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/references/error-type-actions.md
@@ -1,0 +1,41 @@
+# Immediate Actions by Error Type
+
+Diagnostic commands and remediation steps for each common Shopify incident error type.
+
+## 401 — Token Expired/Revoked
+
+```bash
+# Verify the token is still valid
+curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
+  "https://$SHOPIFY_STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" | jq '.shop.name'
+
+# If 401: merchant may have uninstalled and reinstalled
+# → Trigger re-authentication flow
+# → Check APP_UNINSTALLED webhook logs
+```
+
+## 429 — Rate Limited
+
+```bash
+# Check if you have a runaway loop
+# Look for rapid sequential API calls in your logs
+
+# Immediate mitigation: pause all non-critical API calls
+# Check GraphQL query costs — are any queries > 500 points?
+
+# For REST: check the bucket header
+curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" \
+  | grep "x-shopify-shop-api-call-limit"
+# If "40/40" — bucket is full, wait 20 seconds (40 / 2 per second)
+```
+
+## 5xx — Shopify Internal Error
+
+```bash
+# Capture the X-Request-Id for support
+curl -sI -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" \
+  | grep -i "x-request-id"
+# Include this ID when contacting Shopify Partner Support
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/references/triage-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/references/triage-script.md
@@ -1,0 +1,49 @@
+# Shopify Incident Triage Script
+
+Quick triage script to run in the first 5 minutes of an incident. Checks Shopify status, API connectivity, REST rate limits, and GraphQL throttle state.
+
+```bash
+#!/bin/bash
+echo "=== SHOPIFY INCIDENT TRIAGE ==="
+echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 1. Is Shopify itself down?
+echo ""
+echo "--- Shopify Status ---"
+echo "Check: https://www.shopifystatus.com"
+echo "API Status: https://www.shopifystatus.com/api/v2/status.json"
+curl -sf "https://www.shopifystatus.com/api/v2/status.json" 2>/dev/null \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'Overall: {d[\"status\"][\"description\"]}')" \
+  2>/dev/null || echo "Could not reach status page"
+
+# 2. Can we reach the Shopify API?
+echo ""
+echo "--- API Connectivity ---"
+echo -n "Admin API: "
+HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
+  -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
+  "https://$SHOPIFY_STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" 2>/dev/null)
+echo "$HTTP_CODE"
+
+# 3. Rate limit state
+echo ""
+echo "--- Rate Limit State ---"
+curl -sI -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
+  "https://$SHOPIFY_STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/shop.json" 2>/dev/null \
+  | grep -i "x-shopify-shop-api-call-limit"
+
+# 4. GraphQL rate limit
+echo ""
+echo "--- GraphQL Throttle ---"
+curl -sf -H "X-Shopify-Access-Token: $SHOPIFY_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ shop { name } }"}' \
+  "https://$SHOPIFY_STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/graphql.json" 2>/dev/null \
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+t=d.get('extensions',{}).get('cost',{}).get('throttleStatus',{})
+print(f'Available: {t.get(\"currentlyAvailable\",\"?\")}/{t.get(\"maximumAvailable\",\"?\")}')
+print(f'Restore rate: {t.get(\"restoreRate\",\"?\")}/sec')
+" 2>/dev/null || echo "Could not query"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/SKILL.md
@@ -57,7 +57,8 @@ SHOPIFY_HOST_NAME=your-app.example.com
 SHOPIFY_ACCESS_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxx
 
 # API version — use a stable quarterly release
-SHOPIFY_API_VERSION=2024-10
+# Update quarterly — see shopify.dev/docs/api/usage/versioning
+SHOPIFY_API_VERSION=2025-04
 ```
 
 ```bash
@@ -79,7 +80,7 @@ const shopify = shopifyApi({
   apiSecretKey: process.env.SHOPIFY_API_SECRET!,
   scopes: process.env.SHOPIFY_SCOPES!.split(","),
   hostName: process.env.SHOPIFY_HOST_NAME!,
-  apiVersion: LATEST_API_VERSION, // or "2024-10"
+  apiVersion: LATEST_API_VERSION,
   isEmbeddedApp: true,
 });
 
@@ -88,47 +89,9 @@ export default shopify;
 
 ### Step 4: Implement OAuth Flow (Public Apps)
 
-```typescript
-// routes/auth.ts — Express example
-import express from "express";
-import shopify from "../shopify";
+Express-based OAuth flow that redirects to Shopify and handles the callback token exchange.
 
-const router = express.Router();
-
-// Step 1: Begin OAuth — redirect merchant to Shopify
-router.get("/auth", async (req, res) => {
-  const shop = req.query.shop as string;
-  // Generates the authorization URL with HMAC validation
-  const authRoute = await shopify.auth.begin({
-    shop: shopify.utils.sanitizeShop(shop, true)!,
-    callbackPath: "/auth/callback",
-    isOnline: false, // offline = long-lived token
-    rawRequest: req,
-    rawResponse: res,
-  });
-});
-
-// Step 2: Handle callback — exchange code for access token
-router.get("/auth/callback", async (req, res) => {
-  const callback = await shopify.auth.callback({
-    rawRequest: req,
-    rawResponse: res,
-  });
-
-  // callback.session contains the access token
-  const session: Session = callback.session;
-  console.log("Access token:", session.accessToken);
-  console.log("Shop:", session.shop); // "store-name.myshopify.com"
-  console.log("Scopes:", session.scope); // "read_products,write_products,..."
-
-  // IMPORTANT: Persist session to your database
-  await saveSession(session);
-
-  res.redirect(`/?shop=${session.shop}&host=${req.query.host}`);
-});
-
-export default router;
-```
+See [OAuth Flow](references/oauth-flow.md) for the complete Express route implementation.
 
 ### Step 5: Token Exchange (Embedded Apps)
 
@@ -153,30 +116,9 @@ async function exchangeToken(
 
 ### Step 6: Custom App / Private App Auth
 
-For custom apps (installed on a single store), use a permanent access token:
+For custom apps installed on a single store, use a permanent access token with no OAuth needed.
 
-```typescript
-// Custom app — no OAuth needed, use Admin API access token directly
-import "@shopify/shopify-api/adapters/node";
-import { shopifyApi } from "@shopify/shopify-api";
-
-const shopify = shopifyApi({
-  apiKey: process.env.SHOPIFY_API_KEY!,
-  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
-  hostName: process.env.SHOPIFY_HOST_NAME!,
-  apiVersion: "2024-10",
-  isCustomStoreApp: true,
-  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!, // shpat_xxx
-});
-
-// Create a session for the custom app
-const session = shopify.session.customAppSession(
-  "your-store.myshopify.com"
-);
-
-// Use GraphQL client directly
-const client = new shopify.clients.Graphql({ session });
-```
+See [Custom App Auth](references/custom-app-auth.md) for the complete setup.
 
 ### Step 7: Verify Auth is Working
 
@@ -239,31 +181,9 @@ async function verifyShopifyAuth(session: Session): Promise<void> {
 
 ### Storefront API Access
 
-```typescript
-// Storefront API uses a different token — generated in admin
-const storefrontClient = new shopify.clients.Storefront({
-  session,
-  apiVersion: "2024-10",
-});
+The Storefront API uses a separate token with its own higher rate limits.
 
-const products = await storefrontClient.request(`{
-  products(first: 10) {
-    edges {
-      node {
-        id
-        title
-        handle
-        priceRange {
-          minVariantPrice {
-            amount
-            currencyCode
-          }
-        }
-      }
-    }
-  }
-}`);
-```
+See [Storefront API Access](references/storefront-api-access.md) for the complete client setup.
 
 ## Resources
 
@@ -272,7 +192,3 @@ const products = await storefrontClient.request(`{
 - [@shopify/shopify-api on npm](https://www.npmjs.com/package/@shopify/shopify-api)
 - [Session Token Reference](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens)
 - [Token Exchange](https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/docs/reference/auth/tokenExchange.md)
-
-## Next Steps
-
-After successful auth, proceed to `shopify-hello-world` for your first API call.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/custom-app-auth.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/custom-app-auth.md
@@ -1,0 +1,26 @@
+# Custom App / Private App Auth
+
+For custom apps installed on a single store, use a permanent access token — no OAuth flow needed.
+
+```typescript
+// Custom app — no OAuth needed, use Admin API access token directly
+import "@shopify/shopify-api/adapters/node";
+import { shopifyApi, LATEST_API_VERSION } from "@shopify/shopify-api";
+
+const shopify = shopifyApi({
+  apiKey: process.env.SHOPIFY_API_KEY!,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
+  hostName: process.env.SHOPIFY_HOST_NAME!,
+  apiVersion: LATEST_API_VERSION,
+  isCustomStoreApp: true,
+  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN!, // shpat_xxx
+});
+
+// Create a session for the custom app
+const session = shopify.session.customAppSession(
+  "your-store.myshopify.com"
+);
+
+// Use GraphQL client directly
+const client = new shopify.clients.Graphql({ session });
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/oauth-flow.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/oauth-flow.md
@@ -1,0 +1,45 @@
+# OAuth Flow Implementation (Public Apps)
+
+Express-based OAuth flow for public Shopify apps. Handles the redirect to Shopify and the callback that exchanges the authorization code for an access token.
+
+```typescript
+// routes/auth.ts — Express example
+import express from "express";
+import shopify from "../shopify";
+
+const router = express.Router();
+
+// Step 1: Begin OAuth — redirect merchant to Shopify
+router.get("/auth", async (req, res) => {
+  const shop = req.query.shop as string;
+  // Generates the authorization URL with HMAC validation
+  const authRoute = await shopify.auth.begin({
+    shop: shopify.utils.sanitizeShop(shop, true)!,
+    callbackPath: "/auth/callback",
+    isOnline: false, // offline = long-lived token
+    rawRequest: req,
+    rawResponse: res,
+  });
+});
+
+// Step 2: Handle callback — exchange code for access token
+router.get("/auth/callback", async (req, res) => {
+  const callback = await shopify.auth.callback({
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // callback.session contains the access token
+  const session: Session = callback.session;
+  console.log("Access token:", session.accessToken);
+  console.log("Shop:", session.shop); // "store-name.myshopify.com"
+  console.log("Scopes:", session.scope); // "read_products,write_products,..."
+
+  // IMPORTANT: Persist session to your database
+  await saveSession(session);
+
+  res.redirect(`/?shop=${session.shop}&host=${req.query.host}`);
+});
+
+export default router;
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/storefront-api-access.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/references/storefront-api-access.md
@@ -1,0 +1,29 @@
+# Storefront API Access
+
+The Storefront API uses a different token (generated in admin) and has its own rate limits separate from the Admin API.
+
+```typescript
+// Storefront API uses a different token — generated in admin
+const storefrontClient = new shopify.clients.Storefront({
+  session,
+  apiVersion: LATEST_API_VERSION,
+});
+
+const products = await storefrontClient.request(`{
+  products(first: 10) {
+    edges {
+      node {
+        id
+        title
+        handle
+        priceRange {
+          minVariantPrice {
+            amount
+            currencyCode
+          }
+        }
+      }
+    }
+  }
+}`);
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
@@ -22,8 +22,10 @@ The 10 most common mistakes when building Shopify apps, with real API examples s
 
 ## Prerequisites
 
-- Shopify app codebase to review
-- Understanding of GraphQL Admin API patterns
+- Existing Shopify app codebase to review or audit
+- Familiarity with GraphQL Admin API query patterns and response shapes
+- Access scopes configured for the APIs your app uses
+- `@shopify/shopify-api` v9+ installed (for code examples)
 
 ## Instructions
 

--- a/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-known-pitfalls
 description: |
   Identify and avoid Shopify API anti-patterns: ignoring userErrors, wrong API version,
   REST instead of GraphQL, missing GDPR webhooks, and webhook timeout issues.
+  Use when reviewing a Shopify codebase, preparing for App Store submission, or debugging mysterious API failures.
   Trigger with phrases like "shopify mistakes", "shopify anti-patterns",
   "shopify pitfalls", "shopify what not to do", "shopify code review".
 allowed-tools: Read, Grep
@@ -26,248 +27,47 @@ The 10 most common mistakes when building Shopify apps, with real API examples s
 
 ## Instructions
 
+Each pitfall includes a wrong-way and right-way code example. See [Pitfall Examples](references/pitfall-examples.md) for all 10 complete code comparisons.
+
 ### Pitfall #1: Not Checking userErrors (The #1 Mistake)
 
-Shopify GraphQL mutations return HTTP 200 even when they fail. The errors are in `userErrors`.
-
-```typescript
-// WRONG — assumes 200 means success
-const response = await client.request(PRODUCT_CREATE, { variables });
-const product = response.data.productCreate.product; // null!
-console.log(product.title); // TypeError: Cannot read property 'title' of null
-
-// RIGHT — always check userErrors
-const response = await client.request(PRODUCT_CREATE, { variables });
-const { product, userErrors } = response.data.productCreate;
-if (userErrors.length > 0) {
-  console.error("Shopify validation failed:", userErrors);
-  // [{ field: ["title"], message: "Title can't be blank", code: "BLANK" }]
-  throw new ShopifyValidationError(userErrors);
-}
-console.log(product.title); // Safe
-```
-
----
+Shopify GraphQL mutations return HTTP 200 even when they fail. The errors are in `userErrors`. Always check `userErrors.length > 0` before accessing the result.
 
 ### Pitfall #2: Using REST When GraphQL Is Required
 
-REST Admin API is legacy as of October 2024. New public apps after April 2025 **must** use GraphQL.
-
-```typescript
-// WRONG — REST API (legacy, higher bandwidth, returns all fields)
-const { body } = await restClient.get({ path: "products", query: { limit: 250 } });
-// Returns EVERYTHING: body_html, template_suffix, published_scope...
-
-// RIGHT — GraphQL (get only what you need)
-const response = await graphqlClient.request(`{
-  products(first: 50) {
-    edges { node { id title status } }
-    pageInfo { hasNextPage endCursor }
-  }
-}`);
-```
-
----
+REST Admin API is legacy as of October 2024. New public apps after April 2025 **must** use GraphQL. GraphQL also lets you request only the fields you need.
 
 ### Pitfall #3: Ignoring API Version Deprecation
 
-Shopify deprecates API versions ~12 months after release. Your app will break silently when your version is removed.
-
-```typescript
-// WRONG — hardcoded old version, no monitoring
-const shopify = shopifyApi({ apiVersion: "2023-04" }); // DEAD version
-
-// RIGHT — use recent stable version, monitor deprecation
-const shopify = shopifyApi({ apiVersion: "2024-10" });
-
-// Monitor for deprecation warnings in responses
-function checkDeprecation(headers: Headers): void {
-  const warning = headers.get("x-shopify-api-deprecated-reason");
-  if (warning) {
-    console.warn(`[DEPRECATION] ${warning}`);
-    // Alert team to upgrade
-  }
-}
-```
-
----
+Shopify deprecates API versions ~12 months after release. Use `LATEST_API_VERSION` from `@shopify/shopify-api` and monitor `x-shopify-api-deprecated-reason` response headers.
 
 ### Pitfall #4: Missing Mandatory GDPR Webhooks
 
-Your app **will be rejected** from the App Store without these three webhooks.
-
-```typescript
-// WRONG — no GDPR handlers
-// shopify.app.toml has no webhook subscriptions
-// App Store review: REJECTED
-
-// RIGHT — all three mandatory webhooks
-// shopify.app.toml:
-// [[webhooks.subscriptions]]
-// topics = ["customers/data_request"]
-// uri = "/webhooks/gdpr/data-request"
-//
-// [[webhooks.subscriptions]]
-// topics = ["customers/redact"]
-// uri = "/webhooks/gdpr/customers-redact"
-//
-// [[webhooks.subscriptions]]
-// topics = ["shop/redact"]
-// uri = "/webhooks/gdpr/shop-redact"
-```
-
----
+Your app **will be rejected** from the App Store without `customers/data_request`, `customers/redact`, and `shop/redact` webhook handlers.
 
 ### Pitfall #5: Webhook Handler Takes Too Long
 
-Shopify expects a 200 response within 5 seconds. If your handler does API calls inline, it will time out and Shopify will retry — causing duplicates.
-
-```typescript
-// WRONG — processing inline, takes 10+ seconds
-app.post("/webhooks", rawBodyParser, async (req, res) => {
-  const order = JSON.parse(req.body);
-  await syncToERP(order);           // 3 seconds
-  await updateInventory(order);      // 2 seconds
-  await sendNotification(order);     // 2 seconds
-  res.status(200).send("OK");       // 7+ seconds — Shopify considers this failed!
-});
-
-// RIGHT — respond immediately, process async
-app.post("/webhooks", rawBodyParser, async (req, res) => {
-  res.status(200).send("OK"); // Respond within milliseconds
-
-  // Process asynchronously
-  const order = JSON.parse(req.body);
-  await queue.add("process-order", order);
-});
-```
-
----
+Shopify expects a 200 response within 5 seconds. Respond immediately and queue work asynchronously, otherwise Shopify retries and creates duplicates.
 
 ### Pitfall #6: Using ProductInput on API 2024-10+
 
-The `ProductInput` type was split into `ProductCreateInput` and `ProductUpdateInput` in 2024-10.
-
-```typescript
-// WRONG — old ProductInput type (breaks on 2024-10+)
-mutation($input: ProductInput!) {  // ERROR: ProductInput is not defined
-  productCreate(input: $input) { ... }
-}
-
-// RIGHT — separate types for create and update
-mutation($input: ProductCreateInput!) {
-  productCreate(product: $input) { ... }  // Note: "product:" not "input:"
-}
-
-mutation($input: ProductUpdateInput!) {
-  productUpdate(product: $input) { ... }
-}
-```
-
----
+The `ProductInput` type was split into `ProductCreateInput` and `ProductUpdateInput` in 2024-10. Use the specific type for each operation.
 
 ### Pitfall #7: Not Using Cursor Pagination
 
-Shopify uses Relay-style cursor pagination, not page numbers.
-
-```typescript
-// WRONG — trying page numbers (doesn't work in GraphQL)
-const page1 = await query("products(first: 50, page: 1)"); // ERROR
-const page2 = await query("products(first: 50, page: 2)"); // ERROR
-
-// RIGHT — cursor-based pagination
-let cursor = null;
-let hasMore = true;
-while (hasMore) {
-  const response = await client.request(`{
-    products(first: 50, after: ${cursor ? `"${cursor}"` : "null"}) {
-      edges { node { id title } cursor }
-      pageInfo { hasNextPage endCursor }
-    }
-  }`);
-  // Process products...
-  cursor = response.data.products.pageInfo.endCursor;
-  hasMore = response.data.products.pageInfo.hasNextPage;
-}
-```
-
----
+Shopify uses Relay-style cursor pagination, not page numbers. Use `after` / `endCursor` with `pageInfo`.
 
 ### Pitfall #8: Requesting 250 Items Per Page
 
-`first: 250` with nested connections creates enormous query costs that THROTTLE immediately.
-
-```typescript
-// WRONG — cost explosion
-// products(first: 250) × variants(first: 100) = 25,000 point cost
-const response = await client.request(`{
-  products(first: 250) {
-    edges { node {
-      variants(first: 100) { edges { node { id price } } }
-    }}
-  }
-}`);
-// Result: THROTTLED immediately
-
-// RIGHT — reasonable page sizes
-const response = await client.request(`{
-  products(first: 50) {
-    edges { node {
-      variants(first: 10) { edges { node { id price } } }
-    }}
-    pageInfo { hasNextPage endCursor }
-  }
-}`);
-```
-
----
+`first: 250` with nested connections creates enormous query costs that THROTTLE immediately. Use `first: 50` or smaller with nested resources.
 
 ### Pitfall #9: Exposing Admin Token in Client-Side Code
 
-Admin API tokens have full access. Never send them to the browser.
-
-```typescript
-// WRONG — admin token in React component
-const response = await fetch(`https://store.myshopify.com/admin/api/2024-10/graphql.json`, {
-  headers: { "X-Shopify-Access-Token": "shpat_xxx" }, // Visible in browser devtools!
-});
-
-// RIGHT — proxy through your server
-// Client calls your API, your server calls Shopify
-const response = await fetch("/api/shopify/products"); // Your server
-
-// Server-side only
-app.get("/api/shopify/products", async (req, res) => {
-  const { admin } = await authenticate.admin(req);
-  const data = await admin.graphql(PRODUCTS_QUERY);
-  res.json(data);
-});
-```
-
----
+Admin API tokens have full access. Never send them to the browser — proxy through your server.
 
 ### Pitfall #10: Not Handling APP_UNINSTALLED Webhook
 
-When a merchant uninstalls your app, you need to clean up sessions. Otherwise, stale sessions cause auth loops.
-
-```typescript
-// WRONG — no cleanup on uninstall
-// Result: when merchant reinstalls, old stale session is found,
-// API calls fail with 401, auth redirect loop
-
-// RIGHT — clean up on uninstall
-async function handleAppUninstalled(shop: string): Promise<void> {
-  // Delete session from database
-  await prisma.session.deleteMany({ where: { shop } });
-  // Disable features for this shop
-  await prisma.appSettings.update({
-    where: { shop },
-    data: { active: false },
-  });
-  console.log(`Cleaned up data for uninstalled shop: ${shop}`);
-  // shop/redact webhook will fire 48 hours later for full data deletion
-}
-```
+When a merchant uninstalls your app, clean up sessions immediately. Stale sessions cause auth redirect loops on reinstall.
 
 ## Output
 
@@ -294,15 +94,9 @@ async function handleAppUninstalled(shop: string): Promise<void> {
 
 ### Quick Pitfall Scan
 
-```bash
-# Run these against your Shopify codebase
-echo "=== Shopify Pitfall Scan ==="
-echo -n "REST API usage: "; grep -rc "clients.Rest\|admin-rest" app/ src/ 2>/dev/null | grep -v ":0" | wc -l
-echo -n "Missing userErrors check: "; grep -rn "mutation\|Mutation" app/ src/ --include="*.ts" | wc -l
-echo -n "Old API versions: "; grep -rn "2023-\|2022-" app/ src/ --include="*.ts" 2>/dev/null | wc -l
-echo -n "Hardcoded tokens: "; grep -rc "shpat_" app/ src/ 2>/dev/null | grep -v ":0" | wc -l
-echo -n "first: 250: "; grep -rn "first: 250\|first:250" app/ src/ --include="*.ts" 2>/dev/null | wc -l
-```
+Run automated detection against your Shopify codebase to find REST usage, missing userErrors checks, old API versions, hardcoded tokens, and oversized page requests.
+
+See [Pitfall Scan Script](references/pitfall-scan-script.md) for the complete scan script.
 
 ## Resources
 
@@ -317,7 +111,7 @@ echo -n "first: 250: "; grep -rn "first: 250\|first:250" app/ src/ --include="*.
 |---------|-----------|-----|
 | No userErrors check | Null crashes on mutations | Always check `userErrors.length > 0` |
 | REST instead of GraphQL | `grep "clients.Rest"` | Migrate to `clients.Graphql` |
-| Old API version | `grep "2023-"` | Update to `2024-10` |
+| Old API version | `grep "2023-"` | Use `LATEST_API_VERSION` from SDK |
 | Missing GDPR webhooks | App Store rejection | Add 3 mandatory webhook handlers |
 | Webhook timeout | Retry storms, duplicates | Respond 200 immediately, queue processing |
 | ProductInput on 2024-10 | Type error | Use `ProductCreateInput` / `ProductUpdateInput` |

--- a/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/references/pitfall-examples.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/references/pitfall-examples.md
@@ -1,0 +1,211 @@
+# Shopify Pitfall Code Examples
+
+Complete wrong-way/right-way code examples for each of the 10 most common Shopify API anti-patterns.
+
+## Pitfall #1: Not Checking userErrors
+
+```typescript
+// WRONG — assumes 200 means success
+const response = await client.request(PRODUCT_CREATE, { variables });
+const product = response.data.productCreate.product; // null!
+console.log(product.title); // TypeError: Cannot read property 'title' of null
+
+// RIGHT — always check userErrors
+const response = await client.request(PRODUCT_CREATE, { variables });
+const { product, userErrors } = response.data.productCreate;
+if (userErrors.length > 0) {
+  console.error("Shopify validation failed:", userErrors);
+  // [{ field: ["title"], message: "Title can't be blank", code: "BLANK" }]
+  throw new ShopifyValidationError(userErrors);
+}
+console.log(product.title); // Safe
+```
+
+## Pitfall #2: Using REST When GraphQL Is Required
+
+```typescript
+// WRONG — REST API (legacy, higher bandwidth, returns all fields)
+const { body } = await restClient.get({ path: "products", query: { limit: 250 } });
+// Returns EVERYTHING: body_html, template_suffix, published_scope...
+
+// RIGHT — GraphQL (get only what you need)
+const response = await graphqlClient.request(`{
+  products(first: 50) {
+    edges { node { id title status } }
+    pageInfo { hasNextPage endCursor }
+  }
+}`);
+```
+
+## Pitfall #3: Ignoring API Version Deprecation
+
+```typescript
+// WRONG — hardcoded old version, no monitoring
+const shopify = shopifyApi({ apiVersion: "2023-04" }); // DEAD version
+
+// RIGHT — use LATEST_API_VERSION from the SDK
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+const shopify = shopifyApi({ apiVersion: LATEST_API_VERSION });
+
+// Monitor for deprecation warnings in responses
+function checkDeprecation(headers: Headers): void {
+  const warning = headers.get("x-shopify-api-deprecated-reason");
+  if (warning) {
+    console.warn(`[DEPRECATION] ${warning}`);
+    // Alert team to upgrade
+  }
+}
+```
+
+## Pitfall #4: Missing Mandatory GDPR Webhooks
+
+```typescript
+// WRONG — no GDPR handlers
+// shopify.app.toml has no webhook subscriptions
+// App Store review: REJECTED
+
+// RIGHT — all three mandatory webhooks
+// shopify.app.toml:
+// [[webhooks.subscriptions]]
+// topics = ["customers/data_request"]
+// uri = "/webhooks/gdpr/data-request"
+//
+// [[webhooks.subscriptions]]
+// topics = ["customers/redact"]
+// uri = "/webhooks/gdpr/customers-redact"
+//
+// [[webhooks.subscriptions]]
+// topics = ["shop/redact"]
+// uri = "/webhooks/gdpr/shop-redact"
+```
+
+## Pitfall #5: Webhook Handler Takes Too Long
+
+```typescript
+// WRONG — processing inline, takes 10+ seconds
+app.post("/webhooks", rawBodyParser, async (req, res) => {
+  const order = JSON.parse(req.body);
+  await syncToERP(order);           // 3 seconds
+  await updateInventory(order);      // 2 seconds
+  await sendNotification(order);     // 2 seconds
+  res.status(200).send("OK");       // 7+ seconds — Shopify considers this failed!
+});
+
+// RIGHT — respond immediately, process async
+app.post("/webhooks", rawBodyParser, async (req, res) => {
+  res.status(200).send("OK"); // Respond within milliseconds
+
+  // Process asynchronously
+  const order = JSON.parse(req.body);
+  await queue.add("process-order", order);
+});
+```
+
+## Pitfall #6: Using ProductInput on API 2024-10+
+
+The `ProductInput` type was split into `ProductCreateInput` and `ProductUpdateInput` in 2024-10.
+
+```typescript
+// WRONG — old ProductInput type (breaks on 2024-10+)
+mutation($input: ProductInput!) {  // ERROR: ProductInput is not defined
+  productCreate(input: $input) { ... }
+}
+
+// RIGHT — separate types for create and update
+mutation($input: ProductCreateInput!) {
+  productCreate(product: $input) { ... }  // Note: "product:" not "input:"
+}
+
+mutation($input: ProductUpdateInput!) {
+  productUpdate(product: $input) { ... }
+}
+```
+
+## Pitfall #7: Not Using Cursor Pagination
+
+```typescript
+// WRONG — trying page numbers (doesn't work in GraphQL)
+const page1 = await query("products(first: 50, page: 1)"); // ERROR
+const page2 = await query("products(first: 50, page: 2)"); // ERROR
+
+// RIGHT — cursor-based pagination
+let cursor = null;
+let hasMore = true;
+while (hasMore) {
+  const response = await client.request(`{
+    products(first: 50, after: ${cursor ? `"${cursor}"` : "null"}) {
+      edges { node { id title } cursor }
+      pageInfo { hasNextPage endCursor }
+    }
+  }`);
+  // Process products...
+  cursor = response.data.products.pageInfo.endCursor;
+  hasMore = response.data.products.pageInfo.hasNextPage;
+}
+```
+
+## Pitfall #8: Requesting 250 Items Per Page
+
+```typescript
+// WRONG — cost explosion
+// products(first: 250) × variants(first: 100) = 25,000 point cost
+const response = await client.request(`{
+  products(first: 250) {
+    edges { node {
+      variants(first: 100) { edges { node { id price } } }
+    }}
+  }
+}`);
+// Result: THROTTLED immediately
+
+// RIGHT — reasonable page sizes
+const response = await client.request(`{
+  products(first: 50) {
+    edges { node {
+      variants(first: 10) { edges { node { id price } } }
+    }}
+    pageInfo { hasNextPage endCursor }
+  }
+}`);
+```
+
+## Pitfall #9: Exposing Admin Token in Client-Side Code
+
+```typescript
+// WRONG — admin token in React component
+const response = await fetch(`https://store.myshopify.com/admin/api/2025-04/graphql.json`, {
+  headers: { "X-Shopify-Access-Token": "shpat_xxx" }, // Visible in browser devtools!
+});
+
+// RIGHT — proxy through your server
+// Client calls your API, your server calls Shopify
+const response = await fetch("/api/shopify/products"); // Your server
+
+// Server-side only
+app.get("/api/shopify/products", async (req, res) => {
+  const { admin } = await authenticate.admin(req);
+  const data = await admin.graphql(PRODUCTS_QUERY);
+  res.json(data);
+});
+```
+
+## Pitfall #10: Not Handling APP_UNINSTALLED Webhook
+
+```typescript
+// WRONG — no cleanup on uninstall
+// Result: when merchant reinstalls, old stale session is found,
+// API calls fail with 401, auth redirect loop
+
+// RIGHT — clean up on uninstall
+async function handleAppUninstalled(shop: string): Promise<void> {
+  // Delete session from database
+  await prisma.session.deleteMany({ where: { shop } });
+  // Disable features for this shop
+  await prisma.appSettings.update({
+    where: { shop },
+    data: { active: false },
+  });
+  console.log(`Cleaned up data for uninstalled shop: ${shop}`);
+  // shop/redact webhook will fire 48 hours later for full data deletion
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/references/pitfall-scan-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/references/pitfall-scan-script.md
@@ -1,0 +1,13 @@
+# Quick Pitfall Scan Script
+
+Run these commands against your Shopify codebase to detect the most common anti-patterns.
+
+```bash
+# Run these against your Shopify codebase
+echo "=== Shopify Pitfall Scan ==="
+echo -n "REST API usage: "; grep -rc "clients.Rest\|admin-rest" app/ src/ 2>/dev/null | grep -v ":0" | wc -l
+echo -n "Missing userErrors check: "; grep -rn "mutation\|Mutation" app/ src/ --include="*.ts" | wc -l
+echo -n "Old API versions: "; grep -rn "2023-\|2022-" app/ src/ --include="*.ts" 2>/dev/null | wc -l
+echo -n "Hardcoded tokens: "; grep -rc "shpat_" app/ src/ 2>/dev/null | grep -v ":0" | wc -l
+echo -n "first: 250: "; grep -rn "first: 250\|first:250" app/ src/ --include="*.ts" 2>/dev/null | wc -l
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-load-scale
 description: |
   Load test Shopify integrations respecting API rate limits, plan capacity with
   k6, and scale for Shopify Plus burst events (flash sales, BFCM).
+  Use when preparing for high-traffic events, benchmarking API throughput, or sizing infrastructure for Shopify webhook volume.
   Trigger with phrases like "shopify load test", "shopify scale",
   "shopify BFCM", "shopify flash sale", "shopify capacity", "shopify k6 test".
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(curl:*)
@@ -40,92 +41,9 @@ A typical product query costs 10-50 points. At 50 points/query, Standard support
 
 ### Step 2: k6 Load Test Script
 
-```javascript
-// shopify-load-test.js
-import http from "k6/http";
-import { check, sleep } from "k6";
-import { Rate, Counter, Trend } from "k6/metrics";
+k6 script with Shopify-specific custom metrics (throttle tracking, query cost trends, error rates) and automatic request pacing.
 
-// Custom metrics
-const shopifyErrors = new Rate("shopify_errors");
-const throttledRequests = new Counter("shopify_throttled");
-const queryCost = new Trend("shopify_query_cost");
-
-export const options = {
-  stages: [
-    { duration: "1m", target: 2 },    // Warm up — 2 VUs
-    { duration: "3m", target: 5 },    // Normal load
-    { duration: "2m", target: 10 },   // Peak load
-    { duration: "1m", target: 0 },    // Ramp down
-  ],
-  thresholds: {
-    http_req_duration: ["p(95)<2000"],  // 95% under 2s
-    shopify_errors: ["rate<0.05"],      // < 5% error rate
-    shopify_throttled: ["count<10"],    // < 10 throttled requests
-  },
-};
-
-const STORE = __ENV.SHOPIFY_STORE;
-const TOKEN = __ENV.SHOPIFY_ACCESS_TOKEN;
-const API_VERSION = "2024-10";
-
-export default function () {
-  const query = JSON.stringify({
-    query: `{
-      products(first: 10) {
-        edges {
-          node { id title status totalInventory }
-        }
-      }
-    }`,
-  });
-
-  const res = http.post(
-    `https://${STORE}/admin/api/${API_VERSION}/graphql.json`,
-    query,
-    {
-      headers: {
-        "Content-Type": "application/json",
-        "X-Shopify-Access-Token": TOKEN,
-      },
-    }
-  );
-
-  const body = JSON.parse(res.body);
-
-  // Track GraphQL-level throttling (returns 200 with THROTTLED error)
-  const isThrottled = body.errors?.some(
-    (e) => e.extensions?.code === "THROTTLED"
-  );
-
-  if (isThrottled) {
-    throttledRequests.add(1);
-    // Wait for restore rate to refill
-    const available = body.extensions?.cost?.throttleStatus?.currentlyAvailable || 0;
-    const restoreRate = body.extensions?.cost?.throttleStatus?.restoreRate || 50;
-    const waitTime = Math.max(1, (100 - available) / restoreRate);
-    sleep(waitTime);
-    return;
-  }
-
-  // Track query cost
-  if (body.extensions?.cost?.actualQueryCost) {
-    queryCost.add(body.extensions.cost.actualQueryCost);
-  }
-
-  check(res, {
-    "status is 200": (r) => r.status === 200,
-    "no errors": () => !body.errors,
-    "has products": () => body.data?.products?.edges?.length > 0,
-  });
-
-  shopifyErrors.add(res.status !== 200 || !!body.errors);
-
-  // Pace requests to stay within rate limits
-  // Standard: 50 points/sec restore, queries ~10 points each
-  sleep(0.5); // ~2 queries/sec per VU
-}
-```
+See [k6 Load Test Script](references/k6-load-test-script.md) for the complete test script.
 
 ### Step 3: Run Load Test
 
@@ -142,68 +60,9 @@ k6 run --out influxdb=http://localhost:8086/k6 shopify-load-test.js
 
 ### Step 4: BFCM / Flash Sale Preparation
 
-```typescript
-// Pre-BFCM checklist for Shopify apps
+Pre-BFCM preparation including cache pre-warming, Storefront API offloading, bulk inventory sync, and Kubernetes HPA configuration for webhook processing.
 
-// 1. Pre-fetch and cache product data before the sale starts
-async function prewarmCache(productIds: string[]): Promise<void> {
-  console.log(`Pre-warming cache for ${productIds.length} products`);
-  for (const id of productIds) {
-    await cachedQuery(`product:${id}`, () =>
-      shopifyQuery(shop, PRODUCT_QUERY, { id })
-    );
-    await new Promise((r) => setTimeout(r, 100)); // Pace for rate limits
-  }
-}
-
-// 2. Use Storefront API for customer-facing queries (separate rate limits)
-// Admin API rate limits are shared across all apps
-// Storefront API has its own higher limits
-
-// 3. Use bulk operations to sync inventory before the event
-// Don't rely on real-time inventory queries during peak traffic
-
-// 4. Queue webhook processing — don't process inline during peak
-async function handleOrderWebhook(payload: any): Promise<void> {
-  // Queue for later processing instead of immediate API calls
-  await queue.add("process-order", payload, {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 5000 },
-  });
-}
-```
-
-### Step 5: Scaling Your App (Not Shopify's Limits)
-
-Your infrastructure must handle the webhook volume:
-
-```yaml
-# BFCM webhook volume estimates:
-# 100 orders/hour → 100 orders/create webhooks/hour
-# 1,000 orders/hour → 1,000 webhooks/hour (Plus stores during BFCM)
-# Each webhook must respond 200 within 5 seconds
-
-# Kubernetes HPA for webhook processing
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: shopify-webhook-processor
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: shopify-webhook-processor
-  minReplicas: 2
-  maxReplicas: 20
-  metrics:
-    - type: Pods
-      pods:
-        metric:
-          name: webhook_queue_depth
-        target:
-          type: AverageValue
-          averageValue: "50"
-```
+See [BFCM Preparation](references/bfcm-preparation.md) for application-level and infrastructure scaling patterns.
 
 ## Output
 
@@ -230,7 +89,7 @@ spec:
 # Standard plan: 50 points/sec restore
 # Your query costs: check with debug header
 
-curl -sf "https://$STORE/admin/api/2024-10/graphql.json" \
+curl -sf "https://$STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/graphql.json" \
   -H "X-Shopify-Access-Token: $TOKEN" \
   -H "Content-Type: application/json" \
   -H "Shopify-GraphQL-Cost-Debug: 1" \
@@ -244,7 +103,3 @@ curl -sf "https://$STORE/admin/api/2024-10/graphql.json" \
 - [Shopify Plus Rate Limits](https://shopify.dev/changelog/increased-admin-api-rate-limits-for-shopify-plus)
 - [k6 Documentation](https://k6.io/docs/)
 - [BFCM Preparation Guide](https://www.shopify.com/blog/bfcm-checklist)
-
-## Next Steps
-
-For reliability patterns, see `shopify-reliability-patterns`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/references/bfcm-preparation.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/references/bfcm-preparation.md
@@ -1,0 +1,66 @@
+# BFCM / Flash Sale Preparation
+
+Pre-BFCM checklist and scaling patterns for Shopify apps handling high-traffic burst events.
+
+## Application-Level Preparation
+
+```typescript
+// Pre-BFCM checklist for Shopify apps
+
+// 1. Pre-fetch and cache product data before the sale starts
+async function prewarmCache(productIds: string[]): Promise<void> {
+  console.log(`Pre-warming cache for ${productIds.length} products`);
+  for (const id of productIds) {
+    await cachedQuery(`product:${id}`, () =>
+      shopifyQuery(shop, PRODUCT_QUERY, { id })
+    );
+    await new Promise((r) => setTimeout(r, 100)); // Pace for rate limits
+  }
+}
+
+// 2. Use Storefront API for customer-facing queries (separate rate limits)
+// Admin API rate limits are shared across all apps
+// Storefront API has its own higher limits
+
+// 3. Use bulk operations to sync inventory before the event
+// Don't rely on real-time inventory queries during peak traffic
+
+// 4. Queue webhook processing — don't process inline during peak
+async function handleOrderWebhook(payload: any): Promise<void> {
+  // Queue for later processing instead of immediate API calls
+  await queue.add("process-order", payload, {
+    attempts: 5,
+    backoff: { type: "exponential", delay: 5000 },
+  });
+}
+```
+
+## Infrastructure Scaling (Kubernetes HPA)
+
+```yaml
+# BFCM webhook volume estimates:
+# 100 orders/hour → 100 orders/create webhooks/hour
+# 1,000 orders/hour → 1,000 webhooks/hour (Plus stores during BFCM)
+# Each webhook must respond 200 within 5 seconds
+
+# Kubernetes HPA for webhook processing
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: shopify-webhook-processor
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: shopify-webhook-processor
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: webhook_queue_depth
+        target:
+          type: AverageValue
+          averageValue: "50"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/references/k6-load-test-script.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/references/k6-load-test-script.md
@@ -1,0 +1,91 @@
+# k6 Load Test Script for Shopify
+
+Load test script that tracks Shopify-specific metrics: throttle state, query costs, and error rates. Automatically paces requests to stay within rate limits.
+
+```javascript
+// shopify-load-test.js
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Counter, Trend } from "k6/metrics";
+
+// Custom metrics
+const shopifyErrors = new Rate("shopify_errors");
+const throttledRequests = new Counter("shopify_throttled");
+const queryCost = new Trend("shopify_query_cost");
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 2 },    // Warm up — 2 VUs
+    { duration: "3m", target: 5 },    // Normal load
+    { duration: "2m", target: 10 },   // Peak load
+    { duration: "1m", target: 0 },    // Ramp down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<2000"],  // 95% under 2s
+    shopify_errors: ["rate<0.05"],      // < 5% error rate
+    shopify_throttled: ["count<10"],    // < 10 throttled requests
+  },
+};
+
+const STORE = __ENV.SHOPIFY_STORE;
+const TOKEN = __ENV.SHOPIFY_ACCESS_TOKEN;
+// Use a recent stable API version (e.g., 2025-04)
+const API_VERSION = __ENV.SHOPIFY_API_VERSION || "2025-04";
+
+export default function () {
+  const query = JSON.stringify({
+    query: `{
+      products(first: 10) {
+        edges {
+          node { id title status totalInventory }
+        }
+      }
+    }`,
+  });
+
+  const res = http.post(
+    `https://${STORE}/admin/api/${API_VERSION}/graphql.json`,
+    query,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": TOKEN,
+      },
+    }
+  );
+
+  const body = JSON.parse(res.body);
+
+  // Track GraphQL-level throttling (returns 200 with THROTTLED error)
+  const isThrottled = body.errors?.some(
+    (e) => e.extensions?.code === "THROTTLED"
+  );
+
+  if (isThrottled) {
+    throttledRequests.add(1);
+    // Wait for restore rate to refill
+    const available = body.extensions?.cost?.throttleStatus?.currentlyAvailable || 0;
+    const restoreRate = body.extensions?.cost?.throttleStatus?.restoreRate || 50;
+    const waitTime = Math.max(1, (100 - available) / restoreRate);
+    sleep(waitTime);
+    return;
+  }
+
+  // Track query cost
+  if (body.extensions?.cost?.actualQueryCost) {
+    queryCost.add(body.extensions.cost.actualQueryCost);
+  }
+
+  check(res, {
+    "status is 200": (r) => r.status === 200,
+    "no errors": () => !body.errors,
+    "has products": () => body.data?.products?.edges?.length > 0,
+  });
+
+  shopifyErrors.add(res.status !== 200 || !!body.errors);
+
+  // Pace requests to stay within rate limits
+  // Standard: 50 points/sec restore, queries ~10 points each
+  sleep(0.5); // ~2 queries/sec per VU
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/SKILL.md
@@ -63,37 +63,9 @@ my-shopify-app/
 
 ### Step 3: Configure shopify.app.toml
 
-```toml
-# shopify.app.toml — central app configuration
-name = "My App"
-client_id = "your_api_key_here"
+Central app configuration with scopes, auth redirects, and mandatory GDPR webhook subscriptions.
 
-[access_scopes]
-scopes = "read_products,write_products,read_orders"
-
-[auth]
-redirect_urls = [
-  "https://localhost/auth/callback",
-  "https://localhost/auth/shopify/callback",
-]
-
-[webhooks]
-api_version = "2024-10"
-
-  [webhooks.subscriptions]
-  # Mandatory GDPR webhooks
-  [[webhooks.subscriptions]]
-  topics = ["customers/data_request"]
-  uri = "/webhooks"
-
-  [[webhooks.subscriptions]]
-  topics = ["customers/redact"]
-  uri = "/webhooks"
-
-  [[webhooks.subscriptions]]
-  topics = ["shop/redact"]
-  uri = "/webhooks"
-```
+See [App TOML Config](references/app-toml-config.md) for the complete configuration file.
 
 ### Step 4: Start Dev Server with Tunnel
 
@@ -111,67 +83,20 @@ shopify app dev
 
 ### Step 5: Set Up Testing
 
-```typescript
-// tests/shopify-client.test.ts
-import { describe, it, expect, vi, beforeEach } from "vitest";
+Vitest setup with mocked Shopify API client and recommended package.json scripts for the dev workflow.
 
-// Mock the Shopify API client
-vi.mock("@shopify/shopify-api", () => ({
-  shopifyApi: vi.fn(() => ({
-    clients: {
-      Graphql: vi.fn().mockImplementation(() => ({
-        request: vi.fn().mockResolvedValue({
-          data: {
-            products: {
-              edges: [
-                { node: { id: "gid://shopify/Product/1", title: "Test Product" } },
-              ],
-            },
-          },
-        }),
-      })),
-    },
-    session: {
-      customAppSession: vi.fn(() => ({ shop: "test.myshopify.com" })),
-    },
-  })),
-}));
-
-describe("Shopify Integration", () => {
-  it("should fetch products", async () => {
-    // Test your product-fetching logic here
-  });
-
-  it("should handle GraphQL errors", async () => {
-    // Test error handling
-  });
-});
-```
-
-```json
-{
-  "scripts": {
-    "dev": "shopify app dev",
-    "build": "remix vite:build",
-    "test": "vitest",
-    "test:watch": "vitest --watch",
-    "lint": "eslint app/",
-    "shopify": "shopify",
-    "deploy": "shopify app deploy"
-  }
-}
-```
+See [Vitest Shopify Mock](references/vitest-shopify-mock.md) for the complete test setup.
 
 ### Step 6: GraphQL Explorer for Development
 
 ```bash
 # Open the Shopify GraphiQL explorer for your store
-# Navigate to: https://your-store.myshopify.com/admin/api/2024-10/graphql.json
+# Navigate to: https://your-store.myshopify.com/admin/api/2025-04/graphql.json
 # Use the Shopify Admin GraphiQL app (install from admin)
 
 # Or use curl to test queries directly:
 curl -X POST \
-  "https://your-store.myshopify.com/admin/api/2024-10/graphql.json" \
+  "https://your-store.myshopify.com/admin/api/${SHOPIFY_API_VERSION:-2025-04}/graphql.json" \
   -H "Content-Type: application/json" \
   -H "X-Shopify-Access-Token: shpat_xxx" \
   -d '{"query": "{ shop { name } }"}'
@@ -243,7 +168,3 @@ async function seedStore(client: any) {
 - [Shopify App Remix Template](https://github.com/Shopify/shopify-app-template-remix)
 - [Vitest Documentation](https://vitest.dev/)
 - [Shopify GraphiQL Explorer](https://shopify.dev/docs/apps/build/graphql)
-
-## Next Steps
-
-See `shopify-sdk-patterns` for production-ready code patterns.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/references/app-toml-config.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/references/app-toml-config.md
@@ -1,0 +1,36 @@
+# shopify.app.toml Configuration
+
+Central app configuration file for Shopify CLI projects. Includes scopes, auth redirect URLs, and mandatory GDPR webhook subscriptions.
+
+```toml
+# shopify.app.toml — central app configuration
+name = "My App"
+client_id = "your_api_key_here"
+
+[access_scopes]
+scopes = "read_products,write_products,read_orders"
+
+[auth]
+redirect_urls = [
+  "https://localhost/auth/callback",
+  "https://localhost/auth/shopify/callback",
+]
+
+[webhooks]
+# Update quarterly — see shopify.dev/docs/api/usage/versioning
+api_version = "2025-04"
+
+  [webhooks.subscriptions]
+  # Mandatory GDPR webhooks
+  [[webhooks.subscriptions]]
+  topics = ["customers/data_request"]
+  uri = "/webhooks"
+
+  [[webhooks.subscriptions]]
+  topics = ["customers/redact"]
+  uri = "/webhooks"
+
+  [[webhooks.subscriptions]]
+  topics = ["shop/redact"]
+  uri = "/webhooks"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/references/vitest-shopify-mock.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/references/vitest-shopify-mock.md
@@ -1,0 +1,56 @@
+# Vitest Shopify API Mock Setup
+
+Test setup with mocked Shopify API client for unit testing without hitting the real API.
+
+```typescript
+// tests/shopify-client.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Shopify API client
+vi.mock("@shopify/shopify-api", () => ({
+  shopifyApi: vi.fn(() => ({
+    clients: {
+      Graphql: vi.fn().mockImplementation(() => ({
+        request: vi.fn().mockResolvedValue({
+          data: {
+            products: {
+              edges: [
+                { node: { id: "gid://shopify/Product/1", title: "Test Product" } },
+              ],
+            },
+          },
+        }),
+      })),
+    },
+    session: {
+      customAppSession: vi.fn(() => ({ shop: "test.myshopify.com" })),
+    },
+  })),
+}));
+
+describe("Shopify Integration", () => {
+  it("should fetch products", async () => {
+    // Test your product-fetching logic here
+  });
+
+  it("should handle GraphQL errors", async () => {
+    // Test error handling
+  });
+});
+```
+
+### package.json scripts
+
+```json
+{
+  "scripts": {
+    "dev": "shopify app dev",
+    "build": "remix vite:build",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "eslint app/",
+    "shopify": "shopify",
+    "deploy": "shopify app deploy"
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: shopify-metafields-metaobjects
+description: |
+  Model custom data with Shopify metafields and metaobjects via the GraphQL Admin API.
+  Use when adding custom fields to products/orders, creating custom content types,
+  or building structured data models beyond Shopify's default schema.
+  Trigger with phrases like "shopify metafields", "shopify metaobjects",
+  "custom data shopify", "shopify custom fields", "metafield definition".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify Metafields & Metaobjects
+
+## Overview
+
+Metafields attach key-value custom data to existing resources (products, variants, orders, customers). Metaobjects define entirely new content types with custom schemas. Together they replace the need for external databases for most custom data needs.
+
+## Prerequisites
+
+- Completed `shopify-install-auth` setup
+- Access scopes: `read_metaobjects`, `write_metaobjects`, `read_metaobject_definitions`, `write_metaobject_definitions`
+- Metafield scopes per resource: `read_products`/`write_products` for product metafields, etc.
+
+## Instructions
+
+### Step 1: Define a Metafield on Products
+
+Use `metafieldDefinitionCreate` with `namespace`, `key`, `type`, and `ownerType`:
+
+```typescript
+await client.request(METAFIELD_DEFINITION_CREATE, {
+  variables: {
+    definition: {
+      namespace: "custom",
+      key: "care_instructions",
+      name: "Care Instructions",
+      type: "multi_line_text_field",  // See references/metafield-types.md
+      ownerType: "PRODUCT",
+      pin: true, // Show in admin UI
+    },
+  },
+});
+// Always check userErrors — Shopify returns 200 even on validation failures
+```
+
+### Step 2: Set Values in Batch with metafieldsSet
+
+```typescript
+await client.request(METAFIELDS_SET, {
+  variables: {
+    metafields: [
+      {
+        ownerId: "gid://shopify/Product/123456",
+        namespace: "custom",
+        key: "care_instructions",
+        value: "Machine wash cold.\nTumble dry low.",
+        type: "multi_line_text_field",
+      },
+      // Up to 25 metafields per call
+    ],
+  },
+});
+```
+
+### Step 3: Create a Metaobject Definition
+
+Define a custom content type (e.g., "Designer" with typed fields):
+
+```typescript
+await client.request(METAOBJECT_DEFINITION_CREATE, {
+  variables: {
+    definition: {
+      type: "$app:designer",
+      displayNameKey: "name",
+      fieldDefinitions: [
+        { key: "name", name: "Name", type: "single_line_text_field" },
+        { key: "bio", name: "Bio", type: "multi_line_text_field" },
+        { key: "photo", name: "Photo", type: "file_reference" },
+      ],
+      access: { storefront: "PUBLIC_READ" },
+    },
+  },
+});
+```
+
+### Step 4: Create Metaobject Instances
+
+```typescript
+await client.request(METAOBJECT_CREATE, {
+  variables: {
+    metaobject: {
+      type: "$app:designer",
+      handle: "jane-doe",
+      fields: [
+        { key: "name", value: "Jane Doe" },
+        { key: "bio", value: "Award-winning textile designer." },
+      ],
+    },
+  },
+});
+```
+
+See [metafield-types.md](references/metafield-types.md) for all types, [toml-config.md](references/toml-config.md) for app config, and [bulk-metafield-ops.md](references/bulk-metafield-ops.md) for bulk operations.
+
+## Output
+
+- Metafield definitions registered on target resource types
+- Metafield values set on individual resources (batch supported, max 25 per call)
+- Custom metaobject types with typed field schemas
+- Metaobject instances queryable via Storefront and Admin APIs
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `TAKEN` | Namespace + key already exists on this owner type | Use `metafieldDefinitionUpdate` or choose a different key |
+| `INVALID_TYPE` | Type string not in Shopify's registry | Check [metafield-types.md](references/metafield-types.md) |
+| `INVALID_VALUE` | Value doesn't match declared type | Cast value to correct format before setting |
+| `TOO_LONG` | Value exceeds type limit (512KB for text types) | Truncate or switch to `multi_line_text_field` |
+
+## Examples
+
+### Adding Care Instructions to All Products
+
+Define a "care_instructions" metafield on the PRODUCT owner type, then bulk-set values across hundreds of products in batches of 25.
+
+See [Bulk Metafield Ops](references/bulk-metafield-ops.md) for the batch set/delete operations.
+
+### Choosing the Right Metafield Type
+
+You need to store a color swatch, a date range, or a product reference. Pick the correct type from Shopify's type registry.
+
+See [Metafield Types](references/metafield-types.md) for the complete type list with value format examples.
+
+### Declaring Metafields in App Configuration
+
+Define metafield and metaobject schemas in `shopify.app.toml` so they deploy automatically with the app instead of making API calls.
+
+See [TOML Config](references/toml-config.md) for the app configuration syntax.
+
+## Resources
+
+- [Metafield Definition API](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldDefinitionCreate)
+- [metafieldsSet Mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldsSet)
+- [Metaobject API Guide](https://shopify.dev/docs/apps/build/custom-data/metaobjects)
+- [Metafield Types Reference](https://shopify.dev/docs/apps/build/custom-data/metafields/types)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/bulk-metafield-ops.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/bulk-metafield-ops.md
@@ -1,0 +1,112 @@
+Bulk metafield operations for setting and deleting metafields across many resources.
+
+## Bulk Set via metafieldsSet
+
+The `metafieldsSet` mutation accepts up to 25 metafield inputs per call. Each input targets a specific owner resource.
+
+```typescript
+const BULK_SET = `
+  mutation metafieldsSet($metafields: [MetafieldsSetInput!]!) {
+    metafieldsSet(metafields: $metafields) {
+      metafields {
+        id
+        namespace
+        key
+        value
+        owner { ... on Product { id title } }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+// Set metafields on multiple products in one call (max 25 per mutation)
+await client.request(BULK_SET, {
+  variables: {
+    metafields: [
+      {
+        ownerId: "gid://shopify/Product/111",
+        namespace: "custom",
+        key: "care_instructions",
+        value: "Dry clean only",
+        type: "single_line_text_field",
+      },
+      {
+        ownerId: "gid://shopify/Product/222",
+        namespace: "custom",
+        key: "care_instructions",
+        value: "Machine wash warm",
+        type: "single_line_text_field",
+      },
+      // ...up to 25 total
+    ],
+  },
+});
+```
+
+## Bulk Delete
+
+```typescript
+const BULK_DELETE = `
+  mutation metafieldsDelete($metafields: [MetafieldIdentifierInput!]!) {
+    metafieldsDelete(metafields: $metafields) {
+      deletedMetafields { ownerId namespace key }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(BULK_DELETE, {
+  variables: {
+    metafields: [
+      {
+        ownerId: "gid://shopify/Product/111",
+        namespace: "custom",
+        key: "care_instructions",
+      },
+      {
+        ownerId: "gid://shopify/Product/222",
+        namespace: "custom",
+        key: "care_instructions",
+      },
+    ],
+  },
+});
+```
+
+## Large-Scale Operations with Bulk API
+
+For thousands of resources, use Shopify's `bulkOperationRunMutation`:
+
+```typescript
+const BULK_MUTATION = `
+  mutation bulkOperationRunMutation($mutation: String!, $stagedUploadPath: String!) {
+    bulkOperationRunMutation(
+      mutation: $mutation,
+      stagedUploadPath: $stagedUploadPath
+    ) {
+      bulkOperation { id status }
+      userErrors { field message }
+    }
+  }
+`;
+
+// 1. Stage upload a JSONL file with one mutation per line
+// 2. Each line: {"input":{"ownerId":"gid://shopify/Product/1","namespace":"custom","key":"tag","value":"sale","type":"single_line_text_field"}}
+// 3. The mutation string references the metafieldsSet mutation
+// 4. Poll bulkOperation for completion
+```
+
+### JSONL File Format
+
+```jsonl
+{"input":{"ownerId":"gid://shopify/Product/111","namespace":"custom","key":"sale_price","value":"19.99","type":"number_decimal"}}
+{"input":{"ownerId":"gid://shopify/Product/222","namespace":"custom","key":"sale_price","value":"24.99","type":"number_decimal"}}
+{"input":{"ownerId":"gid://shopify/Product/333","namespace":"custom","key":"sale_price","value":"14.99","type":"number_decimal"}}
+```
+
+## Rate Limit Considerations
+
+- `metafieldsSet`: Each call costs query points based on input count. Budget ~10 points per call.
+- `bulkOperationRunMutation`: No direct cost, but only one bulk operation runs at a time per app.
+- Polling: Check `bulkOperation.status` every 5-10 seconds. Statuses: `CREATED`, `RUNNING`, `COMPLETED`, `FAILED`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/metafield-types.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/metafield-types.md
@@ -1,0 +1,79 @@
+Complete list of Shopify metafield types with value format examples.
+
+## Scalar Types
+
+| Type | Value Example | Notes |
+|------|--------------|-------|
+| `single_line_text_field` | `"Hello world"` | Max 512KB, no newlines |
+| `multi_line_text_field` | `"Line 1\nLine 2"` | Max 512KB, newlines allowed |
+| `number_integer` | `"42"` | String-encoded integer |
+| `number_decimal` | `"19.99"` | String-encoded decimal |
+| `boolean` | `"true"` | `"true"` or `"false"` only |
+| `color` | `"#FF5733"` | Hex color code |
+| `date` | `"2025-06-15"` | ISO 8601 date |
+| `date_time` | `"2025-06-15T10:30:00Z"` | ISO 8601 datetime |
+| `dimension` | `{"value": 10.5, "unit": "CENTIMETERS"}` | JSON object, units: `INCHES`, `FEET`, `CENTIMETERS`, `METERS` |
+| `weight` | `{"value": 250, "unit": "GRAMS"}` | JSON object, units: `GRAMS`, `KILOGRAMS`, `OUNCES`, `POUNDS` |
+| `volume` | `{"value": 500, "unit": "MILLILITERS"}` | JSON object |
+| `money` | `{"amount": "29.99", "currency_code": "USD"}` | JSON object |
+| `rating` | `{"value": "4.5", "scale_min": "1.0", "scale_max": "5.0"}` | JSON object |
+| `url` | `"https://example.com"` | Valid URL string |
+| `json` | `"{\"key\": \"value\"}"` | Arbitrary JSON, max 512KB |
+| `rich_text_field` | `{"type":"root","children":[...]}` | Shopify rich text JSON schema |
+
+## Reference Types
+
+| Type | Value Example | Notes |
+|------|--------------|-------|
+| `file_reference` | `"gid://shopify/MediaImage/123"` | Reference to uploaded file |
+| `product_reference` | `"gid://shopify/Product/123"` | Reference to a product |
+| `variant_reference` | `"gid://shopify/ProductVariant/123"` | Reference to a variant |
+| `collection_reference` | `"gid://shopify/Collection/123"` | Reference to a collection |
+| `page_reference` | `"gid://shopify/Page/123"` | Reference to a page |
+| `metaobject_reference` | `"gid://shopify/Metaobject/123"` | Reference to a metaobject |
+| `mixed_reference` | `"gid://shopify/Product/123"` | Can reference any resource type |
+
+## List Types
+
+Any scalar or reference type can be a list by prefixing with `list.`:
+
+```
+list.single_line_text_field  → ["Red", "Blue", "Green"]
+list.product_reference       → ["gid://shopify/Product/1", "gid://shopify/Product/2"]
+list.number_integer          → ["1", "2", "3"]
+list.url                     → ["https://a.com", "https://b.com"]
+list.metaobject_reference    → ["gid://shopify/Metaobject/1", "gid://shopify/Metaobject/2"]
+```
+
+**Important:** List values are JSON arrays encoded as strings. The outer value passed to the API is always a string.
+
+## Validation Rules
+
+Metafield definitions support validations per type:
+
+```typescript
+// Example: number_integer with min/max
+{
+  type: "number_integer",
+  validations: [
+    { name: "min", value: "0" },
+    { name: "max", value: "100" },
+  ],
+}
+
+// Example: single_line_text_field with regex
+{
+  type: "single_line_text_field",
+  validations: [
+    { name: "regex", value: "^SKU-[A-Z0-9]+$" },
+  ],
+}
+
+// Example: file_reference restricted to images
+{
+  type: "file_reference",
+  validations: [
+    { name: "file_type_options", value: '["Image"]' },
+  ],
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/toml-config.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/references/toml-config.md
@@ -1,0 +1,97 @@
+Shopify app TOML configuration for metafield definitions and metaobject schemas.
+
+## shopify.app.toml Metafield Configuration
+
+App-owned metafield definitions can be declared in `shopify.app.toml` so they deploy automatically with the app. This replaces making `metafieldDefinitionCreate` API calls during installation.
+
+```toml
+# shopify.app.toml
+
+[access_scopes]
+scopes = "read_products,write_products,read_metaobjects,write_metaobjects"
+
+# Product metafield — deployed with the app
+[[metafields]]
+namespace = "custom"
+key = "care_instructions"
+name = "Care Instructions"
+description = "Product washing and care details"
+type = "multi_line_text_field"
+owner_type = "PRODUCT"
+pin = true
+
+[[metafields]]
+namespace = "custom"
+key = "weight_grams"
+name = "Weight (grams)"
+type = "number_integer"
+owner_type = "PRODUCT"
+validations = [
+  { name = "min", value = "0" },
+  { name = "max", value = "100000" },
+]
+
+# Variant-level metafield
+[[metafields]]
+namespace = "custom"
+key = "material"
+name = "Material"
+type = "single_line_text_field"
+owner_type = "PRODUCTVARIANT"
+
+# Customer metafield
+[[metafields]]
+namespace = "custom"
+key = "loyalty_tier"
+name = "Loyalty Tier"
+type = "single_line_text_field"
+owner_type = "CUSTOMER"
+validations = [
+  { name = "choices", value = '["Bronze","Silver","Gold","Platinum"]' },
+]
+```
+
+## Metaobject Definitions in TOML
+
+```toml
+# Custom content type — deploys with app
+[[metaobject_definitions]]
+type = "$app:designer"
+name = "Designer"
+description = "Product designer profiles"
+
+[[metaobject_definitions.field_definitions]]
+key = "name"
+name = "Name"
+type = "single_line_text_field"
+required = true
+
+[[metaobject_definitions.field_definitions]]
+key = "bio"
+name = "Bio"
+type = "multi_line_text_field"
+
+[[metaobject_definitions.field_definitions]]
+key = "photo"
+name = "Photo"
+type = "file_reference"
+validations = [
+  { name = "file_type_options", value = '["Image"]' },
+]
+
+[[metaobject_definitions.field_definitions]]
+key = "portfolio_url"
+name = "Portfolio URL"
+type = "url"
+
+[metaobject_definitions.access]
+storefront = "PUBLIC_READ"
+```
+
+## Key Rules
+
+- **Namespace `$app:`**: App-owned definitions use the `$app:` prefix. Shopify auto-scopes these to your app.
+- **Deployment**: Run `shopify app deploy` to push definitions. Shopify diffs against existing definitions and applies changes.
+- **Pinning**: `pin = true` shows the metafield in the Shopify admin UI for that resource.
+- **Deletions**: Removing a definition from TOML does NOT delete it from the store. Use `metafieldDefinitionDelete` mutation for cleanup.
+- **Type immutability**: You cannot change a metafield's `type` after creation. Delete and recreate if the type is wrong.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/SKILL.md
@@ -3,6 +3,7 @@ name: shopify-migration-deep-dive
 description: |
   Migrate e-commerce data to Shopify using bulk operations, product imports,
   and the strangler fig pattern for gradual platform migration.
+  Use when replatforming to Shopify, importing product catalogs, or migrating customer and order data from another e-commerce system.
   Trigger with phrases like "migrate to shopify", "shopify data migration",
   "import products shopify", "shopify replatform", "move to shopify".
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*)
@@ -42,221 +43,27 @@ Migrate product catalogs, customers, and orders to Shopify using the GraphQL Adm
 
 ### Step 2: Bulk Product Import with productSet
 
-`productSet` is idempotent — it creates or updates based on `handle`. Perfect for migrations.
+`productSet` is idempotent — it creates or updates based on `handle`, making it perfect for migrations. Handles variants, metafields, and all product attributes in a single mutation.
 
-```typescript
-const PRODUCT_SET = `
-  mutation productSet($input: ProductSetInput!) {
-    productSet(input: $input) {
-      product {
-        id
-        title
-        handle
-        variants(first: 50) {
-          edges {
-            node { id sku price inventoryQuantity }
-          }
-        }
-      }
-      userErrors { field message code }
-    }
-  }
-`;
-
-// Migrate products in batches
-async function migrateProducts(sourceProducts: SourceProduct[]): Promise<MigrationResult> {
-  const results: MigrationResult = { success: 0, errors: [] };
-
-  for (const product of sourceProducts) {
-    try {
-      const response = await client.request(PRODUCT_SET, {
-        variables: {
-          input: {
-            title: product.name,
-            handle: product.slug, // unique identifier for upsert
-            descriptionHtml: product.description,
-            vendor: product.brand,
-            productType: product.category,
-            tags: product.tags,
-            status: "DRAFT", // Keep as draft until verified
-            variants: product.variants.map((v) => ({
-              price: String(v.price),
-              sku: v.sku,
-              barcode: v.barcode,
-              optionValues: v.options.map((opt) => ({
-                optionName: opt.name,
-                name: opt.value,
-              })),
-            })),
-            metafields: product.metadata?.map((m) => ({
-              namespace: "migration",
-              key: m.key,
-              value: m.value,
-              type: "single_line_text_field",
-            })),
-          },
-        },
-      });
-
-      if (response.data.productSet.userErrors.length > 0) {
-        results.errors.push({
-          product: product.name,
-          errors: response.data.productSet.userErrors,
-        });
-      } else {
-        results.success++;
-      }
-    } catch (error) {
-      results.errors.push({ product: product.name, errors: [{ message: (error as Error).message }] });
-    }
-
-    // Respect rate limits — pause between batches
-    await new Promise((r) => setTimeout(r, 200));
-  }
-
-  return results;
-}
-```
+See [Product Set Migration](references/product-set-migration.md) for the complete migration function.
 
 ### Step 3: Bulk Operations for Large Imports
 
-For importing thousands of products, use Shopify's staged uploads + bulk mutation:
+For importing thousands of products, use Shopify's staged uploads combined with bulk mutation to avoid rate limit issues.
 
-```typescript
-// Step 1: Create a staged upload target
-const STAGED_UPLOAD = `
-  mutation stagedUploadsCreate($input: [StagedUploadInput!]!) {
-    stagedUploadsCreate(input: $input) {
-      stagedTargets {
-        url
-        resourceUrl
-        parameters { name value }
-      }
-      userErrors { field message }
-    }
-  }
-`;
+See [Bulk Operations Import](references/bulk-operations-import.md) for the staged upload and bulk mutation workflow.
 
-const uploadTarget = await client.request(STAGED_UPLOAD, {
-  variables: {
-    input: [{
-      resource: "BULK_MUTATION_VARIABLES",
-      filename: "products.jsonl",
-      mimeType: "text/jsonl",
-      httpMethod: "POST",
-    }],
-  },
-});
+### Step 4: Set Inventory Levels & URL Redirects
 
-// Step 2: Upload JSONL file to the staged target
-// Each line is the variables for one mutation call
-const jsonlContent = products.map((p) =>
-  JSON.stringify({ input: { title: p.name, handle: p.slug } })
-).join("\n");
+After products are created, set inventory quantities at each location and create URL redirects to preserve SEO from the old platform.
 
-// Upload to the staged target URL...
+See [Inventory and Redirects](references/inventory-and-redirects.md) for both mutation implementations.
 
-// Step 3: Run bulk mutation
-const BULK_MUTATION = `
-  mutation bulkOperationRunMutation($mutation: String!, $stagedUploadPath: String!) {
-    bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {
-      bulkOperation { id status }
-      userErrors { field message }
-    }
-  }
-`;
-```
+### Step 5: Post-Migration Validation
 
-### Step 4: Set Inventory Levels
+Automated validation that compares expected source counts against actual Shopify counts for products, customers, and other data types.
 
-```typescript
-// After products are created, set inventory quantities
-const SET_INVENTORY = `
-  mutation inventorySetQuantities($input: InventorySetQuantitiesInput!) {
-    inventorySetQuantities(input: $input) {
-      inventoryAdjustmentGroup {
-        reason
-        changes {
-          name
-          delta
-          quantityAfterChange
-        }
-      }
-      userErrors { field message }
-    }
-  }
-`;
-
-await client.request(SET_INVENTORY, {
-  variables: {
-    input: {
-      reason: "correction",
-      name: "available",
-      quantities: [
-        {
-          inventoryItemId: "gid://shopify/InventoryItem/12345",
-          locationId: "gid://shopify/Location/67890",
-          quantity: 100,
-        },
-      ],
-    },
-  },
-});
-```
-
-### Step 5: URL Redirects (SEO Preservation)
-
-```typescript
-// Preserve old URLs by creating redirects
-const CREATE_REDIRECT = `
-  mutation urlRedirectCreate($urlRedirect: UrlRedirectInput!) {
-    urlRedirectCreate(urlRedirect: $urlRedirect) {
-      urlRedirect { id path target }
-      userErrors { field message }
-    }
-  }
-`;
-
-// Map old URLs to new Shopify URLs
-for (const redirect of urlMappings) {
-  await client.request(CREATE_REDIRECT, {
-    variables: {
-      urlRedirect: {
-        path: redirect.oldPath,     // "/old-product-page"
-        target: redirect.newPath,   // "/products/new-handle"
-      },
-    },
-  });
-}
-```
-
-### Step 6: Post-Migration Validation
-
-```typescript
-async function validateMigration(expectedCounts: Record<string, number>): Promise<void> {
-  const checks = [
-    {
-      name: "Products",
-      query: "{ productsCount { count } }",
-      path: "productsCount.count",
-      expected: expectedCounts.products,
-    },
-    {
-      name: "Customers",
-      query: "{ customersCount { count } }",
-      path: "customersCount.count",
-      expected: expectedCounts.customers,
-    },
-  ];
-
-  for (const check of checks) {
-    const response = await client.request(check.query);
-    const actual = check.path.split(".").reduce((obj: any, k) => obj[k], response.data);
-    const status = actual >= check.expected ? "PASS" : "FAIL";
-    console.log(`${status}: ${check.name} — expected ${check.expected}, got ${actual}`);
-  }
-}
-```
+See [Post-Migration Validation](references/post-migration-validation.md) for the validation script.
 
 ## Output
 
@@ -284,7 +91,7 @@ echo "Shopify product count:"
 curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ productsCount { count } }"}' \
-  "https://$STORE/admin/api/2024-10/graphql.json" \
+  "https://$STORE/admin/api/${SHOPIFY_API_VERSION:-2025-04}/graphql.json" \
   | jq '.data.productsCount.count'
 ```
 
@@ -294,7 +101,3 @@ curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
 - [Bulk Operations Mutations](https://shopify.dev/docs/api/usage/bulk-operations/imports)
 - [Inventory Management](https://shopify.dev/docs/apps/build/orders-fulfillment/inventory-management-apps)
 - [URL Redirects](https://shopify.dev/docs/api/admin-graphql/latest/mutations/urlRedirectCreate)
-
-## Next Steps
-
-For advanced troubleshooting, see `shopify-advanced-troubleshooting`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/bulk-operations-import.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/bulk-operations-import.md
@@ -1,0 +1,48 @@
+# Bulk Operations for Large Imports
+
+For importing thousands of products, use Shopify's staged uploads combined with bulk mutation. This avoids rate limit issues by offloading the processing to Shopify's infrastructure.
+
+```typescript
+// Step 1: Create a staged upload target
+const STAGED_UPLOAD = `
+  mutation stagedUploadsCreate($input: [StagedUploadInput!]!) {
+    stagedUploadsCreate(input: $input) {
+      stagedTargets {
+        url
+        resourceUrl
+        parameters { name value }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+const uploadTarget = await client.request(STAGED_UPLOAD, {
+  variables: {
+    input: [{
+      resource: "BULK_MUTATION_VARIABLES",
+      filename: "products.jsonl",
+      mimeType: "text/jsonl",
+      httpMethod: "POST",
+    }],
+  },
+});
+
+// Step 2: Upload JSONL file to the staged target
+// Each line is the variables for one mutation call
+const jsonlContent = products.map((p) =>
+  JSON.stringify({ input: { title: p.name, handle: p.slug } })
+).join("\n");
+
+// Upload to the staged target URL...
+
+// Step 3: Run bulk mutation
+const BULK_MUTATION = `
+  mutation bulkOperationRunMutation($mutation: String!, $stagedUploadPath: String!) {
+    bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {
+      bulkOperation { id status }
+      userErrors { field message }
+    }
+  }
+`;
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/inventory-and-redirects.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/inventory-and-redirects.md
@@ -1,0 +1,66 @@
+# Inventory Levels & URL Redirects
+
+Post-product-import steps: setting inventory quantities at locations and creating URL redirects to preserve SEO.
+
+## Set Inventory Levels
+
+```typescript
+// After products are created, set inventory quantities
+const SET_INVENTORY = `
+  mutation inventorySetQuantities($input: InventorySetQuantitiesInput!) {
+    inventorySetQuantities(input: $input) {
+      inventoryAdjustmentGroup {
+        reason
+        changes {
+          name
+          delta
+          quantityAfterChange
+        }
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+await client.request(SET_INVENTORY, {
+  variables: {
+    input: {
+      reason: "correction",
+      name: "available",
+      quantities: [
+        {
+          inventoryItemId: "gid://shopify/InventoryItem/12345",
+          locationId: "gid://shopify/Location/67890",
+          quantity: 100,
+        },
+      ],
+    },
+  },
+});
+```
+
+## URL Redirects (SEO Preservation)
+
+```typescript
+// Preserve old URLs by creating redirects
+const CREATE_REDIRECT = `
+  mutation urlRedirectCreate($urlRedirect: UrlRedirectInput!) {
+    urlRedirectCreate(urlRedirect: $urlRedirect) {
+      urlRedirect { id path target }
+      userErrors { field message }
+    }
+  }
+`;
+
+// Map old URLs to new Shopify URLs
+for (const redirect of urlMappings) {
+  await client.request(CREATE_REDIRECT, {
+    variables: {
+      urlRedirect: {
+        path: redirect.oldPath,     // "/old-product-page"
+        target: redirect.newPath,   // "/products/new-handle"
+      },
+    },
+  });
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/post-migration-validation.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/post-migration-validation.md
@@ -1,0 +1,29 @@
+# Post-Migration Validation
+
+Automated validation script that compares expected source counts against actual Shopify counts to verify migration completeness.
+
+```typescript
+async function validateMigration(expectedCounts: Record<string, number>): Promise<void> {
+  const checks = [
+    {
+      name: "Products",
+      query: "{ productsCount { count } }",
+      path: "productsCount.count",
+      expected: expectedCounts.products,
+    },
+    {
+      name: "Customers",
+      query: "{ customersCount { count } }",
+      path: "customersCount.count",
+      expected: expectedCounts.customers,
+    },
+  ];
+
+  for (const check of checks) {
+    const response = await client.request(check.query);
+    const actual = check.path.split(".").reduce((obj: any, k) => obj[k], response.data);
+    const status = actual >= check.expected ? "PASS" : "FAIL";
+    console.log(`${status}: ${check.name} — expected ${check.expected}, got ${actual}`);
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/product-set-migration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/references/product-set-migration.md
@@ -1,0 +1,77 @@
+# Bulk Product Import with productSet
+
+The `productSet` mutation is idempotent — it creates or updates based on `handle`, making it ideal for migrations.
+
+```typescript
+const PRODUCT_SET = `
+  mutation productSet($input: ProductSetInput!) {
+    productSet(input: $input) {
+      product {
+        id
+        title
+        handle
+        variants(first: 50) {
+          edges {
+            node { id sku price inventoryQuantity }
+          }
+        }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+// Migrate products in batches
+async function migrateProducts(sourceProducts: SourceProduct[]): Promise<MigrationResult> {
+  const results: MigrationResult = { success: 0, errors: [] };
+
+  for (const product of sourceProducts) {
+    try {
+      const response = await client.request(PRODUCT_SET, {
+        variables: {
+          input: {
+            title: product.name,
+            handle: product.slug, // unique identifier for upsert
+            descriptionHtml: product.description,
+            vendor: product.brand,
+            productType: product.category,
+            tags: product.tags,
+            status: "DRAFT", // Keep as draft until verified
+            variants: product.variants.map((v) => ({
+              price: String(v.price),
+              sku: v.sku,
+              barcode: v.barcode,
+              optionValues: v.options.map((opt) => ({
+                optionName: opt.name,
+                name: opt.value,
+              })),
+            })),
+            metafields: product.metadata?.map((m) => ({
+              namespace: "migration",
+              key: m.key,
+              value: m.value,
+              type: "single_line_text_field",
+            })),
+          },
+        },
+      });
+
+      if (response.data.productSet.userErrors.length > 0) {
+        results.errors.push({
+          product: product.name,
+          errors: response.data.productSet.userErrors,
+        });
+      } else {
+        results.success++;
+      }
+    } catch (error) {
+      results.errors.push({ product: product.name, errors: [{ message: (error as Error).message }] });
+    }
+
+    // Respect rate limits — pause between batches
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  return results;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-multi-env-setup
 description: |
   Configure Shopify apps across development, staging, and production environments
   with separate stores, API credentials, and app instances.
+  Use when setting up isolated dev/staging/prod environments for a Shopify app,
+  managing multiple development stores, or configuring per-environment credentials.
   Trigger with phrases like "shopify environments", "shopify staging",
   "shopify dev vs prod", "shopify multi-store", "shopify environment setup".
 allowed-tools: Read, Write, Edit, Bash(shopify:*)
@@ -41,133 +43,21 @@ Each app gets its own `API_KEY`, `API_SECRET`, and `ACCESS_TOKEN`.
 
 ### Step 2: Environment Configuration Files
 
-```bash
-# .env.development (git-ignored)
-SHOPIFY_API_KEY=dev_api_key
-SHOPIFY_API_SECRET=dev_api_secret
-SHOPIFY_STORE=dev-store.myshopify.com
-SHOPIFY_ACCESS_TOKEN=shpat_dev_token
-SHOPIFY_APP_URL=https://localhost:3000
-SHOPIFY_API_VERSION=2024-10
-NODE_ENV=development
+Create `.env.*` files for each environment and corresponding Shopify CLI TOML configs. Production secrets should never be stored on disk -- use a secret manager.
 
-# .env.staging (git-ignored)
-SHOPIFY_API_KEY=staging_api_key
-SHOPIFY_API_SECRET=staging_api_secret
-SHOPIFY_STORE=staging-store.myshopify.com
-SHOPIFY_ACCESS_TOKEN=shpat_staging_token
-SHOPIFY_APP_URL=https://staging.your-app.com
-SHOPIFY_API_VERSION=2024-10
-NODE_ENV=staging
+See [Environment Config Files](references/environment-config-files.md) for the complete `.env` and `.toml` configuration templates.
 
-# .env.production (never on disk — use secret manager)
-# All values stored in Vault / AWS Secrets Manager / GCP Secret Manager
-```
+### Step 3: Environment-Aware Configuration
 
-### Step 3: Shopify CLI Configuration Per Environment
+TypeScript config module that loads environment-specific settings (debug mode, session storage type) with `LATEST_API_VERSION` from `@shopify/shopify-api`.
 
-```toml
-# shopify.app.dev.toml — development config
-name = "My App (Dev)"
-client_id = "dev_api_key"
+See [Environment-Aware Config](references/environment-aware-config.md) for the complete implementation.
 
-[access_scopes]
-scopes = "read_products,write_products,read_orders,write_orders"
+### Step 4: Environment Guards
 
-[auth]
-redirect_urls = ["https://localhost/auth/callback"]
+Safety functions that prevent dangerous operations from running in the wrong environment (e.g., blocking test data seeding in production, requiring production for billing activation).
 
-[webhooks]
-api_version = "2024-10"
-```
-
-```bash
-# Switch between app configs
-shopify app config use shopify.app.dev.toml
-shopify app dev
-
-shopify app config use shopify.app.toml  # production
-shopify app deploy
-```
-
-### Step 4: Environment-Aware Configuration
-
-```typescript
-// src/config.ts
-interface ShopifyEnvConfig {
-  apiKey: string;
-  apiSecret: string;
-  appUrl: string;
-  apiVersion: string;
-  scopes: string[];
-  environment: "development" | "staging" | "production";
-  debug: boolean;
-  sessionStorageType: "memory" | "sqlite" | "postgresql";
-}
-
-function getConfig(): ShopifyEnvConfig {
-  const env = (process.env.NODE_ENV || "development") as ShopifyEnvConfig["environment"];
-
-  const base = {
-    apiKey: process.env.SHOPIFY_API_KEY!,
-    apiSecret: process.env.SHOPIFY_API_SECRET!,
-    appUrl: process.env.SHOPIFY_APP_URL!,
-    apiVersion: process.env.SHOPIFY_API_VERSION || "2024-10",
-    scopes: (process.env.SHOPIFY_SCOPES || "read_products").split(","),
-    environment: env,
-  };
-
-  const envOverrides: Record<string, Partial<ShopifyEnvConfig>> = {
-    development: {
-      debug: true,
-      sessionStorageType: "sqlite",
-    },
-    staging: {
-      debug: false,
-      sessionStorageType: "postgresql",
-    },
-    production: {
-      debug: false,
-      sessionStorageType: "postgresql",
-    },
-  };
-
-  return { ...base, ...envOverrides[env] } as ShopifyEnvConfig;
-}
-```
-
-### Step 5: Environment Guards
-
-```typescript
-// Prevent dangerous operations outside production
-function requireProduction(operation: string): void {
-  if (process.env.NODE_ENV !== "production") {
-    console.log(`[DEV] ${operation} — would execute in production`);
-    return;
-  }
-}
-
-function blockInProduction(operation: string): void {
-  if (process.env.NODE_ENV === "production") {
-    throw new Error(
-      `Operation "${operation}" is blocked in production. ` +
-      `Use staging or development environment.`
-    );
-  }
-}
-
-// Example: prevent test data seeding in production
-async function seedTestProducts() {
-  blockInProduction("seedTestProducts");
-  // ... seeding logic
-}
-
-// Example: ensure billing only runs in production
-async function activateBilling(session: Session) {
-  requireProduction("activateBilling");
-  // ... billing logic
-}
-```
+See [Environment Guards](references/environment-guards.md) for the complete implementation.
 
 ## Output
 
@@ -207,7 +97,3 @@ shopify populate customers --count=20
 - [Shopify Development Stores](https://shopify.dev/docs/apps/tools/development-stores)
 - [Shopify CLI Config](https://shopify.dev/docs/apps/build/cli-for-apps/app-configuration)
 - [12-Factor App Config](https://12factor.net/config)
-
-## Next Steps
-
-For observability setup, see `shopify-observability`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-aware-config.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-aware-config.md
@@ -1,0 +1,49 @@
+# Environment-Aware Configuration
+
+TypeScript configuration module that loads environment-specific settings with type-safe overrides.
+
+```typescript
+// src/config.ts
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+
+interface ShopifyEnvConfig {
+  apiKey: string;
+  apiSecret: string;
+  appUrl: string;
+  apiVersion: string;
+  scopes: string[];
+  environment: "development" | "staging" | "production";
+  debug: boolean;
+  sessionStorageType: "memory" | "sqlite" | "postgresql";
+}
+
+function getConfig(): ShopifyEnvConfig {
+  const env = (process.env.NODE_ENV || "development") as ShopifyEnvConfig["environment"];
+
+  const base = {
+    apiKey: process.env.SHOPIFY_API_KEY!,
+    apiSecret: process.env.SHOPIFY_API_SECRET!,
+    appUrl: process.env.SHOPIFY_APP_URL!,
+    apiVersion: process.env.SHOPIFY_API_VERSION || LATEST_API_VERSION,
+    scopes: (process.env.SHOPIFY_SCOPES || "read_products").split(","),
+    environment: env,
+  };
+
+  const envOverrides: Record<string, Partial<ShopifyEnvConfig>> = {
+    development: {
+      debug: true,
+      sessionStorageType: "sqlite",
+    },
+    staging: {
+      debug: false,
+      sessionStorageType: "postgresql",
+    },
+    production: {
+      debug: false,
+      sessionStorageType: "postgresql",
+    },
+  };
+
+  return { ...base, ...envOverrides[env] } as ShopifyEnvConfig;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-config-files.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-config-files.md
@@ -1,0 +1,50 @@
+# Environment Configuration Files
+
+Environment variable files and Shopify CLI TOML configs for dev, staging, and production.
+
+```bash
+# .env.development (git-ignored)
+SHOPIFY_API_KEY=dev_api_key
+SHOPIFY_API_SECRET=dev_api_secret
+SHOPIFY_STORE=dev-store.myshopify.com
+SHOPIFY_ACCESS_TOKEN=shpat_dev_token
+SHOPIFY_APP_URL=https://localhost:3000
+SHOPIFY_API_VERSION=2025-04  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+NODE_ENV=development
+
+# .env.staging (git-ignored)
+SHOPIFY_API_KEY=staging_api_key
+SHOPIFY_API_SECRET=staging_api_secret
+SHOPIFY_STORE=staging-store.myshopify.com
+SHOPIFY_ACCESS_TOKEN=shpat_staging_token
+SHOPIFY_APP_URL=https://staging.your-app.com
+SHOPIFY_API_VERSION=2025-04  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+NODE_ENV=staging
+
+# .env.production (never on disk — use secret manager)
+# All values stored in Vault / AWS Secrets Manager / GCP Secret Manager
+```
+
+```toml
+# shopify.app.dev.toml — development config
+name = "My App (Dev)"
+client_id = "dev_api_key"
+
+[access_scopes]
+scopes = "read_products,write_products,read_orders,write_orders"
+
+[auth]
+redirect_urls = ["https://localhost/auth/callback"]
+
+[webhooks]
+api_version = "2025-04"  # Update quarterly — see shopify.dev/docs/api/usage/versioning
+```
+
+```bash
+# Switch between app configs
+shopify app config use shopify.app.dev.toml
+shopify app dev
+
+shopify app config use shopify.app.toml  # production
+shopify app deploy
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-guards.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/references/environment-guards.md
@@ -1,0 +1,34 @@
+# Environment Guards
+
+Safety functions to prevent dangerous operations from running in the wrong environment.
+
+```typescript
+// Prevent dangerous operations outside production
+function requireProduction(operation: string): void {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(`[DEV] ${operation} — would execute in production`);
+    return;
+  }
+}
+
+function blockInProduction(operation: string): void {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      `Operation "${operation}" is blocked in production. ` +
+      `Use staging or development environment.`
+    );
+  }
+}
+
+// Example: prevent test data seeding in production
+async function seedTestProducts() {
+  blockInProduction("seedTestProducts");
+  // ... seeding logic
+}
+
+// Example: ensure billing only runs in production
+async function activateBilling(session: Session) {
+  requireProduction("activateBilling");
+  // ... billing logic
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-observability
 description: |
   Set up observability for Shopify app integrations with query cost tracking,
   rate limit monitoring, webhook delivery metrics, and structured logging.
+  Use when instrumenting a Shopify app for production monitoring, setting up
+  Prometheus metrics for API health, or configuring alerts for rate limit issues.
   Trigger with phrases like "shopify monitoring", "shopify metrics",
   "shopify observability", "monitor shopify API", "shopify alerts", "shopify dashboard".
 allowed-tools: Read, Write, Edit
@@ -29,118 +31,26 @@ Instrument your Shopify app to track GraphQL query cost, rate limit consumption,
 
 ### Step 1: Shopify-Specific Metrics
 
-```typescript
-import { Registry, Counter, Histogram, Gauge } from "prom-client";
+Define Prometheus counters, histograms, and gauges for query cost, rate limit headroom, REST bucket state, API duration, webhook processing, and error classification.
 
-const registry = new Registry();
-
-// GraphQL query cost tracking
-const queryCostHistogram = new Histogram({
-  name: "shopify_graphql_query_cost",
-  help: "Shopify GraphQL actual query cost",
-  labelNames: ["operation", "shop"],
-  buckets: [1, 10, 50, 100, 250, 500, 1000],
-  registers: [registry],
-});
-
-// Rate limit headroom
-const rateLimitGauge = new Gauge({
-  name: "shopify_rate_limit_available",
-  help: "Shopify rate limit points currently available",
-  labelNames: ["shop", "api_type"],
-  registers: [registry],
-});
-
-// REST bucket state
-const restBucketGauge = new Gauge({
-  name: "shopify_rest_bucket_used",
-  help: "REST API leaky bucket current fill level",
-  labelNames: ["shop"],
-  registers: [registry],
-});
-
-// API request duration
-const apiDuration = new Histogram({
-  name: "shopify_api_duration_seconds",
-  help: "Shopify API call duration",
-  labelNames: ["operation", "status", "api_type"],
-  buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
-  registers: [registry],
-});
-
-// Webhook processing
-const webhookCounter = new Counter({
-  name: "shopify_webhooks_total",
-  help: "Shopify webhooks received",
-  labelNames: ["topic", "status"], // status: success, error, invalid_hmac
-  registers: [registry],
-});
-
-// API errors by type
-const apiErrors = new Counter({
-  name: "shopify_api_errors_total",
-  help: "Shopify API errors by type",
-  labelNames: ["error_type", "status_code"],
-  registers: [registry],
-});
-```
+See [Shopify Metrics Definitions](references/shopify-metrics-definitions.md) for the complete metric registrations.
 
 ### Step 2: Instrumented GraphQL Client
 
-```typescript
-async function instrumentedGraphqlQuery<T>(
-  shop: string,
-  operation: string,
-  query: string,
-  variables?: Record<string, unknown>
-): Promise<T> {
-  const timer = apiDuration.startTimer({ operation, api_type: "graphql" });
+Wrap the Shopify GraphQL client to automatically record query cost from `extensions.cost`, update rate limit gauges, and classify errors (throttled, auth, API error).
 
-  try {
-    const client = getGraphqlClient(shop);
-    const response = await client.request(query, { variables });
-
-    // Record cost metrics from Shopify's response
-    const cost = response.extensions?.cost;
-    if (cost) {
-      queryCostHistogram.observe(
-        { operation, shop },
-        cost.actualQueryCost || cost.requestedQueryCost
-      );
-      rateLimitGauge.set(
-        { shop, api_type: "graphql" },
-        cost.throttleStatus.currentlyAvailable
-      );
-    }
-
-    timer({ status: "success" });
-    return response.data as T;
-  } catch (error: any) {
-    const statusCode = error.response?.code || "unknown";
-    const errorType =
-      error.body?.errors?.[0]?.extensions?.code === "THROTTLED"
-        ? "throttled"
-        : statusCode === 401
-        ? "auth"
-        : "api_error";
-
-    apiErrors.inc({ error_type: errorType, status_code: String(statusCode) });
-    timer({ status: "error" });
-    throw error;
-  }
-}
-```
+See [Instrumented GraphQL Client](references/instrumented-graphql-client.md) for the complete implementation.
 
 ### Step 3: REST API Header Tracking
 
+Parse `X-Shopify-Shop-Api-Call-Limit` headers (e.g., `"32/40"`) from REST responses to track leaky bucket fill level. Warn when bucket exceeds 80% capacity.
+
 ```typescript
 function trackRestHeaders(shop: string, headers: Record<string, string>): void {
-  // Parse X-Shopify-Shop-Api-Call-Limit: "32/40"
   const callLimit = headers["x-shopify-shop-api-call-limit"];
   if (callLimit) {
     const [used, max] = callLimit.split("/").map(Number);
     restBucketGauge.set({ shop }, used);
-
     if (used > max * 0.8) {
       console.warn(`[shopify] REST bucket at ${used}/${max} for ${shop}`);
     }
@@ -150,109 +60,21 @@ function trackRestHeaders(shop: string, headers: Record<string, string>): void {
 
 ### Step 4: Webhook Observability
 
-```typescript
-app.post("/webhooks", express.raw({ type: "application/json" }), (req, res) => {
-  const topic = req.headers["x-shopify-topic"] as string;
-  const shop = req.headers["x-shopify-shop-domain"] as string;
+Track HMAC validation results, processing success/failure, and duration for all incoming webhooks.
 
-  // Track HMAC validation
-  if (!verifyHmac(req.body, req.headers["x-shopify-hmac-sha256"]!)) {
-    webhookCounter.inc({ topic, status: "invalid_hmac" });
-    return res.status(401).send();
-  }
-
-  res.status(200).send("OK");
-
-  // Track processing
-  const start = Date.now();
-  processWebhook(topic, shop, JSON.parse(req.body.toString()))
-    .then(() => {
-      webhookCounter.inc({ topic, status: "success" });
-      apiDuration.observe(
-        { operation: `webhook:${topic}`, status: "success", api_type: "webhook" },
-        (Date.now() - start) / 1000
-      );
-    })
-    .catch((err) => {
-      webhookCounter.inc({ topic, status: "error" });
-      console.error(`Webhook ${topic} failed:`, err.message);
-    });
-});
-```
+See [Webhook Observability](references/webhook-observability.md) for the complete Express middleware.
 
 ### Step 5: Structured Logging
 
-```typescript
-import pino from "pino";
+Pino-based logger with automatic PII redaction and Shopify-specific context fields (query cost, available points, operation name).
 
-const logger = pino({
-  name: "shopify-app",
-  level: process.env.LOG_LEVEL || "info",
-  serializers: {
-    // Redact sensitive fields automatically
-    shopifyRequest: (req: any) => ({
-      shop: req.shop,
-      operation: req.operation,
-      queryCost: req.cost?.actualQueryCost,
-      available: req.cost?.throttleStatus?.currentlyAvailable,
-      // Never log: accessToken, apiSecret, customer PII
-    }),
-  },
-});
-
-// Log every Shopify API call with structured context
-function logShopifyCall(operation: string, shop: string, cost: any, durationMs: number) {
-  logger.info({
-    msg: "shopify_api_call",
-    operation,
-    shop,
-    queryCost: cost?.actualQueryCost,
-    requestedCost: cost?.requestedQueryCost,
-    availablePoints: cost?.throttleStatus?.currentlyAvailable,
-    durationMs,
-  });
-}
-```
+See [Structured Logging](references/structured-logging.md) for the complete implementation.
 
 ### Step 6: Alert Rules
 
-```yaml
-# prometheus/shopify-alerts.yml
-groups:
-  - name: shopify
-    rules:
-      - alert: ShopifyRateLimitLow
-        expr: shopify_rate_limit_available < 100
-        for: 2m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Shopify rate limit below 100 points for {{ $labels.shop }}"
+Prometheus alert rules for low rate limits, high query cost (P95 > 500), webhook failures (> 10%), and API latency (P95 > 3s).
 
-      - alert: ShopifyHighQueryCost
-        expr: histogram_quantile(0.95, rate(shopify_graphql_query_cost_bucket[5m])) > 500
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "P95 Shopify query cost > 500 points"
-
-      - alert: ShopifyWebhookFailures
-        expr: rate(shopify_webhooks_total{status="error"}[5m]) > 0.1
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Shopify webhook processing failures > 10%"
-
-      - alert: ShopifyAPILatencyHigh
-        expr: histogram_quantile(0.95, rate(shopify_api_duration_seconds_bucket[5m])) > 3
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Shopify API P95 latency > 3 seconds"
-```
+See [Alert Rules](references/alert-rules.md) for the complete Prometheus configuration.
 
 ## Output
 
@@ -287,7 +109,3 @@ app.get("/metrics", async (req, res) => {
 - [Shopify Rate Limit Headers](https://shopify.dev/docs/api/usage/rate-limits)
 - [Prometheus Best Practices](https://prometheus.io/docs/practices/naming/)
 - [OpenTelemetry Node.js](https://opentelemetry.io/docs/instrumentation/js/)
-
-## Next Steps
-
-For incident response, see `shopify-incident-runbook`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/alert-rules.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/alert-rules.md
@@ -1,0 +1,41 @@
+# Prometheus Alert Rules
+
+Shopify-specific Prometheus alert rules for rate limits, query cost, webhook failures, and API latency.
+
+```yaml
+# prometheus/shopify-alerts.yml
+groups:
+  - name: shopify
+    rules:
+      - alert: ShopifyRateLimitLow
+        expr: shopify_rate_limit_available < 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Shopify rate limit below 100 points for {{ $labels.shop }}"
+
+      - alert: ShopifyHighQueryCost
+        expr: histogram_quantile(0.95, rate(shopify_graphql_query_cost_bucket[5m])) > 500
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 Shopify query cost > 500 points"
+
+      - alert: ShopifyWebhookFailures
+        expr: rate(shopify_webhooks_total{status="error"}[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Shopify webhook processing failures > 10%"
+
+      - alert: ShopifyAPILatencyHigh
+        expr: histogram_quantile(0.95, rate(shopify_api_duration_seconds_bucket[5m])) > 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Shopify API P95 latency > 3 seconds"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/instrumented-graphql-client.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/instrumented-graphql-client.md
@@ -1,0 +1,47 @@
+# Instrumented GraphQL Client
+
+Wraps the Shopify GraphQL client to automatically record query cost, rate limit headroom, and error classification.
+
+```typescript
+async function instrumentedGraphqlQuery<T>(
+  shop: string,
+  operation: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const timer = apiDuration.startTimer({ operation, api_type: "graphql" });
+
+  try {
+    const client = getGraphqlClient(shop);
+    const response = await client.request(query, { variables });
+
+    // Record cost metrics from Shopify's response
+    const cost = response.extensions?.cost;
+    if (cost) {
+      queryCostHistogram.observe(
+        { operation, shop },
+        cost.actualQueryCost || cost.requestedQueryCost
+      );
+      rateLimitGauge.set(
+        { shop, api_type: "graphql" },
+        cost.throttleStatus.currentlyAvailable
+      );
+    }
+
+    timer({ status: "success" });
+    return response.data as T;
+  } catch (error: any) {
+    const statusCode = error.response?.code || "unknown";
+    const errorType =
+      error.body?.errors?.[0]?.extensions?.code === "THROTTLED"
+        ? "throttled"
+        : statusCode === 401
+        ? "auth"
+        : "api_error";
+
+    apiErrors.inc({ error_type: errorType, status_code: String(statusCode) });
+    timer({ status: "error" });
+    throw error;
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/shopify-metrics-definitions.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/shopify-metrics-definitions.md
@@ -1,0 +1,59 @@
+# Shopify Metrics Definitions
+
+Prometheus metric definitions for Shopify-specific observability: query cost, rate limits, API duration, webhooks, and errors.
+
+```typescript
+import { Registry, Counter, Histogram, Gauge } from "prom-client";
+
+const registry = new Registry();
+
+// GraphQL query cost tracking
+const queryCostHistogram = new Histogram({
+  name: "shopify_graphql_query_cost",
+  help: "Shopify GraphQL actual query cost",
+  labelNames: ["operation", "shop"],
+  buckets: [1, 10, 50, 100, 250, 500, 1000],
+  registers: [registry],
+});
+
+// Rate limit headroom
+const rateLimitGauge = new Gauge({
+  name: "shopify_rate_limit_available",
+  help: "Shopify rate limit points currently available",
+  labelNames: ["shop", "api_type"],
+  registers: [registry],
+});
+
+// REST bucket state
+const restBucketGauge = new Gauge({
+  name: "shopify_rest_bucket_used",
+  help: "REST API leaky bucket current fill level",
+  labelNames: ["shop"],
+  registers: [registry],
+});
+
+// API request duration
+const apiDuration = new Histogram({
+  name: "shopify_api_duration_seconds",
+  help: "Shopify API call duration",
+  labelNames: ["operation", "status", "api_type"],
+  buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
+  registers: [registry],
+});
+
+// Webhook processing
+const webhookCounter = new Counter({
+  name: "shopify_webhooks_total",
+  help: "Shopify webhooks received",
+  labelNames: ["topic", "status"], // status: success, error, invalid_hmac
+  registers: [registry],
+});
+
+// API errors by type
+const apiErrors = new Counter({
+  name: "shopify_api_errors_total",
+  help: "Shopify API errors by type",
+  labelNames: ["error_type", "status_code"],
+  registers: [registry],
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/structured-logging.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/structured-logging.md
@@ -1,0 +1,35 @@
+# Structured Logging
+
+Pino-based structured logger with automatic PII redaction and Shopify-specific context fields.
+
+```typescript
+import pino from "pino";
+
+const logger = pino({
+  name: "shopify-app",
+  level: process.env.LOG_LEVEL || "info",
+  serializers: {
+    // Redact sensitive fields automatically
+    shopifyRequest: (req: any) => ({
+      shop: req.shop,
+      operation: req.operation,
+      queryCost: req.cost?.actualQueryCost,
+      available: req.cost?.throttleStatus?.currentlyAvailable,
+      // Never log: accessToken, apiSecret, customer PII
+    }),
+  },
+});
+
+// Log every Shopify API call with structured context
+function logShopifyCall(operation: string, shop: string, cost: any, durationMs: number) {
+  logger.info({
+    msg: "shopify_api_call",
+    operation,
+    shop,
+    queryCost: cost?.actualQueryCost,
+    requestedCost: cost?.requestedQueryCost,
+    availablePoints: cost?.throttleStatus?.currentlyAvailable,
+    durationMs,
+  });
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/webhook-observability.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/references/webhook-observability.md
@@ -1,0 +1,33 @@
+# Webhook Observability
+
+Express middleware for tracking webhook HMAC validation, processing success/failure, and duration metrics.
+
+```typescript
+app.post("/webhooks", express.raw({ type: "application/json" }), (req, res) => {
+  const topic = req.headers["x-shopify-topic"] as string;
+  const shop = req.headers["x-shopify-shop-domain"] as string;
+
+  // Track HMAC validation
+  if (!verifyHmac(req.body, req.headers["x-shopify-hmac-sha256"]!)) {
+    webhookCounter.inc({ topic, status: "invalid_hmac" });
+    return res.status(401).send();
+  }
+
+  res.status(200).send("OK");
+
+  // Track processing
+  const start = Date.now();
+  processWebhook(topic, shop, JSON.parse(req.body.toString()))
+    .then(() => {
+      webhookCounter.inc({ topic, status: "success" });
+      apiDuration.observe(
+        { operation: `webhook:${topic}`, status: "success", api_type: "webhook" },
+        (Date.now() - start) / 1000
+      );
+    })
+    .catch((err) => {
+      webhookCounter.inc({ topic, status: "error" });
+      console.error(`Webhook ${topic} failed:`, err.message);
+    });
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-performance-tuning
 description: |
   Optimize Shopify API performance with GraphQL query cost reduction, bulk operations,
   caching strategies, and Storefront API for high-traffic storefronts.
+  Use when queries are slow or hitting THROTTLED errors, exporting large datasets,
+  or optimizing API throughput for a high-traffic storefront.
   Trigger with phrases like "shopify performance", "optimize shopify",
   "shopify slow", "shopify caching", "shopify bulk operation", "shopify query cost".
 allowed-tools: Read, Write, Edit
@@ -27,216 +29,29 @@ Optimize Shopify API performance through GraphQL query cost reduction, bulk oper
 
 ## Instructions
 
-### Step 1: Analyze Query Cost
+### Step 1: Analyze and Reduce Query Cost
 
-```bash
-# Debug query cost with special header
-curl -X POST "https://$STORE/admin/api/2024-10/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Shopify-GraphQL-Cost-Debug: 1" \
-  -d '{"query": "{ products(first: 50) { edges { node { id title variants(first: 20) { edges { node { id price } } } } } } }"}' \
-  | jq '.extensions.cost'
-```
+Use the debug header to inspect `requestedQueryCost` vs `actualQueryCost`. Reduce cost by selecting only needed fields and lowering `first:` page sizes (250 to 50 can cut cost by 5x).
 
-Response shows cost breakdown:
-```json
-{
-  "requestedQueryCost": 152,
-  "actualQueryCost": 42,
-  "throttleStatus": {
-    "maximumAvailable": 1000.0,
-    "currentlyAvailable": 958.0,
-    "restoreRate": 50.0
-  }
-}
-```
+See [Query Cost Optimization](references/query-cost-optimization.md) for debug commands and before/after examples.
 
-**Key rule:** `requestedQueryCost` is calculated as `first * nested_fields`. Reducing `first:` from 250 to 50 can cut cost by 5x.
+### Step 2: Use Bulk Operations for Large Exports
 
-### Step 2: Reduce Query Cost
+Bulk operations bypass rate limits and are designed for exporting large datasets. Start a mutation, poll for completion, then download JSONL results.
 
-```typescript
-// BEFORE: High cost — requests too many fields and items
-// requestedQueryCost: ~5,502
-const EXPENSIVE_QUERY = `{
-  products(first: 250) {
-    edges {
-      node {
-        id title description descriptionHtml vendor productType tags
-        variants(first: 100) {
-          edges {
-            node {
-              id title price compareAtPrice sku barcode
-              inventoryQuantity weight weightUnit
-              selectedOptions { name value }
-              metafields(first: 10) {
-                edges { node { namespace key value type } }
-              }
-            }
-          }
-        }
-        images(first: 20) {
-          edges { node { url altText width height } }
-        }
-        metafields(first: 10) {
-          edges { node { namespace key value type } }
-        }
-      }
-    }
-  }
-}`;
+See [Bulk Operations](references/bulk-operations.md) for the complete mutation/poll/download flow and performance comparison table.
 
-// AFTER: Optimized — only needed fields, smaller page sizes
-// requestedQueryCost: ~112
-const OPTIMIZED_QUERY = `{
-  products(first: 50) {
-    edges {
-      node {
-        id
-        title
-        status
-        variants(first: 5) {
-          edges {
-            node { id price sku inventoryQuantity }
-          }
-        }
-      }
-    }
-    pageInfo { hasNextPage endCursor }
-  }
-}`;
-```
+### Step 3: Cache Frequently Accessed Data
 
-### Step 3: Use Bulk Operations for Large Exports
+LRU cache layer with webhook-driven invalidation. Cache product data for 5 minutes, then clear on `products/update` webhook events.
 
-Bulk operations bypass rate limits and are designed for exporting large datasets:
+See [Response Caching](references/response-caching.md) for the complete implementation.
 
-```typescript
-// Step 1: Start bulk operation
-const START_BULK = `
-  mutation {
-    bulkOperationRunQuery(query: """
-      {
-        products {
-          edges {
-            node {
-              id
-              title
-              handle
-              variants {
-                edges {
-                  node {
-                    id
-                    sku
-                    price
-                    inventoryQuantity
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    """) {
-      bulkOperation {
-        id
-        status
-      }
-      userErrors { field message }
-    }
-  }
-`;
+### Step 4: Use Storefront API for Public Queries
 
-// Step 2: Poll for completion
-const CHECK_BULK = `{
-  currentBulkOperation {
-    id
-    status       # CREATED, RUNNING, COMPLETED, FAILED
-    errorCode
-    objectCount
-    fileSize
-    url          # JSONL download URL when COMPLETED
-    createdAt
-  }
-}`;
+The Storefront API has separate rate limits and is designed for high-traffic public storefronts. Uses `LATEST_API_VERSION` from `@shopify/shopify-api`.
 
-// Step 3: Download results (JSONL format — one JSON object per line)
-// const response = await fetch(bulkOperation.url);
-// Each line: {"id":"gid://shopify/Product/123","title":"Widget",...}
-```
-
-### Step 4: Cache Frequently Accessed Data
-
-```typescript
-import { LRUCache } from "lru-cache";
-
-const shopifyCache = new LRUCache<string, any>({
-  max: 500,
-  ttl: 5 * 60 * 1000, // 5 minutes
-  updateAgeOnGet: true,
-});
-
-async function cachedQuery<T>(
-  cacheKey: string,
-  queryFn: () => Promise<T>,
-  ttlMs?: number
-): Promise<T> {
-  const cached = shopifyCache.get(cacheKey);
-  if (cached !== undefined) return cached as T;
-
-  const result = await queryFn();
-  shopifyCache.set(cacheKey, result, { ttl: ttlMs });
-  return result;
-}
-
-// Usage — cache product data for 5 minutes
-const product = await cachedQuery(
-  `product:${productId}`,
-  () => shopifyQuery(shop, PRODUCT_QUERY, { id: productId })
-);
-
-// Invalidate on webhook
-app.post("/webhooks", (req, res) => {
-  const topic = req.headers["x-shopify-topic"];
-  if (topic === "products/update") {
-    const payload = JSON.parse(req.body);
-    shopifyCache.delete(`product:gid://shopify/Product/${payload.id}`);
-  }
-});
-```
-
-### Step 5: Use Storefront API for Public Queries
-
-The Storefront API has separate rate limits and is designed for high-traffic public storefronts:
-
-```typescript
-// Storefront API — safe for client-side, higher rate limits
-const storefrontClient = new shopify.clients.Storefront({
-  session,
-  apiVersion: "2024-10",
-});
-
-// Storefront API query — no admin credentials exposed
-const products = await storefrontClient.request(`{
-  products(first: 12, sortKey: BEST_SELLING) {
-    edges {
-      node {
-        id
-        title
-        handle
-        priceRange {
-          minVariantPrice { amount currencyCode }
-        }
-        featuredImage {
-          url(transform: { maxWidth: 400 })
-          altText
-        }
-      }
-    }
-  }
-}`);
-```
+See [Storefront API Usage](references/storefront-api-usage.md) for the complete implementation.
 
 ## Output
 
@@ -256,13 +71,23 @@ const products = await storefrontClient.request(`{
 
 ## Examples
 
-### Performance Comparison
+### Reducing Query Cost on a Product Sync
 
-| Approach | 10K Products Export | Rate Limit Impact |
-|----------|-------------------|-------------------|
-| Paginated (first: 250) | 40 queries, ~60s | Uses ~6,000 points |
-| Paginated (first: 50) | 200 queries, ~300s | Uses ~22,000 points |
-| Bulk Operation | 1 query + poll, ~30s | Minimal impact |
+A product sync job hits THROTTLED errors. Analyze the cost breakdown, reduce `first:` page sizes, and remove unused fields.
+
+See [Query Cost Optimization](references/query-cost-optimization.md) for debug commands and before/after examples.
+
+### Exporting Orders with Bulk Operations
+
+Export 50,000 orders with line items using a bulk operation that bypasses rate limits and returns JSONL results.
+
+See [Bulk Operations](references/bulk-operations.md) for the complete mutation, polling, and download flow.
+
+### Caching Product Data with Webhook Invalidation
+
+Add an LRU cache layer for product queries that auto-invalidates when `products/update` webhook events fire.
+
+See [Response Caching](references/response-caching.md) for the complete caching implementation.
 
 ## Resources
 
@@ -270,7 +95,3 @@ const products = await storefrontClient.request(`{
 - [Bulk Operations](https://shopify.dev/docs/api/usage/bulk-operations/queries)
 - [Storefront API](https://shopify.dev/docs/api/storefront)
 - [Query Cost Debug Header](https://shopify.dev/docs/api/usage/rate-limits#query-cost)
-
-## Next Steps
-
-For cost optimization, see `shopify-cost-tuning`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/bulk-operations.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/bulk-operations.md
@@ -1,0 +1,65 @@
+# Bulk Operations for Large Exports
+
+Shopify bulk operations bypass rate limits and are designed for exporting large datasets asynchronously.
+
+```typescript
+// Step 1: Start bulk operation
+const START_BULK = `
+  mutation {
+    bulkOperationRunQuery(query: """
+      {
+        products {
+          edges {
+            node {
+              id
+              title
+              handle
+              variants {
+                edges {
+                  node {
+                    id
+                    sku
+                    price
+                    inventoryQuantity
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """) {
+      bulkOperation {
+        id
+        status
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+// Step 2: Poll for completion
+const CHECK_BULK = `{
+  currentBulkOperation {
+    id
+    status       # CREATED, RUNNING, COMPLETED, FAILED
+    errorCode
+    objectCount
+    fileSize
+    url          # JSONL download URL when COMPLETED
+    createdAt
+  }
+}`;
+
+// Step 3: Download results (JSONL format — one JSON object per line)
+// const response = await fetch(bulkOperation.url);
+// Each line: {"id":"gid://shopify/Product/123","title":"Widget",...}
+```
+
+### Performance Comparison
+
+| Approach | 10K Products Export | Rate Limit Impact |
+|----------|-------------------|-------------------|
+| Paginated (first: 250) | 40 queries, ~60s | Uses ~6,000 points |
+| Paginated (first: 50) | 200 queries, ~300s | Uses ~22,000 points |
+| Bulk Operation | 1 query + poll, ~30s | Minimal impact |

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/query-cost-optimization.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/query-cost-optimization.md
@@ -1,0 +1,85 @@
+# Query Cost Optimization
+
+Before-and-after examples of GraphQL query cost reduction through field selection and page size tuning.
+
+### Debug Query Cost
+
+```bash
+# Debug query cost with special header
+curl -X POST "https://$STORE/admin/api/2025-04/graphql.json" \
+  -H "X-Shopify-Access-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Shopify-GraphQL-Cost-Debug: 1" \
+  -d '{"query": "{ products(first: 50) { edges { node { id title variants(first: 20) { edges { node { id price } } } } } } }"}' \
+  | jq '.extensions.cost'
+```
+
+Use a recent stable version (e.g., 2025-04) in the API URL. Response shows cost breakdown:
+
+```json
+{
+  "requestedQueryCost": 152,
+  "actualQueryCost": 42,
+  "throttleStatus": {
+    "maximumAvailable": 1000.0,
+    "currentlyAvailable": 958.0,
+    "restoreRate": 50.0
+  }
+}
+```
+
+### Before vs After
+
+```typescript
+// BEFORE: High cost — requests too many fields and items
+// requestedQueryCost: ~5,502
+const EXPENSIVE_QUERY = `{
+  products(first: 250) {
+    edges {
+      node {
+        id title description descriptionHtml vendor productType tags
+        variants(first: 100) {
+          edges {
+            node {
+              id title price compareAtPrice sku barcode
+              inventoryQuantity weight weightUnit
+              selectedOptions { name value }
+              metafields(first: 10) {
+                edges { node { namespace key value type } }
+              }
+            }
+          }
+        }
+        images(first: 20) {
+          edges { node { url altText width height } }
+        }
+        metafields(first: 10) {
+          edges { node { namespace key value type } }
+        }
+      }
+    }
+  }
+}`;
+
+// AFTER: Optimized — only needed fields, smaller page sizes
+// requestedQueryCost: ~112
+const OPTIMIZED_QUERY = `{
+  products(first: 50) {
+    edges {
+      node {
+        id
+        title
+        status
+        variants(first: 5) {
+          edges {
+            node { id price sku inventoryQuantity }
+          }
+        }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}`;
+```
+
+**Key rule:** `requestedQueryCost` is calculated as `first * nested_fields`. Reducing `first:` from 250 to 50 can cut cost by 5x.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/response-caching.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/response-caching.md
@@ -1,0 +1,41 @@
+# Response Caching with Webhook Invalidation
+
+LRU cache layer for Shopify API responses with automatic invalidation via webhook events.
+
+```typescript
+import { LRUCache } from "lru-cache";
+
+const shopifyCache = new LRUCache<string, any>({
+  max: 500,
+  ttl: 5 * 60 * 1000, // 5 minutes
+  updateAgeOnGet: true,
+});
+
+async function cachedQuery<T>(
+  cacheKey: string,
+  queryFn: () => Promise<T>,
+  ttlMs?: number
+): Promise<T> {
+  const cached = shopifyCache.get(cacheKey);
+  if (cached !== undefined) return cached as T;
+
+  const result = await queryFn();
+  shopifyCache.set(cacheKey, result, { ttl: ttlMs });
+  return result;
+}
+
+// Usage — cache product data for 5 minutes
+const product = await cachedQuery(
+  `product:${productId}`,
+  () => shopifyQuery(shop, PRODUCT_QUERY, { id: productId })
+);
+
+// Invalidate on webhook
+app.post("/webhooks", (req, res) => {
+  const topic = req.headers["x-shopify-topic"];
+  if (topic === "products/update") {
+    const payload = JSON.parse(req.body);
+    shopifyCache.delete(`product:gid://shopify/Product/${payload.id}`);
+  }
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/storefront-api-usage.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/references/storefront-api-usage.md
@@ -1,0 +1,33 @@
+# Storefront API for Public Queries
+
+The Storefront API has separate rate limits and is designed for high-traffic public storefronts. Safe for client-side use.
+
+```typescript
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+
+// Storefront API — safe for client-side, higher rate limits
+const storefrontClient = new shopify.clients.Storefront({
+  session,
+  apiVersion: LATEST_API_VERSION,
+});
+
+// Storefront API query — no admin credentials exposed
+const products = await storefrontClient.request(`{
+  products(first: 12, sortKey: BEST_SELLING) {
+    edges {
+      node {
+        id
+        title
+        handle
+        priceRange {
+          minVariantPrice { amount currencyCode }
+        }
+        featuredImage {
+          url(transform: { maxWidth: 400 })
+          altText
+        }
+      }
+    }
+  }
+}`);
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-policy-guardrails
 description: |
   Implement Shopify app policy enforcement with ESLint rules for API key detection,
   query cost budgets, and App Store compliance checks.
+  Use when hardening a Shopify app against secret leaks, enforcing query cost limits,
+  or preparing for App Store submission review.
   Trigger with phrases like "shopify policy", "shopify lint",
   "shopify guardrails", "shopify compliance", "shopify eslint", "shopify app review".
 allowed-tools: Read, Write, Edit, Bash(npx:*)
@@ -30,102 +32,19 @@ Automated policy enforcement for Shopify apps: secret detection, query cost budg
 
 ### Step 1: Secret Detection Rules
 
-```javascript
-// eslint-rules/no-shopify-secrets.js
-module.exports = {
-  meta: {
-    type: "problem",
-    docs: { description: "Detect hardcoded Shopify tokens and secrets" },
-    messages: {
-      adminToken: "Hardcoded Shopify Admin API token detected (shpat_*)",
-      apiSecret: "Potential Shopify API secret detected",
-      storefrontToken: "Hardcoded Storefront API token detected",
-    },
-  },
-  create(context) {
-    return {
-      Literal(node) {
-        if (typeof node.value !== "string") return;
-        const v = node.value;
+Custom ESLint rule that catches hardcoded Shopify tokens (`shpat_*`, `shpss_*`) and API secrets in string literals and template literals.
 
-        // Admin API access token: shpat_ + 32 hex chars
-        if (/^shpat_[a-f0-9]{32}$/i.test(v)) {
-          context.report({ node, messageId: "adminToken" });
-        }
-        // Storefront token: shpss_ pattern
-        if (/^shpss_[a-f0-9]{32}$/i.test(v)) {
-          context.report({ node, messageId: "storefrontToken" });
-        }
-        // Generic secret pattern (32+ hex that's clearly a token)
-        if (/^[a-f0-9]{32,}$/i.test(v) && v.length === 32) {
-          context.report({ node, messageId: "apiSecret" });
-        }
-      },
-      TemplateLiteral(node) {
-        for (const quasi of node.quasis) {
-          if (/shpat_[a-f0-9]/i.test(quasi.value.raw)) {
-            context.report({ node, messageId: "adminToken" });
-          }
-        }
-      },
-    };
-  },
-};
-```
+See [Secret Detection ESLint](references/secret-detection-eslint.md) for the complete rule implementation.
 
 ### Step 2: Query Cost Budget Enforcement
 
-```typescript
-// Enforce query cost budgets at build/test time
-interface QueryCostBudget {
-  maxFirstParam: number;        // Max items per page
-  maxNestedDepth: number;       // Max nested connection depth
-  maxEstimatedCost: number;     // Max estimated query cost
-}
+Static analysis of GraphQL queries enforcing budgets: max 100 items per `first:` param, max 3 levels of nesting, and max 500 estimated cost. Runs at build/test time.
 
-const BUDGET: QueryCostBudget = {
-  maxFirstParam: 100,           // Never request more than 100 items
-  maxNestedDepth: 3,            // No more than 3 levels of edges/node
-  maxEstimatedCost: 500,        // Stay well under 1,000 point limit
-};
-
-function validateQueryCost(query: string): string[] {
-  const violations: string[] = [];
-
-  // Check `first:` parameter values
-  const firstParams = query.matchAll(/first:\s*(\d+)/g);
-  for (const match of firstParams) {
-    if (parseInt(match[1]) > BUDGET.maxFirstParam) {
-      violations.push(
-        `first: ${match[1]} exceeds budget of ${BUDGET.maxFirstParam}`
-      );
-    }
-  }
-
-  // Check nesting depth (count "edges { node {" patterns)
-  const depth = (query.match(/edges\s*\{/g) || []).length;
-  if (depth > BUDGET.maxNestedDepth) {
-    violations.push(
-      `Nesting depth ${depth} exceeds budget of ${BUDGET.maxNestedDepth}`
-    );
-  }
-
-  // Estimate cost: multiply all `first` values along nested path
-  const firstValues = [...query.matchAll(/first:\s*(\d+)/g)].map((m) =>
-    parseInt(m[1])
-  );
-  const estimatedCost = firstValues.reduce((a, b) => a * b, 1);
-  if (estimatedCost > BUDGET.maxEstimatedCost) {
-    violations.push(
-      `Estimated cost ${estimatedCost} exceeds budget of ${BUDGET.maxEstimatedCost}`
-    );
-  }
-
-  return violations;
-}
-```
+See [Query Cost Budget](references/query-cost-budget.md) for the complete implementation.
 
 ### Step 3: Pre-Commit Hooks
+
+Git hooks that scan staged changes for Shopify tokens and block `.env` files from being committed.
 
 ```yaml
 # .pre-commit-config.yaml
@@ -155,133 +74,15 @@ repos:
 
 ### Step 4: App Store Compliance Checker
 
-```typescript
-// scripts/check-app-compliance.ts
-// Run before submitting to Shopify App Store
+Pre-submission script that validates all three GDPR webhooks, token hygiene, CSP headers, and API version stability.
 
-interface ComplianceCheck {
-  name: string;
-  required: boolean;
-  check: () => Promise<boolean>;
-}
-
-const checks: ComplianceCheck[] = [
-  {
-    name: "GDPR webhook: customers/data_request",
-    required: true,
-    check: async () => {
-      const toml = await readFile("shopify.app.toml", "utf-8");
-      return toml.includes("customers/data_request");
-    },
-  },
-  {
-    name: "GDPR webhook: customers/redact",
-    required: true,
-    check: async () => {
-      const toml = await readFile("shopify.app.toml", "utf-8");
-      return toml.includes("customers/redact");
-    },
-  },
-  {
-    name: "GDPR webhook: shop/redact",
-    required: true,
-    check: async () => {
-      const toml = await readFile("shopify.app.toml", "utf-8");
-      return toml.includes("shop/redact");
-    },
-  },
-  {
-    name: "No hardcoded tokens in source",
-    required: true,
-    check: async () => {
-      const { execSync } = require("child_process");
-      const result = execSync(
-        'grep -rE "shpat_[a-f0-9]{32}" app/ --include="*.ts" --include="*.tsx" || true'
-      ).toString();
-      return result.trim() === "";
-    },
-  },
-  {
-    name: "CSP frame-ancestors header set",
-    required: true,
-    check: async () => {
-      const files = await glob("app/**/*.ts");
-      const hasCSP = files.some((f) => {
-        const content = readFileSync(f, "utf-8");
-        return content.includes("frame-ancestors");
-      });
-      return hasCSP;
-    },
-  },
-  {
-    name: "API version is not unstable",
-    required: true,
-    check: async () => {
-      const toml = await readFile("shopify.app.toml", "utf-8");
-      return !toml.includes('api_version = "unstable"');
-    },
-  },
-];
-
-async function runComplianceChecks(): Promise<void> {
-  console.log("=== Shopify App Store Compliance Check ===\n");
-  let passed = 0;
-  let failed = 0;
-
-  for (const check of checks) {
-    const result = await check.check();
-    const status = result ? "PASS" : check.required ? "FAIL" : "WARN";
-    console.log(`${status}: ${check.name}`);
-    result ? passed++ : failed++;
-  }
-
-  console.log(`\n${passed} passed, ${failed} failed`);
-  if (failed > 0) process.exit(1);
-}
-```
+See [Compliance Checker](references/compliance-checker.md) for the complete implementation.
 
 ### Step 5: CI Policy Pipeline
 
-```yaml
-# .github/workflows/shopify-policy.yml
-name: Shopify Policy
+GitHub Actions workflow enforcing token scanning, GDPR webhook configuration, and API version stability on every push and PR.
 
-on: [push, pull_request]
-
-jobs:
-  policy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Scan for hardcoded Shopify tokens
-        run: |
-          if grep -rE "shpat_[a-f0-9]{32}|shpss_[a-f0-9]{32}" \
-            --include="*.ts" --include="*.tsx" --include="*.js" \
-            app/ src/ ; then
-            echo "::error::Hardcoded Shopify tokens found!"
-            exit 1
-          fi
-
-      - name: Check GDPR webhooks configured
-        run: |
-          for topic in "customers/data_request" "customers/redact" "shop/redact"; do
-            if ! grep -q "$topic" shopify.app.toml; then
-              echo "::error::Missing mandatory GDPR webhook: $topic"
-              exit 1
-            fi
-          done
-          echo "All GDPR webhooks configured"
-
-      - name: Validate API version
-        run: |
-          VERSION=$(grep 'api_version' shopify.app.toml | head -1 | grep -oP '\d{4}-\d{2}')
-          if [ "$VERSION" = "unstable" ]; then
-            echo "::error::Cannot use unstable API version"
-            exit 1
-          fi
-          echo "API version: $VERSION"
-```
+See [CI Policy Pipeline](references/ci-policy-pipeline.md) for the complete workflow.
 
 ## Output
 
@@ -318,7 +119,3 @@ grep -c "customers/data_request\|customers/redact\|shop/redact" shopify.app.toml
 - [Shopify App Store Requirements](https://shopify.dev/docs/apps/launch/app-requirements)
 - [ESLint Plugin Development](https://eslint.org/docs/latest/extend/plugins)
 - [git-secrets](https://github.com/awslabs/git-secrets)
-
-## Next Steps
-
-For architecture blueprints, see `shopify-architecture-variants`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/ci-policy-pipeline.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/ci-policy-pipeline.md
@@ -1,0 +1,44 @@
+# CI Policy Pipeline
+
+GitHub Actions workflow that enforces token scanning, GDPR webhook configuration, and API version stability on every push and PR.
+
+```yaml
+# .github/workflows/shopify-policy.yml
+name: Shopify Policy
+
+on: [push, pull_request]
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for hardcoded Shopify tokens
+        run: |
+          if grep -rE "shpat_[a-f0-9]{32}|shpss_[a-f0-9]{32}" \
+            --include="*.ts" --include="*.tsx" --include="*.js" \
+            app/ src/ ; then
+            echo "::error::Hardcoded Shopify tokens found!"
+            exit 1
+          fi
+
+      - name: Check GDPR webhooks configured
+        run: |
+          for topic in "customers/data_request" "customers/redact" "shop/redact"; do
+            if ! grep -q "$topic" shopify.app.toml; then
+              echo "::error::Missing mandatory GDPR webhook: $topic"
+              exit 1
+            fi
+          done
+          echo "All GDPR webhooks configured"
+
+      - name: Validate API version
+        run: |
+          VERSION=$(grep 'api_version' shopify.app.toml | head -1 | grep -oP '\d{4}-\d{2}')
+          if [ "$VERSION" = "unstable" ]; then
+            echo "::error::Cannot use unstable API version"
+            exit 1
+          fi
+          echo "API version: $VERSION"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/compliance-checker.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/compliance-checker.md
@@ -1,0 +1,88 @@
+# App Store Compliance Checker
+
+Pre-submission script that validates GDPR webhooks, token hygiene, CSP headers, and API version stability.
+
+```typescript
+// scripts/check-app-compliance.ts
+// Run before submitting to Shopify App Store
+
+interface ComplianceCheck {
+  name: string;
+  required: boolean;
+  check: () => Promise<boolean>;
+}
+
+const checks: ComplianceCheck[] = [
+  {
+    name: "GDPR webhook: customers/data_request",
+    required: true,
+    check: async () => {
+      const toml = await readFile("shopify.app.toml", "utf-8");
+      return toml.includes("customers/data_request");
+    },
+  },
+  {
+    name: "GDPR webhook: customers/redact",
+    required: true,
+    check: async () => {
+      const toml = await readFile("shopify.app.toml", "utf-8");
+      return toml.includes("customers/redact");
+    },
+  },
+  {
+    name: "GDPR webhook: shop/redact",
+    required: true,
+    check: async () => {
+      const toml = await readFile("shopify.app.toml", "utf-8");
+      return toml.includes("shop/redact");
+    },
+  },
+  {
+    name: "No hardcoded tokens in source",
+    required: true,
+    check: async () => {
+      const { execSync } = require("child_process");
+      const result = execSync(
+        'grep -rE "shpat_[a-f0-9]{32}" app/ --include="*.ts" --include="*.tsx" || true'
+      ).toString();
+      return result.trim() === "";
+    },
+  },
+  {
+    name: "CSP frame-ancestors header set",
+    required: true,
+    check: async () => {
+      const files = await glob("app/**/*.ts");
+      const hasCSP = files.some((f) => {
+        const content = readFileSync(f, "utf-8");
+        return content.includes("frame-ancestors");
+      });
+      return hasCSP;
+    },
+  },
+  {
+    name: "API version is not unstable",
+    required: true,
+    check: async () => {
+      const toml = await readFile("shopify.app.toml", "utf-8");
+      return !toml.includes('api_version = "unstable"');
+    },
+  },
+];
+
+async function runComplianceChecks(): Promise<void> {
+  console.log("=== Shopify App Store Compliance Check ===\n");
+  let passed = 0;
+  let failed = 0;
+
+  for (const check of checks) {
+    const result = await check.check();
+    const status = result ? "PASS" : check.required ? "FAIL" : "WARN";
+    console.log(`${status}: ${check.name}`);
+    result ? passed++ : failed++;
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/query-cost-budget.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/query-cost-budget.md
@@ -1,0 +1,53 @@
+# Query Cost Budget Enforcement
+
+Static analysis of GraphQL queries to enforce cost budgets at build/test time before they hit Shopify's API.
+
+```typescript
+// Enforce query cost budgets at build/test time
+interface QueryCostBudget {
+  maxFirstParam: number;        // Max items per page
+  maxNestedDepth: number;       // Max nested connection depth
+  maxEstimatedCost: number;     // Max estimated query cost
+}
+
+const BUDGET: QueryCostBudget = {
+  maxFirstParam: 100,           // Never request more than 100 items
+  maxNestedDepth: 3,            // No more than 3 levels of edges/node
+  maxEstimatedCost: 500,        // Stay well under 1,000 point limit
+};
+
+function validateQueryCost(query: string): string[] {
+  const violations: string[] = [];
+
+  // Check `first:` parameter values
+  const firstParams = query.matchAll(/first:\s*(\d+)/g);
+  for (const match of firstParams) {
+    if (parseInt(match[1]) > BUDGET.maxFirstParam) {
+      violations.push(
+        `first: ${match[1]} exceeds budget of ${BUDGET.maxFirstParam}`
+      );
+    }
+  }
+
+  // Check nesting depth (count "edges { node {" patterns)
+  const depth = (query.match(/edges\s*\{/g) || []).length;
+  if (depth > BUDGET.maxNestedDepth) {
+    violations.push(
+      `Nesting depth ${depth} exceeds budget of ${BUDGET.maxNestedDepth}`
+    );
+  }
+
+  // Estimate cost: multiply all `first` values along nested path
+  const firstValues = [...query.matchAll(/first:\s*(\d+)/g)].map((m) =>
+    parseInt(m[1])
+  );
+  const estimatedCost = firstValues.reduce((a, b) => a * b, 1);
+  if (estimatedCost > BUDGET.maxEstimatedCost) {
+    violations.push(
+      `Estimated cost ${estimatedCost} exceeds budget of ${BUDGET.maxEstimatedCost}`
+    );
+  }
+
+  return violations;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/secret-detection-eslint.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/references/secret-detection-eslint.md
@@ -1,0 +1,46 @@
+# Secret Detection ESLint Rule
+
+Custom ESLint rule that detects hardcoded Shopify tokens (`shpat_*`, `shpss_*`) and API secrets in source code.
+
+```javascript
+// eslint-rules/no-shopify-secrets.js
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: { description: "Detect hardcoded Shopify tokens and secrets" },
+    messages: {
+      adminToken: "Hardcoded Shopify Admin API token detected (shpat_*)",
+      apiSecret: "Potential Shopify API secret detected",
+      storefrontToken: "Hardcoded Storefront API token detected",
+    },
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value !== "string") return;
+        const v = node.value;
+
+        // Admin API access token: shpat_ + 32 hex chars
+        if (/^shpat_[a-f0-9]{32}$/i.test(v)) {
+          context.report({ node, messageId: "adminToken" });
+        }
+        // Storefront token: shpss_ pattern
+        if (/^shpss_[a-f0-9]{32}$/i.test(v)) {
+          context.report({ node, messageId: "storefrontToken" });
+        }
+        // Generic secret pattern (32+ hex that's clearly a token)
+        if (/^[a-f0-9]{32,}$/i.test(v) && v.length === 32) {
+          context.report({ node, messageId: "apiSecret" });
+        }
+      },
+      TemplateLiteral(node) {
+        for (const quasi of node.quasis) {
+          if (/shpat_[a-f0-9]/i.test(quasi.value.raw)) {
+            context.report({ node, messageId: "adminToken" });
+          }
+        }
+      },
+    };
+  },
+};
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-prod-checklist
 description: |
   Execute Shopify app production deployment checklist covering App Store requirements,
   mandatory webhooks, API versioning, and rollback procedures.
+  Use when preparing a Shopify app for production launch, submitting to the App Store,
+  or auditing an existing deployment for compliance gaps.
   Trigger with phrases like "shopify production", "deploy shopify",
   "shopify go-live", "shopify launch checklist", "shopify app store submit".
 allowed-tools: Read, Bash(curl:*), Grep
@@ -29,7 +31,7 @@ Complete pre-launch checklist for deploying Shopify apps to production and submi
 
 ### Step 1: API and Authentication
 
-- [ ] Using a stable API version (e.g., `2024-10`), not `unstable`
+- [ ] Using a recent stable API version (e.g., 2025-04), not `unstable`
 - [ ] Access token stored in secure environment variables (never in code)
 - [ ] API secret stored securely for webhook HMAC verification
 - [ ] OAuth flow tested with a fresh install on a clean dev store
@@ -91,35 +93,9 @@ curl -s -H "X-Shopify-Access-Token: $TOKEN" \
 
 ### Step 8: Health Check Endpoint
 
-```typescript
-app.get("/health", async (req, res) => {
-  const checks: Record<string, any> = {};
+Express endpoint that tests Shopify API connectivity and database availability, returning structured status with latency metrics.
 
-  // Test Shopify connectivity
-  try {
-    const start = Date.now();
-    await client.request("{ shop { name } }");
-    checks.shopify = { status: "ok", latencyMs: Date.now() - start };
-  } catch (err) {
-    checks.shopify = { status: "error", message: (err as Error).message };
-  }
-
-  // Test database
-  try {
-    await db.query("SELECT 1");
-    checks.database = { status: "ok" };
-  } catch (err) {
-    checks.database = { status: "error" };
-  }
-
-  const allHealthy = Object.values(checks).every((c: any) => c.status === "ok");
-  res.status(allHealthy ? 200 : 503).json({
-    status: allHealthy ? "healthy" : "degraded",
-    checks,
-    timestamp: new Date().toISOString(),
-  });
-});
-```
+See [Health Check Endpoint](references/health-check-endpoint.md) for the complete implementation.
 
 ## Output
 
@@ -142,36 +118,9 @@ app.get("/health", async (req, res) => {
 
 ### Pre-Deploy Smoke Test
 
-```bash
-#!/bin/bash
-echo "=== Shopify Pre-Deploy Smoke Test ==="
-STORE="$SHOPIFY_STORE"
-TOKEN="$SHOPIFY_ACCESS_TOKEN"
-PASS=0; FAIL=0
+Bash script that validates Shopify auth and API scopes before deploying to production.
 
-# Auth test
-if curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/api/2024-10/shop.json" > /dev/null; then
-  echo "PASS: Auth"; ((PASS++))
-else
-  echo "FAIL: Auth"; ((FAIL++))
-fi
-
-# Scopes test
-SCOPES=$(curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
-  "https://$STORE/admin/oauth/access_scopes.json" | jq -r '.access_scopes[].handle')
-for required in read_products read_orders; do
-  if echo "$SCOPES" | grep -q "$required"; then
-    echo "PASS: Scope $required"; ((PASS++))
-  else
-    echo "FAIL: Missing scope $required"; ((FAIL++))
-  fi
-done
-
-echo "---"
-echo "Results: $PASS passed, $FAIL failed"
-[ $FAIL -eq 0 ] && echo "READY FOR DEPLOY" || echo "FIX FAILURES FIRST"
-```
+See [Pre-Deploy Smoke Test](references/pre-deploy-smoke-test.md) for the complete script.
 
 ## Resources
 
@@ -179,7 +128,3 @@ echo "Results: $PASS passed, $FAIL failed"
 - [GDPR Compliance Webhooks](https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance)
 - [API Versioning](https://shopify.dev/docs/api/usage/versioning)
 - [Shopify Status Page](https://www.shopifystatus.com)
-
-## Next Steps
-
-For version upgrades, see `shopify-upgrade-migration`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/references/health-check-endpoint.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/references/health-check-endpoint.md
@@ -1,0 +1,33 @@
+# Health Check Endpoint
+
+Express health check that tests Shopify API connectivity and database availability, returning structured status with latency metrics.
+
+```typescript
+app.get("/health", async (req, res) => {
+  const checks: Record<string, any> = {};
+
+  // Test Shopify connectivity
+  try {
+    const start = Date.now();
+    await client.request("{ shop { name } }");
+    checks.shopify = { status: "ok", latencyMs: Date.now() - start };
+  } catch (err) {
+    checks.shopify = { status: "error", message: (err as Error).message };
+  }
+
+  // Test database
+  try {
+    await db.query("SELECT 1");
+    checks.database = { status: "ok" };
+  } catch (err) {
+    checks.database = { status: "error" };
+  }
+
+  const allHealthy = Object.values(checks).every((c: any) => c.status === "ok");
+  res.status(allHealthy ? 200 : 503).json({
+    status: allHealthy ? "healthy" : "degraded",
+    checks,
+    timestamp: new Date().toISOString(),
+  });
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/references/pre-deploy-smoke-test.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/references/pre-deploy-smoke-test.md
@@ -1,0 +1,34 @@
+# Pre-Deploy Smoke Test
+
+Bash script that validates Shopify auth, API scopes, and connectivity before deploying to production.
+
+```bash
+#!/bin/bash
+echo "=== Shopify Pre-Deploy Smoke Test ==="
+STORE="$SHOPIFY_STORE"
+TOKEN="$SHOPIFY_ACCESS_TOKEN"
+PASS=0; FAIL=0
+
+# Auth test — use a recent stable API version (e.g., 2025-04)
+if curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/api/2025-04/shop.json" > /dev/null; then
+  echo "PASS: Auth"; ((PASS++))
+else
+  echo "FAIL: Auth"; ((FAIL++))
+fi
+
+# Scopes test
+SCOPES=$(curl -sf -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE/admin/oauth/access_scopes.json" | jq -r '.access_scopes[].handle')
+for required in read_products read_orders; do
+  if echo "$SCOPES" | grep -q "$required"; then
+    echo "PASS: Scope $required"; ((PASS++))
+  else
+    echo "FAIL: Missing scope $required"; ((FAIL++))
+  fi
+done
+
+echo "---"
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && echo "READY FOR DEPLOY" || echo "FIX FAILURES FIRST"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/SKILL.md
@@ -28,201 +28,41 @@ Shopify uses two distinct rate limiting systems: leaky bucket for REST and calcu
 
 ### Step 1: Understand the Two Rate Limit Systems
 
-**REST Admin API** — Leaky Bucket:
+**REST Admin API** -- Leaky Bucket:
 
 | Plan | Bucket Size | Leak Rate |
 |------|------------|-----------|
 | Standard | 40 requests | 2/second |
 | Shopify Plus | 80 requests | 4/second |
 
-The `X-Shopify-Shop-Api-Call-Limit` header shows your bucket state:
+The `X-Shopify-Shop-Api-Call-Limit` header shows your bucket state (e.g., `32/40` means 32 of 40 slots used). When full, you get HTTP 429 with `Retry-After` header.
 
-```
-X-Shopify-Shop-Api-Call-Limit: 32/40
-```
-
-Means: 32 of 40 slots used. When full, you get HTTP 429 with `Retry-After` header.
-
-**GraphQL Admin API** — Calculated Query Cost:
+**GraphQL Admin API** -- Calculated Query Cost:
 
 | Plan | Max Available | Restore Rate |
 |------|--------------|-------------|
 | Standard | 1,000 points | 50 points/second |
 | Shopify Plus | 2,000 points | 100 points/second |
 
-Every GraphQL response includes cost info in `extensions`:
-
-```json
-{
-  "extensions": {
-    "cost": {
-      "requestedQueryCost": 252,
-      "actualQueryCost": 12,
-      "throttleStatus": {
-        "maximumAvailable": 1000.0,
-        "currentlyAvailable": 988.0,
-        "restoreRate": 50.0
-      }
-    }
-  }
-}
-```
-
-Key insight: `requestedQueryCost` is the *worst case* estimate. `actualQueryCost` is the real cost (often much lower). When `currentlyAvailable` drops to 0, you get `THROTTLED`.
+Every GraphQL response includes cost info in `extensions.cost` with `requestedQueryCost` (worst-case estimate), `actualQueryCost` (real cost, often much lower), and `throttleStatus` (available points and restore rate). When `currentlyAvailable` drops to 0, you get `THROTTLED`.
 
 ### Step 2: Implement GraphQL Cost-Aware Throttling
 
-```typescript
-interface ShopifyThrottleStatus {
-  maximumAvailable: number;
-  currentlyAvailable: number;
-  restoreRate: number;
-}
+Client-side rate limiter that tracks the query cost bucket and pre-emptively waits before sending requests that would be throttled. Updates available points from each response's `throttleStatus`.
 
-class ShopifyRateLimiter {
-  private available: number;
-  private restoreRate: number;
-  private lastUpdate: number;
-
-  constructor(maxAvailable = 1000, restoreRate = 50) {
-    this.available = maxAvailable;
-    this.restoreRate = restoreRate;
-    this.lastUpdate = Date.now();
-  }
-
-  updateFromResponse(throttleStatus: ShopifyThrottleStatus): void {
-    this.available = throttleStatus.currentlyAvailable;
-    this.restoreRate = throttleStatus.restoreRate;
-    this.lastUpdate = Date.now();
-  }
-
-  async waitIfNeeded(estimatedCost: number): Promise<void> {
-    // Estimate current available based on restore rate
-    const elapsed = (Date.now() - this.lastUpdate) / 1000;
-    const estimated = Math.min(
-      this.available + elapsed * this.restoreRate,
-      1000
-    );
-
-    if (estimated < estimatedCost) {
-      const waitSeconds = (estimatedCost - estimated) / this.restoreRate;
-      console.log(`Rate limit: waiting ${waitSeconds.toFixed(1)}s for ${estimatedCost} points`);
-      await new Promise((r) => setTimeout(r, waitSeconds * 1000));
-    }
-  }
-}
-
-// Usage
-const limiter = new ShopifyRateLimiter();
-
-async function rateLimitedQuery(client: any, query: string, variables?: any) {
-  await limiter.waitIfNeeded(100); // estimate cost
-
-  const response = await client.request(query, { variables });
-
-  // Update limiter from actual response
-  if (response.extensions?.cost?.throttleStatus) {
-    limiter.updateFromResponse(response.extensions.cost.throttleStatus);
-  }
-
-  return response;
-}
-```
+See [Cost-Aware Rate Limiter](references/cost-aware-rate-limiter.md) for the complete `ShopifyRateLimiter` class.
 
 ### Step 3: Implement Retry with Backoff for 429s
 
-```typescript
-async function withShopifyRetry<T>(
-  operation: () => Promise<T>,
-  maxRetries = 5
-): Promise<T> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await operation();
-    } catch (error: any) {
-      const isThrottled =
-        error.response?.code === 429 ||
-        error.body?.errors?.[0]?.extensions?.code === "THROTTLED";
+Generic retry wrapper handling both REST 429 responses and GraphQL THROTTLED errors. Uses `Retry-After` header when available, otherwise exponential backoff with jitter (max 30s).
 
-      if (!isThrottled || attempt === maxRetries) throw error;
-
-      // Use Retry-After header if available (REST), otherwise calculate
-      const retryAfter = error.response?.headers?.["retry-after"];
-      const delay = retryAfter
-        ? parseFloat(retryAfter) * 1000
-        : Math.min(1000 * Math.pow(2, attempt) + Math.random() * 500, 30000);
-
-      console.warn(
-        `Shopify throttled (attempt ${attempt + 1}/${maxRetries}). ` +
-        `Retrying in ${(delay / 1000).toFixed(1)}s`
-      );
-
-      await new Promise((r) => setTimeout(r, delay));
-    }
-  }
-  throw new Error("Unreachable");
-}
-```
+See [Retry with Backoff](references/retry-with-backoff.md) for the complete implementation.
 
 ### Step 4: Reduce Query Cost
 
-```typescript
-// EXPENSIVE query — requests all fields, high cost
-const EXPENSIVE = `{
-  products(first: 250) {
-    edges {
-      node {
-        id title description
-        variants(first: 100) {
-          edges {
-            node {
-              id title price sku inventoryQuantity
-              metafields(first: 10) {
-                edges { node { key value } }
-              }
-            }
-          }
-        }
-        images(first: 20) {
-          edges { node { url altText } }
-        }
-      }
-    }
-  }
-}`;
-// requestedQueryCost: ~5,502 (may THROTTLE immediately)
+Prune unused fields and lower `first:` page sizes to reduce `requestedQueryCost`. A query dropping from `first: 250` to `first: 50` with fewer nested fields can go from ~5,500 to ~112 cost.
 
-// OPTIMIZED query — only needed fields, lower page sizes
-const OPTIMIZED = `{
-  products(first: 50) {
-    edges {
-      node {
-        id
-        title
-        variants(first: 10) {
-          edges {
-            node { id price sku }
-          }
-        }
-      }
-    }
-    pageInfo { hasNextPage endCursor }
-  }
-}`;
-// requestedQueryCost: ~112 (safe, leaves room for other queries)
-```
-
-### Step 5: Debug Query Cost
-
-```bash
-# Add this header to see cost breakdown per field
-curl -X POST "https://store.myshopify.com/admin/api/2024-10/graphql.json" \
-  -H "X-Shopify-Access-Token: $TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Shopify-GraphQL-Cost-Debug: 1" \
-  -d '{"query": "{ products(first: 10) { edges { node { id title } } } }"}' \
-  | jq '.extensions.cost'
-```
+See [Query Cost Reduction](references/query-cost-reduction.md) for before/after examples and the debug curl command.
 
 ## Output
 
@@ -243,32 +83,27 @@ curl -X POST "https://store.myshopify.com/admin/api/2024-10/graphql.json" \
 
 ### Queue-Based Bulk Operations
 
+For large data exports, use Shopify's bulk query API which bypasses rate limits entirely:
+
 ```typescript
 import PQueue from "p-queue";
 
-// For bulk operations, use Shopify's bulk query API instead
 const BULK_QUERY = `
   mutation bulkOperationRunQuery($query: String!) {
     bulkOperationRunQuery(query: $query) {
-      bulkOperation {
-        id
-        status
-        url
-      }
+      bulkOperation { id status url }
       userErrors { field message }
     }
   }
 `;
 
-// Bulk queries bypass rate limits for large data exports
 await client.request(BULK_QUERY, {
   variables: {
     query: `{
       products {
         edges {
           node {
-            id
-            title
+            id title
             variants { edges { node { id sku price } } }
           }
         }
@@ -284,7 +119,3 @@ await client.request(BULK_QUERY, {
 - [REST Rate Limits](https://shopify.dev/docs/api/admin-rest/usage/rate-limits)
 - [GraphQL Rate Limits](https://shopify.dev/docs/api/usage/rate-limits#graphql-admin-api-rate-limits)
 - [Bulk Operations](https://shopify.dev/docs/api/usage/bulk-operations/queries)
-
-## Next Steps
-
-For security configuration, see `shopify-security-basics`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/cost-aware-rate-limiter.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/cost-aware-rate-limiter.md
@@ -1,0 +1,60 @@
+# Cost-Aware GraphQL Rate Limiter
+
+Client-side rate limiter that tracks Shopify's calculated query cost bucket and pre-emptively waits before sending requests that would be throttled.
+
+```typescript
+interface ShopifyThrottleStatus {
+  maximumAvailable: number;
+  currentlyAvailable: number;
+  restoreRate: number;
+}
+
+class ShopifyRateLimiter {
+  private available: number;
+  private restoreRate: number;
+  private lastUpdate: number;
+
+  constructor(maxAvailable = 1000, restoreRate = 50) {
+    this.available = maxAvailable;
+    this.restoreRate = restoreRate;
+    this.lastUpdate = Date.now();
+  }
+
+  updateFromResponse(throttleStatus: ShopifyThrottleStatus): void {
+    this.available = throttleStatus.currentlyAvailable;
+    this.restoreRate = throttleStatus.restoreRate;
+    this.lastUpdate = Date.now();
+  }
+
+  async waitIfNeeded(estimatedCost: number): Promise<void> {
+    // Estimate current available based on restore rate
+    const elapsed = (Date.now() - this.lastUpdate) / 1000;
+    const estimated = Math.min(
+      this.available + elapsed * this.restoreRate,
+      1000
+    );
+
+    if (estimated < estimatedCost) {
+      const waitSeconds = (estimatedCost - estimated) / this.restoreRate;
+      console.log(`Rate limit: waiting ${waitSeconds.toFixed(1)}s for ${estimatedCost} points`);
+      await new Promise((r) => setTimeout(r, waitSeconds * 1000));
+    }
+  }
+}
+
+// Usage
+const limiter = new ShopifyRateLimiter();
+
+async function rateLimitedQuery(client: any, query: string, variables?: any) {
+  await limiter.waitIfNeeded(100); // estimate cost
+
+  const response = await client.request(query, { variables });
+
+  // Update limiter from actual response
+  if (response.extensions?.cost?.throttleStatus) {
+    limiter.updateFromResponse(response.extensions.cost.throttleStatus);
+  }
+
+  return response;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/query-cost-reduction.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/query-cost-reduction.md
@@ -1,0 +1,63 @@
+# Query Cost Reduction Examples
+
+Before-and-after examples showing how to reduce GraphQL query cost through field pruning and page size limits.
+
+```typescript
+// EXPENSIVE query — requests all fields, high cost
+const EXPENSIVE = `{
+  products(first: 250) {
+    edges {
+      node {
+        id title description
+        variants(first: 100) {
+          edges {
+            node {
+              id title price sku inventoryQuantity
+              metafields(first: 10) {
+                edges { node { key value } }
+              }
+            }
+          }
+        }
+        images(first: 20) {
+          edges { node { url altText } }
+        }
+      }
+    }
+  }
+}`;
+// requestedQueryCost: ~5,502 (may THROTTLE immediately)
+
+// OPTIMIZED query — only needed fields, lower page sizes
+const OPTIMIZED = `{
+  products(first: 50) {
+    edges {
+      node {
+        id
+        title
+        variants(first: 10) {
+          edges {
+            node { id price sku }
+          }
+        }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}`;
+// requestedQueryCost: ~112 (safe, leaves room for other queries)
+```
+
+### Debug Query Cost
+
+```bash
+# Add this header to see cost breakdown per field
+curl -X POST "https://store.myshopify.com/admin/api/2025-04/graphql.json" \
+  -H "X-Shopify-Access-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Shopify-GraphQL-Cost-Debug: 1" \
+  -d '{"query": "{ products(first: 10) { edges { node { id title } } } }"}' \
+  | jq '.extensions.cost'
+```
+
+Use a recent stable version (e.g., 2025-04) in the API URL.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/retry-with-backoff.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/references/retry-with-backoff.md
@@ -1,0 +1,36 @@
+# Retry with Exponential Backoff
+
+Generic retry wrapper that handles both REST 429 responses and GraphQL THROTTLED errors with exponential backoff and jitter.
+
+```typescript
+async function withShopifyRetry<T>(
+  operation: () => Promise<T>,
+  maxRetries = 5
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: any) {
+      const isThrottled =
+        error.response?.code === 429 ||
+        error.body?.errors?.[0]?.extensions?.code === "THROTTLED";
+
+      if (!isThrottled || attempt === maxRetries) throw error;
+
+      // Use Retry-After header if available (REST), otherwise calculate
+      const retryAfter = error.response?.headers?.["retry-after"];
+      const delay = retryAfter
+        ? parseFloat(retryAfter) * 1000
+        : Math.min(1000 * Math.pow(2, attempt) + Math.random() * 500, 30000);
+
+      console.warn(
+        `Shopify throttled (attempt ${attempt + 1}/${maxRetries}). ` +
+        `Retrying in ${(delay / 1000).toFixed(1)}s`
+      );
+
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw new Error("Unreachable");
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-reference-architecture
 description: |
   Implement Shopify app reference architecture with Remix, Prisma session storage,
   and the official app template patterns.
+  Use when setting up a new Shopify app, structuring a Remix-based project,
+  or configuring Prisma session storage for production.
   Trigger with phrases like "shopify architecture", "shopify app structure",
   "shopify project layout", "shopify Remix template", "shopify app design".
 allowed-tools: Read, Grep
@@ -45,9 +47,6 @@ my-shopify-app/
 │   └── root.tsx
 ├── extensions/
 │   ├── theme-app-extension/        # Theme blocks for Online Store
-│   │   ├── blocks/
-│   │   │   └── product-rating.liquid
-│   │   └── locales/
 │   ├── checkout-ui/                # Checkout UI extension
 │   └── product-discount/           # Shopify Function
 ├── prisma/
@@ -61,190 +60,27 @@ my-shopify-app/
 
 ### Step 2: Core App Configuration
 
-```typescript
-// app/shopify.server.ts — the heart of the app
-import "@shopify/shopify-app-remix/adapters/node";
-import { AppDistribution, shopifyApp } from "@shopify/shopify-app-remix/server";
-import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
-import prisma from "./db.server";
+The `shopify.server.ts` singleton configures the API client, session storage, webhooks, and auth hooks. It uses `LATEST_API_VERSION` from `@shopify/shopify-api` and exports all auth/session helpers.
 
-const shopify = shopifyApp({
-  apiKey: process.env.SHOPIFY_API_KEY!,
-  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
-  appUrl: process.env.SHOPIFY_APP_URL!,
-  scopes: process.env.SHOPIFY_SCOPES?.split(","),
-  apiVersion: "2024-10",
-  distribution: AppDistribution.AppStore, // or SingleMerchant
-  sessionStorage: new PrismaSessionStorage(prisma),
-  webhooks: {
-    APP_UNINSTALLED: {
-      deliveryMethod: "http",
-      callbackUrl: "/webhooks",
-    },
-    PRODUCTS_UPDATE: {
-      deliveryMethod: "http",
-      callbackUrl: "/webhooks",
-    },
-  },
-  hooks: {
-    afterAuth: async ({ session }) => {
-      // Register webhooks after successful auth
-      shopify.registerWebhooks({ session });
-    },
-  },
-  future: {
-    unstable_newEmbeddedAuthStrategy: true,
-  },
-});
-
-export default shopify;
-export const apiVersion = "2024-10";
-export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
-export const authenticate = shopify.authenticate;
-export const unauthenticated = shopify.unauthenticated;
-export const login = shopify.login;
-export const registerWebhooks = shopify.registerWebhooks;
-export const sessionStorage = shopify.sessionStorage;
-```
+See [Core App Configuration](references/core-app-configuration.md) for the complete implementation.
 
 ### Step 3: Session Storage with Prisma
 
-```prisma
-// prisma/schema.prisma
-datasource db {
-  provider = "sqlite"  // or "postgresql" for production
-  url      = env("DATABASE_URL")
-}
+The Prisma schema defines the required `Session` model (matching Shopify's session fields) plus your app's custom models. Use SQLite for dev and PostgreSQL for production.
 
-model Session {
-  id            String    @id
-  shop          String
-  state         String
-  isOnline      Boolean   @default(false)
-  scope         String?
-  expires       DateTime?
-  accessToken   String
-  userId        BigInt?
-  firstName     String?
-  lastName      String?
-  email         String?
-  accountOwner  Boolean   @default(false)
-  locale        String?
-  collaborator  Boolean?  @default(false)
-  emailVerified Boolean?  @default(false)
-}
-
-// Your app's custom models
-model ProductSync {
-  id          String   @id @default(cuid())
-  shop        String
-  productId   String
-  lastSynced  DateTime @default(now())
-  status      String   @default("pending")
-  @@unique([shop, productId])
-}
-```
+See [Prisma Session Storage](references/prisma-session-storage.md) for the complete schema.
 
 ### Step 4: Route Pattern — Authenticated Admin Page
 
-```typescript
-// app/routes/app.products.tsx
-import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
-import { authenticate } from "../shopify.server";
-import { Page, Layout, Card, DataTable } from "@shopify/polaris";
+Each app route calls `authenticate.admin(request)` to get a pre-authenticated GraphQL client, then renders with Polaris components. Data flows through Remix loaders.
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { admin } = await authenticate.admin(request);
-
-  // admin.graphql is a pre-authenticated GraphQL client
-  const response = await admin.graphql(`{
-    products(first: 25, sortKey: UPDATED_AT, reverse: true) {
-      edges {
-        node {
-          id
-          title
-          status
-          totalInventory
-          priceRangeV2 {
-            minVariantPrice { amount currencyCode }
-          }
-        }
-      }
-    }
-  }`);
-
-  const data = await response.json();
-  return json({ products: data.data.products.edges.map((e: any) => e.node) });
-}
-
-export default function Products() {
-  const { products } = useLoaderData<typeof loader>();
-
-  return (
-    <Page title="Products">
-      <Layout>
-        <Layout.Section>
-          <Card>
-            <DataTable
-              columnContentTypes={["text", "text", "numeric", "text"]}
-              headings={["Title", "Status", "Inventory", "Price"]}
-              rows={products.map((p: any) => [
-                p.title,
-                p.status,
-                p.totalInventory,
-                `$${p.priceRangeV2.minVariantPrice.amount}`,
-              ])}
-            />
-          </Card>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-```
+See [Authenticated Admin Route](references/authenticated-admin-route.md) for the complete implementation.
 
 ### Step 5: Theme App Extension
 
-```liquid
-{% comment %} extensions/theme-app-extension/blocks/product-rating.liquid {% endcomment %}
+Theme app extensions add customizable blocks to the Online Store. Each block defines a Liquid template with a `{% schema %}` JSON block for merchant-facing settings.
 
-{% schema %}
-{
-  "name": "Product Rating",
-  "target": "section",
-  "settings": [
-    {
-      "type": "range",
-      "id": "max_stars",
-      "label": "Maximum Stars",
-      "min": 1,
-      "max": 5,
-      "default": 5
-    },
-    {
-      "type": "color",
-      "id": "star_color",
-      "label": "Star Color",
-      "default": "#FFD700"
-    }
-  ]
-}
-{% endschema %}
-
-<div class="product-rating" style="--star-color: {{ block.settings.star_color }}">
-  {% assign rating = product.metafields.custom.rating.value | default: 0 %}
-  {% for i in (1..block.settings.max_stars) %}
-    <span class="star {% if i <= rating %}filled{% endif %}">&#9733;</span>
-  {% endfor %}
-  <span class="rating-text">{{ rating }}/{{ block.settings.max_stars }}</span>
-</div>
-
-<style>
-  .product-rating .star { color: #ccc; font-size: 1.2em; }
-  .product-rating .star.filled { color: var(--star-color); }
-</style>
-```
+See [Theme App Extension](references/theme-app-extension.md) for the complete implementation.
 
 ## Output
 
@@ -284,7 +120,3 @@ shopify app dev
 - [Prisma Session Storage](https://www.npmjs.com/package/@shopify/shopify-app-session-storage-prisma)
 - [Polaris Components](https://polaris.shopify.com/components)
 - [Theme App Extensions](https://shopify.dev/docs/apps/build/online-store/theme-app-extensions)
-
-## Next Steps
-
-For multi-environment setup, see `shopify-multi-env-setup`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/authenticated-admin-route.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/authenticated-admin-route.md
@@ -1,0 +1,60 @@
+# Authenticated Admin Route Pattern
+
+Complete Remix route with authenticated loader and Polaris UI for product listing.
+
+```typescript
+// app/routes/app.products.tsx
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { authenticate } from "../shopify.server";
+import { Page, Layout, Card, DataTable } from "@shopify/polaris";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { admin } = await authenticate.admin(request);
+
+  // admin.graphql is a pre-authenticated GraphQL client
+  const response = await admin.graphql(`{
+    products(first: 25, sortKey: UPDATED_AT, reverse: true) {
+      edges {
+        node {
+          id
+          title
+          status
+          totalInventory
+          priceRangeV2 {
+            minVariantPrice { amount currencyCode }
+          }
+        }
+      }
+    }
+  }`);
+
+  const data = await response.json();
+  return json({ products: data.data.products.edges.map((e: any) => e.node) });
+}
+
+export default function Products() {
+  const { products } = useLoaderData<typeof loader>();
+
+  return (
+    <Page title="Products">
+      <Layout>
+        <Layout.Section>
+          <Card>
+            <DataTable
+              columnContentTypes={["text", "text", "numeric", "text"]}
+              headings={["Title", "Status", "Inventory", "Price"]}
+              rows={products.map((p: any) => [
+                p.title,
+                p.status,
+                p.totalInventory,
+                `$${p.priceRangeV2.minVariantPrice.amount}`,
+              ])}
+            />
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/core-app-configuration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/core-app-configuration.md
@@ -1,0 +1,50 @@
+# Core App Configuration
+
+Complete `shopify.server.ts` singleton — the heart of a Shopify Remix app.
+
+```typescript
+// app/shopify.server.ts — the heart of the app
+import "@shopify/shopify-app-remix/adapters/node";
+import { AppDistribution, shopifyApp } from "@shopify/shopify-app-remix/server";
+import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+import prisma from "./db.server";
+
+const shopify = shopifyApp({
+  apiKey: process.env.SHOPIFY_API_KEY!,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
+  appUrl: process.env.SHOPIFY_APP_URL!,
+  scopes: process.env.SHOPIFY_SCOPES?.split(","),
+  apiVersion: LATEST_API_VERSION,
+  distribution: AppDistribution.AppStore, // or SingleMerchant
+  sessionStorage: new PrismaSessionStorage(prisma),
+  webhooks: {
+    APP_UNINSTALLED: {
+      deliveryMethod: "http",
+      callbackUrl: "/webhooks",
+    },
+    PRODUCTS_UPDATE: {
+      deliveryMethod: "http",
+      callbackUrl: "/webhooks",
+    },
+  },
+  hooks: {
+    afterAuth: async ({ session }) => {
+      // Register webhooks after successful auth
+      shopify.registerWebhooks({ session });
+    },
+  },
+  future: {
+    unstable_newEmbeddedAuthStrategy: true,
+  },
+});
+
+export default shopify;
+export const apiVersion = LATEST_API_VERSION;
+export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
+export const authenticate = shopify.authenticate;
+export const unauthenticated = shopify.unauthenticated;
+export const login = shopify.login;
+export const registerWebhooks = shopify.registerWebhooks;
+export const sessionStorage = shopify.sessionStorage;
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/prisma-session-storage.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/prisma-session-storage.md
@@ -1,0 +1,39 @@
+# Prisma Session Storage Schema
+
+Complete Prisma schema with Shopify session model and example custom models.
+
+```prisma
+// prisma/schema.prisma
+datasource db {
+  provider = "sqlite"  // or "postgresql" for production
+  url      = env("DATABASE_URL")
+}
+
+model Session {
+  id            String    @id
+  shop          String
+  state         String
+  isOnline      Boolean   @default(false)
+  scope         String?
+  expires       DateTime?
+  accessToken   String
+  userId        BigInt?
+  firstName     String?
+  lastName      String?
+  email         String?
+  accountOwner  Boolean   @default(false)
+  locale        String?
+  collaborator  Boolean?  @default(false)
+  emailVerified Boolean?  @default(false)
+}
+
+// Your app's custom models
+model ProductSync {
+  id          String   @id @default(cuid())
+  shop        String
+  productId   String
+  lastSynced  DateTime @default(now())
+  status      String   @default("pending")
+  @@unique([shop, productId])
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/theme-app-extension.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/references/theme-app-extension.md
@@ -1,0 +1,43 @@
+# Theme App Extension
+
+Complete Liquid block for a product rating widget with configurable settings.
+
+```liquid
+{% comment %} extensions/theme-app-extension/blocks/product-rating.liquid {% endcomment %}
+
+{% schema %}
+{
+  "name": "Product Rating",
+  "target": "section",
+  "settings": [
+    {
+      "type": "range",
+      "id": "max_stars",
+      "label": "Maximum Stars",
+      "min": 1,
+      "max": 5,
+      "default": 5
+    },
+    {
+      "type": "color",
+      "id": "star_color",
+      "label": "Star Color",
+      "default": "#FFD700"
+    }
+  ]
+}
+{% endschema %}
+
+<div class="product-rating" style="--star-color: {{ block.settings.star_color }}">
+  {% assign rating = product.metafields.custom.rating.value | default: 0 %}
+  {% for i in (1..block.settings.max_stars) %}
+    <span class="star {% if i <= rating %}filled{% endif %}">&#9733;</span>
+  {% endfor %}
+  <span class="rating-text">{{ rating }}/{{ block.settings.max_stars }}</span>
+</div>
+
+<style>
+  .product-rating .star { color: #ccc; font-size: 1.2em; }
+  .product-rating .star.filled { color: var(--star-color); }
+</style>
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: shopify-reliability-patterns
 description: |
   Implement reliability patterns for Shopify apps including circuit breakers
   for API outages, webhook retry handling, and graceful degradation.
+  Use when building fault-tolerant Shopify integrations, handling webhook retry storms,
+  or adding resilience to API calls.
   Trigger with phrases like "shopify reliability", "shopify circuit breaker",
   "shopify resilience", "shopify fallback", "shopify retry webhook".
 allowed-tools: Read, Write, Edit
@@ -29,242 +31,33 @@ Build fault-tolerant Shopify integrations that handle API outages, webhook retry
 
 ### Step 1: Circuit Breaker for Shopify API
 
-```typescript
-import CircuitBreaker from "opossum";
+Wrap all Shopify API calls in a circuit breaker (using opossum) that opens at 50% error rate, only counting 5xx and timeout errors. When open, serve cached data. The breaker auto-tests recovery after 30 seconds in half-open state.
 
-// Create circuit breaker wrapping Shopify API calls
-const shopifyCircuit = new CircuitBreaker(
-  async (fn: () => Promise<any>) => fn(),
-  {
-    timeout: 10000,                 // 10s timeout per request
-    errorThresholdPercentage: 50,   // Open at 50% error rate
-    resetTimeout: 30000,            // Try half-open after 30s
-    volumeThreshold: 5,             // Need 5 requests before tripping
-    errorFilter: (error: any) => {
-      // Don't count 422 validation errors as circuit failures
-      // Only count 5xx and timeout errors
-      const code = error.response?.code || error.statusCode;
-      return code >= 500 || error.code === "ECONNRESET" || error.code === "ETIMEDOUT";
-    },
-  }
-);
-
-shopifyCircuit.on("open", () => {
-  console.error("[CIRCUIT OPEN] Shopify API failing — serving cached data");
-});
-shopifyCircuit.on("halfOpen", () => {
-  console.info("[CIRCUIT HALF-OPEN] Testing Shopify recovery...");
-});
-shopifyCircuit.on("close", () => {
-  console.info("[CIRCUIT CLOSED] Shopify API recovered");
-});
-
-// Usage
-async function resilientShopifyQuery<T>(
-  shop: string,
-  query: string,
-  variables?: Record<string, unknown>
-): Promise<T> {
-  return shopifyCircuit.fire(async () => {
-    const client = getGraphqlClient(shop);
-    const response = await client.request(query, { variables });
-
-    // Check for THROTTLED in GraphQL response
-    if (response.errors?.some((e: any) => e.extensions?.code === "THROTTLED")) {
-      throw new Error("THROTTLED"); // Triggers circuit breaker
-    }
-
-    return response.data as T;
-  });
-}
-```
+See [Circuit Breaker](references/circuit-breaker.md) for the complete implementation.
 
 ### Step 2: Webhook Idempotency
 
-Shopify retries webhooks up to 19 times over 48 hours if your endpoint doesn't return 200. Your handler **must** be idempotent.
+Shopify retries webhooks up to 19 times over 48 hours if your endpoint doesn't return 200. Your handler **must** be idempotent. Use Redis to track `X-Shopify-Webhook-Id` with a 7-day TTL. Always respond 200 within 5 seconds, then process asynchronously.
 
-```typescript
-import { Redis } from "ioredis";
-const redis = new Redis(process.env.REDIS_URL!);
-
-async function processWebhookIdempotently(
-  webhookId: string, // X-Shopify-Webhook-Id header
-  topic: string,
-  handler: () => Promise<void>
-): Promise<{ processed: boolean; duplicate: boolean }> {
-  const key = `shopify:webhook:${webhookId}`;
-
-  // Check if already processed
-  const exists = await redis.exists(key);
-  if (exists) {
-    console.log(`Duplicate webhook ${webhookId} for ${topic} — skipping`);
-    return { processed: false, duplicate: true };
-  }
-
-  // Mark as processing (with TTL to auto-expire)
-  await redis.set(key, "processing", "EX", 7 * 86400, "NX"); // 7 day TTL
-
-  try {
-    await handler();
-    await redis.set(key, "completed", "EX", 7 * 86400);
-    return { processed: true, duplicate: false };
-  } catch (error) {
-    // Remove the key so Shopify's retry can re-process
-    await redis.del(key);
-    throw error;
-  }
-}
-
-// Usage in webhook handler
-app.post("/webhooks", rawBodyParser, async (req, res) => {
-  const webhookId = req.headers["x-shopify-webhook-id"] as string;
-  const topic = req.headers["x-shopify-topic"] as string;
-
-  // ALWAYS respond 200 within 5 seconds
-  res.status(200).send("OK");
-
-  // Process asynchronously with idempotency
-  await processWebhookIdempotently(webhookId, topic, async () => {
-    const payload = JSON.parse(req.body.toString());
-    await handleWebhookEvent(topic, payload);
-  });
-});
-```
+See [Webhook Idempotency](references/webhook-idempotency.md) for the complete implementation.
 
 ### Step 3: Graceful Degradation with Cached Fallback
 
-```typescript
-async function withFallback<T>(
-  primary: () => Promise<T>,
-  fallback: () => Promise<T>,
-  cacheKey?: string
-): Promise<{ data: T; source: "live" | "cached" | "fallback" }> {
-  try {
-    const data = await primary();
-    // Update cache for future fallback
-    if (cacheKey) {
-      await redis.set(`fallback:${cacheKey}`, JSON.stringify(data), "EX", 3600);
-    }
-    return { data, source: "live" };
-  } catch (error) {
-    console.warn("Shopify API failed, trying cached data:", (error as Error).message);
+Implement a three-tier fallback: try the live API first (caching the result), fall back to cached data, then fall back to an alternative data source (e.g., local DB). Track the data source so you can log degraded responses.
 
-    // Try cached data first
-    if (cacheKey) {
-      const cached = await redis.get(`fallback:${cacheKey}`);
-      if (cached) {
-        return { data: JSON.parse(cached), source: "cached" };
-      }
-    }
-
-    // Fall back to alternative data source
-    try {
-      const data = await fallback();
-      return { data, source: "fallback" };
-    } catch {
-      throw error; // Re-throw original error if all fallbacks fail
-    }
-  }
-}
-
-// Usage
-const { data: products, source } = await withFallback(
-  () => shopifyQuery(shop, PRODUCTS_QUERY),
-  () => db.cachedProducts.findMany({ where: { shop } }),
-  `products:${shop}`
-);
-
-if (source !== "live") {
-  console.warn(`Serving ${source} product data for ${shop}`);
-}
-```
+See [Cached Fallback](references/cached-fallback.md) for the complete implementation.
 
 ### Step 4: Webhook Processing Queue
 
-Don't process webhooks inline — queue them for resilience:
+Don't process webhooks inline — queue them with BullMQ for resilience. Verify HMAC first, respond 200 immediately, then enqueue with topic/shop/payload metadata. The worker processes jobs with exponential backoff (5 retries) and idempotency checks.
 
-```typescript
-import { Queue, Worker } from "bullmq";
-
-const webhookQueue = new Queue("shopify-webhooks", {
-  connection: { host: "localhost", port: 6379 },
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 5000 },
-    removeOnComplete: 1000,
-    removeOnFail: 5000,
-  },
-});
-
-// Enqueue webhook for processing
-app.post("/webhooks", rawBodyParser, (req, res) => {
-  // Verify HMAC first
-  if (!verifyHmac(req.body, req.headers["x-shopify-hmac-sha256"]!)) {
-    return res.status(401).send();
-  }
-
-  // Respond immediately
-  res.status(200).send("OK");
-
-  // Queue for async processing
-  webhookQueue.add(req.headers["x-shopify-topic"] as string, {
-    topic: req.headers["x-shopify-topic"],
-    shop: req.headers["x-shopify-shop-domain"],
-    webhookId: req.headers["x-shopify-webhook-id"],
-    payload: req.body.toString(),
-  });
-});
-
-// Worker processes queued webhooks
-const worker = new Worker("shopify-webhooks", async (job) => {
-  const { topic, shop, webhookId, payload } = job.data;
-
-  await processWebhookIdempotently(webhookId, topic, async () => {
-    await handleWebhookEvent(topic, JSON.parse(payload));
-  });
-}, {
-  connection: { host: "localhost", port: 6379 },
-  concurrency: 10,
-});
-```
+See [Webhook Processing Queue](references/webhook-processing-queue.md) for the complete implementation.
 
 ### Step 5: Rate Limit-Aware Retry
 
-```typescript
-async function shopifyRetry<T>(
-  fn: () => Promise<T>,
-  maxRetries = 5
-): Promise<T> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error: any) {
-      const isRetryable =
-        error.response?.code === 429 ||
-        error.response?.code >= 500 ||
-        error.body?.errors?.[0]?.extensions?.code === "THROTTLED";
+Retry logic that respects Shopify's `Retry-After` header (REST 429) and GraphQL throttle status restore rate. Calculates optimal wait time from available points rather than blindly backing off.
 
-      if (!isRetryable || attempt === maxRetries) throw error;
-
-      // For REST 429: use Retry-After header
-      const retryAfter = error.response?.headers?.["retry-after"];
-      // For GraphQL THROTTLED: calculate from available points
-      const throttle = error.body?.extensions?.cost?.throttleStatus;
-      const waitForPoints = throttle
-        ? ((100 - throttle.currentlyAvailable) / throttle.restoreRate) * 1000
-        : 0;
-
-      const delay = retryAfter
-        ? parseFloat(retryAfter) * 1000
-        : Math.max(waitForPoints, 1000 * Math.pow(2, attempt));
-
-      console.warn(`Retry ${attempt + 1}/${maxRetries} in ${(delay / 1000).toFixed(1)}s`);
-      await new Promise((r) => setTimeout(r, delay));
-    }
-  }
-  throw new Error("Unreachable");
-}
-```
+See [Rate Limit-Aware Retry](references/rate-limit-retry.md) for the complete implementation.
 
 ## Output
 
@@ -310,7 +103,3 @@ app.get("/health", async (req, res) => {
 - [Opossum Circuit Breaker](https://nodeshift.dev/opossum/)
 - [BullMQ Documentation](https://docs.bullmq.io/)
 - [Shopify Webhook Retry Policy](https://shopify.dev/docs/apps/build/webhooks)
-
-## Next Steps
-
-For policy enforcement, see `shopify-policy-guardrails`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/cached-fallback.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/cached-fallback.md
@@ -1,0 +1,49 @@
+# Graceful Degradation with Cached Fallback
+
+Three-tier fallback strategy: live API, cached data, then alternative data source.
+
+```typescript
+async function withFallback<T>(
+  primary: () => Promise<T>,
+  fallback: () => Promise<T>,
+  cacheKey?: string
+): Promise<{ data: T; source: "live" | "cached" | "fallback" }> {
+  try {
+    const data = await primary();
+    // Update cache for future fallback
+    if (cacheKey) {
+      await redis.set(`fallback:${cacheKey}`, JSON.stringify(data), "EX", 3600);
+    }
+    return { data, source: "live" };
+  } catch (error) {
+    console.warn("Shopify API failed, trying cached data:", (error as Error).message);
+
+    // Try cached data first
+    if (cacheKey) {
+      const cached = await redis.get(`fallback:${cacheKey}`);
+      if (cached) {
+        return { data: JSON.parse(cached), source: "cached" };
+      }
+    }
+
+    // Fall back to alternative data source
+    try {
+      const data = await fallback();
+      return { data, source: "fallback" };
+    } catch {
+      throw error; // Re-throw original error if all fallbacks fail
+    }
+  }
+}
+
+// Usage
+const { data: products, source } = await withFallback(
+  () => shopifyQuery(shop, PRODUCTS_QUERY),
+  () => db.cachedProducts.findMany({ where: { shop } }),
+  `products:${shop}`
+);
+
+if (source !== "live") {
+  console.warn(`Serving ${source} product data for ${shop}`);
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/circuit-breaker.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/circuit-breaker.md
@@ -1,0 +1,53 @@
+# Circuit Breaker for Shopify API
+
+Full circuit breaker implementation using opossum with Shopify-specific error filtering.
+
+```typescript
+import CircuitBreaker from "opossum";
+
+// Create circuit breaker wrapping Shopify API calls
+const shopifyCircuit = new CircuitBreaker(
+  async (fn: () => Promise<any>) => fn(),
+  {
+    timeout: 10000,                 // 10s timeout per request
+    errorThresholdPercentage: 50,   // Open at 50% error rate
+    resetTimeout: 30000,            // Try half-open after 30s
+    volumeThreshold: 5,             // Need 5 requests before tripping
+    errorFilter: (error: any) => {
+      // Don't count 422 validation errors as circuit failures
+      // Only count 5xx and timeout errors
+      const code = error.response?.code || error.statusCode;
+      return code >= 500 || error.code === "ECONNRESET" || error.code === "ETIMEDOUT";
+    },
+  }
+);
+
+shopifyCircuit.on("open", () => {
+  console.error("[CIRCUIT OPEN] Shopify API failing — serving cached data");
+});
+shopifyCircuit.on("halfOpen", () => {
+  console.info("[CIRCUIT HALF-OPEN] Testing Shopify recovery...");
+});
+shopifyCircuit.on("close", () => {
+  console.info("[CIRCUIT CLOSED] Shopify API recovered");
+});
+
+// Usage
+async function resilientShopifyQuery<T>(
+  shop: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  return shopifyCircuit.fire(async () => {
+    const client = getGraphqlClient(shop);
+    const response = await client.request(query, { variables });
+
+    // Check for THROTTLED in GraphQL response
+    if (response.errors?.some((e: any) => e.extensions?.code === "THROTTLED")) {
+      throw new Error("THROTTLED"); // Triggers circuit breaker
+    }
+
+    return response.data as T;
+  });
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/rate-limit-retry.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/rate-limit-retry.md
@@ -1,0 +1,39 @@
+# Rate Limit-Aware Retry
+
+Retry logic that respects Shopify's `Retry-After` header and GraphQL throttle status restore rate.
+
+```typescript
+async function shopifyRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries = 5
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error: any) {
+      const isRetryable =
+        error.response?.code === 429 ||
+        error.response?.code >= 500 ||
+        error.body?.errors?.[0]?.extensions?.code === "THROTTLED";
+
+      if (!isRetryable || attempt === maxRetries) throw error;
+
+      // For REST 429: use Retry-After header
+      const retryAfter = error.response?.headers?.["retry-after"];
+      // For GraphQL THROTTLED: calculate from available points
+      const throttle = error.body?.extensions?.cost?.throttleStatus;
+      const waitForPoints = throttle
+        ? ((100 - throttle.currentlyAvailable) / throttle.restoreRate) * 1000
+        : 0;
+
+      const delay = retryAfter
+        ? parseFloat(retryAfter) * 1000
+        : Math.max(waitForPoints, 1000 * Math.pow(2, attempt));
+
+      console.warn(`Retry ${attempt + 1}/${maxRetries} in ${(delay / 1000).toFixed(1)}s`);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw new Error("Unreachable");
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/webhook-idempotency.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/webhook-idempotency.md
@@ -1,0 +1,51 @@
+# Webhook Idempotency
+
+Redis-backed idempotency handler using `X-Shopify-Webhook-Id` for deduplication.
+
+```typescript
+import { Redis } from "ioredis";
+const redis = new Redis(process.env.REDIS_URL!);
+
+async function processWebhookIdempotently(
+  webhookId: string, // X-Shopify-Webhook-Id header
+  topic: string,
+  handler: () => Promise<void>
+): Promise<{ processed: boolean; duplicate: boolean }> {
+  const key = `shopify:webhook:${webhookId}`;
+
+  // Check if already processed
+  const exists = await redis.exists(key);
+  if (exists) {
+    console.log(`Duplicate webhook ${webhookId} for ${topic} — skipping`);
+    return { processed: false, duplicate: true };
+  }
+
+  // Mark as processing (with TTL to auto-expire)
+  await redis.set(key, "processing", "EX", 7 * 86400, "NX"); // 7 day TTL
+
+  try {
+    await handler();
+    await redis.set(key, "completed", "EX", 7 * 86400);
+    return { processed: true, duplicate: false };
+  } catch (error) {
+    // Remove the key so Shopify's retry can re-process
+    await redis.del(key);
+    throw error;
+  }
+}
+
+// Usage in webhook handler
+app.post("/webhooks", rawBodyParser, async (req, res) => {
+  const webhookId = req.headers["x-shopify-webhook-id"] as string;
+  const topic = req.headers["x-shopify-topic"] as string;
+
+  // ALWAYS respond 200 within 5 seconds
+  res.status(200).send("OK");
+
+  // Process asynchronously with idempotency
+  await processWebhookIdempotently(webhookId, topic, async () => {
+    const payload = JSON.parse(req.body.toString());
+    await handleWebhookEvent(topic, payload);
+  });
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/webhook-processing-queue.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/references/webhook-processing-queue.md
@@ -1,0 +1,48 @@
+# Webhook Processing Queue
+
+BullMQ-based async webhook processing with HMAC verification, exponential backoff, and idempotency.
+
+```typescript
+import { Queue, Worker } from "bullmq";
+
+const webhookQueue = new Queue("shopify-webhooks", {
+  connection: { host: "localhost", port: 6379 },
+  defaultJobOptions: {
+    attempts: 5,
+    backoff: { type: "exponential", delay: 5000 },
+    removeOnComplete: 1000,
+    removeOnFail: 5000,
+  },
+});
+
+// Enqueue webhook for processing
+app.post("/webhooks", rawBodyParser, (req, res) => {
+  // Verify HMAC first
+  if (!verifyHmac(req.body, req.headers["x-shopify-hmac-sha256"]!)) {
+    return res.status(401).send();
+  }
+
+  // Respond immediately
+  res.status(200).send("OK");
+
+  // Queue for async processing
+  webhookQueue.add(req.headers["x-shopify-topic"] as string, {
+    topic: req.headers["x-shopify-topic"],
+    shop: req.headers["x-shopify-shop-domain"],
+    webhookId: req.headers["x-shopify-webhook-id"],
+    payload: req.body.toString(),
+  });
+});
+
+// Worker processes queued webhooks
+const worker = new Worker("shopify-webhooks", async (job) => {
+  const { topic, shop, webhookId, payload } = job.data;
+
+  await processWebhookIdempotently(webhookId, topic, async () => {
+    await handleWebhookEvent(topic, JSON.parse(payload));
+  });
+}, {
+  connection: { host: "localhost", port: 6379 },
+  concurrency: 10,
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/SKILL.md
@@ -19,7 +19,7 @@ compatible-with: claude-code
 
 ## Overview
 
-Production-ready patterns for the `@shopify/shopify-api` library: singleton clients, typed GraphQL operations, session management, cursor-based pagination, and error handling wrappers.
+Production-ready patterns for the `@shopify/shopify-api` library: singleton clients, typed GraphQL operations, session management, cursor-based pagination, codegen-typed operations, bulk operations, and webhook registry patterns.
 
 ## Prerequisites
 
@@ -31,246 +31,175 @@ Production-ready patterns for the `@shopify/shopify-api` library: singleton clie
 
 ### Step 1: Typed GraphQL Client Wrapper
 
-```typescript
-// src/shopify/client.ts
-import "@shopify/shopify-api/adapters/node";
-import { shopifyApi, Session, GraphqlClient } from "@shopify/shopify-api";
+Initialize a singleton `shopifyApi` instance with `LATEST_API_VERSION`, cache sessions per shop, and expose a typed `shopifyQuery<T>()` helper that wraps `client.request()`.
 
-const shopify = shopifyApi({
-  apiKey: process.env.SHOPIFY_API_KEY!,
-  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
-  hostName: process.env.SHOPIFY_HOST_NAME!,
-  apiVersion: "2024-10",
-  isCustomStoreApp: !!process.env.SHOPIFY_ACCESS_TOKEN,
-  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN,
-});
-
-// Singleton session cache per shop
-const sessionCache = new Map<string, Session>();
-
-export function getSession(shop: string): Session {
-  if (!sessionCache.has(shop)) {
-    const session = shopify.session.customAppSession(shop);
-    sessionCache.set(shop, session);
-  }
-  return sessionCache.get(shop)!;
-}
-
-export function getGraphqlClient(shop: string): GraphqlClient {
-  return new shopify.clients.Graphql({
-    session: getSession(shop),
-  });
-}
-
-// Typed query helper
-export async function shopifyQuery<T = any>(
-  shop: string,
-  query: string,
-  variables?: Record<string, unknown>
-): Promise<T> {
-  const client = getGraphqlClient(shop);
-  const response = await client.request(query, { variables });
-  return response.data as T;
-}
-```
+See [Typed GraphQL Client](references/typed-graphql-client.md) for the complete implementation.
 
 ### Step 2: Error Handling with Shopify Error Types
 
-```typescript
-// src/shopify/errors.ts
-import { HttpResponseError, GraphqlQueryError } from "@shopify/shopify-api";
+Custom `ShopifyServiceError` class that distinguishes retryable errors (429, 5xx) from permanent ones. Includes `handleShopifyError()` for error translation and `safeShopifyCall()` that returns `{data, error}` tuples instead of throwing.
 
-export class ShopifyServiceError extends Error {
-  constructor(
-    message: string,
-    public readonly statusCode: number,
-    public readonly retryable: boolean,
-    public readonly shopifyRequestId?: string,
-    public readonly originalError?: Error
-  ) {
-    super(message);
-    this.name = "ShopifyServiceError";
-  }
-}
-
-export function handleShopifyError(error: unknown): never {
-  if (error instanceof HttpResponseError) {
-    const retryable = [429, 500, 502, 503, 504].includes(error.response.code);
-    throw new ShopifyServiceError(
-      `Shopify API ${error.response.code}: ${error.message}`,
-      error.response.code,
-      retryable,
-      error.response.headers?.["x-request-id"] as string,
-      error
-    );
-  }
-
-  if (error instanceof GraphqlQueryError) {
-    // GraphQL errors in the response body
-    const msg = error.body?.errors
-      ?.map((e: any) => e.message)
-      .join("; ") || error.message;
-    throw new ShopifyServiceError(msg, 200, false, undefined, error);
-  }
-
-  throw error;
-}
-
-// Safe wrapper
-export async function safeShopifyCall<T>(
-  operation: () => Promise<T>
-): Promise<{ data: T | null; error: ShopifyServiceError | null }> {
-  try {
-    const data = await operation();
-    return { data, error: null };
-  } catch (err) {
-    try {
-      handleShopifyError(err);
-    } catch (shopifyErr) {
-      return { data: null, error: shopifyErr as ShopifyServiceError };
-    }
-    return { data: null, error: err as ShopifyServiceError };
-  }
-}
-```
+See [Error Handling](references/error-handling.md) for the complete implementation.
 
 ### Step 3: Cursor-Based Pagination
 
-```typescript
-// src/shopify/pagination.ts
-// Shopify uses Relay-style cursor pagination for all list queries
+Async generator `paginateShopify<T>()` for Relay-style cursor pagination. Yields batches of nodes, automatically following `pageInfo.endCursor` until `hasNextPage` is false. Memory-efficient for large datasets.
 
-interface PageInfo {
-  hasNextPage: boolean;
-  endCursor: string | null;
-}
-
-interface PaginatedResult<T> {
-  edges: Array<{ node: T; cursor: string }>;
-  pageInfo: PageInfo;
-}
-
-export async function* paginateShopify<T>(
-  shop: string,
-  query: string,
-  connectionPath: string, // e.g. "products" or "orders"
-  variables: Record<string, unknown> = {},
-  pageSize: number = 50
-): AsyncGenerator<T[], void, undefined> {
-  let cursor: string | null = null;
-  let hasNextPage = true;
-
-  while (hasNextPage) {
-    const response = await shopifyQuery(shop, query, {
-      ...variables,
-      first: pageSize,
-      after: cursor,
-    });
-
-    // Navigate to the connection in the response
-    const connection = connectionPath
-      .split(".")
-      .reduce((obj: any, key) => obj[key], response) as PaginatedResult<T>;
-
-    yield connection.edges.map((e) => e.node);
-
-    hasNextPage = connection.pageInfo.hasNextPage;
-    cursor = connection.pageInfo.endCursor;
-  }
-}
-
-// Usage example:
-// for await (const batch of paginateShopify<Product>(
-//   "store.myshopify.com",
-//   PRODUCTS_QUERY,
-//   "products",
-//   { query: "status:active" }
-// )) {
-//   await processProducts(batch);
-// }
-```
+See [Cursor Pagination](references/cursor-pagination.md) for the complete implementation.
 
 ### Step 4: Multi-Tenant Client Factory
 
+`ShopifyClientFactory` class for apps installed on multiple stores. Creates isolated `GraphqlClient` instances per merchant with session caching. Includes `removeClient()` for eviction on app uninstall.
+
+See [Multi-Tenant Factory](references/multi-tenant-factory.md) for the complete implementation.
+
+### Step 5: Codegen-Typed Operations
+
+Use `@shopify/api-codegen-preset` to generate TypeScript types from your GraphQL operations. This eliminates manual type definitions and catches schema changes at build time.
+
 ```typescript
-// src/shopify/factory.ts
-// For apps installed on multiple stores
+// codegen.ts — project root config
+import { shopifyApiProject, ApiType } from "@shopify/api-codegen-preset";
 
-import { Session, GraphqlClient } from "@shopify/shopify-api";
-
-interface TenantConfig {
-  shop: string;
-  accessToken: string;
-}
-
-class ShopifyClientFactory {
-  private clients = new Map<string, GraphqlClient>();
-
-  getClient(config: TenantConfig): GraphqlClient {
-    if (!this.clients.has(config.shop)) {
-      const session = new Session({
-        id: config.shop,
-        shop: config.shop,
-        state: "",
-        isOnline: false,
-        accessToken: config.accessToken,
-      });
-
-      this.clients.set(
-        config.shop,
-        new shopify.clients.Graphql({ session })
-      );
-    }
-    return this.clients.get(config.shop)!;
-  }
-
-  // Evict when merchant uninstalls
-  removeClient(shop: string): void {
-    this.clients.delete(shop);
-  }
-}
-
-export const clientFactory = new ShopifyClientFactory();
+export default {
+  schema: "https://shopify.dev/admin-graphql-direct-proxy",
+  documents: ["src/**/*.{ts,tsx}"],
+  projects: {
+    default: shopifyApiProject({
+      apiType: ApiType.Admin,
+      apiVersion: "2025-04", // Update quarterly
+      outputDir: "./src/types",
+    }),
+  },
+};
 ```
 
-### Step 5: Response Validation with Zod
+```typescript
+// src/operations/products.ts — typed query with codegen output
+import type { ProductsQuery } from "../types/admin.generated";
+
+const PRODUCTS_QUERY = `#graphql
+  query Products($first: Int!, $after: String) {
+    products(first: $first, after: $after) {
+      edges {
+        node { id title status totalInventory }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+` as const;
+
+// Return type is fully inferred from codegen
+export async function getProducts(shop: string): Promise<ProductsQuery> {
+  return shopifyQuery<ProductsQuery>(shop, PRODUCTS_QUERY, { first: 50 });
+}
+```
+
+Run `npx graphql-codegen` after changing any GraphQL operation or upgrading API versions.
+
+### Step 6: Bulk Operation Helpers
+
+For datasets too large for pagination (100k+ records), use Shopify's Bulk Operations API. It runs a query server-side and produces a JSONL file you download when ready.
 
 ```typescript
-// src/shopify/validators.ts
-import { z } from "zod";
+// src/shopify/bulk.ts
+const BULK_QUERY = `
+  mutation bulkOperationRunQuery($query: String!) {
+    bulkOperationRunQuery(query: $query) {
+      bulkOperation { id status }
+      userErrors { field message }
+    }
+  }
+`;
 
-// Validate Shopify product response shape
-const ShopifyMoneySchema = z.object({
-  amount: z.string(),
-  currencyCode: z.string(),
-});
+const POLL_QUERY = `{
+  currentBulkOperation {
+    id status errorCode objectCount url
+  }
+}`;
 
-const ShopifyProductSchema = z.object({
-  id: z.string().startsWith("gid://shopify/Product/"),
-  title: z.string(),
-  handle: z.string(),
-  status: z.enum(["ACTIVE", "ARCHIVED", "DRAFT"]),
-  totalInventory: z.number(),
-  variants: z.object({
-    edges: z.array(z.object({
-      node: z.object({
-        id: z.string(),
-        title: z.string(),
-        price: z.string(),
-        sku: z.string().nullable(),
-      }),
-    })),
-  }),
-});
+export async function runBulkOperation(
+  shop: string,
+  query: string
+): Promise<string> {
+  // Start the bulk operation
+  const { bulkOperationRunQuery } = await shopifyQuery(shop, BULK_QUERY, { query });
+  if (bulkOperationRunQuery.userErrors?.length) {
+    throw new Error(bulkOperationRunQuery.userErrors[0].message);
+  }
 
-export type ShopifyProduct = z.infer<typeof ShopifyProductSchema>;
+  // Poll until complete (typically 1-10 minutes for large datasets)
+  let result;
+  do {
+    await new Promise((r) => setTimeout(r, 5000)); // 5s interval
+    result = (await shopifyQuery(shop, POLL_QUERY)).currentBulkOperation;
+  } while (result.status === "RUNNING" || result.status === "CREATED");
 
-// Validated fetch
-export async function fetchProducts(shop: string): Promise<ShopifyProduct[]> {
-  const data = await shopifyQuery(shop, PRODUCTS_QUERY);
-  return data.products.edges.map(
-    (e: any) => ShopifyProductSchema.parse(e.node)
-  );
+  if (result.status !== "COMPLETED") {
+    throw new Error(`Bulk operation failed: ${result.errorCode}`);
+  }
+
+  return result.url; // JSONL download URL
+}
+
+// Usage: export all products
+const url = await runBulkOperation(shop, `{
+  products { edges { node { id title status variants { edges { node { sku price } } } } } }
+}`);
+const response = await fetch(url);
+const jsonl = await response.text();
+const products = jsonl.trim().split("\n").map(JSON.parse);
+```
+
+### Step 7: Webhook Registry Patterns
+
+Programmatically register webhook subscriptions using `webhookSubscriptionCreate` with typed `WebhookSubscriptionInput`. Supports both HTTP and EventBridge/PubSub endpoints.
+
+```typescript
+// src/shopify/webhooks.ts
+const REGISTER_WEBHOOK = `
+  mutation webhookSubscriptionCreate(
+    $topic: WebhookSubscriptionTopic!,
+    $webhookSubscription: WebhookSubscriptionInput!
+  ) {
+    webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
+      webhookSubscription { id topic }
+      userErrors { field message }
+    }
+  }
+`;
+
+interface WebhookConfig {
+  topic: string;
+  callbackUrl: string;
+  format?: "JSON" | "XML";
+}
+
+export async function registerWebhooks(
+  shop: string,
+  webhooks: WebhookConfig[]
+): Promise<{ registered: string[]; errors: string[] }> {
+  const registered: string[] = [];
+  const errors: string[] = [];
+
+  for (const wh of webhooks) {
+    const result = await shopifyQuery(shop, REGISTER_WEBHOOK, {
+      topic: wh.topic,
+      webhookSubscription: {
+        callbackUrl: wh.callbackUrl,
+        format: wh.format ?? "JSON",
+      },
+    });
+
+    const userErrors = result.webhookSubscriptionCreate.userErrors;
+    if (userErrors?.length) {
+      errors.push(`${wh.topic}: ${userErrors[0].message}`);
+    } else {
+      registered.push(wh.topic);
+    }
+  }
+
+  return { registered, errors };
 }
 ```
 
@@ -280,7 +209,9 @@ export async function fetchProducts(shop: string): Promise<ShopifyProduct[]> {
 - Structured error handling that distinguishes retryable from permanent errors
 - Cursor-based pagination generator for large datasets
 - Multi-tenant client factory for apps serving multiple stores
-- Zod validation for API response shape verification
+- Codegen-typed operations eliminating manual type definitions
+- Bulk operation helpers for large dataset exports
+- Webhook registry patterns for programmatic subscription management
 
 ## Error Handling
 
@@ -289,42 +220,32 @@ export async function fetchProducts(shop: string): Promise<ShopifyProduct[]> {
 | `safeShopifyCall` | All API calls | Returns `{data, error}` instead of throwing |
 | `handleShopifyError` | Error translation | Maps HTTP/GraphQL errors to typed errors |
 | Cursor pagination | Large datasets | Memory-efficient streaming with backpressure |
-| Zod validation | Response parsing | Catches breaking API changes immediately |
+| Bulk operations | 100k+ records | Server-side execution, no client memory pressure |
 | Client factory | Multi-tenant apps | Isolated sessions per merchant |
 
 ## Examples
 
-### Retry with Exponential Backoff
+### Setting Up a Type-Safe GraphQL Client
 
-```typescript
-export async function withRetry<T>(
-  operation: () => Promise<T>,
-  maxRetries = 3,
-  baseDelayMs = 1000
-): Promise<T> {
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await operation();
-    } catch (err) {
-      if (err instanceof ShopifyServiceError && err.retryable && attempt < maxRetries) {
-        const delay = baseDelayMs * Math.pow(2, attempt - 1) + Math.random() * 500;
-        console.warn(`Shopify retry ${attempt}/${maxRetries} in ${delay.toFixed(0)}ms`);
-        await new Promise((r) => setTimeout(r, delay));
-        continue;
-      }
-      throw err;
-    }
-  }
-  throw new Error("Unreachable");
-}
-```
+Initialize a singleton Shopify client with session caching and a typed `shopifyQuery<T>()` helper for all API calls.
+
+See [Typed GraphQL Client](references/typed-graphql-client.md) for the complete implementation.
+
+### Handling Retryable vs Permanent Errors
+
+Distinguish 429/5xx retryable errors from permanent validation failures using a structured error class and safe call wrapper.
+
+See [Error Handling](references/error-handling.md) for the complete error handling implementation.
+
+### Building a Multi-Tenant App
+
+Create isolated GraphQL clients per merchant with session caching and eviction on app uninstall using a client factory.
+
+See [Multi-Tenant Factory](references/multi-tenant-factory.md) for the complete implementation.
 
 ## Resources
 
 - [@shopify/shopify-api Reference](https://github.com/Shopify/shopify-api-js)
 - [GraphQL Pagination (Relay Spec)](https://shopify.dev/docs/api/usage/pagination-graphql)
-- [Zod Documentation](https://zod.dev/)
-
-## Next Steps
-
-Apply patterns in `shopify-core-workflow-a` for real-world product management.
+- [@shopify/api-codegen-preset](https://github.com/Shopify/shopify-api-js/tree/main/packages/api-codegen-preset)
+- [Bulk Operations](https://shopify.dev/docs/api/usage/bulk-operations/queries)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/cursor-pagination.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/cursor-pagination.md
@@ -1,0 +1,57 @@
+# Cursor-Based Pagination
+
+Async generator for Relay-style cursor pagination used by all Shopify list queries.
+
+```typescript
+// src/shopify/pagination.ts
+// Shopify uses Relay-style cursor pagination for all list queries
+
+interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+interface PaginatedResult<T> {
+  edges: Array<{ node: T; cursor: string }>;
+  pageInfo: PageInfo;
+}
+
+export async function* paginateShopify<T>(
+  shop: string,
+  query: string,
+  connectionPath: string, // e.g. "products" or "orders"
+  variables: Record<string, unknown> = {},
+  pageSize: number = 50
+): AsyncGenerator<T[], void, undefined> {
+  let cursor: string | null = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const response = await shopifyQuery(shop, query, {
+      ...variables,
+      first: pageSize,
+      after: cursor,
+    });
+
+    // Navigate to the connection in the response
+    const connection = connectionPath
+      .split(".")
+      .reduce((obj: any, key) => obj[key], response) as PaginatedResult<T>;
+
+    yield connection.edges.map((e) => e.node);
+
+    hasNextPage = connection.pageInfo.hasNextPage;
+    cursor = connection.pageInfo.endCursor;
+  }
+}
+
+// Usage example:
+// for await (const batch of paginateShopify<Product>(
+//   "store.myshopify.com",
+//   PRODUCTS_QUERY,
+//   "products",
+//   { query: "status:active" }
+// )) {
+//   await processProducts(batch);
+// }
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/error-handling.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/error-handling.md
@@ -1,0 +1,61 @@
+# Error Handling with Shopify Error Types
+
+Custom error class that distinguishes retryable from permanent errors, plus a safe wrapper returning `{data, error}` tuples.
+
+```typescript
+// src/shopify/errors.ts
+import { HttpResponseError, GraphqlQueryError } from "@shopify/shopify-api";
+
+export class ShopifyServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly retryable: boolean,
+    public readonly shopifyRequestId?: string,
+    public readonly originalError?: Error
+  ) {
+    super(message);
+    this.name = "ShopifyServiceError";
+  }
+}
+
+export function handleShopifyError(error: unknown): never {
+  if (error instanceof HttpResponseError) {
+    const retryable = [429, 500, 502, 503, 504].includes(error.response.code);
+    throw new ShopifyServiceError(
+      `Shopify API ${error.response.code}: ${error.message}`,
+      error.response.code,
+      retryable,
+      error.response.headers?.["x-request-id"] as string,
+      error
+    );
+  }
+
+  if (error instanceof GraphqlQueryError) {
+    // GraphQL errors in the response body
+    const msg = error.body?.errors
+      ?.map((e: any) => e.message)
+      .join("; ") || error.message;
+    throw new ShopifyServiceError(msg, 200, false, undefined, error);
+  }
+
+  throw error;
+}
+
+// Safe wrapper
+export async function safeShopifyCall<T>(
+  operation: () => Promise<T>
+): Promise<{ data: T | null; error: ShopifyServiceError | null }> {
+  try {
+    const data = await operation();
+    return { data, error: null };
+  } catch (err) {
+    try {
+      handleShopifyError(err);
+    } catch (shopifyErr) {
+      return { data: null, error: shopifyErr as ShopifyServiceError };
+    }
+    return { data: null, error: err as ShopifyServiceError };
+  }
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/multi-tenant-factory.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/multi-tenant-factory.md
@@ -1,0 +1,44 @@
+# Multi-Tenant Client Factory
+
+Client factory for apps installed on multiple stores with per-merchant session isolation and eviction on uninstall.
+
+```typescript
+// src/shopify/factory.ts
+// For apps installed on multiple stores
+
+import { Session, GraphqlClient } from "@shopify/shopify-api";
+
+interface TenantConfig {
+  shop: string;
+  accessToken: string;
+}
+
+class ShopifyClientFactory {
+  private clients = new Map<string, GraphqlClient>();
+
+  getClient(config: TenantConfig): GraphqlClient {
+    if (!this.clients.has(config.shop)) {
+      const session = new Session({
+        id: config.shop,
+        shop: config.shop,
+        state: "",
+        isOnline: false,
+        accessToken: config.accessToken,
+      });
+
+      this.clients.set(
+        config.shop,
+        new shopify.clients.Graphql({ session })
+      );
+    }
+    return this.clients.get(config.shop)!;
+  }
+
+  // Evict when merchant uninstalls
+  removeClient(shop: string): void {
+    this.clients.delete(shop);
+  }
+}
+
+export const clientFactory = new ShopifyClientFactory();
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/typed-graphql-client.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/references/typed-graphql-client.md
@@ -1,0 +1,46 @@
+# Typed GraphQL Client Wrapper
+
+Full singleton client setup with session caching and typed query helper.
+
+```typescript
+// src/shopify/client.ts
+import "@shopify/shopify-api/adapters/node";
+import { shopifyApi, Session, GraphqlClient, LATEST_API_VERSION } from "@shopify/shopify-api";
+
+const shopify = shopifyApi({
+  apiKey: process.env.SHOPIFY_API_KEY!,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET!,
+  hostName: process.env.SHOPIFY_HOST_NAME!,
+  apiVersion: LATEST_API_VERSION,
+  isCustomStoreApp: !!process.env.SHOPIFY_ACCESS_TOKEN,
+  adminApiAccessToken: process.env.SHOPIFY_ACCESS_TOKEN,
+});
+
+// Singleton session cache per shop
+const sessionCache = new Map<string, Session>();
+
+export function getSession(shop: string): Session {
+  if (!sessionCache.has(shop)) {
+    const session = shopify.session.customAppSession(shop);
+    sessionCache.set(shop, session);
+  }
+  return sessionCache.get(shop)!;
+}
+
+export function getGraphqlClient(shop: string): GraphqlClient {
+  return new shopify.clients.Graphql({
+    session: getSession(shop),
+  });
+}
+
+// Typed query helper
+export async function shopifyQuery<T = any>(
+  shop: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const client = getGraphqlClient(shop);
+  const response = await client.request(query, { variables });
+  return response.data as T;
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/SKILL.md
@@ -53,82 +53,15 @@ SHOPIFY_ACCESS_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ### Step 2: Webhook HMAC Verification
 
-Shopify signs every webhook with your app's API secret using HMAC-SHA256. The signature is in the `X-Shopify-Hmac-Sha256` header.
+Shopify signs every webhook with your app's API secret using HMAC-SHA256. The signature is in the `X-Shopify-Hmac-Sha256` header. Use `crypto.timingSafeEqual` for comparison to prevent timing attacks. The middleware must use raw body parser (not JSON parser).
 
-```typescript
-import crypto from "crypto";
-import express from "express";
-
-function verifyShopifyWebhook(
-  rawBody: Buffer,
-  hmacHeader: string,
-  secret: string
-): boolean {
-  const computed = crypto
-    .createHmac("sha256", secret)
-    .update(rawBody)
-    .digest("base64");
-
-  // Timing-safe comparison prevents timing attacks
-  return crypto.timingSafeEqual(
-    Buffer.from(computed),
-    Buffer.from(hmacHeader)
-  );
-}
-
-// Express middleware — MUST use raw body parser
-app.post(
-  "/webhooks",
-  express.raw({ type: "application/json" }),
-  (req, res) => {
-    const hmac = req.headers["x-shopify-hmac-sha256"] as string;
-    const topic = req.headers["x-shopify-topic"] as string;
-    const shop = req.headers["x-shopify-shop-domain"] as string;
-
-    if (!verifyShopifyWebhook(req.body, hmac, process.env.SHOPIFY_API_SECRET!)) {
-      console.warn(`Invalid webhook HMAC from ${shop}, topic: ${topic}`);
-      return res.status(401).send("HMAC validation failed");
-    }
-
-    const payload = JSON.parse(req.body.toString());
-    console.log(`Verified webhook: ${topic} from ${shop}`);
-
-    // Process asynchronously — respond 200 within 5 seconds
-    processWebhookAsync(topic, shop, payload);
-    res.status(200).send("OK");
-  }
-);
-```
+See [Webhook HMAC Verification](references/webhook-hmac-verification.md) for the complete implementation.
 
 ### Step 3: OAuth Request Verification
 
-Verify that incoming requests from Shopify are authentic by checking the HMAC query parameter:
+Verify that incoming OAuth requests from Shopify are authentic by checking the HMAC query parameter. The library handles this automatically, but the manual approach sorts params alphabetically, creates a query string, and compares HMAC hex digests.
 
-```typescript
-import { shopifyApi } from "@shopify/shopify-api";
-
-// The library handles this automatically, but here's the manual approach:
-function verifyShopifyRequest(query: Record<string, string>, secret: string): boolean {
-  const { hmac, ...params } = query;
-  if (!hmac) return false;
-
-  // Sort parameters and create query string
-  const message = Object.keys(params)
-    .sort()
-    .map((key) => `${key}=${params[key]}`)
-    .join("&");
-
-  const computed = crypto
-    .createHmac("sha256", secret)
-    .update(message)
-    .digest("hex");
-
-  return crypto.timingSafeEqual(
-    Buffer.from(computed),
-    Buffer.from(hmac)
-  );
-}
-```
+See [OAuth Request Verification](references/oauth-request-verification.md) for the complete implementation.
 
 ### Step 4: Minimal Access Scopes
 
@@ -219,7 +152,3 @@ git secrets --install
 - [Shopify API Authentication](https://shopify.dev/docs/api/usage/authentication)
 - [Access Scopes Reference](https://shopify.dev/docs/api/usage/access-scopes)
 - [Embedded App Security](https://shopify.dev/docs/apps/build/authentication-authorization)
-
-## Next Steps
-
-For production deployment, see `shopify-prod-checklist`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/references/oauth-request-verification.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/references/oauth-request-verification.md
@@ -1,0 +1,29 @@
+# OAuth Request Verification
+
+Manual HMAC verification for incoming OAuth requests from Shopify (the library handles this automatically, but this shows the underlying approach).
+
+```typescript
+import { shopifyApi } from "@shopify/shopify-api";
+
+// The library handles this automatically, but here's the manual approach:
+function verifyShopifyRequest(query: Record<string, string>, secret: string): boolean {
+  const { hmac, ...params } = query;
+  if (!hmac) return false;
+
+  // Sort parameters and create query string
+  const message = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${params[key]}`)
+    .join("&");
+
+  const computed = crypto
+    .createHmac("sha256", secret)
+    .update(message)
+    .digest("hex");
+
+  return crypto.timingSafeEqual(
+    Buffer.from(computed),
+    Buffer.from(hmac)
+  );
+}
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/references/webhook-hmac-verification.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/references/webhook-hmac-verification.md
@@ -1,0 +1,48 @@
+# Webhook HMAC Verification
+
+Complete Express middleware for verifying Shopify webhook signatures using HMAC-SHA256 with timing-safe comparison.
+
+```typescript
+import crypto from "crypto";
+import express from "express";
+
+function verifyShopifyWebhook(
+  rawBody: Buffer,
+  hmacHeader: string,
+  secret: string
+): boolean {
+  const computed = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("base64");
+
+  // Timing-safe comparison prevents timing attacks
+  return crypto.timingSafeEqual(
+    Buffer.from(computed),
+    Buffer.from(hmacHeader)
+  );
+}
+
+// Express middleware — MUST use raw body parser
+app.post(
+  "/webhooks",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const hmac = req.headers["x-shopify-hmac-sha256"] as string;
+    const topic = req.headers["x-shopify-topic"] as string;
+    const shop = req.headers["x-shopify-shop-domain"] as string;
+
+    if (!verifyShopifyWebhook(req.body, hmac, process.env.SHOPIFY_API_SECRET!)) {
+      console.warn(`Invalid webhook HMAC from ${shop}, topic: ${topic}`);
+      return res.status(401).send("HMAC validation failed");
+    }
+
+    const payload = JSON.parse(req.body.toString());
+    console.log(`Verified webhook: ${topic} from ${shop}`);
+
+    // Process asynchronously — respond 200 within 5 seconds
+    processWebhookAsync(topic, shop, payload);
+    res.status(200).send("OK");
+  }
+);
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: shopify-storefront-headless
+description: |
+  Build headless storefronts with Shopify's Storefront API and Cart API.
+  Use when building custom frontends, setting up Hydrogen, querying products
+  for customer-facing apps, or managing cart operations programmatically.
+  Trigger with phrases like "shopify headless", "shopify storefront api",
+  "shopify hydrogen", "shopify cart api", "headless commerce shopify".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify Storefront & Headless Commerce
+
+## Overview
+
+The Storefront API is Shopify's public-facing GraphQL API for customer experiences. Unlike the Admin API (server-side, privileged), it uses a public access token safe for client-side code. Paired with the Cart API, it powers headless storefronts, mobile apps, and custom buying experiences.
+
+## Prerequisites
+
+- Shopify store with a Storefront API access token (Headless channel or custom app)
+- For Hydrogen: Node.js 18+ and Shopify CLI 3.x+
+- Storefront API scopes: `unauthenticated_read_products`, `unauthenticated_read_collections`
+
+## Instructions
+
+### Step 1: Storefront API Client Setup
+
+```typescript
+import { createStorefrontApiClient } from "@shopify/storefront-api-client";
+
+const client = createStorefrontApiClient({
+  storeDomain: "my-store.myshopify.com",
+  apiVersion: LATEST_API_VERSION,
+  publicAccessToken: "your-storefront-public-token", // Safe in browser
+});
+```
+
+### Step 2: Cart Operations
+
+```typescript
+const { data } = await client.request(CART_CREATE, {
+  variables: {
+    input: {
+      lines: [{ merchandiseId: "gid://shopify/ProductVariant/123", quantity: 2 }],
+      buyerIdentity: { email: "customer@example.com", countryCode: "US" },
+    },
+  },
+});
+// Redirect to data.cartCreate.cart.checkoutUrl to complete purchase
+```
+
+Full cart mutations (`cartLinesAdd`, `cartLinesUpdate`, `cartLinesRemove`, `cartDiscountCodesUpdate`) in [cart-api.md](references/cart-api.md).
+
+### Step 3: Query Products (Storefront Schema)
+
+```typescript
+// Storefront API schema differs from Admin API — field names are NOT the same
+const { data } = await client.request(`
+  query { products(first: 10) { edges { node {
+    id title handle availableForSale
+    priceRange { minVariantPrice { amount currencyCode } }
+    variants(first: 5) { edges { node {
+      id title availableForSale
+      price { amount currencyCode }  // MoneyV2 object, not a string
+      selectedOptions { name value }
+    }}}
+  }}}}
+`);
+```
+
+### Step 4: Storefront vs Admin API Decision Guide
+
+| Concern | Storefront API | Admin API |
+|---------|---------------|-----------|
+| Token type | Public (safe in browser) | Private (server-only) |
+| Rate limiting | Request-based | Query cost-based (1000 pts/sec) |
+| Cart/Checkout | Full cart + checkout URL | No cart operations |
+| Product data | Customer-facing fields only | Full data + inventory |
+| Mutations | Cart, customer, checkout | Full CRUD on all resources |
+
+Detailed comparison in [storefront-vs-admin.md](references/storefront-vs-admin.md). Hydrogen framework setup in [hydrogen-patterns.md](references/hydrogen-patterns.md).
+
+## Output
+
+- Storefront API client configured with public access token
+- Cart created with line items and checkout URL
+- Product catalog queryable from client-side code
+- Clear separation of Storefront (public) vs Admin (privileged) API usage
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `INVALID_STOREFRONT_ACCESS_TOKEN` | Token missing, expired, or wrong store | Regenerate in Shopify admin under Headless channel |
+| `THROTTLED` | Exceeded request rate limit | Retry with backoff; cache product data |
+| `PRODUCT_NOT_AVAILABLE` | Product not published to Headless channel | Publish product to the Headless sales channel |
+| `CART_DOES_NOT_EXIST` | Cart ID expired (10-day inactivity) | Create a new cart; don't persist IDs long-term |
+
+## Examples
+
+### Building a Custom Cart Experience
+
+Create a cart, add line items, apply discount codes, and redirect to Shopify's hosted checkout using the Storefront Cart API.
+
+See [Cart API](references/cart-api.md) for the complete cart lifecycle mutations and response shapes.
+
+### Scaffolding a Hydrogen Storefront
+
+Set up a new Hydrogen project with Remix loaders, Storefront client configuration, and server-side product queries.
+
+See [Hydrogen Patterns](references/hydrogen-patterns.md) for the framework setup and loader patterns.
+
+### Choosing Between Storefront and Admin APIs
+
+Decide which API to use based on token type, rate limiting model, available mutations, and data access scope.
+
+See [Storefront vs Admin](references/storefront-vs-admin.md) for the detailed comparison.
+
+## Resources
+
+- [Storefront API Reference](https://shopify.dev/docs/api/storefront)
+- [Cart API Guide](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart)
+- [Hydrogen Framework](https://shopify.dev/docs/storefronts/hydrogen)
+- [Storefront API Authentication](https://shopify.dev/docs/api/storefront#authentication)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/cart-api.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/cart-api.md
@@ -1,0 +1,180 @@
+Complete Storefront Cart API mutations with real field names and response shapes.
+
+## Cart Lifecycle
+
+```
+cartCreate → cartLinesAdd/Update/Remove → customer visits checkoutUrl → order created
+```
+
+Carts expire after **10 days of inactivity**. Do not persist cart IDs in long-term storage.
+
+## cartCreate
+
+```typescript
+const CART_CREATE = `#graphql
+  mutation cartCreate($input: CartInput!) {
+    cartCreate(input: $input) {
+      cart { ...CartFragment }
+      userErrors { field message code }
+    }
+  }
+
+  fragment CartFragment on Cart {
+    id
+    checkoutUrl
+    totalQuantity
+    note
+    cost {
+      totalAmount { amount currencyCode }
+      subtotalAmount { amount currencyCode }
+      totalTaxAmount { amount currencyCode }
+      totalDutyAmount { amount currencyCode }
+    }
+    lines(first: 100) {
+      edges { node {
+        id
+        quantity
+        cost {
+          amountPerQuantity { amount currencyCode }
+          totalAmount { amount currencyCode }
+        }
+        merchandise {
+          ... on ProductVariant {
+            id
+            title
+            product { title handle }
+            image { url altText }
+            price { amount currencyCode }
+            selectedOptions { name value }
+          }
+        }
+        attributes { key value }
+      }}
+    }
+    buyerIdentity {
+      email
+      countryCode
+    }
+    discountCodes { code applicable }
+  }
+`;
+```
+
+## cartLinesAdd
+
+```typescript
+const CART_LINES_ADD = `#graphql
+  mutation cartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
+    cartLinesAdd(cartId: $cartId, lines: $lines) {
+      cart { ...CartFragment }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CART_LINES_ADD, {
+  variables: {
+    cartId: "gid://shopify/Cart/abc123",
+    lines: [
+      {
+        merchandiseId: "gid://shopify/ProductVariant/456",
+        quantity: 1,
+        attributes: [{ key: "Gift wrapping", value: "Yes" }],
+      },
+    ],
+  },
+});
+```
+
+## cartLinesUpdate
+
+```typescript
+const CART_LINES_UPDATE = `#graphql
+  mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart { ...CartFragment }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CART_LINES_UPDATE, {
+  variables: {
+    cartId: "gid://shopify/Cart/abc123",
+    lines: [
+      {
+        id: "gid://shopify/CartLine/789",  // Line ID, not variant ID
+        quantity: 3,
+      },
+    ],
+  },
+});
+```
+
+## cartLinesRemove
+
+```typescript
+const CART_LINES_REMOVE = `#graphql
+  mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
+    cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
+      cart { ...CartFragment }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CART_LINES_REMOVE, {
+  variables: {
+    cartId: "gid://shopify/Cart/abc123",
+    lineIds: ["gid://shopify/CartLine/789"],
+  },
+});
+```
+
+## cartDiscountCodesUpdate
+
+```typescript
+const CART_DISCOUNT = `#graphql
+  mutation cartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!) {
+    cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
+      cart {
+        id
+        discountCodes { code applicable }
+        cost { totalAmount { amount currencyCode } }
+      }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CART_DISCOUNT, {
+  variables: {
+    cartId: "gid://shopify/Cart/abc123",
+    discountCodes: ["SUMMER20"],
+  },
+});
+```
+
+## cartBuyerIdentityUpdate
+
+```typescript
+const CART_BUYER = `#graphql
+  mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
+    cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
+      cart { ...CartFragment }
+      userErrors { field message code }
+    }
+  }
+`;
+
+await client.request(CART_BUYER, {
+  variables: {
+    cartId: "gid://shopify/Cart/abc123",
+    buyerIdentity: {
+      email: "customer@example.com",
+      countryCode: "US",
+      customerAccessToken: "token-from-customerAccessTokenCreate",
+    },
+  },
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/hydrogen-patterns.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/hydrogen-patterns.md
@@ -1,0 +1,174 @@
+Hydrogen framework setup, client configuration, and Remix loader patterns.
+
+## Project Scaffolding
+
+```bash
+# Create a new Hydrogen project
+npx @shopify/create-hydrogen@latest my-store
+
+# Or with Shopify CLI
+shopify hydrogen init --template demo-store
+```
+
+## Storefront Client in Hydrogen
+
+```typescript
+// app/lib/createStorefrontClient.server.ts
+import { createStorefrontClient } from "@shopify/hydrogen";
+
+export function getStorefrontClient(env: Env) {
+  return createStorefrontClient({
+    storeDomain: env.PUBLIC_STORE_DOMAIN,
+    publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
+    privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN, // optional, server-side
+    storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || "2025-01",
+  });
+}
+```
+
+## Loader Pattern (Product Page)
+
+```typescript
+// app/routes/($locale).products.$handle.tsx
+import { json, type LoaderFunctionArgs } from "@shopify/remix-oxygen";
+import { useLoaderData } from "@remix-run/react";
+
+const PRODUCT_QUERY = `#graphql
+  query Product($handle: String!) {
+    product(handle: $handle) {
+      id
+      title
+      description
+      descriptionHtml
+      vendor
+      availableForSale
+      options {
+        name
+        values
+      }
+      selectedVariant: variantBySelectedOptions(selectedOptions: $selectedOptions) {
+        id
+        price { amount currencyCode }
+        availableForSale
+      }
+      variants(first: 100) {
+        nodes {
+          id
+          title
+          price { amount currencyCode }
+          availableForSale
+          selectedOptions { name value }
+          image { url altText width height }
+        }
+      }
+      images(first: 10) {
+        nodes { url altText width height }
+      }
+      seo { title description }
+    }
+  }
+`;
+
+export async function loader({ params, context }: LoaderFunctionArgs) {
+  const { storefront } = context;
+  const { product } = await storefront.query(PRODUCT_QUERY, {
+    variables: { handle: params.handle },
+  });
+
+  if (!product) {
+    throw new Response("Product not found", { status: 404 });
+  }
+
+  return json({ product });
+}
+
+export default function ProductPage() {
+  const { product } = useLoaderData<typeof loader>();
+  return (
+    <div>
+      <h1>{product.title}</h1>
+      {/* Product UI */}
+    </div>
+  );
+}
+```
+
+## Deferred Loading (Streaming)
+
+```typescript
+// Use defer for non-critical data to speed up initial render
+import { defer, type LoaderFunctionArgs } from "@shopify/remix-oxygen";
+
+export async function loader({ context }: LoaderFunctionArgs) {
+  const { storefront } = context;
+
+  // Critical: await immediately
+  const featuredProducts = await storefront.query(FEATURED_QUERY);
+
+  // Non-critical: defer (loads after initial render)
+  const recommendations = storefront.query(RECOMMENDATIONS_QUERY);
+
+  return defer({
+    featuredProducts,
+    recommendations, // This is a Promise, resolved client-side
+  });
+}
+```
+
+## Collection Page Pattern
+
+```typescript
+// app/routes/($locale).collections.$handle.tsx
+const COLLECTION_QUERY = `#graphql
+  query Collection($handle: String!, $first: Int!, $after: String) {
+    collection(handle: $handle) {
+      id
+      title
+      description
+      products(first: $first, after: $after, sortKey: BEST_SELLING) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          title
+          handle
+          availableForSale
+          priceRange {
+            minVariantPrice { amount currencyCode }
+          }
+          featuredImage { url altText }
+        }
+      }
+    }
+  }
+`;
+
+export async function loader({ params, request, context }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const after = url.searchParams.get("cursor");
+
+  const { collection } = await context.storefront.query(COLLECTION_QUERY, {
+    variables: {
+      handle: params.handle,
+      first: 24,
+      after,
+    },
+  });
+
+  if (!collection) {
+    throw new Response("Collection not found", { status: 404 });
+  }
+
+  return json({ collection });
+}
+```
+
+## Environment Variables
+
+```env
+# .env (Hydrogen project)
+PUBLIC_STORE_DOMAIN="my-store.myshopify.com"
+PUBLIC_STOREFRONT_API_TOKEN="public-token-here"
+PRIVATE_STOREFRONT_API_TOKEN="private-token-here"  # Server-side only, higher rate limits
+PUBLIC_STOREFRONT_API_VERSION="2025-01"
+SESSION_SECRET="random-secret-for-sessions"
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/storefront-vs-admin.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/references/storefront-vs-admin.md
@@ -1,0 +1,98 @@
+Detailed comparison of Shopify Storefront API vs Admin API capabilities and access patterns.
+
+## Authentication
+
+| Aspect | Storefront API | Admin API |
+|--------|---------------|-----------|
+| Token type | Public access token | Private access token (`shpat_*`) |
+| Safe in browser | Yes | Never (server-only) |
+| Token source | Headless channel or custom app | Custom app or OAuth |
+| Scopes | `unauthenticated_*` prefixed | Standard scopes (`read_products`, etc.) |
+
+## Rate Limiting
+
+| Aspect | Storefront API | Admin API |
+|--------|---------------|-----------|
+| Model | Request-based | Query cost-based |
+| Limit | ~100 requests/second per IP | 1000 points/second per app |
+| Burst | Allowed (no bucket) | 2000 point bucket |
+| Header | `Retry-After` | `X-Shopify-Shop-Api-Call-Limit` |
+| Strategy | Simple retry with backoff | Calculate query cost, throttle proactively |
+
+## Data Access Comparison
+
+| Resource | Storefront API | Admin API |
+|----------|---------------|-----------|
+| Products | Published products only | All products (draft, archived, active) |
+| Variants | `availableForSale`, `price`, `selectedOptions` | Full variant data + inventory quantities |
+| Collections | Published collections only | All collections |
+| Orders | Customer's own orders (with token) | All orders |
+| Customers | Self-service (create, login, address) | Full CRUD on all customers |
+| Metafields | Only if `storefront` access enabled | All metafields |
+| Metaobjects | Only if `storefront` access enabled | All metaobjects |
+| Cart | Full cart lifecycle | No cart operations |
+| Checkout | Via `checkoutUrl` redirect | Draft orders (not checkout) |
+| Inventory | Not available | Full inventory management |
+| Fulfillment | Not available | Full fulfillment management |
+| Discounts | Apply via discount codes on cart | Create/manage discount rules |
+
+## When to Use Each
+
+### Use Storefront API When:
+- Building a customer-facing storefront or mobile app
+- Running code in the browser (public token is safe)
+- Managing shopping cart and checkout flow
+- Displaying product catalogs, collections, search
+- Handling customer authentication (login, register, addresses)
+
+### Use Admin API When:
+- Managing products, inventory, or orders (back-office)
+- Processing webhooks on your server
+- Syncing data with external systems (ERP, warehouse)
+- Building admin tools or dashboards
+- Running bulk operations (imports, exports)
+- Creating draft orders programmatically
+
+### Use Both When:
+- Full headless storefront: Storefront API for the frontend, Admin API for backend order processing
+- Custom checkout: Storefront API for cart, Admin API for post-purchase fulfillment
+- Loyalty programs: Storefront API for customer-facing UI, Admin API for managing customer metafields
+
+## GraphQL Schema Differences
+
+The two APIs have **different schemas**. Field names and structures differ:
+
+```graphql
+# Storefront API — product price
+product {
+  priceRange {
+    minVariantPrice { amount currencyCode }
+  }
+}
+
+# Admin API — product price
+product {
+  priceRangeV2 {
+    minVariantPrice { amount currencyCode }
+  }
+}
+```
+
+```graphql
+# Storefront API — variant fields
+variant {
+  price { amount currencyCode }        # MoneyV2 object
+  availableForSale                      # Boolean
+  selectedOptions { name value }
+}
+
+# Admin API — variant fields
+variant {
+  price                                 # String ("29.99")
+  inventoryQuantity                     # Int (not on Storefront)
+  selectedOptions { name value }
+  sku                                   # Not on Storefront
+}
+```
+
+Do not copy queries between APIs without adjusting field names and types.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: shopify-theme-performance
+description: |
+  Optimize Shopify theme performance for Core Web Vitals (LCP, CLS, INP).
+  Use when diagnosing slow page loads, fixing lazy-loaded hero images,
+  profiling Liquid render times, or optimizing image delivery.
+  Trigger with phrases like "shopify theme performance", "shopify core web vitals",
+  "shopify lcp", "shopify liquid profiler", "shopify image optimization".
+allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, ecommerce, shopify]
+compatible-with: claude-code
+---
+
+# Shopify Theme Performance
+
+## Overview
+
+59% of Shopify stores lazy-load their LCP image, adding 3-5 seconds to perceived load time. This skill covers the highest-impact theme optimizations: fixing LCP image loading, switching to the modern `image_url` filter, profiling Liquid render times, and optimizing font delivery.
+
+## Prerequisites
+
+- Access to the Shopify theme editor or theme files via CLI (`shopify theme dev`)
+- Theme using Online Store 2.0 architecture (sections + JSON templates)
+- Google Chrome DevTools or Lighthouse for measurement
+
+## Instructions
+
+### Step 1: Fix LCP Image Loading
+
+The LCP element is usually the hero banner image. Find it in your theme's hero section:
+
+```liquid
+{% comment %} BAD: lazy-loading the LCP image costs 3-5s {% endcomment %}
+{{ section.settings.hero_image | image_url: width: 1200 | image_tag: loading: 'lazy' }}
+
+{% comment %} GOOD: eager load + fetchpriority for LCP {% endcomment %}
+{{ section.settings.hero_image | image_url: width: 1200 | image_tag:
+    loading: 'eager',
+    fetchpriority: 'high',
+    sizes: '100vw' }}
+```
+
+Add a preload hint in `theme.liquid` inside `<head>`:
+
+```liquid
+{%- if template.name == 'index' -%}
+  <link rel="preload"
+        href="{{ section.settings.hero_image | image_url: width: 1200 }}"
+        as="image"
+        fetchpriority="high">
+{%- endif -%}
+```
+
+### Step 2: Use the `image_url` Filter
+
+The modern `image_url` filter replaces the deprecated `img_url`. It supports responsive images via srcset:
+
+```liquid
+{% assign image = product.featured_image %}
+
+<img src="{{ image | image_url: width: 800 }}"
+     srcset="{{ image | image_url: width: 400 }} 400w,
+             {{ image | image_url: width: 600 }} 600w,
+             {{ image | image_url: width: 800 }} 800w,
+             {{ image | image_url: width: 1200 }} 1200w"
+     sizes="(max-width: 749px) 100vw, 50vw"
+     width="{{ image.width }}"
+     height="{{ image.height }}"
+     loading="lazy"
+     alt="{{ image.alt | escape }}">
+```
+
+Always set explicit `width` and `height` attributes to prevent CLS (Cumulative Layout Shift).
+
+### Step 3: Liquid Profiler
+
+Append `?profile=true` to any storefront URL to activate the Liquid profiler. It renders a table at the bottom of the page showing render times per snippet.
+
+See [references/liquid-profiling.md](references/liquid-profiling.md) for how to read the output and common slow patterns.
+
+### Step 4: Font Loading
+
+Preload critical fonts and use `font-display: swap` to prevent invisible text:
+
+```liquid
+{% comment %} In theme.liquid <head> {% endcomment %}
+<link rel="preload"
+      href="{{ 'your-font.woff2' | asset_url }}"
+      as="font"
+      type="font/woff2"
+      crossorigin>
+
+<style>
+  @font-face {
+    font-family: 'YourFont';
+    src: url('{{ "your-font.woff2" | asset_url }}') format('woff2');
+    font-display: swap;
+    font-weight: 400;
+  }
+</style>
+```
+
+Limit to 2-3 font files maximum. Each additional font file blocks rendering.
+
+## Output
+
+- LCP image loading eagerly with `fetchpriority="high"` and preload hint
+- Responsive images using `image_url` with proper srcset and sizes
+- Liquid profiler data identifying slow snippets
+- Fonts preloaded with `font-display: swap`
+
+## Error Handling
+
+| Mistake | Impact | Fix |
+|---------|--------|-----|
+| Lazy-loading LCP image | +3-5s LCP | `loading="eager"` + `fetchpriority="high"` |
+| Using `img_url` filter | No responsive images, larger payloads | Switch to `image_url` with width param |
+| Render-blocking CSS | Delayed FCP | Inline critical CSS, defer non-critical |
+| Too many Liquid `include` tags | Slow server render (variable scope leak) | Use `render` instead of `include` |
+| Missing width/height on images | CLS jumps during load | Set explicit dimensions from `image.width`/`image.height` |
+| Too many font files | Render blocking | Limit to 2-3 woff2 files, preload critical ones |
+
+## Examples
+
+### Fixing a Lazy-Loaded Hero Image
+
+The homepage LCP score is 5+ seconds because the hero banner uses `loading="lazy"`. Switch to eager loading with fetchpriority and add a preload hint.
+
+See [Core Web Vitals](references/core-web-vitals.md) for targets and measurement techniques.
+
+### Migrating from img_url to image_url
+
+Replace deprecated `img_url` filters with the modern `image_url` filter to enable responsive srcset images and reduce payload sizes.
+
+See [Image Optimization](references/image-optimization.md) for the complete migration patterns.
+
+### Profiling Slow Liquid Renders
+
+A collection page takes 800ms to render server-side. Use the Liquid profiler to identify which snippets are slow and apply fixes.
+
+See [Liquid Profiling](references/liquid-profiling.md) for profiler usage and common slow patterns.
+
+## Resources
+
+- [Shopify Theme Performance](https://shopify.dev/docs/storefronts/themes/best-practices/performance)
+- [image_url Filter Reference](https://shopify.dev/docs/api/liquid/filters/image_url)
+- [Liquid Profiler](https://shopify.dev/docs/storefronts/themes/tools/liquid-profiler)
+- [Core Web Vitals for Shopify](https://shopify.dev/docs/storefronts/themes/best-practices/performance#core-web-vitals)
+- [font-display CSS Property](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/core-web-vitals.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/core-web-vitals.md
@@ -1,0 +1,103 @@
+Core Web Vitals targets and measurement techniques specific to Shopify themes.
+
+## Targets for Shopify Themes
+
+| Metric | Good | Needs Improvement | Poor | Shopify Avg |
+|--------|------|-------------------|------|-------------|
+| **LCP** (Largest Contentful Paint) | < 2.5s | 2.5s - 4.0s | > 4.0s | ~3.2s |
+| **CLS** (Cumulative Layout Shift) | < 0.1 | 0.1 - 0.25 | > 0.25 | ~0.08 |
+| **INP** (Interaction to Next Paint) | < 200ms | 200ms - 500ms | > 500ms | ~250ms |
+
+## Measuring with Lighthouse
+
+### Local Measurement
+
+```bash
+# CLI Lighthouse (most accurate for development)
+npx lighthouse https://your-store.myshopify.com \
+  --only-categories=performance \
+  --output=json \
+  --output-path=./lighthouse-report.json
+
+# Quick scores only
+npx lighthouse https://your-store.myshopify.com \
+  --only-categories=performance \
+  --output=json | jq '.categories.performance.score'
+```
+
+### Chrome DevTools
+
+1. Open DevTools > Performance tab
+2. Check "Web Vitals" checkbox
+3. Click Record, reload page, stop recording
+4. LCP, CLS, and INP markers appear on the timeline
+
+### PageSpeed Insights (Field Data)
+
+```
+https://pagespeed.web.dev/analysis?url=https://your-store.myshopify.com
+```
+
+Field data from CrUX (Chrome User Experience Report) shows real-user metrics over 28 days. This is what Google uses for ranking.
+
+## CrUX API for Programmatic Access
+
+```bash
+curl "https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://your-store.myshopify.com/",
+    "metrics": [
+      "largest_contentful_paint",
+      "cumulative_layout_shift",
+      "interaction_to_next_paint"
+    ]
+  }'
+```
+
+## Shopify-Specific LCP Elements
+
+The LCP element varies by page type:
+
+| Page | Typical LCP Element | Optimization |
+|------|---------------------|-------------|
+| Homepage | Hero banner image | `fetchpriority="high"`, preload in `<head>` |
+| Collection | First product image grid | `loading="eager"` on first 4 images only |
+| Product | Featured product image | `fetchpriority="high"`, preload in section |
+| Blog | Featured article image | `loading="eager"` on first article image |
+
+## CLS Common Causes in Shopify
+
+| Cause | Fix |
+|-------|-----|
+| Images without dimensions | Set `width` and `height` from `image.width`/`image.height` |
+| Dynamic banners/announcements | Reserve space with `min-height` on container |
+| Web fonts loading | `font-display: swap` + preload critical fonts |
+| Lazy-loaded content above fold | Only lazy-load below-the-fold content |
+| App embeds injecting DOM | Use `content-visibility: auto` on app containers |
+
+## INP Optimization for Shopify
+
+INP measures responsiveness to user interactions. Common Shopify offenders:
+
+```javascript
+// BAD: Heavy click handler blocks main thread
+document.querySelector('.add-to-cart').addEventListener('click', () => {
+  // Synchronous DOM manipulation + fetch
+  updateCartDOM();
+  fetchCartAPI();
+});
+
+// GOOD: Defer non-critical work
+document.querySelector('.add-to-cart').addEventListener('click', async () => {
+  // Immediate visual feedback
+  button.classList.add('loading');
+  button.disabled = true;
+
+  // Async work
+  await fetchCartAPI();
+
+  // Deferred DOM update
+  requestAnimationFrame(() => updateCartDOM());
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/image-optimization.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/image-optimization.md
@@ -1,0 +1,126 @@
+Image optimization patterns for Shopify themes using the modern `image_url` filter.
+
+## `image_url` vs `img_url`
+
+| Feature | `img_url` (deprecated) | `image_url` (current) |
+|---------|----------------------|----------------------|
+| Responsive srcset | Not supported | Full srcset support |
+| Exact width control | Predefined sizes only (100x100, 300x300, etc.) | Any width up to 5760px |
+| Crop control | `_crop_center` suffix | `crop: 'center'` param |
+| Format control | None | Automatic WebP/AVIF via CDN |
+| Max resolution | 2048px | 5760px |
+
+## Basic Usage
+
+```liquid
+{% comment %} Old way (deprecated) {% endcomment %}
+{{ product.featured_image | img_url: '800x' }}
+
+{% comment %} New way {% endcomment %}
+{{ product.featured_image | image_url: width: 800 }}
+```
+
+## Responsive Image Pattern
+
+```liquid
+{% assign image = product.featured_image %}
+
+<img
+  src="{{ image | image_url: width: 800 }}"
+  srcset="
+    {{ image | image_url: width: 200 }} 200w,
+    {{ image | image_url: width: 400 }} 400w,
+    {{ image | image_url: width: 600 }} 600w,
+    {{ image | image_url: width: 800 }} 800w,
+    {{ image | image_url: width: 1000 }} 1000w,
+    {{ image | image_url: width: 1200 }} 1200w"
+  sizes="(max-width: 749px) calc(100vw - 32px),
+         (max-width: 1199px) calc(50vw - 48px),
+         400px"
+  width="{{ image.width }}"
+  height="{{ image.height }}"
+  loading="lazy"
+  alt="{{ image.alt | escape }}">
+```
+
+## Image Loading Strategy by Position
+
+```liquid
+{% for product in collection.products %}
+  {% if forloop.index <= 4 %}
+    {% comment %} Above the fold: eager load first 4 product images {% endcomment %}
+    {{ product.featured_image | image_url: width: 600 | image_tag:
+        loading: 'eager',
+        sizes: '(max-width: 749px) 50vw, 25vw',
+        widths: '200,400,600' }}
+  {% else %}
+    {% comment %} Below the fold: lazy load the rest {% endcomment %}
+    {{ product.featured_image | image_url: width: 600 | image_tag:
+        loading: 'lazy',
+        sizes: '(max-width: 749px) 50vw, 25vw',
+        widths: '200,400,600' }}
+  {% endif %}
+{% endfor %}
+```
+
+## Using `image_tag` Filter
+
+The `image_tag` filter generates a complete `<img>` element with srcset:
+
+```liquid
+{% comment %} Basic image_tag {% endcomment %}
+{{ product.featured_image | image_url: width: 800 | image_tag }}
+
+{% comment %} With attributes {% endcomment %}
+{{ product.featured_image | image_url: width: 800 | image_tag:
+    class: 'product-image',
+    loading: 'lazy',
+    sizes: '(max-width: 749px) 100vw, 50vw',
+    widths: '200,400,600,800,1000,1200' }}
+
+{% comment %} Output:
+<img src="//cdn.shopify.com/...800x.jpg"
+     srcset="//cdn.shopify.com/...200x.jpg 200w, ...400x.jpg 400w, ..."
+     sizes="(max-width: 749px) 100vw, 50vw"
+     class="product-image"
+     loading="lazy"
+     width="800"
+     height="600">
+{% endcomment %}
+```
+
+## Crop and Focal Point
+
+```liquid
+{% comment %} Center crop to exact dimensions {% endcomment %}
+{{ image | image_url: width: 400, height: 400, crop: 'center' }}
+
+{% comment %} Focal point crop (if set by merchant in admin) {% endcomment %}
+{{ image | image_url: width: 400, height: 300, crop: 'center' }}
+```
+
+## Placeholder Images
+
+Handle missing images gracefully:
+
+```liquid
+{% if product.featured_image %}
+  {{ product.featured_image | image_url: width: 600 | image_tag:
+      loading: 'lazy',
+      alt: product.title }}
+{% else %}
+  {{ 'product-placeholder.svg' | asset_url | image_tag:
+      class: 'placeholder-image',
+      alt: product.title }}
+{% endif %}
+```
+
+## Performance Checklist
+
+- [ ] Hero/LCP image uses `loading: 'eager'` and `fetchpriority: 'high'`
+- [ ] All other images use `loading: 'lazy'`
+- [ ] Every `<img>` has explicit `width` and `height` attributes
+- [ ] `srcset` includes at least 4 size options for responsive delivery
+- [ ] `sizes` attribute matches your CSS layout breakpoints
+- [ ] No images wider than needed (check with DevTools Network tab)
+- [ ] Using `image_url` (not deprecated `img_url`)

--- a/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/liquid-profiling.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/references/liquid-profiling.md
@@ -1,0 +1,108 @@
+How to use Shopify's Liquid profiler to identify slow theme code and optimize server-side render times.
+
+## Activating the Profiler
+
+Append `?profile=true` to any storefront URL:
+
+```
+https://your-store.myshopify.com/?profile=true
+https://your-store.myshopify.com/products/my-product?profile=true
+https://your-store.myshopify.com/collections/all?profile=true
+```
+
+The profiler output appears as an HTML comment at the bottom of the page source (View Source, scroll to bottom) or in a visible table if your theme supports it.
+
+## Reading Profiler Output
+
+The profiler shows a table with these columns:
+
+| Column | Meaning |
+|--------|---------|
+| **Snippet** | Template or snippet file name |
+| **Total Time** | Wall-clock time including children |
+| **Self Time** | Time in this file only (excluding includes/renders) |
+| **Count** | Number of times this snippet was rendered |
+
+**Focus on Self Time** — high Total Time with low Self Time means the slowness is in a child snippet. Drill into the children.
+
+## Common Slow Patterns
+
+### Nested For Loops
+
+```liquid
+{% comment %} BAD: O(n*m) complexity {% endcomment %}
+{% for product in collection.products %}
+  {% for variant in product.variants %}
+    {% for option in variant.options %}
+      {{ option }}
+    {% endfor %}
+  {% endfor %}
+{% endfor %}
+
+{% comment %} BETTER: limit depth, paginate outer loop {% endcomment %}
+{% paginate collection.products by 12 %}
+  {% for product in collection.products %}
+    {{ product.variants.first.title }}
+  {% endfor %}
+{% endpaginate %}
+```
+
+### Excessive `include` Tags
+
+The `include` tag creates a new variable scope for each call, which is expensive:
+
+```liquid
+{% comment %} BAD: include copies parent scope every time {% endcomment %}
+{% for product in collection.products %}
+  {% include 'product-card' %}
+{% endfor %}
+
+{% comment %} GOOD: render has isolated scope, much faster {% endcomment %}
+{% for product in collection.products %}
+  {% render 'product-card', product: product %}
+{% endfor %}
+```
+
+The `render` tag is 20-40% faster than `include` because it does not copy the parent scope.
+
+### Unfiltered Collection Access
+
+```liquid
+{% comment %} BAD: loads ALL products in a collection {% endcomment %}
+{% for product in collections['all'].products %}
+  {{ product.title }}
+{% endfor %}
+
+{% comment %} GOOD: paginate to control how many load {% endcomment %}
+{% paginate collections['sale'].products by 24 %}
+  {% for product in collections['sale'].products %}
+    {{ product.title }}
+  {% endfor %}
+{% endpaginate %}
+```
+
+### Heavy Metafield Access in Loops
+
+```liquid
+{% comment %} BAD: metafield access in a loop is slow {% endcomment %}
+{% for product in collection.products %}
+  {{ product.metafields.custom.care_instructions.value }}
+  {{ product.metafields.custom.material.value }}
+  {{ product.metafields.custom.origin_country.value }}
+{% endfor %}
+
+{% comment %} BETTER: assign outside loop if possible, or limit metafield access {% endcomment %}
+{% for product in collection.products %}
+  {% assign care = product.metafields.custom.care_instructions %}
+  {% if care %}{{ care.value }}{% endif %}
+{% endfor %}
+```
+
+## Performance Targets
+
+| Metric | Target | Measured Where |
+|--------|--------|---------------|
+| Total Liquid render time | < 200ms | Profiler Total Time (root) |
+| Single snippet Self Time | < 50ms | Profiler Self Time |
+| Snippet render count | < 100 per page | Profiler Count column |
+| Template depth | < 4 levels | Manual inspection |

--- a/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/SKILL.md
@@ -42,7 +42,7 @@ curl -s -H "X-Shopify-Access-Token: $TOKEN" \
   | jq '.supported_versions[] | {handle, display_name, supported, latest}'
 ```
 
-Shopify releases quarterly: `2024-01`, `2024-04`, `2024-07`, `2024-10`. Versions are supported for ~12 months after release.
+Shopify releases quarterly (e.g., `2025-01`, `2025-04`, `2025-07`, `2025-10`). Versions are supported for ~12 months after release.
 
 ### Step 2: Review Breaking Changes
 
@@ -58,55 +58,21 @@ Key breaking changes by version:
 
 ### Step 3: Migrate REST to GraphQL
 
-```typescript
-// BEFORE: REST Admin API
-const restClient = new shopify.clients.Rest({ session });
-const { body } = await restClient.get({
-  path: "products",
-  query: { limit: 50, status: "active" },
-});
-const products = body.products;
+Side-by-side comparison of REST vs GraphQL patterns, plus a mapping table for common endpoints (products, orders, customers, webhooks).
 
-// AFTER: GraphQL Admin API
-const graphqlClient = new shopify.clients.Graphql({ session });
-const response = await graphqlClient.request(`{
-  products(first: 50, query: "status:active") {
-    edges {
-      node {
-        id
-        title
-        status
-        variants(first: 10) {
-          edges { node { id price sku } }
-        }
-      }
-    }
-    pageInfo { hasNextPage endCursor }
-  }
-}`);
-const products = response.data.products.edges.map((e: any) => e.node);
-```
-
-Common REST-to-GraphQL mappings:
-
-| REST Endpoint | GraphQL Query/Mutation |
-|--------------|----------------------|
-| `GET /products.json` | `query { products(first: N) { edges { node { ... } } } }` |
-| `POST /products.json` | `mutation { productCreate(product: $input) { ... } }` |
-| `PUT /products/{id}.json` | `mutation { productUpdate(product: $input) { ... } }` |
-| `GET /orders.json` | `query { orders(first: N) { edges { node { ... } } } }` |
-| `GET /customers/{id}.json` | `query { customer(id: $id) { ... } }` |
-| `POST /webhooks.json` | `mutation { webhookSubscriptionCreate(...) { ... } }` |
+See [REST to GraphQL Migration](references/rest-to-graphql-migration.md) for the complete examples and mapping table.
 
 ### Step 4: Update API Version in Config
 
 ```typescript
-// src/shopify.ts — update the version
+// src/shopify.ts — use LATEST_API_VERSION instead of hardcoded dates
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+
 const shopify = shopifyApi({
   apiKey: process.env.SHOPIFY_API_KEY!,
   apiSecretKey: process.env.SHOPIFY_API_SECRET!,
   hostName: process.env.SHOPIFY_HOST_NAME!,
-  apiVersion: "2024-10", // <-- update this
+  apiVersion: LATEST_API_VERSION,
   // ...
 });
 ```
@@ -114,38 +80,14 @@ const shopify = shopifyApi({
 ```toml
 # shopify.app.toml
 [webhooks]
-api_version = "2024-10"  # Update here too
+api_version = "2025-04"  # Update quarterly
 ```
 
 ### Step 5: Handle the ProductInput Split (2024-10)
 
-```typescript
-// BEFORE (pre-2024-10): single ProductInput for create AND update
-const OLD_CREATE = `
-  mutation($input: ProductInput!) {
-    productCreate(input: $input) { ... }
-  }
-`;
+In API version 2024-10, Shopify split the single `ProductInput` type into `ProductCreateInput` and `ProductUpdateInput`. All product mutations need updating.
 
-// AFTER (2024-10+): separate types
-const NEW_CREATE = `
-  mutation($input: ProductCreateInput!) {
-    productCreate(product: $input) {
-      product { id title }
-      userErrors { field message }
-    }
-  }
-`;
-
-const NEW_UPDATE = `
-  mutation($input: ProductUpdateInput!) {
-    productUpdate(product: $input) {
-      product { id title }
-      userErrors { field message }
-    }
-  }
-`;
-```
+See [ProductInput Split](references/product-input-split.md) for before/after examples.
 
 ## Output
 
@@ -169,8 +111,8 @@ const NEW_UPDATE = `
 
 ```bash
 #!/bin/bash
-OLD_VERSION="2024-04"
-NEW_VERSION="2024-10"
+OLD_VERSION="2024-10"
+NEW_VERSION="2025-04"
 
 echo "Upgrading Shopify API from $OLD_VERSION to $NEW_VERSION"
 
@@ -201,10 +143,5 @@ function checkDeprecationHeaders(headers: Headers): void {
 ## Resources
 
 - [Shopify API Release Notes](https://shopify.dev/docs/api/release-notes)
-- [2024-10 Release Notes](https://shopify.dev/docs/api/release-notes/2024-10)
 - [Migrate REST to GraphQL](https://shopify.dev/docs/apps/build/graphql/migrate/learn-how)
 - [API Versioning Guide](https://shopify.dev/docs/api/usage/versioning)
-
-## Next Steps
-
-For CI integration during upgrades, see `shopify-ci-integration`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/references/product-input-split.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/references/product-input-split.md
@@ -1,0 +1,31 @@
+# ProductInput Split (2024-10)
+
+In API version 2024-10, Shopify split `ProductInput` into separate types for create and update operations.
+
+```typescript
+// BEFORE (pre-2024-10): single ProductInput for create AND update
+const OLD_CREATE = `
+  mutation($input: ProductInput!) {
+    productCreate(input: $input) { ... }
+  }
+`;
+
+// AFTER (2024-10+): separate types
+const NEW_CREATE = `
+  mutation($input: ProductCreateInput!) {
+    productCreate(product: $input) {
+      product { id title }
+      userErrors { field message }
+    }
+  }
+`;
+
+const NEW_UPDATE = `
+  mutation($input: ProductUpdateInput!) {
+    productUpdate(product: $input) {
+      product { id title }
+      userErrors { field message }
+    }
+  }
+`;
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/references/rest-to-graphql-migration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/references/rest-to-graphql-migration.md
@@ -1,0 +1,43 @@
+# REST to GraphQL Migration
+
+Side-by-side comparison of REST vs GraphQL Admin API patterns plus a mapping table for common endpoints.
+
+```typescript
+// BEFORE: REST Admin API
+const restClient = new shopify.clients.Rest({ session });
+const { body } = await restClient.get({
+  path: "products",
+  query: { limit: 50, status: "active" },
+});
+const products = body.products;
+
+// AFTER: GraphQL Admin API
+const graphqlClient = new shopify.clients.Graphql({ session });
+const response = await graphqlClient.request(`{
+  products(first: 50, query: "status:active") {
+    edges {
+      node {
+        id
+        title
+        status
+        variants(first: 10) {
+          edges { node { id price sku } }
+        }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}`);
+const products = response.data.products.edges.map((e: any) => e.node);
+```
+
+## Common REST-to-GraphQL Mappings
+
+| REST Endpoint | GraphQL Query/Mutation |
+|--------------|----------------------|
+| `GET /products.json` | `query { products(first: N) { edges { node { ... } } } }` |
+| `POST /products.json` | `mutation { productCreate(product: $input) { ... } }` |
+| `PUT /products/{id}.json` | `mutation { productUpdate(product: $input) { ... } }` |
+| `GET /orders.json` | `query { orders(first: N) { edges { node { ... } } } }` |
+| `GET /customers/{id}.json` | `query { customer(id: $id) { ... } }` |
+| `POST /webhooks.json` | `mutation { webhookSubscriptionCreate(...) { ... } }` |

--- a/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/SKILL.md
@@ -30,53 +30,9 @@ Register webhooks via GraphQL, handle events with HMAC verification, and impleme
 
 ### Step 1: Register Webhooks via GraphQL
 
-```typescript
-// Register a webhook subscription
-const REGISTER_WEBHOOK = `
-  mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: WebhookSubscriptionInput!) {
-    webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
-      webhookSubscription {
-        id
-        topic
-        endpoint {
-          ... on WebhookHttpEndpoint {
-            callbackUrl
-          }
-        }
-        format
-      }
-      userErrors { field message }
-    }
-  }
-`;
+Use the `webhookSubscriptionCreate` mutation with `WebhookSubscriptionTopic` and `WebhookSubscriptionInput` to register subscriptions for all critical event topics (orders, products, customers, inventory, app lifecycle).
 
-// Common webhook topics
-const topics = [
-  "ORDERS_CREATE",
-  "ORDERS_UPDATED",
-  "ORDERS_PAID",
-  "ORDERS_FULFILLED",
-  "PRODUCTS_CREATE",
-  "PRODUCTS_UPDATE",
-  "PRODUCTS_DELETE",
-  "CUSTOMERS_CREATE",
-  "CUSTOMERS_UPDATE",
-  "APP_UNINSTALLED",
-  "INVENTORY_LEVELS_UPDATE",
-];
-
-for (const topic of topics) {
-  await client.request(REGISTER_WEBHOOK, {
-    variables: {
-      topic,
-      webhookSubscription: {
-        callbackUrl: "https://your-app.example.com/webhooks",
-        format: "JSON",
-      },
-    },
-  });
-}
-```
+See [Webhook Registration](references/webhook-registration.md) for the complete implementation.
 
 ### Step 2: Configure Mandatory GDPR Webhooks
 
@@ -85,7 +41,7 @@ for (const topic of topics) {
 ```toml
 # shopify.app.toml
 [webhooks]
-api_version = "2024-10"
+api_version = "2025-04"  # Update quarterly
 
   # MANDATORY: customers/data_request
   [[webhooks.subscriptions]]
@@ -105,137 +61,15 @@ api_version = "2024-10"
 
 ### Step 3: Implement GDPR Webhook Handlers
 
-```typescript
-// Mandatory GDPR handlers — your app will be REJECTED without these
+Three mandatory handlers: (1) customer data request -- collect and send all data for a customer, (2) customer redact -- delete customer personal data and specified orders, (3) shop redact -- delete ALL shop data 48 hours after uninstall.
 
-// 1. Customer Data Request — merchant forwards customer's data request
-app.post("/webhooks/gdpr/data-request", rawBodyParser, async (req, res) => {
-  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
-    return res.status(401).send("Unauthorized");
-  }
-
-  const payload = JSON.parse(req.body.toString());
-  // payload shape:
-  // {
-  //   "shop_id": 12345,
-  //   "shop_domain": "store.myshopify.com",
-  //   "orders_requested": [123, 456],
-  //   "customer": { "id": 789, "email": "customer@example.com", "phone": "+1234567890" },
-  //   "data_request": { "id": 101112 }
-  // }
-
-  // Collect all data you have for this customer
-  const customerData = await collectCustomerData(payload.customer.id);
-  await sendDataToMerchant(payload.shop_domain, customerData);
-
-  res.status(200).send("OK");
-});
-
-// 2. Customer Redact — delete customer's personal data
-app.post("/webhooks/gdpr/customers-redact", rawBodyParser, async (req, res) => {
-  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
-    return res.status(401).send("Unauthorized");
-  }
-
-  const payload = JSON.parse(req.body.toString());
-  // payload shape:
-  // {
-  //   "shop_id": 12345,
-  //   "shop_domain": "store.myshopify.com",
-  //   "customer": { "id": 789, "email": "customer@example.com", "phone": "+1234567890" },
-  //   "orders_to_redact": [123, 456]
-  // }
-
-  await deleteCustomerData(payload.customer.id);
-  await deleteOrderData(payload.orders_to_redact);
-
-  res.status(200).send("OK");
-});
-
-// 3. Shop Redact — 48 hours after app uninstall, delete ALL shop data
-app.post("/webhooks/gdpr/shop-redact", rawBodyParser, async (req, res) => {
-  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
-    return res.status(401).send("Unauthorized");
-  }
-
-  const payload = JSON.parse(req.body.toString());
-  // { "shop_id": 12345, "shop_domain": "store.myshopify.com" }
-
-  await deleteAllShopData(payload.shop_id);
-
-  res.status(200).send("OK");
-});
-```
+See [GDPR Webhook Handlers](references/gdpr-webhook-handlers.md) for the complete implementation.
 
 ### Step 4: Event Handler Pattern
 
-```typescript
-import crypto from "crypto";
-import express from "express";
+A typed webhook dispatcher maps topics to handler functions. Verifies HMAC first, responds 200 immediately, then processes asynchronously. Unknown topics are logged but not rejected.
 
-type WebhookTopic =
-  | "orders/create"
-  | "orders/updated"
-  | "orders/paid"
-  | "products/create"
-  | "products/update"
-  | "products/delete"
-  | "app/uninstalled"
-  | "inventory_levels/update";
-
-const handlers: Record<WebhookTopic, (shop: string, payload: any) => Promise<void>> = {
-  "orders/create": async (shop, payload) => {
-    console.log(`New order ${payload.name} from ${shop}: $${payload.total_price}`);
-    // payload has: id, name, email, total_price, line_items[], shipping_address, etc.
-  },
-  "orders/paid": async (shop, payload) => {
-    console.log(`Order ${payload.name} paid: ${payload.financial_status}`);
-  },
-  "products/update": async (shop, payload) => {
-    console.log(`Product updated: ${payload.title} (${payload.id})`);
-    // Sync to your catalog
-  },
-  "products/delete": async (shop, payload) => {
-    console.log(`Product deleted: ${payload.id}`);
-    // Remove from your catalog
-  },
-  "app/uninstalled": async (shop, payload) => {
-    console.log(`App uninstalled from ${shop}`);
-    // Clean up session, disable features, prepare for shop/redact
-  },
-};
-
-app.post(
-  "/webhooks",
-  express.raw({ type: "application/json" }),
-  async (req, res) => {
-    const hmac = req.headers["x-shopify-hmac-sha256"] as string;
-    const topic = req.headers["x-shopify-topic"] as WebhookTopic;
-    const shop = req.headers["x-shopify-shop-domain"] as string;
-
-    if (!verifyShopifyWebhook(req.body, hmac, process.env.SHOPIFY_API_SECRET!)) {
-      return res.status(401).send("Invalid HMAC");
-    }
-
-    // Respond immediately — Shopify requires 200 within 5 seconds
-    res.status(200).send("OK");
-
-    // Process asynchronously
-    const payload = JSON.parse(req.body.toString());
-    const handler = handlers[topic];
-    if (handler) {
-      try {
-        await handler(shop, payload);
-      } catch (err) {
-        console.error(`Webhook handler failed for ${topic}:`, err);
-        // Shopify will retry failed webhooks (no 200 response)
-      }
-    } else {
-      console.log(`No handler for topic: ${topic}`);
-    }
-  }
-);
-```
+See [Event Handler Pattern](references/event-handler-pattern.md) for the complete implementation.
 
 ### Step 5: List and Manage Existing Webhooks
 
@@ -309,7 +143,3 @@ curl -X POST http://localhost:3000/webhooks \
 - [Webhook Topics Reference](https://shopify.dev/docs/api/admin-graphql/latest/enums/WebhookSubscriptionTopic)
 - [GDPR Mandatory Webhooks](https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance)
 - [Webhook Delivery](https://shopify.dev/docs/apps/build/webhooks)
-
-## Next Steps
-
-For performance optimization, see `shopify-performance-tuning`.

--- a/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/event-handler-pattern.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/event-handler-pattern.md
@@ -1,0 +1,71 @@
+# Event Handler Pattern
+
+Typed webhook event dispatcher with HMAC verification, immediate 200 response, and async processing.
+
+```typescript
+import crypto from "crypto";
+import express from "express";
+
+type WebhookTopic =
+  | "orders/create"
+  | "orders/updated"
+  | "orders/paid"
+  | "products/create"
+  | "products/update"
+  | "products/delete"
+  | "app/uninstalled"
+  | "inventory_levels/update";
+
+const handlers: Record<WebhookTopic, (shop: string, payload: any) => Promise<void>> = {
+  "orders/create": async (shop, payload) => {
+    console.log(`New order ${payload.name} from ${shop}: $${payload.total_price}`);
+    // payload has: id, name, email, total_price, line_items[], shipping_address, etc.
+  },
+  "orders/paid": async (shop, payload) => {
+    console.log(`Order ${payload.name} paid: ${payload.financial_status}`);
+  },
+  "products/update": async (shop, payload) => {
+    console.log(`Product updated: ${payload.title} (${payload.id})`);
+    // Sync to your catalog
+  },
+  "products/delete": async (shop, payload) => {
+    console.log(`Product deleted: ${payload.id}`);
+    // Remove from your catalog
+  },
+  "app/uninstalled": async (shop, payload) => {
+    console.log(`App uninstalled from ${shop}`);
+    // Clean up session, disable features, prepare for shop/redact
+  },
+};
+
+app.post(
+  "/webhooks",
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    const hmac = req.headers["x-shopify-hmac-sha256"] as string;
+    const topic = req.headers["x-shopify-topic"] as WebhookTopic;
+    const shop = req.headers["x-shopify-shop-domain"] as string;
+
+    if (!verifyShopifyWebhook(req.body, hmac, process.env.SHOPIFY_API_SECRET!)) {
+      return res.status(401).send("Invalid HMAC");
+    }
+
+    // Respond immediately — Shopify requires 200 within 5 seconds
+    res.status(200).send("OK");
+
+    // Process asynchronously
+    const payload = JSON.parse(req.body.toString());
+    const handler = handlers[topic];
+    if (handler) {
+      try {
+        await handler(shop, payload);
+      } catch (err) {
+        console.error(`Webhook handler failed for ${topic}:`, err);
+        // Shopify will retry failed webhooks (no 200 response)
+      }
+    } else {
+      console.log(`No handler for topic: ${topic}`);
+    }
+  }
+);
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/gdpr-webhook-handlers.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/gdpr-webhook-handlers.md
@@ -1,0 +1,65 @@
+# GDPR Webhook Handlers
+
+Mandatory handlers required for Shopify App Store submission: customer data request, customer redact, and shop redact.
+
+```typescript
+// Mandatory GDPR handlers — your app will be REJECTED without these
+
+// 1. Customer Data Request — merchant forwards customer's data request
+app.post("/webhooks/gdpr/data-request", rawBodyParser, async (req, res) => {
+  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
+    return res.status(401).send("Unauthorized");
+  }
+
+  const payload = JSON.parse(req.body.toString());
+  // payload shape:
+  // {
+  //   "shop_id": 12345,
+  //   "shop_domain": "store.myshopify.com",
+  //   "orders_requested": [123, 456],
+  //   "customer": { "id": 789, "email": "customer@example.com", "phone": "+1234567890" },
+  //   "data_request": { "id": 101112 }
+  // }
+
+  // Collect all data you have for this customer
+  const customerData = await collectCustomerData(payload.customer.id);
+  await sendDataToMerchant(payload.shop_domain, customerData);
+
+  res.status(200).send("OK");
+});
+
+// 2. Customer Redact — delete customer's personal data
+app.post("/webhooks/gdpr/customers-redact", rawBodyParser, async (req, res) => {
+  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
+    return res.status(401).send("Unauthorized");
+  }
+
+  const payload = JSON.parse(req.body.toString());
+  // payload shape:
+  // {
+  //   "shop_id": 12345,
+  //   "shop_domain": "store.myshopify.com",
+  //   "customer": { "id": 789, "email": "customer@example.com", "phone": "+1234567890" },
+  //   "orders_to_redact": [123, 456]
+  // }
+
+  await deleteCustomerData(payload.customer.id);
+  await deleteOrderData(payload.orders_to_redact);
+
+  res.status(200).send("OK");
+});
+
+// 3. Shop Redact — 48 hours after app uninstall, delete ALL shop data
+app.post("/webhooks/gdpr/shop-redact", rawBodyParser, async (req, res) => {
+  if (!verifyShopifyWebhook(req.body, req.headers["x-shopify-hmac-sha256"]!, SECRET)) {
+    return res.status(401).send("Unauthorized");
+  }
+
+  const payload = JSON.parse(req.body.toString());
+  // { "shop_id": 12345, "shop_domain": "store.myshopify.com" }
+
+  await deleteAllShopData(payload.shop_id);
+
+  res.status(200).send("OK");
+});
+```

--- a/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/webhook-registration.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/references/webhook-registration.md
@@ -1,0 +1,51 @@
+# Webhook Registration via GraphQL
+
+Register webhook subscriptions using the `webhookSubscriptionCreate` mutation for all critical event topics.
+
+```typescript
+// Register a webhook subscription
+const REGISTER_WEBHOOK = `
+  mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: WebhookSubscriptionInput!) {
+    webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
+      webhookSubscription {
+        id
+        topic
+        endpoint {
+          ... on WebhookHttpEndpoint {
+            callbackUrl
+          }
+        }
+        format
+      }
+      userErrors { field message }
+    }
+  }
+`;
+
+// Common webhook topics
+const topics = [
+  "ORDERS_CREATE",
+  "ORDERS_UPDATED",
+  "ORDERS_PAID",
+  "ORDERS_FULFILLED",
+  "PRODUCTS_CREATE",
+  "PRODUCTS_UPDATE",
+  "PRODUCTS_DELETE",
+  "CUSTOMERS_CREATE",
+  "CUSTOMERS_UPDATE",
+  "APP_UNINSTALLED",
+  "INVENTORY_LEVELS_UPDATE",
+];
+
+for (const topic of topics) {
+  await client.request(REGISTER_WEBHOOK, {
+    variables: {
+      topic,
+      webhookSubscription: {
+        callbackUrl: "https://your-app.example.com/webhooks",
+        format: "JSON",
+      },
+    },
+  });
+}
+```


### PR DESCRIPTION
## Summary

- **30 → 38 skills**: Added 8 new skills covering metafields/metaobjects, Functions (WASM), Storefront/headless, checkout extensions, theme performance, GraphQL cost optimization, B2B/wholesale, and AI Toolkit MCP wrapper
- **116 reference files created**: Extracted code blocks >30 lines from all 38 skills into `references/` directories, keeping SKILL.md files concise (~100-130 lines each)
- **Enterprise score: 81.9 → 93.0/100**: Fixed all descriptions (added "Use when" + "Trigger with"), removed all `## Next Steps` stubs, added `## Examples` sections, replaced hardcoded `"2024-10"` API versions with `LATEST_API_VERSION`

### Changes by category

| Change | Count |
|--------|-------|
| Skills modified | 30 |
| Skills created | 8 |
| Skills deleted (empty skeletons) | 2 |
| Reference files created | 116 |
| Files changed total | 156 |

### New skills

| Skill | Pain Point |
|-------|-----------|
| `shopify-metafields-metaobjects` | Custom data modeling (#4 pain point) |
| `shopify-functions` | WASM-sandboxed checkout logic |
| `shopify-storefront-headless` | Headless commerce (#5 pain point) |
| `shopify-checkout-extensions` | checkout.liquid deprecation (Aug 2025) |
| `shopify-theme-performance` | 59% of stores lazy-load LCP image |
| `shopify-graphql-cost-optimizer` | Query cost confusion (#3 pain point) |
| `shopify-b2b-wholesale` | B2B catalog/pricing (Plus) |
| `shopify-ai-toolkit-wrapper` | Official Shopify MCP server integration |

### Deleted

- `shopify-data-sync/` — empty skeleton (references/ dir only)
- `shopify-entity-management/` — empty skeleton (references/ dir only)

### Rewritten

- `shopify-sdk-patterns` — removed generic Zod validation + retry/backoff (duplicated rate-limits), added codegen-typed operations, bulk operation helpers, webhook registry patterns

## Test plan

- [x] Enterprise validator: 93.0/100 average, zero ERRORs
- [x] Zero `## Next Steps` sections remain
- [x] Zero skills missing `## Examples`
- [x] Zero skills missing "Use when" in description
- [x] Zero empty `references/` directories
- [x] `pnpm run sync-marketplace` passes
- [x] `./scripts/quick-test.sh` passes (build + lint)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)