### PR TITLE
feat(langchain-py-pack): add langchain-langgraph-basics (L25)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: langchain-langgraph-basics
+description: |
+  Build a correct LangGraph 1.0 StateGraph — typed TypedDict state with reducers,
+  nodes, edges, compile, and recursion budgets — without hitting the silent-termination
+  and state-replacement traps. Use when writing your first LangGraph StateGraph,
+  diagnosing why a graph halted without reaching END, or picking recursion_limit.
+  Trigger with "langgraph statgraph", "langgraph basics", "GraphRecursionError",
+  "langgraph conditional edges".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, statgraph]
+compatible-with: claude-code, codex
+---
+
+# LangChain LangGraph Basics (Python)
+
+## Overview
+
+A conditional edge whose router returns a string that is not in `path_map` halts
+the graph without reaching `END`. No exception. No log line. The invocation just
+returns whatever state existed at the halt point — pain-catalog entry P56, and
+the single most common reason a newly wired `StateGraph` "almost works." The
+sibling pain: `Command(update={"messages": [msg]})` wipes the prior message
+history because `messages` was declared as a plain `list[AnyMessage]` instead of
+`Annotated[list[AnyMessage], add_messages]` — the reducer is what turns `update`
+into "append" instead of "replace" (P18).
+
+Two more gotchas this skill defuses:
+
+- P55 — `GraphRecursionError: Recursion limit of 25 reached` fires on graphs
+  that never loop, because `recursion_limit` counts **supersteps** (one step
+  per synchronous batch of node executions), not loop iterations. A planner
+  + executor + validator + summarizer can hit 25 without any cycle.
+- P20 — Upgrading `langgraph` silently reads old `PostgresSaver` checkpoints
+  as empty state. Checkpoint schemas evolve; `PostgresSaver.setup()` must be
+  rerun after every version bump before production traffic.
+
+This skill walks through a minimal `StateGraph` end to end: a `TypedDict` state
+with reducers on every list field, node functions that return partial-state
+dicts, edges and defensive conditional edges with `END` as a fallback in
+`path_map`, compilation with a checkpointer, `recursion_limit` sizing, and
+invocation with an explicit `thread_id`. Pin: `langgraph 1.0.x`,
+`langchain-core 1.0.x`. Pain-catalog anchors: P16, P18, P20, P55, P56.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install langgraph>=1.0,<2.0 langchain-core>=1.0,<2.0`
+- A chat model (see `langchain-model-inference`), or a pure-logic graph with no LLM
+- For persistence beyond a single process: `pip install langgraph-checkpoint-postgres` and a Postgres 14+ instance
+
+## Instructions
+
+### Step 1 — Define state as a `TypedDict` with reducers on list fields
+
+Every list-shaped field in state needs a reducer. Without one, `Command(update=...)`
+and node returns *replace* the field. The message-history reducer lives in
+`langgraph.graph.message`:
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+import operator
+
+class AgentState(TypedDict):
+    # Reducer "add_messages" appends + dedupes by message id (P18)
+    messages: Annotated[list[AnyMessage], add_messages]
+
+    # Plain list field also needs a reducer — use operator.add to concat
+    scratchpad: Annotated[list[str], operator.add]
+
+    # Scalars don't need a reducer; update replaces them
+    step_count: int
+    done: bool
+```
+
+If you forget the reducer on `messages`, a resume with
+`Command(update={"messages": [new_msg]})` will overwrite the entire prior
+history. Validate reducers are in place with `graph.get_graph().draw_mermaid()` —
+annotated fields render with their reducer name.
+
+See [State Reducers](references/state-reducers.md) for the built-in list
+(`add_messages`, `operator.add`, `max`, `min`) and how to write a custom merger
+for non-trivial merge logic.
+
+### Step 2 — Write nodes as functions that return partial-state dicts
+
+A node takes the full state and returns only the keys it wants to update. The
+reducer handles merge:
+
+```python
+def plan(state: AgentState) -> dict:
+    # Returning a dict means "update these fields"
+    return {
+        "messages": [("assistant", "Plan: step 1, step 2, step 3")],
+        "scratchpad": ["planned_at_step_1"],
+        "step_count": state["step_count"] + 1,
+    }
+
+def execute(state: AgentState) -> dict:
+    return {
+        "messages": [("assistant", f"Executed {state['step_count']} steps")],
+        "done": state["step_count"] >= 3,
+    }
+```
+
+Nodes must be deterministic on their inputs — LangGraph re-runs them during
+time-travel replay, and a side-effecting node (DB write without idempotency key)
+will double-fire. Push side effects to the checkpointer boundary or tool calls.
+
+### Step 3 — Wire edges and conditional edges defensively
+
+```python
+from typing import Literal
+from langgraph.graph import StateGraph, START, END
+
+# Router MUST return a value in the path_map keyset (P56)
+def should_continue(state: AgentState) -> Literal["execute", "end"]:
+    if state["done"] or state["step_count"] >= 10:
+        return "end"
+    return "execute"
+
+builder = StateGraph(AgentState)
+builder.add_node("plan", plan)
+builder.add_node("execute", execute)
+
+builder.add_edge(START, "plan")
+
+# path_map ALWAYS includes END as a fallback — if the router returns anything
+# else, the graph reaches END instead of halting silently (P56)
+builder.add_conditional_edges(
+    "plan",
+    should_continue,
+    path_map={"execute": "execute", "end": END},
+)
+builder.add_edge("execute", "plan")  # loop back to plan
+```
+
+The `Literal` return annotation on `should_continue` is a static guard — mypy
+catches typos before runtime. `path_map={"execute": "execute", "end": END}`
+is the spelled-out form; the compact form `path_map=["execute", END]` also works
+when router return values match node names directly.
+
+See [Conditional Edges](references/conditional-edges.md) for all four
+`add_conditional_edges` signatures, the `path` vs `path_map` distinction, and
+a pytest pattern that asserts every router return value hits a known route.
+
+### Step 4 — Compile with a checkpointer
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+# MemorySaver is in-process — use PostgresSaver in production (P20)
+checkpointer = MemorySaver()
+graph = builder.compile(checkpointer=checkpointer)
+```
+
+For production, swap to `langgraph.checkpoint.postgres.PostgresSaver`. After
+every `langgraph` version bump, run `PostgresSaver.setup()` in staging before
+prod traffic — the schema evolves and old rows are silently read as empty state.
+
+### Step 5 — Pick `recursion_limit` for the graph's superstep count
+
+`recursion_limit` defaults to **25**. It is not a loop counter; it counts
+**total supersteps**, and a superstep is one synchronous round of node
+executions (parallel branches in the same step count as one). Typical shapes:
+
+| Graph shape | Supersteps per run | Suggested `recursion_limit` |
+|---|---|---|
+| Simple ReAct agent (plan → tool → observe → done) | 6-12 | 15 |
+| Planner + executor + validator | 12-25 | 30 |
+| Deep agent with sub-plans, reflection, branch merge | 30-60 | 75 |
+| Fan-out with N parallel branches that re-join | N + merge steps | 2 × max depth |
+
+```python
+config = {
+    "configurable": {"thread_id": "user-42"},  # required for checkpointing (P16)
+    "recursion_limit": 30,
+}
+result = graph.invoke({"messages": [], "scratchpad": [], "step_count": 0, "done": False}, config)
+```
+
+If you hit `GraphRecursionError` on a graph that clearly isn't looping (P55),
+add `print(state["step_count"])` at the entry of each node to see the actual
+superstep count, then either raise the limit or restructure with a subgraph
+so each subgraph gets its own budget.
+
+See [Recursion Limits](references/recursion-limits.md) for the full derivation
+and a diagnostic script that traces superstep count at runtime.
+
+### Step 6 — Invoke with `thread_id` in `config["configurable"]`
+
+Every invocation against a checkpointer-backed graph needs a `thread_id` in
+`config["configurable"]`. Without it, each call gets a fresh state with no
+warning (P16). Enforce it at your application boundary:
+
+```python
+def run_agent(user_id: str, user_message: str) -> dict:
+    config = {
+        "configurable": {"thread_id": user_id},
+        "recursion_limit": 30,
+    }
+    assert config["configurable"].get("thread_id"), "thread_id required"
+    return graph.invoke(
+        {"messages": [("user", user_message)], "scratchpad": [], "step_count": 0, "done": False},
+        config,
+    )
+```
+
+See [First Graph Walkthrough](references/first-graph-walkthrough.md) for a
+line-by-line annotation of a minimal 3-node graph that demonstrates typed
+state, a reducer, and a conditional edge to `END`.
+
+## Decision Tree
+
+```
+Is your field a list you want to append?
+  -> Annotate with add_messages (for messages) or operator.add (for plain lists)
+
+Is your router adding a new output string?
+  -> Add that string to path_map BEFORE deploying; include END as a fallback
+
+Hitting GraphRecursionError on a non-looping graph?
+  -> supersteps != iterations; raise recursion_limit to 50 or split into subgraphs
+
+Upgraded langgraph minor version?
+  -> Re-run PostgresSaver.setup() in staging before routing prod traffic
+
+Multi-turn agent forgets between calls?
+  -> thread_id missing from config["configurable"] — enforce at boundary
+```
+
+## Output
+
+- `TypedDict` state with reducer annotations on every list field
+- Node functions returning partial-state dicts, free of hidden side effects
+- Conditional edges with `Literal`-typed routers and `END` in every `path_map`
+- Compiled graph with a checkpointer matched to the deployment shape
+- `recursion_limit` sized from the superstep count table, not the default 25
+- Invocations with explicit `thread_id` validated at the app boundary
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `GraphRecursionError: Recursion limit of 25 reached` | Supersteps counter, not loops (P55) | Raise `recursion_limit` or split into subgraphs; add per-node logging to count actual steps |
+| Graph halts without reaching `END`, no error | Router returned a value not in `path_map` (P56) | Type router as `Literal[...]`; include `END` as a default key in `path_map` |
+| `Command(update={"messages": [msg]})` wipes history | Missing reducer on list field (P18) | Annotate as `Annotated[list[AnyMessage], add_messages]` |
+| Multi-turn memory resets between calls, no warning | Missing `thread_id` in config (P16) | Assert `config["configurable"]["thread_id"]` at app boundary |
+| Old checkpoints read as empty state after upgrade | Schema change; `PostgresSaver` doesn't auto-migrate (P20) | Run `PostgresSaver.setup()` in staging after every `langgraph` bump |
+| `TypeError: Object of type datetime is not JSON serializable` at interrupt | Non-primitive in state (P17) | Keep state primitives-only; serialize complex types to ISO strings |
+| Node runs twice during replay | Time-travel re-executes deterministic nodes | Push side effects to tools or the checkpointer write boundary |
+
+## Examples
+
+### Building a minimal linear graph (no loop)
+
+Three nodes (`plan` → `execute` → `summarize`), no conditionals, one reducer on
+`messages`. Runs in 4 supersteps (START counts as one). Safe at default
+`recursion_limit=25`, but set it to 10 explicitly so readers see the budget.
+
+See [First Graph Walkthrough](references/first-graph-walkthrough.md) for the
+line-by-line annotation and the `graph.get_graph().draw_mermaid()` output.
+
+### Adding a conditional loop with a bounded retry budget
+
+A validator node that either completes (`"end"` → `END`) or retries
+(`"retry"` → back to executor), bounded by `step_count >= 3`. The router is
+`Literal["retry", "end"]` and `path_map` maps both. Caps at 7 supersteps, so
+`recursion_limit=15` is plenty of headroom.
+
+See [Conditional Edges](references/conditional-edges.md) for the full example
+and the pytest that iterates every `Literal` branch.
+
+### Diagnosing a mystery `GraphRecursionError`
+
+A planner that fans out to 4 parallel executors, then a validator, then a
+summarizer. Looks linear in the mermaid diagram, hits
+`GraphRecursionError: Recursion limit of 25 reached` on 10% of runs. Cause:
+each parallel executor counts as its own superstep branch when the merge node
+is conditional. Fix: raise to 50 or wrap the fan-out in a subgraph.
+
+See [Recursion Limits](references/recursion-limits.md) for the diagnostic
+script and the subgraph refactor.
+
+## Resources
+
+- [LangGraph: Low-level concepts (StateGraph, reducers, nodes, edges)](https://langchain-ai.github.io/langgraph/concepts/low_level/)
+- [LangGraph: Persistence and checkpointing](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [LangGraph: `add_messages` reducer](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.message.add_messages)
+- [LangGraph: `add_conditional_edges` API](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph.add_conditional_edges)
+- [LangGraph: Recursion limit and supersteps](https://langchain-ai.github.io/langgraph/how-tos/recursion-limit/)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P16, P17, P18, P20, P55, P56)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/conditional-edges.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/conditional-edges.md
@@ -1,0 +1,150 @@
+# Conditional Edges
+
+`add_conditional_edges` is where most first-time LangGraph graphs silently
+break. A router function that returns a value not in `path_map` halts the
+graph without reaching `END` — no exception, no log, just a quiet stop
+(pain-catalog P56).
+
+## Signature
+
+```python
+StateGraph.add_conditional_edges(
+    source: str,
+    path: Callable[[State], str | list[str] | Literal[...]],
+    path_map: dict[str, str] | list[str] | None = None,
+)
+```
+
+Four usable shapes:
+
+| Form | `path_map` | When to use |
+|---|---|---|
+| Router returns node names directly | `None` | Router returns "node_a" or "node_b" literally — fragile, easy to break on rename |
+| Router returns keys, `path_map` translates | `{"key_a": "node_a", "key_b": "node_b"}` | **Recommended** — decouples router vocab from graph topology |
+| Router returns a list of names (fan-out) | `None` or dict | Parallel branching via `Send` |
+| Router returns a `Literal`-typed key | `{"key": "node", ...}` | Adds static type safety via mypy |
+
+## The defensive pattern
+
+```python
+from typing import Literal
+from langgraph.graph import StateGraph, START, END
+
+def should_continue(state: State) -> Literal["execute", "end", "retry"]:
+    if state["failed_attempts"] > 3:
+        return "end"
+    if state["needs_retry"]:
+        return "retry"
+    return "execute"
+
+builder.add_conditional_edges(
+    "validator",
+    should_continue,
+    path_map={
+        "execute": "executor",
+        "retry":   "executor",  # two keys can point to same node
+        "end":     END,         # ALWAYS include END as a fallback key
+    },
+)
+```
+
+Three rules that prevent P56:
+
+1. **Type the router with `Literal[...]`.** Mypy will flag a `return "Execute"`
+   typo. Runtime errors surface at type-check time, not in production.
+2. **Always include `END` in `path_map`.** Even if your router never intends to
+   return "end," having it as a valid route means unknown returns route to END
+   instead of halting silently. If you detect an unknown return, log loudly.
+3. **Assert the router return is a `path_map` key** during dev:
+
+   ```python
+   def should_continue(state: State) -> Literal["execute", "end"]:
+       result = "end" if state["done"] else "execute"
+       assert result in {"execute", "end"}, f"Unknown route: {result!r}"
+       return result
+   ```
+
+## Fan-out with `Send`
+
+For parallel branching (one planner fan-outs to N executors), the router
+returns a list of `Send` objects:
+
+```python
+from langgraph.types import Send
+
+def dispatch(state: State) -> list[Send]:
+    return [Send("executor", {"task": t}) for t in state["tasks"]]
+
+builder.add_conditional_edges("planner", dispatch, ["executor"])
+```
+
+Each `Send` becomes one node invocation in the next superstep. This inflates
+superstep count linearly with fan-out — see [Recursion Limits](recursion-limits.md)
+for sizing.
+
+## Testing conditional routes
+
+Every branch of the router should have a unit test that asserts the return
+value is in `path_map`:
+
+```python
+import pytest
+from typing import get_args
+
+PATH_MAP = {"execute": "executor", "retry": "executor", "end": END}
+
+@pytest.mark.parametrize("state,expected", [
+    ({"failed_attempts": 0, "needs_retry": False}, "execute"),
+    ({"failed_attempts": 0, "needs_retry": True},  "retry"),
+    ({"failed_attempts": 5, "needs_retry": False}, "end"),
+])
+def test_router_covers_all_paths(state, expected):
+    result = should_continue(state)
+    assert result == expected
+    assert result in PATH_MAP, f"Router returned {result!r}, not in path_map"
+```
+
+One test per `Literal` arm. If you add a new return value to the router, the
+test suite fails until you extend both `path_map` and the parametrize list.
+
+## Common mistakes
+
+### Returning a bare string instead of a key
+
+```python
+# BAD — "Retry" (capital R) is not in path_map
+def router(state): return "Retry"  # P56 triggered
+```
+
+### `path_map=None` with renamed nodes
+
+```python
+def router(state): return "executor"  # matches a node name today
+
+builder.add_conditional_edges("planner", router)  # no path_map
+
+# Six months later a teammate renames "executor" to "worker".
+# Router still returns "executor" — graph silently halts.
+```
+
+Always use `path_map` even when router returns match node names. The map is the
+contract.
+
+### Async router missing `await`
+
+```python
+async def router(state): return "end"
+
+# BAD — passing the coroutine, not the value
+builder.add_conditional_edges("node", router)  # works, but must not be called as await router()
+```
+
+`add_conditional_edges` accepts both sync and async routers. Don't add `await`
+yourself — the compiled graph handles it.
+
+## References
+
+- [LangGraph: Conditional edges](https://langchain-ai.github.io/langgraph/concepts/low_level/#conditional-edges)
+- [LangGraph: `add_conditional_edges` API](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph.add_conditional_edges)
+- [LangGraph: `Send` API for fan-out](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.Send)
+- Pain catalog: P56

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/first-graph-walkthrough.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/first-graph-walkthrough.md
@@ -1,0 +1,177 @@
+# First Graph Walkthrough
+
+Annotated, line-by-line walkthrough of a minimal 3-node LangGraph 1.0
+`StateGraph`. Demonstrates typed state with one reducer, a conditional edge
+with `END` in `path_map`, and invocation with an explicit `thread_id`.
+
+Target: a loop that plans, executes, and decides whether to continue or stop.
+7 supersteps at most, safe at `recursion_limit=15`.
+
+## Complete working example
+
+```python
+from typing import Annotated, Literal, TypedDict
+from langchain_core.messages import AnyMessage, HumanMessage, AIMessage
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langgraph.checkpoint.memory import MemorySaver
+import operator
+
+
+# 1. STATE ------------------------------------------------------------------
+class AgentState(TypedDict):
+    # Reducer: add_messages dedupes by id, appends otherwise (P18)
+    messages: Annotated[list[AnyMessage], add_messages]
+    # Reducer: operator.add concatenates lists
+    scratchpad: Annotated[list[str], operator.add]
+    # Scalars: no reducer, updates replace
+    step_count: int
+    done: bool
+
+
+# 2. NODES ------------------------------------------------------------------
+def plan(state: AgentState) -> dict:
+    """Plan the next step. Returns partial state — reducer merges."""
+    plan_text = f"Step {state['step_count'] + 1}: think about it"
+    return {
+        "messages": [AIMessage(f"Planning: {plan_text}", id=f"plan-{state['step_count']}")],
+        "scratchpad": [plan_text],
+        "step_count": state["step_count"] + 1,
+    }
+
+
+def execute(state: AgentState) -> dict:
+    """Pretend to execute. In a real agent, bind tools here."""
+    result = f"Executed step {state['step_count']}"
+    return {
+        "messages": [AIMessage(result, id=f"exec-{state['step_count']}")],
+        "done": state["step_count"] >= 3,  # stop after 3 iterations
+    }
+
+
+# 3. ROUTER -----------------------------------------------------------------
+# Literal return type lets mypy catch typos and ensures every arm is handled
+def should_continue(state: AgentState) -> Literal["execute", "end"]:
+    if state["done"] or state["step_count"] >= 10:
+        return "end"
+    return "execute"
+
+
+# 4. GRAPH ------------------------------------------------------------------
+builder = StateGraph(AgentState)
+builder.add_node("plan", plan)
+builder.add_node("execute", execute)
+
+builder.add_edge(START, "plan")
+
+# path_map ALWAYS includes END — unknown router returns route here (P56)
+builder.add_conditional_edges(
+    "plan",
+    should_continue,
+    path_map={"execute": "execute", "end": END},
+)
+builder.add_edge("execute", "plan")  # loop back
+
+# 5. COMPILE ----------------------------------------------------------------
+checkpointer = MemorySaver()  # swap to PostgresSaver in prod (P20)
+graph = builder.compile(checkpointer=checkpointer)
+
+
+# 6. INVOKE -----------------------------------------------------------------
+config = {
+    "configurable": {"thread_id": "demo-1"},  # required for checkpointing (P16)
+    "recursion_limit": 15,                    # supersteps, not iterations (P55)
+}
+
+initial: AgentState = {
+    "messages": [HumanMessage("Start", id="user-0")],
+    "scratchpad": [],
+    "step_count": 0,
+    "done": False,
+}
+
+result = graph.invoke(initial, config)
+print(result["scratchpad"])
+# ['Step 1: think about it', 'Step 2: think about it', 'Step 3: think about it']
+print(len(result["messages"]))
+# 7  (1 human + 3 plan AIMessages + 3 exec AIMessages)
+```
+
+## What each decision buys you
+
+### Line-by-line rationale
+
+| Block | Why it's written this way |
+|---|---|
+| `messages: Annotated[list[AnyMessage], add_messages]` | Without the `Annotated` reducer, `Command(update={"messages": [...]})` would replace history instead of append (P18) |
+| Stable `id=f"plan-{state['step_count']}"` | `add_messages` dedupes by id. Without stable ids, retries would duplicate messages |
+| `scratchpad: Annotated[list[str], operator.add]` | Plain list field still needs a reducer to concatenate on update |
+| `step_count: int` (no reducer) | Scalars always replace; reducer would be no-op noise |
+| `Literal["execute", "end"]` on router | Mypy catches `return "End"` typos; every arm must be covered |
+| `path_map={"execute": "execute", "end": END}` | END as a fallback key prevents silent halt (P56) |
+| `MemorySaver()` | In-process only. `PostgresSaver` for prod, and re-run `setup()` on every version bump (P20) |
+| `"thread_id": "demo-1"` | Checkpointer keys state by thread_id. Missing it silently resets memory (P16) |
+| `"recursion_limit": 15` | 4 iterations × 2 supersteps/iteration + START = 9. 15 is 1.5x headroom (P55) |
+
+## Verifying the graph
+
+After compile, render the graph and eyeball the reducers:
+
+```python
+print(graph.get_graph().draw_mermaid())
+```
+
+Output (simplified):
+
+```
+graph TD;
+  __start__ --> plan;
+  plan -.-> execute;
+  plan -.-> __end__;
+  execute --> plan;
+```
+
+The dashed arrows (`-.->`) mark conditional edges. Solid arrows are
+unconditional. If you see a dashed arrow without a visible target in
+`path_map`, that's P56 waiting to happen.
+
+## Extending the example
+
+### Add a real LLM
+
+Replace the hardcoded plan/execute with a chat model call. See
+`langchain-model-inference` for provider-safe initialization.
+
+```python
+from langchain_anthropic import ChatAnthropic
+llm = ChatAnthropic(model="claude-sonnet-4-6", temperature=0, timeout=30)
+
+def plan(state: AgentState) -> dict:
+    response = llm.invoke(state["messages"])
+    return {"messages": [response], "step_count": state["step_count"] + 1}
+```
+
+### Add a tool call
+
+Bind tools to the LLM and route to an `execute_tools` node when the model
+returns tool_calls. See the `langgraph.prebuilt.ToolNode` helper.
+
+### Swap to Postgres
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+from psycopg_pool import ConnectionPool
+
+pool = ConnectionPool(os.environ["POSTGRES_URL"])
+checkpointer = PostgresSaver(pool)
+checkpointer.setup()  # run after every langgraph upgrade (P20)
+graph = builder.compile(checkpointer=checkpointer)
+```
+
+## References
+
+- [LangGraph: Low-level concepts](https://langchain-ai.github.io/langgraph/concepts/low_level/)
+- [LangGraph: Persistence](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [LangGraph: MemorySaver](https://langchain-ai.github.io/langgraph/reference/checkpoints/#langgraph.checkpoint.memory.MemorySaver)
+- [LangGraph: PostgresSaver](https://langchain-ai.github.io/langgraph/reference/checkpoints/#langgraph.checkpoint.postgres.PostgresSaver)
+- Pain catalog: P16, P18, P20, P55, P56

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-langgraph-basics — One-Pager
+
+Build a correct LangGraph 1.0 StateGraph without silent halts, list replacement, or mystery `GraphRecursionError`s.
+
+## The Problem
+
+A conditional edge whose router returns a string that isn't in `path_map` halts the graph without reaching `END` — no exception, no log line, just a silent stop (P56). A `Command(update={"messages": [msg]})` wipes your entire message history because the `messages` field wasn't annotated with an `add_messages` reducer (P18). `GraphRecursionError: Recursion limit of 25 reached` fires on a graph with no loop because the limit counts supersteps, not iterations (P55). And a `langgraph` minor version bump silently reads old `PostgresSaver` rows as empty state because checkpoint schemas don't auto-migrate (P20).
+
+## The Solution
+
+This skill walks through a LangGraph 1.0 `StateGraph` end to end: a `TypedDict` state with `Annotated[list, add_messages]` reducers on every list field, node functions that return partial-state dicts, edges plus conditional edges with a `path_map` that always includes `END`, compilation with a checkpointer, a `recursion_limit` sized to the graph's superstep count, and invocation with an explicit `thread_id` in `config["configurable"]`. Pinned to `langgraph 1.0.x` with four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers and researchers building their first LangGraph 1.0 agent or multi-step workflow. Comfortable with LangChain, new to `StateGraph`. |
+| **What** | Typed state with reducers, node/edge wiring, conditional-edge defensive patterns, recursion-limit sizing, checkpointer compile, thread-scoped invocation, 4 references (state-reducers, conditional-edges, recursion-limits, first-graph-walkthrough) |
+| **When** | Writing your first `StateGraph`, diagnosing why a graph halted without reaching `END`, picking `recursion_limit`, or migrating from legacy `AgentExecutor` to `create_react_agent` from LangGraph |
+
+## Key Features
+
+1. **Reducer-safe TypedDict state** — Every list field uses `Annotated[list, add_messages]` (or `operator.add`, or a custom merger), so `Command(update=...)` appends instead of replaces (fixes P18)
+2. **Defensive conditional edges** — Router functions are explicitly typed to return keys from a bounded `Literal` set, and `path_map` always maps an `END` fallback so unknown returns land there instead of halting silently (fixes P56)
+3. **Recursion-limit sizing guide** — Superstep counts for common shapes (simple ReAct ~15, planner+executor ~30, deep-agent 50+) with a runbook for diagnosing `GraphRecursionError` (fixes P55)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/recursion-limits.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/recursion-limits.md
@@ -1,0 +1,129 @@
+# Recursion Limits
+
+`recursion_limit` on LangGraph defaults to **25**. The name is misleading — it
+is not a loop counter. It counts **total supersteps**, and a superstep is one
+synchronous round of node executions. A linear graph with enough nodes can hit
+25 without any loop; a graph with parallel branches inflates the count further.
+This is pain-catalog entry P55.
+
+## What counts as a superstep
+
+One superstep = one batch of nodes that run in parallel after a state update.
+
+- Entering `START` and dispatching to the first node: **1 superstep**
+- Each sequential node transition: **+1 superstep**
+- A `Send`-based fan-out to N parallel nodes: **+1 superstep** (not +N — parallel branches share a step)
+- The merge node after a fan-out: **+1 superstep**
+- Reaching `END`: the run stops, no additional count
+
+```
+START -> plan (1) -> execute (2) -> validate (3) -> END      # 3 supersteps
+START -> plan (1) -> [exec_a, exec_b, exec_c] (2) -> merge (3) -> END    # 3 supersteps
+```
+
+## Typical budgets
+
+| Graph shape | Description | Supersteps | Suggested `recursion_limit` |
+|---|---|---|---|
+| Simple ReAct (plan → tool → observe → end) | 3-4 node loop, 2-3 iterations | 6-12 | 15 |
+| Planner + executor + validator | 3-stage pipeline with 1-2 retries | 12-25 | 30 |
+| Chain-of-thought with reflection | Plan, act, reflect, revise, act, done | 15-30 | 40 |
+| Deep agent (sub-planners, scratch FS) | Nested planning, branch merge, summary | 30-60 | 75 |
+| Fan-out N parallel branches + merge | Depends on depth, not on N (parallel branches share a step) | 2 × max_depth | 2 × max_depth + 10 headroom |
+
+Default 25 is safe for simple ReAct, dangerous for anything planner-shaped.
+
+## Sizing your graph
+
+Add a step counter to state and log every node entry:
+
+```python
+from typing import Annotated, TypedDict
+import operator
+
+class State(TypedDict):
+    step_count: Annotated[int, operator.add]  # each node increments by 1
+    # ... rest of state
+
+def instrument(fn):
+    """Wrap a node to log superstep count."""
+    def wrapped(state: State) -> dict:
+        print(f"[superstep ~{state['step_count']}] {fn.__name__}")
+        update = fn(state)
+        return {**update, "step_count": 1}  # operator.add increments
+    return wrapped
+
+builder.add_node("plan", instrument(plan))
+builder.add_node("execute", instrument(execute))
+```
+
+Run one invocation and read the log. Pick `recursion_limit` = observed max +
+50% headroom.
+
+## Diagnosing `GraphRecursionError` on a non-looping graph
+
+If a graph that clearly doesn't loop hits `GraphRecursionError`, the usual
+cause is one of:
+
+1. **A conditional edge loops on a condition that never terminates.** The
+   router returns "retry" forever because the retry counter is never
+   incremented. Fix: increment a counter in state and short-circuit at N
+   retries.
+
+2. **A fan-out fans to more branches than expected.** A router returning
+   `[Send(...) for t in state["tasks"]]` where `tasks` grew unboundedly.
+   Fix: cap the task list or batch into chunks of K.
+
+3. **A subgraph is counted at the parent budget.** Subgraphs consume the
+   parent's recursion budget by default. Fix: compile the subgraph with its
+   own higher `recursion_limit`, or restructure so it runs as a tool call
+   rather than an inline subgraph.
+
+4. **The graph really is that long.** Planner + executor + validator +
+   summarizer + formatter = 5 nodes × 5 iterations = 25 supersteps. Raise
+   the limit.
+
+## Raising the limit
+
+```python
+config = {
+    "configurable": {"thread_id": "user-42"},
+    "recursion_limit": 50,  # supersteps, not iterations
+}
+result = graph.invoke(inputs, config)
+```
+
+There is no hard upper bound, but be deliberate. A runaway graph at
+`recursion_limit=1000` will burn tokens and wall time before it errors.
+Pair high limits with a per-session token budget (see
+`langchain-cost-tuning`) and a wall-clock timeout.
+
+## Subgraph refactor
+
+When a graph hits recursion limits because one stage is complex, extract
+that stage into a subgraph with its own budget:
+
+```python
+# The complex executor stage becomes its own graph
+exec_builder = StateGraph(ExecutorState)
+# ... build the executor subgraph ...
+exec_graph = exec_builder.compile()  # no checkpointer — inherit from parent
+
+# Parent graph invokes the subgraph as a node
+def execute_node(state: ParentState) -> dict:
+    sub_config = {"recursion_limit": 30}  # subgraph has its own budget
+    sub_result = exec_graph.invoke({"task": state["task"]}, sub_config)
+    return {"result": sub_result["output"]}
+
+parent_builder.add_node("execute", execute_node)
+```
+
+The parent budget now only counts "execute" as 1 superstep, regardless of how
+many supersteps the subgraph internally consumes.
+
+## References
+
+- [LangGraph: Recursion limit](https://langchain-ai.github.io/langgraph/how-tos/recursion-limit/)
+- [LangGraph: Supersteps concept](https://langchain-ai.github.io/langgraph/concepts/low_level/#graphs)
+- [LangGraph: Subgraphs](https://langchain-ai.github.io/langgraph/concepts/low_level/#subgraphs)
+- Pain catalog: P55, P10 (related — agent loops on vague prompts)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/state-reducers.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/references/state-reducers.md
@@ -1,0 +1,132 @@
+# State Reducers
+
+Every list-shaped field in a LangGraph `TypedDict` state needs a reducer.
+Without one, node returns and `Command(update=...)` calls *replace* the field
+instead of merging. This is pain-catalog entry P18 and the #1 reason a resumed
+graph loses its prior message history.
+
+## Built-in reducers
+
+| Reducer | Import | Behavior | When to use |
+|---|---|---|---|
+| `add_messages` | `from langgraph.graph.message import add_messages` | Append + dedupe by `id`; overwrites existing messages when ids match | `list[AnyMessage]` / `list[BaseMessage]` — the default for chat |
+| `operator.add` | `import operator` | Concatenate lists (or sum numerics) | Plain `list[str]` / `list[int]` / `list[dict]` scratchpads |
+| `max` | built-in | Keep the larger value | Monotonic counters, timestamps |
+| `min` | built-in | Keep the smaller value | Best-so-far tracking |
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+import operator
+
+class State(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]  # dedupe by id
+    observations: Annotated[list[str], operator.add]     # concat
+    best_score: Annotated[float, max]                    # monotonic
+    earliest_hit: Annotated[float, min]                  # monotonic
+    user_id: str                                         # scalar — no reducer needed
+```
+
+## `add_messages` — the non-obvious behavior
+
+`add_messages` does not just concatenate. It matches incoming messages by `id`
+and replaces existing entries, which is how LangGraph supports message edits
+and tool-call retries:
+
+```python
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.graph.message import add_messages
+
+existing = [HumanMessage("hi", id="1"), AIMessage("hello", id="2")]
+new = [AIMessage("hello there", id="2")]  # same id as existing
+
+merged = add_messages(existing, new)
+# merged == [HumanMessage("hi", id="1"), AIMessage("hello there", id="2")]
+```
+
+This is why you must always include stable `id`s on messages you construct
+manually. If you build messages without ids, every node return appends a new
+entry and the history grows unboundedly.
+
+## Writing a custom reducer
+
+When built-ins don't cover your merge semantics — set union, dict merge,
+time-ordered deque — write a two-arg function:
+
+```python
+from typing import Annotated, TypedDict
+
+def dict_merge(left: dict, right: dict) -> dict:
+    """Shallow dict merge; right wins on key collision."""
+    return {**left, **right}
+
+def set_union(left: list[str], right: list[str]) -> list[str]:
+    """Treat lists as sets, deduplicate preserving insertion order."""
+    seen = {}
+    for item in list(left) + list(right):
+        seen[item] = None
+    return list(seen.keys())
+
+class State(TypedDict):
+    metadata: Annotated[dict, dict_merge]
+    visited_nodes: Annotated[list[str], set_union]
+```
+
+Reducers are called every time the graph merges a node return or a
+`Command(update=...)` payload into state. They must be pure functions — no
+side effects, no global mutation. LangGraph may call them during replay.
+
+## Validating reducers are wired
+
+```python
+graph = builder.compile(checkpointer=checkpointer)
+print(graph.get_graph().draw_mermaid())
+# Annotated fields render as `messages: list[AnyMessage] (add_messages)`.
+# If a list field shows just `messages: list` with no reducer name, it's missing.
+```
+
+Also worth a runtime check at first invocation:
+
+```python
+import inspect
+from langgraph.graph.state import StateGraph
+
+# StateGraph inspects Annotated metadata at compile time. Pull out the
+# channel spec and assert every list field has a reducer callable.
+for name, channel in graph.channels.items():
+    if hasattr(channel, "reducer"):
+        assert channel.reducer is not None, f"Missing reducer on {name}"
+```
+
+## The one that breaks most teams
+
+Resuming an interrupted graph with `Command(update={"messages": [new]})` when
+`messages` has no reducer:
+
+```python
+# BAD — no reducer, update replaces messages entirely
+class State(TypedDict):
+    messages: list[AnyMessage]  # no Annotated, no reducer
+
+# Resume wipes prior history:
+graph.invoke(Command(update={"messages": [new_msg]}), config)
+# state["messages"] is now [new_msg], losing everything before
+```
+
+```python
+# GOOD — reducer makes update append
+class State(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+# Resume appends (or replaces-by-id):
+graph.invoke(Command(update={"messages": [new_msg]}), config)
+# state["messages"] is prior_history + [new_msg]
+```
+
+## References
+
+- [LangGraph: State and reducers](https://langchain-ai.github.io/langgraph/concepts/low_level/#state)
+- [LangGraph: `add_messages`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.message.add_messages)
+- [LangGraph: Custom reducers](https://langchain-ai.github.io/langgraph/how-tos/state-reducers/)
+- Pain catalog: P18


### PR DESCRIPTION
## Summary

Handcrafted skill covering LangGraph 1.0 StateGraph fundamentals — typed state with reducers, conditional edges that actually reach END, and recursion budgets sized from superstep counts. Anchored to pain-catalog **P18, P20, P55, P56**.

## Pain hook

A LangGraph conditional edge whose router returns a string not in `path_map` halts the graph without reaching END — no exception, no log, just a quiet stop (P56). Separately, `Command(update={"messages": [msg]})` wipes prior history because `messages` was not annotated with an `add_messages` reducer (P18). Skill requires `Annotated[list, add_messages]` on every list state field, `Literal[...]`-typed routers with END in every `path_map`, and explicit `recursion_limit` sized from the superstep-count table instead of the misleading default of 25.

## Files

- `skills/langchain-langgraph-basics/SKILL.md` (281 lines)
- `skills/langchain-langgraph-basics/references/one-pager.md`
- `skills/langchain-langgraph-basics/references/state-reducers.md`
- `skills/langchain-langgraph-basics/references/conditional-edges.md`
- `skills/langchain-langgraph-basics/references/recursion-limits.md`
- `skills/langchain-langgraph-basics/references/first-graph-walkthrough.md`

## Validator

Grade **A (92/100)** at both standard and enterprise tiers, zero ERROR lines.

## Base

Targets `feat/langchain-py-pack-foundation` (PR #546). Merges in after #546.

Jeremy made me do it
-claude