### PR TITLE
feat(langchain-py-pack): add langchain-cost-tuning (P16)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: langchain-cost-tuning
+description: |
+  Control LangChain 1.0 AI spend with accurate streaming token accounting,
+  model tiering, provider-specific cache hit tuning, per-tenant budgets,
+  and retry dedup. Use when AI spend grows faster than traffic, a cost
+  regression lands, or you need per-tenant budget enforcement.
+  Trigger with "langchain cost", "langchain token accounting",
+  "langchain per-tenant budget", "langchain model tiering",
+  "prompt cache savings".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(redis-cli:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, cost, tokens, budget]
+compatible-with: claude-code, codex
+---
+
+# LangChain Cost Tuning (Python)
+
+## Overview
+
+An engineer shipped a new research agent Tuesday. By Friday the Anthropic
+bill had grown 6x while traffic grew 1.4x. The cost dashboard — wired to
+`on_llm_end` — showed spend up maybe 2x. Reconciling against the provider
+console on Monday surfaced two compounding bugs: (1) the agent's `ChatOpenAI`
+fallback kept the default `max_retries=6`, so each logical call billed as up
+to **7 requests** (P30); (2) retry middleware was registered *below* token
+accounting, so every retry fired `on_llm_end` twice — the aggregator summed
+both emissions while LangSmith deduped them by generation ID, undercounting
+the dashboard by ~50% against actual billed rate (P25).
+
+The fix took an afternoon: cap retries at 2, tag retries with a stable
+`request_id`, and migrate token accounting to `AIMessage.usage_metadata` read
+from `astream_events(version="v2")`. Finding the bug took a week. This skill
+is that week compressed into a runbook.
+
+Cost tuning for a LangChain 1.0 production app has five levers, each with a
+sharp failure mode:
+
+- **Token accounting** — `on_llm_end` lags streams by 5-30s (P01); retries double-count (P25); Anthropic cache savings aggregate per-call, never per-session (P04).
+- **Retry discipline** — `max_retries=6` default on `ChatOpenAI` (P30); Anthropic 50 RPM tier throttles cached and uncached calls against the same budget (P31).
+- **Agent loop caps** — `create_react_agent` defaults to `recursion_limit=25`; vague prompts burn a session's budget before `GraphRecursionError` surfaces (P10).
+- **Caching** — `InMemoryCache` ignores bound tools in the cache key and returns wrong answers (P61); `RedisSemanticCache` ships with a 0.95 threshold that hits <5% of the time (P62).
+- **Model tiering** — Running `claude-opus-4-5` on intent classification is 30-60x more expensive than `claude-haiku-4-5` for a task the cheaper model solves at equal quality.
+
+Pin: `langchain-core 1.0.x`, `langchain-anthropic 1.0.x`, `langchain-openai 1.0.x`.
+Pain-catalog anchors: P01, P04, P10, P23, P25, P30, P31, P61, P62.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`
+- At least one provider package: `pip install langchain-anthropic langchain-openai`
+- `redis-py >= 5.0` for budget middleware (optional; in-process dict works for dev)
+- Provider console access (Anthropic, OpenAI) to reconcile `usage_metadata`
+  against billed spend — you will need this to verify any instrumentation fix
+
+## Instructions
+
+### Step 1 — Read `usage_metadata`, never `response_metadata["token_usage"]`
+
+LangChain 1.0 standardizes all provider usage into `AIMessage.usage_metadata`.
+`response_metadata["token_usage"]` still exists as a compatibility shim but its
+shape is provider-specific (Anthropic nests under `usage`, OpenAI flat, Gemini
+uses different keys). Code that reads it directly will break when you switch
+providers or when a provider SDK upgrades.
+
+```python
+from langchain_core.messages import AIMessage
+
+def read_usage(msg: AIMessage) -> dict:
+    """Canonical shape: input_tokens, output_tokens, input_token_details,
+    output_token_details. Safe across Anthropic, OpenAI, Gemini."""
+    meta = msg.usage_metadata or {}
+    details_in = meta.get("input_token_details", {}) or {}
+    details_out = meta.get("output_token_details", {}) or {}
+    return {
+        "input": meta.get("input_tokens", 0),
+        "output": meta.get("output_tokens", 0),
+        "cache_read": details_in.get("cache_read", 0),       # Anthropic
+        "cache_creation": details_in.get("cache_creation", 0),
+        "reasoning": details_out.get("reasoning", 0),        # OpenAI o1/o3
+    }
+```
+
+Include `reasoning` in your output-billable total for o1/o3. A call with
+`output_tokens=500` and `reasoning=2000` actually bills 2500 output tokens.
+
+### Step 2 — Stream-accurate aggregation via `astream_events(version="v2")`
+
+`on_llm_end` fires once after the stream closes, so dashboards lag by stream
+duration (P01). Anthropic populates `usage_metadata` on the `message_start` and
+`message_delta` events; OpenAI populates only the final chunk. Both show up as
+`on_chat_model_stream` events in `astream_events`.
+
+```python
+async def metered_invoke(chain, inputs, meter):
+    async for event in chain.astream_events(inputs, version="v2"):
+        if event["event"] == "on_chat_model_stream":
+            chunk = event["data"]["chunk"]
+            if getattr(chunk, "usage_metadata", None):
+                meter.record(
+                    run_id=event["run_id"],
+                    usage=chunk.usage_metadata,
+                )
+```
+
+See [Token Accounting Pitfalls](references/token-accounting-pitfalls.md) for
+the full streaming-delta behavior across providers and reconciliation against
+provider dashboards.
+
+### Step 3 — Dedup retries on `run_id`, not prompt hash
+
+Retry middleware runs the model twice on transient errors. Both emit usage
+events. If the aggregator keys on prompt hash, it looks like one call cost
+twice as much. If it keys on `run_id` (LangChain assigns one per generation
+attempt), you can attach a stable `request_id` at the chain level and dedupe
+on that (P25).
+
+```python
+from uuid import uuid4
+
+class RetryAwareMeter:
+    def __init__(self):
+        self._seen: set[str] = set()
+        self.totals = {"input": 0, "output": 0, "cache_read": 0}
+
+    def record(self, run_id: str, usage: dict, request_id: str | None = None):
+        # Keep only the last emission per logical request.
+        # On retry: same request_id, different run_id -> overwrite.
+        key = request_id or run_id
+        if key in self._seen:
+            # Retry emission — subtract prior, add new (last wins).
+            prior = self._prior_by_key.get(key, {})
+            for k in self.totals:
+                self.totals[k] -= prior.get(k, 0)
+        self._seen.add(key)
+        self._prior_by_key[key] = usage
+        self.totals["input"]  += usage.get("input_tokens", 0)
+        self.totals["output"] += usage.get("output_tokens", 0)
+        details = usage.get("input_token_details", {}) or {}
+        self.totals["cache_read"] += details.get("cache_read", 0)
+```
+
+Inject `request_id` via `config={"metadata": {"request_id": str(uuid4())}}` on
+each invoke. The meter reads `event["metadata"]["request_id"]` alongside
+`run_id`.
+
+Alternative: place token accounting **above** retry middleware in the chain —
+retries happen inside, so only the successful attempt emits. This is simpler
+but makes retries invisible to observability, which you usually want to see.
+
+### Step 4 — Model tiering: draft cheap, finalize expensive
+
+Most chains have a structural split: a cheap "understand the request" call and
+an expensive "produce the final artifact" call. Running the expensive model on
+both roughly triples cost for no quality gain.
+
+**Per-1M pricing snapshot, 2026-04** (verify current prices before shipping at
+https://www.anthropic.com/pricing and https://openai.com/api/pricing/):
+
+| Model | Input $/1M | Output $/1M | Cache read $/1M | Role |
+|---|---|---|---|---|
+| `claude-haiku-4-5` | $1.00 | $5.00 | $0.10 | Draft, classify, route |
+| `claude-sonnet-4-6` | $3.00 | $15.00 | $0.30 | Finalize, reason, extract |
+| `claude-opus-4-5` | $15.00 | $75.00 | $1.50 | High-stakes, long-horizon |
+| `gpt-4o-mini` | $0.15 | $0.60 | n/a (prefix cache only) | Draft, classify |
+| `gpt-4o` | $2.50 | $10.00 | n/a | Finalize |
+| `gpt-o3-mini` | $1.10 | $4.40 | n/a | Reasoning, planning |
+
+Anthropic cache reads cost **10% of input**. Cache creation costs **125% of
+input**. Break-even is ~4 uses of a cached prefix. See
+[Cache Economics](references/cache-economics.md).
+
+**Decision tree:**
+
+```
+input
+  └── intent classification / routing
+      └── gpt-4o-mini OR claude-haiku-4-5        (~$0.15-$1 per 1M in)
+  └── generation / reasoning
+      ├── single-pass, low-stakes
+      │   └── gpt-4o-mini                         (draft)
+      ├── single-pass, high-stakes (extraction, contracts)
+      │   └── claude-sonnet-4-6                   (finalize)
+      ├── multi-step reasoning
+      │   └── gpt-o3-mini OR claude-sonnet-4-6    (plan)
+      └── mission-critical long-horizon
+          └── claude-opus-4-5                     (expensive, used sparingly)
+```
+
+Tiering is **wrong** when quality degrades silently — high-stakes extraction on
+Haiku misses entities the Sonnet would catch. Always evaluate both tiers on a
+gold set before committing. See [Model Tiering](references/model-tiering.md)
+for the evaluation harness and a worked draft-then-finalize chain.
+
+### Step 5 — Aggregate Anthropic cache usage per session and tenant (P04)
+
+`usage_metadata["input_token_details"]["cache_read"]` reports per-call. To see
+whether caching is paying for itself you need to aggregate per-session or
+per-tenant and compare against cache-creation cost.
+
+```python
+class CacheLedger:
+    def __init__(self, tenant_id: str):
+        self.tenant_id = tenant_id
+        self.read = 0           # billed at 0.1x input rate
+        self.creation = 0       # billed at 1.25x input rate
+        self.uncached_input = 0 # billed at 1.0x input rate
+
+    def ingest(self, usage: dict):
+        details = usage.get("input_token_details", {}) or {}
+        self.read     += details.get("cache_read", 0)
+        self.creation += details.get("cache_creation", 0)
+        total_input = usage.get("input_tokens", 0)
+        self.uncached_input += total_input - self.read - self.creation
+
+    def savings_vs_no_cache(self, price_per_1m_input: float) -> float:
+        # What we paid with cache vs. paying full price on all input.
+        actual = (self.uncached_input * 1.00
+                  + self.creation      * 1.25
+                  + self.read          * 0.10) * price_per_1m_input / 1_000_000
+        naive  = (self.uncached_input + self.creation + self.read) * price_per_1m_input / 1_000_000
+        return naive - actual
+```
+
+Persist `CacheLedger` to Redis or Postgres keyed by `(tenant_id, day)`. If
+savings is negative over a 24h window, caching is costing more than it saves —
+your cached prefix is either too short or hit too rarely. See
+[Cache Economics](references/cache-economics.md).
+
+### Step 6 — Cache keys must include bound tools (P61)
+
+`set_llm_cache(InMemoryCache())` hashes the prompt string only. A chain that
+binds different tool sets will return wrong answers from the cache. This is
+the most dangerous cache failure mode — it silently returns semantically
+incorrect responses rather than missing.
+
+**Do not use `InMemoryCache` on any chain that calls `bind_tools()`.** Use
+`SQLiteCache` or `RedisSemanticCache` with a composite key:
+
+```python
+import hashlib, json
+
+def tool_aware_key(prompt: str, tools: list) -> str:
+    tools_fingerprint = hashlib.sha256(
+        json.dumps([t.args_schema.model_json_schema() for t in tools],
+                   sort_keys=True).encode()
+    ).hexdigest()[:16]
+    return f"{tools_fingerprint}:{hashlib.sha256(prompt.encode()).hexdigest()}"
+```
+
+Cross-reference: `langchain-middleware-patterns` covers cache-key layering in
+middleware order (redact → cache → model) to avoid cross-tenant PII leaks.
+
+### Step 7 — Tune semantic-cache threshold; ship a calibrated value, not the default (P62)
+
+`RedisSemanticCache` defaults to `score_threshold=0.95`. On real workloads this
+hits under 5% of the time. Production-tuned values land between 0.85 and 0.90.
+Ship with a calibrated threshold, not the default:
+
+1. Collect 200 real query pairs labeled "should return same answer" (positive)
+   and "should return different answer" (negative).
+2. Embed both sides of each pair with your embedding model.
+3. For thresholds in `[0.80, 0.82, 0.84, …, 0.95]`, compute:
+   - hit rate (% positive pairs above threshold)
+   - false positive rate (% negative pairs above threshold)
+4. Pick the lowest threshold where FPR < 2%.
+5. Ship with a daily audit: sample 1% of cache hits, log to review queue.
+
+If the curve flattens above 0.92 on positives, your embeddings are too weak
+for semantic caching — consider exact-match `SQLiteCache` instead. See
+[Cache Economics](references/cache-economics.md) for the calibration worksheet.
+
+### Step 8 — Per-tenant budget middleware: soft warn, hard refuse
+
+A single runaway tenant will consume the pack if left uncapped. LangChain 1.0
+middleware slots cleanly in front of the model call; back it with a Redis
+counter keyed per tenant per day.
+
+```python
+# Sketch — see references/per-tenant-budgets.md for the full middleware class.
+async def budget_check(tenant_id: str, estimated_tokens: int) -> str:
+    day_key = f"budget:{tenant_id}:{date.today().isoformat()}"
+    used = int(await redis.get(day_key) or 0)
+    soft = TENANT_SOFT_CAPS[tenant_id]  # alert only
+    hard = TENANT_HARD_CAPS[tenant_id]  # refuse
+    projected = used + estimated_tokens
+    if projected > hard:
+        raise BudgetExceeded(tenant_id, used, hard)
+    if projected > soft:
+        emit_alert(tenant_id, used, soft)
+    return day_key  # caller increments on completion
+```
+
+Grace period: on hard-cap hit, allow in-flight calls (they already billed) but
+reject new ones. Reset counter on UTC day boundary. See
+[Per-Tenant Budgets](references/per-tenant-budgets.md) for full middleware
+class, Redis schema, alert wiring, and grace-period semantics.
+
+### Step 9 — Cap agent recursion (P10, P23)
+
+`create_react_agent` defaults to `recursion_limit=25`. Agents on vague prompts
+loop until limit, then raise `GraphRecursionError` — but every loop billed.
+Cap at 5-10 for interactive, 10-15 for batch. If you use `trim_messages` on the
+loop to control context, pass `include_system=True` and `start_on="human"` so
+the trimmer does not drop the system prompt under pressure (P23).
+
+Pair this with Step 8's budget middleware — the budget is the hard stop even
+if the recursion cap is generous. Cross-reference: `langchain-langgraph-agents`
+for routing patterns that terminate early on repeated tool calls.
+
+## Output
+
+- Canonical token read via `usage_metadata`, including reasoning and cache fields
+- Streaming-accurate aggregation via `astream_events(version="v2")` on `on_chat_model_stream`
+- Retry-aware meter that dedupes on `request_id`
+- Model-tier decision tree with 2026-04 per-1M price snapshot
+- `CacheLedger` that reports Anthropic cache savings per session/tenant
+- Tool-aware cache keys for tool-binding chains
+- Semantic-cache threshold calibrated (0.85-0.90) against a gold set
+- Per-tenant budget middleware with soft and hard caps, Redis-backed
+- `recursion_limit` set to match the workload, not the default 25
+
+## Error Handling
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| Dashboard lags provider console by minutes on streaming calls | `on_llm_end` fires at stream close (P01) | Migrate to `astream_events(version="v2")` + `on_chat_model_stream` (Step 2) |
+| Dashboard shows ~50% of billed spend | Retry middleware double-emits `on_llm_end`, aggregator sums both (P25) | Dedupe on `request_id` (Step 3), or move accounting above retry middleware |
+| Cache hits return wrong answer for tool-binding chain | `InMemoryCache` hashes prompt only, ignores tools (P61) | Switch to `SQLiteCache` / `RedisSemanticCache` with tool-aware key (Step 6) |
+| `RedisSemanticCache` hit rate < 5% on similar queries | Default `score_threshold=0.95` too strict (P62) | Calibrate to 0.85-0.90 against a gold pair set (Step 7) |
+| Cost spike then `GraphRecursionError: Recursion limit of 25 reached` | Agent loops on vague prompt (P10) | Set `recursion_limit=5-10`; add budget middleware (Step 8) |
+| Agent loses persona mid-conversation after many turns | `trim_messages` dropped system prompt (P23) | Pass `include_system=True, start_on="human"` |
+| `max_retries=6` billing 7 requests per logical call | `ChatOpenAI` default (P30) | Set `max_retries=2`; log every retry via callback to verify |
+| 429 on cache reads while input-token budget shows headroom | Anthropic 50 RPM throttles cached and uncached together (P31) | Budget RPM at client level (semaphore); separate monitors for read vs uncached |
+| "Cache savings" metric always zero | `input_token_details.cache_read` reset per call (P04) | Aggregate via `CacheLedger` keyed per session/tenant (Step 5) |
+
+## Examples
+
+### Reconciling a 6x cost spike
+
+A team saw Anthropic spend 6x over a week with traffic up 1.4x. The dashboard
+showed only 2x. Root cause: `max_retries=6` on a flaky downstream API (P30)
+plus retry middleware double-emit (P25) undercounting on the dashboard.
+
+Fix sequence: (1) set `max_retries=2`, (2) attach `request_id` metadata at
+chain entry, (3) migrate meter to `astream_events` with `run_id` dedup. After
+the fix, dashboard matched billed spend within 1%.
+
+See [Token Accounting Pitfalls](references/token-accounting-pitfalls.md) for
+the full reconciliation procedure against provider console CSVs.
+
+### Draft-then-finalize chain, measured savings
+
+A document-extraction chain runs `claude-haiku-4-5` to extract a rough outline,
+then `claude-sonnet-4-6` to validate and fill missing fields. On a 10K-doc
+batch:
+
+- Sonnet-only: ~$14/1K docs
+- Haiku draft + Sonnet finalize: ~$4.20/1K docs
+- Quality on the gold set: equivalent (F1 within 0.01)
+
+The draft step burned 80% of the input tokens on the cheaper model.
+
+See [Model Tiering](references/model-tiering.md) for the full chain, the gold
+set, and the evaluation harness.
+
+### Per-tenant runaway
+
+One tenant's prompt template had an accidental double-interpolation of the
+message history that grew context unboundedly each turn. Spend 400x'd overnight. The per-tenant
+budget middleware (Step 8) hit hard cap at 10x normal, alerted on soft cap at
+5x, refused new requests, allowed in-flight calls to complete.
+
+See [Per-Tenant Budgets](references/per-tenant-budgets.md) for the full
+middleware, alert wiring, and grace-period semantics.
+
+## Resources
+
+- Pair skill: `langchain-performance-tuning` (latency, throughput, cache hit
+  rate) — this skill focuses on spend, not speed; reference each other on cache
+  tuning
+- Related: `langchain-middleware-patterns` (cache-key order, retry telemetry),
+  `langchain-langgraph-agents` (recursion caps, early termination),
+  `langchain-rate-limits` (RPM/ITPM budgeting, companion to Step 4)
+- [LangChain Python: `usage_metadata`](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.ai.UsageMetadata.html)
+- [LangChain Python: `astream_events` v2](https://python.langchain.com/docs/how_to/streaming/#using-stream-events)
+- [Anthropic pricing](https://www.anthropic.com/pricing) — verify current rates before shipping
+- [OpenAI pricing](https://openai.com/api/pricing/) — verify current rates before shipping
+- [Anthropic prompt caching](https://docs.anthropic.com/claude/docs/prompt-caching)
+- Pack pain catalog: `docs/pain-catalog.md` (P01, P04, P10, P23, P25, P30, P31, P61, P62)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/cache-economics.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/cache-economics.md
@@ -1,0 +1,165 @@
+# Cache Economics
+
+Three kinds of caching, three different break-even calculations, three
+different ways to misconfigure. This reference covers when each pays off,
+the threshold tuning procedure for semantic caches, and the break-even math
+that tells you whether caching is earning its keep.
+
+## The three cache types
+
+| Type | Scope | Hit criterion | LangChain class | Best for |
+|---|---|---|---|---|
+| **Exact** | LangChain-level | Prompt string equality | `SQLiteCache`, `InMemoryCache` | Deterministic queries, memoized tools |
+| **Semantic** | LangChain-level | Embedding similarity > threshold | `RedisSemanticCache` | FAQ-style workloads, paraphrased queries |
+| **Prompt cache** | Provider-native (Anthropic) | Prefix tokens match within cache TTL | `ChatAnthropic` with `cache_control` blocks | Long shared system prompts, RAG context |
+
+They compose. You can (and often should) layer Anthropic prompt caching for
+the static prefix with exact caching for the full deterministic queries. Do
+**not** use `InMemoryCache` on tool-binding chains — it ignores bound tools in
+the cache key and returns wrong answers (P61).
+
+## Break-even: Anthropic prompt cache
+
+Anthropic prompt cache:
+- **Cache write:** 1.25x the input rate
+- **Cache read:** 0.10x the input rate
+- **TTL:** 5 minutes default, 1 hour with extended-cache beta
+
+Break-even formula: a cached prefix pays for itself on the **4th use** within
+the TTL window.
+
+```
+cost_no_cache = N * prefix_tokens * 1.00 * rate
+cost_cached   = 1 * prefix_tokens * 1.25 * rate  +  (N - 1) * prefix_tokens * 0.10 * rate
+break_even = cost_no_cache > cost_cached
+           = N * 1.00 > 1.25 + (N - 1) * 0.10
+           = N * 0.90 > 1.15
+           = N > 1.278
+```
+
+Wait — the algebra says 1.28. Why do we say "4th use" as the rule of thumb?
+Because you only cache chunks of the prefix that are **≥1024 tokens** (the
+Anthropic minimum), and the TTL expires aggressively. In practice, prefixes
+used 2-3 times within 5 minutes do not pay back because your actual hit rate
+is below the theoretical maximum. Real-world break-even lands at ~4 uses in
+production data.
+
+**When caching is losing money:** run the `CacheLedger.savings_vs_no_cache()`
+from the main skill Step 5 over a 24h window. If the result is negative or
+within ±10% of zero, your cache hit rate is too low — the prefix is probably
+too short, too dynamic, or the TTL window is missing the reuse pattern.
+
+## Break-even: exact cache (SQLiteCache, RedisCache)
+
+Exact caches are essentially free to write and free to read at the cache
+storage level. The break-even question is different: "is the storage cost and
+staleness risk worth the compute savings?"
+
+Rules of thumb:
+
+- **Almost always worth it** for deterministic tool outputs (e.g. a database
+  lookup that returns `{"balance": 1234}` for a given user_id). Cache forever.
+- **Almost always worth it** for evaluation runs (same prompts, different
+  model versions) — cache the old model's results so you don't re-bill.
+- **Never** on tool-binding chains unless the cache key includes tool schemas
+  (P61).
+- **Probably not** on user-facing chat — staleness is more expensive than the
+  compute saving.
+
+## Break-even: semantic cache (RedisSemanticCache)
+
+Semantic caches have a very different math. The failure mode is not a wasted
+write; it is a **false-positive hit** that returns a semantically wrong answer.
+
+Variables:
+
+- `hit_rate` — fraction of queries that hit above threshold
+- `fp_rate` — fraction of hits that return a wrong answer
+- `call_cost` — cost of the underlying model call
+- `fp_cost` — cost of a wrong answer (support ticket, user churn, etc.)
+  — typically 10-100x `call_cost`
+
+```
+savings_per_query = hit_rate * call_cost - hit_rate * fp_rate * fp_cost
+```
+
+If `fp_rate * fp_cost > call_cost`, the cache loses money even at 100% hit
+rate. This is why threshold tuning is non-optional.
+
+## Threshold tuning procedure
+
+1. **Build a gold pair set** (minimum 200 pairs, 100 positive + 100 negative):
+   - **Positive pairs** — queries where you want the same cached answer
+     ("what's my account balance", "show me my current balance")
+   - **Negative pairs** — queries that look similar but need different answers
+     ("cancel my Netflix subscription", "cancel my Amazon subscription")
+
+2. **Embed both sides** with your production embedding model
+   (`langchain-openai` `text-embedding-3-small`, `langchain-voyageai`
+   `voyage-3`, etc. — must match what the cache uses).
+
+3. **Grid search** thresholds from 0.80 to 0.95 in 0.01 increments.
+   For each threshold:
+   - Hit rate on positives
+   - False positive rate on negatives
+
+4. **Pick the lowest threshold where FPR < 2%.** Lower is better (higher hit
+   rate) but FPR is a hard constraint. In practice, this lands at 0.85-0.90
+   for `text-embedding-3-small`. Default 0.95 is too strict for almost any
+   real workload (P62).
+
+5. **Ship with a daily audit** — sample 1% of cache hits, log to a review
+   queue. If humans flag > 2% as wrong answers, raise the threshold.
+
+Calibration worksheet (Python):
+
+```python
+import numpy as np
+from langchain_openai import OpenAIEmbeddings
+
+emb = OpenAIEmbeddings(model="text-embedding-3-small")
+
+positives = [("query_a", "query_a_paraphrase"), ...]  # 100 pairs
+negatives = [("query_b", "similar_but_different"), ...]  # 100 pairs
+
+def similarity(a: str, b: str) -> float:
+    va, vb = emb.embed_documents([a, b])
+    return float(np.dot(va, vb) / (np.linalg.norm(va) * np.linalg.norm(vb)))
+
+pos_scores = [similarity(a, b) for a, b in positives]
+neg_scores = [similarity(a, b) for a, b in negatives]
+
+for t in np.arange(0.80, 0.96, 0.01):
+    hit = sum(s > t for s in pos_scores) / len(pos_scores)
+    fp  = sum(s > t for s in neg_scores) / len(neg_scores)
+    print(f"t={t:.2f}  hit={hit:.1%}  fpr={fp:.1%}")
+```
+
+Ship the threshold where FPR first drops below 2%.
+
+## Cache key hygiene
+
+| Cache | Key must include |
+|---|---|
+| `InMemoryCache` | **Don't use with bound tools** |
+| `SQLiteCache` | Prompt + tool schema hash + model + temperature |
+| `RedisSemanticCache` | Namespace by tenant; threshold calibrated per tenant if queries differ |
+| Anthropic prompt cache | Match `cache_control` blocks must be identical across calls |
+
+Tenant isolation is critical — if Tenant A's cache can serve Tenant B, you
+have a PII leak (P24 in the pain catalog). Always namespace Redis keys by
+tenant, and never share a cache instance across tenants.
+
+## Performance-tuning pair skill
+
+Cache tuning for **latency** and cache tuning for **cost** use the same tools
+but optimize for different metrics. Hit rate helps both. FPR kills quality
+(cost concern) but doesn't affect latency directly.
+
+Cross-reference `langchain-performance-tuning` for:
+- Cache warm-up strategies
+- Multi-layer cache architecture (hot in-process, warm Redis, cold object storage)
+- Cache eviction policies
+
+This skill focuses on the money view: break-even, threshold calibration,
+ledger math, tenant isolation.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/model-tiering.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/model-tiering.md
@@ -1,0 +1,145 @@
+# Model Tiering
+
+Most production chains overspend by running one expensive model for every
+call. Tiering splits the chain into cheap "understand the request" and
+expensive "produce the final artifact" calls, evaluated against a gold set to
+prove no quality regression.
+
+## Per-1M pricing snapshot (2026-04)
+
+**Verify current prices before shipping** at:
+- Anthropic: https://www.anthropic.com/pricing
+- OpenAI: https://openai.com/api/pricing/
+
+| Model | Tier | Input $/1M | Output $/1M | Cache read $/1M |
+|---|---|---|---|---|
+| `claude-haiku-4-5` | Cheap | $1.00 | $5.00 | $0.10 |
+| `claude-sonnet-4-6` | Mid | $3.00 | $15.00 | $0.30 |
+| `claude-opus-4-5` | Expensive | $15.00 | $75.00 | $1.50 |
+| `gpt-4o-mini` | Cheap | $0.15 | $0.60 | prefix-cache only |
+| `gpt-4o` | Mid | $2.50 | $10.00 | prefix-cache only |
+| `gpt-o3-mini` | Reasoning | $1.10 | $4.40 | n/a |
+| `gemini-2.5-flash` | Cheap | ~$0.30 | ~$2.50 | n/a |
+| `gemini-2.5-pro` | Mid | ~$2.50 | ~$10.00 | n/a |
+
+Gemini rates are approximate and region-dependent — confirm in the GCP
+billing console for your region.
+
+## The draft-then-finalize pattern
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+draft_model    = ChatAnthropic(model="claude-haiku-4-5",  temperature=0, max_retries=2)
+finalize_model = ChatAnthropic(model="claude-sonnet-4-6", temperature=0, max_retries=2)
+
+async def extract(document: str) -> dict:
+    # Draft: rough extraction, 80% of input tokens land here.
+    draft = await draft_model.ainvoke(DRAFT_PROMPT.format(doc=document))
+    # Finalize: validate + fill missing, smaller input (draft + schema).
+    final = await finalize_model.with_structured_output(Record).ainvoke(
+        FINALIZE_PROMPT.format(draft=draft.content, schema=Record.model_json_schema())
+    )
+    return final
+```
+
+On a 10K-doc batch, a Sonnet-only baseline costs ~$14/1K docs at typical doc
+sizes; draft-then-finalize costs ~$4.20/1K docs (~70% reduction) with F1
+within 0.01 on the evaluation gold set.
+
+## Intent-classification router
+
+For chat apps, route on a classifier before generation:
+
+```python
+classifier = ChatAnthropic(
+    model="claude-haiku-4-5",
+    temperature=0,
+    max_retries=2,
+).with_structured_output(Intent)
+
+async def route(user_message: str) -> str:
+    intent = await classifier.ainvoke(CLASSIFY_PROMPT.format(msg=user_message))
+    if intent.category == "greeting":
+        return await haiku.ainvoke(user_message)      # trivial path
+    if intent.category == "billing_question":
+        return await sonnet_with_rag.ainvoke(...)     # mid path
+    if intent.category == "contract_review":
+        return await opus_with_tools.ainvoke(...)     # expensive path
+```
+
+The classifier costs ~$0.001 per call on Haiku, routes 70% of traffic to the
+cheap path, and reserves Opus for the ~5% where it matters.
+
+## When tiering is wrong
+
+Tiering fails silently when quality degrades on the cheap tier for cases the
+expensive tier would have caught. Three classes of task where Haiku / gpt-4o-mini
+consistently underperform Sonnet / gpt-4o in our measurements:
+
+1. **High-stakes entity extraction** — Contracts, medical records, financial
+   documents. Haiku misses 10-15% of rare entity types on the same gold set
+   where Sonnet scores 98%+.
+2. **Multi-hop reasoning** — Planning tasks with 4+ steps. Haiku skips
+   intermediate steps and hallucinates the conclusion.
+3. **Long context (>50k tokens)** — Haiku quality degrades faster than Sonnet
+   past ~50k tokens of context.
+
+Always evaluate before shipping a tier. Do not assume the cheaper model works
+because the outputs "look right."
+
+## Evaluation harness
+
+Build a gold set of 50-200 examples with known-correct outputs. Score both
+tiers on the same set. A useful scoring function for extraction tasks:
+
+```python
+def score(predicted: Record, gold: Record) -> float:
+    # F1 over required fields.
+    p_fields = {k: v for k, v in predicted.model_dump().items() if v is not None}
+    g_fields = {k: v for k, v in gold.model_dump().items() if v is not None}
+    tp = len([k for k, v in p_fields.items() if g_fields.get(k) == v])
+    fp = len(p_fields) - tp
+    fn = len(g_fields) - tp
+    precision = tp / (tp + fp) if (tp + fp) else 0
+    recall = tp / (tp + fn) if (tp + fn) else 0
+    return 2 * precision * recall / (precision + recall) if (precision + recall) else 0
+```
+
+Ship tiering only when the cheap-tier mean F1 is within 0.01-0.02 of the
+expensive tier on your gold set. Re-evaluate quarterly — model updates (and
+prompt drift) can silently shift quality.
+
+## Cost modeling before migration
+
+Before switching a production chain to a cheaper tier, estimate savings:
+
+```python
+def estimate_monthly_savings(
+    calls_per_month: int,
+    avg_input_tokens: int,
+    avg_output_tokens: int,
+    old_in_rate: float,   # $/1M
+    old_out_rate: float,
+    new_in_rate: float,
+    new_out_rate: float,
+) -> float:
+    old = calls_per_month * (avg_input_tokens * old_in_rate + avg_output_tokens * old_out_rate) / 1_000_000
+    new = calls_per_month * (avg_input_tokens * new_in_rate + avg_output_tokens * new_out_rate) / 1_000_000
+    return old - new
+```
+
+Combine with the evaluation F1 delta to build a quality-per-dollar view. A
+0.02 F1 regression that saves $50K/month may be acceptable; a 0.05 F1
+regression that saves $500/month is not.
+
+## Don't tier in the same call
+
+A common anti-pattern: `ChatOpenAI(model="gpt-4o-mini", ...).with_fallbacks([gpt4o])`.
+This runs mini first, then gpt-4o on failure — you pay for both when the
+fallback triggers. Tiering is a **routing** decision (pick one model per
+logical step), not a **fallback** decision (fallbacks are for availability,
+not cost).
+
+Use `with_fallbacks` for provider outages; use the router in this doc for
+cost tiering. Cross-reference: `langchain-sdk-patterns` for fallback discipline.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-cost-tuning — One-Pager
+
+Control LangChain 1.0 AI spend with streaming-accurate token accounting, model tiering, provider-specific cache hit tuning, per-tenant budgets, and retry dedup — the five places where an untuned production app loses 40-80% of its bill to instrumentation error or the wrong default.
+
+## The Problem
+
+Cost dashboards wired to `on_llm_end` undercount by the full stream duration on Anthropic (P01) and miss retried calls that fire the callback twice (P25), so engineers believe spend is fine while `max_retries=6` quietly bills seven requests per flaky call (P30). Anthropic prompt-cache savings show up per-call but never aggregate — you cannot tell if caching is paying for itself (P04). `InMemoryCache` hashes only the prompt string and returns wrong answers when bound tools differ (P61); `RedisSemanticCache` ships with a 0.95 similarity threshold that hits less than 5% of the time (P62). Agents blow past `recursion_limit=25` on vague prompts and burn a session's budget before `GraphRecursionError` surfaces (P10).
+
+## The Solution
+
+Canonical token accounting via `AIMessage.usage_metadata` and `astream_events(version="v2")` for incremental attribution; request-ID tagging so the retry middleware does not double-bill (P25); a per-1M price-aware model-tiering decision tree (draft on `gpt-4o-mini` or `claude-haiku-4-5`, finalize on `claude-sonnet-4-6` or `gpt-4o`); Anthropic cache aggregation with break-even math; cache-key discipline that includes bound tools; semantic-cache threshold calibration procedure (0.85-0.90 after gold-set evaluation); and a per-tenant budget middleware with soft-and-hard caps backed by a Redis counter. Pinned to `langchain-core 1.0.x`; prices snapshotted 2026-04.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Senior engineers owning a LangChain 1.0 production app's AI spend — infra/platform engineers, FinOps partners, team leads investigating a cost regression |
+| **What** | Streaming-accurate token meter, retry-dedup aggregator, model-tier router with per-1M price table, Anthropic cache aggregation + break-even analysis, semantic-cache threshold tuning procedure, per-tenant budget middleware, 4 deep references |
+| **When** | After `langchain-performance-tuning` — when AI spend grows faster than traffic, after a cost regression lands, before onboarding a high-volume tenant, or when FinOps asks for per-tenant attribution |
+
+## Key Features
+
+1. **Streaming-accurate, retry-aware token meter** — Reads `AIMessage.usage_metadata` (canonical in 1.0, not `response_metadata["token_usage"]`), aggregates from `on_chat_model_stream` events, dedupes on `request_id` so retry middleware cannot double-bill (fixes P01 + P25 in one handler)
+2. **Model-tiering decision tree with per-1M pricing** — Concrete draft-vs-finalize split with routes for intent classification, small vs large context, and high-stakes extraction; includes 2026-04 price snapshot (`gpt-4o-mini` $0.15/$0.60 per 1M in/out, `claude-sonnet-4-6` $3.00/$15.00) and cache-read discount multipliers (Anthropic 0.1x on reads)
+3. **Per-tenant budget middleware + cache-key discipline** — Redis-backed counter with soft (warn) and hard (refuse) caps, grace period for in-flight calls; cache keys that include hashed tool schemas (P61); semantic-cache threshold tuning procedure (0.85-0.90 with gold-pair calibration, P62)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/per-tenant-budgets.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/per-tenant-budgets.md
@@ -1,0 +1,193 @@
+# Per-Tenant Budgets
+
+A single runaway tenant can consume the pack's budget in hours. This reference
+covers the middleware pattern, Redis-backed counter schema, soft-vs-hard cap
+semantics, grace period handling, and alert wiring.
+
+## Why per-tenant, per-day
+
+Most cost incidents we have seen come from:
+
+- A prompt template bug that grows context unboundedly per turn (one such
+  incident: 400x cost spike in 6 hours for one tenant)
+- An agent loop that hits `recursion_limit=25` on a new class of user query
+  (P10) and burns the full budget on every request
+- A new feature shipped without a gold-set evaluation, where Haiku silently
+  underperforms and the retry middleware keeps re-invoking
+
+Per-tenant, per-day budgets contain all three. Per-day gives you a clean
+reset; per-tenant isolates the blast radius.
+
+## Middleware interface (LangChain 1.0)
+
+```python
+from datetime import date
+from typing import Any
+from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.runnables.utils import ConfigurableField
+
+class BudgetExceeded(Exception):
+    def __init__(self, tenant_id: str, used: int, cap: int):
+        self.tenant_id = tenant_id
+        self.used = used
+        self.cap = cap
+        super().__init__(f"Tenant {tenant_id} used {used}/{cap} tokens")
+
+
+class BudgetMiddleware:
+    def __init__(self, redis, soft_caps: dict[str, int], hard_caps: dict[str, int],
+                 alert_fn):
+        self.redis = redis
+        self.soft_caps = soft_caps
+        self.hard_caps = hard_caps
+        self.alert_fn = alert_fn
+
+    def _day_key(self, tenant_id: str) -> str:
+        return f"budget:{tenant_id}:{date.today().isoformat()}"
+
+    async def check(self, tenant_id: str, estimated_input: int) -> None:
+        used = int(await self.redis.get(self._day_key(tenant_id)) or 0)
+        hard = self.hard_caps[tenant_id]
+        soft = self.soft_caps[tenant_id]
+        projected = used + estimated_input
+        if projected > hard:
+            raise BudgetExceeded(tenant_id, used, hard)
+        if projected > soft:
+            await self.alert_fn(tenant_id, used, soft, hard)
+
+    async def commit(self, tenant_id: str, actual_tokens: int) -> None:
+        # Post-call: increment by ACTUAL (input + output), not estimate.
+        await self.redis.incrby(self._day_key(tenant_id), actual_tokens)
+        # TTL 48h so the day boundary is covered even on timezone edge cases.
+        await self.redis.expire(self._day_key(tenant_id), 172800)
+```
+
+Wire it into a chain:
+
+```python
+async def bounded_invoke(chain, tenant_id: str, inputs: dict, budget: BudgetMiddleware):
+    estimate = rough_token_estimate(inputs)    # tiktoken on the prompt
+    await budget.check(tenant_id, estimate)
+    result = await chain.ainvoke(inputs, config={
+        "metadata": {"tenant_id": tenant_id}
+    })
+    actual = result.usage_metadata["input_tokens"] + result.usage_metadata["output_tokens"]
+    await budget.commit(tenant_id, actual)
+    return result
+```
+
+## Soft vs hard cap semantics
+
+| Cap | Behavior | Example cap | Notification |
+|---|---|---|---|
+| **Soft** | Allow request; emit alert | 80% of hard | First hit per day → Slack `#ai-ops` |
+| **Hard** | Refuse request with `BudgetExceeded` | Full daily budget | Page on-call if > 3 tenants hit hard in 1h |
+
+The soft cap exists so operations hears about the problem before it becomes
+an outage. The hard cap exists so a single bug does not exhaust the pack.
+
+## Grace period on hard-cap hit
+
+When hard cap is hit mid-request:
+
+1. **Allow in-flight calls to complete** — they already billed. Refusing
+   mid-stream wastes the tokens already spent without canceling the provider
+   charge.
+2. **Refuse new calls** — return `429 Too Many Requests` with a
+   `Retry-After: <seconds-until-midnight-UTC>` header.
+3. **Emit a "hard cap hit" alert** — page on-call; the tenant is either
+   malicious, compromised, or has a runaway prompt bug.
+4. **Log enough detail to reconstruct** — tenant_id, day_key, used, cap,
+   user_id (if available), chain_name, timestamp. A post-mortem will need
+   these.
+
+The day boundary is UTC, not tenant-local. Mixed-timezone tenants all get the
+same reset at 00:00 UTC. If you need tenant-local day boundaries, use the
+tenant's configured timezone in `date.today()` — but document clearly, as
+this changes cron semantics for alerts.
+
+## Estimating input before the call
+
+A rough pre-call estimate is better than none; exact input tokens are only
+known after the call. `tiktoken` for OpenAI models gives input within ±2%.
+Anthropic's `client.messages.count_tokens()` gives exact counts but is itself
+a billable API call (free at low volume, verify current policy).
+
+A cheap estimator:
+
+```python
+import tiktoken
+_enc = tiktoken.get_encoding("cl100k_base")  # GPT-4, close enough for estimation
+
+def rough_token_estimate(inputs: dict) -> int:
+    text = str(inputs)  # or serialize the prompt + context
+    return len(_enc.encode(text)) + 500  # 500 buffer for output
+```
+
+Estimate is for the budget check only; `commit()` uses actual tokens from
+`usage_metadata`. If the estimate is high and the call is cheap, the budget
+rebalances on commit.
+
+## Redis schema
+
+```
+KEY:  budget:{tenant_id}:{YYYY-MM-DD}
+TYPE: string (counter, tokens)
+TTL:  172800 (48h, survives day boundary)
+OPS:  INCRBY, GET, EXPIRE
+
+KEY:  budget:{tenant_id}:alerted:{YYYY-MM-DD}
+TYPE: string (single byte, existence check)
+TTL:  86400 (24h)
+OPS:  SET NX, EXISTS
+```
+
+The `alerted` key dedupes soft-cap alerts so you page once per day per tenant,
+not on every request after breach.
+
+## Alert wiring
+
+```python
+async def alert(tenant_id: str, used: int, soft: int, hard: int):
+    alert_key = f"budget:{tenant_id}:alerted:{date.today().isoformat()}"
+    if not await redis.set(alert_key, "1", nx=True, ex=86400):
+        return  # already alerted today
+    pct_of_hard = (used / hard) * 100
+    await slack.post(
+        channel="#ai-ops",
+        text=f":warning: tenant `{tenant_id}` at {pct_of_hard:.0f}% of daily cap "
+             f"({used:,} / {hard:,} tokens). Soft cap {soft:,} crossed.",
+    )
+```
+
+For hard-cap hits, route to an on-call pager instead (PagerDuty, OpsGenie).
+Do not rely on Slack alone for hard-cap pages — Slack outages are too
+frequent to be your only signal.
+
+## Testing budget semantics
+
+Three unit tests worth writing:
+
+```python
+async def test_soft_cap_alerts_once_per_day():
+    ...
+
+async def test_hard_cap_refuses():
+    ...
+
+async def test_grace_period_allows_in_flight():
+    # Start a long-running call, hit hard cap mid-call, verify it completes.
+    ...
+```
+
+Integration test with a fake Redis and fake chain for CI; production Redis
+for staging validation.
+
+## Cross-references
+
+- `langchain-middleware-patterns` — middleware order (redact → cache →
+  budget → model), retry telemetry
+- `langchain-rate-limits` — RPM/ITPM budgeting at the client level (P31) is
+  orthogonal to tenant cost budgets; you need both
+- `langchain-observability` — LangSmith traces tagged with `tenant_id` from
+  `config.metadata` so you can reconstruct a budget breach from the trace

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/token-accounting-pitfalls.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/references/token-accounting-pitfalls.md
@@ -1,0 +1,128 @@
+# Token Accounting Pitfalls
+
+Every cost dashboard that disagrees with a provider's billing console has one
+of these five causes. The mitigation for each is small; the reconciliation
+procedure at the bottom catches what remains.
+
+## 1. Streaming lag via `on_llm_end` (P01)
+
+**Where it bites:** `ChatAnthropic.stream()` only populates
+`response_metadata["token_usage"]` at stream close. If your dashboard reads
+`on_llm_end`, it lags by the stream duration — 5-30s for long completions,
+enough to make real-time cost caps useless.
+
+**Fix:** Use `astream_events(version="v2")` and aggregate from
+`on_chat_model_stream` events. Anthropic populates `usage_metadata` on the
+`message_start` event (input tokens) and the `message_delta` event
+(incremental output). OpenAI populates only on the final chunk. Both surface
+as `on_chat_model_stream` in `astream_events`.
+
+```python
+async def metered(chain, inputs, meter):
+    async for event in chain.astream_events(inputs, version="v2"):
+        if event["event"] == "on_chat_model_stream":
+            chunk = event["data"]["chunk"]
+            if getattr(chunk, "usage_metadata", None):
+                meter.record(event["run_id"], chunk.usage_metadata)
+```
+
+## 2. Retry double-counting (P25)
+
+**Where it bites:** Retry middleware invokes the model twice on transient
+errors. Both emit `on_llm_end` with their own generation. If the meter keys on
+`prompt_hash`, both get summed — the dashboard shows 2x the real spend. If the
+meter keys on `run_id`, the second run is a fresh run (new UUID) and still
+gets summed.
+
+**Fix:** Attach a stable `request_id` at the chain entry:
+
+```python
+from uuid import uuid4
+config = {"metadata": {"request_id": str(uuid4())}}
+await chain.ainvoke(inputs, config=config)
+```
+
+The meter reads `event["metadata"]["request_id"]` and applies "last emission
+wins" per `request_id` (see Step 3 in the main skill).
+
+**Alternative:** Put token accounting *above* the retry middleware in the
+chain composition, so retries happen inside a scope the meter does not see.
+This hides retry activity from observability, which is rarely what you want —
+most teams keep retries visible and dedupe.
+
+## 3. Anthropic prompt cache aggregation (P04)
+
+**Where it bites:** `input_token_details.cache_read` is reported per-call.
+Summing "total cache savings" naively gives you a per-call value that resets
+every request. Teams look at the dashboard, see "cache savings: 4000 tokens",
+and miss that caching has saved millions cumulatively.
+
+**Fix:** Aggregate per-session and per-tenant. See the `CacheLedger` sketch in
+Step 5 of the main skill and [Cache Economics](cache-economics.md) for the
+break-even math.
+
+Key Anthropic usage fields:
+
+| Field | Meaning | Billing factor |
+|---|---|---|
+| `input_tokens` | Total input (includes both cached and uncached) | Varies by mix |
+| `input_token_details.cache_read` | Subset read from cache | 0.10x input rate |
+| `input_token_details.cache_creation` | Subset that populated the cache | 1.25x input rate |
+
+Uncached input = `input_tokens - cache_read - cache_creation`. Never assume
+`input_tokens` is uncached.
+
+## 4. OpenAI reasoning tokens (o1, o3)
+
+**Where it bites:** `output_token_details.reasoning` is the internal reasoning
+trace for o1 and o3 — billed at the output rate but not visible in `content`.
+A call with `output_tokens=500` and `reasoning=2000` actually bills 2500
+output tokens. Dashboards that sum `output_tokens` only undercount o1/o3 spend
+by the reasoning multiple.
+
+**Fix:** Add reasoning to your output-billable total:
+
+```python
+def output_billable(m: AIMessage) -> int:
+    details = (m.usage_metadata or {}).get("output_token_details", {}) or {}
+    return (m.usage_metadata or {}).get("output_tokens", 0) + details.get("reasoning", 0)
+```
+
+## 5. Subgraph callbacks not propagating (P28, related)
+
+**Where it bites:** In LangGraph, if a callback handler is attached at the
+top-level chain only, subgraph invocations may not emit callbacks. The meter
+sees the outer call but not the inner one.
+
+**Fix:** Pass callbacks through `config={"callbacks": [meter], "run_name": ...}`
+on every invoke, not constructor-time. LangChain 1.0 propagates config through
+subgraphs when passed on invoke.
+
+## Reconciliation procedure
+
+Weekly — or after any instrumentation change — reconcile your meter against
+the provider console for a 24h window:
+
+1. **Pull the provider CSV.** Anthropic Console → Usage → Export.
+   OpenAI → Usage → Export to CSV.
+2. **Sum your meter totals** for the same window.
+3. **Compute delta.** `(your_total - provider_total) / provider_total`.
+4. **Expected delta:** Within ±1%. Provider rounding accounts for ~0.3%.
+5. **If delta > 5%:** Run the four checks above in order. Most often it is
+   retries (P25) or streaming (P01). If your meter is *above* provider by more
+   than 5%, check for double-attachment of callbacks on nested chains.
+
+Keep the last 8 weekly reconciliations in a JSONL log so you can see drift
+trending before it becomes a regression.
+
+## Canonical field access
+
+Use `AIMessage.usage_metadata`, not `response_metadata["token_usage"]`. The
+latter has provider-specific shape:
+
+- Anthropic: `response_metadata["usage"]["input_tokens"]`
+- OpenAI: `response_metadata["token_usage"]["prompt_tokens"]`
+- Gemini: `response_metadata["prompt_feedback"]["token_count"]`
+
+`usage_metadata` is provider-agnostic. Use it everywhere; your cost accounting
+survives provider switches.


### PR DESCRIPTION
## Summary

Handcrafted Pro-tier cost-discipline skill — streaming-accurate token accounting, model tiering, Anthropic cache aggregation, tool-aware cache keys, per-tenant Redis budgets. Anchored to pain-catalog **P01, P04, P10, P23, P25, P30, P31, P61, P62**.

## Pain hook

Opens on an engineer whose Anthropic bill grew 6x in a week while the dashboard showed only 2x — `max_retries=6` (P30) was billing 7 requests per flaky call while retry middleware double-emitted `on_llm_end` (P25), making the dashboard undercount ~50%. Skill converts that week of debugging into a runbook: `AIMessage.usage_metadata` + `astream_events(version="v2")` for streaming accuracy, `request_id` dedup for retries, per-1M pricing decision tree for tiering, `CacheLedger` for Anthropic cache aggregation (P04), tool-aware cache keys (P61), 0.85-0.90 semantic threshold calibration (P62), and Redis-backed per-tenant budget middleware with soft/hard caps.

## Files

- `skills/langchain-cost-tuning/SKILL.md` (375 lines)
- `skills/langchain-cost-tuning/references/one-pager.md`
- `skills/langchain-cost-tuning/references/token-accounting-pitfalls.md`
- `skills/langchain-cost-tuning/references/model-tiering.md`
- `skills/langchain-cost-tuning/references/per-tenant-budgets.md`
- `skills/langchain-cost-tuning/references/cache-economics.md`

## Validator

Grade **A (92/100)** at standard + enterprise, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude