### PR TITLE
fix(publish): avoid SIGPIPE abort in mass-publish enumerate step

### DIFF
--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -97,7 +97,9 @@ jobs:
           # Emit as JSON string (jq -c ensures single line)
           echo "packages_json=$(jq -c . /tmp/packages.json)" >> $GITHUB_OUTPUT
           echo "Found $COUNT publishable @intentsolutionsio/* packages"
-          jq -r '.[] | "  \(.name)@\(.version)  (\(.dir))"' /tmp/packages.json | head -20
+          # Use jq slice instead of `| head -20` — SIGPIPE under `set -o pipefail`
+          # was aborting the whole step even though the listing succeeded.
+          jq -r '.[:20] | .[] | "  \(.name)@\(.version)  (\(.dir))"' /tmp/packages.json
           if [ "$COUNT" -gt 20 ]; then
             echo "  ... and $((COUNT - 20)) more"
           fi


### PR DESCRIPTION
## Summary

The mass-publish workflow aborted during enumeration (run 24700889168) because `jq … | head -20` caused SIGPIPE once head had read its 20 lines — under `set -o pipefail` this propagated as exit code 2 even though the listing itself succeeded.

Switched to jq's `.[:20]` slice so there is no pipe to break.

## Test plan

- [ ] After merge, re-dispatch \`publish-all-packages.yml\` with \`confirm=publish all\`, \`dry_run_only=false\`
- [ ] Phase 1 (dry-run) completes cleanly for all packages
- [ ] Phase 2 publishes to npm

Jeremy made me do it
-claude