### PR TITLE
feat(langchain-py-pack): add langchain-langgraph-human-in-loop (L28)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: langchain-langgraph-human-in-loop
+description: |
+  Build LangGraph 1.0 human-in-the-loop approval flows with `interrupt_before` /
+  `interrupt_after` and `Command(resume=...)` — JSON-serializable state, clean
+  resume semantics, and UI wiring for approval decisions. Use when adding an
+  approval gate before an expensive tool call, wiring a Slack/web UI for agent
+  approvals, or debugging a graph that crashes on interrupt.
+  Trigger with "langgraph human in loop", "langgraph interrupt_before",
+  "langgraph approval flow", "Command resume", "langgraph HITL".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, human-in-loop, approval, interrupts]
+compatible-with: claude-code, codex
+---
+
+# LangChain LangGraph Human-in-the-Loop (Python)
+
+## Overview
+
+A team adds `interrupt_before=["send_email"]` to require a human approval
+before the email goes out. First integration test crashes at the interrupt
+boundary with:
+
+```
+TypeError: Object of type datetime is not JSON serializable
+```
+
+The culprit is two nodes upstream: a `classify` node stashed
+`"received_at": datetime.utcnow()` into state. Every node-level unit test
+passed because node completion does not serialize state — only the
+checkpointer does, and only at supersteps that include an interrupt. The
+failure is invisible until interrupt time (P17).
+
+A week later the resume path ships. The human reviews the draft, clicks
+"approve with edits," and the backend runs:
+
+```python
+graph.invoke(Command(update={"messages": [corrected_msg]}, resume="approved"), config)
+```
+
+The prior 47 messages vanish. `messages` was typed as plain
+`list[AnyMessage]` with no reducer, so `update` replaces the field instead of
+appending (P18).
+
+This skill covers: three interrupt styles (`interrupt_before`,
+`interrupt_after`, inline `interrupt()`), the JSON-only state invariant with
+a pre-interrupt scanner, the `Command(resume=...)` /
+`Command(update=..., resume=...)` contract, an approval UI wire format
+(GET pending / POST decision with optimistic concurrency), safe-cancellation
+routing to `END`, and the tradeoff between native interrupts and a separate
+approval service. Pin: `langgraph 1.0.x`, `langgraph-checkpoint 2.0.x`.
+Pain-catalog anchors: **P17**, **P18** (adjacent: P16, P20).
+
+## Prerequisites
+
+- Python 3.10+
+- `langgraph >= 1.0, < 2.0`
+- A checkpointer: `MemorySaver` (dev), `PostgresSaver` (prod), or `SqliteSaver` (single-box)
+- A `thread_id` contract at the app boundary (see `langchain-langgraph-checkpointing`)
+- Familiarity with `langchain-langgraph-basics` — nodes, edges, `TypedDict` state with reducers
+
+## Instructions
+
+### Step 1 — Choose the interrupt style
+
+LangGraph 1.0 exposes three interrupt mechanisms. They are not interchangeable.
+
+| Style | Syntax | Use when |
+|-------|--------|----------|
+| `interrupt_before=[node]` | `compile(interrupt_before=["send_email"])` | Review inputs before an irreversible tool. Graph pauses *before* node runs. State shown is the input. |
+| `interrupt_after=[node]` | `compile(interrupt_after=["draft_email"])` | Review output of a node (e.g., an LLM draft). Graph pauses *after* node completes. |
+| Inline `interrupt()` | Inside a node: `decision = interrupt({"kind": "..."})` | Structured prompt mid-node with custom payload. Most flexible; lives in node code. |
+
+Rule of thumb: prefer `interrupt_before` for hard gates (tool must not run
+without approval). Use `interrupt_after` for review loops (draft → approve →
+send). Use inline `interrupt()` when the prompt varies on intermediate
+computation.
+
+Typical interrupt round-trip latency in production is **50-300 ms** from
+pause to checkpoint write (local Postgres) plus UI time; budget **1-5 s**
+total for a Slack-based approval. Checkpoint row sizes average **2-20 KB** on
+small graphs and cap at **~1 MB** on `PostgresSaver` before historical
+checkpoints need pruning.
+
+See [Interrupt Decision Tree](references/interrupt-decision-tree.md) for full
+criteria, multiple-interrupt-per-graph patterns, and the interrupt-vs-tool
+comparison.
+
+### Step 2 — Enforce the JSON-serializable state invariant (P17)
+
+Checkpointers serialize state to JSON on every superstep. Any non-JSON type
+raises `TypeError` at the interrupt boundary — not at the offending node.
+Canonical offenders:
+
+| Type | Fix |
+|------|-----|
+| `datetime` / `date` | `dt.isoformat()` — ISO 8601 string |
+| `bytes` | `base64.b64encode(b).decode()` |
+| `set` | `sorted(s)` |
+| Pydantic `BaseModel` with non-primitive fields | `.model_dump(mode="json")` |
+| Custom classes | `dataclasses.asdict(obj)` or `vars(obj)` |
+| `numpy.ndarray` | `.tolist()` |
+| `decimal.Decimal` | `str(d)` or `float(d)` (lossy) |
+| `float("nan")` / `float("inf")` | `None` (JSON forbids them; some savers crash on `allow_nan=False`) |
+
+Ship a pre-interrupt scanner in dev and CI:
+
+```python
+import json
+from typing import Any
+
+class NonSerializableStateError(TypeError):
+    """Raised when state contains values the checkpointer cannot serialize."""
+
+def assert_state_is_json_serializable(state: dict[str, Any], *, path: str = "state") -> None:
+    """Walk state depth-first and raise a typed error naming the offending key path."""
+    _walk(state, path)
+
+def _walk(v: Any, path: str) -> None:
+    if v is None or isinstance(v, (bool, int, float, str)):
+        return
+    if isinstance(v, list):
+        for i, item in enumerate(v):
+            _walk(item, f"{path}[{i}]")
+        return
+    if isinstance(v, dict):
+        for k, val in v.items():
+            _walk(val, f"{path}.{k}")
+        return
+    raise NonSerializableStateError(
+        f"{path} is {type(v).__name__}, not JSON-serializable. "
+        f"Convert at node boundary."
+    )
+```
+
+Call `assert_state_is_json_serializable(state)` at the end of every node
+preceding an interrupt-flagged node, or attach as LangGraph middleware. In
+CI, run the full graph to interrupt against a fixture that exercises every
+branch — the only way to catch P17 before prod.
+
+See [State Serialization for Interrupts](references/state-serialization-for-interrupts.md)
+for the full forbidden-types list, the Pydantic-in-state pattern, and the
+integration-test harness.
+
+### Step 3 — The resume contract
+
+Two shapes. They are not equivalent.
+
+```python
+from langgraph.types import Command
+
+# Shape A — resume only: human approved as-is
+graph.invoke(Command(resume="approved"), config)
+
+# Shape B — update + resume: human edited state mid-graph
+graph.invoke(
+    Command(update={"recipient": "new@example.com"}, resume="approved"),
+    config,
+)
+```
+
+`resume="..."` is the value returned from inline `interrupt()` inside the
+node (if any). For `interrupt_before` / `interrupt_after`, no node reads
+`resume`, but the checkpoint records it for audit.
+
+`update={...}` merges into state via the reducer declared in the `TypedDict`.
+**Without a reducer, `update` replaces the field** (P18). Always annotate
+list and dict state:
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+
+class AgentState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]      # append, not replace
+    approvals: Annotated[list[dict], lambda l, r: l + r]     # custom append reducer
+    draft: Annotated[dict, lambda l, r: {**l, **r}]          # dict merge reducer
+    last_decision: str                                        # scalar: replace is fine
+```
+
+See [Resume Patterns](references/resume-patterns.md) for the five canonical
+resume shapes (plain approve, approve with edits, reject to `END`, partial
+approval, inline-interrupt structured return), the reducer cookbook, and the
+audit-log write order.
+
+### Step 4 — Wire the approval UI
+
+Two HTTP endpoints. Keep them boring.
+
+**GET `/approvals/pending`** lists paused threads:
+
+```json
+[
+  {
+    "thread_id": "conv-abc123",
+    "checkpoint_id": "01JABC...",
+    "interrupted_at": "2026-04-21T15:32:11Z",
+    "node": "send_email",
+    "state_diff": {"draft": {"to": "user@example.com", "subject": "Welcome"}}
+  }
+]
+```
+
+**POST `/approvals/<thread-id>/decision`** applies the decision:
+
+```json
+{
+  "decision": "approve" | "reject" | "edit",
+  "edits": {"recipient": "corrected@example.com"},
+  "approver": "jeremy@intentsolutions.io",
+  "reason": "Verified against ticket INT-4821",
+  "expected_checkpoint_id": "01JABC...",
+  "idempotency_key": "c2f5e8a0-..."
+}
+```
+
+Optimistic concurrency (the `expected_checkpoint_id` check) matters the
+moment two approvers open the same thread in two browser tabs. Without it,
+the second click silently overwrites the first. Return `409 Conflict` on
+mismatch; UI refreshes.
+
+Server-side flow: authz → idempotency dedupe → checkpoint check → audit-log
+write (BEFORE mutation) → build `Command` → `graph.ainvoke(cmd, config)` →
+audit-log finalize.
+
+See [Approval UI Wiring](references/approval-ui-wiring.md) for the full
+HTTP contract with status codes, FastAPI implementation, Slack Block Kit
+mapping, state-diff redaction, and an audit-log schema compatible with SOC2
+evidence requirements.
+
+### Step 5 — Safe cancellation: route to `END` on reject
+
+When the human rejects, the gated node must NOT execute. Two clean patterns:
+
+**Pattern A — conditional edge after the interrupted node (preferred):**
+
+```python
+from langgraph.graph import END
+
+def route_after_approval(state: AgentState) -> str:
+    if state.get("last_decision") == "rejected":
+        return END
+    return "send_email"
+
+builder.add_conditional_edges("await_approval", route_after_approval, {
+    "send_email": "send_email",
+    END: END,
+})
+```
+
+**Pattern B — `Command(goto=END)` at resume:**
+
+```python
+graph.invoke(Command(resume="rejected", goto=END), config)
+```
+
+Prefer Pattern A in production: graph topology stays the source of truth,
+audit replays work without the UI. Always log the rejection to the checkpoint
+via `Command(update={"last_decision": "rejected", "reject_reason": ...})`
+BEFORE routing to END — otherwise the audit trail lives only in the UI DB.
+
+### Step 6 — Native interrupts vs a separate approval service
+
+| Dimension | LangGraph interrupts | Separate approval service |
+|-----------|---------------------|---------------------------|
+| **Latency** | 50-300 ms pause + human time | Human time + queue latency |
+| **State coherence** | Single source of truth (checkpoint) | Two systems to reconcile |
+| **Concurrency** | Checkpoint-based optimistic locking | Whatever the queue provides |
+| **Multi-graph** | Per-graph, per-thread | Centralized policy engine |
+| **Observability** | `get_state()` + checkpoint history | Separate audit system |
+| **Failure mode** | JSON-serialization at interrupt (P17) | Network partition between services |
+| **Best for** | Single LangGraph app, 1-10 approval types, <1k/day | Multi-app enterprise, complex RBAC, 10k+/day |
+
+Single LangGraph app with fewer than a dozen approval types: native
+interrupts are simpler and more reliable. Cross-app approval platform with
+escalations, delegations, and SLAs: run a dedicated service and call it from
+a tool, not from an interrupt.
+
+## Output
+
+- Graph compiled with explicit `interrupt_before` / `interrupt_after` lists, or inline `interrupt()` calls where payload structure matters
+- JSON-only state: `datetime` → ISO strings, `bytes` → base64, Pydantic → `.model_dump(mode="json")`, custom classes → dicts
+- `TypedDict` state with explicit reducers on every list and dict field
+- Pre-interrupt state scanner attached as middleware or called at node exits; raises `NonSerializableStateError` with a key path
+- Approval HTTP endpoints: GET pending with state diffs, POST decision with `expected_checkpoint_id` optimistic-concurrency check and `idempotency_key` dedupe
+- Rejection routes to `END` via conditional edge (Pattern A) with `last_decision` recorded in state for audit
+- Audit log written BEFORE state mutation with `approver`, `reason`, `thread_id`, `checkpoint_id_before`, `checkpoint_id_after`
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `TypeError: Object of type datetime is not JSON serializable` at interrupt | Non-JSON value in state (P17) | Convert at node boundary; add pre-interrupt scanner in CI |
+| Resume with `Command(update={"messages": [new]})` loses history | `messages` field missing reducer (P18) | Annotate as `Annotated[list[AnyMessage], add_messages]` |
+| `ValueError: Thread ... has no interrupted nodes` on resume | Graph already ran to completion, or `thread_id` mismatch | Call `graph.get_state(config)` first; assert `snapshot.next` is non-empty |
+| Human clicks approve, nothing happens | Missing checkpointer on `compile()` — interrupts require persistence | `graph.compile(checkpointer=MemorySaver() or PostgresSaver(...))` |
+| Two approvers both click approve, second one's edits win silently | No optimistic concurrency | Include `expected_checkpoint_id` in POST body; return 409 on mismatch |
+| `KeyError: 'configurable'` at resume | `config` dict missing `thread_id` | `config = {"configurable": {"thread_id": tid}}` — required by every checkpointer |
+| Approval UI shows stale state after another approver acted | Cached GET /pending response | `Cache-Control: no-store` on the pending endpoint |
+| Graph halts silently after reject | Conditional edge router returned value not in `path_map` | Include `END` in `path_map`; assert router output in keyset |
+
+## Examples
+
+### Approval gate before an expensive tool
+
+Email-sending agent that must not send without approval. State carries
+`draft: {to, subject, body}`, graph compiles with
+`interrupt_before=["send_email"]`, resume either invokes the send tool or
+routes to `END` on reject. See
+[Resume Patterns](references/resume-patterns.md) for the full worked example
+including audit-log write order.
+
+### Partial approval — approve one argument, edit another
+
+Human accepts the recipient but rewrites the subject. Resume is
+`Command(update={"draft": {**state["draft"], "subject": new_subject}}, resume="approved")`.
+Note the spread — without it the draft is replaced. Scalar dicts replace by
+default; declare a dict reducer to merge partials cleanly. See
+[Resume Patterns](references/resume-patterns.md).
+
+### Inline `interrupt()` with a custom payload
+
+Inside a `validate_purchase` node, the model has decided to buy three items
+at USD 450 total. The node calls
+`decision = interrupt({"kind": "confirm_purchase", "items": items, "total": 450})`
+and the UI reads the payload to render a rich confirmation dialog. On resume,
+`decision` is whatever the UI sent via
+`Command(resume={"approved": True, "notes": "..."})`. See
+[Interrupt Decision Tree](references/interrupt-decision-tree.md).
+
+### Slack-driven approval
+
+GET /pending feeds a cron that posts Block Kit messages with approve/reject
+buttons. Button callback POSTs to /decision. Slack's interaction payload
+carries `user.id`, which becomes `approver` in the audit log. See
+[Approval UI Wiring](references/approval-ui-wiring.md) for the Block Kit
+template and signing-secret validation.
+
+## Resources
+
+- [LangGraph: Human-in-the-loop (concepts)](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/)
+- [LangGraph: How to add human-in-the-loop](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/)
+- [LangGraph: `Command` type reference](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.Command)
+- [LangGraph: `interrupt` function reference](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.interrupt)
+- [LangGraph: Persistence and checkpointers](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [LangGraph 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P16, P17, P18, P20)
+- Related skills: `langchain-langgraph-basics`, `langchain-langgraph-checkpointing`, `langchain-middleware-patterns`

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/approval-ui-wiring.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/approval-ui-wiring.md
@@ -1,0 +1,346 @@
+# Approval UI Wiring
+
+The HTTP contract and Slack Block Kit mapping for a LangGraph-backed approval
+UI. Two endpoints, one concurrency primitive, one audit log. Everything else
+is glue.
+
+## Endpoint 1 — GET `/approvals/pending`
+
+Lists all paused threads. The UI (web dashboard, Slack cron poster, whatever)
+calls this to render the approval queue.
+
+### Request
+
+```
+GET /approvals/pending?tenant=acme&limit=50
+Authorization: Bearer <user_token>
+```
+
+### Response
+
+```json
+{
+  "pending": [
+    {
+      "thread_id": "conv-abc123",
+      "checkpoint_id": "01JABCXYZ000000000000000",
+      "interrupted_at": "2026-04-21T15:32:11Z",
+      "node": "send_email",
+      "interrupt_kind": "before",
+      "payload": null,
+      "state_diff": {
+        "draft": {
+          "to": "user@example.com",
+          "subject": "Welcome to Acme",
+          "body_preview": "Hi Sarah, welcome..."
+        }
+      },
+      "requested_by": "agent:onboarding-flow",
+      "tags": ["email", "external-recipient"]
+    }
+  ],
+  "total": 12,
+  "as_of": "2026-04-21T15:34:02Z"
+}
+```
+
+Fields:
+
+- **`thread_id`** — pass back verbatim to POST /decision
+- **`checkpoint_id`** — ULID from the checkpointer. Pass back in
+  `expected_checkpoint_id` for optimistic concurrency
+- **`node`** — which node is about to run (for `interrupt_before`) or just
+  ran (for `interrupt_after`)
+- **`interrupt_kind`** — `"before"`, `"after"`, or `"inline"`
+- **`payload`** — for inline `interrupt(payload)`, the payload dict; null otherwise
+- **`state_diff`** — subset of state relevant to this approval. DO NOT ship
+  full state — it may contain PII, internal reasoning traces, or tokens
+- **`tags`** — your categorization. Lets the UI filter ("show only email
+  approvals," "show only high-risk")
+
+### Implementation sketch (FastAPI + PostgresSaver)
+
+```python
+@app.get("/approvals/pending")
+async def list_pending(
+    tenant: str,
+    user: User = Depends(current_user),
+    limit: int = 50,
+) -> list[dict]:
+    # Authorize: user must have "approve" permission for tenant
+    if not user.can_approve(tenant):
+        raise HTTPException(403)
+
+    results = []
+    async for thread_id in _list_threads_for_tenant(tenant, limit=limit):
+        snapshot = await graph.aget_state({"configurable": {"thread_id": thread_id}})
+        if not snapshot.next:
+            continue  # thread completed, skip
+        results.append({
+            "thread_id": thread_id,
+            "checkpoint_id": snapshot.config["configurable"]["checkpoint_id"],
+            "interrupted_at": snapshot.created_at,
+            "node": snapshot.next[0],
+            "interrupt_kind": _classify_interrupt(snapshot),
+            "payload": snapshot.values.get("_interrupt_payload"),
+            "state_diff": _redact_and_diff(snapshot.values),
+            "tags": _tags_from_state(snapshot.values),
+        })
+    return {"pending": results, "total": len(results), "as_of": utcnow()}
+```
+
+Cache policy: `Cache-Control: no-store`. The queue changes as soon as any
+approver acts.
+
+## Endpoint 2 — POST `/approvals/{thread_id}/decision`
+
+The approver submits their decision. Idempotent by `expected_checkpoint_id`.
+
+### Request
+
+```
+POST /approvals/conv-abc123/decision
+Authorization: Bearer <user_token>
+Content-Type: application/json
+
+{
+  "decision": "edit",
+  "edits": {
+    "draft": {"subject": "Welcome to Acme (Revised)"}
+  },
+  "approver": "jeremy@intentsolutions.io",
+  "reason": "Matches ticket INT-4821",
+  "expected_checkpoint_id": "01JABCXYZ000000000000000",
+  "idempotency_key": "c2f5e8a0-...-abc"
+}
+```
+
+Fields:
+
+- **`decision`** — `"approve"`, `"reject"`, or `"edit"`
+- **`edits`** — only present when `decision == "edit"`. Dict of state patches
+  (merged via reducers)
+- **`approver`** — who approved. Your auth middleware should set this, not
+  trust the client — but echoing it here makes audit-log inspection easy
+- **`reason`** — free-text justification. Required for `reject` and `edit`;
+  optional for `approve`
+- **`expected_checkpoint_id`** — optimistic lock. Server returns 409 if the
+  thread has advanced since the approver loaded it
+- **`idempotency_key`** — client-generated UUID. Server dedupes duplicate
+  POSTs (network retry, double-click, etc.)
+
+### Response
+
+```json
+{
+  "thread_id": "conv-abc123",
+  "checkpoint_id_before": "01JABCXYZ000000000000000",
+  "checkpoint_id_after": "01JABCXYZ111111111111111",
+  "status": "applied",
+  "audit_id": "aud-7c3f9e"
+}
+```
+
+### Response codes
+
+| Code | Meaning | UI action |
+|------|---------|-----------|
+| 200 | Applied | Show success, refresh queue |
+| 400 | Malformed request, missing field | Surface the validation error |
+| 403 | Approver lacks permission for this thread | "You cannot approve this" |
+| 404 | Thread not found | "Thread was deleted" |
+| 409 | `expected_checkpoint_id` mismatch | "Another approver acted first" — refresh |
+| 410 | Thread already completed (not paused) | "Nothing to approve" — dismiss |
+| 422 | Reducer conflict (edit shape mismatches schema) | Surface the error |
+| 423 | Thread locked for concurrent edit | Retry after short backoff |
+
+### Implementation sketch
+
+```python
+@app.post("/approvals/{thread_id}/decision")
+async def post_decision(
+    thread_id: str,
+    body: DecisionBody,
+    user: User = Depends(current_user),
+) -> dict:
+    # 1. Authz
+    if not user.can_approve_thread(thread_id):
+        raise HTTPException(403)
+
+    # 2. Idempotency
+    cached = await idempotency_store.get(body.idempotency_key)
+    if cached:
+        return cached
+
+    config = {"configurable": {"thread_id": thread_id}}
+
+    # 3. Optimistic concurrency check
+    snapshot = await graph.aget_state(config)
+    if not snapshot.next:
+        raise HTTPException(410, "Thread not paused")
+    actual_ckpt = snapshot.config["configurable"]["checkpoint_id"]
+    if actual_ckpt != body.expected_checkpoint_id:
+        raise HTTPException(409, f"Checkpoint moved; expected {body.expected_checkpoint_id}, got {actual_ckpt}")
+
+    # 4. Audit log BEFORE mutation
+    audit_id = await audit_log.write(
+        thread_id=thread_id,
+        checkpoint_id=actual_ckpt,
+        decision=body.decision,
+        edits=body.edits,
+        approver=user.email,
+        reason=body.reason,
+        outcome="pending",
+    )
+
+    # 5. Build command
+    if body.decision == "reject":
+        cmd = Command(
+            update={"last_decision": "rejected", "reject_reason": body.reason},
+            resume="rejected",
+        )
+    elif body.decision == "edit":
+        cmd = Command(update=body.edits, resume="approved")
+    else:  # approve
+        cmd = Command(resume="approved")
+
+    # 6. Apply
+    try:
+        result = await graph.ainvoke(cmd, config)
+    except Exception as e:
+        await audit_log.update(audit_id, outcome="error", error=str(e))
+        raise HTTPException(500, "Graph invocation failed; audit entry recorded")
+
+    # 7. Finalize audit
+    new_snapshot = await graph.aget_state(config)
+    await audit_log.update(audit_id, outcome="applied", applied_at=utcnow())
+
+    response = {
+        "thread_id": thread_id,
+        "checkpoint_id_before": actual_ckpt,
+        "checkpoint_id_after": new_snapshot.config["configurable"]["checkpoint_id"],
+        "status": "applied",
+        "audit_id": audit_id,
+    }
+    await idempotency_store.put(body.idempotency_key, response, ttl=24*3600)
+    return response
+```
+
+## State-diff rendering
+
+Shipping full state to the UI is dangerous (PII, internal tokens) and usually
+noisy. Filter to the keys that matter for *this* approval:
+
+```python
+INTEREST_KEYS_BY_NODE = {
+    "send_email": ["draft", "recipient_verification"],
+    "charge_card": ["amount", "card_last4", "merchant"],
+    "deploy_release": ["version", "environment", "changeset"],
+}
+
+def build_state_diff(node: str, state: dict) -> dict:
+    keys = INTEREST_KEYS_BY_NODE.get(node, [])
+    return {k: state.get(k) for k in keys if k in state}
+```
+
+For `draft` or `body` that might contain long text, send a preview:
+
+```python
+def preview(s: str, n: int = 200) -> str:
+    return s if len(s) <= n else s[:n] + "..."
+```
+
+## Slack Block Kit mapping
+
+Slack is the most common approval UI because it works without building a web
+dashboard. Post one message per pending approval:
+
+```python
+def pending_to_slack_blocks(pending: dict) -> list[dict]:
+    return [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": f"Approval needed: {pending['node']}"},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Thread:* `{pending['thread_id']}`"},
+                {"type": "mrkdwn", "text": f"*Waiting since:* {pending['interrupted_at']}"},
+            ],
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"```{json.dumps(pending['state_diff'], indent=2)}```"},
+        },
+        {
+            "type": "actions",
+            "block_id": f"approval:{pending['thread_id']}:{pending['checkpoint_id']}",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Approve"},
+                    "style": "primary",
+                    "action_id": "approve",
+                    "value": pending["checkpoint_id"],
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Reject"},
+                    "style": "danger",
+                    "action_id": "reject",
+                    "value": pending["checkpoint_id"],
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Edit..."},
+                    "action_id": "edit",
+                    "value": pending["checkpoint_id"],
+                },
+            ],
+        },
+    ]
+```
+
+The `block_id` encodes `thread_id` + `checkpoint_id`. When Slack POSTs the
+interaction, parse it and call POST /decision. Validate the Slack signing
+secret (`X-Slack-Signature`) before trusting any fields.
+
+The "Edit..." button opens a modal with the state-diff as editable fields.
+Map the modal submission to `edits` in the decision body.
+
+## Rate-limiting the approval endpoint
+
+POST /decision is cheap (one DB read, one graph invoke) but the graph invoke
+can fan out to expensive tool calls. Rate-limit per approver to prevent a
+compromised account from mass-approving:
+
+- Per approver: 10 decisions/minute
+- Per tenant: 100 decisions/minute
+- Global: whatever your infra handles
+
+429 on limit; include `Retry-After` header.
+
+## What NOT to put in the approval UI
+
+- Raw LLM system prompts (leaks your prompt engineering)
+- Internal tool names (leaks architecture)
+- Full state object (PII risk; too noisy)
+- Any token, secret, credential — ever
+- Raw tool_use block JSON — map to a human-friendly description
+
+## Audit log retention
+
+SOC2 / ISO 27001 typically require 1-7 years of audit log retention. LangGraph
+checkpoints live on the checkpointer DB; the audit log should live separately
+with retention policies matching your compliance posture.
+
+Minimum fields to retain:
+
+- `thread_id`, `checkpoint_id_before`, `checkpoint_id_after`
+- `approver` (email/user ID), `approved_at`
+- `decision`, `edits` (redacted), `reason`
+- Hash of state-diff the approver saw (to prove what was shown)
+
+Periodically garbage-collect completed threads from the checkpointer, but
+NEVER garbage-collect audit entries before their retention expires.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/interrupt-decision-tree.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/interrupt-decision-tree.md
@@ -1,0 +1,170 @@
+# Interrupt Decision Tree
+
+LangGraph 1.0 ships three interrupt mechanisms. Picking the wrong one gives
+you a UX that either pauses too early (approving before you can see the draft),
+too late (approving after the email already went out), or with the wrong
+payload shape (UI has to guess what the human is reviewing).
+
+## The three styles
+
+| Style | Where configured | Pauses | State visible to human |
+|-------|------------------|--------|-----------------------|
+| `interrupt_before=[...]` | `graph.compile(...)` | Before node runs | State *entering* the node |
+| `interrupt_after=[...]` | `graph.compile(...)` | After node completes | State *after* the node's mutation |
+| Inline `interrupt(payload)` | Inside a node function | At that line | Whatever you passed as `payload` |
+
+## `interrupt_before` — gate expensive/irreversible tools
+
+```python
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.memory import MemorySaver
+
+builder = StateGraph(AgentState)
+builder.add_node("draft_email", draft_node)
+builder.add_node("send_email", send_node)
+builder.add_edge("draft_email", "send_email")
+builder.add_edge("send_email", END)
+
+graph = builder.compile(
+    checkpointer=MemorySaver(),
+    interrupt_before=["send_email"],
+)
+```
+
+**Use when:** the node is irreversible. Sending an email, charging a card,
+shipping a deploy, writing to a production DB, calling an external webhook.
+
+**Human sees:** state *before* the node ran. For `send_email`, they see the
+draft sitting in `state["draft"]`.
+
+**Resume:** `graph.invoke(Command(resume="approved"), config)` executes the
+node. `Command(resume="rejected")` — you need a conditional edge to skip it
+(see safe-cancellation in SKILL.md Step 5); `resume` alone does not skip.
+
+**Trap:** if you also list the node in `interrupt_after`, it pauses twice
+(before and after). Rarely useful.
+
+## `interrupt_after` — review a node's output
+
+```python
+graph = builder.compile(
+    checkpointer=MemorySaver(),
+    interrupt_after=["draft_email"],
+)
+```
+
+**Use when:** you want a human to review what the node just produced. Common
+for LLM drafts — the model wrote an email, the human edits it, then approves
+forwarding to the send node.
+
+**Human sees:** state *after* the node's mutation — the draft is now in state.
+
+**Resume with edits:**
+```python
+graph.invoke(
+    Command(update={"draft": {**state["draft"], "subject": edited}}, resume="approved"),
+    config,
+)
+```
+
+The next node (`send_email`) runs with the edited state.
+
+**Trap:** the node has already done its work. If `draft_email` logged a
+telemetry event or made a side-effectful API call, that already happened.
+Only gate idempotent nodes here; irreversible ones go in `interrupt_before`.
+
+## Inline `interrupt(payload)` — structured mid-node prompt
+
+```python
+from langgraph.types import interrupt
+
+def validate_purchase(state: AgentState) -> AgentState:
+    items = state["cart"]
+    total = sum(i["price"] for i in items)
+
+    # Collect structured input from the human
+    decision = interrupt({
+        "kind": "confirm_purchase",
+        "items": items,
+        "total": total,
+        "currency": "USD",
+    })
+    # `decision` is whatever the caller sent via Command(resume=...)
+
+    if not decision.get("approved"):
+        return {**state, "status": "cancelled", "notes": decision.get("notes")}
+    return {**state, "status": "confirmed", "approver": decision["approver"]}
+```
+
+**Use when:**
+- The prompt payload varies by runtime state (a purchase needs price, a
+  deploy needs a diff, an escalation needs a risk score).
+- You want multiple interrupt points inside one node.
+- You need the return value from the human to flow directly into node logic
+  (the other two styles pause *outside* node code).
+
+**Human sees:** the payload you passed to `interrupt(...)`. No free state
+snooping — you decide what to show. Safer for multi-tenant because you
+strip PII at the payload-construction site.
+
+**Resume:** `graph.invoke(Command(resume={"approved": True, "notes": "..."}), config)`.
+The value is returned from `interrupt()` inside the node.
+
+**Trap:** inline `interrupt()` still serializes state at the pause boundary.
+P17 applies here too — JSON-only state invariant holds regardless of which
+interrupt style you pick.
+
+## Decision criteria (choose one)
+
+Answer these in order:
+
+1. **Is the node irreversible?** → `interrupt_before`. Stop reading.
+2. **Is the node producing content the human must review/edit?** → `interrupt_after`.
+3. **Do you need a structured prompt with runtime-computed fields?** → inline `interrupt()`.
+4. **All three could work?** → `interrupt_before` is cheapest to reason about.
+   The human-visible state is the input, which matches the mental model of "am
+   I OK with this tool being called with these args?"
+
+## Multiple interrupts per graph
+
+A single graph can list many nodes in `interrupt_before` and `interrupt_after`.
+Each pause checkpoints independently. The `next` field on the snapshot tells
+you which node is about to run.
+
+```python
+graph = builder.compile(
+    checkpointer=saver,
+    interrupt_before=["send_email", "charge_card", "deploy_release"],
+    interrupt_after=["draft_email", "compose_announcement"],
+)
+```
+
+A thread can hit multiple interrupts during one run. The UI lists them via
+`graph.get_state(config)` — `snapshot.next` reveals the current pause point.
+
+## What interrupts do NOT do
+
+- **They do not create parallel approval branches.** If you need concurrent
+  approvers (two reviewers must both approve), coordinate above the graph —
+  collect both signatures, then send a single resume.
+- **They do not enforce SLAs.** If the human never approves, the thread sits
+  paused forever. Add a sweeper that routes to `END` with `rejected` after N
+  hours if pending.
+- **They do not authenticate the approver.** Your HTTP layer does that;
+  LangGraph trusts whoever calls `invoke(Command(resume=...))`.
+
+## Cross-check: interrupts vs tools that ask
+
+An alternative to interrupts is a "human_approval" *tool* the agent calls.
+The tool posts to a queue, waits, and returns the decision as a tool result.
+
+| Property | Interrupt | Approval tool |
+|----------|-----------|---------------|
+| Graph pauses cleanly, resumable from checkpoint | Yes | No — tool call blocks or times out |
+| Agent can reason about why approval is needed | Limited (state only) | Yes (free-form tool prompt) |
+| Works across graph restarts (process crash) | Yes (checkpoint survives) | Only if tool is idempotent and awaitable |
+| Cost of adoption | Medium (serialization discipline) | Low (just another tool) |
+
+Interrupts are better for hard gates (the tool *must not* run without
+approval). Approval tools are better for soft gates (the agent *asks* when
+unsure, proceeds autonomously most of the time).

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-langgraph-human-in-loop — One-Pager
+
+Build LangGraph 1.0 human-in-the-loop approval flows that actually pause cleanly — JSON-serializable state, reducer-safe resume, and a UI wire format that survives concurrent approvals.
+
+## The Problem
+
+Teams add `interrupt_before=["send_email"]` expecting a clean pause, and the first test crashes with `TypeError: Object of type datetime is not JSON serializable` — because an earlier node stashed `datetime.utcnow()` into state and the error surfaces only at the interrupt boundary, not on node completion (P17). A week later the human clicks "approve" with an edited argument, the graph resumes via `Command(update={"messages": [decision]})`, and the prior message history vanishes because `messages` was never annotated with `add_messages` (P18). Both bugs look like LangGraph brokenness; both are state-schema violations that only the interrupt path exercises.
+
+## The Solution
+
+Treat graph state as a JSON document (str/int/float/bool/list/dict only — ISO-string any `datetime`, base64 any `bytes`, `.model_dump()` any Pydantic), always declare reducers for list fields, and define one approval-decision wire format: `{"decision": "approve"|"reject"|"edit", "edits": {...}, "approver": "...", "reason": "..."}`. Choose interrupt granularity with a three-row decision tree (`interrupt_before`: gate expensive tool; `interrupt_after`: review tool output; inline `interrupt()`: mid-node collect + resume). Resume with `Command(resume=decision)`; route to `END` on reject; validate state with a pre-interrupt middleware in CI.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers adding approval gates to LangGraph 1.0 agents (Slack/web HITL), platform teams wiring approval UIs to LangGraph workflows, researchers doing mid-trajectory RLHF-style corrections |
+| **What** | Three-style interrupt decision tree, JSON-serializable state invariant with a pre-interrupt scanner, `Command(resume=...)` / `Command(update=..., resume=...)` contract, approval UI wire format (GET pending / POST decision / optimistic-concurrency), audit-log pattern, safe-cancellation routing, 3 deep references |
+| **When** | After `langchain-langgraph-basics` and `langchain-langgraph-checkpointing` (you need a checkpointer first), before wiring any irreversible tool (DB mutation, email send, purchase, deploy) |
+
+## Key Features
+
+1. **JSON-only state invariant with a pre-interrupt scanner** — A tiny middleware that walks state with `json.dumps(state, default=None)` before any interrupt-flagged node and raises a typed `NonSerializableStateError` with the offending key path — fails the test, not production
+2. **Three-style interrupt decision tree** — `interrupt_before=[node]` for expensive-tool gates, `interrupt_after=[node]` for reviewing a tool result, inline `interrupt({"kind": "..."})` for mid-node structured prompts — with concrete "use this when" criteria
+3. **Approval UI wire format** — Exact JSON schema for GET `/approvals/pending` (lists paused threads with state diffs) and POST `/approvals/{thread_id}/decision` (idempotent, includes `expected_checkpoint_id` for optimistic concurrency) — wires cleanly to Slack Block Kit or a React form
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/resume-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/resume-patterns.md
@@ -1,0 +1,281 @@
+# Resume Patterns
+
+Five resume shapes cover every HITL flow in practice. This reference has the
+exact code for each, plus the reducer discipline that keeps P18 from biting.
+
+## Preamble: the `Command` type
+
+```python
+from langgraph.types import Command
+```
+
+`Command` has three fields that matter for HITL:
+
+| Field | Purpose | When to use |
+|-------|---------|-------------|
+| `resume` | Value returned from inline `interrupt()` and recorded on checkpoint | Always on resume |
+| `update` | State patch applied via reducers | When the human edits state |
+| `goto` | Force routing to a specific node (or `END`) | When rejection bypasses nodes |
+
+## Pattern 1 — Plain approve (no edits)
+
+```python
+from langgraph.types import Command
+
+config = {"configurable": {"thread_id": thread_id}}
+graph.invoke(Command(resume="approved"), config)
+```
+
+- `resume="approved"` is just a marker. For `interrupt_before` / `interrupt_after`
+  nodes, no node reads it — but the checkpoint records it for audit.
+- For inline `interrupt()`, the value is returned from the `interrupt()` call.
+  So `resume` here is the node's input for decision logic.
+
+## Pattern 2 — Approve with edits
+
+```python
+graph.invoke(
+    Command(
+        update={"draft": edited_draft},   # merged via reducer
+        resume="approved",
+    ),
+    config,
+)
+```
+
+**P18 landmine:** without a reducer, `update` *replaces* the field. If `draft`
+is a dict and you pass a partial, you lose the rest:
+
+```python
+# Before: state["draft"] = {"to": "a@b.com", "subject": "Hi", "body": "Hello"}
+Command(update={"draft": {"subject": "Updated Hi"}})
+# After (no reducer): state["draft"] = {"subject": "Updated Hi"}  # to and body GONE
+```
+
+**Fix — merge at the call site:**
+
+```python
+current = graph.get_state(config).values
+merged_draft = {**current["draft"], "subject": "Updated Hi"}
+graph.invoke(Command(update={"draft": merged_draft}, resume="approved"), config)
+```
+
+**Better — declare a dict reducer:**
+
+```python
+def merge_dict(left: dict, right: dict) -> dict:
+    return {**left, **right}
+
+class AgentState(TypedDict):
+    draft: Annotated[dict, merge_dict]
+```
+
+Now partials merge automatically.
+
+## Pattern 3 — Reject and route to `END`
+
+### 3a. Conditional edge (preferred)
+
+Graph topology carries the rejection logic:
+
+```python
+from langgraph.graph import END
+
+def route_after_approval(state: AgentState) -> str:
+    if state.get("last_decision") == "rejected":
+        return END
+    return "send_email"
+
+builder.add_conditional_edges("await_approval", route_after_approval, {
+    "send_email": "send_email",
+    END: END,
+})
+```
+
+Resume with the rejection recorded in state:
+
+```python
+graph.invoke(
+    Command(
+        update={"last_decision": "rejected", "reject_reason": reason},
+        resume="rejected",
+    ),
+    config,
+)
+```
+
+The next superstep runs `route_after_approval`, sees `rejected`, routes to END.
+
+### 3b. `Command(goto=END)` at resume time
+
+```python
+from langgraph.graph import END
+graph.invoke(Command(resume="rejected", goto=END), config)
+```
+
+Less preferred — routing logic leaks into the HTTP layer. But sometimes
+necessary (e.g., you cannot modify the compiled graph).
+
+## Pattern 4 — Partial approval (approve arg X, reject arg Y)
+
+The human approves most of the tool call but wants to drop one argument:
+
+```python
+# Agent planned to send an email AND CC legal@. Human approves email, rejects CC.
+current = graph.get_state(config).values
+edited = {**current["draft"]}
+edited["cc"] = []  # drop CCs
+graph.invoke(
+    Command(
+        update={
+            "draft": edited,
+            "last_decision": "partial_approval",
+            "decision_notes": "Approved without CC",
+        },
+        resume="approved",
+    ),
+    config,
+)
+```
+
+For the UI, render an editable form of `state["draft"]` — each field becomes
+an input the human can modify. POST back the full edited dict; merge
+server-side.
+
+## Pattern 5 — Inline `interrupt()` with structured return
+
+```python
+from langgraph.types import interrupt
+
+def confirm_purchase(state: PurchaseState) -> PurchaseState:
+    decision = interrupt({
+        "kind": "confirm_purchase",
+        "items": state["cart"],
+        "total_usd": state["total"],
+    })
+    # decision is the value caller sent via Command(resume=<value>)
+    if not decision["approved"]:
+        return {**state, "status": "cancelled", "cancel_reason": decision.get("reason")}
+    return {**state, "status": "confirmed", "approver": decision["approver"]}
+```
+
+Resume:
+
+```python
+graph.invoke(
+    Command(resume={"approved": True, "approver": "jeremy@intentsolutions.io"}),
+    config,
+)
+```
+
+The dict is returned from `interrupt(...)` inside the node. Type it tightly —
+use a `TypedDict` or a Pydantic model the UI validates against.
+
+## Reducer cookbook
+
+| Field shape | Typical reducer | Import |
+|------------|-----------------|--------|
+| `list[AnyMessage]` (conversation history) | `add_messages` | `from langgraph.graph.message import add_messages` |
+| `list[dict]` (append-only events, approvals log) | `lambda l, r: l + r` | n/a |
+| `dict` (draft with partial edits) | `lambda l, r: {**l, **r}` | n/a |
+| `set[str]` serialized as list (tags) | `lambda l, r: sorted(set(l) | set(r))` | n/a |
+| Counter / accumulator (`int`) | `lambda l, r: l + r` | n/a |
+| Scalar (latest-wins, default) | None (omit reducer) | n/a |
+
+Declare with `Annotated`:
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+
+class AgentState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+    approvals: Annotated[list[dict], lambda l, r: l + r]
+    draft: Annotated[dict, lambda l, r: {**l, **r}]
+    total_tokens: Annotated[int, lambda l, r: l + r]
+    last_decision: str  # no reducer — latest-wins
+```
+
+## Audit log: write order matters
+
+```
+1. Validate optimistic-concurrency (expected_checkpoint_id)
+2. Write audit log entry (before any mutation)
+3. graph.invoke(Command(...))  # may succeed or fail
+4. If invoke failed, mark audit entry with outcome="error"
+   If invoke succeeded, mark outcome="applied"
+```
+
+Writing the audit entry BEFORE the mutation means you can reconstruct what
+*should* have happened even if the mutation crashed. Writing after means you
+lose the evidence on crash.
+
+Schema:
+
+```python
+class ApprovalAuditEntry(BaseModel):
+    id: UUID
+    thread_id: str
+    checkpoint_id: str          # the checkpoint the approver saw
+    decision: Literal["approve", "reject", "edit"]
+    edits: dict | None          # diff applied
+    approver: str               # email or user ID
+    reason: str | None
+    requested_at: datetime
+    applied_at: datetime | None # null until invoke returns
+    outcome: Literal["pending", "applied", "error", "conflict"]
+    error_message: str | None
+```
+
+Store this in your own DB (Postgres table, Firestore collection, whatever) —
+NOT in LangGraph state. The audit log survives thread deletion, state
+migrations, and LangGraph upgrades.
+
+## Checkpoint ID vs thread ID (quick reference)
+
+- `thread_id` — your app-level conversation or session identifier. Stable.
+- `checkpoint_id` — monotonic ID within a thread. Every superstep creates
+  one. Changes on every `invoke()` even if state is unchanged.
+
+The HITL optimistic-concurrency check compares `checkpoint_id`, not
+`thread_id`. Two approvers opening the same thread see the same
+`thread_id` but the same `checkpoint_id` only if neither has acted yet.
+First to POST wins; second gets 409.
+
+## Gotcha: `Command(resume=...)` after graph already completed
+
+```python
+graph.invoke({"input": "hi"}, config)  # runs to END, no interrupts
+graph.invoke(Command(resume="approved"), config)  # ???
+```
+
+Behavior depends on the LangGraph version. Safest: check
+`snapshot.next` before resuming:
+
+```python
+snapshot = graph.get_state(config)
+if not snapshot.next:
+    raise HTTPException(410, "Thread already completed; nothing to resume")
+```
+
+Return `410 Gone` from the approval endpoint — the UI can refresh and drop
+the stale pending entry.
+
+## Gotcha: resume on a different checkpointer instance
+
+If your app restarts between pause and resume, the in-process `MemorySaver`
+loses state. The thread is gone. Always use `PostgresSaver` or `SqliteSaver`
+for any non-ephemeral HITL flow.
+
+```python
+# WRONG in production — state lost on pod restart
+saver = MemorySaver()
+
+# RIGHT — state survives restarts
+from langgraph.checkpoint.postgres import PostgresSaver
+saver = PostgresSaver.from_conn_string("postgresql://...")
+saver.setup()
+```
+
+Run `.setup()` after every `langgraph` package upgrade (P20).

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/state-serialization-for-interrupts.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/references/state-serialization-for-interrupts.md
@@ -1,0 +1,213 @@
+# State Serialization for Interrupts
+
+Pain catalog entry P17:
+
+> `interrupt_before=[node]` raises `TypeError: Object of type <custom> is not
+> JSON serializable` the moment a node tries to interrupt. The failure surfaces
+> only at the interrupt boundary, not on node completion.
+
+This reference is the complete, field-tested list of what breaks and how to
+fix it.
+
+## Why it fails at the interrupt, not at the node
+
+LangGraph's checkpointers (`MemorySaver`, `PostgresSaver`, `SqliteSaver`,
+`RedisSaver`) serialize the full state to JSON on every **superstep** — the
+atomic unit between one node finishing and the next starting. Most graph
+flows cross supersteps without touching the checkpointer's *persist-on-disk*
+path aggressively — but the interrupt path **always** persists, because that
+is how resume works.
+
+So a `datetime` field in state makes every node pass its unit test, the graph
+runs happily through five supersteps, and then the moment you hit
+`interrupt_before=["send_email"]` the checkpointer serializes state,
+`json.dumps` raises, and the error bubbles up from deep in LangGraph
+internals.
+
+## Forbidden types (complete list)
+
+| Python type | Why it fails | Convert to |
+|------------|--------------|------------|
+| `datetime.datetime` | No JSON type | `dt.isoformat()` — ISO 8601 string |
+| `datetime.date` | No JSON type | `d.isoformat()` |
+| `datetime.timedelta` | No JSON type | `td.total_seconds()` (float) |
+| `bytes` / `bytearray` | No JSON type | `base64.b64encode(b).decode()` |
+| `set` / `frozenset` | Not in JSON spec | `sorted(s)` — lists are JSON |
+| `tuple` | Silently becomes list, reducer may not expect it | Use `list` explicitly |
+| `uuid.UUID` | No JSON type | `str(u)` |
+| `decimal.Decimal` | No JSON type | `str(d)` (exact) or `float(d)` (lossy) |
+| `pathlib.Path` | No JSON type | `str(p)` |
+| `enum.Enum` member | No JSON type | `e.value` or `e.name` |
+| Pydantic `BaseModel` (pre-v2 non-JSON fields) | `json.dumps` can't recurse | `.model_dump(mode="json")` in v2 |
+| `dataclass` instances | No JSON serializer | `dataclasses.asdict(obj)` |
+| `numpy.ndarray` | No JSON type | `arr.tolist()` |
+| `numpy.float32` / `numpy.int64` | Not Python scalars | `float(x)` / `int(x)` |
+| `pandas.DataFrame` | No JSON type | `df.to_dict(orient="records")` |
+| Custom class instances | No default serializer | `to_dict()` method or `vars(obj)` |
+| `Exception` instances | Not JSON | `{"type": type(e).__name__, "msg": str(e)}` |
+| `io.BytesIO` / file handles | Not JSON, not meaningful across processes | Store a reference (URL, path) not the handle |
+
+## Permitted types (the complete allowlist)
+
+- `None`
+- `bool`
+- `int`
+- `float` (but NOT `float("nan")`, `float("inf")`, `float("-inf")` — JSON forbids them)
+- `str`
+- `list` of permitted types (recursive)
+- `dict` with `str` keys and permitted values (recursive)
+
+That is it. If a type is not in this list, convert it at the node boundary.
+
+## The `float("nan")` trap
+
+`json.dumps(float("nan"))` returns `"NaN"` by default (Python-specific
+extension). `PostgresSaver`'s writer uses `json.dumps(..., allow_nan=False)` on
+some backends, which raises `ValueError: Out of range float values are not JSON
+compliant`. Always sanitize:
+
+```python
+import math
+
+def clean_float(x: float) -> float | None:
+    return None if math.isnan(x) or math.isinf(x) else x
+```
+
+## Pre-interrupt scanner middleware
+
+Drop this in `common/state_scanner.py` and import from every skill-under-test:
+
+```python
+import json
+from typing import Any
+
+class NonSerializableStateError(TypeError):
+    """Raised when state cannot be checkpointed."""
+
+def assert_json_serializable(state: dict[str, Any], *, path: str = "state") -> None:
+    """Walk state depth-first and raise a typed error with the key path.
+
+    Use as a sanity check at the end of any node that precedes an interrupt,
+    or run as CI middleware after every node invocation in test mode.
+    """
+    _walk(state, path)
+
+def _walk(v: Any, path: str) -> None:
+    if v is None or isinstance(v, (bool, int, str)):
+        return
+    if isinstance(v, float):
+        import math
+        if math.isnan(v) or math.isinf(v):
+            raise NonSerializableStateError(
+                f"{path} is {v!r} — JSON forbids NaN/Inf. Replace with None or a sentinel."
+            )
+        return
+    if isinstance(v, list):
+        for i, item in enumerate(v):
+            _walk(item, f"{path}[{i}]")
+        return
+    if isinstance(v, dict):
+        for k, val in v.items():
+            if not isinstance(k, str):
+                raise NonSerializableStateError(
+                    f"{path} has non-string key {k!r} ({type(k).__name__}). "
+                    f"JSON objects require string keys."
+                )
+            _walk(val, f"{path}.{k}")
+        return
+    raise NonSerializableStateError(
+        f"{path} is {type(v).__name__}, not JSON-serializable. "
+        f"See state-serialization-for-interrupts.md for conversions."
+    )
+```
+
+Wire as a LangGraph callback or call at node exits:
+
+```python
+def classify_node(state: AgentState) -> AgentState:
+    state = {**state, "classified_at": datetime.utcnow().isoformat()}  # NOT datetime object
+    assert_json_serializable(state)  # dev/CI only; omit in prod for perf
+    return state
+```
+
+## Test harness that exercises the interrupt path
+
+Unit tests that call `node(state)` directly do NOT exercise the checkpointer.
+You must invoke the compiled graph and trigger a pause:
+
+```python
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+@pytest.fixture
+def graph():
+    builder = StateGraph(AgentState)
+    # ... add nodes / edges ...
+    return builder.compile(
+        checkpointer=MemorySaver(),
+        interrupt_before=["send_email"],
+    )
+
+def test_graph_reaches_interrupt_without_serialization_error(graph):
+    config = {"configurable": {"thread_id": "test-1"}}
+    # This is the only way to catch P17. If state has a datetime buried
+    # in it, this raises TypeError.
+    graph.invoke({"messages": [("user", "send the email")]}, config)
+    snapshot = graph.get_state(config)
+    assert snapshot.next == ("send_email",), "Graph did not pause at send_email"
+
+def test_resume_preserves_message_history(graph):
+    config = {"configurable": {"thread_id": "test-2"}}
+    graph.invoke({"messages": [("user", "hello")]}, config)
+    # ... build up state with multiple messages ...
+    pre_resume = graph.get_state(config).values["messages"]
+    graph.invoke(Command(resume="approved"), config)
+    post_resume = graph.get_state(config).values["messages"]
+    assert len(post_resume) >= len(pre_resume), "History lost on resume (P18)"
+```
+
+Both tests are mandatory. The first catches P17 at CI time; the second
+catches P18 at CI time.
+
+## Pydantic in state: the right way
+
+If your domain types are Pydantic models, do not store the model instance in
+state. Store `.model_dump(mode="json")` — which recursively converts
+`datetime`, `UUID`, `Decimal`, etc. to JSON-safe values:
+
+```python
+from pydantic import BaseModel
+
+class EmailDraft(BaseModel):
+    to: str
+    subject: str
+    body: str
+    scheduled_for: datetime
+
+class AgentState(TypedDict):
+    draft: dict  # serialized EmailDraft, not EmailDraft itself
+
+def draft_node(state: AgentState) -> AgentState:
+    model = EmailDraft(to="...", subject="...", body="...", scheduled_for=datetime.utcnow())
+    return {**state, "draft": model.model_dump(mode="json")}  # JSON-safe dict
+
+def send_node(state: AgentState) -> AgentState:
+    model = EmailDraft.model_validate(state["draft"])  # revive if needed
+    # ... use model.scheduled_for as datetime ...
+    return state
+```
+
+Revive in the node that needs the typed form, checkpoint the dict. Symmetric
+at every boundary.
+
+## What about `MessagesState` / `add_messages`?
+
+`langchain_core.messages.AnyMessage` subclasses (`HumanMessage`, `AIMessage`,
+`ToolMessage`, `SystemMessage`) are serializable by LangGraph's message
+encoder out of the box. You do NOT need to dump them manually. `add_messages`
+reducer handles append semantics.
+
+Where people get bitten: custom subclasses of `BaseMessage` that add Python
+fields. The default encoder drops unknown fields silently, which can lose
+data across a resume. Keep message types stock; put custom fields in a
+sibling state key as a plain dict.


### PR DESCRIPTION
## Summary

Handcrafted LangGraph 1.0 human-in-the-loop skill — `interrupt_before` / `interrupt_after` / inline `interrupt()`, JSON-serializable state discipline, `Command(resume=...)` contract, and approval-UI wire format. Anchored to pain-catalog **P17, P18**.

## Pain hook

Team ships `interrupt_before=["send_email"]`, tests crash with `TypeError: Object of type datetime is not JSON serializable` because a node two steps back stashed a `datetime` into state — invisible until the interrupt boundary serializes (P17). Their resume fix then wipes the 47-message history because `messages` was typed without the `add_messages` reducer, so `Command(update={...})` replaced instead of appended (P18). Skill ships the JSON-only state invariant, a pre-interrupt scanner, the full resume contract, and a concurrency-safe approval UI wire format.

## Files

- `skills/langchain-langgraph-human-in-loop/SKILL.md` (334 lines)
- `skills/langchain-langgraph-human-in-loop/references/one-pager.md`
- `skills/langchain-langgraph-human-in-loop/references/interrupt-decision-tree.md`
- `skills/langchain-langgraph-human-in-loop/references/state-serialization-for-interrupts.md`
- `skills/langchain-langgraph-human-in-loop/references/resume-patterns.md`
- `skills/langchain-langgraph-human-in-loop/references/approval-ui-wiring.md`

## Validator

Grade **A (90/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude