### PR TITLE
fix(npm): align repository.url with canonical repo slug for provenance

### DIFF
--- a/plugins/ai-agency/discovery-questionnaire/package.json
+++ b/plugins/ai-agency/discovery-questionnaire/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/discovery-questionnaire"
   },
   "homepage": "https://tonsofskills.com/plugins/discovery-questionnaire",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-agency/make-scenario-builder/package.json
+++ b/plugins/ai-agency/make-scenario-builder/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/make-scenario-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/make-scenario-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-agency/n8n-workflow-designer/package.json
+++ b/plugins/ai-agency/n8n-workflow-designer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/n8n-workflow-designer"
   },
   "homepage": "https://tonsofskills.com/plugins/n8n-workflow-designer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-agency/roi-calculator/package.json
+++ b/plugins/ai-agency/roi-calculator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/roi-calculator"
   },
   "homepage": "https://tonsofskills.com/plugins/roi-calculator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-agency/shipwright/package.json
+++ b/plugins/ai-agency/shipwright/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/shipwright"
   },
   "homepage": "https://tonsofskills.com/plugins/shipwright",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Nate Nelson",

--- a/plugins/ai-agency/sow-generator/package.json
+++ b/plugins/ai-agency/sow-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/sow-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/sow-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-agency/zapier-zap-builder/package.json
+++ b/plugins/ai-agency/zapier-zap-builder/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-agency/zapier-zap-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/zapier-zap-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/ai-ml/ai-ethics-validator/package.json
+++ b/plugins/ai-ml/ai-ethics-validator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/ai-ethics-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/ai-ethics-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/ai-sdk-agents/package.json
+++ b/plugins/ai-ml/ai-sdk-agents/package.json
@@ -23,11 +23,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/ai-sdk-agents"
   },
   "homepage": "https://tonsofskills.com/plugins/ai-sdk-agents",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/anomaly-detection-system/package.json
+++ b/plugins/ai-ml/anomaly-detection-system/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/anomaly-detection-system"
   },
   "homepage": "https://tonsofskills.com/plugins/anomaly-detection-system",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/automl-pipeline-builder/package.json
+++ b/plugins/ai-ml/automl-pipeline-builder/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/automl-pipeline-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/automl-pipeline-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/classification-model-builder/package.json
+++ b/plugins/ai-ml/classification-model-builder/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/classification-model-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/classification-model-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/clustering-algorithm-runner/package.json
+++ b/plugins/ai-ml/clustering-algorithm-runner/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/clustering-algorithm-runner"
   },
   "homepage": "https://tonsofskills.com/plugins/clustering-algorithm-runner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/computer-vision-processor/package.json
+++ b/plugins/ai-ml/computer-vision-processor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/computer-vision-processor"
   },
   "homepage": "https://tonsofskills.com/plugins/computer-vision-processor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/data-preprocessing-pipeline/package.json
+++ b/plugins/ai-ml/data-preprocessing-pipeline/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/data-preprocessing-pipeline"
   },
   "homepage": "https://tonsofskills.com/plugins/data-preprocessing-pipeline",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/data-visualization-creator/package.json
+++ b/plugins/ai-ml/data-visualization-creator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/data-visualization-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/data-visualization-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/dataset-splitter/package.json
+++ b/plugins/ai-ml/dataset-splitter/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/dataset-splitter"
   },
   "homepage": "https://tonsofskills.com/plugins/dataset-splitter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/deep-learning-optimizer/package.json
+++ b/plugins/ai-ml/deep-learning-optimizer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/deep-learning-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/deep-learning-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/experiment-tracking-setup/package.json
+++ b/plugins/ai-ml/experiment-tracking-setup/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/experiment-tracking-setup"
   },
   "homepage": "https://tonsofskills.com/plugins/experiment-tracking-setup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/feature-engineering-toolkit/package.json
+++ b/plugins/ai-ml/feature-engineering-toolkit/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/feature-engineering-toolkit"
   },
   "homepage": "https://tonsofskills.com/plugins/feature-engineering-toolkit",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/hyperparameter-tuner/package.json
+++ b/plugins/ai-ml/hyperparameter-tuner/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/hyperparameter-tuner"
   },
   "homepage": "https://tonsofskills.com/plugins/hyperparameter-tuner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/jeremy-adk-orchestrator/package.json
+++ b/plugins/ai-ml/jeremy-adk-orchestrator/package.json
@@ -19,11 +19,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-adk-orchestrator"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-adk-orchestrator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/jeremy-adk-software-engineer/package.json
+++ b/plugins/ai-ml/jeremy-adk-software-engineer/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-adk-software-engineer"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-adk-software-engineer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/jeremy-gcp-starter-examples/package.json
+++ b/plugins/ai-ml/jeremy-gcp-starter-examples/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-gcp-starter-examples"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-gcp-starter-examples",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/jeremy-genkit-pro/package.json
+++ b/plugins/ai-ml/jeremy-genkit-pro/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-genkit-pro"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-genkit-pro",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/jeremy-vertex-engine/package.json
+++ b/plugins/ai-ml/jeremy-vertex-engine/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-vertex-engine"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-vertex-engine",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/jeremy-vertex-validator/package.json
+++ b/plugins/ai-ml/jeremy-vertex-validator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/jeremy-vertex-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-vertex-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/local-tts/package.json
+++ b/plugins/ai-ml/local-tts/package.json
@@ -22,11 +22,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/local-tts"
   },
   "homepage": "https://tonsofskills.com/plugins/local-tts",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "Apache-2.0",
   "author": {
     "name": "Bubble Invest",

--- a/plugins/ai-ml/ml-model-trainer/package.json
+++ b/plugins/ai-ml/ml-model-trainer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/ml-model-trainer"
   },
   "homepage": "https://tonsofskills.com/plugins/ml-model-trainer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/model-deployment-helper/package.json
+++ b/plugins/ai-ml/model-deployment-helper/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/model-deployment-helper"
   },
   "homepage": "https://tonsofskills.com/plugins/model-deployment-helper",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/model-evaluation-suite/package.json
+++ b/plugins/ai-ml/model-evaluation-suite/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/model-evaluation-suite"
   },
   "homepage": "https://tonsofskills.com/plugins/model-evaluation-suite",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/model-explainability-tool/package.json
+++ b/plugins/ai-ml/model-explainability-tool/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/model-explainability-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/model-explainability-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/model-versioning-tracker/package.json
+++ b/plugins/ai-ml/model-versioning-tracker/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/model-versioning-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/model-versioning-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/neural-network-builder/package.json
+++ b/plugins/ai-ml/neural-network-builder/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/neural-network-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/neural-network-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/nlp-text-analyzer/package.json
+++ b/plugins/ai-ml/nlp-text-analyzer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/nlp-text-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/nlp-text-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/ollama-local-ai/package.json
+++ b/plugins/ai-ml/ollama-local-ai/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/ollama-local-ai"
   },
   "homepage": "https://tonsofskills.com/plugins/ollama-local-ai",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/ai-ml/recommendation-engine/package.json
+++ b/plugins/ai-ml/recommendation-engine/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/recommendation-engine"
   },
   "homepage": "https://tonsofskills.com/plugins/recommendation-engine",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/regression-analysis-tool/package.json
+++ b/plugins/ai-ml/regression-analysis-tool/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/regression-analysis-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/regression-analysis-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/sentiment-analysis-tool/package.json
+++ b/plugins/ai-ml/sentiment-analysis-tool/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/sentiment-analysis-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/sentiment-analysis-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/time-series-forecaster/package.json
+++ b/plugins/ai-ml/time-series-forecaster/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/time-series-forecaster"
   },
   "homepage": "https://tonsofskills.com/plugins/time-series-forecaster",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/ai-ml/transfer-learning-adapter/package.json
+++ b/plugins/ai-ml/transfer-learning-adapter/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/ai-ml/transfer-learning-adapter"
   },
   "homepage": "https://tonsofskills.com/plugins/transfer-learning-adapter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/api-development/api-authentication-builder/package.json
+++ b/plugins/api-development/api-authentication-builder/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-authentication-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/api-authentication-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-batch-processor/package.json
+++ b/plugins/api-development/api-batch-processor/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-batch-processor"
   },
   "homepage": "https://tonsofskills.com/plugins/api-batch-processor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-cache-manager/package.json
+++ b/plugins/api-development/api-cache-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-cache-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/api-cache-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-contract-generator/package.json
+++ b/plugins/api-development/api-contract-generator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-contract-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/api-contract-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-documentation-generator/package.json
+++ b/plugins/api-development/api-documentation-generator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-documentation-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/api-documentation-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-error-handler/package.json
+++ b/plugins/api-development/api-error-handler/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-error-handler"
   },
   "homepage": "https://tonsofskills.com/plugins/api-error-handler",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-event-emitter/package.json
+++ b/plugins/api-development/api-event-emitter/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-event-emitter"
   },
   "homepage": "https://tonsofskills.com/plugins/api-event-emitter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-gateway-builder/package.json
+++ b/plugins/api-development/api-gateway-builder/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-gateway-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/api-gateway-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-load-tester/package.json
+++ b/plugins/api-development/api-load-tester/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-load-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/api-load-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-migration-tool/package.json
+++ b/plugins/api-development/api-migration-tool/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-migration-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/api-migration-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-mock-server/package.json
+++ b/plugins/api-development/api-mock-server/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-mock-server"
   },
   "homepage": "https://tonsofskills.com/plugins/api-mock-server",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-monitoring-dashboard/package.json
+++ b/plugins/api-development/api-monitoring-dashboard/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-monitoring-dashboard"
   },
   "homepage": "https://tonsofskills.com/plugins/api-monitoring-dashboard",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-rate-limiter/package.json
+++ b/plugins/api-development/api-rate-limiter/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-rate-limiter"
   },
   "homepage": "https://tonsofskills.com/plugins/api-rate-limiter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-request-logger/package.json
+++ b/plugins/api-development/api-request-logger/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-request-logger"
   },
   "homepage": "https://tonsofskills.com/plugins/api-request-logger",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-response-validator/package.json
+++ b/plugins/api-development/api-response-validator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-response-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/api-response-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-schema-validator/package.json
+++ b/plugins/api-development/api-schema-validator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-schema-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/api-schema-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-sdk-generator/package.json
+++ b/plugins/api-development/api-sdk-generator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-sdk-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/api-sdk-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-security-scanner/package.json
+++ b/plugins/api-development/api-security-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-security-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/api-security-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-throttling-manager/package.json
+++ b/plugins/api-development/api-throttling-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-throttling-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/api-throttling-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/api-versioning-manager/package.json
+++ b/plugins/api-development/api-versioning-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/api-versioning-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/api-versioning-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/graphql-server-builder/package.json
+++ b/plugins/api-development/graphql-server-builder/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/graphql-server-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/graphql-server-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/grpc-service-generator/package.json
+++ b/plugins/api-development/grpc-service-generator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/grpc-service-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/grpc-service-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/rest-api-generator/package.json
+++ b/plugins/api-development/rest-api-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/rest-api-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/rest-api-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/webhook-handler-creator/package.json
+++ b/plugins/api-development/webhook-handler-creator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/webhook-handler-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/webhook-handler-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/api-development/websocket-server-builder/package.json
+++ b/plugins/api-development/websocket-server-builder/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/api-development/websocket-server-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/websocket-server-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/business-tools/brand-strategy-framework/package.json
+++ b/plugins/business-tools/brand-strategy-framework/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/brand-strategy-framework"
   },
   "homepage": "https://tonsofskills.com/plugins/brand-strategy-framework",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Rowan Brooks",

