### PR TITLE
feat(langchain-py-pack): add langchain-debug-bundle (S10)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: langchain-debug-bundle
+description: |
+  Produce a reproducible, sanitized diagnostic bundle for a LangChain / LangGraph
+  incident — environment snapshot, version manifest, filtered astream_events(v2)
+  transcript, propagating callback stack, LangSmith trace URL — so a debug
+  colleague can reproduce the failure without a live terminal. Use when triaging
+  a production incident, filing a Discord or GitHub bug report, asking for help
+  on the LangChain forum, or archiving a post-mortem artifact.
+  Trigger with "langchain debug bundle", "langgraph debug dump",
+  "langchain diagnostic export", "langsmith trace export", "astream_events dump",
+  "langchain incident bundle".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, debugging, observability, incident-response]
+compatible-with: claude-code, codex
+---
+
+# LangChain Debug Bundle (Python)
+
+## Overview
+
+An on-call engineer pages you at 2am: the production agent loops, `ToolMessage`
+outputs are empty strings, the user sees "I could not find the answer." Someone
+asks the right question — *what state was the graph in when it gave up?* — and
+there is no answer, because the terminal that caught the failure is already
+gone, the Kubernetes pod has restarted, and the LangSmith URL was never
+recorded.
+
+This skill produces one artifact: a single `bundle-<incident_id>.tar.gz` (typically
+1-10 MB) containing everything a second engineer needs to reproduce the failure
+without a live terminal — environment and version manifest, filtered
+`astream_events(version="v2")` JSONL, a propagating callback stack, the
+LangSmith trace URL, and a post-write sanitization pass.
+
+Four pitfalls make naive bundles useless:
+
+- **P01** — `ChatAnthropic.stream()` reports `token_usage` only on stream close; token math read from `on_llm_end` lags by stream duration, so cost context in the bundle is wrong.
+- **P28** — `BaseCallbackHandler.with_config(callbacks=[...])` does NOT propagate into subgraphs or inner `create_react_agent` loops. A debug callback bound that way silently captures zero events from the place the incident actually happened.
+- **P47** — `astream_events(version="v2")` emits 2,000+ events per invocation. A raw dump is 50 MB and unreadable; an SSE viewer crashes on it.
+- **P67** — `astream_log()` is soft-deprecated in 1.0. Diagnostic tooling built on it breaks on the next minor version.
+
+The skill's answer: assemble the manifest, capture v2 events with a whitelist
+(drop lifecycle noise, keep `on_chat_model_stream` / `on_tool_*` / any `*_error`
+event), attach `DebugCallbackHandler` via `config["callbacks"]` at invoke time,
+pull the LangSmith URL from the active `RunTree`, run the sanitization pass,
+tar it up. Pinned: `langchain-core 1.0.x`, `langgraph 1.0.x`, `langsmith 0.1.x`.
+Pain-catalog anchors: P01, P28, P47, P67.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- `langsmith >= 0.1.40` for `RunTree` access
+- Active LangSmith project (`LANGSMITH_TRACING=true`, `LANGSMITH_API_KEY=...`,
+  `LANGSMITH_PROJECT=...`) — canonical 1.0 env-var names, not the legacy
+  `LANGCHAIN_TRACING_V2` (see P26).
+- Write access to a staging directory outside the repo tree.
+
+## Instructions
+
+### Step 1 — Assemble the environment manifest
+
+Record the runtime snapshot that lets a colleague reproduce on a different
+host. See [env-manifest-template.md](references/env-manifest-template.md) for
+the exact YAML shape.
+
+```python
+import platform, sys, os, subprocess, datetime
+
+RELEVANT = [
+    "langchain-core", "langchain", "langgraph",
+    "langchain-anthropic", "langchain-openai",
+    "langsmith", "anthropic", "openai", "pydantic",
+]
+
+def pip_show(name: str) -> str | None:
+    try:
+        out = subprocess.check_output(
+            [sys.executable, "-m", "pip", "show", name],
+            stderr=subprocess.DEVNULL, text=True,
+        )
+        for line in out.splitlines():
+            if line.startswith("Version:"):
+                return line.split(":", 1)[1].strip()
+    except subprocess.CalledProcessError:
+        return None
+
+def build_manifest(incident_id: str, invoke_meta: dict) -> dict:
+    return {
+        "bundle_spec_version": "1.0",
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "incident_id": incident_id,
+        "runtime": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "cpu_count": os.cpu_count(),
+        },
+        "packages": [
+            {"name": n, "version": pip_show(n)}
+            for n in RELEVANT if pip_show(n) is not None
+        ],
+        # NAMES only — never values. Sanitized by design (P27 posture).
+        "env_var_names_present": sorted(
+            k for k in os.environ
+            if k.startswith(("LANGSMITH_", "LANGCHAIN_", "ANTHROPIC_", "OPENAI_", "GOOGLE_"))
+        ),
+        "invocation": invoke_meta,
+    }
+```
+
+Record env-var *names*, not values. Values go through the sanitization pass in
+Step 5, but the safest design is never to capture them.
+
+### Step 2 — Capture `astream_events(version="v2")` with a filter
+
+Raw v2 events flood 2,000+ per invocation (P47). A server-side filter drops
+lifecycle noise (`on_chain_start`/`on_chain_end`) and keeps model, tool, and
+error events — yielding 50-200 events per invocation and a ~500 KB JSONL.
+
+```python
+import json, itertools
+from pathlib import Path
+
+KEEP = {
+    "on_chat_model_start", "on_chat_model_end",
+    "on_tool_start", "on_tool_end", "on_tool_error",
+    "on_retriever_start", "on_retriever_end",
+    "on_custom_event",
+}
+# Additionally: any event whose name ends in "_error"
+# Additionally: 1-in-10 sampled on_chat_model_stream (for response reconstruction)
+
+async def capture_events(graph, inputs, config, out_path: Path) -> int:
+    sample = itertools.count()
+    written = 0
+    with out_path.open("w") as f:
+        async for evt in graph.astream_events(inputs, config=config, version="v2"):
+            name = evt["event"]
+            if name == "on_chat_model_stream" and next(sample) % 10 != 0:
+                continue
+            if name not in KEEP and not name.endswith("_error"):
+                continue
+            f.write(json.dumps({
+                "event": name,
+                "name": evt.get("name"),
+                "run_id": str(evt.get("run_id")),
+                "tags": evt.get("tags"),
+                "metadata": evt.get("metadata"),
+                "data": _json_safe(evt.get("data", {})),
+            }, default=str) + "\n")
+            written += 1
+    return written
+```
+
+Never use `astream_log()` (P67). The full event taxonomy and `_json_safe`
+helper live in [astream-events-capture.md](references/astream-events-capture.md).
+
+### Step 3 — Attach callbacks that propagate into subgraphs (P28)
+
+Callbacks bound via `Runnable.with_config(callbacks=[...])` fire on the outer
+chain only. They go silent the moment the graph crosses into a subgraph or an
+inner `create_react_agent` loop — exactly where incidents happen. Pass them via
+`config["callbacks"]` at invoke time instead.
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class DebugCallbackHandler(BaseCallbackHandler):
+    def __init__(self): self.records: list[dict] = []
+    def on_tool_start(self, serialized, input_str, *, run_id, parent_run_id=None, **kw):
+        self.records.append({
+            "kind": "tool_start", "run_id": str(run_id),
+            "parent_run_id": str(parent_run_id) if parent_run_id else None,
+            "tool": serialized.get("name"), "input": input_str[:500],
+        })
+    def on_tool_error(self, error, *, run_id, **kw):
+        self.records.append({
+            "kind": "tool_error", "run_id": str(run_id),
+            "error_type": type(error).__name__, "error_message": str(error)[:1000],
+        })
+
+debug = DebugCallbackHandler()
+
+result = await agent.ainvoke(
+    {"messages": [("user", reproducer_prompt)]},
+    config={
+        "configurable": {"thread_id": thread_id},
+        "callbacks": [debug],                      # propagates into subgraphs
+        "tags": ["debug-bundle", incident_id],
+        "metadata": {"incident_id": incident_id},
+    },
+)
+```
+
+The full handler (LLM + retriever + tool lifecycle) and a propagation smoke
+test live in [callback-propagation.md](references/callback-propagation.md).
+
+### Step 4 — Record the LangSmith trace URL
+
+A trace URL is cheaper than any local artifact — one click and the colleague
+sees the full run with latency, token counts, and input/output per node. Pull
+it from the active `RunTree` if you have a live handle; otherwise construct it
+from the invoke's `run_id`:
+
+```python
+from langsmith.run_helpers import get_current_run_tree
+
+def capture_langsmith_url() -> str | None:
+    rt = get_current_run_tree()
+    if rt is None:
+        return None  # tracing not enabled or run already closed
+    return rt.get_url()  # https://smith.langchain.com/o/.../r/<run_id>
+
+# Write to langsmith.url in the bundle:
+url = capture_langsmith_url()
+(staging / "langsmith.url").write_text(url or "(no trace URL available)")
+```
+
+The URL requires the colleague to have access to the LangSmith project. For
+public sharing, use `RunTree.share()` to generate a public snapshot URL. Never
+paste a non-shared URL into a public Discord thread — the page redirects to a
+login and leaks the project name.
+
+### Step 5 — Sanitize before packaging
+
+Every file in the staging dir passes through the redaction pass **before** the
+tar.gz is written. This is the last-mile guard; upstream redaction middleware
+should already have caught credential material, but the bundle cannot assume
+that.
+
+```python
+import re
+
+PATTERNS = [
+    ("openai_key",    r"sk-proj-[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9_-]{32,}"),
+    ("anthropic_key", r"sk-ant-[A-Za-z0-9_-]{16,}"),
+    ("google_key",    r"AIza[A-Za-z0-9_-]{35}"),
+    ("langsmith_key", r"lsv2_(?:pt|sk)_[A-Za-z0-9]{32,}"),
+    ("bearer",        r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+    ("db_uri",        r"[a-z]+://[^:/\s]+:[^@\s]+@[^/\s]+"),
+    ("private_key",   r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"),
+]
+
+def sanitize_file(path, patterns=PATTERNS) -> dict[str, int]:
+    text, counts = path.read_text(), {}
+    for name, pat in patterns:
+        new, n = re.subn(pat, f"[REDACTED:{name}]", text)
+        if n: counts[name] = n; text = new
+    path.write_text(text)
+    return counts
+```
+
+The full pattern catalog (credentials, session tokens, PII, internal URLs) and
+the pre-upload `tar -xzf ... && grep` scan live in
+[sanitization-checklist.md](references/sanitization-checklist.md). For the
+production-grade upstream redaction middleware, use the forthcoming
+`langchain-security-basics` skill.
+
+### Step 6 — Bundle with an index
+
+Write a top-level `MANIFEST.yaml` that describes every file and records the
+sanitization summary. Then tar.gz the staging dir.
+
+```python
+import tarfile, yaml
+from pathlib import Path
+
+def write_bundle(staging: Path, manifest: dict, sanitize_report: dict,
+                 out: Path, events_count: int, callback_count: int) -> Path:
+    index = {
+        "bundle_spec_version": "1.0",
+        "incident_id": manifest["incident_id"],
+        "generated_at": manifest["generated_at"],
+        "files": [
+            {"name": "manifest.yaml",  "purpose": "env + version snapshot"},
+            {"name": "events.jsonl",   "purpose": f"filtered astream_events(v2), {events_count} events"},
+            {"name": "callbacks.txt",  "purpose": f"DebugCallbackHandler records, {callback_count} entries"},
+            {"name": "langsmith.url",  "purpose": "trace URL (shared) or (none)"},
+            {"name": "notes.txt",      "purpose": "free-form engineer notes, sanitized"},
+        ],
+        "sanitization": sanitize_report,
+    }
+    (staging / "MANIFEST.yaml").write_text(yaml.safe_dump(index, sort_keys=False))
+    with tarfile.open(out, "w:gz") as tar:
+        tar.add(staging, arcname=out.stem)
+    return out
+
+bundle = write_bundle(
+    staging=Path("/tmp/bundle-INC-2026-0421-A"),
+    manifest=m, sanitize_report=report,
+    out=Path("/tmp/bundle-INC-2026-0421-A.tar.gz"),
+    events_count=n_events, callback_count=len(debug.records),
+)
+```
+
+## Output
+
+| File in bundle | Purpose | Source | Sanitization step |
+|---|---|---|---|
+| `MANIFEST.yaml`   | Index + file descriptions + redaction counts | Step 6 | N/A (authored) |
+| `manifest.yaml`   | Python/OS/package/env-var-name snapshot      | Step 1 | Run pass; env-var *names* only by design |
+| `events.jsonl`    | Filtered `astream_events(v2)` — model, tool, error events | Step 2 | Per-line regex redaction |
+| `callbacks.txt`   | `DebugCallbackHandler` records (JSONL)       | Step 3 | Per-line regex redaction |
+| `langsmith.url`   | `RunTree.get_url()` (shared if public)       | Step 4 | Verify no embedded API key param |
+| `notes.txt`       | Engineer's free-form observations            | Manual | Per-line regex redaction |
+
+Typical size: **1-10 MB** compressed. Typical event count after filter: **50-200**
+per invocation (down from 2,000+ raw). Bundle is self-contained — no external
+dependencies beyond `tar -xzf` and a text editor.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `events.jsonl` has no subgraph events | Callbacks bound via `Runnable.with_config(callbacks=[...])` instead of `config["callbacks"]` (P28) | Move callbacks to invoke-time config; see [callback-propagation.md](references/callback-propagation.md) |
+| `events.jsonl` is 50 MB+ | Filter not applied or `on_chain_*` events not excluded (P47) | Enforce `KEEP` whitelist and 1:10 streaming sample; Step 2 |
+| `DeprecationWarning: astream_log is deprecated` | Captured via `astream_log()` instead of `astream_events(v2)` (P67) | Migrate to `graph.astream_events(..., version="v2")` |
+| `response_metadata["token_usage"]` empty in `on_chat_model_end` records | Read before stream closed (P01) | Aggregate from `on_chat_model_stream` chunks with `usage_metadata`; see model-inference skill |
+| `langsmith.url` is empty | Tracing not enabled or `get_current_run_tree()` returned `None` | Set `LANGSMITH_TRACING=true`, `LANGSMITH_API_KEY=...`, `LANGSMITH_PROJECT=...` (P26) |
+| `TypeError: Object of type X is not JSON serializable` in events capture | Tool returned a custom class with no `.model_dump()` | Extend `_json_safe` in [astream-events-capture.md](references/astream-events-capture.md) |
+| Pre-upload scan finds `sk-...` pattern | Upstream middleware missed a key, or regex too lax | Add specific pattern to `PATTERNS`, re-run Step 5, re-archive |
+
+## Examples
+
+### Triage decision tree — "which file in the bundle do I read first?"
+
+Give a colleague this table with the bundle so they know where to start:
+
+| Symptom in the ticket | Start with | Then |
+|---|---|---|
+| "Agent looped forever" / `GraphRecursionError` | `events.jsonl` (filter `on_tool_start`) | `callbacks.txt` for tool→tool timing |
+| "Tool returned empty" / "Could not find the answer" (P09) | `events.jsonl` (grep `on_tool_error`) | `callbacks.txt` for the parent `run_id` |
+| "Wrong answer, correct tool called" | `events.jsonl` (grep `on_chat_model_start` + last `on_tool_end`) | LangSmith trace URL for full context |
+| "Token count wrong in dashboard" (P01, P25) | `events.jsonl` `on_chat_model_stream` chunks | `manifest.yaml` for retry middleware presence |
+| "Works locally, fails in prod" | `manifest.yaml` diff against local | `events.jsonl` for env-specific branches |
+| "Memory resets between turns" (P16) | `manifest.yaml` → `langgraph.thread_id` present? | `events.jsonl` → checkpointer restore events |
+
+### Incident-driven capture — reproducing and bundling in one script
+
+See [callback-propagation.md](references/callback-propagation.md) for the full
+invoke-time config pattern. The skeleton:
+
+```python
+async def reproduce_and_bundle(agent, reproducer, incident_id: str) -> Path:
+    debug = DebugCallbackHandler()
+    staging = Path(f"/tmp/bundle-{incident_id}"); staging.mkdir(exist_ok=True)
+
+    try:
+        result = await agent.ainvoke(
+            reproducer,
+            config={"configurable": {"thread_id": f"debug-{incident_id}"},
+                    "callbacks": [debug], "tags": ["debug-bundle", incident_id]},
+        )
+        invoke_meta = {"status": "success"}
+    except Exception as e:
+        invoke_meta = {"status": "error",
+                       "error_class": type(e).__name__, "error_message": str(e)[:500]}
+
+    # Step 2 — capture events (separate invocation with same inputs OR replay
+    # from RunTree if already in LangSmith)
+    n_events = await capture_events(agent, reproducer, {...}, staging / "events.jsonl")
+
+    # Step 1 — manifest, Step 3 — callbacks, Step 4 — LangSmith URL, Step 5 — sanitize
+    # Step 6 — bundle
+    return write_bundle(staging, build_manifest(incident_id, invoke_meta), ..., ...)
+```
+
+### Discord / forum bug report checklist
+
+Before posting to the LangChain Discord or GitHub Issues:
+
+1. Run the pre-upload `tar -xzf && grep` scan ([sanitization-checklist.md](references/sanitization-checklist.md))
+2. Confirm `langsmith.url` is a *shared* URL (public), not a project-internal one
+3. Strip the `incident_id` if it maps to internal ticket numbers you cannot disclose
+4. Include in the post: bundle attachment, a 3-sentence symptom description, the
+   exact reproducer prompt, the first line of `MANIFEST.yaml` (spec version
+   and versions of `langchain-core` + `langgraph`)
+
+## Resources
+
+- [LangChain callbacks concept](https://python.langchain.com/docs/concepts/callbacks/)
+- [`astream_events` v2](https://python.langchain.com/docs/how_to/streaming/#using-stream-events)
+- [LangSmith observability](https://docs.smith.langchain.com/observability)
+- [LangSmith `RunTree` API](https://docs.smith.langchain.com/reference/python/run_helpers)
+- [LangGraph streaming modes](https://langchain-ai.github.io/langgraph/how-tos/streaming/)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P01, P26, P28, P47, P67)
+- Companion skills: `langchain-observability`, `langchain-security-basics` (upstream redaction middleware), `langchain-model-inference` (token accounting)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/astream-events-capture.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/astream-events-capture.md
@@ -1,0 +1,173 @@
+# Capturing `astream_events(version="v2")` for a Debug Bundle
+
+Streaming events are the richest evidence in a debug bundle — every token, every
+tool call, every node transition. They are also the most dangerous: a single
+invocation of a 4-node graph on a 2000-token response emits 2000+ events. Dump
+it raw and the JSONL file is 50 MB; load it in jq and your laptop hangs.
+
+Related pain-catalog entries: P47 (events flood), P67 (`astream_log` soft-deprecated).
+
+## The event taxonomy (v2)
+
+| Event                    | Volume       | Keep? | Why |
+|--------------------------|--------------|-------|-----|
+| `on_chat_model_start`    | 1 per call   | Yes   | Captures prompt, model params |
+| `on_chat_model_stream`   | 1 per token  | Yes (sample) | Reconstructs the actual response |
+| `on_chat_model_end`      | 1 per call   | Yes   | Usage metadata, stop reason |
+| `on_tool_start`          | 1 per call   | Yes   | Tool name + args |
+| `on_tool_end`            | 1 per call   | Yes   | Tool output |
+| `on_tool_error`          | rare         | **Always** | Primary diagnostic signal |
+| `on_chain_start`         | 1 per node   | No (noise) | Drop unless debugging graph structure |
+| `on_chain_end`           | 1 per node   | No (noise) | Drop unless debugging graph structure |
+| `on_chain_stream`        | 1 per chunk  | No    | Duplicates `on_chat_model_stream` |
+| `on_retriever_start`     | 1 per query  | Yes   | What did we search for? |
+| `on_retriever_end`       | 1 per query  | Yes   | What did we get back? |
+| `on_parser_start`/`end`  | 1 per parser | No    | Low signal |
+| `on_prompt_start`/`end`  | 1 per prompt | No    | Low signal |
+| `on_custom_event`        | varies       | Yes   | User-emitted, probably important |
+
+Default **keep set** that works for 90% of incidents:
+
+```python
+KEEP_EVENTS = {
+    "on_chat_model_start",
+    "on_chat_model_end",
+    "on_tool_start",
+    "on_tool_end",
+    "on_tool_error",
+    "on_retriever_start",
+    "on_retriever_end",
+    "on_custom_event",
+}
+# Plus: all events whose type ends in "_error"
+# Plus: sampled `on_chat_model_stream` (every Nth chunk, N≈10)
+```
+
+## Capture pattern
+
+```python
+import json, itertools
+from pathlib import Path
+
+async def capture_events(graph, inputs, config, out_path: Path,
+                         keep: set[str] = None,
+                         stream_sample_every: int = 10) -> int:
+    """Run the graph once, write filtered v2 events as JSONL.
+
+    Returns the number of events written (typical: 50-200 for an agent call).
+    """
+    keep = keep or KEEP_EVENTS
+    stream_counter = itertools.count()
+    written = 0
+    with out_path.open("w") as f:
+        async for evt in graph.astream_events(inputs, config=config, version="v2"):
+            name = evt["event"]
+            # Sample streaming tokens; keep every Nth
+            if name == "on_chat_model_stream":
+                if next(stream_counter) % stream_sample_every != 0:
+                    continue
+            # Keep anything in the whitelist OR any error event
+            if name in keep or name.endswith("_error"):
+                # Strip the runnable instance (not JSON-serializable)
+                evt_out = {
+                    "event": name,
+                    "name": evt.get("name"),
+                    "run_id": evt.get("run_id"),
+                    "tags": evt.get("tags"),
+                    "metadata": evt.get("metadata"),
+                    "data": _scrub_data(evt.get("data", {})),
+                }
+                f.write(json.dumps(evt_out, default=str) + "\n")
+                written += 1
+    return written
+
+
+def _scrub_data(data: dict) -> dict:
+    """Convert LangChain objects to JSON-safe dicts.
+
+    AIMessage, ToolMessage, etc. have a .dict() method that serializes cleanly.
+    """
+    out = {}
+    for k, v in data.items():
+        if hasattr(v, "model_dump"):       # Pydantic v2
+            out[k] = v.model_dump()
+        elif hasattr(v, "dict"):            # Pydantic v1 fallback
+            out[k] = v.dict()
+        elif isinstance(v, dict):
+            out[k] = {kk: _scrub_data({"_": vv})["_"] for kk, vv in v.items()}
+        else:
+            out[k] = v
+    return out
+```
+
+Sampling `on_chat_model_stream` at every 10th chunk is the single biggest size
+win — a 2000-token response goes from 2000 events to 200. The reconstructed
+response quality is still good enough for triage because `on_chat_model_end`
+captures the full final message.
+
+## JSONL schema
+
+Each line is one JSON object. Fields that matter for triage:
+
+```json
+{
+  "event": "on_tool_error",
+  "name": "search_orders",
+  "run_id": "<uuid>",
+  "tags": ["graph:route_intent", "seq:4"],
+  "metadata": {"langgraph_node": "call_tool", "langgraph_step": 4},
+  "data": {
+    "input": {"tool_call_id": "tc_xyz", "name": "search_orders", "args": {"customer_id": "[REDACTED]"}},
+    "error": "psycopg.errors.ConnectionFailure: connection refused",
+    "error_type": "ConnectionFailure"
+  }
+}
+```
+
+`metadata.langgraph_node` and `langgraph_step` are the single most useful fields
+for reproducing the failure path through the graph.
+
+## Replay pattern
+
+A colleague reading the bundle can replay the event stream to understand the
+flow without reconnecting to the LLM:
+
+```python
+import json
+
+with open("events.jsonl") as f:
+    for line in f:
+        evt = json.loads(line)
+        if evt["event"] == "on_tool_start":
+            print(f"[step {evt['metadata']['langgraph_step']}] → tool {evt['name']}({evt['data']['input']['args']})")
+        elif evt["event"] == "on_tool_end":
+            print(f"  ← {evt['data']['output']!r:.120}")
+        elif evt["event"].endswith("_error"):
+            print(f"  !! {evt['data'].get('error_type')}: {evt['data'].get('error')}")
+```
+
+## Size budget
+
+| Scenario                         | Raw events  | Filtered (keep-set + 1:10 sample) |
+|----------------------------------|-------------|-----------------------------------|
+| Single LLM call, 500 output tokens | ~520      | ~55 |
+| Agent call, 3 tool uses            | ~2,100    | ~110 |
+| Multi-turn graph, 10 nodes         | ~8,000    | ~200 |
+| Deep agent, 25 recursion steps     | ~20,000   | ~450 |
+
+A 450-event JSONL is ~500 KB — fits in an email, loads in any editor.
+
+## Do NOT use `astream_log`
+
+`astream_log()` is soft-deprecated in 1.0 (P67). It emits a different shape and
+no longer receives new event types. Any diagnostic tooling written against it
+will break on the next minor version.
+
+## Failure modes
+
+| Symptom                          | Cause                                      | Fix |
+|----------------------------------|--------------------------------------------|-----|
+| JSONL is empty                   | Graph invocation raised before first event | Wrap the `astream_events` iterator in try/except and still write manifest |
+| JSONL has no subgraph events     | Callbacks attached via `with_config`       | See [callback-propagation.md](callback-propagation.md) — use `config["callbacks"]` |
+| 100 MB+ JSONL                    | No filter applied, or stream-sample disabled | Enforce `KEEP_EVENTS` whitelist; sample 1:10 minimum |
+| `TypeError: not JSON serializable` | A tool returned a custom object            | `_scrub_data` missed a type — add a `model_dump`/`dict` fallback |

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/callback-propagation.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/callback-propagation.md
@@ -1,0 +1,186 @@
+# Callback Propagation into Subgraphs
+
+This is the single most common reason a debug bundle comes back empty from the
+inside of a LangGraph agent: the `DebugCallbackHandler` fires on the outer
+chain, then goes silent the moment the graph crosses into a subgraph,
+`create_react_agent` inner loop, or a tool-executed sub-chain.
+
+Pain-catalog anchor: **P28 — custom callbacks are not inherited by subgraphs**.
+
+## The rule in one sentence
+
+**Pass callbacks via `config["callbacks"]` at invocation time. Do not bind
+them via `Runnable.with_config(callbacks=[...])` at definition time.**
+
+## Why
+
+LangGraph creates a child runtime per subgraph. Configuration passed at invoke
+time propagates down through the `RunnableConfig` that is threaded through
+every node call. Configuration bound at definition time is attached to the
+parent `Runnable` only — the child runtime builds its own config from scratch.
+
+A concise way to hold it: **definition-time config is for the node's own
+execution; invoke-time config is for the whole tree below it.**
+
+## Wrong vs right
+
+### Wrong — callback binds at definition; fires only on outer chain
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class DebugCallback(BaseCallbackHandler):
+    def __init__(self, out):
+        self.out = out
+    def on_tool_start(self, *a, **kw): self.out.append(("tool_start", a, kw))
+
+debug = DebugCallback(out=[])
+
+# DO NOT DO THIS for diagnostics
+agent = create_react_agent(model, tools).with_config(callbacks=[debug])
+# agent.invoke(...)  # debug.out captures outer events only; inner tool calls silent
+```
+
+### Right — callback passed at invoke; propagates everywhere
+
+```python
+agent = create_react_agent(model, tools)
+
+debug = DebugCallback(out=[])
+result = agent.invoke(
+    {"messages": [("user", "...")]},
+    config={
+        "configurable": {"thread_id": "t-1"},
+        "callbacks": [debug],                # <-- propagates into subgraphs
+        "max_concurrency": 5,
+    },
+)
+# debug.out now contains events from every node, every tool, every inner subgraph
+```
+
+Same rule applies to `ainvoke`, `stream`, `astream`, and `astream_events`.
+
+## `DebugCallbackHandler` — a minimal capture
+
+A bundle-friendly callback records just enough to reconstruct what happened,
+without loading the process memory with every token:
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+import time, json
+
+class DebugCallbackHandler(BaseCallbackHandler):
+    """Records tool calls, LLM start/end, and errors.
+
+    Deliberately DOES NOT record per-token stream chunks — that is the job of
+    the astream_events JSONL capture. Callbacks are for coarse-grained stack
+    context; events are for fine-grained traces.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+        self._start: dict[str, float] = {}
+
+    def _ts(self) -> float:
+        return time.monotonic()
+
+    def on_chat_model_start(self, serialized, messages, *, run_id, parent_run_id=None, **kw):
+        self._start[str(run_id)] = self._ts()
+        self.records.append({
+            "kind": "llm_start",
+            "run_id": str(run_id),
+            "parent_run_id": str(parent_run_id) if parent_run_id else None,
+            "model": serialized.get("kwargs", {}).get("model"),
+            "message_count": len(messages[0]) if messages else 0,
+        })
+
+    def on_llm_end(self, response, *, run_id, **kw):
+        dt = self._ts() - self._start.pop(str(run_id), self._ts())
+        usage = {}
+        for gen in response.generations:
+            for g in gen:
+                meta = getattr(g.message, "usage_metadata", None) or {}
+                usage = meta
+        self.records.append({
+            "kind": "llm_end",
+            "run_id": str(run_id),
+            "duration_ms": int(dt * 1000),
+            "usage_metadata": usage,
+        })
+
+    def on_tool_start(self, serialized, input_str, *, run_id, parent_run_id=None, **kw):
+        self._start[str(run_id)] = self._ts()
+        self.records.append({
+            "kind": "tool_start",
+            "run_id": str(run_id),
+            "parent_run_id": str(parent_run_id) if parent_run_id else None,
+            "tool": serialized.get("name"),
+            "input": input_str[:500],   # cap payload; full input lives in events.jsonl
+        })
+
+    def on_tool_end(self, output, *, run_id, **kw):
+        dt = self._ts() - self._start.pop(str(run_id), self._ts())
+        self.records.append({
+            "kind": "tool_end",
+            "run_id": str(run_id),
+            "duration_ms": int(dt * 1000),
+            "output_snippet": str(output)[:500],
+        })
+
+    def on_tool_error(self, error, *, run_id, **kw):
+        self.records.append({
+            "kind": "tool_error",
+            "run_id": str(run_id),
+            "error_type": type(error).__name__,
+            "error_message": str(error)[:1000],
+        })
+
+    def dump_jsonl(self, path) -> int:
+        """Serialize records to JSONL, return count."""
+        with open(path, "w") as f:
+            for r in self.records:
+                f.write(json.dumps(r) + "\n")
+        return len(self.records)
+```
+
+The `run_id` / `parent_run_id` pair is how you reconstruct the callback stack
+in a post-hoc reader — they form a tree.
+
+## Verifying propagation
+
+Before you ship a debug bundle, confirm callbacks actually fired inside the
+subgraph. A useful smoke test:
+
+```python
+debug = DebugCallbackHandler()
+agent.invoke({"messages": [("user", "what time is it?")]},
+             config={"callbacks": [debug], "configurable": {"thread_id": "smoke"}})
+
+# Expect: at least one tool_start record with parent_run_id set (i.e. called
+# from inside the agent subgraph, not from the top-level invoke)
+assert any(r["kind"] == "tool_start" and r["parent_run_id"] for r in debug.records), \
+    "No callbacks fired inside subgraph — P28 regression"
+```
+
+If that assertion fails, the callback was bound at definition time somewhere
+in the chain construction. Grep for `with_config(callbacks=` and move all of
+them to the invoke-time config.
+
+## Interaction with other `config` keys
+
+`config["callbacks"]` coexists with other propagating keys:
+
+| Key | Propagates? | Common use |
+|---|---|---|
+| `callbacks` | Yes (into subgraphs) | Diagnostic handlers |
+| `configurable.thread_id` | Yes | LangGraph checkpointer key |
+| `configurable.tenant_id` | Yes | Per-request retriever factory |
+| `max_concurrency` | Yes (to `.batch()` children) | P08 |
+| `recursion_limit` | Yes | P10, P55 |
+| `tags` | Yes | Free-form metadata for traces |
+| `metadata` | Yes | LangSmith trace annotations |
+
+A diagnostic invocation should set all of: `callbacks`, `tags` (e.g.
+`["debug-bundle", incident_id]`), and `metadata` (e.g.
+`{"incident_id": "INC-2026-0421-A"}`) so the resulting LangSmith trace is
+immediately findable.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/env-manifest-template.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/env-manifest-template.md
@@ -1,0 +1,165 @@
+# Environment Manifest Template
+
+The first file in every debug bundle is `manifest.yaml` — a plain-text snapshot
+that lets a colleague reproduce the exact environment on a different host.
+
+## Non-negotiable rule
+
+**Env-var names only, never values.** The manifest records that
+`ANTHROPIC_API_KEY` was set, not what it was. Values go through the sanitization
+pass ([sanitization-checklist.md](sanitization-checklist.md)) — but the safest
+design is to never capture them in the first place.
+
+## Exact shape
+
+```yaml
+bundle_spec_version: "1.0"
+generated_at: "2026-04-21T18:42:17Z"
+incident_id: "INC-2026-0421-A"    # free-form, link to ticket if any
+
+runtime:
+  python: "3.12.3"
+  platform: "Linux-6.8.0-101-generic-x86_64"
+  cpu_count: 8
+  architecture: "x86_64"
+  process:
+    pid: 48231
+    cwd: "/app"
+    argv: ["python", "app/main.py"]
+
+packages:                          # pip show output, one entry per relevant package
+  - name: langchain-core
+    version: "1.0.4"
+  - name: langchain
+    version: "1.0.3"
+  - name: langgraph
+    version: "1.0.2"
+  - name: langchain-anthropic
+    version: "1.0.3"
+  - name: langchain-openai
+    version: "1.0.5"
+  - name: langsmith
+    version: "0.1.52"
+  - name: anthropic
+    version: "0.42.0"
+  - name: openai
+    version: "1.57.0"
+  - name: pydantic
+    version: "2.10.3"
+
+models:                            # discovered from running chain, not static
+  - provider: anthropic
+    model_id: "claude-sonnet-4-6"
+    temperature: 0
+    max_tokens: 4096
+    timeout: 30
+
+env_var_names_present:             # NAMES ONLY. Never values.
+  - ANTHROPIC_API_KEY              # redacted: present=true
+  - OPENAI_API_KEY
+  - LANGSMITH_API_KEY
+  - LANGSMITH_TRACING              # value captured only for this one (bool-safe)
+  - LANGSMITH_PROJECT              # value captured (project name is not secret)
+  - LANGSMITH_ENDPOINT
+
+langsmith:
+  tracing_enabled: true            # from LANGSMITH_TRACING env var
+  project: "my-project"
+  trace_url: "https://smith.langchain.com/public/<uuid>/r"   # from RunTree
+  run_id: "<uuid>"
+
+langgraph:                         # if a graph is running
+  graph_name: "support_agent"
+  thread_id: "thread-abc-123"       # REDACT if user-identifying
+  checkpointer: "PostgresSaver"
+  recursion_limit: 25
+  current_node: "route_intent"     # last node that emitted
+
+invocation:
+  invoke_id: "inv-2026-0421-1842-xyz"
+  started_at: "2026-04-21T18:42:10Z"
+  duration_ms: 7342
+  status: "error"                  # success | error | timeout | user_abort
+  error_class: "GraphRecursionError"
+  error_message: "Recursion limit of 25 reached without hitting a stop condition."
+
+notes: |
+  Free-form text from the on-call engineer. What they observed, what they tried,
+  what the user reported. Sanitize manually — anything you type here is published.
+```
+
+## Population at runtime
+
+```python
+# ${CLAUDE_SKILL_DIR}/bundle_builder.py  -- conceptual, adapt to your app
+import platform, sys, os, datetime, subprocess, json
+from langchain import __version__ as lc_version
+
+RELEVANT = [
+    "langchain-core", "langchain", "langgraph",
+    "langchain-anthropic", "langchain-openai", "langchain-google-genai",
+    "langsmith", "anthropic", "openai", "pydantic",
+]
+
+def pip_show(name: str) -> str | None:
+    """Read version from pip show. Returns None if not installed."""
+    try:
+        out = subprocess.check_output(
+            [sys.executable, "-m", "pip", "show", name],
+            stderr=subprocess.DEVNULL, text=True,
+        )
+        for line in out.splitlines():
+            if line.startswith("Version:"):
+                return line.split(":", 1)[1].strip()
+    except subprocess.CalledProcessError:
+        return None
+
+def build_manifest(incident_id: str, invoke_meta: dict) -> dict:
+    return {
+        "bundle_spec_version": "1.0",
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "incident_id": incident_id,
+        "runtime": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "cpu_count": os.cpu_count(),
+            "architecture": platform.machine(),
+            "process": {
+                "pid": os.getpid(),
+                "cwd": os.getcwd(),
+                "argv": sys.argv,
+            },
+        },
+        "packages": [
+            {"name": n, "version": pip_show(n)} for n in RELEVANT
+            if pip_show(n) is not None
+        ],
+        "env_var_names_present": sorted(
+            name for name in os.environ
+            if name.startswith(("LANGSMITH_", "LANGCHAIN_", "ANTHROPIC_", "OPENAI_", "GOOGLE_"))
+        ),
+        "langsmith": {
+            "tracing_enabled": os.environ.get("LANGSMITH_TRACING", "").lower() == "true",
+            "project": os.environ.get("LANGSMITH_PROJECT"),
+        },
+        "invocation": invoke_meta,
+    }
+```
+
+Emit as YAML so humans can read it at triage time — JSON is fine if your tooling
+prefers it, but the human reader is the primary consumer.
+
+## What to NOT include
+
+- API key values, even partial prefixes
+- Raw user PII (names, emails, phone numbers) from prompts — that goes through
+  [sanitization](sanitization-checklist.md)
+- Full chat history beyond the failing invocation
+- Database URIs with embedded credentials (`postgres://user:pass@host/db`)
+- Internal hostnames or IPs of services not directly relevant to the incident
+
+## Versioning
+
+`bundle_spec_version` is pinned at the top. When the shape changes (new field,
+renamed field), bump the spec and update the triage playbook — old bundles
+stay readable under the old spec.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-debug-bundle — One-Pager
+
+Produce a reproducible, sanitized diagnostic bundle for a LangChain / LangGraph incident — env manifest, filtered `astream_events(v2)` transcript, callback stack, LangSmith trace URL — so a debug colleague can reproduce the failure without a live terminal.
+
+## The Problem
+
+An on-call engineer pages you: the agent loops, tools return nothing, the user sees "I could not find the answer." Without a bundle, the next engineer has no reproducible snapshot — no graph state, no event stream, no version manifest, no trace URL. Custom callbacks attached at definition time never fire on subgraphs (P28). Raw `astream_events(v2)` dumps flood thousands of events per invocation (P47) and crash the viewer. Ad-hoc prints leak API keys into Slack.
+
+## The Solution
+
+This skill produces a tar.gz bundle with an env manifest (`manifest.yaml`: Python, OS, `pip show` versions, model IDs, env-var *names*), a filtered `astream_events(version="v2")` JSONL transcript (drop lifecycle noise, keep `on_chat_model_stream` / `on_tool_*` / `on_chain_*` errors), a callback stack captured via `config["callbacks"]` so it propagates into subgraphs (P28), the LangSmith trace URL pulled from the active `RunTree`, and a post-write sanitization pass that redacts API keys and PII. Typical bundle size 1-10 MB; filtered event count 50-200 per invocation.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | On-call engineers triaging a LangChain/LangGraph production incident, authors preparing a Discord bug report, or anyone archiving a post-mortem artifact |
+| **What** | `bundle-<timestamp>.tar.gz` containing `manifest.yaml`, `events.jsonl`, `callbacks.txt`, `langsmith.url`, `MANIFEST.yaml` index; a triage decision tree; 4 references (env manifest, event capture, callback propagation, sanitization) |
+| **When** | During or immediately after an incident, before closing the terminal session — the active process state and trace URL are load-bearing |
+
+## Key Features
+
+1. **Filtered `astream_events(v2)` JSONL transcript** — Server-side filter drops lifecycle noise (`on_chain_start`/`on_chain_end`) and keeps `on_chat_model_stream` + `on_tool_*` + any `*_error` event; typical invocation drops from 2000+ events to 50-200 (P47, P67)
+2. **Propagating callback stack via `config["callbacks"]`** — `DebugCallbackHandler` passed at invoke time (not bound via `with_config`) so it fires inside subgraphs and `create_react_agent` inner loops (P28)
+3. **Pre-upload sanitization pass** — Regex-based redaction of `sk-*`, `sk-ant-*`, `AIza*`, Bearer tokens, cookies, and configurable PII patterns before the tar.gz is written; plus env-var *names only* in the manifest (never values)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/sanitization-checklist.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/sanitization-checklist.md
@@ -1,0 +1,167 @@
+# Sanitization Checklist
+
+A debug bundle is effectively public the moment it leaves your machine —
+uploaded to Slack, attached to a Discord bug report, forwarded to a support
+ticket, pasted into a chat with a colleague. Every bundle MUST pass the
+sanitization pass below before it is packaged.
+
+This list is a cross-reference to the forthcoming `langchain-security-basics`
+skill's redaction patterns. Use that skill for the production-grade upstream
+middleware — this checklist is the last-mile guard before `tar.gz`.
+
+## What must be redacted
+
+### Tier 1 — credential material (blockers; bundle is unsafe to share)
+
+| Class | Example pattern | Regex |
+|---|---|---|
+| OpenAI API key | `sk-proj-...`, `sk-...` | `sk-[A-Za-z0-9_-]{16,}` |
+| Anthropic API key | `sk-ant-api03-...` | `sk-ant-[A-Za-z0-9_-]{16,}` |
+| Google API key | `AIza...` | `AIza[A-Za-z0-9_-]{35}` |
+| LangSmith key | `lsv2_pt_...`, `lsv2_sk_...` | `lsv2_(pt|sk)_[A-Za-z0-9]{32,}` |
+| Bearer token (HTTP header) | `Authorization: Bearer <token>` | `(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}` |
+| AWS access key | `AKIA...` | `AKIA[0-9A-Z]{16}` |
+| AWS secret | 40-char base64-ish | `(?i)aws(.{0,20})?['\"][0-9a-zA-Z/+]{40}['\"]` |
+| GitHub token | `ghp_...`, `ghs_...`, `gho_...` | `gh[pous]_[A-Za-z0-9]{36}` |
+| Slack token | `xox[abpsr]-...` | `xox[abpsr]-[A-Za-z0-9-]{10,}` |
+| Private key block | `-----BEGIN ... PRIVATE KEY-----` | `-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----` |
+| JDBC / DB URI with password | `postgres://user:pass@host/db` | `[a-z]+://[^:/]+:[^@]+@[^/\s]+` |
+
+### Tier 2 — session / auth material
+
+| Class | Example |
+|---|---|
+| Cookie header | `Cookie: session=abc123; csrf=...` |
+| Set-Cookie response | `Set-Cookie: sid=...` |
+| OAuth refresh token | usually long base64 string in JSON `refresh_token` field |
+| SAML assertion | XML `<saml:Assertion>` blobs |
+| JWT | three base64 segments joined by dots; redact if found in URLs or headers |
+
+### Tier 3 — PII (caller's responsibility to declare)
+
+PII is domain-specific. The bundle tool ships with *no default PII regexes*
+because false positives cost more than false negatives here — you configure
+them. The canonical classes are:
+
+| Class | Pattern | Notes |
+|---|---|---|
+| Email | `[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}` | Enable for customer-facing apps |
+| US phone | `\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}` | Many false positives on order IDs — tune |
+| SSN | `\d{3}-\d{2}-\d{4}` | Enable for health/financial |
+| Credit card | Luhn-valid 13-19 digits | Enable for payments; prefer upstream tokenization |
+| IP address | `\b\d{1,3}(\.\d{1,3}){3}\b` | Often load-bearing for debugging — redact only last octet |
+
+### Tier 4 — internal URLs and hostnames
+
+Internal hostnames and VPN-only URLs leak infrastructure shape. Configure a
+redaction list:
+
+```yaml
+internal_url_patterns:
+  - "https?://[^/\\s]*\\.corp\\.example\\.com[^\\s]*"
+  - "https?://10\\.\\d+\\.\\d+\\.\\d+[^\\s]*"
+  - "https?://10\\.\\d+[^\\s]*"
+```
+
+## Where to apply the pass
+
+Sanitization runs **after** all files are written to the bundle staging dir
+and **before** the tar.gz is created. Order:
+
+1. `manifest.yaml` — env-var names only (see env-manifest-template.md); still
+   run the pass in case a value leaked via `notes:`.
+2. `events.jsonl` — highest-risk file; every `on_chat_model_start` / `on_tool_start`
+   contains raw inputs. Redact line-by-line.
+3. `callbacks.txt` — records have `input`/`output_snippet` fields, capped at
+   500 chars each; still redact.
+4. `langsmith.url` — safe, but verify URL does not embed an API key parameter.
+5. `notes.txt` (free-form engineer notes) — human-provided; redact.
+
+## Implementation — streaming redaction
+
+For JSONL, redact per-line; for YAML/text, read, redact, write. A single
+regex pass with `re.compile` caches patterns:
+
+```python
+import re
+from pathlib import Path
+
+DEFAULT_PATTERNS: list[tuple[str, str]] = [
+    # (name, regex) — order matters: specific before generic
+    ("openai_key",    r"sk-proj-[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9_-]{32,}"),
+    ("anthropic_key", r"sk-ant-[A-Za-z0-9_-]{16,}"),
+    ("google_key",    r"AIza[A-Za-z0-9_-]{35}"),
+    ("langsmith_key", r"lsv2_(?:pt|sk)_[A-Za-z0-9]{32,}"),
+    ("gh_token",      r"gh[pousr]_[A-Za-z0-9]{36,}"),
+    ("slack_token",   r"xox[abpsr]-[A-Za-z0-9-]{10,}"),
+    ("bearer",        r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+    ("db_uri",        r"[a-z]+://[^:/\s]+:[^@\s]+@[^/\s]+"),
+    ("private_key",   r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"),
+]
+
+def sanitize_text(text: str, patterns=None) -> tuple[str, dict[str, int]]:
+    """Redact matches, return (cleaned_text, counts_by_pattern)."""
+    patterns = patterns or DEFAULT_PATTERNS
+    counts: dict[str, int] = {}
+    for name, pat in patterns:
+        compiled = re.compile(pat)
+        new, n = compiled.subn(f"[REDACTED:{name}]", text)
+        if n:
+            counts[name] = n
+            text = new
+    return text, counts
+
+def sanitize_file(path: Path, patterns=None) -> dict[str, int]:
+    text = path.read_text()
+    cleaned, counts = sanitize_text(text, patterns)
+    path.write_text(cleaned)
+    return counts
+```
+
+## Pre-upload scan
+
+After the tar.gz is written, **extract it to a temp dir and scan once more**.
+This is the safety net that catches formats the redactor missed (e.g., a
+base64-encoded secret that happened to land inside an `on_tool_end` output):
+
+```bash
+tmp=$(mktemp -d)
+tar -xzf bundle-*.tar.gz -C "$tmp"
+# High-signal greps
+grep -RInE "sk-[A-Za-z0-9_-]{20,}" "$tmp" && echo "UNSAFE: OpenAI key pattern found" && exit 1
+grep -RInE "sk-ant-" "$tmp"                && echo "UNSAFE: Anthropic key pattern found" && exit 1
+grep -RInE "AKIA[0-9A-Z]{16}" "$tmp"       && echo "UNSAFE: AWS key pattern found" && exit 1
+grep -RInE "-----BEGIN .*PRIVATE KEY" "$tmp" && echo "UNSAFE: private key found" && exit 1
+rm -rf "$tmp"
+echo "clean"
+```
+
+If any of these fire, the bundle is **not safe to share**. Re-run the
+sanitization pass with the missing pattern added to `DEFAULT_PATTERNS`, or
+delete the offending file from the bundle and re-archive.
+
+## False-positive management
+
+The most common false positive is `sk-` appearing in a JSON Schema description
+("sk- prefix indicates OpenAI credentials" — ironically, explaining the regex).
+Two mitigations:
+
+1. Require a minimum length suffix (`[A-Za-z0-9_-]{32,}` instead of `{16,}`).
+2. Negative lookbehind for `"description"` context (regex gets complex; often
+   easier to hand-inspect the match and add a `--allow-substring` flag).
+
+## Logging the redactions
+
+The bundle's `MANIFEST.yaml` index (separate from `manifest.yaml` env snapshot)
+records how many patterns matched, so a reviewer knows whether the bundle was
+"clean at capture" or "aggressively scrubbed":
+
+```yaml
+sanitization:
+  ran_at: "2026-04-21T18:42:19Z"
+  pattern_counts:
+    openai_key: 3
+    anthropic_key: 1
+    bearer: 2
+  files_scanned: ["events.jsonl", "callbacks.txt", "manifest.yaml", "notes.txt"]
+```


### PR DESCRIPTION
## Summary

Handcrafted Operations-tier skill producing a reproducible, sanitized LangChain / LangGraph incident bundle — env manifest, `astream_events(v2)` transcript, propagating callback, LangSmith trace URL. Anchored to pain-catalog **P01, P28, P47, P67**.

## Pain hook

An on-call engineer asks "what state was the graph in when it gave up?" and there is no answer because the terminal is gone and callbacks bound via `Runnable.with_config(callbacks=[...])` never fired inside the subgraph (P28). Skill fixes this with a propagating `DebugCallbackHandler` at invoke time plus a filtered `astream_events(v2)` JSONL (P47 / P67) of 50-200 events — packaged into a sanitized 1-10 MB tar.gz with a LangSmith trace URL for zero-terminal reproduction.

## Files

- `skills/langchain-debug-bundle/SKILL.md` (391 lines)
- `skills/langchain-debug-bundle/references/one-pager.md`
- `skills/langchain-debug-bundle/references/env-manifest-template.md`
- `skills/langchain-debug-bundle/references/astream-events-capture.md`
- `skills/langchain-debug-bundle/references/callback-propagation.md`
- `skills/langchain-debug-bundle/references/sanitization-checklist.md`

## Validator

Grade **A (94/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude