### PR TITLE
feat(langchain-py-pack): add langchain-langgraph-agents (L26)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: langchain-langgraph-agents
+description: |
+  Build a correct LangGraph 1.0 ReAct agent with `create_react_agent` — typed tools,
+  error propagation, recursion caps, and stop conditions that actually stop. Use when
+  writing your first tool-calling agent, migrating from `AgentExecutor` / `initialize_agent`,
+  or diagnosing an agent that loops on vague prompts.
+  Trigger with "langgraph agent", "create_react_agent", "langgraph tool calling",
+  "AgentExecutor migration", "agent loop cost".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, agents, tool-calling]
+compatible-with: claude-code, codex
+---
+
+# LangChain LangGraph Agents (Python)
+
+## Overview
+
+Two failure modes hit every team writing their first LangGraph 1.0 ReAct agent:
+
+**Loop-to-cap on vague prompts (P10).** `create_react_agent` defaults to
+`recursion_limit=25`. A prompt like "help me with my account" never converges —
+the model calls a retrieval tool, gets irrelevant results, calls another tool,
+and repeats until `GraphRecursionError: Recursion limit of 25 reached without
+hitting a stop condition` fires. Cost dashboards show the damage *after* the
+fact: $5-$15 per runaway loop on Sonnet with a 3-tool agent, assuming no tool
+is itself expensive.
+
+**Silent tool errors on legacy `AgentExecutor` (P09).** The legacy executor
+defaults `handle_parsing_errors=True` and catches tool exceptions, feeding the
+error string back as the next observation. When the error serializes to empty
+(e.g., a `ValueError("")` or an HTTP 500 with no body), the loop continues with
+no signal. The agent says "I couldn't find the answer" — which was actually a
+silent crash three tool calls ago.
+
+This skill walks through defining typed tools with `@tool` + Pydantic; building
+an agent with `create_react_agent(model, tools, checkpointer=MemorySaver())`;
+invoking with `{"messages": [...]}` and a thread-scoped config; setting
+`recursion_limit` per expected agent depth (5-10 interactive, 20-30 planner);
+adding middleware for a per-session token budget; and raise-by-default error
+propagation. Pin: `langgraph >= 1.0, < 2.0`, `langchain-core >= 1.0, < 2.0`.
+Pain-catalog anchors: P09, P10, P11, P32, P41, P42, P63.
+
+## Prerequisites
+
+- Python 3.10+
+- `langgraph >= 1.0, < 2.0` and `langchain-core >= 1.0, < 2.0`
+- At least one provider package: `pip install langchain-anthropic` or `langchain-openai`
+- Completed skill: `langchain-langgraph-basics` (L25) — you already know `StateGraph`,
+  `MessagesState`, and checkpointers
+- Provider API key: `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`
+
+## Instructions
+
+### Step 1 — Define tools with typed schemas and short docstrings
+
+```python
+from typing import Annotated
+from pydantic import BaseModel, Field
+from langchain_core.tools import tool
+
+class LookupAccountArgs(BaseModel):
+    account_id: str = Field(..., description="Account UUID. No email addresses.")
+
+@tool("lookup_account", args_schema=LookupAccountArgs)
+def lookup_account(account_id: str) -> dict:
+    """Fetch an account record by UUID. Returns status, plan, and owner email."""
+    if not account_id:
+        raise ValueError("account_id is required")  # raised → agent sees real error
+    return {"id": account_id, "status": "active", "plan": "pro", "owner": "a@b.co"}
+```
+
+Two rules that catch teams off-guard:
+
+1. **Docstring is the tool description the provider sees.** Keep it under
+   **1024 chars** (P11). Anthropic truncates at ~1024; OpenAI's effective cap is
+   softer but still bites on tool descriptions over ~2KB. Long docstrings with
+   examples should move into a system prompt, not the tool description.
+2. **Raise real exceptions.** Unlike the legacy `AgentExecutor`, LangGraph's
+   `create_react_agent` does not silently swallow tool errors — the exception
+   propagates and surfaces in your observability layer. See Step 6.
+
+For async tools, use `@tool` on an `async def` — LangGraph invokes it via
+`await`. For structured return types, annotate the return with a Pydantic model.
+
+See [Tool Definition Patterns](references/tool-definition-patterns.md) for the
+`@tool` vs `tool()` decision, async tools, and the `args_schema` vs
+auto-inferred trade-off.
+
+### Step 2 — Build the agent with `create_react_agent`
+
+```python
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import MemorySaver
+from langchain_anthropic import ChatAnthropic
+
+model = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    temperature=0,
+    timeout=30,
+    max_retries=2,
+)
+
+agent = create_react_agent(
+    model=model,
+    tools=[lookup_account],
+    checkpointer=MemorySaver(),  # required for stateful invocations
+)
+```
+
+`create_react_agent` is the LangGraph 1.0 replacement for the removed
+`initialize_agent` factory (P41). Under the hood it builds a `StateGraph` with
+a `model` node and a `ToolNode`, plus a conditional edge that routes to
+`END` when the model emits no tool calls. The `checkpointer` persists state
+per-thread — required for multi-turn conversations and for resuming after
+interruption.
+
+### Step 3 — Invoke with a thread-scoped config
+
+```python
+config = {"configurable": {"thread_id": "user-42"}}
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "look up account uuid-abc"}]},
+    config=config,
+)
+print(result["messages"][-1].content)
+```
+
+Key contracts:
+
+- **Input** is `{"messages": [...]}` — a list of message dicts or LangChain
+  `HumanMessage` / `SystemMessage` objects. You append to this list across turns.
+- **`thread_id`** scopes the checkpointer. Reusing it resumes the conversation.
+- **Output** is the full updated state. `result["messages"]` is the complete
+  message list; the final assistant message is at index `-1`.
+
+### Step 4 — Set `recursion_limit` to your expected agent depth
+
+`create_react_agent` defaults to `recursion_limit=25`. In LangGraph one
+"recursion step" is one node visit, and each tool round-trip is two visits
+(model node + tool node), so 25 means ~12 tool calls. For most workloads this
+is too generous and hides bugs:
+
+| Agent kind | Suggested `recursion_limit` | Rationale |
+|---|---|---|
+| Interactive chat with 1-3 tools | 5-10 | One tool call + one final answer is 3 visits. Cap low to expose loops. |
+| Task-completion (e.g., booking flow) | 10-15 | 3-5 tool calls + final answer. |
+| Planner / research agent | 20-30 | Expect multiple retrieval + synthesis rounds. |
+| Multi-agent supervisor | 40+ | Coordinator + worker rounds. Budget tokens separately. |
+
+Apply it on invocation, not at construction time:
+
+```python
+result = agent.invoke(
+    {"messages": [...]},
+    config={"configurable": {"thread_id": "user-42"}, "recursion_limit": 10},
+)
+```
+
+When the limit fires, LangGraph raises `GraphRecursionError` — catch it and
+surface a user-facing message; do not retry without a cost guard.
+
+### Step 5 — Add a per-session token budget via middleware
+
+`recursion_limit` alone does not bound cost. A single tool call that returns a
+large document and triggers a long model response can cost more than 10 cheap
+tool calls. Cap tokens explicitly:
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class TokenBudget(BaseCallbackHandler):
+    def __init__(self, max_tokens: int = 50_000):
+        self.used = 0
+        self.max = max_tokens
+
+    def on_llm_end(self, response, **kwargs):
+        usage = getattr(response, "llm_output", {}).get("token_usage", {}) or {}
+        self.used += usage.get("total_tokens", 0)
+        if self.used > self.max:
+            raise RuntimeError(f"Token budget exceeded: {self.used}/{self.max}")
+
+budget = TokenBudget(max_tokens=50_000)
+result = agent.invoke(
+    {"messages": [...]},
+    config={
+        "configurable": {"thread_id": "user-42"},
+        "recursion_limit": 10,
+        "callbacks": [budget],
+    },
+)
+```
+
+A per-session budget of 50K tokens on Sonnet is roughly $0.25 — a safe cap for
+interactive agents. For background planners raise to 200K-500K. See
+[Loop Caps and Budgets](references/loop-caps-and-budgets.md) for a
+repeated-tool-call early-stop node and a middleware pattern that terminates on
+the N-th identical call.
+
+### Step 6 — Propagate tool errors; do not silently swallow
+
+LangGraph's default is to raise. Legacy `AgentExecutor(handle_parsing_errors=True)`
+swallowed everything. The new defaults are safer but different:
+
+```python
+# Tool raises → the exception propagates out of agent.invoke()
+try:
+    result = agent.invoke({"messages": [{"role": "user", "content": "..."}]}, config=config)
+except ValueError as e:
+    # Your tool's own ValueError — log + user-facing message
+    ...
+```
+
+When you *want* tolerant behavior (e.g., the tool is a flaky third-party API
+and you want the model to try a different approach), wrap the tool itself:
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def search_kb(query: str) -> str:
+    """Search the internal knowledge base. Returns hits or a 'no results' string."""
+    try:
+        return _real_search(query)
+    except HTTPError as e:
+        return f"search_kb unavailable: {e.response.status_code}. Try a different query."
+```
+
+The key insight: the *tool* decides to degrade gracefully by returning a string
+the model can reason about. The *agent* never silently drops an error. See
+[Error Propagation](references/error-propagation.md) for a custom error-handler
+node that routes tool failures to a fallback tool.
+
+### Step 7 — Choose `create_react_agent` vs custom `StateGraph` vs legacy
+
+| Decision | Use | Why |
+|---|---|---|
+| Single agent, tool-calling loop | `create_react_agent` | Correct defaults, provider-native tool calling, smallest code surface |
+| Multi-stage pipeline (plan → execute → review) | Custom `StateGraph` | You need named nodes, explicit conditional edges, typed state |
+| Multi-agent supervisor | `create_supervisor` + workers built with `create_react_agent` | Built-in routing, per-worker checkpointing |
+| New code in 2026+ | Never use `AgentExecutor` or `initialize_agent` | Removed / deprecated in 1.0 (P41); shape changes in `intermediate_steps` (P42) |
+
+For a single forced-tool single-shot (e.g., "always classify into one of these
+buckets"), skip agents entirely: use `model.bind_tools([Schema],
+tool_choice={"type": "tool", "name": "Schema"})`. But never loop a forced
+`tool_choice` (P63) — the model cannot emit `stop_reason="end_turn"` under
+forced tool_choice, so the agent never terminates.
+
+## Output
+
+- Agent built with `create_react_agent(model, tools, checkpointer=MemorySaver())`
+- Tools defined with `@tool` + Pydantic `args_schema`, docstrings under 1024 chars
+- Invocations pass `{"configurable": {"thread_id": ...}, "recursion_limit": N}`
+- `TokenBudget` callback enforces per-session cost ceiling
+- Tool errors raise and surface in observability; graceful-degrade patterns are
+  explicit (return-a-string, not silent-swallow)
+- Decision table resolved: `create_react_agent` vs custom `StateGraph` vs
+  supervisor vs legacy
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition` | Vague prompt never converges; default cap too high (P10) | Lower `recursion_limit` to 5-10 interactive; add repeated-tool-call early-stop node |
+| `ImportError: cannot import name 'initialize_agent' from 'langchain.agents'` | Legacy 0.2 agent factory removed (P41) | `from langgraph.prebuilt import create_react_agent` |
+| `AttributeError: 'ToolCall' object has no attribute 'tool'` | Old code accessing `step.tool` on new intermediate step shape (P42) | Use `step.tool_name` (or `step["name"]` on dict form); check `isinstance(step, ToolCall)` |
+| Agent says "couldn't find answer" but tool actually raised | Legacy `AgentExecutor` `handle_parsing_errors=True` silently swallowed exception (P09) | Migrate to `create_react_agent`; errors raise by default |
+| Agent loops when `tool_choice={"type": "tool", "name": "X"}` is set | Forced tool_choice blocks `stop_reason="end_turn"` (P63) | Use `tool_choice="auto"` for agent loops; reserve forced choice for one-shot calls |
+| Agent hallucinates a tool name like `exec` that is not in `tools=[...]` | Older free-text ReAct parser accepts any string (P32) | Use `create_react_agent` — it relies on provider-native tool calling; the allowlist is wire-enforced |
+| `RuntimeError: Token budget exceeded` | Your `TokenBudget` callback fired | Working as intended; raise the cap or shorten the agent's scope |
+| Tool description truncated, model calls with wrong args | Docstring exceeded 1024-char cap (P11) | Shorten docstring; move examples into system prompt |
+
+## Examples
+
+### Migrating a legacy `AgentExecutor` agent
+
+Before (LangChain 0.2):
+
+```python
+from langchain.agents import initialize_agent, AgentType
+agent = initialize_agent(
+    tools, llm, agent=AgentType.OPENAI_FUNCTIONS,
+    handle_parsing_errors=True, return_intermediate_steps=True,
+)
+result = agent.invoke({"input": "..."})
+for action, observation in result["intermediate_steps"]:
+    print(action.tool, observation)  # .tool attribute
+```
+
+After (LangGraph 1.0):
+
+```python
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import MemorySaver
+agent = create_react_agent(llm, tools, checkpointer=MemorySaver())
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "..."}]},
+    config={"configurable": {"thread_id": "t1"}, "recursion_limit": 10},
+)
+# intermediate steps are now ToolMessage entries in the messages list
+for m in result["messages"]:
+    if m.type == "tool":
+        print(m.name, m.content)  # .name, not .tool
+```
+
+See [AgentExecutor Migration](references/agent-executor-migration.md) for the
+full before/after including `handle_parsing_errors`, `return_intermediate_steps`,
+and `max_iterations` translations.
+
+### Interactive agent with a strict cost cap
+
+A customer-support agent with two tools, 10-step recursion cap, and a 30K
+token budget. See [Loop Caps and Budgets](references/loop-caps-and-budgets.md)
+for the full example with a repeated-tool-call early-stop node.
+
+## Resources
+
+- [LangGraph: Agents overview](https://langchain-ai.github.io/langgraph/agents/overview/)
+- [`create_react_agent` reference](https://langchain-ai.github.io/langgraph/reference/prebuilt/#langgraph.prebuilt.chat_agent_executor.create_react_agent)
+- [LangGraph: Recursion limits](https://langchain-ai.github.io/langgraph/how-tos/recursion-limit/)
+- [LangGraph: Tool calling](https://langchain-ai.github.io/langgraph/how-tos/tool-calling/)
+- [LangChain: `@tool` decorator](https://python.langchain.com/docs/how_to/custom_tools/)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P09, P10, P11, P32, P41, P42, P63)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/agent-executor-migration.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/agent-executor-migration.md
@@ -1,0 +1,187 @@
+# `AgentExecutor` → `create_react_agent` Migration
+
+LangChain 1.0 removed `initialize_agent` (P41) and changed the shape of
+`intermediate_steps` (P42). This reference is the concrete before/after.
+
+## Import changes
+
+```python
+# BEFORE (0.2.x)
+from langchain.agents import initialize_agent, AgentExecutor, AgentType
+from langchain.agents.output_parsers import OpenAIFunctionsAgentOutputParser
+
+# AFTER (1.0.x)
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import MemorySaver
+```
+
+Attempting to import `initialize_agent` in 1.0 raises
+`ImportError: cannot import name 'initialize_agent' from 'langchain.agents'`.
+
+## Agent construction
+
+### Before
+
+```python
+from langchain.agents import initialize_agent, AgentType
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4", temperature=0)
+agent = initialize_agent(
+    tools=tools,
+    llm=llm,
+    agent=AgentType.OPENAI_FUNCTIONS,
+    handle_parsing_errors=True,
+    return_intermediate_steps=True,
+    max_iterations=10,
+    verbose=True,
+)
+```
+
+### After
+
+```python
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import MemorySaver
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4o", temperature=0, timeout=30, max_retries=2)
+agent = create_react_agent(
+    model=llm,
+    tools=tools,
+    checkpointer=MemorySaver(),
+)
+```
+
+## Parameter translations
+
+| Old `AgentExecutor` / `initialize_agent` | New `create_react_agent` |
+|---|---|
+| `max_iterations=10` | Pass `recursion_limit=20` on invocation (doubled: each iteration = 2 node visits) |
+| `handle_parsing_errors=True` | Not a param. Errors raise by default. Wrap tools to return strings for tolerant behavior. |
+| `return_intermediate_steps=True` | Not needed. `result["messages"]` contains all `ToolMessage` entries. |
+| `verbose=True` | Use LangSmith tracing or `stream()` / `astream()` instead. |
+| `agent=AgentType.OPENAI_FUNCTIONS` | Implicit — `create_react_agent` uses provider-native tool calling. |
+| `early_stopping_method="generate"` | Not a param. Implement via custom `StateGraph` with a conditional edge to `END`. |
+| `max_execution_time=30` | Apply at the API boundary with `asyncio.wait_for` or your framework's request timeout. |
+
+## Invocation shape
+
+### Before
+
+```python
+result = agent.invoke({"input": "look up account abc"})
+print(result["output"])
+for action, observation in result["intermediate_steps"]:
+    print(f"Tool: {action.tool}")       # AgentAction.tool
+    print(f"Input: {action.tool_input}")  # AgentAction.tool_input
+    print(f"Output: {observation}")
+```
+
+### After
+
+```python
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "look up account abc"}]},
+    config={"configurable": {"thread_id": "t1"}, "recursion_limit": 10},
+)
+
+# Final answer
+print(result["messages"][-1].content)
+
+# Tool invocation history
+for m in result["messages"]:
+    if m.type == "ai" and getattr(m, "tool_calls", None):
+        for tc in m.tool_calls:
+            print(f"Tool: {tc['name']}")   # ToolCall.name (or tc['name'] on dict form)
+            print(f"Args: {tc['args']}")   # ToolCall.args (renamed from tool_input)
+    elif m.type == "tool":
+        print(f"Output: {m.content}")
+```
+
+## `intermediate_steps` shape change (P42)
+
+The single biggest source of migration bugs — attribute names moved:
+
+| 0.2.x `AgentAction` | 1.0.x `ToolCall` |
+|---|---|
+| `.tool` (str) | `.name` (str) — also `["name"]` on dict form |
+| `.tool_input` (dict or str) | `.args` (dict) — also `["args"]` |
+| N/A | `.id` (str) — new, used for matching ToolCall ↔ ToolMessage |
+| N/A | `.type` — always `"tool_call"` on typed form |
+
+The structure also changes: instead of a flat `list[tuple[AgentAction, str]]`
+under `result["intermediate_steps"]`, you walk `result["messages"]` and match
+`AIMessage.tool_calls` to subsequent `ToolMessage` entries by `id`.
+
+Helper for legacy-shape consumers:
+
+```python
+def legacy_intermediate_steps(messages):
+    """Adapter: return [(tool_name, args, output), ...] from a 1.0 messages list."""
+    out = []
+    tool_calls_by_id = {}
+    for m in messages:
+        if m.type == "ai" and getattr(m, "tool_calls", None):
+            for tc in m.tool_calls:
+                tool_calls_by_id[tc["id"]] = (tc["name"], tc["args"])
+        elif m.type == "tool":
+            call = tool_calls_by_id.get(m.tool_call_id)
+            if call:
+                name, args = call
+                out.append((name, args, m.content))
+    return out
+```
+
+## Streaming shape change
+
+### Before
+
+```python
+for chunk in agent.stream({"input": "..."}):
+    if "actions" in chunk:
+        for action in chunk["actions"]:
+            print(action.tool)
+    elif "steps" in chunk:
+        for step in chunk["steps"]:
+            print(step.observation)
+    elif "output" in chunk:
+        print(chunk["output"])
+```
+
+### After
+
+```python
+# Node-level streaming (default): each chunk is {node_name: state_update}
+for chunk in agent.stream({"messages": [...]}, config=config):
+    for node, update in chunk.items():
+        if "messages" in update:
+            last = update["messages"][-1]
+            print(f"[{node}] {last.type}: {getattr(last, 'content', '')[:80]}")
+
+# Token-level streaming: use astream_events(version="v2")
+async for event in agent.astream_events({"messages": [...]}, config=config, version="v2"):
+    if event["event"] == "on_chat_model_stream":
+        print(event["data"]["chunk"].content, end="", flush=True)
+```
+
+## What to grep for in your codebase
+
+Before a migration PR, scan for these patterns — each is a breaking change:
+
+| Grep pattern | Migrate to |
+|---|---|
+| `initialize_agent` | `create_react_agent` |
+| `AgentExecutor(` | `create_react_agent(...)` |
+| `handle_parsing_errors=` | Remove; handle in tools |
+| `return_intermediate_steps=` | Remove; walk `result["messages"]` |
+| `.intermediate_steps` | Walk messages, match by `tool_call_id` |
+| `action.tool` (where `action` is an AgentAction) | `tc["name"]` or `tc.name` on `ToolCall` |
+| `action.tool_input` | `tc["args"]` or `tc.args` |
+| `max_iterations=N` | `recursion_limit=2*N` on invocation |
+| `result["output"]` | `result["messages"][-1].content` |
+| `AgentType.` | Remove; `create_react_agent` has no type enum |
+
+After the mechanical replacement, re-run your eval harness. The recursion-limit
+doubling is the most common source of false "it got slower" bug reports —
+old `max_iterations=10` ≈ new `recursion_limit=20`, not 10.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/error-propagation.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/error-propagation.md
@@ -1,0 +1,198 @@
+# Error Propagation in LangGraph Agents
+
+The headline change from legacy `AgentExecutor` to `create_react_agent` is
+error semantics: legacy swallowed everything (P09); new raises by default.
+This reference covers when to keep that, when to degrade gracefully, and how
+to build a custom error-handler node for partial tolerance.
+
+## The three error classes
+
+1. **Tool validation errors** (`ValidationError` from Pydantic `args_schema`).
+   Raised before the tool body runs. By default `create_react_agent` converts
+   these to a `ToolMessage` with the error text and lets the model retry. This
+   is the right default.
+
+2. **Tool runtime errors** (`ValueError`, `HTTPError`, anything your tool
+   raises). By default these *also* become `ToolMessage` entries — the model
+   sees the exception string as the observation. On the legacy `AgentExecutor`
+   with `handle_parsing_errors=True`, empty-string exceptions led to silent
+   loops (P09). On `create_react_agent`, empty strings still happen but the
+   failure surfaces in traces.
+
+3. **Model errors** (`anthropic.RateLimitError`, `openai.APIError`, etc).
+   Propagate up from `agent.invoke()`. These should be caught at the API
+   boundary and mapped to HTTP 429 / 503 / retry.
+
+## Default behavior (the raise-by-default contract)
+
+```python
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+
+@tool
+def get_user(user_id: str) -> dict:
+    """Fetch a user by ID."""
+    if not user_id:
+        raise ValueError("user_id is required")
+    return db.get(user_id)  # may raise KeyError
+
+agent = create_react_agent(model, [get_user])
+result = agent.invoke({"messages": [{"role": "user", "content": "get user bob"}]})
+```
+
+What happens if `db.get("bob")` raises `KeyError: 'bob'`:
+
+- The exception is caught by LangGraph's `ToolNode`.
+- A `ToolMessage` is created with `content="Error: KeyError('bob')"`.
+- The model sees it in the next step and can recover ("I couldn't find that
+  user. Could you check the ID?").
+
+What happens if you set `handle_tool_errors=False`:
+
+- The exception propagates out of `agent.invoke()`.
+- Your API handler catches it.
+
+## When to change the default
+
+### Pattern 1: Tool returns a string on recoverable failures
+
+The tool is the right place to decide "this error is the model's business":
+
+```python
+@tool
+def search_kb(query: str) -> str:
+    """Search the KB. Returns results as text, or a 'no results' notice."""
+    try:
+        hits = kb.search(query)
+    except ConnectionError:
+        return "KB temporarily unavailable. Ask the user to try again later."
+    if not hits:
+        return f"No results for {query!r}. Try different keywords."
+    return "\n".join(f"- {h.title}: {h.snippet}" for h in hits[:5])
+```
+
+The model reads "KB temporarily unavailable" and gracefully communicates it.
+You never propagate the `ConnectionError` — it is expected, not exceptional.
+
+### Pattern 2: Tool raises for un-recoverable failures
+
+If an error means the entire session should abort (security violation, tenant
+mismatch, missing auth), raise a custom exception:
+
+```python
+class TenantViolationError(Exception):
+    pass
+
+@tool
+def lookup_account(account_id: str, *, config) -> dict:
+    tenant = config["configurable"]["tenant_id"]
+    if not account_id.startswith(f"{tenant}:"):
+        raise TenantViolationError(f"Cross-tenant lookup: {account_id}")
+    return db.fetch(account_id)
+
+# In your handler:
+try:
+    result = agent.invoke(...)
+except TenantViolationError as e:
+    alert_security(e)
+    return {"error": "forbidden"}, 403
+```
+
+To bypass LangGraph's default error-capture, set `handle_tool_errors=False` on
+the `ToolNode` — but with the prebuilt agent, the cleaner path is to subclass
+the exception and catch at the boundary:
+
+```python
+# The ToolNode will still catch it and emit a ToolMessage, but the model
+# should reliably fail the next step. Safer to build a custom graph:
+from langgraph.prebuilt import ToolNode
+tool_node = ToolNode([lookup_account], handle_tool_errors=False)
+# ...then wire into a custom StateGraph.
+```
+
+### Pattern 3: Custom error-handler node
+
+For a real recovery policy — "on tool failure, route to a fallback tool or a
+graceful-response node" — a custom `StateGraph` is the right level:
+
+```python
+from langgraph.graph import StateGraph, END, START
+from langgraph.graph import MessagesState
+
+def check_tool_error(state: MessagesState) -> str:
+    last = state["messages"][-1]
+    if last.type == "tool" and last.content.startswith("Error:"):
+        return "error_handler"
+    return "model"
+
+def error_handler(state: MessagesState):
+    return {"messages": [{"role": "assistant", "content":
+        "I hit a problem with my tools. Let me try a different approach."}]}
+
+graph = StateGraph(MessagesState)
+graph.add_node("model", model_node)
+graph.add_node("tools", tool_node)
+graph.add_node("error_handler", error_handler)
+graph.add_edge(START, "model")
+graph.add_conditional_edges("model", route_after_model, {"tools": "tools", "end": END})
+graph.add_conditional_edges("tools", check_tool_error, {
+    "error_handler": "error_handler",
+    "model": "model",
+})
+graph.add_edge("error_handler", END)
+```
+
+## Migrating from `handle_parsing_errors=True`
+
+The legacy flag did three things:
+
+1. Caught parsing errors (bad JSON from the model).
+2. Caught tool exceptions.
+3. Fed the error back as the next observation.
+
+In LangGraph 1.0:
+
+- **Parsing errors:** Not an issue. `create_react_agent` uses provider-native
+  tool calling, so the provider rejects invalid JSON before it reaches you.
+- **Tool exceptions:** Default is the same behavior (error as observation),
+  but the error text is the full exception `repr`, not an empty string.
+- **Silent empty-string bug (P09):** Fixed — the exception's `repr()` is
+  never empty.
+
+If you relied on `handle_parsing_errors="Check your output"` (a custom
+message), move that logic into the tool itself:
+
+```python
+@tool
+def strict_tool(x: int) -> str:
+    """Do the thing. x must be a positive int."""
+    if x <= 0:
+        # Explicit message the model will see
+        return "Error: x must be > 0. Please retry with a positive integer."
+    return _work(x)
+```
+
+## Observability
+
+In production, every tool error should:
+
+1. Log the full exception with the session `thread_id`.
+2. Emit a metric (`tool_error_total{tool="search_kb"}`).
+3. Leave the `ToolMessage` in the trace.
+
+```python
+import logging
+logger = logging.getLogger("agent.tools")
+
+@tool
+def search_kb(query: str) -> str:
+    """Search the KB."""
+    try:
+        return _search(query)
+    except Exception as e:
+        logger.exception("search_kb failed", extra={"query": query})
+        return f"KB error: {type(e).__name__}. Try a different query."
+```
+
+The tool returns a user-safe string; your logs have the full traceback. The
+agent never silently drops an error; you never leak internals to the model.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/loop-caps-and-budgets.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/loop-caps-and-budgets.md
@@ -1,0 +1,169 @@
+# Loop Caps and Budgets for LangGraph Agents
+
+`create_react_agent` has exactly one built-in cap: `recursion_limit=25`. That is
+not enough. This reference covers the three layers of defense: the recursion
+cap, a token budget, and a repeated-tool-call early-stop node — the stack that
+prevents P10 ("agent loops exceed 15 iterations on vague prompts").
+
+## Layer 1: `recursion_limit`
+
+A recursion step is one node visit. Each tool round-trip is two visits (model
+node → tool node → model node). So `recursion_limit=25` ≈ 12 tool rounds.
+
+| Agent kind | `recursion_limit` | Approx tool calls allowed |
+|---|---|---|
+| Chat with 1-3 tools | 5-10 | 2-5 |
+| Task-completion flow | 10-15 | 4-7 |
+| Planner / research | 20-30 | 10-15 |
+| Multi-agent supervisor | 40+ | Coordinator rounds; budget worker calls separately |
+
+Apply on invocation:
+
+```python
+result = agent.invoke(
+    {"messages": [...]},
+    config={"configurable": {"thread_id": "t1"}, "recursion_limit": 10},
+)
+```
+
+On exhaustion: `GraphRecursionError`. Catch it at the API boundary and surface
+a user message ("I couldn't complete the request in time"). Do not auto-retry.
+
+## Layer 2: Per-session token budget
+
+The recursion cap does not bound cost. One tool returning a 50K-token document
+plus a long completion can cost more than 20 cheap rounds. Enforce a token
+ceiling with a callback:
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class TokenBudget(BaseCallbackHandler):
+    def __init__(self, max_tokens: int = 50_000):
+        self.used = 0
+        self.max = max_tokens
+
+    def on_llm_end(self, response, **kwargs):
+        # LangChain 1.0: token_usage is nested under llm_output or generations
+        usage = {}
+        if hasattr(response, "llm_output") and response.llm_output:
+            usage = response.llm_output.get("token_usage", {}) or {}
+        elif response.generations:
+            gen = response.generations[0][0]
+            meta = getattr(gen.message, "usage_metadata", None) or {}
+            usage = {
+                "total_tokens": meta.get("input_tokens", 0) + meta.get("output_tokens", 0),
+            }
+        self.used += usage.get("total_tokens", 0)
+        if self.used > self.max:
+            raise RuntimeError(f"Token budget exceeded: {self.used}/{self.max}")
+
+budget = TokenBudget(max_tokens=30_000)
+result = agent.invoke(
+    {"messages": [...]},
+    config={
+        "configurable": {"thread_id": "t1"},
+        "recursion_limit": 10,
+        "callbacks": [budget],
+    },
+)
+```
+
+### Suggested budgets
+
+| Agent use case | Token ceiling | Approx $ on Claude Sonnet |
+|---|---|---|
+| Interactive chat | 30K | ~$0.15 |
+| Customer support | 50K | ~$0.25 |
+| Task completion | 100K | ~$0.50 |
+| Background planner | 250K | ~$1.25 |
+| Research agent | 500K | ~$2.50 |
+
+Multiply by your volume. An agent billed at $0.25 per session running 10K
+sessions/day is $75K/month — real money if you don't cap.
+
+## Layer 3: Repeated-tool-call early stop
+
+A common loop pattern: the model calls `search_kb("help")`, gets 5 vague
+results, calls `search_kb("assistance")`, gets the same 5 results, repeats.
+The recursion cap will eventually fire — but we can detect the loop earlier
+by watching for repeated tool calls with similar args.
+
+Custom `StateGraph` approach (not the prebuilt):
+
+```python
+from langgraph.graph import StateGraph, END, START
+from langgraph.graph import MessagesState
+
+class State(MessagesState):
+    tool_call_history: list[tuple[str, str]]  # (tool_name, args_hash)
+
+def model_node(state: State):
+    response = model.invoke(state["messages"])
+    return {"messages": [response]}
+
+def repeated_check(state: State) -> str:
+    last = state["messages"][-1]
+    if not getattr(last, "tool_calls", None):
+        return "end"
+    call = last.tool_calls[0]
+    import hashlib, json
+    args_hash = hashlib.md5(json.dumps(call["args"], sort_keys=True).encode()).hexdigest()[:8]
+    history = state.get("tool_call_history", [])
+    if sum(1 for (n, h) in history if n == call["name"] and h == args_hash) >= 2:
+        return "end"  # same tool + same args 3 times → stop
+    return "tools"
+
+# ...wire with graph.add_conditional_edges("model", repeated_check, {"tools": "tools", "end": END})
+```
+
+For the prebuilt `create_react_agent`, you can achieve the same effect with a
+callback that tracks tool calls and raises when a threshold is hit:
+
+```python
+class RepeatedToolStopper(BaseCallbackHandler):
+    def __init__(self, max_repeats: int = 3):
+        self.calls: dict[tuple[str, str], int] = {}
+        self.max = max_repeats
+
+    def on_tool_start(self, serialized, input_str, **kwargs):
+        key = (serialized.get("name", "?"), input_str[:200])
+        self.calls[key] = self.calls.get(key, 0) + 1
+        if self.calls[key] >= self.max:
+            raise RuntimeError(f"Tool {key[0]} called {self.max}x with same args — likely stuck")
+```
+
+## Combining all three layers
+
+```python
+result = agent.invoke(
+    {"messages": [...]},
+    config={
+        "configurable": {"thread_id": "t1"},
+        "recursion_limit": 10,         # layer 1: step cap
+        "callbacks": [
+            TokenBudget(max_tokens=30_000),    # layer 2: cost cap
+            RepeatedToolStopper(max_repeats=3),  # layer 3: loop detection
+        ],
+    },
+)
+```
+
+Wrap in `try`/`except` at the API boundary:
+
+```python
+try:
+    result = agent.invoke(...)
+except GraphRecursionError:
+    return "I couldn't complete that in the time I had. Could you rephrase?"
+except RuntimeError as e:
+    if "Token budget" in str(e):
+        return "This request is more complex than I can handle in one step. Try breaking it down."
+    if "called" in str(e) and "same args" in str(e):
+        return "I kept trying the same search. Could you give me a more specific question?"
+    raise
+```
+
+The three messages above are user-facing bailouts, each mapped to one failure
+mode. Log the full error to observability — the customer sees a friendly line,
+your on-call sees the stack.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-langgraph-agents — One-Pager
+
+Build a correct LangGraph 1.0 ReAct agent with `create_react_agent` — typed tools, error propagation, recursion caps, and stop conditions that actually stop.
+
+## The Problem
+
+`create_react_agent` defaults to `recursion_limit=25`: a vague prompt like "help me with my account" loops to the cap and surfaces a `GraphRecursionError` only after burning $5+ in tool and completion tokens (P10). The legacy `AgentExecutor` it replaced swallowed tool exceptions as empty-string observations with `handle_parsing_errors=True`, so "I couldn't find the answer" was actually a silent `ValueError` the model never saw (P09). And `initialize_agent` no longer exists — code that worked on LangChain 0.2 raises `ImportError` on 1.0 (P41), with the tuple shape of `intermediate_steps` changed from `AgentAction.tool` to `ToolCall.tool_name` (P42).
+
+## The Solution
+
+This skill walks through `create_react_agent(model, tools, checkpointer=MemorySaver())` with typed `@tool` definitions (Pydantic schemas, docstring under the 1024-char cap — P11), explicit `recursion_limit` per expected agent depth (5-10 interactive, 20-30 planner), raise-by-default tool errors (no more silent crashes), and middleware that enforces a per-session token budget. Includes a decision matrix for `create_react_agent` vs custom `StateGraph` vs the legacy `AgentExecutor`, and a concrete before/after migration table. Pinned to `langgraph 1.0.x` + `langchain-core 1.0.x`.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers and researchers building production ReAct-style agents who have LangGraph basics (L25) and are now wiring tools |
+| **What** | Typed `@tool` definitions, `create_react_agent` invocation, `recursion_limit` + cost-cap middleware, tool-call counter nodes, raise-by-default error propagation, 4 references (tool-definition-patterns, loop-caps-and-budgets, agent-executor-migration, error-propagation) |
+| **When** | After `langchain-langgraph-basics` (L25), when writing your first tool-calling agent, migrating from `AgentExecutor` / `initialize_agent`, or diagnosing an agent that loops on vague prompts |
+
+## Key Features
+
+1. **Provider-native tool enforcement** — `create_react_agent` uses the provider's tool-calling API, so the allowlist is enforced at the wire level; the model cannot hallucinate a tool name that isn't in `tools=[...]` (P32)
+2. **Raise-by-default tool errors** — Tool exceptions propagate as `GraphInterrupt` / real tracebacks instead of empty-string observations the agent silently ignores (P09); custom error-handler nodes re-enable tolerant behavior where you need it
+3. **Bounded recursion and cost** — `recursion_limit=5-10` for interactive, 20-30 for planners; middleware caps per-session tokens and early-stops on repeated tool calls before the default 25-step ceiling fires `GraphRecursionError` (P10)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/tool-definition-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/references/tool-definition-patterns.md
@@ -1,0 +1,161 @@
+# Tool Definition Patterns for LangGraph 1.0 Agents
+
+LangGraph's `create_react_agent` consumes LangChain `BaseTool` instances. You
+have three ways to produce one: the `@tool` decorator, the `tool()` factory,
+and a `BaseTool` subclass. This reference covers the decision and the
+gotchas — most of which trace back to P11 (tool descriptions > 1024 chars) and
+the provider-enforcement model of tool calling.
+
+## The three ways
+
+### `@tool` decorator — the default
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def search_kb(query: str) -> list[dict]:
+    """Search the knowledge base. Returns the top 5 matching articles."""
+    return _search(query)[:5]
+```
+
+The decorator infers the schema from the function signature and uses the
+docstring as the tool description. This is what you want 80% of the time.
+
+### `@tool` + `args_schema` — when you need validators
+
+```python
+from pydantic import BaseModel, Field, field_validator
+from langchain_core.tools import tool
+
+class SearchArgs(BaseModel):
+    query: str = Field(..., min_length=1, max_length=500)
+    top_k: int = Field(5, ge=1, le=20)
+
+    @field_validator("query")
+    @classmethod
+    def no_sql(cls, v: str) -> str:
+        if any(kw in v.upper() for kw in ["DROP ", "DELETE ", ";--"]):
+            raise ValueError("query contains SQL keywords")
+        return v
+
+@tool("search_kb", args_schema=SearchArgs)
+def search_kb(query: str, top_k: int = 5) -> list[dict]:
+    """Search the knowledge base. Returns up to top_k hits."""
+    return _search(query)[:top_k]
+```
+
+Pydantic validators run *before* your function. If the model passes bad args,
+the agent sees a `ValidationError` it can retry against. This is cheaper than
+letting your function raise mid-way through an expensive call.
+
+### `BaseTool` subclass — when you need instance state
+
+```python
+from langchain_core.tools import BaseTool
+
+class KBSearchTool(BaseTool):
+    name: str = "search_kb"
+    description: str = "Search the knowledge base. Returns top 5 matches."
+    args_schema: type = SearchArgs
+    client: Any  # your KB client — pydantic-validated
+
+    def _run(self, query: str, top_k: int = 5) -> list[dict]:
+        return self.client.search(query)[:top_k]
+
+    async def _arun(self, query: str, top_k: int = 5) -> list[dict]:
+        return await self.client.asearch(query)[:top_k]
+```
+
+Use when the tool needs config at construction time (per-tenant client, per-
+environment base URL). With `@tool` you would end up closing over module
+globals, which breaks testing.
+
+## Docstring = tool description (P11)
+
+Whatever you write in the docstring is the description the provider sees:
+
+- **Anthropic Claude:** truncates at ~1024 characters per tool description.
+- **OpenAI GPT-4o:** no hard cap, but descriptions > ~2KB degrade accuracy.
+
+Validate before binding:
+
+```python
+for t in tools:
+    if len(t.description) > 1024:
+        raise ValueError(f"Tool {t.name} description too long: {len(t.description)} chars")
+```
+
+Long examples and format specs belong in the system prompt, not the docstring.
+The docstring should answer *when* to use the tool in one or two sentences.
+
+## Async tools
+
+```python
+@tool
+async def fetch_url(url: str) -> str:
+    """Fetch a URL and return the body as UTF-8 text."""
+    async with httpx.AsyncClient() as c:
+        r = await c.get(url, timeout=10)
+        return r.text
+```
+
+LangGraph detects the coroutine and awaits it. Do not mix sync and async
+wrappers — pick one per tool. If you need both, use a `BaseTool` subclass
+with both `_run` and `_arun`.
+
+## Return types the model can reason about
+
+Tools should return one of:
+
+- `str` — the model reads it as text in the next turn
+- `dict` / `list` — serialized to JSON in the `ToolMessage.content`
+- A Pydantic model — auto-serialized
+
+Avoid returning binary data, large blobs, or raw HTML. If you must, summarize
+in the tool itself before returning.
+
+## Security-adjacent patterns
+
+### Allowlist is wire-enforced — do not re-check
+
+In legacy free-text ReAct (P32), agents could hallucinate tool names because
+the parser took any string as a valid action. `create_react_agent` relies on
+the provider's native tool-calling API, which enforces that only bound tools
+are callable. You do not need to re-check `tool_name in allowed_tools` — the
+provider will refuse to emit unknown tool calls.
+
+### Validators are your authorization boundary
+
+Pydantic `args_schema` validators are the right place to enforce tenant
+isolation, PII policies, and rate-limits. They run before the tool body and
+raise `ValidationError` cleanly.
+
+```python
+class AccountLookupArgs(BaseModel):
+    account_id: str
+
+    @field_validator("account_id")
+    @classmethod
+    def tenant_scoped(cls, v: str, info) -> str:
+        tenant = info.context.get("tenant_id") if info.context else None
+        if not v.startswith(f"{tenant}:"):
+            raise ValueError("account_id is cross-tenant")
+        return v
+```
+
+(`info.context` is threaded through `RunnableConfig.configurable.context` in
+LangChain 1.0. See the core-workflow skill for the plumbing.)
+
+## When a tool is not a tool
+
+If the step is deterministic (e.g., format a date, stringify a number), do not
+expose it as a tool — do it in your graph's pre-processing node. Tools should
+have side effects or external-state dependencies. Every tool in the list
+increases:
+
+1. The token cost of each model call (descriptions are in the prompt).
+2. The decision space the model has to search.
+3. The surface area for the agent to get confused.
+
+Aim for 3-7 tools per agent. More than that → split into supervisor + workers.


### PR DESCRIPTION
## Summary

Handcrafted skill covering LangGraph 1.0 `create_react_agent` — typed tools, raise-by-default error propagation, recursion budgets, and stop conditions. Anchored to pain-catalog **P09, P10, P32, P41, P42, P63**.

## Pain hook

A vague "help me with my account" prompt loops to the `recursion_limit=25` default before surfacing `GraphRecursionError` — \$5+ wasted on tool tokens (P10). Legacy `AgentExecutor(handle_parsing_errors=True)` caught tool `ValueError`s and fed empty-string observations back to the model (P09), so "I couldn't find the answer" was actually a silent crash. Fixed by `create_react_agent`'s raise-by-default contract plus a 3-layer defense (recursion cap, token budget callback, repeated-tool-call stopper).

## Files

- `skills/langchain-langgraph-agents/SKILL.md`
- `skills/langchain-langgraph-agents/references/one-pager.md`
- `skills/langchain-langgraph-agents/references/tool-definition-patterns.md`
- `skills/langchain-langgraph-agents/references/loop-caps-and-budgets.md`
- `skills/langchain-langgraph-agents/references/agent-executor-migration.md`
- `skills/langchain-langgraph-agents/references/error-propagation.md`

## Validator

Grade **A (93/100)** at standard + enterprise, zero ERROR lines.

## Base

Targets `feat/langchain-py-pack-foundation` (#546).

Jeremy made me do it
-claude