--- a/plugins/business-tools/excel-analyst-pro/package.json
+++ b/plugins/business-tools/excel-analyst-pro/package.json
@@ -19,11 +19,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/excel-analyst-pro"
   },
   "homepage": "https://tonsofskills.com/plugins/excel-analyst-pro",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "ClaudeCodePlugins",

--- a/plugins/business-tools/executive-assistant-skills/package.json
+++ b/plugins/business-tools/executive-assistant-skills/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/executive-assistant-skills"
   },
   "homepage": "https://tonsofskills.com/plugins/executive-assistant-skills",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Martin Gontovnikas",

--- a/plugins/business-tools/general-legal-assistant/package.json
+++ b/plugins/business-tools/general-legal-assistant/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/general-legal-assistant"
   },
   "homepage": "https://tonsofskills.com/plugins/general-legal-assistant",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions",

--- a/plugins/business-tools/openbb-terminal/package.json
+++ b/plugins/business-tools/openbb-terminal/package.json
@@ -24,11 +24,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/openbb-terminal"
   },
   "homepage": "https://tonsofskills.com/plugins/openbb-terminal",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/business-tools/promptbook/package.json
+++ b/plugins/business-tools/promptbook/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/promptbook"
   },
   "homepage": "https://tonsofskills.com/plugins/promptbook",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Promptbook",

--- a/plugins/business-tools/wondelai-blue-ocean-strategy/package.json
+++ b/plugins/business-tools/wondelai-blue-ocean-strategy/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-blue-ocean-strategy"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-blue-ocean-strategy",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-contagious/package.json
+++ b/plugins/business-tools/wondelai-contagious/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-contagious"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-contagious",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-cro-methodology/package.json
+++ b/plugins/business-tools/wondelai-cro-methodology/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-cro-methodology"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-cro-methodology",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-crossing-the-chasm/package.json
+++ b/plugins/business-tools/wondelai-crossing-the-chasm/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-crossing-the-chasm"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-crossing-the-chasm",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-drive-motivation/package.json
+++ b/plugins/business-tools/wondelai-drive-motivation/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-drive-motivation"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-drive-motivation",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-hundred-million-offers/package.json
+++ b/plugins/business-tools/wondelai-hundred-million-offers/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-hundred-million-offers"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-hundred-million-offers",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-influence-psychology/package.json
+++ b/plugins/business-tools/wondelai-influence-psychology/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-influence-psychology"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-influence-psychology",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-jobs-to-be-done/package.json
+++ b/plugins/business-tools/wondelai-jobs-to-be-done/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-jobs-to-be-done"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-jobs-to-be-done",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-made-to-stick/package.json
+++ b/plugins/business-tools/wondelai-made-to-stick/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-made-to-stick"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-made-to-stick",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-negotiation/package.json
+++ b/plugins/business-tools/wondelai-negotiation/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-negotiation"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-negotiation",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-obviously-awesome/package.json
+++ b/plugins/business-tools/wondelai-obviously-awesome/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-obviously-awesome"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-obviously-awesome",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-one-page-marketing/package.json
+++ b/plugins/business-tools/wondelai-one-page-marketing/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-one-page-marketing"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-one-page-marketing",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-predictable-revenue/package.json
+++ b/plugins/business-tools/wondelai-predictable-revenue/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-predictable-revenue"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-predictable-revenue",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-scorecard-marketing/package.json
+++ b/plugins/business-tools/wondelai-scorecard-marketing/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-scorecard-marketing"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-scorecard-marketing",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-storybrand-messaging/package.json
+++ b/plugins/business-tools/wondelai-storybrand-messaging/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-storybrand-messaging"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-storybrand-messaging",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/business-tools/wondelai-traction-eos/package.json
+++ b/plugins/business-tools/wondelai-traction-eos/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/business-tools/wondelai-traction-eos"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-traction-eos",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/community/b12-claude-plugin/package.json
+++ b/plugins/community/b12-claude-plugin/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/b12-claude-plugin"
   },
   "homepage": "https://tonsofskills.com/plugins/b12-claude-plugin",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "Apache-2.0",
   "author": {
     "name": "B12.io",

--- a/plugins/community/boycott-filter/package.json
+++ b/plugins/community/boycott-filter/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/boycott-filter"
   },
   "homepage": "https://tonsofskills.com/plugins/boycott-filter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Bubble Invest",

--- a/plugins/community/claude-never-forgets/package.json
+++ b/plugins/community/claude-never-forgets/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/claude-never-forgets"
   },
   "homepage": "https://tonsofskills.com/plugins/claude-never-forgets",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "yldrmahmet",

--- a/plugins/community/claude-reflect/package.json
+++ b/plugins/community/claude-reflect/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/claude-reflect"
   },
   "homepage": "https://tonsofskills.com/plugins/claude-reflect",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Bayram Annakov",

--- a/plugins/community/fairdb-ops-manager/package.json
+++ b/plugins/community/fairdb-ops-manager/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/fairdb-ops-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/fairdb-ops-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/community/framecraft/package.json
+++ b/plugins/community/framecraft/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/framecraft"
   },
   "homepage": "https://tonsofskills.com/plugins/framecraft",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Srinivas Vaddisrinivas",

--- a/plugins/community/gastown/package.json
+++ b/plugins/community/gastown/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/gastown"
   },
   "homepage": "https://tonsofskills.com/plugins/gastown",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "Apache-2.0",
   "author": {
     "name": "Numman Ali",

--- a/plugins/community/geepers-agents/package.json
+++ b/plugins/community/geepers-agents/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/geepers-agents"
   },
   "homepage": "https://tonsofskills.com/plugins/geepers-agents",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Luke Steuber"

--- a/plugins/community/jeremy-firebase/package.json
+++ b/plugins/community/jeremy-firebase/package.json
@@ -23,11 +23,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/jeremy-firebase"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-firebase",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/community/jeremy-firestore/package.json
+++ b/plugins/community/jeremy-firestore/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/jeremy-firestore"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-firestore",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/community/sprint/package.json
+++ b/plugins/community/sprint/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/sprint"
   },
   "homepage": "https://tonsofskills.com/plugins/sprint",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Damien Laine",

--- a/plugins/community/zai-cli/package.json
+++ b/plugins/community/zai-cli/package.json
@@ -19,11 +19,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/community/zai-cli"
   },
   "homepage": "https://tonsofskills.com/plugins/zai-cli",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "Apache-2.0",
   "author": {
     "name": "Numman Ali",

--- a/plugins/crypto/arbitrage-opportunity-finder/package.json
+++ b/plugins/crypto/arbitrage-opportunity-finder/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/arbitrage-opportunity-finder"
   },
   "homepage": "https://tonsofskills.com/plugins/arbitrage-opportunity-finder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/blockchain-explorer-cli/package.json
+++ b/plugins/crypto/blockchain-explorer-cli/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/blockchain-explorer-cli"
   },
   "homepage": "https://tonsofskills.com/plugins/blockchain-explorer-cli",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/cross-chain-bridge-monitor/package.json
+++ b/plugins/crypto/cross-chain-bridge-monitor/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/cross-chain-bridge-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/cross-chain-bridge-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/crypto-derivatives-tracker/package.json
+++ b/plugins/crypto/crypto-derivatives-tracker/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/crypto-derivatives-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/crypto-derivatives-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/crypto-news-aggregator/package.json
+++ b/plugins/crypto/crypto-news-aggregator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/crypto-news-aggregator"
   },
   "homepage": "https://tonsofskills.com/plugins/crypto-news-aggregator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/crypto-portfolio-tracker/package.json
+++ b/plugins/crypto/crypto-portfolio-tracker/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/crypto-portfolio-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/crypto-portfolio-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/crypto-signal-generator/package.json
+++ b/plugins/crypto/crypto-signal-generator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/crypto-signal-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/crypto-signal-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/crypto-tax-calculator/package.json
+++ b/plugins/crypto/crypto-tax-calculator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/crypto-tax-calculator"
   },
   "homepage": "https://tonsofskills.com/plugins/crypto-tax-calculator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/defi-yield-optimizer/package.json
+++ b/plugins/crypto/defi-yield-optimizer/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/defi-yield-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/defi-yield-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/dex-aggregator-router/package.json
+++ b/plugins/crypto/dex-aggregator-router/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/dex-aggregator-router"
   },
   "homepage": "https://tonsofskills.com/plugins/dex-aggregator-router",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/flash-loan-simulator/package.json
+++ b/plugins/crypto/flash-loan-simulator/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/flash-loan-simulator"
   },
   "homepage": "https://tonsofskills.com/plugins/flash-loan-simulator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/gas-fee-optimizer/package.json
+++ b/plugins/crypto/gas-fee-optimizer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/gas-fee-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/gas-fee-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/liquidity-pool-analyzer/package.json
+++ b/plugins/crypto/liquidity-pool-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/liquidity-pool-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/liquidity-pool-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/market-movers-scanner/package.json
+++ b/plugins/crypto/market-movers-scanner/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/market-movers-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/market-movers-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/market-price-tracker/package.json
+++ b/plugins/crypto/market-price-tracker/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/market-price-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/market-price-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/market-sentiment-analyzer/package.json
+++ b/plugins/crypto/market-sentiment-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/market-sentiment-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/market-sentiment-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/mempool-analyzer/package.json
+++ b/plugins/crypto/mempool-analyzer/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/mempool-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/mempool-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/nft-rarity-analyzer/package.json
+++ b/plugins/crypto/nft-rarity-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/nft-rarity-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/nft-rarity-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/on-chain-analytics/package.json
+++ b/plugins/crypto/on-chain-analytics/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/on-chain-analytics"
   },
   "homepage": "https://tonsofskills.com/plugins/on-chain-analytics",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/options-flow-analyzer/package.json
+++ b/plugins/crypto/options-flow-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/options-flow-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/options-flow-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/staking-rewards-optimizer/package.json
+++ b/plugins/crypto/staking-rewards-optimizer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/staking-rewards-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/staking-rewards-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/token-launch-tracker/package.json
+++ b/plugins/crypto/token-launch-tracker/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/token-launch-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/token-launch-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/trading-strategy-backtester/package.json
+++ b/plugins/crypto/trading-strategy-backtester/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/trading-strategy-backtester"
   },
   "homepage": "https://tonsofskills.com/plugins/trading-strategy-backtester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/wallet-portfolio-tracker/package.json
+++ b/plugins/crypto/wallet-portfolio-tracker/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/wallet-portfolio-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/wallet-portfolio-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/crypto/wallet-security-auditor/package.json
+++ b/plugins/crypto/wallet-security-auditor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/wallet-security-auditor"
   },
   "homepage": "https://tonsofskills.com/plugins/wallet-security-auditor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/crypto/whale-alert-monitor/package.json
+++ b/plugins/crypto/whale-alert-monitor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/crypto/whale-alert-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/whale-alert-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/database/data-seeder-generator/package.json
+++ b/plugins/database/data-seeder-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/data-seeder-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/data-seeder-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/data-validation-engine/package.json
+++ b/plugins/database/data-validation-engine/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/data-validation-engine"
   },
   "homepage": "https://tonsofskills.com/plugins/data-validation-engine",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-archival-system/package.json
+++ b/plugins/database/database-archival-system/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-archival-system"
   },
   "homepage": "https://tonsofskills.com/plugins/database-archival-system",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-audit-logger/package.json
+++ b/plugins/database/database-audit-logger/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-audit-logger"
   },
   "homepage": "https://tonsofskills.com/plugins/database-audit-logger",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-backup-automator/package.json
+++ b/plugins/database/database-backup-automator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-backup-automator"
   },
   "homepage": "https://tonsofskills.com/plugins/database-backup-automator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-cache-layer/package.json
+++ b/plugins/database/database-cache-layer/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-cache-layer"
   },
   "homepage": "https://tonsofskills.com/plugins/database-cache-layer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-connection-pooler/package.json
+++ b/plugins/database/database-connection-pooler/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-connection-pooler"
   },
   "homepage": "https://tonsofskills.com/plugins/database-connection-pooler",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-deadlock-detector/package.json
+++ b/plugins/database/database-deadlock-detector/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-deadlock-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/database-deadlock-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-diff-tool/package.json
+++ b/plugins/database/database-diff-tool/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-diff-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/database-diff-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-documentation-gen/package.json
+++ b/plugins/database/database-documentation-gen/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-documentation-gen"
   },
   "homepage": "https://tonsofskills.com/plugins/database-documentation-gen",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-health-monitor/package.json
+++ b/plugins/database/database-health-monitor/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-health-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/database-health-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-index-advisor/package.json
+++ b/plugins/database/database-index-advisor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-index-advisor"
   },
   "homepage": "https://tonsofskills.com/plugins/database-index-advisor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-migration-manager/package.json
+++ b/plugins/database/database-migration-manager/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-migration-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-migration-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-partition-manager/package.json
+++ b/plugins/database/database-partition-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-partition-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-partition-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-recovery-manager/package.json
+++ b/plugins/database/database-recovery-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-recovery-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-recovery-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-replication-manager/package.json
+++ b/plugins/database/database-replication-manager/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-replication-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-replication-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-schema-designer/package.json
+++ b/plugins/database/database-schema-designer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-schema-designer"
   },
   "homepage": "https://tonsofskills.com/plugins/database-schema-designer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-security-scanner/package.json
+++ b/plugins/database/database-security-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-security-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/database-security-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-sharding-manager/package.json
+++ b/plugins/database/database-sharding-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-sharding-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-sharding-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/database-transaction-monitor/package.json
+++ b/plugins/database/database-transaction-monitor/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/database-transaction-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/database-transaction-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/freshie-inventory-manager/package.json
+++ b/plugins/database/freshie-inventory-manager/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/freshie-inventory-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/freshie-inventory-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/database/nosql-data-modeler/package.json
+++ b/plugins/database/nosql-data-modeler/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/nosql-data-modeler"
   },
   "homepage": "https://tonsofskills.com/plugins/nosql-data-modeler",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/orm-code-generator/package.json
+++ b/plugins/database/orm-code-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/orm-code-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/orm-code-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/query-performance-analyzer/package.json
+++ b/plugins/database/query-performance-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/query-performance-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/query-performance-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/sql-query-optimizer/package.json
+++ b/plugins/database/sql-query-optimizer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/sql-query-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/sql-query-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/database/stored-procedure-generator/package.json
+++ b/plugins/database/stored-procedure-generator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/database/stored-procedure-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/stored-procedure-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/design/wondelai-design-everyday-things/package.json
+++ b/plugins/design/wondelai-design-everyday-things/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-design-everyday-things"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-design-everyday-things",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-hooked-ux/package.json
+++ b/plugins/design/wondelai-hooked-ux/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-hooked-ux"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-hooked-ux",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-ios-hig-design/package.json
+++ b/plugins/design/wondelai-ios-hig-design/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-ios-hig-design"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-ios-hig-design",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-refactoring-ui/package.json
+++ b/plugins/design/wondelai-refactoring-ui/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-refactoring-ui"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-refactoring-ui",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-top-design/package.json
+++ b/plugins/design/wondelai-top-design/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-top-design"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-top-design",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-ux-heuristics/package.json
+++ b/plugins/design/wondelai-ux-heuristics/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-ux-heuristics"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-ux-heuristics",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/design/wondelai-web-typography/package.json
+++ b/plugins/design/wondelai-web-typography/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/design/wondelai-web-typography"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-web-typography",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/devops/ansible-playbook-creator/package.json
+++ b/plugins/devops/ansible-playbook-creator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/ansible-playbook-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/ansible-playbook-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/auto-scaling-configurator/package.json
+++ b/plugins/devops/auto-scaling-configurator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/auto-scaling-configurator"
   },
   "homepage": "https://tonsofskills.com/plugins/auto-scaling-configurator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/backup-strategy-implementor/package.json
+++ b/plugins/devops/backup-strategy-implementor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/backup-strategy-implementor"
   },
   "homepage": "https://tonsofskills.com/plugins/backup-strategy-implementor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/ci-cd-pipeline-builder/package.json
+++ b/plugins/devops/ci-cd-pipeline-builder/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/ci-cd-pipeline-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/ci-cd-pipeline-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/cloud-cost-optimizer/package.json
+++ b/plugins/devops/cloud-cost-optimizer/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/cloud-cost-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/cloud-cost-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/compliance-checker/package.json
+++ b/plugins/devops/compliance-checker/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/compliance-checker"
   },
   "homepage": "https://tonsofskills.com/plugins/compliance-checker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/container-registry-manager/package.json
+++ b/plugins/devops/container-registry-manager/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/container-registry-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/container-registry-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/container-security-scanner/package.json
+++ b/plugins/devops/container-security-scanner/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/container-security-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/container-security-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/deployment-pipeline-orchestrator/package.json
+++ b/plugins/devops/deployment-pipeline-orchestrator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/deployment-pipeline-orchestrator"
   },
   "homepage": "https://tonsofskills.com/plugins/deployment-pipeline-orchestrator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/deployment-rollback-manager/package.json
+++ b/plugins/devops/deployment-rollback-manager/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/deployment-rollback-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/deployment-rollback-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/disaster-recovery-planner/package.json
+++ b/plugins/devops/disaster-recovery-planner/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/disaster-recovery-planner"
   },
   "homepage": "https://tonsofskills.com/plugins/disaster-recovery-planner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/docker-compose-generator/package.json
+++ b/plugins/devops/docker-compose-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/docker-compose-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/docker-compose-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/environment-config-manager/package.json
+++ b/plugins/devops/environment-config-manager/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/environment-config-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/environment-config-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/fairdb-operations-kit/package.json
+++ b/plugins/devops/fairdb-operations-kit/package.json
@@ -22,11 +22,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/fairdb-operations-kit"
   },
   "homepage": "https://tonsofskills.com/plugins/fairdb-operations-kit",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/gh-dash/package.json
+++ b/plugins/devops/gh-dash/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/gh-dash"
   },
   "homepage": "https://tonsofskills.com/plugins/gh-dash",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jake Kozloski",

--- a/plugins/devops/git-commit-smart/package.json
+++ b/plugins/devops/git-commit-smart/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/git-commit-smart"
   },
   "homepage": "https://tonsofskills.com/plugins/git-commit-smart",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/gitops-workflow-builder/package.json
+++ b/plugins/devops/gitops-workflow-builder/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/gitops-workflow-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/gitops-workflow-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/helm-chart-generator/package.json
+++ b/plugins/devops/helm-chart-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/helm-chart-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/helm-chart-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/infrastructure-as-code-generator/package.json
+++ b/plugins/devops/infrastructure-as-code-generator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/infrastructure-as-code-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/infrastructure-as-code-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/infrastructure-drift-detector/package.json
+++ b/plugins/devops/infrastructure-drift-detector/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/infrastructure-drift-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/infrastructure-drift-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/jeremy-adk-terraform/package.json
+++ b/plugins/devops/jeremy-adk-terraform/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/jeremy-adk-terraform"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-adk-terraform",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/jeremy-genkit-terraform/package.json
+++ b/plugins/devops/jeremy-genkit-terraform/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/jeremy-genkit-terraform"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-genkit-terraform",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/jeremy-github-actions-gcp/package.json
+++ b/plugins/devops/jeremy-github-actions-gcp/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/jeremy-github-actions-gcp"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-github-actions-gcp",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/jeremy-vertex-terraform/package.json
+++ b/plugins/devops/jeremy-vertex-terraform/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/jeremy-vertex-terraform"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-vertex-terraform",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/devops/kubernetes-deployment-creator/package.json
+++ b/plugins/devops/kubernetes-deployment-creator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/kubernetes-deployment-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/kubernetes-deployment-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/load-balancer-configurator/package.json
+++ b/plugins/devops/load-balancer-configurator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/load-balancer-configurator"
   },
   "homepage": "https://tonsofskills.com/plugins/load-balancer-configurator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/log-aggregation-setup/package.json
+++ b/plugins/devops/log-aggregation-setup/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/log-aggregation-setup"
   },
   "homepage": "https://tonsofskills.com/plugins/log-aggregation-setup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/mattyp-changelog/package.json
+++ b/plugins/devops/mattyp-changelog/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/mattyp-changelog"
   },
   "homepage": "https://tonsofskills.com/plugins/mattyp-changelog",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Mattyp",

--- a/plugins/devops/monitoring-stack-deployer/package.json
+++ b/plugins/devops/monitoring-stack-deployer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/monitoring-stack-deployer"
   },
   "homepage": "https://tonsofskills.com/plugins/monitoring-stack-deployer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/network-policy-manager/package.json
+++ b/plugins/devops/network-policy-manager/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/network-policy-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/network-policy-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/secrets-manager-integrator/package.json
+++ b/plugins/devops/secrets-manager-integrator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/secrets-manager-integrator"
   },
   "homepage": "https://tonsofskills.com/plugins/secrets-manager-integrator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/service-mesh-configurator/package.json
+++ b/plugins/devops/service-mesh-configurator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/service-mesh-configurator"
   },
   "homepage": "https://tonsofskills.com/plugins/service-mesh-configurator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/sugar/package.json
+++ b/plugins/devops/sugar/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/sugar"
   },
   "homepage": "https://tonsofskills.com/plugins/sugar",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Steven Leggett",

--- a/plugins/devops/terraform-module-builder/package.json
+++ b/plugins/devops/terraform-module-builder/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/terraform-module-builder"
   },
   "homepage": "https://tonsofskills.com/plugins/terraform-module-builder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/devops/tweetclaw/package.json
+++ b/plugins/devops/tweetclaw/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/devops/tweetclaw"
   },
   "homepage": "https://tonsofskills.com/plugins/tweetclaw",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Burak Bayir",

--- a/plugins/examples/formatter/package.json
+++ b/plugins/examples/formatter/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/examples/formatter"
   },
   "homepage": "https://tonsofskills.com/plugins/formatter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/examples/hello-world/package.json
+++ b/plugins/examples/hello-world/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/examples/hello-world"
   },
   "homepage": "https://tonsofskills.com/plugins/hello-world",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/examples/jeremy-plugin-tool/package.json
+++ b/plugins/examples/jeremy-plugin-tool/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/examples/jeremy-plugin-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/jeremy-plugin-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/examples/pi-pathfinder/package.json
+++ b/plugins/examples/pi-pathfinder/package.json
@@ -20,11 +20,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/examples/pi-pathfinder"
   },
   "homepage": "https://tonsofskills.com/plugins/pi-pathfinder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/examples/security-agent/package.json
+++ b/plugins/examples/security-agent/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/examples/security-agent"
   },
   "homepage": "https://tonsofskills.com/plugins/security-agent",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore"

--- a/plugins/packages/ai-ml-engineering-pack/package.json
+++ b/plugins/packages/ai-ml-engineering-pack/package.json
@@ -25,11 +25,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/packages/ai-ml-engineering-pack"
   },
   "homepage": "https://tonsofskills.com/plugins/ai-ml-engineering-pack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/packages/creator-studio-pack/package.json
+++ b/plugins/packages/creator-studio-pack/package.json
@@ -25,11 +25,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/packages/creator-studio-pack"
   },
   "homepage": "https://tonsofskills.com/plugins/creator-studio-pack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/packages/devops-automation-pack/package.json
+++ b/plugins/packages/devops-automation-pack/package.json
@@ -22,11 +22,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/packages/devops-automation-pack"
   },
   "homepage": "https://tonsofskills.com/plugins/devops-automation-pack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/packages/fullstack-starter-pack/package.json
+++ b/plugins/packages/fullstack-starter-pack/package.json
@@ -25,11 +25,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/packages/fullstack-starter-pack"
   },
   "homepage": "https://tonsofskills.com/plugins/fullstack-starter-pack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/packages/security-pro-pack/package.json
+++ b/plugins/packages/security-pro-pack/package.json
@@ -26,11 +26,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/packages/security-pro-pack"
   },
   "homepage": "https://tonsofskills.com/plugins/security-pro-pack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/performance/alerting-rule-creator/package.json
+++ b/plugins/performance/alerting-rule-creator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/alerting-rule-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/alerting-rule-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/apm-dashboard-creator/package.json
+++ b/plugins/performance/apm-dashboard-creator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/apm-dashboard-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/apm-dashboard-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/application-profiler/package.json
+++ b/plugins/performance/application-profiler/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/application-profiler"
   },
   "homepage": "https://tonsofskills.com/plugins/application-profiler",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/bottleneck-detector/package.json
+++ b/plugins/performance/bottleneck-detector/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/bottleneck-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/bottleneck-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/cache-performance-optimizer/package.json
+++ b/plugins/performance/cache-performance-optimizer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/cache-performance-optimizer"
   },
   "homepage": "https://tonsofskills.com/plugins/cache-performance-optimizer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/capacity-planning-analyzer/package.json
+++ b/plugins/performance/capacity-planning-analyzer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/capacity-planning-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/capacity-planning-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/cpu-usage-monitor/package.json
+++ b/plugins/performance/cpu-usage-monitor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/cpu-usage-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/cpu-usage-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/database-query-profiler/package.json
+++ b/plugins/performance/database-query-profiler/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/database-query-profiler"
   },
   "homepage": "https://tonsofskills.com/plugins/database-query-profiler",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/distributed-tracing-setup/package.json
+++ b/plugins/performance/distributed-tracing-setup/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/distributed-tracing-setup"
   },
   "homepage": "https://tonsofskills.com/plugins/distributed-tracing-setup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/error-rate-monitor/package.json
+++ b/plugins/performance/error-rate-monitor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/error-rate-monitor"
   },
   "homepage": "https://tonsofskills.com/plugins/error-rate-monitor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/infrastructure-metrics-collector/package.json
+++ b/plugins/performance/infrastructure-metrics-collector/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/infrastructure-metrics-collector"
   },
   "homepage": "https://tonsofskills.com/plugins/infrastructure-metrics-collector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/load-test-runner/package.json
+++ b/plugins/performance/load-test-runner/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/load-test-runner"
   },
   "homepage": "https://tonsofskills.com/plugins/load-test-runner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/log-analysis-tool/package.json
+++ b/plugins/performance/log-analysis-tool/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/log-analysis-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/log-analysis-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/memory-leak-detector/package.json
+++ b/plugins/performance/memory-leak-detector/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/memory-leak-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/memory-leak-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/metrics-aggregator/package.json
+++ b/plugins/performance/metrics-aggregator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/metrics-aggregator"
   },
   "homepage": "https://tonsofskills.com/plugins/metrics-aggregator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/network-latency-analyzer/package.json
+++ b/plugins/performance/network-latency-analyzer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/network-latency-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/network-latency-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/performance-budget-validator/package.json
+++ b/plugins/performance/performance-budget-validator/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/performance-budget-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/performance-budget-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/performance-optimization-advisor/package.json
+++ b/plugins/performance/performance-optimization-advisor/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/performance-optimization-advisor"
   },
   "homepage": "https://tonsofskills.com/plugins/performance-optimization-advisor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/performance-regression-detector/package.json
+++ b/plugins/performance/performance-regression-detector/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/performance-regression-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/performance-regression-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/real-user-monitoring/package.json
+++ b/plugins/performance/real-user-monitoring/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/real-user-monitoring"
   },
   "homepage": "https://tonsofskills.com/plugins/real-user-monitoring",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/resource-usage-tracker/package.json
+++ b/plugins/performance/resource-usage-tracker/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/resource-usage-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/resource-usage-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/response-time-tracker/package.json
+++ b/plugins/performance/response-time-tracker/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/response-time-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/response-time-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/sla-sli-tracker/package.json
+++ b/plugins/performance/sla-sli-tracker/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/sla-sli-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/sla-sli-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/synthetic-monitoring-setup/package.json
+++ b/plugins/performance/synthetic-monitoring-setup/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/synthetic-monitoring-setup"
   },
   "homepage": "https://tonsofskills.com/plugins/synthetic-monitoring-setup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/performance/throughput-analyzer/package.json
+++ b/plugins/performance/throughput-analyzer/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/performance/throughput-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/throughput-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/productivity/000-jeremy-content-consistency-validator/package.json
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/package.json
@@ -25,11 +25,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/000-jeremy-content-consistency-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/000-jeremy-content-consistency-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/002-jeremy-yaml-master-agent/package.json
+++ b/plugins/productivity/002-jeremy-yaml-master-agent/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/002-jeremy-yaml-master-agent"
   },
   "homepage": "https://tonsofskills.com/plugins/002-jeremy-yaml-master-agent",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/003-jeremy-vertex-ai-media-master/package.json
+++ b/plugins/productivity/003-jeremy-vertex-ai-media-master/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/003-jeremy-vertex-ai-media-master"
   },
   "homepage": "https://tonsofskills.com/plugins/003-jeremy-vertex-ai-media-master",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/004-jeremy-google-cloud-agent-sdk/package.json
+++ b/plugins/productivity/004-jeremy-google-cloud-agent-sdk/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/004-jeremy-google-cloud-agent-sdk"
   },
   "homepage": "https://tonsofskills.com/plugins/004-jeremy-google-cloud-agent-sdk",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/agent-context-manager/package.json
+++ b/plugins/productivity/agent-context-manager/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/agent-context-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/agent-context-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore"

--- a/plugins/productivity/ai-commit-gen/package.json
+++ b/plugins/productivity/ai-commit-gen/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/ai-commit-gen"
   },
   "homepage": "https://tonsofskills.com/plugins/ai-commit-gen",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/box-cloud-filesystem/package.json
+++ b/plugins/productivity/box-cloud-filesystem/package.json
@@ -19,11 +19,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/box-cloud-filesystem"
   },
   "homepage": "https://tonsofskills.com/plugins/box-cloud-filesystem",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/claude-memory-kit/package.json
+++ b/plugins/productivity/claude-memory-kit/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/claude-memory-kit"
   },
   "homepage": "https://tonsofskills.com/plugins/claude-memory-kit",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "builtbyzac"

--- a/plugins/productivity/hyperfocus/package.json
+++ b/plugins/productivity/hyperfocus/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/hyperfocus"
   },
   "homepage": "https://tonsofskills.com/plugins/hyperfocus",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Nestor Magalhaes",

--- a/plugins/productivity/navigating-github/package.json
+++ b/plugins/productivity/navigating-github/package.json
@@ -20,11 +20,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/navigating-github"
   },
   "homepage": "https://tonsofskills.com/plugins/navigating-github",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/neurodivergent-visual-org/package.json
+++ b/plugins/productivity/neurodivergent-visual-org/package.json
@@ -22,11 +22,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/neurodivergent-visual-org"
   },
   "homepage": "https://tonsofskills.com/plugins/neurodivergent-visual-org",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jack Reis",

--- a/plugins/productivity/overnight-dev/package.json
+++ b/plugins/productivity/overnight-dev/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/overnight-dev"
   },
   "homepage": "https://tonsofskills.com/plugins/overnight-dev",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions IO",

--- a/plugins/productivity/pm-ai-partner/package.json
+++ b/plugins/productivity/pm-ai-partner/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/pm-ai-partner"
   },
   "homepage": "https://tonsofskills.com/plugins/pm-ai-partner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Ahmed Khaled",

--- a/plugins/productivity/prettier-markdown-hook/package.json
+++ b/plugins/productivity/prettier-markdown-hook/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/prettier-markdown-hook"
   },
   "homepage": "https://tonsofskills.com/plugins/prettier-markdown-hook",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Terry Li"

--- a/plugins/productivity/travel-assistant/package.json
+++ b/plugins/productivity/travel-assistant/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/travel-assistant"
   },
   "homepage": "https://tonsofskills.com/plugins/travel-assistant",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/productivity/vibe-guide/package.json
+++ b/plugins/productivity/vibe-guide/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/vibe-guide"
   },
   "homepage": "https://tonsofskills.com/plugins/vibe-guide",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Intent Solutions"

--- a/plugins/productivity/wondelai-design-sprint/package.json
+++ b/plugins/productivity/wondelai-design-sprint/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/wondelai-design-sprint"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-design-sprint",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/productivity/wondelai-lean-startup/package.json
+++ b/plugins/productivity/wondelai-lean-startup/package.json
@@ -12,11 +12,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/wondelai-lean-startup"
   },
   "homepage": "https://tonsofskills.com/plugins/wondelai-lean-startup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Wondel.ai"

--- a/plugins/productivity/youtube-strategy/package.json
+++ b/plugins/productivity/youtube-strategy/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/productivity/youtube-strategy"
   },
   "homepage": "https://tonsofskills.com/plugins/youtube-strategy",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins"

--- a/plugins/saas-packs/abridge-pack/package.json
+++ b/plugins/saas-packs/abridge-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/abridge-pack"
   },
   "homepage": "https://tonsofskills.com/learn/abridge/",

--- a/plugins/saas-packs/adobe-pack/package.json
+++ b/plugins/saas-packs/adobe-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/adobe-pack"
   },
   "homepage": "https://tonsofskills.com/learn/adobe/",

--- a/plugins/saas-packs/alchemy-pack/package.json
+++ b/plugins/saas-packs/alchemy-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/alchemy-pack"
   },
   "homepage": "https://tonsofskills.com/learn/alchemy/",

--- a/plugins/saas-packs/algolia-pack/package.json
+++ b/plugins/saas-packs/algolia-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/algolia-pack"
   },
   "homepage": "https://tonsofskills.com/learn/algolia/",

--- a/plugins/saas-packs/anima-pack/package.json
+++ b/plugins/saas-packs/anima-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/anima-pack"
   },
   "homepage": "https://tonsofskills.com/learn/anima/",

--- a/plugins/saas-packs/anthropic-pack/package.json
+++ b/plugins/saas-packs/anthropic-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/anthropic-pack"
   },
   "homepage": "https://tonsofskills.com/learn/anthropic/",

--- a/plugins/saas-packs/apify-pack/package.json
+++ b/plugins/saas-packs/apify-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/apify-pack"
   },
   "homepage": "https://tonsofskills.com/learn/apify/",

--- a/plugins/saas-packs/apollo-pack/package.json
+++ b/plugins/saas-packs/apollo-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/apollo-pack"
   },
   "homepage": "https://tonsofskills.com/learn/apollo/",

--- a/plugins/saas-packs/appfolio-pack/package.json
+++ b/plugins/saas-packs/appfolio-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/appfolio-pack"
   },
   "homepage": "https://tonsofskills.com/learn/appfolio/",

--- a/plugins/saas-packs/apple-notes-pack/package.json
+++ b/plugins/saas-packs/apple-notes-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/apple-notes-pack"
   },
   "homepage": "https://tonsofskills.com/learn/apple-notes/",

--- a/plugins/saas-packs/assemblyai-pack/package.json
+++ b/plugins/saas-packs/assemblyai-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/assemblyai-pack"
   },
   "homepage": "https://tonsofskills.com/learn/assemblyai/",

--- a/plugins/saas-packs/attio-pack/package.json
+++ b/plugins/saas-packs/attio-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/attio-pack"
   },
   "homepage": "https://tonsofskills.com/learn/attio/",

--- a/plugins/saas-packs/bamboohr-pack/package.json
+++ b/plugins/saas-packs/bamboohr-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/bamboohr-pack"
   },
   "homepage": "https://tonsofskills.com/learn/bamboohr/",

--- a/plugins/saas-packs/brightdata-pack/package.json
+++ b/plugins/saas-packs/brightdata-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/brightdata-pack"
   },
   "homepage": "https://tonsofskills.com/learn/brightdata/",

--- a/plugins/saas-packs/canva-pack/package.json
+++ b/plugins/saas-packs/canva-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/canva-pack"
   },
   "homepage": "https://tonsofskills.com/learn/canva/",

--- a/plugins/saas-packs/castai-pack/package.json
+++ b/plugins/saas-packs/castai-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/castai-pack"
   },
   "homepage": "https://tonsofskills.com/learn/castai/",

--- a/plugins/saas-packs/clari-pack/package.json
+++ b/plugins/saas-packs/clari-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/clari-pack"
   },
   "homepage": "https://tonsofskills.com/learn/clari/",

--- a/plugins/saas-packs/claude-pack/package.json
+++ b/plugins/saas-packs/claude-pack/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/claude-pack"
   },
   "homepage": "https://tonsofskills.com/learn/claude/",

--- a/plugins/saas-packs/clay-pack/package.json
+++ b/plugins/saas-packs/clay-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Clay - 30 skills covering data enrichment for sales and marketing",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "clay", "data-enrichment", "sales", "marketing", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "clay",
+    "data-enrichment",
+    "sales",
+    "marketing",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/clay-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/clay-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/clay/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/clerk-pack/package.json
+++ b/plugins/saas-packs/clerk-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Clerk - 24 skills covering authentication, user management, and identity",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "clerk", "authentication", "user-management", "identity", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "clerk",
+    "authentication",
+    "user-management",
+    "identity",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/clerk-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/clerk-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/clerk/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/clickhouse-pack/package.json
+++ b/plugins/saas-packs/clickhouse-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/clickhouse-pack"
   },
   "homepage": "https://tonsofskills.com/learn/clickhouse/",

--- a/plugins/saas-packs/clickup-pack/package.json
+++ b/plugins/saas-packs/clickup-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/clickup-pack"
   },
   "homepage": "https://tonsofskills.com/learn/clickup/",

--- a/plugins/saas-packs/coderabbit-pack/package.json
+++ b/plugins/saas-packs/coderabbit-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for CodeRabbit - 24 skills covering AI code review and pull requests",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "coderabbit", "code-review", "pull-requests", "quality", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "coderabbit",
+    "code-review",
+    "pull-requests",
+    "quality",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/coderabbit-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/coderabbit-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/coderabbit/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/cohere-pack/package.json
+++ b/plugins/saas-packs/cohere-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/cohere-pack"
   },
   "homepage": "https://tonsofskills.com/learn/cohere/",

--- a/plugins/saas-packs/coreweave-pack/package.json
+++ b/plugins/saas-packs/coreweave-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/coreweave-pack"
   },
   "homepage": "https://tonsofskills.com/learn/coreweave/",

--- a/plugins/saas-packs/cursor-pack/package.json
+++ b/plugins/saas-packs/cursor-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Cursor - 30 skills covering AI code editor, completions, chat, and composer",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "cursor", "code-editor", "ai-completions", "composer", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "cursor",
+    "code-editor",
+    "ai-completions",
+    "composer",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/cursor-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/cursor-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/cursor/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/customerio-pack/package.json
+++ b/plugins/saas-packs/customerio-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Customer.io - 24 skills covering marketing automation, email, SMS, and push campaigns",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "customer-io", "marketing-automation", "email", "sms", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "customer-io",
+    "marketing-automation",
+    "email",
+    "sms",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/customerio-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/customerio-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/customerio/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/databricks-pack"
   },
   "homepage": "https://tonsofskills.com/learn/databricks/",

--- a/plugins/saas-packs/deepgram-pack/package.json
+++ b/plugins/saas-packs/deepgram-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Deepgram - 24 skills covering speech-to-text, real-time transcription, and voice intelligence",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "deepgram", "speech-to-text", "transcription", "voice", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "deepgram",
+    "speech-to-text",
+    "transcription",
+    "voice",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/deepgram-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/deepgram-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/deepgram/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/documenso-pack/package.json
+++ b/plugins/saas-packs/documenso-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Documenso - 24 skills covering open-source document signing platform",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "documenso", "e-signature", "document-signing", "open-source", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "documenso",
+    "e-signature",
+    "document-signing",
+    "open-source",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/documenso-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/documenso-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/documenso/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/elevenlabs-pack/package.json
+++ b/plugins/saas-packs/elevenlabs-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/elevenlabs-pack"
   },
   "homepage": "https://tonsofskills.com/learn/elevenlabs/",

--- a/plugins/saas-packs/evernote-pack/package.json
+++ b/plugins/saas-packs/evernote-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Evernote - 24 skills covering note management, organization, and productivity",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "evernote", "notes", "note-taking", "organization", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "evernote",
+    "notes",
+    "note-taking",
+    "organization",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/evernote-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/evernote-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/evernote/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/exa-pack/package.json
+++ b/plugins/saas-packs/exa-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Exa - 30 skills covering neural search and embeddings API",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "exa", "neural-search", "embeddings", "similarity", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "exa",
+    "neural-search",
+    "embeddings",
+    "similarity",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/exa-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/exa-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/exa/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/fathom-pack/package.json
+++ b/plugins/saas-packs/fathom-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/fathom-pack"
   },
   "homepage": "https://tonsofskills.com/learn/fathom/",

--- a/plugins/saas-packs/figma-pack/package.json
+++ b/plugins/saas-packs/figma-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/figma-pack"
   },
   "homepage": "https://tonsofskills.com/learn/figma/",

--- a/plugins/saas-packs/finta-pack/package.json
+++ b/plugins/saas-packs/finta-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/finta-pack"
   },
   "homepage": "https://tonsofskills.com/learn/finta/",

--- a/plugins/saas-packs/firecrawl-pack/package.json
+++ b/plugins/saas-packs/firecrawl-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for FireCrawl - 30 skills covering web scraping and LLM-ready markdown",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "firecrawl", "web-scraping", "markdown", "llm-ready", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "firecrawl",
+    "web-scraping",
+    "markdown",
+    "llm-ready",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/firecrawl-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/firecrawl-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/firecrawl/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/fireflies-pack/package.json
+++ b/plugins/saas-packs/fireflies-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Fireflies.ai - 24 skills covering AI meeting transcription and intelligence",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "fireflies", "meeting-transcription", "ai-notes", "intelligence", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "fireflies",
+    "meeting-transcription",
+    "ai-notes",
+    "intelligence",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/fireflies-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/fireflies-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/fireflies/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/flexport-pack/package.json
+++ b/plugins/saas-packs/flexport-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/flexport-pack"
   },
   "homepage": "https://tonsofskills.com/learn/flexport/",

--- a/plugins/saas-packs/flyio-pack/package.json
+++ b/plugins/saas-packs/flyio-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/flyio-pack"
   },
   "homepage": "https://tonsofskills.com/learn/flyio/",

--- a/plugins/saas-packs/fondo-pack/package.json
+++ b/plugins/saas-packs/fondo-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/fondo-pack"
   },
   "homepage": "https://tonsofskills.com/learn/fondo/",

--- a/plugins/saas-packs/framer-pack/package.json
+++ b/plugins/saas-packs/framer-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/framer-pack"
   },
   "homepage": "https://tonsofskills.com/learn/framer/",

--- a/plugins/saas-packs/gamma-pack/package.json
+++ b/plugins/saas-packs/gamma-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Gamma - 24 skills covering AI presentations, documents, and visual content",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "gamma", "presentations", "ai-documents", "slides", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "gamma",
+    "presentations",
+    "ai-documents",
+    "slides",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/gamma-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/gamma-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/gamma/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/glean-pack/package.json
+++ b/plugins/saas-packs/glean-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/glean-pack"
   },
   "homepage": "https://tonsofskills.com/learn/glean/",

--- a/plugins/saas-packs/grammarly-pack/package.json
+++ b/plugins/saas-packs/grammarly-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/grammarly-pack"
   },
   "homepage": "https://tonsofskills.com/learn/grammarly/",

--- a/plugins/saas-packs/granola-pack/package.json
+++ b/plugins/saas-packs/granola-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Granola - 24 skills covering AI meeting notes, transcription, and summaries",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "granola", "meeting-notes", "transcription", "summaries", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "granola",
+    "meeting-notes",
+    "transcription",
+    "summaries",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/granola-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/granola-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/granola/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/groq-pack/package.json
+++ b/plugins/saas-packs/groq-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Groq - 24 skills covering ultra-fast LLM inference with LPU",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "groq", "llm-inference", "lpu", "fast", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "groq",
+    "llm-inference",
+    "lpu",
+    "fast",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/groq-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/groq-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/groq/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/guidewire-pack/package.json
+++ b/plugins/saas-packs/guidewire-pack/package.json
@@ -4,11 +4,34 @@
   "description": "Claude Code skill pack for Guidewire InsuranceSuite - 24 skills covering PolicyCenter, ClaimCenter, BillingCenter, and insurance operations",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "guidewire", "insurance", "insurancesuite", "policycenter", "claimcenter", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "guidewire",
+    "insurance",
+    "insurancesuite",
+    "policycenter",
+    "claimcenter",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/guidewire-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/guidewire-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/guidewire/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/hex-pack/package.json
+++ b/plugins/saas-packs/hex-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/hex-pack"
   },
   "homepage": "https://tonsofskills.com/learn/hex/",

--- a/plugins/saas-packs/hootsuite-pack/package.json
+++ b/plugins/saas-packs/hootsuite-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/hootsuite-pack"
   },
   "homepage": "https://tonsofskills.com/learn/hootsuite/",

--- a/plugins/saas-packs/hubspot-pack/package.json
+++ b/plugins/saas-packs/hubspot-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/hubspot-pack"
   },
   "homepage": "https://tonsofskills.com/learn/hubspot/",

--- a/plugins/saas-packs/ideogram-pack/package.json
+++ b/plugins/saas-packs/ideogram-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Ideogram - 24 skills covering AI image generation with text rendering",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "ideogram", "image-generation", "ai-art", "text-rendering", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "ideogram",
+    "image-generation",
+    "ai-art",
+    "text-rendering",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/ideogram-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/ideogram-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/ideogram/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/instantly-pack/package.json
+++ b/plugins/saas-packs/instantly-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Instantly - 24 skills covering cold email outreach and sequences",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "instantly", "cold-email", "outreach", "sequences", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "instantly",
+    "cold-email",
+    "outreach",
+    "sequences",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/instantly-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/instantly-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/instantly/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/intercom-pack/package.json
+++ b/plugins/saas-packs/intercom-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/intercom-pack"
   },
   "homepage": "https://tonsofskills.com/learn/intercom/",

--- a/plugins/saas-packs/juicebox-pack/package.json
+++ b/plugins/saas-packs/juicebox-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Juicebox - 24 skills covering people data, enrichment, and contact discovery",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "juicebox", "people-data", "enrichment", "contacts", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "juicebox",
+    "people-data",
+    "enrichment",
+    "contacts",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/juicebox-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/juicebox-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/juicebox/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/klaviyo-pack/package.json
+++ b/plugins/saas-packs/klaviyo-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/klaviyo-pack"
   },
   "homepage": "https://tonsofskills.com/learn/klaviyo/",

--- a/plugins/saas-packs/klingai-pack/package.json
+++ b/plugins/saas-packs/klingai-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Kling AI - 30 skills covering AI video generation and cinematic controls",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "kling-ai", "video-generation", "text-to-video", "cinematic", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "kling-ai",
+    "video-generation",
+    "text-to-video",
+    "cinematic",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/klingai-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/klingai-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/klingai/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/langchain-pack/package.json
+++ b/plugins/saas-packs/langchain-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for LangChain - 24 skills covering chains, agents, RAG pipelines, and LLM applications",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "langchain", "llm-framework", "agents", "rag", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "langchain",
+    "llm-framework",
+    "agents",
+    "rag",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/langchain-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/langchain-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/langchain/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/langfuse-pack/package.json
+++ b/plugins/saas-packs/langfuse-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/langfuse-pack"
   },
   "homepage": "https://tonsofskills.com/learn/langfuse/",

--- a/plugins/saas-packs/lindy-pack/package.json
+++ b/plugins/saas-packs/lindy-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Lindy - 24 skills covering AI assistants, task automation, and workflows",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "lindy", "ai-assistant", "automation", "workflows", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "lindy",
+    "ai-assistant",
+    "automation",
+    "workflows",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/lindy-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/lindy-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/lindy/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/linear-pack/package.json
+++ b/plugins/saas-packs/linear-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Linear - 24 skills covering issue tracking, project management, and workflows",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "linear", "issue-tracking", "project-management", "workflows", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "linear",
+    "issue-tracking",
+    "project-management",
+    "workflows",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/linear-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/linear-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/linear/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/linktree-pack/package.json
+++ b/plugins/saas-packs/linktree-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/linktree-pack"
   },
   "homepage": "https://tonsofskills.com/learn/linktree/",

--- a/plugins/saas-packs/lokalise-pack/package.json
+++ b/plugins/saas-packs/lokalise-pack/package.json
@@ -4,11 +4,34 @@
   "description": "Claude Code skill pack for Lokalise - 24 skills covering translation management system (TMS) for software localization",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "lokalise", "translation", "localization", "i18n", "tms", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "lokalise",
+    "translation",
+    "localization",
+    "i18n",
+    "tms",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/lokalise-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/lokalise-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/lokalise/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/lucidchart-pack/package.json
+++ b/plugins/saas-packs/lucidchart-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/lucidchart-pack"
   },
   "homepage": "https://tonsofskills.com/learn/lucidchart/",

--- a/plugins/saas-packs/maintainx-pack/package.json
+++ b/plugins/saas-packs/maintainx-pack/package.json
@@ -4,11 +4,34 @@
   "description": "Claude Code skill pack for MaintainX - 24 skills covering CMMS work orders, assets, preventive maintenance, and procedures",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "maintainx", "cmms", "work-orders", "maintenance", "assets", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "maintainx",
+    "cmms",
+    "work-orders",
+    "maintenance",
+    "assets",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/maintainx-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/maintainx-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/maintainx/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/mindtickle-pack/package.json
+++ b/plugins/saas-packs/mindtickle-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/mindtickle-pack"
   },
   "homepage": "https://tonsofskills.com/learn/mindtickle/",

--- a/plugins/saas-packs/miro-pack/package.json
+++ b/plugins/saas-packs/miro-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/miro-pack"
   },
   "homepage": "https://tonsofskills.com/learn/miro/",

--- a/plugins/saas-packs/mistral-pack/package.json
+++ b/plugins/saas-packs/mistral-pack/package.json
@@ -4,11 +4,32 @@
   "description": "Claude Code skill pack for Mistral AI - 24 skills covering LLM API integration with chat, embeddings, and function calling",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "mistral", "mistral-ai", "llm", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "mistral",
+    "mistral-ai",
+    "llm",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/mistral-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/mistral-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/mistral/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/navan-pack/package.json
+++ b/plugins/saas-packs/navan-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/navan-pack"
   },
   "homepage": "https://tonsofskills.com/learn/navan/",

--- a/plugins/saas-packs/notion-pack/package.json
+++ b/plugins/saas-packs/notion-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/notion-pack"
   },
   "homepage": "https://tonsofskills.com/learn/notion/",

--- a/plugins/saas-packs/obsidian-pack/package.json
+++ b/plugins/saas-packs/obsidian-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/obsidian-pack"
   },
   "homepage": "https://tonsofskills.com/learn/obsidian/",

--- a/plugins/saas-packs/onenote-pack/package.json
+++ b/plugins/saas-packs/onenote-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/onenote-pack"
   },
   "homepage": "https://tonsofskills.com/learn/onenote/",

--- a/plugins/saas-packs/openevidence-pack/package.json
+++ b/plugins/saas-packs/openevidence-pack/package.json
@@ -4,11 +4,34 @@
   "description": "Claude Code skill pack for OpenEvidence - 24 skills covering medical AI, clinical decision support, and evidence-based medicine",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "openevidence", "medical-ai", "clinical-decision-support", "healthcare", "hipaa", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "openevidence",
+    "medical-ai",
+    "clinical-decision-support",
+    "healthcare",
+    "hipaa",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/openevidence-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/openevidence-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/openevidence/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/openrouter-pack/package.json
+++ b/plugins/saas-packs/openrouter-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for OpenRouter - 30 skills covering multi-model LLM gateway and API routing",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "openrouter", "llm-gateway", "multi-model", "api", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "openrouter",
+    "llm-gateway",
+    "multi-model",
+    "api",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/openrouter-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/openrouter-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/openrouter/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/oraclecloud-pack/package.json
+++ b/plugins/saas-packs/oraclecloud-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/oraclecloud-pack"
   },
   "homepage": "https://tonsofskills.com/learn/oraclecloud/",

--- a/plugins/saas-packs/palantir-pack/package.json
+++ b/plugins/saas-packs/palantir-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/palantir-pack"
   },
   "homepage": "https://tonsofskills.com/learn/palantir/",

--- a/plugins/saas-packs/perplexity-pack/package.json
+++ b/plugins/saas-packs/perplexity-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Perplexity - 30 skills covering AI search and real-time web access",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "perplexity", "ai-search", "web-access", "answer-engine", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "perplexity",
+    "ai-search",
+    "web-access",
+    "answer-engine",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/perplexity-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/perplexity-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/perplexity/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/persona-pack/package.json
+++ b/plugins/saas-packs/persona-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/persona-pack"
   },
   "homepage": "https://tonsofskills.com/learn/persona/",

--- a/plugins/saas-packs/podium-pack/package.json
+++ b/plugins/saas-packs/podium-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/podium-pack"
   },
   "homepage": "https://tonsofskills.com/learn/podium/",

--- a/plugins/saas-packs/posthog-pack/package.json
+++ b/plugins/saas-packs/posthog-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for PostHog - 24 skills covering product analytics and feature flags",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "posthog", "analytics", "feature-flags", "session-replay", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "posthog",
+    "analytics",
+    "feature-flags",
+    "session-replay",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/posthog-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/posthog-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/posthog/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/procore-pack/package.json
+++ b/plugins/saas-packs/procore-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/procore-pack"
   },
   "homepage": "https://tonsofskills.com/learn/procore/",

--- a/plugins/saas-packs/quicknode-pack/package.json
+++ b/plugins/saas-packs/quicknode-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/quicknode-pack"
   },
   "homepage": "https://tonsofskills.com/learn/quicknode/",

--- a/plugins/saas-packs/ramp-pack/package.json
+++ b/plugins/saas-packs/ramp-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/ramp-pack"
   },
   "homepage": "https://tonsofskills.com/learn/ramp/",

--- a/plugins/saas-packs/remofirst-pack/package.json
+++ b/plugins/saas-packs/remofirst-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/remofirst-pack"
   },
   "homepage": "https://tonsofskills.com/learn/remofirst/",

--- a/plugins/saas-packs/replit-pack/package.json
+++ b/plugins/saas-packs/replit-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Replit - 30 skills covering cloud development and AI coding assistant",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "replit", "cloud-development", "ai-coding", "ide", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "replit",
+    "cloud-development",
+    "ai-coding",
+    "ide",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/replit-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/replit-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/replit/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/retellai-pack/package.json
+++ b/plugins/saas-packs/retellai-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Retell AI - 30 skills covering voice AI and conversational agents",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "retell-ai", "voice-ai", "phone-calls", "conversational", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "retell-ai",
+    "voice-ai",
+    "phone-calls",
+    "conversational",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/retellai-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/retellai-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/retellai/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/runway-pack/package.json
+++ b/plugins/saas-packs/runway-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/runway-pack"
   },
   "homepage": "https://tonsofskills.com/learn/runway/",

--- a/plugins/saas-packs/salesforce-pack/package.json
+++ b/plugins/saas-packs/salesforce-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/salesforce-pack"
   },
   "homepage": "https://tonsofskills.com/learn/salesforce/",

--- a/plugins/saas-packs/salesloft-pack/package.json
+++ b/plugins/saas-packs/salesloft-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/salesloft-pack"
   },
   "homepage": "https://tonsofskills.com/learn/salesloft/",

--- a/plugins/saas-packs/sentry-pack/package.json
+++ b/plugins/saas-packs/sentry-pack/package.json
@@ -29,11 +29,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/sentry-pack"
   },
   "bugs": {
-    "url": "https://github.com/jeremylongshore/claude-code-plugins/issues"
+    "url": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues"
   },
   "homepage": "https://tonsofskills.com/learn/sentry/",
   "publishConfig": {

--- a/plugins/saas-packs/serpapi-pack/package.json
+++ b/plugins/saas-packs/serpapi-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/serpapi-pack"
   },
   "homepage": "https://tonsofskills.com/learn/serpapi/",

--- a/plugins/saas-packs/shopify-pack/package.json
+++ b/plugins/saas-packs/shopify-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/shopify-pack"
   },
   "homepage": "https://tonsofskills.com/learn/shopify/",

--- a/plugins/saas-packs/snowflake-pack/package.json
+++ b/plugins/saas-packs/snowflake-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/snowflake-pack"
   },
   "homepage": "https://tonsofskills.com/learn/snowflake/",

--- a/plugins/saas-packs/speak-pack/package.json
+++ b/plugins/saas-packs/speak-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Speak - 24 skills covering AI-powered language learning with speech recognition and personalized tutoring",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "speak", "language-learning", "ai-tutor", "speech-recognition", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "speak",
+    "language-learning",
+    "ai-tutor",
+    "speech-recognition",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/speak-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/speak-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/speak/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/stackblitz-pack/package.json
+++ b/plugins/saas-packs/stackblitz-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/stackblitz-pack"
   },
   "homepage": "https://tonsofskills.com/learn/stackblitz/",

--- a/plugins/saas-packs/supabase-pack/package.json
+++ b/plugins/saas-packs/supabase-pack/package.json
@@ -30,11 +30,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/supabase-pack"
   },
   "bugs": {
-    "url": "https://github.com/jeremylongshore/claude-code-plugins/issues"
+    "url": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues"
   },
   "homepage": "https://tonsofskills.com/learn/supabase/",
   "publishConfig": {

--- a/plugins/saas-packs/techsmith-pack/package.json
+++ b/plugins/saas-packs/techsmith-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/techsmith-pack"
   },
   "homepage": "https://tonsofskills.com/learn/techsmith/",

--- a/plugins/saas-packs/together-pack/package.json
+++ b/plugins/saas-packs/together-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/together-pack"
   },
   "homepage": "https://tonsofskills.com/learn/together/",

--- a/plugins/saas-packs/twinmind-pack/package.json
+++ b/plugins/saas-packs/twinmind-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for TwinMind - 24 skills covering AI meeting assistant, transcription, and memory vault integration",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "twinmind", "meeting-ai", "transcription", "speech-to-text", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "twinmind",
+    "meeting-ai",
+    "transcription",
+    "speech-to-text",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/twinmind-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/twinmind-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/twinmind/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/vastai-pack/package.json
+++ b/plugins/saas-packs/vastai-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Vast.ai - 24 skills covering GPU cloud marketplace and ML training",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "vast-ai", "gpu-cloud", "ml-training", "inference", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "vast-ai",
+    "gpu-cloud",
+    "ml-training",
+    "inference",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/vastai-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/vastai-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/vastai/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/veeva-pack/package.json
+++ b/plugins/saas-packs/veeva-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/veeva-pack"
   },
   "homepage": "https://tonsofskills.com/learn/veeva/",

--- a/plugins/saas-packs/vercel-pack/package.json
+++ b/plugins/saas-packs/vercel-pack/package.json
@@ -30,11 +30,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/vercel-pack"
   },
   "bugs": {
-    "url": "https://github.com/jeremylongshore/claude-code-plugins/issues"
+    "url": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues"
   },
   "homepage": "https://tonsofskills.com/learn/vercel/",
   "publishConfig": {

--- a/plugins/saas-packs/webflow-pack/package.json
+++ b/plugins/saas-packs/webflow-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/webflow-pack"
   },
   "homepage": "https://tonsofskills.com/learn/webflow/",

--- a/plugins/saas-packs/windsurf-pack/package.json
+++ b/plugins/saas-packs/windsurf-pack/package.json
@@ -4,11 +4,33 @@
   "description": "Claude Code skill pack for Windsurf - 30 skills covering AI code editor by Codeium",
   "main": "README.md",
   "type": "module",
-  "files": ["README.md", ".claude-plugin/", "skills/"],
-  "keywords": ["claude-code", "claude-code-plugin", "windsurf", "codeium", "code-editor", "agentic", "ai-skills", "saas-pack"],
-  "author": {"name": "Jeremy Longshore", "email": "jeremy@intentsolutions.io"},
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "windsurf",
+    "codeium",
+    "code-editor",
+    "agentic",
+    "ai-skills",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
   "license": "MIT",
-  "repository": {"type": "git", "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git", "directory": "plugins/saas-packs/windsurf-pack"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/windsurf-pack"
+  },
   "homepage": "https://tonsofskills.com/learn/windsurf/",
-  "publishConfig": {"access": "public"}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/plugins/saas-packs/wispr-pack/package.json
+++ b/plugins/saas-packs/wispr-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/wispr-pack"
   },
   "homepage": "https://tonsofskills.com/learn/wispr/",

--- a/plugins/saas-packs/workhuman-pack/package.json
+++ b/plugins/saas-packs/workhuman-pack/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/saas-packs/workhuman-pack"
   },
   "homepage": "https://tonsofskills.com/learn/workhuman/",

--- a/plugins/security/access-control-auditor/package.json
+++ b/plugins/security/access-control-auditor/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/access-control-auditor"
   },
   "homepage": "https://tonsofskills.com/plugins/access-control-auditor",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/authentication-validator/package.json
+++ b/plugins/security/authentication-validator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/authentication-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/authentication-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/compliance-report-generator/package.json
+++ b/plugins/security/compliance-report-generator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/compliance-report-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/compliance-report-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/cors-policy-validator/package.json
+++ b/plugins/security/cors-policy-validator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/cors-policy-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/cors-policy-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/csrf-protection-validator/package.json
+++ b/plugins/security/csrf-protection-validator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/csrf-protection-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/csrf-protection-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/data-privacy-scanner/package.json
+++ b/plugins/security/data-privacy-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/data-privacy-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/data-privacy-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/dependency-checker/package.json
+++ b/plugins/security/dependency-checker/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/dependency-checker"
   },
   "homepage": "https://tonsofskills.com/plugins/dependency-checker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/encryption-tool/package.json
+++ b/plugins/security/encryption-tool/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/encryption-tool"
   },
   "homepage": "https://tonsofskills.com/plugins/encryption-tool",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/gdpr-compliance-scanner/package.json
+++ b/plugins/security/gdpr-compliance-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/gdpr-compliance-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/gdpr-compliance-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/hipaa-compliance-checker/package.json
+++ b/plugins/security/hipaa-compliance-checker/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/hipaa-compliance-checker"
   },
   "homepage": "https://tonsofskills.com/plugins/hipaa-compliance-checker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/input-validation-scanner/package.json
+++ b/plugins/security/input-validation-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/input-validation-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/input-validation-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/owasp-compliance-checker/package.json
+++ b/plugins/security/owasp-compliance-checker/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/owasp-compliance-checker"
   },
   "homepage": "https://tonsofskills.com/plugins/owasp-compliance-checker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/pci-dss-validator/package.json
+++ b/plugins/security/pci-dss-validator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/pci-dss-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/pci-dss-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/penetration-tester/package.json
+++ b/plugins/security/penetration-tester/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/penetration-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/penetration-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/secret-scanner/package.json
+++ b/plugins/security/secret-scanner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/secret-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/secret-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/security-audit-reporter/package.json
+++ b/plugins/security/security-audit-reporter/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/security-audit-reporter"
   },
   "homepage": "https://tonsofskills.com/plugins/security-audit-reporter",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/security-headers-analyzer/package.json
+++ b/plugins/security/security-headers-analyzer/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/security-headers-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/security-headers-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/security-incident-responder/package.json
+++ b/plugins/security/security-incident-responder/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/security-incident-responder"
   },
   "homepage": "https://tonsofskills.com/plugins/security-incident-responder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/security-misconfiguration-finder/package.json
+++ b/plugins/security/security-misconfiguration-finder/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/security-misconfiguration-finder"
   },
   "homepage": "https://tonsofskills.com/plugins/security-misconfiguration-finder",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/session-security-checker/package.json
+++ b/plugins/security/session-security-checker/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/session-security-checker"
   },
   "homepage": "https://tonsofskills.com/plugins/session-security-checker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/severity1-marketplace/package.json
+++ b/plugins/security/severity1-marketplace/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/severity1-marketplace"
   },
   "homepage": "https://tonsofskills.com/plugins/severity1-marketplace",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "severity1",

--- a/plugins/security/soc2-audit-helper/package.json
+++ b/plugins/security/soc2-audit-helper/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/soc2-audit-helper"
   },
   "homepage": "https://tonsofskills.com/plugins/soc2-audit-helper",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/sql-injection-detector/package.json
+++ b/plugins/security/sql-injection-detector/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/sql-injection-detector"
   },
   "homepage": "https://tonsofskills.com/plugins/sql-injection-detector",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/ssl-certificate-manager/package.json
+++ b/plugins/security/ssl-certificate-manager/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/ssl-certificate-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/ssl-certificate-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/vulnerability-scanner/package.json
+++ b/plugins/security/vulnerability-scanner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/vulnerability-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/vulnerability-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/security/xss-vulnerability-scanner/package.json
+++ b/plugins/security/xss-vulnerability-scanner/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/security/xss-vulnerability-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/xss-vulnerability-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/skill-enhancers/calendar-to-workflow/package.json
+++ b/plugins/skill-enhancers/calendar-to-workflow/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/calendar-to-workflow"
   },
   "homepage": "https://tonsofskills.com/plugins/calendar-to-workflow",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins Team",

--- a/plugins/skill-enhancers/file-to-code/package.json
+++ b/plugins/skill-enhancers/file-to-code/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/file-to-code"
   },
   "homepage": "https://tonsofskills.com/plugins/file-to-code",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins Team",

--- a/plugins/skill-enhancers/research-to-deploy/package.json
+++ b/plugins/skill-enhancers/research-to-deploy/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/research-to-deploy"
   },
   "homepage": "https://tonsofskills.com/plugins/research-to-deploy",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins Team",

--- a/plugins/skill-enhancers/search-to-slack/package.json
+++ b/plugins/skill-enhancers/search-to-slack/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/search-to-slack"
   },
   "homepage": "https://tonsofskills.com/plugins/search-to-slack",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins Team",

--- a/plugins/skill-enhancers/skill-creator/package.json
+++ b/plugins/skill-enhancers/skill-creator/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/skill-creator"
   },
   "homepage": "https://tonsofskills.com/plugins/skill-creator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/skill-enhancers/validate-plugin/package.json
+++ b/plugins/skill-enhancers/validate-plugin/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/skill-enhancers/validate-plugin"
   },
   "homepage": "https://tonsofskills.com/plugins/validate-plugin",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/testing/accessibility-test-scanner/package.json
+++ b/plugins/testing/accessibility-test-scanner/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/accessibility-test-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/accessibility-test-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/api-fuzzer/package.json
+++ b/plugins/testing/api-fuzzer/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/api-fuzzer"
   },
   "homepage": "https://tonsofskills.com/plugins/api-fuzzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/api-test-automation/package.json
+++ b/plugins/testing/api-test-automation/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/api-test-automation"
   },
   "homepage": "https://tonsofskills.com/plugins/api-test-automation",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/browser-compatibility-tester/package.json
+++ b/plugins/testing/browser-compatibility-tester/package.json
@@ -21,11 +21,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/browser-compatibility-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/browser-compatibility-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/chaos-engineering-toolkit/package.json
+++ b/plugins/testing/chaos-engineering-toolkit/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/chaos-engineering-toolkit"
   },
   "homepage": "https://tonsofskills.com/plugins/chaos-engineering-toolkit",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/code-cleanup/package.json
+++ b/plugins/testing/code-cleanup/package.json
@@ -20,11 +20,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/code-cleanup"
   },
   "homepage": "https://tonsofskills.com/plugins/code-cleanup",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/testing/contract-test-validator/package.json
+++ b/plugins/testing/contract-test-validator/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/contract-test-validator"
   },
   "homepage": "https://tonsofskills.com/plugins/contract-test-validator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/database-test-manager/package.json
+++ b/plugins/testing/database-test-manager/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/database-test-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/database-test-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/e2e-test-framework/package.json
+++ b/plugins/testing/e2e-test-framework/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/e2e-test-framework"
   },
   "homepage": "https://tonsofskills.com/plugins/e2e-test-framework",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/integration-test-runner/package.json
+++ b/plugins/testing/integration-test-runner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/integration-test-runner"
   },
   "homepage": "https://tonsofskills.com/plugins/integration-test-runner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/load-balancer-tester/package.json
+++ b/plugins/testing/load-balancer-tester/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/load-balancer-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/load-balancer-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/mobile-app-tester/package.json
+++ b/plugins/testing/mobile-app-tester/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/mobile-app-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/mobile-app-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/mutation-test-runner/package.json
+++ b/plugins/testing/mutation-test-runner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/mutation-test-runner"
   },
   "homepage": "https://tonsofskills.com/plugins/mutation-test-runner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/performance-test-suite/package.json
+++ b/plugins/testing/performance-test-suite/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/performance-test-suite"
   },
   "homepage": "https://tonsofskills.com/plugins/performance-test-suite",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/regression-test-tracker/package.json
+++ b/plugins/testing/regression-test-tracker/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/regression-test-tracker"
   },
   "homepage": "https://tonsofskills.com/plugins/regression-test-tracker",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/security-test-scanner/package.json
+++ b/plugins/testing/security-test-scanner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/security-test-scanner"
   },
   "homepage": "https://tonsofskills.com/plugins/security-test-scanner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/smoke-test-runner/package.json
+++ b/plugins/testing/smoke-test-runner/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/smoke-test-runner"
   },
   "homepage": "https://tonsofskills.com/plugins/smoke-test-runner",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/snapshot-test-manager/package.json
+++ b/plugins/testing/snapshot-test-manager/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/snapshot-test-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/snapshot-test-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/test-coverage-analyzer/package.json
+++ b/plugins/testing/test-coverage-analyzer/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-coverage-analyzer"
   },
   "homepage": "https://tonsofskills.com/plugins/test-coverage-analyzer",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/test-data-generator/package.json
+++ b/plugins/testing/test-data-generator/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-data-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/test-data-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/test-doubles-generator/package.json
+++ b/plugins/testing/test-doubles-generator/package.json
@@ -18,11 +18,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-doubles-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/test-doubles-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/test-environment-manager/package.json
+++ b/plugins/testing/test-environment-manager/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-environment-manager"
   },
   "homepage": "https://tonsofskills.com/plugins/test-environment-manager",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/test-orchestrator/package.json
+++ b/plugins/testing/test-orchestrator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-orchestrator"
   },
   "homepage": "https://tonsofskills.com/plugins/test-orchestrator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/test-report-generator/package.json
+++ b/plugins/testing/test-report-generator/package.json
@@ -16,11 +16,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/test-report-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/test-report-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/unit-test-generator/package.json
+++ b/plugins/testing/unit-test-generator/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/unit-test-generator"
   },
   "homepage": "https://tonsofskills.com/plugins/unit-test-generator",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/testing/visual-regression-tester/package.json
+++ b/plugins/testing/visual-regression-tester/package.json
@@ -17,11 +17,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeremylongshore/claude-code-plugins.git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
     "directory": "plugins/testing/visual-regression-tester"
   },
   "homepage": "https://tonsofskills.com/plugins/visual-regression-tester",
-  "bugs": "https://github.com/jeremylongshore/claude-code-plugins/issues",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
   "license": "MIT",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/scripts/fix-package-json-repo-url.mjs
+++ b/scripts/fix-package-json-repo-url.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * One-shot fixup: rewrite `repository.url` and `bugs` in every
+ * plugins/**\/package.json from the legacy `claude-code-plugins` slug to
+ * the canonical `claude-code-plugins-plus-skills`. npm provenance validates
+ * repository.url against the actual GitHub Actions repo slug at publish
+ * time, and a mismatch causes HTTP 422 for every package.
+ *
+ * Run this once, commit the diff, then re-dispatch publish-all-packages.yml.
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+const PLUGINS = join(ROOT, 'plugins');
+
+const OLD_GIT = 'git+https://github.com/jeremylongshore/claude-code-plugins.git';
+const NEW_GIT = 'git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git';
+const OLD_BUGS = 'https://github.com/jeremylongshore/claude-code-plugins/issues';
+const NEW_BUGS = 'https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues';
+
+const SKIP = new Set(['node_modules', '.git']);
+
+function walkPkgJson(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (SKIP.has(e.name)) continue;
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walkPkgJson(p, out);
+    else if (e.isFile() && e.name === 'package.json') out.push(p);
+  }
+  return out;
+}
+
+let fixed = 0;
+let untouched = 0;
+const files = walkPkgJson(PLUGINS);
+for (const f of files) {
+  const src = readFileSync(f, 'utf-8');
+  let pkg;
+  try {
+    pkg = JSON.parse(src);
+  } catch {
+    continue;
+  }
+  let changed = false;
+  if (pkg.repository?.url === OLD_GIT) {
+    pkg.repository.url = NEW_GIT;
+    changed = true;
+  }
+  if (pkg.bugs === OLD_BUGS) {
+    pkg.bugs = NEW_BUGS;
+    changed = true;
+  } else if (pkg.bugs?.url === OLD_BUGS) {
+    pkg.bugs.url = NEW_BUGS;
+    changed = true;
+  }
+  if (changed) {
+    writeFileSync(f, JSON.stringify(pkg, null, 2) + '\n');
+    fixed++;
+  } else {
+    untouched++;
+  }
+}
+
+console.log(`Scanned: ${files.length} package.json files`);
+console.log(`Rewrote: ${fixed}`);
+console.log(`Untouched: ${untouched}`);

--- a/scripts/generate-plugin-package-jsons.mjs
+++ b/scripts/generate-plugin-package-jsons.mjs
@@ -20,7 +20,10 @@ import { dirname, join, relative, resolve } from 'node:path';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const PLUGINS_DIR = join(ROOT, 'plugins');
-const REPO_URL = 'https://github.com/jeremylongshore/claude-code-plugins';
+// Must be the canonical repo slug (not the legacy `/claude-code-plugins`
+// redirect). npm provenance rejects the publish if this doesn't match the
+// actual repository GitHub Actions is running in.
+const REPO_URL = 'https://github.com/jeremylongshore/claude-code-plugins-plus-skills';
 const SCOPE = '@intentsolutionsio';
 
 // FS-only / personal-prefix dirs and known duplicates — skip entirely.


### PR DESCRIPTION
## Summary

The mass-publish workflow failed 412 of 412 attempted publishes with HTTP 422 because `package.json` files pointed at the legacy repo slug `jeremylongshore/claude-code-plugins`, while npm's sigstore provenance validates against the actual GitHub Actions repo slug `claude-code-plugins-plus-skills`.

Example error from run 24701018882:
\`\`\`
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/jeremylongshore/claude-code-plugins.git",
expected to match "https://github.com/jeremylongshore/claude-code-plugins-plus-skills" from provenance
\`\`\`

## Changes

- **`scripts/generate-plugin-package-jsons.mjs`** — `REPO_URL` constant updated to canonical slug so future scaffolds are correct.
- **`scripts/fix-package-json-repo-url.mjs`** (new, one-shot) — rewrites `repository.url` and `bugs` fields across every existing plugins/**/package.json.
- **412 plugin package.json files** — repository URL + bugs URL aligned.

## Why not update the legacy slug everywhere?

Public install commands (\`/plugin marketplace add jeremylongshore/claude-code-plugins\`) keep using the legacy slug because GitHub redirects it at the repo level — documented in CLAUDE.md as a stable public API. npm provenance is stricter: it hard-checks the GitHub Actions repo environment against \`repository.url\`, no redirect support.

## Test plan

- [ ] After merge, re-dispatch \`publish-all-packages.yml\` with \`confirm=publish all\`, \`dry_run_only=false\`
- [ ] Phase 2 publishes cleanly for the 412 previously-failed packages

Jeremy made me do it
-claude