### PR TITLE
feat(langchain-py-pack): add langchain-langgraph-checkpointing (L27)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: langchain-langgraph-checkpointing
+description: |
+  Persist LangGraph agent state correctly with MemorySaver and PostgresSaver —
+  thread_id discipline, JSON-serializable state rules, time-travel, schema
+  migration. Use when adding chat memory, migrating from ConversationBufferMemory,
+  or time-traveling an agent state to debug an incident.
+  Trigger with "langgraph checkpointer", "MemorySaver", "PostgresSaver",
+  "thread_id", "langgraph time travel", "langgraph state persistence".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(psql:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, checkpointing, persistence, memory]
+compatible-with: claude-code, codex
+---
+
+# LangGraph Checkpointing (Python)
+
+## Overview
+
+A chat agent that "keeps introducing itself" is almost always P16. The caller
+invokes `graph.invoke(state)` without passing `config={"configurable":
+{"thread_id": ...}}` — LangGraph's checkpointer silently spawns a fresh state per
+call. No error, no warning, no log line. The user sees it; the code does not.
+
+That is one of five separate checkpointing pitfalls this skill covers:
+
+- **P16** — missing `thread_id` silently resets memory
+- **P17** — `interrupt_before` raises `TypeError` when state holds non-JSON values
+  (`datetime`, `Decimal`, custom classes) — and it raises *at the interrupt
+  boundary*, not when the bad value was first assigned, so the traceback points
+  at the wrong line
+- **P20** — `PostgresSaver` does not auto-migrate checkpoint schema; upgrading
+  `langgraph` silently reads old checkpoints as empty state
+- **P40** — `ConversationBufferMemory` and the rest of legacy chat memory were
+  removed in LangChain 1.0; checkpointers are the replacement
+- **P51** — Deep Agent virtual-FS state in `state["files"]` grows unboundedly
+  and eventually makes checkpoint writes a latency hotspot
+
+This skill walks through picking a checkpointer by environment, enforcing
+`thread_id` at the application boundary, constraining state to JSON-safe
+primitives, Postgres setup + migration, and time-travel for incident debugging.
+Pinned to `langgraph >= 1.0, < 2.0`, `langgraph-checkpoint-postgres >= 1.0, <
+2.0`. Pain-catalog anchors: P16, P17, P18, P20, P22, P40, P51.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install langgraph langchain-core` (both `>= 1.0, < 2.0`)
+- For Postgres: `pip install langgraph-checkpoint-postgres` and a Postgres 13+
+  instance
+- For async Postgres: the same package plus `asyncpg`
+- A `thread_id` strategy — typically a UUID4 string per conversation; see
+  [thread-id-discipline.md](references/thread-id-discipline.md)
+
+## Instructions
+
+### Step 1 — Pick a checkpointer by environment
+
+| Env | Checkpointer | Import |
+|---|---|---|
+| Dev, tests, notebooks | `MemorySaver` | `langgraph.checkpoint.memory` |
+| Single-host CLI / desktop | `SqliteSaver` | `langgraph.checkpoint.sqlite` |
+| Staging, prod (sync) | `PostgresSaver` | `langgraph.checkpoint.postgres` |
+| Staging, prod (async / FastAPI) | `AsyncPostgresSaver` | `langgraph.checkpoint.postgres.aio` |
+
+`MemorySaver` is in-process only. State vanishes on restart. Every worker has
+its own (P22 analog for LangGraph). Use it anywhere state loss is acceptable;
+never in a multi-worker web backend.
+
+`PostgresSaver` and its async sibling require `setup()` on every startup *and
+after every `langgraph` upgrade* (see Step 5). Checkpoint storage overhead is
+typically **1-10 KB per step** of serialized state; plan your DB size
+accordingly — a 2,000-turn conversation with 3 KB average state fits in
+~6 MB per thread.
+
+See [checkpointer-comparison.md](references/checkpointer-comparison.md) for the
+full matrix including latency, concurrency, and the FastAPI lifespan pattern.
+
+### Step 2 — Require `thread_id` at every invocation
+
+This is the fail-loud middleware that prevents P16:
+
+```python
+from typing import Any
+
+def require_thread_id(config: dict[str, Any]) -> dict[str, Any]:
+    """Raise if thread_id is missing. Fails loud so P16 surfaces in tests,
+    not in user-visible conversation logs."""
+    configurable = (config or {}).get("configurable", {})
+    thread_id = configurable.get("thread_id")
+    if not thread_id:
+        raise ValueError(
+            "thread_id missing from config['configurable']. "
+            "Every graph invocation must carry a thread_id."
+        )
+    if not isinstance(thread_id, str):
+        raise TypeError(
+            f"thread_id must be str (UUID), got {type(thread_id).__name__}"
+        )
+    return config
+```
+
+Call it at every application boundary:
+
+```python
+import uuid
+
+config = {"configurable": {"thread_id": str(uuid.uuid4())}}
+require_thread_id(config)
+result = graph.invoke(initial_state, config=config)
+```
+
+For web endpoints, extract to a FastAPI dependency (`Header(...)` with no
+default — forces `422` on missing). For multi-tenant apps, scope the thread id by composing tenant + user +
+conversation ids into a single colon-delimited string (example:
+`"acme:alice:conv-1"`). See
+[thread-id-discipline.md](references/thread-id-discipline.md) for UUID
+generation, rotation, and the integration test that proves tenants do not share
+state.
+
+### Step 3 — Keep state JSON-serializable (TypedDict, primitives only)
+
+```python
+from typing import Annotated, TypedDict
+from langgraph.graph.message import add_messages
+from langchain_core.messages import AnyMessage
+
+
+class AgentState(TypedDict):
+    # Messages are safe — LangGraph registers a custom serializer.
+    messages: Annotated[list[AnyMessage], add_messages]
+
+    # Primitives only below. NO datetime, NO Decimal, NO custom classes.
+    user_id: str
+    turn_count: int
+    last_action_at: str           # ISO string, not datetime.datetime
+    pending_approval: bool
+    metadata: dict[str, str]      # dict keys must be str
+    plan: list[dict[str, str]]    # list of primitive dicts
+```
+
+The rule: **state fields must be JSON-safe primitives or recursive structures
+of them** (`str`, `int`, `float`, `bool`, `None`, `list`, `dict[str, ...]`).
+`json.dumps(state)` must succeed. If it raises, the checkpointer raises —
+often at a HITL interrupt many steps later (P17), which is why the traceback
+never points at the line that introduced the bad value.
+
+For non-primitive inputs, coerce at node output boundaries with a helper:
+
+```python
+from datetime import datetime
+from decimal import Decimal
+
+def record_purchase(state: AgentState) -> dict:
+    now = datetime.utcnow()
+    price = Decimal("19.99")
+    return {
+        "last_action_at": now.isoformat(),
+        "metadata": {**state["metadata"], "price": str(price)},
+    }
+```
+
+Forbidden-types reference and the full `to_state` / `from_state` helper pair
+are in [json-serializability-rules.md](references/json-serializability-rules.md).
+
+### Step 4 — Compile the graph with a checkpointer (Postgres, sync)
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import StateGraph
+import os
+
+DB_URI = os.environ["DATABASE_URL"]
+
+def build_graph() -> StateGraph:
+    builder = StateGraph(AgentState)
+    builder.add_node("agent", agent_node)
+    builder.add_node("human_approval", human_approval_node)
+    builder.set_entry_point("agent")
+    builder.add_edge("agent", "human_approval")
+    builder.set_finish_point("human_approval")
+    return builder
+
+with PostgresSaver.from_conn_string(DB_URI) as checkpointer:
+    checkpointer.setup()     # Idempotent. Creates checkpoint tables if missing.
+    graph = build_graph().compile(
+        checkpointer=checkpointer,
+        interrupt_before=["human_approval"],
+    )
+
+    config = {"configurable": {"thread_id": "user-123"}}
+    require_thread_id(config)
+    result = graph.invoke({"messages": [HumanMessage("hi")]}, config=config)
+```
+
+For async, mirror the pattern with `AsyncPostgresSaver.from_conn_string(...)`
+inside a FastAPI `@asynccontextmanager` lifespan; every call site uses
+`await graph.ainvoke(...)`.
+
+### Step 5 — Run `setup()` on startup AND after every `langgraph` upgrade
+
+P20 is the quiet one: you `pip install --upgrade langgraph`, tests pass, CI
+goes green, you deploy. Existing threads come back empty. No DB error.
+
+```python
+# Put this in your deploy script / migration runbook:
+with PostgresSaver.from_conn_string(DB_URI) as checkpointer:
+    checkpointer.setup()
+    # Sanity check: read one known thread and assert it's not empty.
+    snap = checkpointer.get({"configurable": {"thread_id": "canary-thread"}})
+    assert snap is not None, "Canary thread lost after schema migration"
+```
+
+Run this in **staging** first, with a canary thread whose state you pre-populated
+from an older `langgraph` version. If the assertion holds, promote. If not,
+the migration path is: dump checkpoints, upgrade, restore via a migration
+script. Do **not** promote to production on a version bump without this check.
+
+### Step 6 — Time-travel for incident debugging
+
+Every checkpoint is keyed by `(thread_id, checkpoint_id)` and reachable via
+`graph.get_state_history(config)`:
+
+```python
+config = {"configurable": {"thread_id": bad_thread_id}}
+history = list(graph.get_state_history(config))
+
+for i, snap in enumerate(history):
+    print(i, snap.metadata.get("step"), snap.next, list(snap.values.keys()))
+
+# Resume from a specific prior checkpoint — None as input = "use this state":
+past = history[3]                                    # history is newest-first
+result = graph.invoke(None, config=past.config)       # past.config pins checkpoint_id
+```
+
+To fix state and replay:
+
+```python
+graph.update_state(
+    past.config,
+    {"retry_count": 0, "error_reason": None},
+    as_node="validator",
+)
+graph.invoke(None, config=past.config)
+```
+
+The original branch is preserved — `update_state` creates a new checkpoint
+alongside the old one. Useful for forensics and for A/B comparing an old vs
+new model on the exact same state.
+
+See [time-travel-and-replay.md](references/time-travel-and-replay.md) for the
+full incident playbook, branching for A/B eval, and checkpoint pruning SQL.
+
+## Output
+
+- A checkpointer selected by environment, not copy-pasted from a tutorial
+- A `require_thread_id` middleware that fails loud on missing `thread_id`, and
+  at least one integration test that asserts two tenants do not share state
+- An `AgentState` TypedDict constrained to JSON-safe primitives, plus a
+  `to_state` helper at node output boundaries for `datetime` / `Decimal` /
+  Pydantic / enums
+- `PostgresSaver.setup()` wired into startup **and** every deploy that bumps
+  `langgraph`
+- An incident runbook that uses `get_state_history` + `update_state` to
+  time-travel an agent state, with prior branches preserved
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Agent forgets every turn, no error logged | Missing `thread_id` (P16) | Add `require_thread_id` middleware at app boundary; FastAPI `Header(...)` with no default |
+| `TypeError: Object of type datetime is not JSON serializable` at a HITL pause | Non-JSON value in state (P17) | Coerce at node output: `dt.isoformat()`, `str(decimal)`, `model.model_dump(mode="json")` |
+| Upgrading `langgraph` returns empty state for existing threads | Checkpoint schema drift (P20) | `PostgresSaver.setup()` after every upgrade; canary-thread assertion in staging before prod |
+| `ImportError: cannot import name 'ConversationBufferMemory'` | Legacy memory removed in 1.0 (P40) | Migrate to `MemorySaver`/`PostgresSaver` + `thread_id` per conversation |
+| Checkpoint writes take 500+ ms on Deep Agent runs | Unbounded `state["files"]` growth (P51) | Add cleanup node that prunes `state["files"]` older than N steps |
+| `Command(update={"messages": [x]})` erases prior messages | Missing reducer (P18) | `messages: Annotated[list[AnyMessage], add_messages]` |
+| Mixed `graph.invoke` with `AsyncPostgresSaver` | Sync call on async saver | Use `await graph.ainvoke(...)` everywhere, or switch to sync `PostgresSaver` |
+
+## Examples
+
+### Minimal chat agent with `MemorySaver`
+
+Dev-mode multi-turn chat that survives within a single process. Good for local
+iteration and pytest fixtures; state vanishes on restart.
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import create_react_agent
+from langchain_anthropic import ChatAnthropic
+
+checkpointer = MemorySaver()
+agent = create_react_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-6"),
+    tools=[...],
+    checkpointer=checkpointer,
+)
+config = {"configurable": {"thread_id": "dev-session-1"}}
+agent.invoke({"messages": [HumanMessage("hi")]}, config=config)
+agent.invoke({"messages": [HumanMessage("remember my name is alice")]}, config=config)
+agent.invoke({"messages": [HumanMessage("what's my name?")]}, config=config)  # alice
+```
+
+### Multi-tenant Postgres + FastAPI lifespan
+
+Async production shape. One `AsyncPostgresSaver` pool, thread-id extracted from
+a required header, tenants isolated by a composite key.
+
+See [checkpointer-comparison.md](references/checkpointer-comparison.md) for the
+complete FastAPI lifespan pattern and pool sizing advice (`max_size` needs to
+exceed concurrent graph count, and the LangGraph pool should be separate from
+the application's primary DB pool).
+
+### Migrating from `ConversationBufferMemory` (P40)
+
+Legacy 0.x pattern replaced end-to-end:
+
+```python
+# OLD — raises ImportError on 1.0:
+# from langchain.memory import ConversationBufferMemory
+# memory = ConversationBufferMemory()
+# chain = LLMChain(llm=llm, memory=memory)
+
+# NEW:
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.postgres import PostgresSaver
+
+with PostgresSaver.from_conn_string(DB_URI) as cp:
+    cp.setup()
+    agent = create_react_agent(model=llm, tools=tools, checkpointer=cp)
+    config = {"configurable": {"thread_id": user_session_id}}
+    agent.invoke({"messages": [HumanMessage(user_input)]}, config=config)
+```
+
+The `thread_id` is now the "session key" that `ConversationBufferMemory` used
+to carry implicitly.
+
+### Incident time-travel
+
+Production returned a wrong answer for `thread_id=bad-thread` at 14:03.
+Walk history newest-first, inspect the prior state, patch and replay:
+
+```python
+config = {"configurable": {"thread_id": "bad-thread"}}
+history = list(graph.get_state_history(config))
+for i, snap in enumerate(history):
+    print(i, snap.metadata.get("step"), snap.next)
+# Assume step 7 wrote the bad output; step 6 is the input.
+prior = history[-7]  # or index by metadata["step"]
+print("input to bad node:", prior.values)
+graph.update_state(prior.config, {"retry_count": 0}, as_node="validator")
+graph.invoke(None, config=prior.config)  # new branch with correct result
+```
+
+Full playbook (finding `thread_id` in logs, inspecting `writes` metadata,
+pruning history) in
+[time-travel-and-replay.md](references/time-travel-and-replay.md).
+
+## Resources
+
+- [LangGraph persistence concepts](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [Checkpointer API reference](https://langchain-ai.github.io/langgraph/reference/checkpoints/)
+- [LangGraph HITL concepts](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/)
+- [LangGraph 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P16, P17, P18, P20, P22, P40, P51)
+- Related skills in this pack: `langchain-langgraph-basics`, `langchain-langgraph-agents`, `langchain-upgrade-migration`, `langchain-common-errors`

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/checkpointer-comparison.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/checkpointer-comparison.md
@@ -1,0 +1,111 @@
+# Checkpointer Comparison — Pick One Per Environment
+
+> LangGraph 1.0.x ships four checkpointers. They are not interchangeable. Picking
+> the wrong one is the difference between a dev-mode demo that loses state on
+> process restart (P22) and a production system whose Postgres checkpoint table
+> becomes a latency hotspot under load.
+
+## Matrix
+
+| Checkpointer | Import | Persistence | Concurrency | Latency (write) | Use when |
+|---|---|---|---|---|---|
+| `MemorySaver` | `langgraph.checkpoint.memory` | Process-local dict. Lost on restart. | Single-process. | ~microseconds. | Dev / pytest / notebooks. Anything throwaway. |
+| `SqliteSaver` | `langgraph.checkpoint.sqlite` | File on disk. Shared with same-host processes. | File-lock serialization. | ~1-5 ms. | Single-host apps, CLI tools, desktop agents. Not for multi-worker web backends. |
+| `PostgresSaver` | `langgraph.checkpoint.postgres` | Postgres DB. Durable, shared, backed up. | Row-level locking; serializable transactions. | ~5-15 ms. | Staging and prod for sync apps. Works everywhere Postgres works. |
+| `AsyncPostgresSaver` | `langgraph.checkpoint.postgres.aio` | Same schema as sync. | `asyncpg` pool; scales to thousands of concurrent threads. | ~5-15 ms. | FastAPI / async web backends, long-running LangGraph servers, high-concurrency production. |
+
+Storage overhead per step is typically **1-10 KB** of serialized state (JSON + pickle headers) plus a small index entry. A year-long conversation of 2,000 turns with 3 KB average state fits in ~6 MB per thread. Index-wise, `PostgresSaver` maintains a B-tree on `(thread_id, checkpoint_id)`; size grows ~20 bytes per checkpoint plus the data row itself.
+
+## Decision Tree
+
+1. **Are you in a test / notebook / dev script?** → `MemorySaver`.
+2. **Do you run multiple processes/workers that need to share state?** → not `MemorySaver`.
+3. **Is this a single-host CLI or desktop app?** → `SqliteSaver`.
+4. **Is this a web backend with multiple workers, or do you need durability + backup?** → `PostgresSaver` (sync) or `AsyncPostgresSaver` (async).
+5. **Is your web framework async (FastAPI, Starlette, Litestar)?** → `AsyncPostgresSaver`. Sync `PostgresSaver` inside an async endpoint blocks the event loop (see P48 for the streaming analog).
+
+## Canonical Init — MemorySaver (dev)
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph
+
+checkpointer = MemorySaver()
+graph = builder.compile(checkpointer=checkpointer)
+```
+
+No setup, no connection, no migration. State dies with the process. Perfect for pytest fixtures and REPL experimentation.
+
+## Canonical Init — PostgresSaver (prod, sync)
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+import os
+
+DB_URI = os.environ["DATABASE_URL"]  # e.g. postgresql://user:pass@host:5432/agent_state
+
+with PostgresSaver.from_conn_string(DB_URI) as checkpointer:
+    checkpointer.setup()          # Idempotent. Run on startup. Run after every langgraph upgrade (P20).
+    graph = builder.compile(checkpointer=checkpointer)
+    result = graph.invoke(
+        {"messages": [...]},
+        config={"configurable": {"thread_id": "user-123"}},
+    )
+```
+
+The context manager shape matters — it owns the connection pool. In a real service, wrap `setup()` + `compile()` in your app's startup hook (FastAPI `@app.lifespan`, Flask `app.before_first_request`).
+
+## Canonical Init — AsyncPostgresSaver (prod, async)
+
+```python
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with AsyncPostgresSaver.from_conn_string(DB_URI) as checkpointer:
+        await checkpointer.setup()
+        app.state.graph = builder.compile(checkpointer=checkpointer)
+        yield
+
+app = FastAPI(lifespan=lifespan)
+
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    result = await app.state.graph.ainvoke(
+        {"messages": [...]},
+        config={"configurable": {"thread_id": req.thread_id}},
+    )
+    return result
+```
+
+Always `ainvoke`/`astream` on the async saver. Mixing sync `invoke` with `AsyncPostgresSaver` raises at runtime.
+
+## Pool Sizing (Postgres)
+
+`asyncpg` default pool is 10 connections. For a LangGraph server handling N concurrent streams, budget **at least N+2** connections (one per active graph, plus headroom for setup checks). Set `max_size` explicitly:
+
+```python
+async with AsyncPostgresSaver.from_conn_string(DB_URI, max_size=50) as cp:
+    ...
+```
+
+If you share the Postgres instance with your application DB, use a separate pool for LangGraph — a stuck graph invocation will starve your app's connections otherwise.
+
+## What Breaks When You Swap
+
+- `MemorySaver` → `SqliteSaver`: state survives restart, but writes serialize on the file lock. Two workers will queue.
+- `SqliteSaver` → `PostgresSaver`: good upgrade. Run `.setup()` in a migration script; do **not** expect old SQLite checkpoints to migrate automatically (they will not).
+- `PostgresSaver` → `AsyncPostgresSaver`: only switch if your endpoints are async. Mixing is worse than either.
+- Any saver → a newer `langgraph` version: run `.setup()` again in staging **before** production. Old rows without the new schema read as empty (P20).
+
+## When Not To Checkpoint At All
+
+For short one-shot runs (classification, extraction, single-turn Q&A), there is no memory to persist. Using a checkpointer adds 5-15 ms per call with no benefit. Compile without one:
+
+```python
+graph = builder.compile()  # No checkpointer. state only lives during invoke().
+```
+
+Reserve checkpointers for multi-turn, HITL, or long-running graphs where state survival or time-travel is a requirement.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/json-serializability-rules.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/json-serializability-rules.md
@@ -1,0 +1,195 @@
+# JSON-Serializability Rules For LangGraph State
+
+> P17 is a delayed-action bug: a non-JSON value enters state at node N, survives
+> every transition, then raises `TypeError: Object of type <X> is not JSON
+> serializable` the moment `interrupt_before`, a HITL pause, or a checkpoint
+> write triggers — often many steps later, far from the line that introduced it.
+
+## The One Rule
+
+**State fields must be JSON-serializable primitives or recursive structures of them.** That is it. The entire rule.
+
+The checkpointer serializes state with Python's `json.dumps` by default (with some pickle fallback for compatibility, but do not rely on pickle for production). If `json.dumps(state)` raises, the checkpointer raises.
+
+## Allowed Types
+
+| Type | Notes |
+|---|---|
+| `str` | No restrictions. UTF-8 safe. |
+| `int` | Any size. |
+| `float` | `NaN` / `Infinity` are valid Python floats but **invalid JSON** — will raise. Filter or coerce. |
+| `bool` | `True` / `False`. |
+| `None` | Becomes JSON `null`. |
+| `list[T]` | Where `T` is itself allowed. |
+| `dict[str, T]` | Keys MUST be strings. `dict[int, str]` becomes `dict[str, str]` after round-trip. |
+| `tuple` | Serialized as list, returns as list. Type changes across round-trip. |
+
+`LangChain` message objects (`HumanMessage`, `AIMessage`, etc.) are explicitly handled — they have `.model_dump()` built in, and LangGraph registers a custom serializer. Safe to put in state as-is, typically under a field with the `add_messages` reducer (P18).
+
+## Forbidden Types (Direct)
+
+| Type | Why | Workaround |
+|---|---|---|
+| `datetime.datetime` / `datetime.date` | No JSON representation. | ISO string: `dt.isoformat()`. Parse back with `datetime.fromisoformat(s)`. |
+| `datetime.timedelta` | Same. | Store as seconds (`int` or `float`). |
+| `decimal.Decimal` | `json.dumps` raises `TypeError`. | Store as string, convert on read. Never as `float` (precision loss). |
+| `uuid.UUID` | Same. | `str(uuid_obj)`; parse with `UUID(s)` on read. |
+| `pathlib.Path` | Same. | `str(path)`. |
+| `set` / `frozenset` | No JSON equivalent. | Convert to sorted `list`. |
+| `bytes` / `bytearray` | Binary data. | Base64 string: `base64.b64encode(b).decode()`. |
+| `enum.Enum` | Depends on base type. | Store `.value` (typically `str` or `int`); reconstruct with `MyEnum(value)`. |
+| Arbitrary custom class | Unless it subclasses `BaseModel` or has `__dict__` of primitives. | Define an explicit `to_state()` / `from_state()` pair. |
+| Pydantic `BaseModel` instance | LangGraph does not auto-dump nested Pydantic models in every code path. | Use `.model_dump(mode="json")` before storing; reconstruct with `Model.model_validate(d)` on read. |
+| `numpy.ndarray` | Binary. | `.tolist()` on write; `np.array(lst)` on read. For large arrays, store a reference (S3 URL, DB key) not the bytes. |
+| Open file / socket / DB cursor | Stateful resources. | Never in state. Pass via `config["configurable"]` or recreate on demand. |
+
+## Pattern: TypedDict With Only Primitives
+
+```python
+from typing import Annotated, TypedDict
+from langgraph.graph.message import add_messages
+from langchain_core.messages import AnyMessage
+
+
+class AgentState(TypedDict):
+    # Built-in LangChain serializer handles messages.
+    messages: Annotated[list[AnyMessage], add_messages]
+
+    # Primitives only below.
+    user_id: str                      # ok
+    turn_count: int                   # ok
+    last_action_at: str                # ISO string — NOT a datetime
+    pending_approval: bool             # ok
+    metadata: dict[str, str]           # string keys + string values
+    scratch: list[str]                 # list of strings
+
+    # Example compound field that stays safe:
+    plan: list[dict[str, str]]         # [{"step": "...", "status": "pending"}]
+```
+
+Avoid this:
+
+```python
+class BrokenState(TypedDict):
+    created_at: datetime              # P17 time bomb
+    amount_owed: Decimal              # raises on serialize
+    user_profile: UserProfile          # Pydantic — may or may not round-trip depending on path
+    visited_urls: set[str]            # silently becomes list; equality tests fail
+```
+
+## Pattern: Serializer Helpers For Non-Primitive Inputs
+
+Do not scatter `isoformat()` calls across 20 nodes. Centralize:
+
+```python
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+
+def to_state(v: Any) -> Any:
+    """Coerce common non-JSON types into JSON-safe primitives.
+
+    Call at node output boundaries before returning state updates.
+    """
+    if isinstance(v, datetime):
+        return v.isoformat()
+    if isinstance(v, Decimal):
+        return str(v)
+    if isinstance(v, UUID):
+        return str(v)
+    if isinstance(v, Enum):
+        return v.value
+    if isinstance(v, set):
+        return sorted(v)
+    if isinstance(v, bytes):
+        import base64
+        return base64.b64encode(v).decode()
+    if isinstance(v, dict):
+        return {str(k): to_state(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [to_state(x) for x in v]
+    return v
+
+
+def from_state_datetime(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+def from_state_decimal(s: str) -> Decimal:
+    return Decimal(s)
+```
+
+Usage in a node:
+
+```python
+def record_purchase(state: AgentState) -> dict:
+    now = datetime.utcnow()
+    price = Decimal("19.99")
+    return {
+        "last_action_at": to_state(now),
+        "metadata": {**state["metadata"], "price": to_state(price)},
+    }
+```
+
+## Pattern: Pydantic Models
+
+Pydantic v2 has explicit JSON support. Always use `mode="json"` when dumping to state:
+
+```python
+from pydantic import BaseModel
+
+
+class Invoice(BaseModel):
+    id: str
+    amount: Decimal          # Pydantic handles Decimal → str with mode="json"
+    issued_at: datetime      # → ISO string
+
+
+def finalize_invoice(state: AgentState, inv: Invoice) -> dict:
+    return {"last_invoice": inv.model_dump(mode="json")}
+
+def read_invoice(state: AgentState) -> Invoice:
+    return Invoice.model_validate(state["last_invoice"])
+```
+
+`mode="json"` is the critical argument. The default `model_dump()` returns Python objects (`Decimal`, `datetime`, `UUID`) — which then trip the serializer.
+
+## Catching P17 Early With A Test
+
+Add an integration test that exercises `interrupt_before` on every HITL path. This forces a JSON round-trip of the full state:
+
+```python
+def test_state_is_checkpointable_at_interrupt():
+    graph = builder.compile(
+        checkpointer=MemorySaver(),
+        interrupt_before=["human_approval"],
+    )
+    result = graph.invoke(initial_state, config={"configurable": {"thread_id": "t1"}})
+    # If any non-JSON value made it into state, the interrupt raises here.
+    snapshot = graph.get_state({"configurable": {"thread_id": "t1"}})
+    assert snapshot.values is not None
+```
+
+Run it on every state-schema change. A caught P17 in CI is cheap; a caught P17 in a Friday-evening incident is not.
+
+## When You Really Need Non-Primitive State
+
+Two honest escape hatches:
+
+1. **Reference, not value.** Store the S3 key, the DB row id, or the URL. Re-fetch in nodes that need the full object. Checkpoint stays small.
+2. **Custom Serde.** `langgraph.checkpoint.serde.jsonplus` supports custom type registration, but this is advanced and ties your checkpoints to a specific serde version. Avoid unless you have measured and confirmed the reference pattern is wrong for your workload.
+
+## Quick Sanity Check
+
+Before compiling a new graph, run this in a REPL:
+
+```python
+import json
+sample_state = {...}    # a realistic starting state
+json.dumps(sample_state)  # if this raises, the checkpointer will too
+```
+
+Two seconds. Catches P17 on the spot.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-langgraph-checkpointing — One-Pager
+
+Persist LangGraph agent state correctly with `MemorySaver` and `PostgresSaver` — `thread_id` discipline, JSON-serializable state rules, time-travel, and schema migration that does not silently drop old checkpoints.
+
+## The Problem
+
+A chatbot forgets every turn because the caller never passed `thread_id` in `config["configurable"]` — LangGraph silently spawns a fresh state per invocation, no error, no log (P16). A `datetime` or Pydantic object lands in state and survives every node transition, then blows up with `TypeError: Object of type datetime is not JSON serializable` the moment `interrupt_before` triggers at a HITL boundary (P17). Upgrading `langgraph` in staging appears clean until a user returns and their entire history is gone — `PostgresSaver` did not auto-migrate the checkpoint schema, and the new reader treats old rows as empty state (P20). Meanwhile, every line of `ConversationBufferMemory` from the 0.x codebase now raises `ImportError` because legacy memory was removed in 1.0 (P40), and Deep Agent runs accumulate megabytes of virtual-FS scratch notes in state until checkpoint writes stall (P51).
+
+## The Solution
+
+Require `thread_id` at the application boundary via middleware that raises on missing, keep state primitives-only (TypedDict with `str` / `int` / `float` / `bool` / `list` / `dict`, datetimes as ISO strings, Pydantic via `model_dump()`), pick the checkpointer by environment (`MemorySaver` for dev/tests, `PostgresSaver.from_conn_string(...)` for staging and prod, `AsyncPostgresSaver` for high-concurrency), run `.setup()` on startup and after every `langgraph` upgrade, and use `graph.get_state_history(config)` + `graph.update_state(config, values, as_node=...)` to time-travel for incident debugging. Pinned to LangGraph 1.0.x with four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Backend engineers adding persistent memory to chat agents; researchers building reproducible multi-turn experiments; ops teams debugging stateful agent incidents with time-travel |
+| **What** | Checkpointer selection matrix, `thread_id` middleware, JSON state-shape rules table, Postgres setup + migration runbook, time-travel + replay recipes, 4 references (checkpointer-comparison, thread-id-discipline, json-serializability-rules, time-travel-and-replay) |
+| **When** | When adding chat memory, migrating from `ConversationBufferMemory`, time-traveling an agent state to debug an incident, or sizing a Postgres checkpoint DB for production |
+
+## Key Features
+
+1. **Checkpointer comparison matrix** — `MemorySaver` / `SqliteSaver` / `PostgresSaver` / `AsyncPostgresSaver` side-by-side on persistence, concurrency, latency, and when-to-use; picks one per environment instead of picking the wrong one everywhere
+2. **`thread_id` enforcement middleware** — Fail-closed wrapper that raises `ValueError` if `config["configurable"].get("thread_id")` is missing, plus UUID generation + tenant-scoping recipes so multi-tenant state never cross-leaks
+3. **JSON-serializable state rules** — TypedDict-with-primitives rule, explicit serializers for `datetime` / `Decimal` / Pydantic / enums, and a safe reducer pattern so interrupts never raise `TypeError` at the HITL boundary
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/thread-id-discipline.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/thread-id-discipline.md
@@ -1,0 +1,135 @@
+# `thread_id` Discipline — Fail Loud On Missing, Scope Per Tenant
+
+> P16 is the single most common LangGraph production incident: multi-turn agent
+> "forgets everything" because the caller never passed `thread_id`. No error
+> raised, no log line. Every invocation gets a fresh `MemorySaver`/`PostgresSaver`
+> entry under a blank key.
+
+## Why This Happens Silently
+
+LangGraph's checkpointer reads `config["configurable"]["thread_id"]` at invoke time. If the key is missing, the checkpointer either (a) uses `None` as the thread key (which is valid from the DB's perspective — it just maps to a specific row that all "no thread" calls share across tenants, which is worse than no memory), or (b) creates a fresh transient state. Neither path raises. The conversation history from turn 1 vanishes by turn 2 and the only signal is user-visible: "the bot keeps introducing itself."
+
+## Fix: Middleware That Raises
+
+Wrap your entry point. Refuse to call `graph.invoke` / `graph.ainvoke` without a `thread_id`.
+
+```python
+from typing import Any
+
+def require_thread_id(config: dict[str, Any]) -> dict[str, Any]:
+    """Raise if thread_id is missing. Return config unchanged otherwise.
+
+    Call this at every application boundary before invoking the graph.
+    Fails loudly so P16 surfaces in tests, not in production conversation logs.
+    """
+    configurable = (config or {}).get("configurable", {})
+    thread_id = configurable.get("thread_id")
+    if not thread_id:
+        raise ValueError(
+            "thread_id missing from config['configurable']. "
+            "Every graph invocation must carry a thread_id for checkpointing. "
+            "See langchain-langgraph-checkpointing skill."
+        )
+    if not isinstance(thread_id, str):
+        raise TypeError(
+            f"thread_id must be str (typically a UUID string), got {type(thread_id).__name__}"
+        )
+    return config
+```
+
+Attach it at every call site:
+
+```python
+config = {"configurable": {"thread_id": user_session.thread_id}}
+require_thread_id(config)
+result = graph.invoke(state, config=config)
+```
+
+For FastAPI, extract into a dependency:
+
+```python
+from fastapi import Depends, Header, HTTPException
+
+async def get_thread_config(x_thread_id: str = Header(...)) -> dict:
+    return {"configurable": {"thread_id": x_thread_id}}
+
+@app.post("/chat")
+async def chat(req: ChatRequest, config: dict = Depends(get_thread_config)):
+    return await graph.ainvoke(req.state, config=config)
+```
+
+The `Header(...)` with no default forces FastAPI to 422 any request missing `X-Thread-Id`. Failure surfaces at the edge, not deep inside the agent loop.
+
+## Generating `thread_id` Values
+
+A `thread_id` is just a string. The checkpointer treats it as opaque. Use UUID4 (36 chars including dashes) unless you have a reason not to:
+
+```python
+import uuid
+thread_id = str(uuid.uuid4())   # e.g. "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+```
+
+Why UUID4 (not a sequential counter):
+
+- Globally unique across processes — two workers generating threads concurrently cannot collide.
+- No enumeration: a leaked URL with `thread_id=42` reveals conversation #42 exists; `thread_id=f47ac10b-...` reveals nothing.
+- Stable across restarts, deploys, DB migrations.
+
+Length matters because `PostgresSaver` indexes on `thread_id` — 36-char UUIDs add ~36 bytes per index entry, negligible. If you need shorter (SMS workflows, QR codes), use `uuid.uuid4().hex[:16]` for a 16-char hex with 64 bits of entropy.
+
+## Where To Store `thread_id`
+
+| Application shape | Storage |
+|---|---|
+| Web chat UI | Cookie or `localStorage`, keyed per logged-in user (or per session for anon) |
+| Mobile app | Keychain / Keystore, rotated per conversation |
+| API clients | Client generates on first call, sends as `X-Thread-Id` header on every subsequent call |
+| Batch jobs | Deterministic from job id: `thread_id = f"batch-{job_id}"` |
+| Slack/Discord bot | `thread_id = f"{workspace_id}:{channel_id}:{thread_ts}"` — one thread_id per platform thread |
+
+Never store `thread_id` in the agent's own state. It is a *key to* the state, not *inside* the state.
+
+## Tenant Scoping — Prevent Cross-Tenant Leaks
+
+In a multi-tenant system, two users in different orgs MUST NOT share a thread_id. Bake the tenant into the key:
+
+```python
+def tenant_thread_id(tenant_id: str, user_id: str, conversation_id: str) -> str:
+    return f"{tenant_id}:{user_id}:{conversation_id}"
+```
+
+This maps one-to-one to LangGraph's keyspace — `PostgresSaver` treats `"acme:alice:conv-1"` and `"globex:alice:conv-1"` as completely separate rows. Add an integration test:
+
+```python
+def test_tenants_do_not_share_state():
+    graph = builder.compile(checkpointer=PostgresSaver.from_conn_string(DB_URI))
+    cfg_a = {"configurable": {"thread_id": "acme:alice:conv-1"}}
+    cfg_b = {"configurable": {"thread_id": "globex:alice:conv-1"}}
+
+    graph.invoke({"messages": [HumanMessage("secret acme info")]}, cfg_a)
+    state_b = graph.get_state(cfg_b)
+    assert state_b.values.get("messages", []) == []  # globex sees nothing from acme
+```
+
+This pairs with P33 (retriever-level tenant isolation) — both must hold for a multi-tenant production system to be safe.
+
+## Rotation
+
+For security-sensitive workflows (financial, healthcare), rotate `thread_id` on a schedule or on logout. Do not reuse a dead thread's id — checkpoint history is still there until you explicitly delete it. To fully retire a conversation:
+
+```python
+# PostgresSaver exposes a delete hook via the underlying DB.
+# The cleanest path is SQL on the checkpoint tables:
+# DELETE FROM checkpoints WHERE thread_id = 'old-thread-id';
+# DELETE FROM checkpoint_writes WHERE thread_id = 'old-thread-id';
+# DELETE FROM checkpoint_blobs WHERE thread_id = 'old-thread-id';
+```
+
+Run this from a maintenance script, not from user-facing code. Wrap in a transaction so a partial delete cannot leave orphaned blobs.
+
+## What NOT To Do
+
+- Do not derive `thread_id` from the prompt hash. Two users typing "hello" get the same thread and see each other's history.
+- Do not use `int` thread ids unless you cast to `str`. Some DB drivers silently coerce in ways that break later lookups.
+- Do not log the full `thread_id` in unredacted access logs if it encodes tenant/user info — hash it first.
+- Do not compile the graph without a checkpointer and then expect `thread_id` to do anything. Without a checkpointer, `thread_id` is a no-op.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/time-travel-and-replay.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/references/time-travel-and-replay.md
@@ -1,0 +1,154 @@
+# Time-Travel And Replay
+
+> When a production agent misbehaves, the usual engineering move — attach a
+> debugger, add log lines, redeploy — is useless: the agent's decision depended
+> on the full state at the moment of the bad call, which is already overwritten.
+> LangGraph checkpointers solve this by keeping the full history of every state
+> transition keyed by `thread_id`. You can enumerate past states, pick one, and
+> resume from it.
+
+## The Primitives
+
+### `graph.get_state(config) -> StateSnapshot`
+
+Returns the *latest* checkpoint for the given `thread_id`. The snapshot includes:
+
+- `.values` — the full state dict at that checkpoint
+- `.next` — a tuple of nodes that would run next (useful for "where did it stop?")
+- `.config` — a config pinned to this exact checkpoint (includes `checkpoint_id`)
+- `.metadata` — `source`, `step`, `writes`, plus any metadata you attached
+
+```python
+config = {"configurable": {"thread_id": "user-123"}}
+snap = graph.get_state(config)
+print(snap.values)
+print("next nodes:", snap.next)
+print("step:", snap.metadata.get("step"))
+```
+
+### `graph.get_state_history(config) -> Iterator[StateSnapshot]`
+
+Enumerates checkpoints from newest to oldest. Each yielded `StateSnapshot` is pinned to a specific `checkpoint_id`:
+
+```python
+for snap in graph.get_state_history(config):
+    print(snap.metadata["step"], snap.next, list(snap.values.keys()))
+```
+
+In production incidents, this is your first move. Walk backwards until you find the step *before* the bad transition, inspect its state, and confirm what the agent saw.
+
+### Resuming From A Specific Checkpoint
+
+Every `StateSnapshot.config` carries a `checkpoint_id`. To replay from there, pass that config back into `invoke`/`stream`:
+
+```python
+past = next(s for s in graph.get_state_history(config) if s.metadata["step"] == 3)
+# past.config is like:
+# {"configurable": {"thread_id": "user-123", "checkpoint_id": "1ef..."}}
+result = graph.invoke(None, config=past.config)   # None = "continue from snapshot"
+```
+
+Passing `None` as the input means "use the state at this checkpoint." The graph resumes as if the remainder of history never happened — but crucially, it **does not delete** the old history; the new execution creates a new branch.
+
+### `graph.update_state(config, values, as_node=None)`
+
+Edit state directly. Useful for "fix the bad field, resume from here":
+
+```python
+graph.update_state(
+    past.config,
+    {"retry_count": 0, "error_reason": None},
+    as_node="validator",   # Pretend this update came from the 'validator' node
+)
+result = graph.invoke(None, config=past.config)
+```
+
+The `as_node` argument controls which node's output reducer handles the update. Without `as_node`, the update merges into state as if applied from outside the graph (usable but less faithful to production execution).
+
+## Incident Playbook — "The Agent Gave A Wrong Answer At 14:03"
+
+1. **Find the thread_id from logs.** Your structured logger should include `thread_id` on every log line (if not, see `langchain-observability`).
+2. **Get the history:**
+   ```python
+   config = {"configurable": {"thread_id": bad_thread_id}}
+   history = list(graph.get_state_history(config))
+   for i, snap in enumerate(history):
+       print(i, snap.metadata.get("step"), snap.next, snap.metadata.get("writes"))
+   ```
+3. **Identify the bad step.** Look for the transition where the output diverged from expected. The `writes` metadata tells you which node wrote what.
+4. **Inspect state at the prior checkpoint.** The node's *input* is the state of the step *before* its write:
+   ```python
+   bad_step = history[i]
+   prior = history[i + 1]   # history is newest-first
+   print("input to bad node:", prior.values)
+   ```
+5. **Decide the fix.** Two paths:
+   - **Reproduce locally.** Use `prior.config` to resume in a dev copy of the graph with breakpoints or added logging.
+   - **Patch in place.** `update_state` to correct the state, then `invoke(None, config=prior.config)` to regenerate the response. The user gets a correct answer, the original branch is still there for forensics.
+
+## Forking For A/B Comparison
+
+Time-travel makes branching free. From a known-good checkpoint, resume with a different prompt, different model, or different tool binding:
+
+```python
+# Branch 1: current production agent
+result_prod = graph.invoke(None, config=known_good.config)
+
+# Branch 2: same state, upgraded model
+alt_graph = builder_with_new_model.compile(checkpointer=cp)
+result_alt = alt_graph.invoke(None, config=known_good.config)
+```
+
+Both results are now in the checkpoint history. `get_state_history` returns them as separate branches (distinguished by `parent_checkpoint_id`). Useful for regression evaluation and for "would the new model have fixed this incident?"
+
+## Checkpoint Pruning — Keeping The DB Bounded
+
+Checkpoint storage grows linearly with turn count. For a user with 10,000 turns across 5 years, you are storing ~50 MB of per-thread state. Most of it is never read again. Strategies:
+
+| Strategy | Pros | Cons |
+|---|---|---|
+| Keep everything | Perfect time-travel forever. | DB grows forever. |
+| Keep last N checkpoints per thread | Bounded size per user. | Time-travel limited to last N steps. |
+| Keep checkpoints at "important" nodes only | Small DB, meaningful history. | Requires tagging; simple resume-from-step less precise. |
+| Archive to cold storage after 30 days | Balanced. | Adds restore step for old incidents. |
+
+Implementation — N=100 per thread:
+
+```sql
+-- Run as a nightly maintenance job.
+WITH ranked AS (
+  SELECT checkpoint_id, thread_id,
+         ROW_NUMBER() OVER (PARTITION BY thread_id ORDER BY checkpoint_id DESC) AS rn
+  FROM checkpoints
+)
+DELETE FROM checkpoints
+WHERE checkpoint_id IN (SELECT checkpoint_id FROM ranked WHERE rn > 100);
+```
+
+Cascade the same delete to `checkpoint_writes` and `checkpoint_blobs` (join by `thread_id` + `checkpoint_id`). Wrap in a transaction.
+
+For Deep Agent workloads specifically (P51), the virtual-FS state in `state["files"]` can bloat a single checkpoint. Consider a node-level cleanup that prunes `state["files"]` entries older than N steps *inside* the graph — checkpoint size stays bounded even without DB-level pruning.
+
+## Replay For Reproducible Evaluations
+
+Research-flavored use: checkpoint at the end of every test case, run the agent, store the thread_id alongside test metadata. Later, replay any test by its thread_id to reproduce bit-for-bit (up to model non-determinism — see P05 for why `temperature=0` is not a guarantee on Claude).
+
+```python
+def run_eval(test_id: str, prompt: str) -> str:
+    config = {"configurable": {"thread_id": f"eval:{test_id}"}}
+    result = graph.invoke({"messages": [HumanMessage(prompt)]}, config=config)
+    return result["messages"][-1].content
+
+def replay_eval(test_id: str) -> list:
+    config = {"configurable": {"thread_id": f"eval:{test_id}"}}
+    return [snap.values for snap in graph.get_state_history(config)]
+```
+
+Pair with `langchain-evaluation-harness` for full pipelines.
+
+## Caveats
+
+- **Time-travel does not undo side effects.** If a node hit an external API (sent an email, charged a card), resuming from before that node re-does the side effect. Wrap external calls in idempotency keys.
+- **Branching multiplies storage.** Every `invoke(None, config=past.config)` creates new checkpoints alongside the originals. Do not branch in a hot loop without pruning.
+- **`update_state` is a write.** It creates a new checkpoint. The prior state is preserved (that is the point), but be mindful of the index cost on extremely busy threads.
+- **`get_state_history` reads can be expensive** on threads with thousands of checkpoints. Paginate by `limit` and `before=checkpoint_id` for UI-facing history browsers.


### PR DESCRIPTION
## Summary

Handcrafted skill covering LangGraph 1.0 state persistence with `MemorySaver` and `PostgresSaver` — `thread_id` discipline, JSON-serializable state rules, time-travel, and upgrade migration. Anchored to pain-catalog **P16, P17, P20, P40, P51**.

## Pain hook

A chat agent that "keeps introducing itself" is almost always P16 — caller invokes `graph.invoke(state)` with no `thread_id` in `config["configurable"]`, and LangGraph silently spawns a fresh state per call with no error or log. Pairs that with P17's delayed `TypeError` at the `interrupt_before` boundary, P20's silent empty-read after a `langgraph` upgrade without `setup()`, P40's removal of legacy `ConversationBufferMemory`, and P51's unbounded Deep Agent virtual-FS growth. Prescribes fail-loud `thread_id` middleware, JSON-primitive state, checkpointer-per-environment selection, and `get_state_history` + `update_state` time-travel for incident debugging.

## Files

- `skills/langchain-langgraph-checkpointing/SKILL.md` (366 lines)
- `skills/langchain-langgraph-checkpointing/references/one-pager.md`
- `skills/langchain-langgraph-checkpointing/references/checkpointer-comparison.md`
- `skills/langchain-langgraph-checkpointing/references/thread-id-discipline.md`
- `skills/langchain-langgraph-checkpointing/references/json-serializability-rules.md`
- `skills/langchain-langgraph-checkpointing/references/time-travel-and-replay.md`

## Validator

Grade **A (92/100)** at standard + enterprise, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude