### PR TITLE
feat(langchain-py-pack): add langchain-upgrade-migration (F24)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: langchain-upgrade-migration
+description: |
+  Migrate a LangChain 0.3.x Python codebase to LangChain 1.0 / LangGraph 1.0 without
+  breaking production — named breaking changes, codemod patterns, and a phased rollout.
+  Use when upgrading LangChain or LangGraph from 0.2 or 0.3 to 1.0, when hitting
+  ImportError after an upgrade, or when preparing a migration PR.
+  Trigger with "langchain 1.0 migration", "langchain upgrade", "LLMChain removed",
+  "initialize_agent removed", "ConversationBufferMemory removed", "astream_log deprecated",
+  "langchain-anthropic 1.0".
+allowed-tools: Read, Write, Edit, Grep, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, migration, upgrade]
+compatible-with: claude-code, codex
+---
+
+# LangChain 1.0 Upgrade Migration (Python)
+
+## Overview
+
+The first deploy after `pip install -U langchain` crashes on import with:
+
+```
+ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'
+```
+
+Fix the import, restart, and the next error lands:
+
+```
+ImportError: cannot import name 'LLMChain' from 'langchain.chains'
+AttributeError: module 'langchain.agents' has no attribute 'initialize_agent'
+AttributeError: 'ConversationBufferMemory' object has no attribute 'save_context'
+```
+
+LangChain 1.0 removed four entire public-API surfaces in one release:
+
+- Provider imports under `langchain.chat_models` / `langchain.llms` (pain code **P38**).
+- The `LLMChain` family under `langchain.chains` (**P39**).
+- `ConversationBufferMemory` and siblings under `langchain.memory` (**P40**).
+- `initialize_agent` under `langchain.agents` (**P41**).
+
+Anything that inspected `intermediate_steps` also breaks because the tuple shape changed from `(AgentAction, observation)` to `(ToolCall, observation)` (**P42**).
+
+This skill walks a reversible, phased migration:
+
+1. A pre-flight grep audit.
+2. A pinned package upgrade (including the `langchain-anthropic` 1.0 peer-pin against `anthropic >= 0.40`, **P66**).
+3. Codemod patterns for the seven removed APIs.
+4. A rollout playbook with shadow traffic and a sub-five-minute rollback.
+
+It covers **7 named breaking changes** and typically touches **10–100 files** in a mid-sized service.
+
+The fix for the error above:
+
+```python
+# BEFORE (0.3)
+from langchain.chat_models import ChatOpenAI
+
+# AFTER (1.0)
+from langchain_openai import ChatOpenAI
+```
+
+See [codemod-patterns.md](references/codemod-patterns.md) for the other six patterns.
+
+## Prerequisites
+
+- Python 3.10+ (LangChain 1.0 dropped 3.8/3.9).
+- A working test suite for the service being migrated (the playbook runs `pytest -W error::DeprecationWarning` at every phase).
+- Git on a clean working tree — the migration uses per-module commits so rollback is per-commit.
+- Access to staging traffic or a request-mirror. Phase 4 of the playbook needs real-shape traffic.
+- If conversations are persisted (Redis / Postgres / DynamoDB), a snapshot of the chat-history store before Phase 2. The LangGraph checkpointer uses a new schema and a naive rollback is data-lossy.
+
+## Instructions
+
+### Step 1 — Pre-flight grep audit
+
+Inventory every 0.3 usage before touching a `requirements.txt`. Each grep below maps to one pain code and one codemod pattern.
+
+```bash
+grep -rn "from langchain\.chat_models\|from langchain\.llms" --include="*.py" .          # P38
+grep -rn "from langchain\.chains\b\|\bLLMChain\b\|\bRetrievalQA\b" --include="*.py" .    # P39
+grep -rn "from langchain\.memory\|ConversationBufferMemory" --include="*.py" .           # P40
+grep -rn "initialize_agent\|AgentType\." --include="*.py" .                              # P41
+grep -rn "\.tool_input\b\|intermediate_steps" --include="*.py" .                         # P42
+grep -rn "astream_log\b" --include="*.py" .                                              # P67
+```
+
+Pipe the full set into `langchain-0.3-hits.txt` — that file is the migration work list. The [migration-detection.md](references/migration-detection.md) reference has the one-shot bundled block and a line-count triage table.
+
+### Step 2 — Pin and upgrade packages together
+
+LangChain 1.0 spans six coordinated packages. A partial upgrade (e.g. `pip install -U langchain-anthropic` without bumping `anthropic`) triggers `AttributeError` at import time (**P66**). Update all six in the same commit:
+
+```
+langchain>=1.0,<2
+langchain-core>=0.3,<0.4
+langchain-openai>=1.0
+langchain-anthropic>=1.0
+langgraph>=1.0,<2
+anthropic>=0.40,<1
+```
+
+Apply:
+
+```bash
+pip install -U \
+  "langchain>=1.0,<2" \
+  "langchain-core>=0.3,<0.4" \
+  "langchain-openai>=1.0" \
+  "langchain-anthropic>=1.0" \
+  "langgraph>=1.0,<2" \
+  "anthropic>=0.40,<1"
+```
+
+Then snapshot the prior state for the rollback: `pip freeze > requirements.lock.pre-1.0.txt`.
+
+### Step 3 — Codemod the four removed APIs
+
+Work through the hits from Step 1 in this order (lowest blast radius first):
+
+1. **Provider imports (P38)** — mechanical find/replace. `from langchain.chat_models import ChatOpenAI` → `from langchain_openai import ChatOpenAI`. Same pattern for `ChatAnthropic`, `OpenAIEmbeddings`, `Chroma`, etc.
+2. **`LLMChain` → LCEL (P39)** — replace `chain = LLMChain(llm=llm, prompt=prompt)` with `chain = prompt | llm | StrOutputParser()`. Caller changes from `chain.run(x=1)` to `chain.invoke({"x": 1})`. If the caller treated the result as a dict, unwrap — `invoke` returns the string directly.
+3. **`initialize_agent` → `create_react_agent` (P41)** — swap the import to `from langgraph.prebuilt import create_react_agent`. Tools written with `Tool(name=..., func=...)` still work; prefer the `@tool` decorator from `langchain_core.tools`. Agent input becomes `{"messages": [("user", "...")]}`; the final reply is `result["messages"][-1].content`.
+4. **`ConversationBufferMemory` → LangGraph checkpointer (P40)** — swap the memory object for `MemorySaver()` (dev) or `SqliteSaver.from_conn_string(...)` (prod). Compile the graph/agent with `checkpointer=saver`, then pass `config={"configurable": {"thread_id": "..."}}` on every `invoke`. The `thread_id` is the conversation primary key.
+
+Full before/after snippets for all four are in [codemod-patterns.md](references/codemod-patterns.md).
+
+### Step 4 — Update streaming callers (P67)
+
+`astream_log` still works in 1.0 but is soft-deprecated. The replacement is `astream_events(version="v2")`:
+
+```python
+# BEFORE
+async for patch in chain.astream_log({"input": "hi"}):
+    for op in patch.ops:
+        if op["op"] == "add" and op["path"].endswith("/streamed_output/-"):
+            print(op["value"], end="")
+
+# AFTER
+async for event in chain.astream_events({"input": "hi"}, version="v2"):
+    if event["event"] == "on_chat_model_stream":
+        print(event["data"]["chunk"].content, end="")
+```
+
+Event names in v2: `on_chain_start`, `on_chain_end`, `on_chat_model_start`, `on_chat_model_stream`, `on_chat_model_end`, `on_tool_start`, `on_tool_end`. The payload under `data` is typed — `chunk` is an `AIMessageChunk`, not a raw string.
+
+### Step 5 — Fix `intermediate_steps` consumers (P42)
+
+If any code iterates `result["intermediate_steps"]` and reads `.tool` / `.tool_input`, it breaks silently in 1.0 — the tuples now hold `ToolCall` dicts, not `AgentAction` objects. The 1.0 equivalent reads from graph state:
+
+```python
+# BEFORE
+for action, observation in result["intermediate_steps"]:
+    log(action.tool, action.tool_input, observation)
+
+# AFTER
+for msg in result["messages"]:
+    for tc in getattr(msg, "tool_calls", []) or []:
+        log(tc["name"], tc["args"])   # .tool -> "name", .tool_input -> "args"
+```
+
+`ToolCall` dict keys are `name`, `args`, `id`. There is no `tool` or `tool_input` accessor anywhere in 1.0.
+
+### Step 6 — Gate on deprecation-as-error tests
+
+Turn `DeprecationWarning` into a test failure so any surviving 0.3 pattern surfaces before the rollout:
+
+```bash
+pytest -W error::DeprecationWarning
+```
+
+Do not promote to staging while this is red. Re-run the Step 1 greps — they should now return zero hits outside intentionally-pinned 0.3 test fixtures.
+
+### Step 7 — Phased rollout on production traffic
+
+Deploy behind a feature flag (`LANGCHAIN_1_0_ENABLED`), canary at 1%, and ramp to 100% over 2–4 hours with a 15-minute soak at each step. The rollback is always "flip the flag off" — not a redeploy. Full playbook (shadow traffic in staging, dual-write for persistent chat histories, per-phase exit criteria) is in [phased-rollout-playbook.md](references/phased-rollout-playbook.md).
+
+## Output
+
+- `requirements.txt` pinning all six 1.0 packages with the `anthropic >= 0.40` peer-pin (P66).
+- `requirements.lock.pre-1.0.txt` in the repo root for five-minute rollback.
+- Per-module git commits referencing pain codes (e.g. `refactor: migrate P39 LLMChain in billing-summariser to LCEL`).
+- `langchain-0.3-hits.txt` work-list returning zero non-test hits on re-run.
+- `pytest -W error::DeprecationWarning` green on the migration branch.
+- Feature-flagged production cutover at 100%, flag removed after a full day of soak.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'` | **P38** — provider imports moved to partner packages | `from langchain_openai import ChatOpenAI` |
+| `ImportError: cannot import name 'LLMChain' from 'langchain.chains'` | **P39** — `LLMChain` removed | Replace with LCEL: `prompt \| llm \| StrOutputParser()` |
+| `AttributeError: 'ConversationBufferMemory' object has no attribute 'save_context'` | **P40** — memory classes removed from the public API | Swap for LangGraph `MemorySaver` / `SqliteSaver` with a `thread_id` |
+| `AttributeError: module 'langchain.agents' has no attribute 'initialize_agent'` | **P41** — legacy agent constructor removed | `from langgraph.prebuilt import create_react_agent` |
+| `AttributeError: 'ToolCall' object has no attribute 'tool'` | **P42** — tuple shape changed, fields renamed | Read `tc["name"]` and `tc["args"]` instead of `.tool` / `.tool_input` |
+| `AttributeError: module 'anthropic' has no attribute 'AsyncAnthropic'` | **P66** — `langchain-anthropic 1.0` needs `anthropic >= 0.40` | Pin `anthropic>=0.40,<1` in the same commit as the `langchain-anthropic` bump |
+| `DeprecationWarning: astream_log is deprecated; use astream_events(version="v2")` | **P67** — soft deprecation | Switch to `astream_events(version="v2")` and update event-name handling |
+
+## Examples
+
+### Example 1 — Minimal LLMChain to LCEL
+
+```python
+# BEFORE (0.3)
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.chains import LLMChain
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+prompt = ChatPromptTemplate.from_messages([("system", "Summarise in one line."), ("user", "{text}")])
+chain = LLMChain(llm=llm, prompt=prompt)
+print(chain.run(text="LangChain 1.0 removed LLMChain."))
+
+# AFTER (1.0)
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+prompt = ChatPromptTemplate.from_messages([("system", "Summarise in one line."), ("user", "{text}")])
+chain = prompt | llm | StrOutputParser()
+print(chain.invoke({"text": "LangChain 1.0 removed LLMChain."}))
+```
+
+### Example 2 — Stateful agent with LangGraph checkpointer
+
+```python
+# AFTER (1.0)
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import MemorySaver    # use SqliteSaver / PostgresSaver in prod
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+agent = create_react_agent(llm, [add], checkpointer=MemorySaver())
+
+config = {"configurable": {"thread_id": "user-42"}}
+r1 = agent.invoke({"messages": [("user", "What's 2 + 3?")]}, config=config)
+r2 = agent.invoke({"messages": [("user", "And plus 10?")]}, config=config)   # remembers "5"
+print(r2["messages"][-1].content)
+```
+
+### Example 3 — Rollback pin
+
+If Phase 5 of the rollout regresses and the feature flag is already off:
+
+```bash
+git checkout main
+pip install -r requirements.lock.pre-1.0.txt
+pytest                      # confirm green on the rollback pin
+# deploy
+```
+
+## Resources
+
+- [LangChain migration guide](https://python.langchain.com/docs/versions/migrating/)
+- [LangChain release policy](https://python.langchain.com/docs/versions/release_policy/)
+- [LangGraph prebuilt `create_react_agent`](https://langchain-ai.github.io/langgraph/reference/prebuilt/)
+- [`astream_events` v2 reference](https://python.langchain.com/docs/concepts/streaming/)
+- [Breaking changes matrix](references/breaking-changes-matrix.md) — all 7 named changes mapped to pain codes
+- [Codemod patterns](references/codemod-patterns.md) — before/after for the 7 most common migrations
+- [Phased rollout playbook](references/phased-rollout-playbook.md) — shadow traffic, dual-write, rollback
+- [Migration detection](references/migration-detection.md) — pre-flight grep audit
+- [One-pager](references/one-pager.md) — executive summary

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/breaking-changes-matrix.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/breaking-changes-matrix.md
@@ -1,0 +1,73 @@
+# Breaking Changes Matrix — LangChain 0.3.x → 1.0.x
+
+Every removed or renamed public API between LangChain 0.3 and LangChain 1.0 / LangGraph 1.0, grouped by module, with the exact 1.0 replacement and a one-line code snippet. Pain codes refer to the `langchain-py-pack` pain catalog.
+
+## Import Paths
+
+| 0.3.x API (removed) | 1.0.x Replacement | Pain | One-liner |
+|---|---|---|---|
+| `from langchain.chat_models import ChatOpenAI` | `from langchain_openai import ChatOpenAI` | P38 | Provider imports live in `langchain-openai`, `langchain-anthropic`, etc. |
+| `from langchain.chat_models import ChatAnthropic` | `from langchain_anthropic import ChatAnthropic` | P38, P66 | Requires `anthropic >= 0.40` alongside `langchain-anthropic >= 1.0`. |
+| `from langchain.llms import OpenAI` | `from langchain_openai import OpenAI` | P38 | Same package as `ChatOpenAI`; completions-style models are still available but the chat model is preferred. |
+| `from langchain.embeddings import OpenAIEmbeddings` | `from langchain_openai import OpenAIEmbeddings` | P38 | Also affects `HuggingFaceEmbeddings` → `langchain_huggingface`. |
+| `from langchain.vectorstores import Chroma` | `from langchain_chroma import Chroma` | P38 | Vectorstores were extracted into `langchain-<store>` partner packages. |
+
+## Chains
+
+| 0.3.x API (removed) | 1.0.x Replacement | Pain | One-liner |
+|---|---|---|---|
+| `from langchain.chains import LLMChain` | LCEL: `prompt \| llm \| StrOutputParser()` | P39 | `chain.invoke({"x": 1})` replaces `chain.run(x=1)` / `chain({"x": 1})`. |
+| `from langchain.chains import ConversationChain` | LCEL + LangGraph checkpointer | P39, P40 | Wire history via a LangGraph `MemorySaver` or `SqliteSaver`. |
+| `from langchain.chains import SequentialChain` | LCEL pipe: `a \| b \| c` | P39 | Named outputs use `RunnablePassthrough.assign(...)`. |
+| `from langchain.chains import RetrievalQA` | `create_retrieval_chain(retriever, combine_docs_chain)` | P39 | `combine_docs_chain = create_stuff_documents_chain(llm, prompt)`. |
+| `from langchain.chains import LLMMathChain` | LCEL tool calling with a Python REPL tool | P39 | No drop-in replacement; rebuild as a tool-using agent. |
+
+## Agents
+
+| 0.3.x API (removed) | 1.0.x Replacement | Pain | One-liner |
+|---|---|---|---|
+| `from langchain.agents import initialize_agent` | `from langgraph.prebuilt import create_react_agent` | P41 | `agent = create_react_agent(llm, tools)`; `invoke({"messages": [...]})`. |
+| `AgentType.ZERO_SHOT_REACT_DESCRIPTION` | `create_react_agent(llm, tools)` | P41 | ReAct is now the default prebuilt; other AgentTypes are gone. |
+| `AgentType.CHAT_CONVERSATIONAL_REACT_DESCRIPTION` | `create_react_agent` + LangGraph checkpointer | P40, P41 | History lives in the graph state, not in a memory object. |
+| `AgentExecutor(...).intermediate_steps` yielding `(AgentAction, str)` | Messages in graph state; `ToolCall` objects with `name`, `args`, `id` | P42 | Old `step.tool` / `step.tool_input` becomes `tool_call["name"]` / `tool_call["args"]`. |
+| `from langchain.agents import Tool` | `from langchain_core.tools import tool` (decorator) or `StructuredTool.from_function` | P41 | Plain `Tool(name=..., func=...)` still works but the decorator is preferred. |
+
+## Memory
+
+| 0.3.x API (removed) | 1.0.x Replacement | Pain | One-liner |
+|---|---|---|---|
+| `from langchain.memory import ConversationBufferMemory` | LangGraph checkpointer: `MemorySaver()` or `SqliteSaver.from_conn_string(...)` | P40 | Persist via `graph.compile(checkpointer=saver)`; thread id via `config={"configurable": {"thread_id": "..."}}`. |
+| `from langchain.memory import ConversationBufferWindowMemory` | LangGraph state + `trim_messages(max_tokens=...)` | P40 | Trimming is explicit in the graph node, not hidden in memory. |
+| `from langchain.memory import ConversationSummaryMemory` | Graph node that periodically summarises and writes back to state | P40 | No drop-in; build a summariser node. |
+| `BaseChatMessageHistory` subclasses (e.g. `RedisChatMessageHistory`) | Still supported under `langchain_community.chat_message_histories` | P40 | Keep the store; wrap it in a checkpointer or a graph node. |
+
+## Streaming / Observability
+
+| 0.3.x API (soft-deprecated) | 1.0.x Replacement | Pain | One-liner |
+|---|---|---|---|
+| `astream_log(...)` | `astream_events(version="v2")` | P67 | `v2` is stable; event names and payload shapes are the supported surface. |
+| `CallbackManager.configure(...)` legacy context | Runnable config (`RunnableConfig`) | — | Pass `config={"callbacks": [...]}` to `invoke` / `astream_events`. |
+| `get_openai_callback()` context manager | Still available; prefer LangSmith tracing or OpenAI usage events from `astream_events` | — | Both work on 1.0, but LangSmith is the recommended path. |
+
+## Embeddings / Indexing
+
+| 0.3.x API (behaviour change) | 1.0.x Behaviour | Pain | One-liner |
+|---|---|---|---|
+| Embedding dimension implicit on vectorstore create | Explicit `dim` required for most partner stores; mismatches raise on upsert | P14 | On model swap (`text-embedding-ada-002` → `text-embedding-3-*`), reindex — the dim differs. |
+| `OpenAIEmbeddings(model="text-embedding-ada-002")` | Works, but ada-002 is deprecated at OpenAI; prefer `text-embedding-3-small` / `-large` | P14 | Schedule a reindex during the migration window. |
+
+## Verification Checklist
+
+After applying every change above, these greps should return **zero hits** in your codebase:
+
+```
+langchain.chat_models         # P38
+langchain.llms                # P38 (except tests that intentionally pin 0.3)
+langchain.chains              # P39
+langchain.memory              # P40
+langchain.agents.initialize_agent   # P41
+AgentAction\.tool             # P42 — both field accesses gone
+astream_log\(                 # P67
+```
+
+If any of these still hit, re-open [codemod-patterns.md](codemod-patterns.md) and apply the matching pattern.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/codemod-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/codemod-patterns.md
@@ -1,0 +1,166 @@
+# Codemod Patterns — 0.3 → 1.0
+
+Before/after snippets for the seven migrations that cover ~95% of a typical LangChain 0.3 codebase. Apply in order — each pattern assumes the import paths from Pattern 1 are already fixed.
+
+## Pattern 1 — Provider Import Paths (P38)
+
+Every import from `langchain.chat_models`, `langchain.llms`, `langchain.embeddings`, or `langchain.vectorstores` is gone. Replace with the partner package.
+
+```python
+# BEFORE (0.3)
+from langchain.chat_models import ChatOpenAI, ChatAnthropic
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import Chroma
+
+# AFTER (1.0)
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_anthropic import ChatAnthropic
+from langchain_chroma import Chroma
+```
+
+Search pattern: `grep -rn "from langchain\.\(chat_models\|llms\|embeddings\|vectorstores\)" .`
+
+## Pattern 2 — LLMChain → LCEL (P39)
+
+`LLMChain` is removed. Replace with the pipe operator and an output parser.
+
+```python
+# BEFORE (0.3)
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
+
+prompt = PromptTemplate.from_template("Translate to French: {text}")
+chain = LLMChain(llm=llm, prompt=prompt)
+result = chain.run(text="hello")           # or: chain({"text": "hello"})["text"]
+
+# AFTER (1.0)
+from langchain_core.prompts import PromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+prompt = PromptTemplate.from_template("Translate to French: {text}")
+chain = prompt | llm | StrOutputParser()
+result = chain.invoke({"text": "hello"})    # returns str directly
+```
+
+Caller change: `chain.run(x=1)` becomes `chain.invoke({"x": 1})`. Any code that treated the result as a dict (`result["text"]`) now gets the unwrapped string.
+
+## Pattern 3 — initialize_agent → create_react_agent (P41)
+
+`initialize_agent` and all `AgentType.*` values are removed. The 1.0 path is LangGraph's prebuilt ReAct agent.
+
+```python
+# BEFORE (0.3)
+from langchain.agents import initialize_agent, AgentType, Tool
+
+tools = [Tool(name="search", func=search_fn, description="Web search")]
+agent = initialize_agent(
+    tools,
+    llm,
+    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+    verbose=True,
+)
+result = agent.run("What's the weather in Austin?")
+
+# AFTER (1.0)
+from langgraph.prebuilt import create_react_agent
+from langchain_core.tools import tool
+
+@tool
+def search(query: str) -> str:
+    """Web search."""
+    return search_fn(query)
+
+agent = create_react_agent(llm, [search])
+result = agent.invoke({"messages": [("user", "What's the weather in Austin?")]})
+final_text = result["messages"][-1].content
+```
+
+Caller change: input shape is `{"messages": [...]}`, output is a dict with `"messages"` whose last element holds the final AI reply.
+
+## Pattern 4 — ConversationBufferMemory → LangGraph Checkpointer (P40)
+
+`ConversationBufferMemory` (and `ConversationBufferWindowMemory`, `ConversationSummaryMemory`) are removed. History is now graph state persisted by a checkpointer.
+
+```python
+# BEFORE (0.3)
+from langchain.memory import ConversationBufferMemory
+from langchain.chains import ConversationChain
+
+memory = ConversationBufferMemory()
+chain = ConversationChain(llm=llm, memory=memory)
+chain.predict(input="Hi, I'm Jeremy")
+chain.predict(input="What's my name?")   # remembers "Jeremy"
+
+# AFTER (1.0)
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import create_react_agent
+
+checkpointer = MemorySaver()              # or SqliteSaver.from_conn_string("checkpoints.sqlite")
+agent = create_react_agent(llm, tools=[], checkpointer=checkpointer)
+
+config = {"configurable": {"thread_id": "user-42"}}
+agent.invoke({"messages": [("user", "Hi, I'm Jeremy")]}, config=config)
+agent.invoke({"messages": [("user", "What's my name?")]}, config=config)   # same thread_id → recalls "Jeremy"
+```
+
+For production, swap `MemorySaver` for `SqliteSaver`, `PostgresSaver`, or `RedisSaver`. The `thread_id` is the primary key for a conversation.
+
+## Pattern 5 — astream_log → astream_events v2 (P67)
+
+`astream_log` still works in 1.0 but is soft-deprecated and will not get new features. The replacement is `astream_events(version="v2")`.
+
+```python
+# BEFORE (0.3) — RunLog patch stream
+async for patch in chain.astream_log({"input": "hi"}):
+    for op in patch.ops:
+        if op["op"] == "add" and op["path"].endswith("/streamed_output/-"):
+            print(op["value"], end="", flush=True)
+
+# AFTER (1.0) — typed event stream
+async for event in chain.astream_events({"input": "hi"}, version="v2"):
+    if event["event"] == "on_chat_model_stream":
+        chunk = event["data"]["chunk"]
+        print(chunk.content, end="", flush=True)
+```
+
+Key event names in v2: `on_chain_start`, `on_chain_end`, `on_chat_model_start`, `on_chat_model_stream`, `on_chat_model_end`, `on_tool_start`, `on_tool_end`. The payload under `data` is typed — `chunk` is an `AIMessageChunk`, not a raw string.
+
+## Pattern 6 — AgentAction → ToolCall field rename (P42)
+
+If you ever inspected `intermediate_steps` on `AgentExecutor`, the tuple shape changed and the field names drifted.
+
+```python
+# BEFORE (0.3)
+for action, observation in result["intermediate_steps"]:
+    print(action.tool, action.tool_input, observation)
+
+# AFTER (1.0) — LangGraph state inspection
+for msg in result["messages"]:
+    for tc in getattr(msg, "tool_calls", []) or []:
+        print(tc["name"], tc["args"])    # .tool -> ["name"], .tool_input -> ["args"]
+```
+
+The `ToolCall` dict keys are `name`, `args`, `id`. There is no `tool` or `tool_input` attribute anywhere in 1.0.
+
+## Pattern 7 — langchain-anthropic + anthropic peer pin (P66)
+
+`langchain-anthropic 1.0` requires `anthropic >= 0.40`. A lone `pip install -U langchain-anthropic` without bumping the `anthropic` SDK triggers `AttributeError: module 'anthropic' has no attribute 'AsyncAnthropic'` at import.
+
+```
+# BEFORE (0.3)
+langchain==0.3.*
+langchain-anthropic==0.2.*
+anthropic==0.34.*          # old SDK — fine with 0.2 integration
+
+# AFTER (1.0)
+langchain==1.*
+langchain-core==0.3.*
+langchain-anthropic==1.*
+anthropic>=0.40,<1.0       # MUST bump together
+```
+
+Pin all four lines in the same commit. If you bump `langchain-anthropic` without `anthropic`, the integration will import-fail before your app code runs.
+
+## After Running All Seven Patterns
+
+Re-run the verification greps from [breaking-changes-matrix.md](breaking-changes-matrix.md). Zero hits means the codemod is complete and the test suite is safe to run.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/migration-detection.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/migration-detection.md
@@ -1,0 +1,87 @@
+# Migration Detection — grep-based Pre-flight
+
+Run these commands from the repo root before starting the upgrade. Each command pairs to a pain code and a codemod pattern. Collect the hits into a file — it is the migration work list.
+
+## The Eight Checks
+
+```bash
+# P38 — Provider import paths (chat models, llms, embeddings, vectorstores)
+grep -rn "from langchain\.chat_models" --include="*.py" .
+grep -rn "from langchain\.llms" --include="*.py" .
+grep -rn "from langchain\.embeddings" --include="*.py" .
+grep -rn "from langchain\.vectorstores" --include="*.py" .
+
+# P39 — LLMChain and siblings
+grep -rn "from langchain\.chains\b" --include="*.py" .
+grep -rn "\bLLMChain\b" --include="*.py" .
+grep -rn "\bConversationChain\b" --include="*.py" .
+grep -rn "\bSequentialChain\b" --include="*.py" .
+grep -rn "\bRetrievalQA\b" --include="*.py" .
+
+# P40 — Memory classes
+grep -rn "from langchain\.memory" --include="*.py" .
+grep -rn "ConversationBufferMemory\|ConversationBufferWindowMemory\|ConversationSummaryMemory" --include="*.py" .
+
+# P41 — Legacy agent constructors
+grep -rn "initialize_agent\|AgentType\." --include="*.py" .
+
+# P42 — AgentAction field access
+grep -rn "\.tool_input\b\|AgentAction\." --include="*.py" .
+grep -rn "intermediate_steps" --include="*.py" .
+
+# P66 — Peer-pin drift between langchain-anthropic and anthropic
+grep -rn "langchain-anthropic" requirements*.txt pyproject.toml 2>/dev/null
+grep -rn "^anthropic" requirements*.txt pyproject.toml 2>/dev/null
+
+# P67 — Soft-deprecated streaming API
+grep -rn "astream_log\b" --include="*.py" .
+```
+
+## Bundled one-shot script (one-liner, not a committed script)
+
+For a single run of all of the above piped into a work-list:
+
+```bash
+{ \
+  grep -rn "from langchain\.chat_models\|from langchain\.llms\|from langchain\.embeddings\|from langchain\.vectorstores" --include="*.py" . ; \
+  grep -rn "from langchain\.chains\b\|LLMChain\|ConversationChain\|SequentialChain\|RetrievalQA" --include="*.py" . ; \
+  grep -rn "from langchain\.memory\|ConversationBufferMemory\|ConversationBufferWindowMemory\|ConversationSummaryMemory" --include="*.py" . ; \
+  grep -rn "initialize_agent\|AgentType\." --include="*.py" . ; \
+  grep -rn "\.tool_input\b\|intermediate_steps" --include="*.py" . ; \
+  grep -rn "astream_log\b" --include="*.py" . ; \
+} > langchain-0.3-hits.txt
+wc -l langchain-0.3-hits.txt
+```
+
+The line count is a rough lower bound on the number of call sites to touch. Typical outcomes:
+
+| Line count | Interpretation |
+|---|---|
+| 0 | Already on 1.0 patterns. Only the version bump and peer-pin (P66) remain. |
+| 1–20 | Small codebase or isolated usage. One afternoon of codemod work. |
+| 21–100 | Typical mid-sized service. Plan a two-day migration with staged commits per module. |
+| 100+ | Multiple teams own parts of the code. Do Phase 2 of the playbook per team, not per file. |
+
+## Reading the Output
+
+Each hit is `path:line_no:matched_line`. Group by `path`, then by pain code, then assign each file to the codemod pattern in [codemod-patterns.md](codemod-patterns.md):
+
+| Matched on | Pain | Apply pattern |
+|---|---|---|
+| `from langchain.chat_models` etc. | P38 | Pattern 1 |
+| `LLMChain`, `RetrievalQA`, `SequentialChain` | P39 | Pattern 2 |
+| `initialize_agent`, `AgentType.` | P41 | Pattern 3 |
+| `ConversationBufferMemory` etc. | P40 | Pattern 4 |
+| `astream_log` | P67 | Pattern 5 |
+| `.tool_input`, `intermediate_steps` | P42 | Pattern 6 |
+| `langchain-anthropic` in requirements without `anthropic >= 0.40` | P66 | Pattern 7 |
+
+## Re-running After the Codemod
+
+Run the same block after Phase 2 of the playbook. Every check should return zero hits except intentional test fixtures that pin 0.3 for comparison. Any non-test hit is unfinished migration work.
+
+## False Positives to Expect
+
+- Third-party code vendored into `.venv/` or `node_modules/` — exclude with `--exclude-dir`. On most setups, grep already skips these by default if they are gitignored.
+- Documentation strings that reference the old API for context. Flag these for the prose update but do not treat them as code migrations.
+- Tests that intentionally assert 0.3 backwards-compat shims (rare). Annotate with `# noqa: langchain-migration` and exclude from the recount.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-upgrade-migration — One-Pager
+
+Ship a LangChain 1.0 / LangGraph 1.0 migration from a 0.2 or 0.3 codebase without breaking production, with a named breaking-change map, codemod patterns, and a phased rollout.
+
+## The Problem
+
+The first process restart after `pip install -U langchain` explodes with `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'` — because `langchain.chat_models`, `langchain.chains.LLMChain`, `langchain.memory.ConversationBufferMemory`, and `langchain.agents.initialize_agent` were all removed in 1.0. The cascade keeps hitting: `LLMChain is not defined`, `ConversationBufferMemory has no attribute 'save_context'`, agents returning a new `ToolCall` shape that no longer matches the old `AgentAction.tool` / `.tool_input` accessors. Worst case, the agent looks like it works but silently drops tool results because `intermediate_steps` now yields `(ToolCall, observation)` tuples instead of `(AgentAction, observation)`.
+
+## The Solution
+
+A phased, reversible migration: (1) pre-flight audit with grep patterns against P38/P39/P40/P41/P42/P66/P67 anchors to inventory every 0.3 usage; (2) pin-together package upgrade (`langchain >= 1.0`, `langchain-core >= 0.3`, `langchain-anthropic >= 1.0` alongside `anthropic >= 0.40`); (3) codemod each removed API to its 1.0 replacement — `LLMChain` → LCEL, `initialize_agent` → `create_react_agent` from LangGraph, `ConversationBufferMemory` → LangGraph checkpointer, `astream_log` → `astream_events(version="v2")`; (4) integration test on shadow traffic before promoting to production.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python backend engineers on LangChain 0.2.x or 0.3.x who have `LLMChain`, `initialize_agent`, `ConversationBufferMemory`, or `langchain.chat_models` imports in their codebase and need to move to 1.0 without a multi-day outage. |
+| **What** | A pre-flight grep audit, a breaking-changes matrix with 7+ named changes, codemod before/after snippets, a pinned `requirements.txt` fragment, and a phased rollout playbook (feature-flag, dual-write for chat histories, rollback plan). |
+| **When** | Before bumping `langchain` past 1.0 in any production service; also when a scheduled dependency refresh surfaces an `ImportError` on `langchain.chat_models` / `langchain.chains` / `langchain.agents` / `langchain.memory` on the next deploy. |
+
+## Key Features
+
+1. **Pain-anchored change matrix** — Every breaking change is tagged to a pain code (P38 `ChatOpenAI` import, P39 `LLMChain` removal, P40 `ConversationBufferMemory` removal, P41 `initialize_agent` removal, P42 `intermediate_steps` shape drift, P66 `langchain-anthropic` 1.0 peer dep, P67 `astream_log` deprecation) with the exact 1.0 replacement.
+2. **Codemod patterns, not theory** — Side-by-side 0.3 → 1.0 snippets for the five most common usages: LCEL replacement of `LLMChain`, `create_react_agent` replacement of `initialize_agent`, LangGraph checkpointer replacement of `ConversationBufferMemory`, `astream_events(version="v2")` replacement of `astream_log`, and `AgentAction` → `ToolCall` field rename.
+3. **Phased rollout with a rollback plan** — Staging-first toggle, per-module migration order, dual-write for persistent chat histories during cutover, and an explicit pin-back `requirements.txt` to revert in under five minutes if shadow traffic regresses.
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/phased-rollout-playbook.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/references/phased-rollout-playbook.md
@@ -1,0 +1,87 @@
+# Phased Rollout Playbook
+
+A reversible rollout plan for a LangChain 0.3 → 1.0 migration that touches production traffic. Designed so that any failure mode can be rolled back in under five minutes.
+
+## Phase 0 — Pre-flight (no production change)
+
+1. Run the pre-flight audit (see SKILL.md Step 1). Inventory every 0.3 usage and pick the owning team for each hit.
+2. Snapshot `pip freeze > requirements.lock.pre-1.0.txt` — this is your rollback pin.
+3. Snapshot the persistent chat-history store (if you have one) — RDS snapshot, Redis RDB dump, or S3 copy. The 1.0 LangGraph checkpointer uses a new schema; a rollback without this snapshot is data-lossy for in-flight conversations.
+4. Branch: `feat/langchain-1.0-migration`. Merge nothing to main yet.
+
+## Phase 1 — Upgrade packages in a sandbox
+
+On the migration branch only:
+
+```
+pip install --upgrade \
+  "langchain>=1.0,<2" \
+  "langchain-core>=0.3,<0.4" \
+  "langchain-openai>=1.0" \
+  "langchain-anthropic>=1.0" \
+  "langgraph>=1.0,<2" \
+  "anthropic>=0.40,<1"
+```
+
+Run `pytest -W error::DeprecationWarning` — every `DeprecationWarning` is now a test failure, so any surviving 0.3 pattern surfaces immediately. Do not proceed to Phase 2 while the test suite is red.
+
+## Phase 2 — Codemod, one module at a time
+
+Per-module order, lowest blast radius first:
+
+1. **Pure-function chains** (LLMChain → LCEL). Easiest. No state, no persistence.
+2. **Embedding + vectorstore imports** (P38). Import path changes only; no behaviour change.
+3. **Stateless agents** (initialize_agent → create_react_agent without memory).
+4. **Streaming callers** (astream_log → astream_events v2). Watch for payload-shape bugs — the event dict is typed.
+5. **Stateful agents + memory** (ConversationBufferMemory → LangGraph checkpointer). Highest risk — needs the dual-write below.
+
+After each module: run its unit tests, commit with a pain-code reference (e.g. `refactor: migrate P39 LLMChain in billing-summariser to LCEL`).
+
+## Phase 3 — Dual-write for persistent chat histories
+
+If conversations are persisted (Redis, Postgres, Dynamo) and you cannot drop existing threads, dual-write for the cutover window:
+
+1. Keep the 0.3 history writer running. Every turn, also write to the 1.0 LangGraph checkpointer table/keyspace under the same `thread_id`.
+2. Reads in 1.0 code path always go to the checkpointer. Reads in any surviving 0.3 code path keep their old source.
+3. Run dual-write for at least one full retention window (24h for most chat products).
+4. After promotion (Phase 5), stop the 0.3 writer and delete the old store on a delay (not immediately — keeps the rollback viable).
+
+## Phase 4 — Shadow traffic in staging
+
+1. Deploy the 1.0 branch to a staging environment that mirrors production traffic shape. A mirror proxy (e.g. `goreplay`, `tcpcopy`, or a logged-request replayer) is ideal.
+2. Compare outputs on a sample (100–1000 requests) against the 0.3 production behaviour. Diff on:
+   - Response content (fuzzy — LLM outputs vary; look for catastrophic drift, not token-level diffs).
+   - Tool-call counts per turn (should be within +/- 1 on average; a big delta means the ReAct prompt changed behaviour).
+   - Latency p50/p95 (LangGraph adds a small state-serialisation cost; watch for regressions > 20%).
+   - Error rate (target: zero new `ImportError`, `AttributeError`, or `KeyError` on `intermediate_steps`).
+3. Exit criteria for Phase 4: 24h of shadow traffic with no new error classes and no regression on the four metrics above.
+
+## Phase 5 — Feature-flagged production cutover
+
+1. Put the 1.0 entrypoint behind a feature flag (`LANGCHAIN_1_0_ENABLED`). Default off.
+2. Canary: flip on for 1% of traffic. Watch dashboards for 30 minutes.
+3. Ramp: 10% → 25% → 50% → 100% over 2–4 hours, with a 15-minute soak at each step.
+4. At each step, the on-call engineer owns the rollback call. Rollback is always "flip the flag off" — not a redeploy.
+
+## Phase 6 — Pin and clean up
+
+1. After 100% for at least one full day, remove the feature flag and the 0.3 code path.
+2. Pin `langchain`, `langchain-core`, `langgraph`, `langchain-openai`, `langchain-anthropic`, and `anthropic` to exact versions in `requirements.txt`. This prevents a drive-by dependency update from re-introducing a 0.3 compatibility shim or a breaking 1.1 change.
+3. Delete the 0.3 dual-write path and, after the retention window, the 0.3 chat history store.
+4. Archive `requirements.lock.pre-1.0.txt` in the repo for one release cycle; delete after that.
+
+## Rollback Plan
+
+If Phase 5 reveals a regression:
+
+1. **Flip the flag off.** This is always step one. Traffic returns to the 0.3 code path within seconds.
+2. If the 0.3 code path has already been deleted (you are past Phase 6): `pip install -r requirements.lock.pre-1.0.txt` on the rollback branch, redeploy. This is a hard rollback and takes one deploy cycle.
+3. If persistent chat histories are involved, restore from the Phase 0 snapshot if the schema drift corrupted any 0.3-readable data. In practice, dual-write (Phase 3) prevents this — do not skip dual-write if you have persisted histories.
+
+## Exit Criteria (Migration is Done)
+
+- Zero hits on the verification greps in [breaking-changes-matrix.md](breaking-changes-matrix.md).
+- `pytest -W error::DeprecationWarning` is green.
+- `LANGCHAIN_1_0_ENABLED` flag is removed and all callers go through the 1.0 path.
+- `requirements.txt` pins all six packages to exact 1.0.x versions.
+- Post-mortem note in the repo: what broke, what the grep audit missed, so the next major bump is cheaper.


### PR DESCRIPTION
## Summary

Handcrafted skill covering the 0.3 → 1.0 migration for teams stuck on the legacy LangChain. Anchored to pain-catalog entries **P38, P39, P40, P41, P42, P66, P67**.

## Pain hook

Overview opens with the exact `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'` cascade that hits on the first restart after `pip install -U langchain`, then maps each removed API to its 1.0 replacement with a one-line codemod. Covers 7 named breaking changes; typically 10-100 files touched in a mid-sized service.

## Files

- `skills/langchain-upgrade-migration/SKILL.md` (271 lines)
- `skills/langchain-upgrade-migration/references/one-pager.md`
- `skills/langchain-upgrade-migration/references/breaking-changes-matrix.md`
- `skills/langchain-upgrade-migration/references/codemod-patterns.md`
- `skills/langchain-upgrade-migration/references/phased-rollout-playbook.md`
- `skills/langchain-upgrade-migration/references/migration-detection.md`

## Validator

Grade **A (96/100)** at both standard and enterprise tiers, zero ERROR lines.

## Base

This PR targets `feat/langchain-py-pack-foundation` (PR #546). Merges in after #546.

Jeremy made me do it
-claude