### PR TITLE
feat(langchain-py-pack): add langchain-langgraph-subgraphs (L30)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: langchain-langgraph-subgraphs
+description: |
+  Compose LangGraph 1.0 subgraphs correctly — shared state key propagation,
+  Send / Command(graph=...) dispatch, callback scoping, per-subgraph recursion
+  budgets, and testing each subgraph in isolation. Use when building a planner +
+  executor, a nested agent team, or a reusable subgraph library. Trigger with
+  "langgraph subgraph", "langgraph composition", "langgraph send",
+  "nested agents", "langgraph state propagation", "Command(graph=...)",
+  "langgraph subgraph callbacks".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, subgraphs, composition]
+compatible-with: claude-code, codex
+---
+
+# LangGraph Subgraphs and Composition (Python)
+
+## Overview
+
+A parent `StateGraph` invokes a compiled child subgraph as a node. The child
+node writes `state["answer"] = "42"` and returns. The parent's next node reads
+`state["answer"]` and gets `None`. No error, no warning, no deprecation notice —
+just a silent `None` that surfaces as a wrong answer three nodes later when the
+router picks the "couldn't find it" branch.
+
+The cause is pain-catalog entry **P21**: LangGraph subgraphs run on an
+**independent state schema**. Only keys declared in *both* the parent's
+`TypedDict` and the child's `TypedDict` propagate across the subgraph boundary.
+`answer` existed in the child schema but not the parent schema, so it was
+discarded on return. The fix is to declare `answer` in both schemas (with
+matching reducers, if the field is a list) or to use explicit
+`Command(graph=ParentGraph, update={"answer": "42"})` to bubble it up.
+
+The second silent failure waits one step further. Attach a tracing callback to
+the parent runnable via `parent.with_config(callbacks=[tracer])` and invoke.
+The tracer fires on parent nodes and never on child tool calls. This is
+pain-catalog entry **P28**: LangGraph creates a fresh runtime per subgraph, so
+callbacks bound at *definition time* do not inherit. The fix is to pass
+callbacks at *invocation time* via `config["callbacks"]`, which does propagate.
+
+This skill walks through the shared-state contract, three dispatch patterns
+(compiled subgraph as a node, `Send` fan-out, `Command(graph=Parent)` bubble-up),
+callback scoping, per-subgraph `recursion_limit` budgets, and a testing pattern
+that exercises every subgraph in isolation before composition. Pin:
+`langgraph 1.0.x`, `langchain-core 1.0.x`. Pain-catalog anchors: **P21, P28**,
+with supporting references to P18 (reducers), P19 (stream modes on nested
+graphs), and P55 (recursion budget).
+
+A planner-executor is typically **1 parent + 2-4 subgraphs**; a hierarchical
+agent team with a supervisor and N specialists is **1 parent + N subgraphs**.
+Each subgraph has its own independent `recursion_limit` (default 25) — a parent
+at step 20 can still invoke a child that runs 25 of its own steps.
+
+## Prerequisites
+
+- Python 3.10+
+- `langgraph >= 1.0, < 2.0`
+- `langchain-core >= 1.0, < 2.0`
+- Completion of `langchain-langgraph-basics` (L25) — `StateGraph`, `TypedDict`
+  state, `Annotated[list, add_messages]` reducer, `MemorySaver` checkpointing
+- Test tooling: `pytest`, `langchain_core.language_models.fake_chat_models.FakeListChatModel`
+
+## Instructions
+
+### Step 1 — Declare the shared-state contract explicitly
+
+The single most important decision when composing subgraphs is: **which keys
+cross the boundary?** Every key that must survive the call *must* appear in
+both `TypedDict` schemas with compatible types and reducers.
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+
+# Keys both schemas declare -> these propagate
+# Keys only in parent -> invisible to child
+# Keys only in child -> discarded on return (P21)
+
+class ParentState(TypedDict):
+    # Shared with every subgraph
+    messages: Annotated[list[AnyMessage], add_messages]  # P18 reducer required
+    session_id: str
+
+    # Parent-only coordination fields
+    plan: list[str]
+    current_step: int
+
+class ExecutorState(TypedDict):
+    # Shared with parent — must match reducer exactly (P18)
+    messages: Annotated[list[AnyMessage], add_messages]
+    session_id: str
+
+    # Executor-only scratch — parent never sees these
+    tool_result: dict | None
+    retries: int
+```
+
+If `messages` on the child used a different reducer (or no reducer), list
+updates would silently replace instead of append on one side of the boundary
+(P18). The `messages` + `session_id` pair is the propagation contract. Everything
+else is private to its owner.
+
+See [State Contract](references/state-contract.md) for the full
+state-propagation matrix and the "subset rule" for schema inheritance.
+
+### Step 2 — Pick the dispatch pattern
+
+Three ways a parent can invoke a subgraph, and each solves a different problem.
+
+**A. Compiled subgraph as a node** — Simplest. Subgraph runs, returns a state
+update, parent continues.
+
+```python
+from langgraph.graph import StateGraph, END
+
+executor_graph = (
+    StateGraph(ExecutorState)
+    .add_node("run_tool", run_tool_node)
+    .add_node("summarize", summarize_node)
+    .add_edge("run_tool", "summarize")
+    .add_edge("summarize", END)
+    .set_entry_point("run_tool")
+    .compile()
+)
+
+parent_graph = (
+    StateGraph(ParentState)
+    .add_node("plan", planner_node)
+    .add_node("execute", executor_graph)   # compiled subgraph as a node
+    .add_node("finalize", finalize_node)
+    .add_edge("plan", "execute")
+    .add_edge("execute", "finalize")
+    .set_entry_point("plan")
+    .compile()
+)
+```
+
+Only `messages` and `session_id` cross the boundary in either direction (from
+Step 1). `tool_result` stays inside the child; `plan` stays inside the parent.
+
+**B. `Send(graph, state)` for fan-out** — One parent step spawns N parallel
+subgraph invocations, each with a different slice of state.
+
+```python
+from langgraph.types import Send
+
+def dispatch_specialists(state: ParentState) -> list[Send]:
+    return [
+        Send("specialist_graph", {"messages": state["messages"],
+                                   "session_id": state["session_id"],
+                                   "topic": topic})
+        for topic in state["plan"]
+    ]
+```
+
+Use `Send` when the number of subgraph calls depends on runtime state.
+Reducers on shared keys merge the parallel results.
+
+**C. `Command(graph=ParentGraph, update=...)` to bubble up** — A subgraph node
+jumps control back to the parent with an explicit state update, skipping the
+rest of the subgraph.
+
+```python
+from langgraph.types import Command
+
+def specialist_early_exit(state: ExecutorState) -> Command:
+    if state.get("tool_result") and state["tool_result"].get("done"):
+        return Command(
+            graph=Command.PARENT,
+            update={"messages": [AIMessage("done")]},
+            goto="finalize",
+        )
+    return {"retries": state.get("retries", 0) + 1}
+```
+
+`Command(graph=Command.PARENT)` is the explicit opposite of P21 — it forces a
+field up to the parent scope regardless of schema overlap.
+
+See [Dispatch Patterns](references/dispatch-patterns.md) for the full decision
+tree (inline function vs subgraph-as-node vs `Send` vs `Command` vs separate
+service) and a sizing guide.
+
+### Step 3 — Scope callbacks at invocation time, not definition time
+
+```python
+# WRONG — callbacks bind at definition time and do NOT propagate to subgraphs (P28)
+traced_parent = parent_graph.with_config(callbacks=[tracer])
+traced_parent.invoke({"messages": [HumanMessage("...")], "session_id": "s1"})
+# tracer fires on parent nodes only. Child tool calls are invisible.
+
+# RIGHT — callbacks pass via config at invocation time, propagating into every subgraph
+parent_graph.invoke(
+    {"messages": [HumanMessage("...")], "session_id": "s1"},
+    config={
+        "configurable": {"thread_id": "s1"},
+        "callbacks": [tracer],
+    },
+)
+# tracer fires on parent nodes AND every child tool, LLM, and chain event.
+```
+
+Every production invocation path — API handler, batch worker, test harness —
+should pass callbacks via `config["callbacks"]`. Lint for
+`with_config(callbacks=` on compiled graphs in CI and flag it.
+
+See [Callback Scoping](references/callback-scoping.md) for the debugging
+playbook when a callback "should be firing but isn't."
+
+### Step 4 — Budget recursion per subgraph
+
+LangGraph's `recursion_limit` (default **25** supersteps) is **per-graph, not
+global**. A parent graph at superstep 20 invoking a subgraph resets the counter
+inside that subgraph to zero. Pros: one runaway subgraph cannot starve the
+parent. Cons: adding subgraphs does not reduce your global budget — a poorly
+bounded specialist can still rack up 25 of its own steps while the parent
+thinks it spent only one.
+
+```python
+# Parent gets 10 steps of its own planning.
+# Each executor call gets its own 15-step budget, independent of the parent's 10.
+parent_graph.invoke(
+    initial_state,
+    config={
+        "configurable": {"thread_id": "s1"},
+        "recursion_limit": 10,
+    },
+)
+
+executor_graph.invoke(
+    sub_state,
+    config={"recursion_limit": 15},
+)
+```
+
+For a parent that dispatches `N` specialists via `Send`, worst-case step count
+is `parent_limit + N * specialist_limit`. Monitor the actual distribution with
+a callback on `on_chain_start` / `on_chain_end` at each graph boundary —
+`GraphRecursionError` with no obvious loop is P55 in the pain catalog, and
+subgraph composition is the most common cause.
+
+### Step 5 — Test every subgraph in isolation before composing
+
+A subgraph that works alone and breaks in composition is almost always a
+state-contract bug (Step 1) or a callback-scoping bug (Step 3). Catch both by
+unit-testing each subgraph with a `FakeListChatModel` and an in-memory
+checkpointer before wiring it into a parent.
+
+```python
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langgraph.checkpoint.memory import MemorySaver
+
+def test_executor_subgraph_standalone():
+    fake = FakeListChatModel(responses=['{"done": true, "result": 42}'])
+    graph = build_executor(llm=fake).compile(checkpointer=MemorySaver())
+    out = graph.invoke(
+        {"messages": [HumanMessage("do the thing")],
+         "session_id": "test",
+         "tool_result": None,
+         "retries": 0},
+        config={"configurable": {"thread_id": "test"},
+                "recursion_limit": 5},
+    )
+    # Assert the shared-contract fields (Step 1) are present on return
+    assert "messages" in out
+    assert out["session_id"] == "test"
+    # Assert child-only field is scoped correctly
+    assert out["tool_result"] == {"done": True, "result": 42}
+```
+
+See [Testing Subgraphs](references/testing-subgraphs.md) for the full isolation
+pattern — fixtures, state-shape assertions per node, and how to assert callback
+propagation with a capturing handler.
+
+### Step 6 — Version subgraphs independently of the parent
+
+A reusable subgraph should ship with its own semantic version and a pinned
+schema contract. Breaking either the shared-state contract (Step 1) or the
+dispatch signature (Step 2) is a major-version bump; adding a new private
+child-only field is a patch.
+
+```python
+# executor_subgraph/__init__.py
+__version__ = "1.2.0"
+
+SHARED_KEYS = frozenset({"messages", "session_id"})  # parent must declare these
+
+def build_executor(llm) -> StateGraph:
+    """v1.2.0 executor — adds 'retries' field (child-only, backward-compatible)."""
+    ...
+```
+
+Parents pin `executor_subgraph>=1.2.0,<2.0.0`. A v2.0.0 that renames `session_id`
+forces every parent to re-sync its `TypedDict`. This is how you catch P21 at
+`pip install` time instead of at runtime.
+
+## Output
+
+- `ParentState` + per-subgraph child `TypedDict`s with the shared-key contract
+  declared explicitly; every shared list field has a matching reducer
+- Dispatch pattern chosen per subgraph (node vs `Send` vs `Command(graph=PARENT)`)
+  with rationale recorded in code comments
+- Every invocation path (API, batch, test) passes `callbacks` via
+  `config["callbacks"]` so observability propagates into every subgraph
+- `recursion_limit` set explicitly on parent and each subgraph, with the
+  worst-case superstep count documented
+- Unit tests for each subgraph in isolation, asserting shared-contract fields
+  on return and callback propagation via a capturing handler
+- Reusable subgraphs ship with their own `__version__` and a frozen
+  `SHARED_KEYS` set
+
+## Error Handling
+
+| Error / Symptom | Cause | Fix |
+|---|---|---|
+| Parent reads `state["foo"]` and gets `None` after subgraph call | Key declared only in child schema; discarded on return (P21) | Add `foo` to parent `TypedDict`; use matching reducer; or return `Command(graph=Command.PARENT, update={"foo": ...})` |
+| Tracer attached to parent never fires on child tool calls | Callback bound at definition time via `.with_config(callbacks=[...])` (P28) | Pass `callbacks=[tracer]` in `config` at each `invoke()` / `ainvoke()` call |
+| `TypeError: unhashable type` from the message reducer in the parent after a `Send` fan-out | Child schema used `list` instead of `Annotated[list, add_messages]` (P18) | Match reducers on both sides of the boundary |
+| `GraphRecursionError: Recursion limit of 25 reached` inside a subgraph only | Subgraph has its own 25-step budget; long sub-loop (P55) | Set `config={"recursion_limit": N}` explicitly or restructure subgraph |
+| Subgraph returns state but parent sees empty `messages` | List field not using `add_messages` reducer on the parent side (P18) | `messages: Annotated[list[AnyMessage], add_messages]` in both `TypedDict`s |
+| `Command(goto="next_node")` halts instead of continuing | `Command` did not set `graph=Command.PARENT` — tried to `goto` a parent node from inside the child scope | Use `Command(graph=Command.PARENT, goto="next_node", update=...)` |
+| Subgraph runs but thread state never persists | Checkpointer attached only to parent; child `invoke()` without `thread_id` | Compile subgraphs with `checkpointer` too, or invoke with a `thread_id` matching the parent |
+
+## Examples
+
+### Planner-executor — shared messages, private scratch
+
+The prototypical 1 + 2-4 composition: a planner writes a step list, an executor
+runs each step, a finalizer summarizes. `messages` and `session_id` cross every
+boundary; `plan` is parent-only; `tool_result` and `retries` are executor-only.
+Uses a compiled-subgraph-as-node dispatch (Step 2A). See
+[Dispatch Patterns](references/dispatch-patterns.md) for the full worked example.
+
+### Hierarchical agent team — supervisor fans out to N specialists
+
+A supervisor picks which specialists to invoke and calls `Send("specialist",
+...)` in parallel. Each specialist runs its own subgraph with its own recursion
+budget. Results merge via the `messages` reducer. See
+[Dispatch Patterns](references/dispatch-patterns.md) for the `Send`-based
+fan-out and the callback propagation pattern needed to trace the team.
+
+### Reusable subgraph library — pinned contract with versioned exports
+
+An `executor_subgraph` package exports `build_executor(llm)` and a frozen
+`SHARED_KEYS` set, ships with a semantic version, and its CI fails if
+`SHARED_KEYS` changes without a major-version bump. See
+[State Contract](references/state-contract.md) for the schema-pinning pattern.
+
+### Testing a specialist with a capturing callback
+
+A `CaptureHandler` subclasses `BaseCallbackHandler`, appends every `on_*` event
+to a list, and asserts both parent and child events are present after a single
+`parent_graph.invoke(..., config={"callbacks": [handler]})`. Catches P28 at PR
+review. See [Testing Subgraphs](references/testing-subgraphs.md) for the full
+fixture and assertion pattern.
+
+## Resources
+
+- [LangGraph subgraph concepts](https://langchain-ai.github.io/langgraph/concepts/subgraphs/)
+- [LangGraph subgraph how-to](https://langchain-ai.github.io/langgraph/how-tos/subgraph/)
+- [`Send` API reference](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.Send)
+- [`Command` API reference](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.Command)
+- [LangGraph callback propagation](https://langchain-ai.github.io/langgraph/how-tos/streaming/)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Sibling skill: `langchain-langgraph-basics` (L25) — prerequisite `StateGraph`, reducers, checkpointing
+- Pack pain catalog: `docs/pain-catalog.md` (entries P18, P19, P21, P28, P55)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/callback-scoping.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/callback-scoping.md
@@ -1,0 +1,163 @@
+# Callback Scoping Across Subgraphs
+
+Pain-catalog entry **P28**: a `BaseCallbackHandler` attached to the parent
+runnable never fires on inner agent tool calls. This is the second silent
+failure in subgraph composition (after P21), and the one most likely to be
+caught in production when the tracing dashboard is missing half the spans.
+
+## Why this happens
+
+LangGraph creates a fresh runtime per subgraph. Callbacks in LangChain are
+attached to `RunnableConfig`, which is passed through the runtime. When a
+`Runnable` is configured at **definition time** via
+`.with_config(callbacks=[tracer])`, the callback is baked into the parent
+runtime only. Child subgraphs spawn their own runtime, do not inherit the
+parent's bound config, and the tracer never sees their events.
+
+When callbacks are passed at **invocation time** via
+`runnable.invoke(inputs, config={"callbacks": [tracer]})`, LangGraph propagates
+the config down into every subgraph's runtime. The tracer sees everything.
+
+The fix is one line, but it is counterintuitive because for non-LangGraph
+Runnables `.with_config(callbacks=[...])` does work. This is LangGraph-specific
+behavior.
+
+## The wrong way
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class Tracer(BaseCallbackHandler):
+    def on_chat_model_start(self, *a, **kw): print("LLM start")
+    def on_tool_start(self, *a, **kw):        print("tool start")
+    def on_chain_start(self, *a, **kw):       print("chain start")
+
+# WRONG — binds to parent runtime only. Subgraph tool/LLM events are lost.
+traced = parent_graph.with_config(callbacks=[Tracer()])
+traced.invoke({"messages": [HumanMessage("...")], "session_id": "s1"},
+              config={"configurable": {"thread_id": "s1"}})
+```
+
+You will see `chain start` for the parent nodes and nothing for anything inside
+a subgraph. LangSmith dashboards show a truncated trace with "gaps" where the
+subgraph ran.
+
+## The right way
+
+```python
+# RIGHT — pass callbacks in config at invocation time; propagates to all subgraphs.
+parent_graph.invoke(
+    {"messages": [HumanMessage("...")], "session_id": "s1"},
+    config={
+        "configurable": {"thread_id": "s1"},
+        "callbacks": [Tracer()],
+    },
+)
+```
+
+Every tool call, LLM call, and chain boundary in every subgraph fires through
+the tracer.
+
+## Covering every invocation path
+
+The rule extends to `ainvoke`, `astream`, `astream_events`, `batch`:
+
+```python
+# async
+await parent_graph.ainvoke(state, config={"callbacks": [tracer], ...})
+
+async for chunk in parent_graph.astream(state, config={"callbacks": [tracer], ...}):
+    ...
+
+async for event in parent_graph.astream_events(state, version="v2",
+                                               config={"callbacks": [tracer], ...}):
+    ...
+
+parent_graph.batch(states, config={"callbacks": [tracer], ...})
+```
+
+A single missed invocation path in a rarely-hit retry code path is enough to
+hide subgraph events.
+
+## Helper: centralize config construction
+
+To avoid this bug recurring across dozens of invocation sites, build configs in
+one place:
+
+```python
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+
+def app_config(*, thread_id: str,
+               callbacks: list | None = None,
+               recursion_limit: int = 25,
+               **extra: Any) -> RunnableConfig:
+    """Always call this to build a config. Never hand-roll one."""
+    cfg: RunnableConfig = {
+        "configurable": {"thread_id": thread_id, **extra},
+        "recursion_limit": recursion_limit,
+    }
+    if callbacks:
+        cfg["callbacks"] = callbacks
+    return cfg
+
+# Usage
+parent_graph.invoke(state, config=app_config(thread_id="s1", callbacks=[Tracer()]))
+```
+
+A lint rule in CI (`grep -r "with_config(callbacks=" --include="*.py"`) catches
+regressions.
+
+## Debugging a "missing callback" gap
+
+1. Does the tracer fire on any event? If not, it is not registered at all.
+2. Does it fire on parent nodes but not child ones? Classic P28. Move to
+   `config["callbacks"]` at the invocation site.
+3. Does it fire on subgraph chain-start but not on LLM calls inside the
+   subgraph? Check that the subgraph's LLM was built without its own
+   conflicting `.with_config(callbacks=[])` that overrode the inherited config.
+4. Does it fire in sync invocations but not async? Check the async handler
+   methods (`on_chat_model_start` has async variants for async code paths —
+   `BaseCallbackHandler` supports both; `AsyncCallbackHandler` is sync-incompatible).
+
+## Capturing handler for tests
+
+Pair with the [Testing Subgraphs](testing-subgraphs.md) reference:
+
+```python
+class CaptureHandler(BaseCallbackHandler):
+    def __init__(self):
+        self.events: list[str] = []
+
+    def on_chain_start(self, serialized, inputs, **kwargs):
+        name = serialized.get("name") if serialized else "?"
+        self.events.append(f"chain_start:{name}")
+
+    def on_tool_start(self, serialized, input_str, **kwargs):
+        self.events.append(f"tool_start:{serialized.get('name', '?')}")
+
+    def on_chat_model_start(self, serialized, messages, **kwargs):
+        self.events.append("llm_start")
+
+def test_callbacks_propagate_to_subgraph():
+    handler = CaptureHandler()
+    parent_graph.invoke(
+        initial_state,
+        config={"configurable": {"thread_id": "t"},
+                "callbacks": [handler]},
+    )
+    # Assert we saw events from BOTH parent and child
+    parent_events = [e for e in handler.events if "planner" in e]
+    child_events = [e for e in handler.events if "executor" in e]
+    assert parent_events, "no parent events captured"
+    assert child_events, "P28: callbacks did not propagate to subgraph"
+```
+
+## Related pain-catalog entries
+
+- **P28** — Custom callbacks are not inherited by subgraphs (the entry this
+  reference anchors)
+- **P19** — `astream_events(version="v2")` emits a different event stream;
+  most subgraph-aware tracing uses it
+- **P01** — `ChatAnthropic.stream()` delays token counts; pair with callback
+  scoping to get cost dashboards right

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/dispatch-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/dispatch-patterns.md
@@ -1,0 +1,180 @@
+# Dispatch Patterns: Node vs `Send` vs `Command(graph=PARENT)`
+
+Four ways a parent graph can talk to a subgraph. Picking the wrong one turns
+what should be clean composition into duct-tape. This reference is the decision
+tree.
+
+## Decision tree — when to use what
+
+```
+Do you need a subgraph at all?
+├── Will the logic be reused by a different parent graph?       -> subgraph
+├── Does it own a distinct failure/retry/recursion budget?      -> subgraph
+├── Does it have a non-trivial internal state machine?          -> subgraph
+├── Does it need to be versioned/shipped independently?         -> subgraph
+├── None of the above but > ~8 related nodes?                   -> subgraph
+└── Otherwise                                                   -> inline function / plain node
+
+Once you've committed to a subgraph, pick the dispatch:
+
+Parent calls child exactly once, serially, with a known state subset?
+   -> A. Compiled subgraph as a node  (simplest, use this by default)
+
+Parent dispatches N parallel children, N depends on runtime state?
+   -> B. Send(graph, state) fan-out   (reducers on shared keys merge results)
+
+Child needs to short-circuit the parent flow and hand control back directly?
+   -> C. Command(graph=Command.PARENT, update=..., goto=...)  (escape hatch)
+
+Child is heavy enough to deserve its own process / scaling / deploy?
+   -> D. Separate service + HTTP / queue (not a subgraph anymore)
+```
+
+## A. Compiled subgraph as a node
+
+The default. The compiled child is passed to `add_node` exactly like a function.
+
+```python
+from langgraph.graph import StateGraph, END
+
+def build_executor(llm) -> StateGraph:
+    return (
+        StateGraph(ExecutorState)
+        .add_node("run_tool", run_tool_node)
+        .add_node("summarize", summarize_node)
+        .add_edge("run_tool", "summarize")
+        .add_edge("summarize", END)
+        .set_entry_point("run_tool")
+        .compile()
+    )
+
+executor_graph = build_executor(llm)
+
+parent = (
+    StateGraph(ParentState)
+    .add_node("plan", planner_node)
+    .add_node("execute", executor_graph)   # compiled subgraph as a node
+    .add_node("finalize", finalize_node)
+    .add_edge("plan", "execute")
+    .add_edge("execute", "finalize")
+    .set_entry_point("plan")
+    .compile()
+)
+```
+
+**When it is right:** a planner-executor pipeline, a data-enrichment pass
+between stages, a nested tool-calling loop that should be reusable.
+
+**Sizing:** 1 parent + 2-4 subgraphs is the typical planner-executor shape.
+
+**Gotchas:** only keys in `SHARED_KEYS` propagate (P21). The subgraph gets its
+own `recursion_limit` budget (P55).
+
+## B. `Send(graph, state)` fan-out
+
+Parallel dispatch. One conditional edge returns a list of `Send` objects; each
+`Send` invokes the named graph/node with its own state slice.
+
+```python
+from langgraph.types import Send
+
+def dispatch_specialists(state: ParentState) -> list[Send]:
+    """Fan out one subgraph call per plan item. N is runtime-determined."""
+    return [
+        Send(
+            "specialist_graph",
+            {
+                "messages": state["messages"],
+                "session_id": state["session_id"],
+                "tenant_id": state["tenant_id"],
+                "topic": topic,                # topic is specialist-only
+            },
+        )
+        for topic in state["plan"]
+    ]
+
+parent.add_conditional_edges("plan", dispatch_specialists, ["specialist_graph"])
+```
+
+**When it is right:** one planner decides to run M research queries in parallel;
+a router invokes 3 specialists concurrently; a batch step dispatches N
+per-tenant subgraphs.
+
+**Sizing:** `Send` is cheap — dispatching 10-50 parallel children is routine.
+At 100+ consider a queue-based worker pool instead.
+
+**Gotchas:**
+- Each `Send` state is evaluated independently — **no shared scratch across
+  siblings**. If two parallel specialists need to see each other's output,
+  use two sequential subgraph-as-node calls instead.
+- The parent's reducer on shared keys is what merges results when the parallel
+  children return. Without an `add_messages`-style reducer on the parent side
+  (P18), you will lose all but one result.
+- `recursion_limit` applies **per `Send`**, not globally for the fan-out.
+
+## C. `Command(graph=Command.PARENT, update=..., goto=...)`
+
+Inside a subgraph node, return a `Command` that jumps control back to the
+parent with an explicit state update. Use sparingly — it breaks the "subgraph
+returns cleanly to its compose point" abstraction.
+
+```python
+from langgraph.types import Command
+
+def specialist_early_exit(state: ExecutorState) -> Command:
+    """If the first tool call already finished the task, skip the rest of the
+    subgraph and jump straight to the parent's finalize node."""
+    if state.get("tool_result", {}).get("done"):
+        return Command(
+            graph=Command.PARENT,
+            update={"messages": [AIMessage("done early")]},
+            goto="finalize",
+        )
+    # normal in-subgraph update
+    return {"retries": state.get("retries", 0) + 1}
+```
+
+**When it is right:** a rare early-exit that needs to bypass the rest of the
+subgraph's teardown. A fatal child error that must bubble up with context. A
+fast-path where invoking the full subgraph is wasted work.
+
+**Gotchas:**
+- `goto` names a **parent** node — not a subgraph node. Omitting `goto` returns
+  control to the point the subgraph was invoked, which is usually what you
+  want.
+- `update` can include keys not in the parent's schema (LangGraph 1.0.x
+  permits this), but do not rely on it — declare the keys for type safety.
+- Mixing `Command(graph=Command.PARENT)` with `Send` fan-out causes surprising
+  interleaving. Do not combine in the same subgraph without careful testing.
+
+## D. Separate service (not a subgraph)
+
+Sometimes the right answer is "this is not a subgraph anymore." Signals that a
+subgraph should be promoted to a separate service:
+
+- It owns its own infrastructure (a GPU, a large model, a specialized DB)
+- It has a different scaling profile (bursty vs steady)
+- It needs to be deployable and restartable independently
+- Multiple unrelated parent graphs call it (cross-product coupling)
+- It has its own security boundary (tenant isolation, PII handling)
+
+At that point, wrap it as an HTTP/gRPC/queue-based service and call it from a
+plain node in the parent graph — not a subgraph. The state contract becomes an
+API contract.
+
+## Sizing reference
+
+| Shape | Typical subgraph count | Dispatch |
+|---|---|---|
+| Planner-executor | 2-4 | A (node) |
+| Hierarchical agent team (supervisor + specialists) | N specialists | B (`Send`) |
+| Stage pipeline (fetch -> enrich -> summarize -> store) | 3-4 | A (node) in sequence |
+| Reusable library (shared across parents) | any | A (node) + versioned contract |
+| Early-exit optimization | 1 (within the child) | C (`Command`) |
+
+## Related pain-catalog entries
+
+- **P18** — Reducers are required for list fields that merge across `Send` fan-out
+- **P19** — `stream_mode="updates"` is usually what you want when observing subgraph output
+- **P21** — Only shared keys propagate (all dispatches)
+- **P55** — Per-subgraph `recursion_limit` budget applies independently

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-langgraph-subgraphs — One-Pager
+
+Compose LangGraph 1.0 subgraphs correctly — shared state-key propagation, `Send` / `Command(graph=...)` dispatch, callback scoping, and testing each subgraph in isolation.
+
+## The Problem
+
+Parent graph calls a compiled child subgraph; the child node sets `state["answer"] = "42"`; the parent's next node reads `state["answer"]` and gets `None`. No error, no warning. The reason is pain-catalog entry P21: LangGraph subgraphs run on an **independent state schema**, and only keys declared in *both* parent and child `TypedDict` schemas propagate. Add an observability callback at parent invocation via `Runnable.with_config(callbacks=[...])` and it never fires on tool calls inside the subgraph — that is P28: callbacks bind at definition time and LangGraph creates a fresh runtime per subgraph, so child tool events are invisible to parent handlers. Both failures look like "my code is silently broken" rather than throwing, and both waste hours before the developer realizes subgraphs are not just "nested nodes."
+
+## The Solution
+
+This skill walks the shared-state contract (which keys must exist in both schemas and which reducers must match), the three dispatch patterns (compiled subgraph as a node, `Send(graph, state)` for fan-out, `Command(graph=Parent, update=...)` to bubble results up), callback propagation via `config["callbacks"]` at invocation time (not at definition time), per-subgraph `recursion_limit` budgets (each subgraph gets its own independent budget), and a testing pattern that exercises subgraphs standalone with `FakeListChatModel` and a `MemorySaver`. Pinned to LangGraph 1.0.x with four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Architects and senior engineers composing multi-stage LangGraph 1.0 workflows — planner + executor pairs, hierarchical agent teams, reusable subgraph libraries |
+| **What** | Shared-state contract matrix, dispatch decision tree (node vs `Send` vs `Command`), callback-scoping pattern via `config["callbacks"]`, per-subgraph recursion budgets, isolation testing, 4 references (state-contract, dispatch-patterns, callback-scoping, testing-subgraphs) |
+| **When** | After `langchain-langgraph-basics` (L25) — whenever a single `StateGraph` crosses ~8 nodes, owns two unrelated responsibilities, or needs to be shipped as a reusable library artifact |
+
+## Key Features
+
+1. **State-propagation matrix** — A four-row table naming what happens to key `K` declared in parent only / child only / both / neither, so the "silent `None`" failure (P21) becomes a lookup, not a debugging session
+2. **Dispatch decision tree** — When to invoke a compiled subgraph as a plain node, when to fan out with `Send(graph, state)`, when to bubble results up with `Command(graph=ParentGraph, update=...)`, and when to promote the subgraph to a separate service
+3. **Callback-scoping recipe** — Always pass observability callbacks via `config["callbacks"]` at invocation time so they propagate into every subgraph; never via `Runnable.with_config(callbacks=[...])` which binds at definition and leaves subgraphs invisible (P28)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/state-contract.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/state-contract.md
@@ -1,0 +1,142 @@
+# Shared-State Contract Across Subgraph Boundaries
+
+LangGraph subgraphs run on **independent state schemas**. The propagation rules
+across the parent-child boundary are not documented as a matrix in the official
+docs, so this file is the definitive reference for this pack.
+
+Anchor: pain-catalog entry **P21** ("Subgraph state is isolated by default; keys
+do not bubble up") plus **P18** ("`Command.update` replaces list fields without
+a reducer").
+
+## The state-propagation matrix
+
+For any key `K`:
+
+| Parent schema | Child schema | What happens to `K` at the boundary |
+|---|---|---|
+| declared | declared | **Propagates both directions.** Parent value is passed in; child updates flow out. If the type is a collection, the reducer on the **parent's** `TypedDict` controls merge on return |
+| declared | not declared | Child **cannot read or write** `K`. Parent value is preserved unchanged across the subgraph call |
+| not declared | declared | Child has a **local-only** `K`. Child can read and write it during the subgraph run, but **discarded on return** (this is the P21 trap) |
+| not declared | not declared | Key does not exist anywhere. Reading returns `None` (or raises `KeyError` depending on `TypedDict` mode) |
+
+## The subset rule
+
+A safe pattern is to make the **child schema a superset** of the keys the
+parent wants to share, plus any private scratch fields. Treat shared keys as an
+explicit contract.
+
+```python
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+
+# The shared contract, declared once and referenced by both schemas
+class _Shared(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+    session_id: str
+    tenant_id: str
+
+class ParentState(_Shared):
+    plan: list[str]
+    current_step: int
+
+class ExecutorState(_Shared):
+    tool_result: dict | None
+    retries: int
+```
+
+Both schemas inherit from `_Shared`, so the contract is single-sourced. Adding
+a new shared key is a one-line change to `_Shared` and both `TypedDict`s pick
+it up. This is the mechanism for avoiding P21 at its source.
+
+## Reducers must match on both sides
+
+A list key declared on both schemas but with different reducers silently does
+the wrong thing on one side:
+
+```python
+# BAD — parent appends, child replaces. After a subgraph call, parent's
+# message history is silently replaced with just the subgraph's additions.
+class ParentState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+class ChildState(TypedDict):
+    messages: list[AnyMessage]   # no reducer -> replace semantics (P18)
+```
+
+```python
+# GOOD — identical reducer on both sides
+class ParentState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+class ChildState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+```
+
+## Explicit bubble-up with `Command(graph=Command.PARENT)`
+
+If you need to pass a field *up* that the parent does not want in its own
+schema (e.g. an error code for logging only), use `Command` instead of adding
+to the shared contract:
+
+```python
+from langgraph.types import Command
+
+def child_emits_signal(state: ExecutorState) -> Command:
+    return Command(
+        graph=Command.PARENT,
+        update={"error_code": "RATE_LIMIT_HIT"},
+        goto="retry_with_backoff",
+    )
+```
+
+`Command(graph=Command.PARENT, update={...})` forces `error_code` onto the
+parent's state regardless of whether the parent's `TypedDict` declares it.
+LangGraph accepts dynamic keys on `update` even when not in the schema (as of
+1.0.x) — though declaring them in the schema is still preferred for type safety.
+
+## Versioned schema contracts for reusable subgraphs
+
+A subgraph shipped as a library should export the `SHARED_KEYS` it expects from
+any parent:
+
+```python
+# executor_subgraph/contract.py
+from typing import Annotated, TypedDict
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+
+SHARED_KEYS = frozenset({"messages", "session_id", "tenant_id"})
+SCHEMA_VERSION = "1.2.0"
+
+class ExecutorInputs(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+    session_id: str
+    tenant_id: str
+```
+
+In CI, add a test that fails if `SHARED_KEYS` changes without a major-version
+bump — that is the mechanism that catches P21 at PR review instead of in
+production. Parents import and assert:
+
+```python
+from executor_subgraph.contract import SHARED_KEYS, SCHEMA_VERSION
+assert SHARED_KEYS.issubset(ParentState.__annotations__.keys())
+```
+
+## Common misreads of P21 to avoid
+
+1. "I'll just use `state.update(...)` inside the child — that bypasses the
+   schema." It does not. The final state that returns to the parent is still
+   filtered against the parent's schema.
+2. "I'll add the key to only the parent schema; the child can set it anyway."
+   The child cannot write keys it does not declare — they are dropped from the
+   child's returned state.
+3. "Reducers are optional." For any list/dict field that is shared, the reducer
+   is load-bearing — see P18 in the pain catalog.
+
+## Related pain-catalog entries
+
+- **P18** — `Command.update` replaces list fields without a reducer
+- **P19** — `stream_mode` choice affects how subgraph updates are surfaced to the caller
+- **P21** — Subgraph state is isolated by default (the entry this skill anchors)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/testing-subgraphs.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/references/testing-subgraphs.md
@@ -1,0 +1,200 @@
+# Testing Subgraphs in Isolation
+
+The defensive move that catches both P21 (state contract) and P28 (callback
+scoping) at PR review instead of in production: **every subgraph ships with a
+standalone unit test that does not require the parent graph**.
+
+## Why isolation testing
+
+Composed systems that fail only in composition are expensive to debug. A
+subgraph that passes its own test suite but breaks when wired into a parent is
+almost always hitting one of:
+
+1. A key the parent expects on return is not declared in the child's schema (P21)
+2. A list reducer on the parent differs from the child's (P18)
+3. The parent passes callbacks via `.with_config(...)` instead of `config[...]`
+   at invoke time, so child events go silent (P28)
+
+Isolation tests pin the child's side of each contract. Composition tests then
+verify the parent correctly holds up the other half.
+
+## Fixture pattern
+
+```python
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langgraph.checkpoint.memory import MemorySaver
+
+@pytest.fixture
+def fake_llm():
+    """Deterministic LLM — returns canned responses in order."""
+    return FakeListChatModel(
+        responses=[
+            '{"tool_result": {"done": true, "result": 42}}',
+            '{"summary": "task complete"}',
+        ]
+    )
+
+@pytest.fixture
+def executor_graph(fake_llm):
+    """Subgraph under test, compiled with an in-memory checkpointer."""
+    from myapp.executor_subgraph import build_executor
+    return build_executor(llm=fake_llm).compile(checkpointer=MemorySaver())
+
+@pytest.fixture
+def base_state():
+    """Matches the SHARED_KEYS contract; any subgraph under test consumes this."""
+    return {
+        "messages": [HumanMessage("do the thing")],
+        "session_id": "test-session",
+        "tenant_id": "test-tenant",
+    }
+```
+
+## Assert the shared-key contract on return
+
+This is the direct defense against P21. Every shared key the parent expects to
+read must be in the output state after the subgraph runs:
+
+```python
+from myapp.executor_subgraph.contract import SHARED_KEYS
+
+def test_executor_returns_every_shared_key(executor_graph, base_state):
+    out = executor_graph.invoke(
+        base_state,
+        config={"configurable": {"thread_id": "t"}, "recursion_limit": 5},
+    )
+    missing = SHARED_KEYS - set(out.keys())
+    assert not missing, f"executor dropped shared keys: {missing} (P21)"
+```
+
+If the subgraph ever stops returning a shared key, this test fails at PR
+review. The message points at P21 so the next engineer knows exactly where to
+look.
+
+## Assert state shape at intermediate nodes
+
+LangGraph checkpointers let you inspect state after each node. This catches
+mutations that a single final-state assertion would miss:
+
+```python
+def test_executor_writes_tool_result_before_summarize(executor_graph, base_state):
+    config = {"configurable": {"thread_id": "step-by-step"},
+              "recursion_limit": 5}
+
+    # Invoke once; walk checkpoints.
+    executor_graph.invoke(base_state, config=config)
+    history = list(executor_graph.get_state_history(config))
+
+    # history[-1] is earliest; history[0] is latest
+    states_by_node = {snap.next[0] if snap.next else "END": snap.values
+                      for snap in history}
+    assert "run_tool" in states_by_node or "summarize" in states_by_node
+    # tool_result must exist by the time summarize runs
+    for snap in reversed(history):
+        if snap.next and snap.next[0] == "summarize":
+            assert snap.values.get("tool_result") is not None
+            break
+```
+
+## Assert callbacks propagate (P28)
+
+A capturing handler exercises the exact path P28 describes. If callbacks are
+plumbed correctly at invocation time, every chain/tool/LLM event fires; if the
+subgraph was built with `.with_config(callbacks=[...])` by mistake, the parent
+events still fire but sub-events are missing.
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class CaptureHandler(BaseCallbackHandler):
+    def __init__(self):
+        self.events: list[str] = []
+    def on_chain_start(self, serialized, inputs, **kw):
+        name = (serialized or {}).get("name", "?")
+        self.events.append(f"chain_start:{name}")
+    def on_chat_model_start(self, serialized, messages, **kw):
+        self.events.append("llm_start")
+    def on_tool_start(self, serialized, input_str, **kw):
+        self.events.append(f"tool_start:{(serialized or {}).get('name', '?')}")
+
+def test_executor_callbacks_see_all_nodes(executor_graph, base_state):
+    handler = CaptureHandler()
+    executor_graph.invoke(
+        base_state,
+        config={
+            "configurable": {"thread_id": "cb-test"},
+            "recursion_limit": 5,
+            "callbacks": [handler],
+        },
+    )
+    # At minimum, every node's on_chain_start should fire
+    run_tool_seen = any("run_tool" in e for e in handler.events)
+    summarize_seen = any("summarize" in e for e in handler.events)
+    assert run_tool_seen and summarize_seen, (
+        f"P28 regression — events: {handler.events}"
+    )
+```
+
+## Assert the subgraph is robust against missing parent keys
+
+Parents may add keys over time. A subgraph that crashes when a future parent
+adds an unrelated key is fragile. Test with an intentionally bloated state:
+
+```python
+def test_executor_ignores_unknown_parent_keys(executor_graph, base_state):
+    bloated = {
+        **base_state,
+        "parent_only_plan": ["a", "b"],
+        "parent_only_current_step": 3,
+    }
+    out = executor_graph.invoke(
+        bloated,
+        config={"configurable": {"thread_id": "bloat"}, "recursion_limit": 5},
+    )
+    # Executor should run fine; parent-only keys are simply not used
+    assert "messages" in out
+```
+
+## Assert reducer compatibility (P18 defense)
+
+If the subgraph shares a list field, write a test that invokes twice on the
+same `thread_id` and asserts the list grew:
+
+```python
+def test_executor_messages_append_not_replace(executor_graph, base_state):
+    config = {"configurable": {"thread_id": "reducer-check"}, "recursion_limit": 5}
+    first = executor_graph.invoke(base_state, config=config)
+    assert len(first["messages"]) >= 1
+
+    follow = {**first, "messages": first["messages"] + [HumanMessage("again")]}
+    second = executor_graph.invoke(follow, config=config)
+    assert len(second["messages"]) > len(first["messages"]), (
+        "messages were replaced, not appended — missing add_messages reducer (P18)"
+    )
+```
+
+## CI wiring
+
+Add these tests under a `tests/subgraphs/` directory, one file per subgraph.
+Run on every PR. A minimum bar before the skill's subgraph is allowed to be
+composed into a parent:
+
+```
+tests/
+  subgraphs/
+    test_executor_contract.py      # SHARED_KEYS / reducer / callback / bloat
+    test_specialist_contract.py    # same four suites
+    test_planner_contract.py
+```
+
+## Related pain-catalog entries
+
+- **P18** — Reducer compatibility (covered by the `messages` append test)
+- **P21** — Shared-key contract (covered by the `SHARED_KEYS` assertion)
+- **P28** — Callback scoping (covered by the `CaptureHandler` test)
+- **P43** — `FakeListChatModel` missing `response_metadata` — guard token
+  assertions behind `isinstance(llm, FakeListChatModel)` where needed
+- **P55** — Recursion budget — set an explicit low `recursion_limit` in tests
+  so a regression into an infinite loop fails fast


### PR DESCRIPTION
## Summary

Handcrafted skill covering LangGraph 1.0 subgraph composition — shared-state contract, dispatch patterns (subgraph-as-node / `Send` fan-out / `Command(graph=Parent)`), callback scoping, isolated testing. Anchored to pain-catalog **P21, P28**.

## Pain hook

A parent graph invokes a child subgraph that sets `state["answer"]`; the parent reads it back and gets `None` because the key was not declared in both `TypedDict` schemas (P21). The second silent failure: callbacks attached via `.with_config(callbacks=[...])` never fire on child tool calls because LangGraph runtimes do not inherit definition-time config — they must be passed via `config["callbacks"]` at invocation time (P28).

## Files

- `skills/langchain-langgraph-subgraphs/SKILL.md` (369 lines)
- `skills/langchain-langgraph-subgraphs/references/one-pager.md`
- `skills/langchain-langgraph-subgraphs/references/state-contract.md`
- `skills/langchain-langgraph-subgraphs/references/dispatch-patterns.md`
- `skills/langchain-langgraph-subgraphs/references/callback-scoping.md`
- `skills/langchain-langgraph-subgraphs/references/testing-subgraphs.md`

## Validator

Grade **A (91/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude