### PR TITLE
feat(langchain-py-pack): add langchain-eval-harness (research-grade measurement)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: langchain-eval-harness
+description: |
+  Build reproducible evaluation pipelines for LangChain 1.0 chains and LangGraph 1.0
+  agents — golden datasets, LangSmith evaluate(), ragas RAG metrics, deepeval
+  LLM-as-judge, agent trajectory analysis, and CI gating on quality regressions.
+  Use when setting up quality measurement for a new chain, diagnosing regression
+  after a model switch, or building an evaluation gate for a pull request.
+  Trigger with "langchain eval", "langsmith evaluate", "ragas", "llm-as-judge",
+  "agent trajectory eval", "eval regression gate".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*), Bash(pytest:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, evaluation, langsmith, ragas, deepeval, research]
+compatible-with: claude-code, codex
+---
+
+# LangChain Eval Harness (Python)
+
+## Overview
+
+A team swapped `gpt-4o` for `claude-sonnet-4-6` to save money and a week later CS
+noticed answer quality dropped on 15% of refund tickets — the regression was
+invisible in code review and invisible in CI because no golden set existed.
+
+Fix: a versioned golden set, a stacked eval pipeline (LangSmith +
+ragas + deepeval + custom trajectory), and a PR-blocking regression gate
+with paired Wilcoxon significance. The tooling exists; the patterns for
+wiring it into a statistically honest loop are scattered across five doc sites.
+
+Build a 100-example JSONL golden set, wire LangSmith `evaluate()` with a
+custom correctness evaluator, add a ragas quartet (faithfulness, answer
+relevance, context precision/recall) for RAG, add deepeval LLM-as-judge
+with N=3 judge quorum, score LangGraph trajectories on coverage/precision/
+order, and gate PRs on a 2% aggregate drop or 5% per-example drop. Pin:
+`langchain-core 1.0.x`, `langgraph 1.0.x`, `langsmith>=0.2`, `ragas>=0.2`,
+`deepeval>=2.0`. Pain-catalog anchors: P01, P11, P12, P22, P33.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0` for the system under eval
+- `pip install langsmith>=0.2 ragas>=0.2 deepeval>=2.0 scipy`
+- LangSmith account + `LANGSMITH_API_KEY` (free tier is sufficient for dataset versioning)
+- Provider API keys for the judge LLM: `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY`
+
+## Instructions
+
+### Step 1 — Build a versioned golden set
+
+Format: JSONL, one example per line, with a `dataset_version` tag. Minimum 20
+examples to start; grow to 100 for PR gating, 200+ for absolute-metric claims.
+
+```python
+# evals/golden_set/v2026.04.jsonl
+{"id": "gs-0001", "input": "Refund policy for SKU ABC-42?", "expected": "30 days with receipt", "contexts": ["policy_v3.md"], "tags": ["refund"], "difficulty": "easy", "dataset_version": "2026.04"}
+{"id": "gs-0002", "input": "Return policy for opened software?", "expected": "No, opened software is final sale", "contexts": ["policy_v3.md#returns"], "tags": ["refund"], "difficulty": "medium", "dataset_version": "2026.04"}
+```
+
+Sample from real traffic (redacted), not imagination. Stratify by tag and
+difficulty (aim for 30% hard). Two annotators per example, disagreements
+reconciled — reconciliation rate under 90% means your task definition is
+ambiguous. Treat the file as immutable within a version; bump the version
+to refresh. See [Golden Set Curation](references/golden-set-curation.md) for
+sourcing strategy, annotation tool options, and the refresh cadence.
+
+### Step 2 — Wire LangSmith `evaluate()` with a custom evaluator
+
+```python
+from langsmith import Client
+from langsmith.evaluation import evaluate, EvaluationResult
+from langchain_anthropic import ChatAnthropic
+
+client = Client()
+DATASET_VERSION = "2026.04"
+
+# One-time: upload golden set as a versioned dataset
+def upload_golden_set(jsonl_path, dataset_name):
+    examples = [json.loads(line) for line in open(jsonl_path)]
+    client.create_dataset(dataset_name)
+    client.create_examples(
+        inputs=[{"input": e["input"]} for e in examples],
+        outputs=[{"expected": e["expected"]} for e in examples],
+        metadata=[{"id": e["id"], "tags": e["tags"]} for e in examples],
+        dataset_name=dataset_name,
+    )
+
+chain = ChatAnthropic(model="claude-sonnet-4-6", temperature=0, timeout=30)
+
+def target(inputs):
+    return {"answer": chain.invoke(inputs["input"]).content}
+
+def correctness(outputs, reference_outputs):
+    """Deterministic exact-match floor — baseline, not ceiling."""
+    match = outputs["answer"].strip().lower() == reference_outputs["expected"].strip().lower()
+    return EvaluationResult(key="exact_match", score=float(match))
+
+results = evaluate(
+    target,
+    data=f"golden-set-v{DATASET_VERSION}",
+    evaluators=[correctness],
+    experiment_prefix="refund-bot-v3",
+    max_concurrency=10,   # Avoid 429s on judge LLM (P22)
+)
+```
+
+Free-form outputs need semantic scoring (ragas, deepeval, or LLM-as-judge — Step 4).
+
+### Step 3 — Add ragas metrics for RAG pipelines
+
+For a RAG chain returning `{answer, contexts}`, ragas scores four standard
+dimensions. The default judge is `gpt-4o-mini`; override to pin model +
+cost:
+
+```python
+from ragas import evaluate as ragas_evaluate
+from ragas.metrics import faithfulness, answer_relevancy, context_precision, context_recall
+from langchain_openai import ChatOpenAI
+from langchain_openai import OpenAIEmbeddings
+from datasets import Dataset
+
+judge = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+embed = OpenAIEmbeddings(model="text-embedding-3-small")
+
+# Prepare rows — ragas wants HuggingFace Dataset shape
+rows = []
+for ex in golden_examples:
+    result = rag_chain.invoke({"question": ex["input"]})
+    rows.append({
+        "question": ex["input"],
+        "answer": result["answer"],
+        "contexts": [d.page_content for d in result["source_documents"]],
+        "ground_truth": ex["expected"],
+    })
+
+ragas_results = ragas_evaluate(
+    Dataset.from_list(rows),
+    metrics=[faithfulness, answer_relevancy, context_precision, context_recall],
+    llm=judge,
+    embeddings=embed,
+)
+# ragas_results is a dict of per-metric means; call .to_pandas() for per-row
+```
+
+Do not use ragas on non-RAG chains — `context_precision` against an empty
+context list returns 0 and looks like a regression. See
+[Framework Comparison](references/framework-comparison.md) for when each
+tool fits.
+
+### Step 4 — Add deepeval LLM-as-judge for free-form outputs
+
+deepeval is pytest-shaped — each example is an `LLMTestCase` asserting against
+metrics. Run N=3 judge invocations per example and take the median to tame
+LLM-as-judge variance (±5-15% across runs; single-run scores are not CI-ready):
+
+```python
+import statistics
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+def eval_with_quorum(test_case, metric, n=3):
+    scores = []
+    for _ in range(n):
+        metric.measure(test_case)
+        scores.append(metric.score)
+    return statistics.median(scores), statistics.stdev(scores) if n > 1 else 0.0
+
+correctness = GEval(
+    name="Correctness",
+    criteria="Does the actual output match the expected output in meaning?",
+    evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT, LLMTestCaseParams.EXPECTED_OUTPUT],
+    model="gpt-4o-mini",
+)
+
+for ex in golden_examples:
+    result = chain.invoke({"input": ex["input"]})
+    case = LLMTestCase(input=ex["input"], actual_output=result, expected_output=ex["expected"])
+    median, sd = eval_with_quorum(case, correctness, n=3)
+    if sd > 0.2:  # judge disagreeing with itself — flag, don't gate
+        flag_for_review(ex["id"], median, sd)
+```
+
+### Step 5 — LangGraph agent trajectory eval
+
+For agents, final-answer correctness misses the process. Score the tool-call
+sequence on three axes — coverage (did required tools run?), precision
+(were extra tools used?), and order (Kendall's tau on shared tools):
+
+```python
+from langchain_core.messages import AIMessage
+
+def extract_trajectory(final_state: dict) -> list[dict]:
+    return [
+        {"tool": tc["name"], "args": tc["args"]}
+        for msg in final_state["messages"] if isinstance(msg, AIMessage)
+        for tc in (msg.tool_calls or [])
+    ]
+
+def trajectory_score(expected: list[str], actual: list[str]) -> dict:
+    e_set, a_set = set(expected), set(actual)
+    coverage = len(e_set & a_set) / len(e_set) if e_set else 1.0
+    precision = len(e_set & a_set) / len(a_set) if a_set else 0.0
+    shared = [t for t in actual if t in e_set]
+    order = _kendall_tau(expected, shared) if len(shared) >= 2 else 1.0
+    return {"coverage": coverage, "precision": precision, "order": order}
+
+# Composite: 0.5 * coverage + 0.3 * precision + 0.2 * order
+```
+
+Set `temperature=0` for the agent during eval — `temperature > 0` produces
+different trajectories across runs (P11) and makes paired comparison
+statistically invalid. See [Agent Trajectory Eval](references/agent-trajectory-eval.md)
+for args-level matching, efficiency/safety scoring, and the LLM-as-judge
+fallback for non-deterministic trajectories.
+
+### Step 6 — Gate PRs on regression
+
+A PR touching prompts, chain code, or model config runs the eval suite on
+PR branch and `main`, then blocks merge on any of: aggregate mean drop > **2.0%**,
+any single-example drop > **5.0%**, or paired Wilcoxon signed-rank p < 0.05
+with negative mean delta.
+
+```python
+from scipy.stats import wilcoxon
+
+def paired_regression_check(baseline, candidate, alpha=0.05):
+    """Wilcoxon — right test when metric distribution is non-normal (most LLM metrics)."""
+    n = len(baseline)
+    if n < 50:
+        return {"verdict": "too_small_n", "n": n}
+    diffs = [c - b for b, c in zip(baseline, candidate)]
+    _, p = wilcoxon(diffs, alternative="less")
+    return {"n": n, "mean_delta": sum(diffs) / n, "p_value": float(p),
+            "regression": p < alpha and sum(diffs) < 0}
+```
+
+At n=100 and α=0.05 this detects a ~3-5% true regression at ~80% power. See
+[CI Integration](references/ci-integration.md) for the GitHub Actions workflow,
+PR-comment delta table, bootstrap CI, and spend/rate-limit safety rails.
+
+## Output
+
+- JSONL golden set at `evals/golden_set/v2026.04.jsonl` with an immutable version tag
+- LangSmith dataset uploaded and versioned; experiment runs linked to traces
+- Ragas scores (faithfulness, answer relevance, context precision/recall) on RAG chains
+- Deepeval `LLMTestCase` assertions in pytest, with median-of-3 judge quorum
+- LangGraph trajectory scores (coverage, precision, order) with composite summary
+- GitHub Actions workflow gating PRs on 2% aggregate / 5% per-example / Wilcoxon p < 0.05
+- PR-comment delta table posted on every eval run
+
+## Framework selection at a glance
+
+| Use case | LangSmith | ragas | deepeval | Custom |
+|---|---|---|---|---|
+| RAG metrics (faithfulness, context recall) | — | **Primary** | Fallback | — |
+| Pytest-style assertion in CI | Secondary | — | **Primary** | — |
+| Trace capture + dataset versioning | **Primary** | Complementary | Complementary | — |
+| Agent trajectory (tool-call sequence) | Secondary (traces) | — | — | **Primary** |
+| Exact match / JSON schema / structured output | — | — | — | **Primary** |
+| Free-form paraphrase scoring | Via custom evaluator | — | **Primary (G-Eval)** | — |
+
+Most real pipelines stack two or three. The anti-pattern is running all four
+on every example — you pay $10-30 per run for signal you are not using. See
+[Framework Comparison](references/framework-comparison.md) for the full
+decision tree and dependency weight comparison.
+
+## Error Handling
+
+| Error / Failure mode | Cause | Fix |
+|---|---|---|
+| `TimeoutError` on eval runs > 20 min | Long agent trajectories on slow models; 100 examples × 30s each exceeds default GH Actions job timeout | Cap `max_concurrency=10`, use `asyncio.gather` with `asyncio.Semaphore`, split eval into sharded jobs |
+| Judge disagreement (stdev > 0.2 on [0,1] scale across N=3 runs) | LLM-as-judge variance on ambiguous examples | Flag example for manual review; do not use that row's score for gating |
+| `ValidationError: missing 'contexts'` in ragas | Chain does not return retrieved docs | Modify chain to surface `source_documents`, or switch to non-RAG evaluator |
+| Wilcoxon p-value is NaN | All paired diffs are 0 (identical outputs) | Expected when the PR did not change behavior — no regression, skip the stat test |
+| LangSmith 429 rate limit during upload | > 50 examples/sec to `create_examples` | Batch with `client.create_examples(..., batch_size=20)` and sleep between batches |
+| Spend overrun ($50+ per run) | Judge calls scaling with `N_examples × N_metrics × N_judge_runs` | Use `gpt-4o-mini` not `gpt-4o` for judge; cache per `(dataset_version, chain_version)` |
+| `AttributeError: 'list' has no attribute 'lower'` in custom evaluator | Claude `AIMessage.content` is `list[dict]` not `str` (P02 — see langchain-model-inference) | Use `msg.text()` or iterate content blocks |
+| Trajectory comparison drifts week-over-week on unchanged agent | `temperature > 0` non-determinism (P11) | Set `temperature=0` for all eval runs; pin `seed` where supported |
+
+## Examples
+
+### Setting up eval for a new RAG chain
+
+Start with 20 production-sampled golden examples, wire up `ragas_evaluate`
+with four metrics, record scores to `evals/baselines/` as the reference,
+and promote to LangSmith dataset versioning once two engineers annotate in
+parallel. See [Golden Set Curation](references/golden-set-curation.md).
+
+### Diagnosing regression after a model swap
+
+Run the main-branch chain on the golden set, then swap the model and rerun.
+Diff per-example scores sorted by delta — the top-10 regressions usually
+cluster by tag (long contexts, one-shot lookups). Report paired Wilcoxon
+and per-tag breakdown before deciding to ship. See [CI Integration](references/ci-integration.md).
+
+### Evaluating a LangGraph tool-calling agent
+
+Record expected tool-call sequences for 50 tasks, capture actual trajectories
+via `extract_trajectory`, and score on coverage/precision/order. Composite
+drops indicate a policy change — diff sequences to find the drift. See
+[Agent Trajectory Eval](references/agent-trajectory-eval.md).
+
+## Resources
+
+- [LangSmith evaluation tutorial](https://docs.smith.langchain.com/evaluation/tutorials/evaluation)
+- [LangSmith `evaluate()` reference](https://docs.smith.langchain.com/reference/python/sdk_reference/langsmith.evaluation)
+- [ragas metrics overview](https://docs.ragas.io/en/latest/concepts/metrics/overview/)
+- [deepeval metrics reference](https://docs.confident-ai.com/docs/metrics-introduction)
+- [scipy Wilcoxon signed-rank](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wilcoxon.html)
+- [G-Eval variance paper](https://arxiv.org/abs/2303.16634)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P01, P11, P12, P22, P33)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/agent-trajectory-eval.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/agent-trajectory-eval.md
@@ -1,0 +1,206 @@
+# Agent Trajectory Evaluation for LangGraph
+
+Agents are harder to eval than chains. The "correct answer" may be reachable
+via multiple tool-call paths; paths differ in efficiency, cost, and safety.
+Scoring only the final answer misses the process — an agent that arrives at
+the right answer after 14 redundant tool calls is not the same as one that
+takes 3.
+
+## What to score
+
+Four complementary signals, from cheap to expensive:
+
+1. **Final-answer correctness** — standard eval (exact match, LLM-as-judge)
+2. **Trajectory match** — did the tool-call sequence match the expected path?
+3. **Efficiency** — number of tool calls, total tokens, wall-clock latency
+4. **Safety** — did the agent avoid disallowed tool calls or side effects?
+
+## Capturing the trajectory from LangGraph
+
+LangGraph gives you the execution trace via the state history:
+
+```python
+from langgraph.graph import StateGraph
+from langchain_core.messages import ToolMessage, AIMessage
+
+def extract_trajectory(final_state: dict) -> list[dict]:
+    """Extract the tool-call sequence from a LangGraph run."""
+    trajectory = []
+    for msg in final_state["messages"]:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            for tc in msg.tool_calls:
+                trajectory.append({
+                    "tool": tc["name"],
+                    "args": tc["args"],
+                })
+    return trajectory
+```
+
+For streaming runs, use `graph.astream(..., stream_mode="updates")` and
+collect tool-call events incrementally.
+
+## Trajectory match with partial credit
+
+Exact-sequence match is too strict — an agent that calls `search` then `fetch`
+is functionally the same as `fetch` then `search` for many tasks. Score
+trajectories on three axes:
+
+```python
+def trajectory_score(expected: list[str], actual: list[str]) -> dict:
+    """
+    Returns scores in [0, 1] for three dimensions.
+    expected / actual are tool-name sequences (ignoring args for now).
+    """
+    expected_set = set(expected)
+    actual_set = set(actual)
+
+    # 1. Coverage — did the agent call every required tool at least once?
+    coverage = len(expected_set & actual_set) / len(expected_set) if expected_set else 1.0
+
+    # 2. Precision — what fraction of actual calls were expected?
+    precision = len(expected_set & actual_set) / len(actual_set) if actual_set else 0.0
+
+    # 3. Order — Kendall's tau on the subsequence of shared tools
+    shared = [t for t in actual if t in expected_set]
+    order = kendall_tau(expected, shared) if len(shared) >= 2 else 1.0
+
+    return {"coverage": coverage, "precision": precision, "order": order}
+
+
+def kendall_tau(expected: list[str], actual: list[str]) -> float:
+    """Normalized Kendall's tau in [0, 1]. 1.0 = same order, 0.0 = reversed."""
+    idx = {t: i for i, t in enumerate(expected)}
+    pairs = [(idx[a], idx[b]) for a, b in zip(actual, actual[1:]) if a in idx and b in idx]
+    if not pairs:
+        return 1.0
+    concordant = sum(1 for a, b in pairs if a < b)
+    return concordant / len(pairs)
+```
+
+Interpret:
+
+- `coverage=1.0, precision=1.0, order=1.0` — exact match
+- `coverage=1.0, precision=0.5, order=1.0` — agent over-explored (extra tools) but got all required
+- `coverage=0.6, precision=1.0, order=1.0` — agent skipped required tools
+- `coverage=1.0, precision=1.0, order=0.3` — agent called the right tools in a bad order
+
+For a single composite score, weighted sum:
+`0.5 * coverage + 0.3 * precision + 0.2 * order`
+
+## Args-level matching (optional)
+
+Tool-name matching misses cases where the agent called `search(query="wrong")`
+instead of `search(query="right")`. For args-level:
+
+```python
+def args_match(expected_call: dict, actual_call: dict, judge=None) -> bool:
+    """Judge whether actual_call.args is equivalent to expected_call.args."""
+    if expected_call["tool"] != actual_call["tool"]:
+        return False
+    # Exact match is too strict for free-form args
+    if judge is None:
+        return expected_call["args"] == actual_call["args"]
+    # LLM-as-judge for paraphrased query args
+    return judge.invoke(
+        f"Are these tool-call args semantically equivalent?\n"
+        f"Expected: {expected_call['args']}\n"
+        f"Actual: {actual_call['args']}\n"
+        f"Reply with only 'yes' or 'no'."
+    ).content.strip().lower() == "yes"
+```
+
+## Efficiency and safety
+
+```python
+def efficiency_score(trajectory: list, max_calls: int = 10) -> float:
+    """Penalize trajectories longer than the expected optimum."""
+    return max(0.0, 1.0 - max(0, len(trajectory) - max_calls) / max_calls)
+
+
+FORBIDDEN_TOOLS = {"delete_user", "send_email"}  # adjust per task
+
+def safety_pass(trajectory: list[dict]) -> bool:
+    return not any(call["tool"] in FORBIDDEN_TOOLS for call in trajectory)
+```
+
+Safety is pass/fail, not a score — one forbidden call fails the run.
+
+## LLM-as-judge fallback for free-form agents
+
+When the trajectory is non-deterministic (a chat agent exploring a knowledge
+base) and coverage/precision are too strict, use LLM-as-judge on the full
+trajectory:
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+judge = ChatAnthropic(model="claude-sonnet-4-6", temperature=0)
+
+def judge_trajectory(goal: str, trajectory: list[dict], final_answer: str) -> dict:
+    prompt = f"""You are scoring an LLM agent's execution trajectory.
+
+Goal: {goal}
+
+Trajectory (tool calls in order):
+{chr(10).join(f'  {i+1}. {c["tool"]}({c["args"]})' for i, c in enumerate(trajectory))}
+
+Final answer: {final_answer}
+
+Score these on a 1-5 scale and return JSON:
+- goal_achievement: did the final answer achieve the goal?
+- efficiency: was the trajectory efficient (no redundant calls)?
+- safety: did the agent avoid unnecessary or risky actions?
+
+Return only JSON: {{"goal_achievement": N, "efficiency": N, "safety": N, "reasoning": "..."}}.
+"""
+    response = judge.invoke(prompt)
+    import json
+    return json.loads(response.content)
+```
+
+**Variance warning:** LLM-as-judge on trajectories is higher-variance than on
+final answers alone (±0.5 on a 5-point scale across runs). Average over 3+
+judge runs and report the mean with SD. See `ci-integration.md` for the
+quorum pattern.
+
+## Visualizing mismatches
+
+When a run fails, a diff view helps. A simple Markdown render:
+
+```python
+def render_trajectory_diff(expected: list[dict], actual: list[dict]) -> str:
+    lines = ["## Expected", ""]
+    for i, c in enumerate(expected, 1):
+        lines.append(f"{i}. `{c['tool']}({c.get('args', '')})`")
+    lines += ["", "## Actual", ""]
+    for i, c in enumerate(actual, 1):
+        mark = "✓" if i <= len(expected) and c["tool"] == expected[i-1]["tool"] else "✗"
+        lines.append(f"{i}. {mark} `{c['tool']}({c.get('args', '')})`")
+    return "\n".join(lines)
+```
+
+Post this to the LangSmith trace comment or the PR CI output. Engineers can
+spot a wrong-tool call faster than they can parse a 0.6 coverage score.
+
+## Non-determinism and seeding
+
+LangGraph agents with `temperature > 0` produce different trajectories across
+runs. For reproducible eval:
+
+- Set `temperature=0` for the eval run even if production uses higher.
+- Pin `seed` on providers that support it (`ChatOpenAI(seed=42)`; Anthropic
+  does not expose seed but temperature=0 is usually deterministic enough).
+- Run each example N=3 times and report the trajectory-score variance —
+  high variance means the agent's policy is unstable on that example.
+
+## Common failure modes
+
+- **Early termination** — agent returns "I don't know" after 1 call when it
+  should have kept searching. Coverage drops to 0. Adjust agent's stopping
+  criteria before declaring the policy broken.
+- **Loop on a failing tool** — agent retries the same failing tool 10 times.
+  Catch with `efficiency_score` threshold (< 0.2 is a failure) or a
+  `max_tool_calls` guard in the graph itself.
+- **Wrong-tool drift** — after a prompt update, agent switches to a less-
+  accurate tool for a task. Detect by monitoring per-tool-call frequency
+  over eval runs.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/ci-integration.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/ci-integration.md
@@ -1,0 +1,263 @@
+# CI Integration: Gating PRs on Eval Regression
+
+The goal: a pull request that changes a prompt, model, retrieval config, or
+chain topology runs the eval suite and blocks merge if quality regressed.
+Without it, "gut-feel" regressions land in main.
+
+## Gating rules (the thresholds we use)
+
+| Signal | Block merge if... | Why |
+|---|---|---|
+| Aggregate mean drop | **mean metric drops > 2.0%** (vs baseline on main) | Bigger than typical judge noise (~1%), small enough to catch drift |
+| Per-example drop | **any single example drops > 5.0%** on metric | Catches "fixed A, broke B" trades that aggregate hides |
+| Statistical significance | Wilcoxon signed-rank **p < 0.05** for paired eval | Ensures the drop is not noise at the current sample size |
+| Cost | Judge cost > $15 per run | Prevents runaway judge calls |
+| Runtime | Eval run > 20 minutes | Catches infinite-loop bugs in chains |
+
+These are starting values — tune on your project. A prompt-engineering-heavy
+repo might relax the per-example threshold; a safety-critical repo tightens it.
+
+## Statistical significance: Wilcoxon signed-rank
+
+Paired comparison on the same golden set before and after a change. Wilcoxon
+is the right test — t-test assumes normal distribution, which LLM metrics
+rarely satisfy (bimodal on easy/hard splits, bounded at 0 or 1).
+
+```python
+from scipy.stats import wilcoxon
+
+def paired_regression_check(
+    baseline_scores: list[float],
+    candidate_scores: list[float],
+    alpha: float = 0.05,
+) -> dict:
+    """Check if candidate regressed vs baseline with statistical significance."""
+    if len(baseline_scores) != len(candidate_scores):
+        raise ValueError("Scores must be paired (same examples, same order)")
+    n = len(baseline_scores)
+    if n < 50:
+        return {"verdict": "too_small", "n": n, "min_n": 50}
+
+    diffs = [c - b for b, c in zip(baseline_scores, candidate_scores)]
+    mean_delta = sum(diffs) / n
+
+    # Wilcoxon tests whether the median paired difference is zero.
+    # alternative="less" = testing for regression (candidate < baseline).
+    stat, p_value = wilcoxon(diffs, alternative="less")
+    significant_regression = p_value < alpha and mean_delta < 0
+
+    return {
+        "n": n,
+        "mean_delta": mean_delta,
+        "p_value": float(p_value),
+        "significant_regression": bool(significant_regression),
+        "verdict": "regression" if significant_regression else "no_regression",
+    }
+```
+
+At n=100 and α=0.05, this detects a true regression of ~3-5% with ~80% power
+on continuous metrics — which is why 100 is the working minimum for PR gates.
+
+## Bootstrap CI for absolute claims
+
+Wilcoxon tests "is there a regression" but does not produce a CI around the
+mean. For "faithfulness is 0.82 ± 0.03" claims, use bootstrap:
+
+```python
+import random
+
+def bootstrap_ci(scores: list[float], n_iter: int = 1000, ci: float = 0.95) -> tuple[float, float]:
+    """Return (lower, upper) percentile bootstrap CI."""
+    means = []
+    n = len(scores)
+    for _ in range(n_iter):
+        resample = [random.choice(scores) for _ in range(n)]
+        means.append(sum(resample) / n)
+    means.sort()
+    lo_idx = int(n_iter * (1 - ci) / 2)
+    hi_idx = int(n_iter * (1 + ci) / 2)
+    return means[lo_idx], means[hi_idx]
+```
+
+Report CI alongside every headline metric. A point estimate without CI is not
+a claim — it's a guess.
+
+## Judge-run quorum (LLM-as-judge variance)
+
+LLM-as-judge scores vary ±5-15% across runs on the same example. Single-run
+judges are not CI-ready. Run each judge call N=3 times and take the median:
+
+```python
+def judge_with_quorum(judge, prompt: str, n: int = 3) -> tuple[float, float]:
+    """Run judge n times, return (median_score, stdev)."""
+    import statistics
+    scores = [float(judge.invoke(prompt).content.strip()) for _ in range(n)]
+    return statistics.median(scores), statistics.stdev(scores)
+```
+
+If stdev > 1.0 (on a 5-point scale) or > 0.2 (on a [0,1] scale), flag the
+example for manual review — the judge is disagreeing with itself, so its
+score is not trustworthy regardless of median.
+
+## GitHub Actions workflow
+
+`.github/workflows/eval.yml`:
+
+```yaml
+name: LLM Eval Gate
+
+on:
+  pull_request:
+    paths:
+      - 'prompts/**'
+      - 'src/chains/**'
+      - 'src/agents/**'
+      - 'config/models.yaml'
+      - 'evals/**'
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - run: pip install -e . && pip install -r evals/requirements.txt
+
+      # Run eval on PR branch
+      - name: Run eval on candidate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+        run: python evals/run.py --output candidate.json
+
+      # Run eval on main baseline
+      - name: Run eval on baseline
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+        run: |
+          git stash
+          git checkout origin/main -- src/ prompts/ config/
+          python evals/run.py --output baseline.json
+          git checkout HEAD -- src/ prompts/ config/
+          git stash pop || true
+
+      - name: Compare and gate
+        run: python evals/compare.py baseline.json candidate.json --gate
+
+      - name: Post PR comment with deltas
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('eval_comment.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });
+```
+
+## `evals/compare.py` skeleton
+
+```python
+"""Compare baseline vs candidate eval runs. Exit non-zero on regression."""
+import argparse, json, sys
+from pathlib import Path
+
+MEAN_DROP_THRESHOLD = 0.02   # 2% aggregate drop
+PER_EX_DROP_THRESHOLD = 0.05 # 5% any-example drop
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--gate", action="store_true")
+    args = parser.parse_args()
+
+    base = json.loads(args.baseline.read_text())
+    cand = json.loads(args.candidate.read_text())
+
+    failures = []
+    report_lines = ["# Eval Report", "", f"Dataset version: `{base['dataset_version']}`", ""]
+    report_lines.append("| Metric | Baseline | Candidate | Delta |")
+    report_lines.append("|---|---|---|---|")
+
+    for metric in base["metrics"]:
+        b = base["metrics"][metric]["mean"]
+        c = cand["metrics"][metric]["mean"]
+        delta = c - b
+        flag = " REGRESSION" if delta < -MEAN_DROP_THRESHOLD else ""
+        report_lines.append(f"| {metric} | {b:.3f} | {c:.3f} | {delta:+.3f}{flag} |")
+        if delta < -MEAN_DROP_THRESHOLD:
+            failures.append(f"{metric} dropped {abs(delta):.2%} (threshold {MEAN_DROP_THRESHOLD:.0%})")
+
+    # Per-example regression check
+    for ex_id, ex_base in base["per_example"].items():
+        ex_cand = cand["per_example"].get(ex_id, {})
+        for metric, b_score in ex_base.items():
+            c_score = ex_cand.get(metric, 0)
+            if c_score < b_score - PER_EX_DROP_THRESHOLD:
+                failures.append(
+                    f"Example {ex_id} / {metric}: {b_score:.2f} → {c_score:.2f}"
+                )
+
+    Path("eval_comment.md").write_text("\n".join(report_lines))
+
+    if args.gate and failures:
+        print("Regression detected:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+```
+
+## Secret and cost safety
+
+- **API keys:** GitHub Secrets only. Never expose in logs.
+- **Spend caps:** Set per-key monthly limits on OpenAI/Anthropic dashboards.
+  Evaluators with bugs can burn through budget in minutes.
+- **Rate limits:** Use `langchain-core`'s built-in retry + `asyncio.Semaphore`
+  to cap concurrency. A 100-example eval with 4 ragas metrics = 400 LLM calls;
+  parallelized at 10 concurrent is manageable, at 50 triggers 429s on most
+  tiers.
+- **Caching:** LangSmith caches evaluator results by `(dataset_version, chain_version)`
+  keys. Re-running an unchanged PR should be nearly free.
+
+## When to run vs skip
+
+Run on every PR that touches:
+
+- `prompts/**`, `src/chains/**`, `src/agents/**`
+- Model config (`config/models.yaml`)
+- Retrieval config, embedding model, chunking
+- The eval set itself (to verify the set still runs)
+
+Skip for documentation-only changes, CI config, or test fixtures. Path
+filters in the `on.pull_request.paths` section handle this.
+
+## Slack / PR-comment surface
+
+Post the delta table as a PR comment with ✓/✗ per metric. Engineers triage
+regressions in the PR conversation, not in a separate dashboard.
+
+For nightly main-branch runs, post a daily summary to Slack with the metric
+trend (`#ml-eval` channel). Drift over weeks is the hardest-to-catch failure
+mode — a daily digest catches it while daily PRs cannot.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/framework-comparison.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/framework-comparison.md
@@ -1,0 +1,78 @@
+# Framework Comparison: LangSmith vs ragas vs deepeval vs Custom
+
+Four tools, overlapping but distinct. Stacking all four is common; picking one
+is also common. This reference is the decision map.
+
+## Side-by-side matrix
+
+| Dimension | LangSmith | ragas | deepeval | Custom (exact-match, trajectory) |
+|---|---|---|---|---|
+| **Primary purpose** | Trace capture + eval orchestration + dataset versioning | RAG-specific metrics (faithfulness, context precision/recall) | pytest-style LLM-as-judge assertions | Deterministic checks (exact match, regex, JSON schema, trajectory) |
+| **Input shape** | `{input, expected}` dict rows | `{question, answer, contexts, ground_truth}` | `LLMTestCase(input, actual_output, expected_output, retrieval_context)` | Any — you own the row format |
+| **Metric output** | Any evaluator you write; built-ins: correctness, cot_qa, labeled_criteria | Faithfulness, answer relevance, context precision, context recall, harmfulness | G-Eval, answer relevancy, faithfulness, contextual precision, bias, toxicity | Exact-match %, trajectory partial-match score, latency/token counters |
+| **Judge LLM** | Your choice — pass a `ChatOpenAI` / `ChatAnthropic` to the evaluator | Default `gpt-4o-mini`, overridable | Default `gpt-4o`, overridable; supports local via `OllamaModel` | None (deterministic) |
+| **Cost per 100-example run** | $0.50-$5 for judge + tracing is free tier | $1-$8 (four metrics × judge calls) | $1-$6 (per metric × judge) | ~$0 |
+| **Setup effort** | Medium — `LANGSMITH_API_KEY` + dataset upload | Low — `pip install ragas` + dataset dict | Low — `pip install deepeval` + pytest | Low — write your own |
+| **Best for** | Orchestration, trace-to-eval traceability, sharing runs with teammates | RAG pipelines where faithfulness and context recall matter | Pytest integration, CI assertions, LLM-as-judge at scale | Structured outputs, tool-call sequences, speed-critical checks |
+| **Worst at** | Offline-only runs (needs API for dataset versioning) | Non-RAG chains (overkill, wrong metrics) | Non-pytest environments (the framework is pytest-shaped) | Semantic correctness (cannot judge paraphrase) |
+| **Dependency weight** | `langsmith>=0.2` (lightweight) | `ragas>=0.2` pulls `datasets`, `pandas` | `deepeval>=2.0` pulls `pytest`, `rich`, `tenacity` | None beyond stdlib |
+
+## Selection decision tree
+
+```
+Is it a RAG pipeline?
+├── Yes → Start with ragas for the four core metrics.
+│         Add LangSmith for orchestration + dataset versioning.
+│         Optionally add deepeval if you need per-metric PR gates in pytest.
+└── No
+    ├── Is it an agent (LangGraph, tool-calling)?
+    │   └── Yes → Custom trajectory eval (deterministic) + deepeval G-Eval
+    │              for free-form final-answer quality.
+    │              LangSmith for trace capture.
+    └── No — is it a chain with a structured output?
+        └── Yes → Custom exact-match / Pydantic-validate eval.
+                   Add deepeval for soft metrics (tone, completeness).
+                   LangSmith optional.
+```
+
+## Why you often stack 2-3
+
+The tools do not compete; they layer.
+
+- **LangSmith** captures the trace of every eval run — you can drill into a
+  failing example and see the exact prompt, tool calls, and token usage. This
+  is the "observability substrate" even if another tool computes the scores.
+- **ragas** owns the RAG-specific math (context precision is rank-aware, not a
+  simple set-overlap). Rewriting it correctly is not worth the time.
+- **deepeval** owns the pytest ergonomics. `assert_test(test_case, metrics)`
+  makes regressions fail CI the way engineers already understand.
+- **Custom** handles the deterministic 60% of eval work (exact match, JSON
+  shape, trajectory) at near-zero cost — use it for anything that does not
+  need a judge LLM.
+
+## Cost-efficiency rule of thumb
+
+LLM-as-judge evaluators dominate cost. A 100-example run × 4 ragas metrics at
+`gpt-4o-mini` is ~$1-2; the same at `gpt-4o` is ~$8-15. For nightly eval on
+large suites, default to the mini tier, and upgrade to the full tier only
+when judge-LLM disagreement is hurting the signal (see `ci-integration.md` on
+judge-run quorum).
+
+## Anti-patterns
+
+- **Running all four frameworks on every example.** Overkill — you will pay
+  $10-30 per run for signal you are not using. Pick the minimum set.
+- **Using ragas for non-RAG chains.** Context precision against an empty
+  context list returns 0 — which looks like a regression.
+- **Using deepeval's `GEval` as the sole metric.** G-Eval is high-variance
+  across judge runs (±10-15%). Pair with a deterministic metric or average
+  over N≥3 judge runs (see `ci-integration.md`).
+- **Skipping LangSmith dataset versioning.** If your eval set can drift, you
+  cannot compare runs across weeks. Pin a dataset version tag.
+
+## Official docs
+
+- LangSmith evaluate: https://docs.smith.langchain.com/evaluation/tutorials/evaluation
+- ragas metrics: https://docs.ragas.io/en/latest/concepts/metrics/overview/
+- deepeval: https://docs.confident-ai.com/docs/evaluation-introduction
+- G-Eval paper (variance characterization): https://arxiv.org/abs/2303.16634

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/golden-set-curation.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/golden-set-curation.md
@@ -1,0 +1,126 @@
+# Golden Set Curation
+
+The golden set is the bedrock. A bad golden set — too small, biased to easy
+cases, unversioned, drifting — makes every downstream metric a lie. This is
+the process we use.
+
+## Format: JSONL + version tag
+
+One example per line. Minimum schema:
+
+```json
+{
+  "id": "gs-0001",
+  "input": "What's the refund policy for SKU ABC-42?",
+  "expected": "Refunds within 30 days with original receipt; see policy link.",
+  "contexts": ["policy_v3_refunds.md#section-4"],
+  "tags": ["refund", "policy-lookup"],
+  "difficulty": "easy",
+  "added": "2026-03-14",
+  "annotator": "jlongshore",
+  "dataset_version": "2026.03"
+}
+```
+
+Fields in detail:
+
+| Field | Required? | Purpose |
+|---|---|---|
+| `id` | Yes | Stable identifier; never reused across splits |
+| `input` | Yes | Exactly what the chain receives (do not pre-process) |
+| `expected` | Yes | Gold answer — reference for correctness metric |
+| `contexts` | For RAG | Ground-truth doc IDs for `context_recall` / `context_precision` |
+| `tags` | Strongly recommended | Stratified reporting (e.g. refund queries vs product queries) |
+| `difficulty` | Strongly recommended | Keep easy:medium:hard ~= 3:5:2 so the set is not skewed |
+| `added`, `annotator` | Recommended | Audit trail |
+| `dataset_version` | **Required** | Pin a tag; eval runs reference this tag so results are comparable over time |
+
+Store in repo at `evals/golden_set/v{version}.jsonl`. Treat the file as
+immutable within a version — bump the version when you add/remove examples.
+
+## Sample size guidance
+
+| Claim you want to make | Minimum n |
+|---|---|
+| "This chain regressed" (paired A/B, same examples) | **50-100** examples |
+| "Metric X is 82% ± 3%" (absolute claim with CI) | **200+** examples |
+| "Chain A beats chain B on tag `refund`" (subgroup claim) | **50+ per subgroup** |
+| Published benchmark / paper result | **500+** examples, stratified |
+
+The 100-example paired-comparison floor comes from the statistical power of the
+Wilcoxon signed-rank test at α=0.05: detecting a 5% true mean shift with 80%
+power needs ~80-100 paired examples for binary correctness and ~40-60 for
+continuous metrics (faithfulness in [0,1]). See `ci-integration.md` for the
+Wilcoxon usage.
+
+## Sourcing strategy
+
+**Never write golden examples from imagination alone.** Imagined queries are
+biased toward the cases you think are important, not the cases your users
+actually send. Sample from real traffic.
+
+1. **Export 7 days of production inputs** from your tracing system (LangSmith
+   has `Client.list_runs` with filters). Redact PII.
+2. **Stratify by tag or intent** — for a support bot, sample evenly across
+   refund / shipping / product / account categories. Uniform sampling
+   under-represents rare-but-important tags.
+3. **Stratify by difficulty** — reserve ~30% hard cases (multi-hop, ambiguous,
+   adversarial). A golden set that is all easy cases cannot detect regression
+   on hard cases.
+4. **Annotate manually** — two annotators per example, disagreements reconciled
+   by a third. Reconciliation rate under 90% means your task definition is
+   ambiguous; fix the definition before shipping the set.
+5. **Adversarial examples (5-10% of set)** — prompt injections, off-topic
+   queries, empty inputs, requests in the wrong language. Agents and chains
+   that pass all happy-path but fail adversarial are a real category.
+
+## Versioning and refresh cadence
+
+- **Version tag format:** `YYYY.MM` for calendar-based releases, or `v1.0`,
+  `v1.1` for milestone releases. Pin at eval time.
+- **Refresh monthly** — add 10-20 new examples from recent traffic, retire
+  examples that have become irrelevant (feature removed, policy changed).
+- **Never edit past versions** — if an example was wrong, mark it deprecated
+  in the new version but keep the old version immutable. Comparing v2026.03
+  vs v2026.04 must always reproduce.
+- **Keep a changelog** at `evals/golden_set/CHANGELOG.md`: which examples were
+  added, removed, or re-annotated, and why.
+
+## Annotation tool options
+
+| Tool | Setup | Best for |
+|---|---|---|
+| **JSONL + git PRs** | Zero tooling; reviewer reads PR diff | Small sets (< 200 examples), single annotator |
+| **LangSmith UI** | `langsmith` dataset with web annotation | Team of 2-5, reconciliation workflow built in |
+| **Argilla** (open source) | Self-hosted or HF Spaces | Larger sets (1000+), multi-annotator with agreement metrics |
+| **Label Studio** | Self-hosted | Complex labels (spans, hierarchies), already used for other NLP |
+
+For a 100-example golden set with two annotators, JSONL + git PRs is enough.
+Moving to LangSmith once you need reconciliation tooling pays off.
+
+## Common pitfalls
+
+- **Leakage from train to eval.** If your prompt engineer looked at eval
+  examples while tuning prompts, the set is contaminated. Lock the eval set
+  before prompt tuning, or maintain a held-out "blind" subset.
+- **Over-specific expected answers.** If `expected` is one exact phrasing but
+  ten paraphrases are equally correct, exact-match will under-report quality.
+  Use an LLM-as-judge or semantic-similarity metric for open-ended outputs.
+- **Stale ground truth.** Policy changed; expected answer is now wrong. Quarterly
+  audit: re-review 10% of the set, flag drift.
+- **Unbalanced difficulty.** If the set is 90% easy, a chain can regress hard
+  cases from 40% to 10% and the aggregate score barely moves. Stratify and
+  report per-difficulty.
+
+## Minimum viable starting point
+
+Shipping today? Build this:
+
+1. 20 real queries from production, redacted.
+2. Expected answers written by a domain expert, two-annotator reconciled.
+3. Tags covering your top 4-5 intent categories, roughly even.
+4. Saved as `evals/golden_set/v2026.04.jsonl` with a `dataset_version` field.
+5. Reference version tag in your first eval run.
+
+This is not enough for publishing, but it is enough to catch regressions in CI.
+Grow to 100 over the next month.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-eval-harness — One-Pager
+
+Build reproducible evaluation pipelines for LangChain 1.0 chains and LangGraph 1.0 agents — golden sets, LangSmith `evaluate()`, ragas, deepeval, trajectory analysis, and CI regression gates.
+
+## The Problem
+
+Most LLM chains and agents ship without measurement. A team swaps `gpt-4o` for `claude-sonnet-4-6` to save money; a week later CS notices answers dropped on 15% of tickets — the regression was invisible in code review and CI because no one had a golden set. LangSmith, ragas, and deepeval all exist, but the patterns for wiring them into a loop with statistical significance, version tags, and PR-blocking thresholds are scattered across five doc sites.
+
+## The Solution
+
+This skill gives you a 100-example golden-set format (JSONL + version tag), a `langsmith.evaluate()` wiring pattern with a custom evaluator, a ragas RAG quartet (faithfulness, answer relevance, context precision/recall) wired through `RagasEvaluator`, a deepeval LLM-as-judge with run-level quorum for judge disagreement, a LangGraph trajectory evaluator that scores tool-call sequences with partial credit, and a GitHub Actions workflow that gates PRs on a 2% mean drop or 5% per-example drop — with bootstrap CI and paired Wilcoxon significance. Pinned to `langchain-core 1.0.x`, `langsmith>=0.2`, `ragas>=0.2`, `deepeval>=2.0`.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Researchers, PhDs, ML engineers, senior backend — anyone shipping LLM systems who needs reproducible measurement |
+| **What** | Golden-set JSONL spec, LangSmith `evaluate()` wiring, ragas RAG metrics, deepeval LLM-as-judge, LangGraph trajectory eval, CI regression gate, 4 references |
+| **When** | Setting up quality measurement for a new chain, diagnosing regression after a model swap, building an eval gate for a PR, or publishing a benchmark |
+
+## Key Features
+
+1. **Statistically honest thresholds** — Paired Wilcoxon signed-rank test on 100-example golden sets with bootstrap CI; a raw mean delta of -1.8% on n=50 is noise, on n=200 is real — this skill names the numbers and the test
+2. **Framework comparison with selection matrix** — LangSmith (traces + orchestration), ragas (RAG-specific metrics), deepeval (pytest-style LLM-as-judge), custom (exact-match, trajectory) compared on cost, setup effort, dependency weight, and integration shape — pick the right tool, not all four
+3. **Trajectory eval for LangGraph agents** — Compare expected vs actual tool-call sequence with partial credit (full match, subset match, reorder penalty), plus LLM-as-judge fallback for free-form outputs when the trajectory is non-deterministic
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.


### PR DESCRIPTION
## Summary

**New skill** — not in original 34-skill plan. Added because PhDs and senior engineers cannot ship LLM systems without rigorous measurement: golden sets, LangSmith `evaluate()`, ragas RAG metrics, deepeval LLM-as-judge, agent trajectory eval for LangGraph, and PR-blocking regression gates.

## Pain hook

A team swapped `gpt-4o` for `claude-sonnet-4-6` to save money; a week later CS noticed answer quality dropped on 15% of refund tickets. The regression was invisible in code review and CI because no golden set existed. This skill gives a versioned-JSONL golden set, stacked LangSmith/ragas/deepeval eval, LangGraph trajectory scoring, and a PR-blocking regression gate with paired Wilcoxon significance (n>=100, 2% aggregate / 5% per-example thresholds).

## Audience

Researchers, PhDs, ML engineers, senior backend — anyone who needs to answer "did this change regress quality?" rigorously.

## Files

- `skills/langchain-eval-harness/SKILL.md` (294 lines)
- `skills/langchain-eval-harness/references/one-pager.md`
- `skills/langchain-eval-harness/references/framework-comparison.md` (LangSmith vs ragas vs deepeval vs custom)
- `skills/langchain-eval-harness/references/golden-set-curation.md` (sampling, annotation, versioning, refresh)
- `skills/langchain-eval-harness/references/agent-trajectory-eval.md` (LangGraph tool-call sequence scoring)
- `skills/langchain-eval-harness/references/ci-integration.md` (GHA workflow with PR comment + merge gate)

## Validator

Grade **A (93/100)** at both standard and enterprise tiers, zero ERROR lines.

## Base

Targets `feat/langchain-py-pack-foundation` (PR #546).

Jeremy made me do it
-claude