### PR TITLE
feat(langchain-py-pack): add langchain-common-errors (S04)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: langchain-common-errors
+description: |
+  Paste-match catalog of 14 real LangChain 1.0 / LangGraph 1.0 exceptions with named
+  causes and named fixes, plus a triage decision tree. Use when you have a traceback
+  and want the specific fix, not speculative documentation. Covers ImportError (0.2/0.3 → 1.0
+  migration), AttributeError on AIMessage.content, KeyError in LCEL and prompts,
+  GraphRecursionError, silent thread_id memory loss, JSON-serialization crashes,
+  and graphs that halt without reaching END. Trigger with "langchain error",
+  "langgraph traceback", "OutputParserException", "GraphRecursionError",
+  "ImportError langchain", "AttributeError AIMessage content".
+allowed-tools: Read, Grep
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, errors, troubleshooting, debugging]
+compatible-with: claude-code, codex
+---
+
+# LangChain Common Errors (Python)
+
+## Overview
+
+The same twelve-plus LangChain 1.0 / LangGraph 1.0 tracebacks show up every week
+in production: `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'`,
+`AttributeError: 'list' object has no attribute 'lower'`, `GraphRecursionError:
+Recursion limit of 25 reached`, `TypeError: Object of type datetime is not JSON
+serializable`, `KeyError: 'question'` deep in LCEL internals. Stack traces are
+ambiguous, docs sprawl across 0.2 / 0.3 / 1.0 eras, and engineers lose
+30–90 minutes per incident re-deriving the fix.
+
+This skill is a **paste-match catalog** of 14 entries (E01–E14) grouped into
+3 reference files by category, plus a triage decision tree. Every entry opens
+with the **exact exception class and message string** you see in your terminal,
+names the cause in one sentence with a pain-catalog code, and gives a one-line
+fix or a reference-file pointer. Pinned to `langchain-core 1.0.x`,
+`langchain 1.0.x`, `langgraph 1.0.x`, verified 2026-04-21.
+
+Pain-catalog anchors: **P02, P06, P09, P10, P16, P17, P38, P39, P40, P41, P42, P55, P56, P57, P66**.
+
+## Prerequisites
+
+- Python 3.10+
+- A traceback or a reproducible bug — **this skill is diagnostic, not preventive**
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`, and any provider
+  integration packages pinned to `1.0.x`
+- `anthropic >= 0.42` when using `langchain-anthropic` 1.0 (see E06)
+
+## Instructions
+
+1. **Triage first.** Read the first line of the traceback. Look up the exception
+   class in the catalog below or in [Triage Decision Tree](references/errors/triage-decision-tree.md).
+2. **Match the message string**, not the call site. Each catalog entry opens with
+   the literal message pattern you see.
+3. **Apply the named fix.** If the entry points to a reference file, read that
+   file for the deep walk-through including codemods, before/after code, and
+   adjacent traps. Otherwise use the one-line fix here.
+4. **Verify with a test.** Every catalog entry names a test that will catch the
+   error in CI next time.
+5. **If no match:** check `docs/pain-catalog.md` for the exception class name or
+   a message substring. Do not add speculative fixes here without catalog evidence.
+
+## Catalog
+
+Each entry is indexed as **E## — ClassName: "message pattern"** with a one-line
+cause (pain-catalog code) and a one-line fix or reference pointer.
+
+### Category A — Import & migration errors (0.2 / 0.3 → 1.0)
+
+Full detail, before/after code, codemod commands: [import-migration.md](references/errors/import-migration.md).
+
+#### E01 — `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'`
+
+- **Cause:** Top-level `langchain.chat_models` / `langchain.llms` re-exports removed in 1.0 (P38).
+- **Fix:** `from langchain_openai import ChatOpenAI`. Run `python -m langchain_cli migrate` for automated rewrites. See E01 in [import-migration.md](references/errors/import-migration.md).
+
+#### E02 — `AttributeError: module 'langchain' has no attribute 'LLMChain'`
+
+- **Cause:** Legacy chain classes (`LLMChain`, `SequentialChain`, `TransformChain`) removed in 1.0 in favor of LCEL (P39).
+- **Fix:** `chain = prompt | llm | StrOutputParser()`; `.run(x)` becomes `.invoke({"input": x})`. See E02 in [import-migration.md](references/errors/import-migration.md).
+
+#### E03 — `ImportError: cannot import name 'ConversationBufferMemory'`
+
+- **Cause:** All legacy memory classes removed in 1.0; LangGraph checkpointing is the replacement (P40).
+- **Fix:** Use `InMemorySaver` / `PostgresSaver` + `thread_id` via LangGraph `create_react_agent`. See E03 in [import-migration.md](references/errors/import-migration.md).
+
+#### E04 — `ImportError: cannot import name 'initialize_agent'`
+
+- **Cause:** Legacy agent factories (`initialize_agent`, `AgentType`, `create_openai_functions_agent`) removed in 1.0 (P41).
+- **Fix:** `from langgraph.prebuilt import create_react_agent`; `create_react_agent(model=llm, tools=tools, checkpointer=InMemorySaver())`. See E04 in [import-migration.md](references/errors/import-migration.md).
+
+#### E05 — `AttributeError: 'AgentAction' object has no attribute 'tool_name'` (or inverse)
+
+- **Cause:** Legacy `AgentAction` / `AgentFinish` shape replaced by `ToolCall` objects; fields renamed `.tool` → `.tool_name`, `.tool_input` → `.args` (P42).
+- **Fix:** Access `tool_call["name"]` / `tool_call["args"]` on message `.tool_calls`, not `result["intermediate_steps"]`. See E05 in [import-migration.md](references/errors/import-migration.md).
+
+#### E06 — `KeyError: 'input'` inside tool_use block parsing
+
+- **Cause:** `langchain-anthropic >= 1.0` requires `anthropic >= 0.40`; SDK tool-use schema changed (P66).
+- **Fix:** `pip install "langchain-anthropic>=1.0,<2.0" "anthropic>=0.42,<1.0"` in the same commit. See E06 in [import-migration.md](references/errors/import-migration.md).
+
+### Category B — Content-shape & prompt-template errors
+
+Full detail, block-iterator extractor, jinja2 escape pattern: [content-shape.md](references/errors/content-shape.md).
+
+#### E07 — `AttributeError: 'list' object has no attribute 'lower'` (or `.strip`, `.split`, `.format`)
+
+- **Cause:** `AIMessage.content` is `list[dict]` on Claude with any non-text block and on OpenAI once tools are bound (P02).
+- **Fix:** Use `msg.text()` (LangChain 1.0+) or iterate and filter `block["type"] == "text"`. See E07 in [content-shape.md](references/errors/content-shape.md).
+
+#### E08 — `KeyError: '<var>'` inside `runnables/passthrough.py` or `runnables/base.py`
+
+- **Cause:** LCEL dict-shape mismatch between runnable stages; error surfaces at the consumer, not the producer (P06).
+- **Fix:** Insert `RunnableLambda` debug probes between stages and enable `set_debug(True)`. See E08 in [content-shape.md](references/errors/content-shape.md).
+
+#### E09 — `KeyError: '<var>'` inside `prompts/chat.py` or `prompts/prompt.py` on user input
+
+- **Cause:** `ChatPromptTemplate.from_messages` defaults to f-string parsing; user-provided `{` / `}` characters are parsed as template variables (P57).
+- **Fix:** Use `MessagesPlaceholder("history")` for variable content, or `template_format="jinja2"` for free-text templates, or escape literals as `{{` / `}}`. See E09 in [content-shape.md](references/errors/content-shape.md).
+
+### Category C — Agent & graph execution traps
+
+Full detail, diagnostic callbacks, thread_id middleware, router asserts: [graph-traps.md](references/errors/graph-traps.md).
+
+#### E10 — `GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition`
+
+- **Cause:** `create_react_agent` and `StateGraph.compile()` default `recursion_limit=25` counts supersteps, not loop iterations; vague prompts never converge (P10, P55).
+- **Fix:** Set `recursion_limit=10` for interactive use; add terminal edge on repeated tool-call names. See E10 in [graph-traps.md](references/errors/graph-traps.md).
+
+#### E11 — `AgentExecutor` returns `"I couldn't find the answer"` on every tool call, no exception
+
+- **Cause:** `handle_parsing_errors=True` catches tool exceptions and passes `str(exc)` (often empty) as observation; loop continues without signal (P09).
+- **Fix:** `return_intermediate_steps=True, handle_parsing_errors=False` or migrate to LangGraph `create_react_agent`. See E11 in [graph-traps.md](references/errors/graph-traps.md).
+
+#### E12 — Multi-turn chat forgets everything between calls, no exception
+
+- **Cause:** LangGraph checkpointers key state by `config["configurable"]["thread_id"]`; omitted `thread_id` means every invocation gets a fresh state with no warning (P16).
+- **Fix:** Require `thread_id` at app boundary; wrap in middleware that raises on missing key. See E12 in [graph-traps.md](references/errors/graph-traps.md).
+
+#### E13 — `TypeError: Object of type <datetime / bytes / Decimal / set> is not JSON serializable`
+
+- **Cause:** `InMemorySaver` / `PostgresSaver` / `SqliteSaver` serialize state as JSON on every superstep; non-primitives break at interrupt or checkpoint boundary (P17).
+- **Fix:** Keep state JSON-primitive only (str/int/float/bool/list/dict); serialize at node boundaries; or use `JsonPlusSerializer` for Pydantic v2. See E13 in [graph-traps.md](references/errors/graph-traps.md).
+
+#### E14 — Graph halts without reaching `END`, no exception, no log
+
+- **Cause:** `add_conditional_edges(node, router, path_map)` where router returns a string not in `path_map` causes silent termination on some 1.0 versions (P56).
+- **Fix:** `assert router_return in path_map`; always include `END` explicitly; inspect `graph.get_state(cfg).next`. See E14 in [graph-traps.md](references/errors/graph-traps.md).
+
+## Output
+
+- Named cause tied to a P## pain-catalog code for every traceback
+- Named fix (one-line or a reference-file walk-through) tied to E## catalog entry
+- A regression test pattern that catches the error in CI next time
+- Triage path recorded for the incident retro (which entry matched, how long it took)
+
+## Error Handling
+
+This skill **is** the error-handling reference for the pack. The triage workflow:
+
+1. **First line of traceback** → pick category in the table below.
+2. **Exception class + message substring** → pick E## entry above.
+3. **Reference file** → read the deep walk-through for before/after code and tests.
+
+| First-line pattern | Category | Entries | Reference |
+|---|---|---|---|
+| `ImportError` from `langchain.*` | A | E01, E03, E04 | import-migration.md |
+| `AttributeError` on `langchain.*` module | A | E02 | import-migration.md |
+| `AttributeError` on `AgentAction` / `ToolCall` | A | E05 | import-migration.md |
+| `ImportError` / `KeyError` against `langchain-anthropic` | A | E06 | import-migration.md |
+| `AttributeError` on `list.lower` / `.strip` | B | E07 | content-shape.md |
+| `KeyError` in `runnables/` | B | E08 | content-shape.md |
+| `KeyError` in `prompts/` | B | E09 | content-shape.md |
+| `GraphRecursionError` | C | E10 | graph-traps.md |
+| Silent wrong answers / empty tool errors | C | E11 | graph-traps.md |
+| Multi-turn memory loss, no exception | C | E12 | graph-traps.md |
+| `TypeError` ... `not JSON serializable` | C | E13 | graph-traps.md |
+| Graph halts without reaching `END` | C | E14 | graph-traps.md |
+
+For tracebacks that do not match: consult [triage-decision-tree.md](references/errors/triage-decision-tree.md)
+for the full routing flowchart, then `docs/pain-catalog.md` for any remaining
+pain codes. Escalate to the main thread before adding speculative fixes.
+
+## Examples
+
+### Example 1 — `ImportError` on a 0.3 → 1.0 upgrade
+
+Incoming traceback:
+
+```
+Traceback (most recent call last):
+  File "app.py", line 3, in <module>
+    from langchain.chat_models import ChatOpenAI
+ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'
+```
+
+Triage:
+
+1. First line is `ImportError` from `langchain.chat_models` → Category A.
+2. Matches **E01** exactly.
+3. Cause: top-level re-exports removed in 1.0 (P38).
+4. Fix: rewrite imports and bump provider packages.
+
+```bash
+pip install "langchain-openai>=1.0,<2.0" "langchain-anthropic>=1.0,<2.0" "langchain-cli>=0.1"
+python -m langchain_cli migrate src/
+```
+
+```python
+# Before
+from langchain.chat_models import ChatOpenAI
+
+# After
+from langchain_openai import ChatOpenAI
+```
+
+Re-run tests. Next failure is almost always **E07** (`AIMessage.content` shape)
+once the imports resolve — walk that one next from [content-shape.md](references/errors/content-shape.md).
+
+### Example 2 — `GraphRecursionError` triage
+
+Incoming traceback:
+
+```
+Traceback (most recent call last):
+  File "worker.py", line 88, in run
+    result = agent.invoke({"messages": [("user", q)]}, config=cfg)
+  ...
+langgraph.errors.GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition. You can increase the limit by setting the `recursion_limit` config key.
+```
+
+Triage:
+
+1. Exception class is `GraphRecursionError` → Category C.
+2. Matches **E10** exactly.
+3. Cause: vague prompt or tool loop; default `recursion_limit=25` (P10, P55).
+4. Before raising the limit, **diagnose first** — attach a `StepLogger` callback
+   (see [graph-traps.md](references/errors/graph-traps.md) § E10) and count
+   real steps. If the same two node names alternate, it is a convergence bug,
+   not a budget bug.
+
+Fix (budget only):
+
+```python
+cfg = {"configurable": {"thread_id": tid}, "recursion_limit": 10}
+agent.invoke(inp, config=cfg)
+```
+
+Fix (convergence + budget):
+
+```python
+def _should_stop(state):
+    recent = [m for m in state["messages"][-6:] if getattr(m, "tool_calls", None)]
+    if len(recent) >= 3 and all(
+        r.tool_calls[0]["name"] == recent[0].tool_calls[0]["name"] for r in recent
+    ):
+        return "end"
+    return "continue"
+
+graph.add_conditional_edges("agent", _should_stop, {"continue": "agent", "end": END})
+```
+
+Pair with a per-session token-budget middleware from `langchain-cost-tuning`.
+
+## Resources
+
+- Pack pain catalog: `docs/pain-catalog.md` — canonical entries for
+  P02, P06, P09, P10, P16, P17, P38, P39, P40, P41, P42, P55, P56, P57, P66
+- [Import & migration errors](references/errors/import-migration.md) — E01–E06
+- [Content-shape & prompt errors](references/errors/content-shape.md) — E07–E09
+- [Agent & graph execution traps](references/errors/graph-traps.md) — E10–E14
+- [Triage decision tree](references/errors/triage-decision-tree.md) — ASCII flowchart + quick-match table
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- [LangChain migration guide](https://python.langchain.com/docs/versions/migrating_chains/)
+- [LangGraph concepts](https://langchain-ai.github.io/langgraph/concepts/)
+- [`langchain-cli` migrate command](https://python.langchain.com/docs/versions/migrating/)
+- [`create_react_agent` reference](https://langchain-ai.github.io/langgraph/reference/prebuilt/)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/content-shape.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/content-shape.md
@@ -1,0 +1,195 @@
+# Content-Shape & Prompt-Template Errors
+
+Pain-catalog anchors: **P02, P06, P57**.
+
+These three errors share a root cause: LangChain 1.0 surfaces provider-native shapes (lists of blocks, typed tool calls) but legacy and user code still assumes string-ish payloads. Stack traces point at user code, not LangChain — which is why they are mis-diagnosed as "my code is wrong."
+
+Last verified against `langchain-core==1.0.0`, `langchain-anthropic==1.0.0`, `langchain-openai==1.0.0`.
+
+---
+
+## E07 — `AttributeError: 'list' object has no attribute 'lower'` (or `.strip()`, `.split()`, `.format()`)
+
+**Pain:** P02
+
+**Where you see it:** First production call against Claude after tests only exercised fake or OpenAI models. Also surfaces on OpenAI as soon as tools are bound.
+
+**Example traceback:**
+
+```
+Traceback (most recent call last):
+  File "app.py", line 42, in handle
+    text = response.content.lower()
+AttributeError: 'list' object has no attribute 'lower'
+```
+
+**Cause:** `AIMessage.content` is a `str` on simple OpenAI calls and a `list[dict | ContentBlock]` the instant any non-text block (`tool_use`, `thinking`, `image`, `document`, `tool_result`) enters the response. Claude responses are lists **whenever** `extended_thinking` is on or tools are bound. OpenAI becomes a list once tools are bound. Gemini is a list for anything multi-modal.
+
+**Fix — preferred (LangChain 1.0 helper):**
+
+```python
+text = msg.text()  # Concatenates all text blocks. Handles both shapes. Returns "" if no text.
+```
+
+**Fix — manual extractor (when you need to filter specific block types):**
+
+```python
+from langchain_core.messages import AIMessage
+
+def extract_text(msg: AIMessage) -> str:
+    if isinstance(msg.content, str):
+        return msg.content
+    parts = []
+    for block in msg.content:
+        # Block may be a dict (provider-native) or a typed object (1.0 wrapper)
+        btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+        if btype == "text":
+            parts.append(block["text"] if isinstance(block, dict) else block.text)
+    return "".join(parts)
+```
+
+**Adjacent traps:**
+
+- `msg.content[0]["text"]` crashes when block 0 is `thinking` or `tool_use`. Iterate and filter — never index.
+- Streaming deltas have the same shape — `chunk.content` is a `list[dict]` on Claude, so your token handler must filter too.
+- In a chain, `prompt | llm | StrOutputParser()` silently swallows non-text blocks. Use `| RunnableLambda(extract_text)` if you need to preserve them for observability.
+
+---
+
+## E08 — `KeyError: 'question'` (or `'input'`, `'context'`) inside LCEL runnable internals
+
+**Pain:** P06
+
+**Where you see it:** Immediately after wiring a new `.pipe()` chain, or after adding a step that changes the dict shape mid-chain.
+
+**Example traceback:**
+
+```
+Traceback (most recent call last):
+  File ".../runnables/passthrough.py", line 451, in assign
+    **step.invoke(input, config, **kwargs),
+KeyError: 'question'
+```
+
+The stack trace names the key but **not** the upstream step that was supposed to produce it.
+
+**Cause:** LCEL `RunnablePassthrough.assign()` and `{...}` dict compositions operate on dict inputs. If the upstream runnable returns a string, a list, or a dict with a different key, the error surfaces at the next `assign` or dict consumer — not where the shape was wrong.
+
+**Fix — add a debug probe between stages:**
+
+```python
+from langchain_core.runnables import RunnableLambda
+import logging
+
+log = logging.getLogger(__name__)
+
+def _probe(label):
+    def _inner(x):
+        log.warning("probe %s: type=%s keys=%s", label,
+                    type(x).__name__,
+                    list(x.keys()) if isinstance(x, dict) else "<not-dict>")
+        return x
+    return RunnableLambda(_inner).with_config({"run_name": f"probe::{label}"})
+
+chain = (
+    retriever
+    | _probe("post-retrieve")
+    | {"context": format_docs, "question": RunnablePassthrough()}
+    | _probe("pre-prompt")
+    | prompt
+    | llm
+    | StrOutputParser()
+)
+```
+
+**Fix — enable LangChain global debug:**
+
+```python
+from langchain.globals import set_debug
+set_debug(True)  # logs every intermediate value; very verbose, use locally
+```
+
+**Fix — type the chain:**
+
+```python
+from langchain_core.runnables import RunnableSerializable
+chain: RunnableSerializable[dict, str] = prompt | llm | StrOutputParser()
+```
+
+Typing does not catch shape mismatches at runtime, but it forces you to declare the expected input shape and surfaces it in review.
+
+---
+
+## E09 — `KeyError: 'username'` when calling `prompt.invoke()` on user-supplied text containing `{` / `}`
+
+**Pain:** P57
+
+**Where you see it:** User pastes a code snippet, JSON blob, or CSS selector into a chat input. The chain crashes instead of responding.
+
+**Example traceback:**
+
+```
+Traceback (most recent call last):
+  File ".../prompts/chat.py", line 384, in format
+    return self.prompt.format(**kwargs)
+KeyError: 'username'
+```
+
+…when the user's message contained `"CREATE TABLE users ({username VARCHAR})"`.
+
+**Cause:** `ChatPromptTemplate.from_messages([...])` defaults to f-string template parsing. User-provided text containing `{var}` markers is treated as a template variable and crashes the format call. Literal braces in Markdown, JSON, code, regexes, Jinja, and CSS all trigger this.
+
+**Fix — for variable content, use `MessagesPlaceholder`:**
+
+```python
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    MessagesPlaceholder("history"),       # chat history — safe, not f-string-parsed
+    ("human", "{question}"),               # bare template variable
+])
+
+prompt.invoke({"history": past_messages, "question": user_text})
+```
+
+`MessagesPlaceholder` inserts messages verbatim without f-string parsing. This is the right default for any variable-length or user-controlled content.
+
+**Fix — for truly free-text templates, use jinja2:**
+
+```python
+prompt = ChatPromptTemplate.from_messages(
+    [("human", "Summarize: {{ text }}")],
+    template_format="jinja2",
+)
+prompt.invoke({"text": "function foo() { return {a:1}; }"})  # literal braces are fine
+```
+
+**Fix — to preserve f-string syntax but allow literal braces, escape them:**
+
+```python
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "Return JSON like {{\"key\": \"value\"}}."),  # {{ and }} escape to { and }
+    ("human", "{question}"),
+])
+```
+
+This is the lowest-risk path for system messages that must contain literal braces (e.g., describing JSON output).
+
+**Testing:** Add a unit test that feeds the prompt a string with unbalanced `{`:
+
+```python
+def test_prompt_safe_on_braces():
+    prompt.invoke({"question": "SELECT * FROM t WHERE j = '{\"a\":1}'"})  # must not raise
+```
+
+Run it on every prompt revision. If it raises, your prompt is not safe for user input.
+
+## Sources
+
+- Pain catalog: `docs/pain-catalog.md` (P02, P06, P57, P58)
+- [`AIMessage` API](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.ai.AIMessage.html)
+- [Content blocks reference](https://python.langchain.com/docs/concepts/messages/#content-blocks)
+- [`ChatPromptTemplate` docs](https://python.langchain.com/docs/concepts/prompt_templates/)
+- [LCEL concepts](https://python.langchain.com/docs/concepts/lcel/)
+- [Debugging chains](https://python.langchain.com/docs/how_to/debugging/)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/graph-traps.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/graph-traps.md
@@ -1,0 +1,238 @@
+# Agent & LangGraph Execution Traps
+
+Pain-catalog anchors: **P09, P10, P16, P17, P55, P56**.
+
+Six errors that show up once you move beyond a single `llm.invoke(...)` into agent loops, multi-turn chat, and conditional graphs. The common thread: LangGraph silently does the wrong thing on missing config or mis-typed state, and you only discover it because answers look wrong, memory looks empty, or the loop never stops.
+
+Last verified against `langgraph==1.0.0`, `langchain-core==1.0.0`.
+
+---
+
+## E10 — `GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition.`
+
+**Pain:** P10, P55
+
+**Where you see it:** Vague agent prompt ("help me with my account"), or a graph with many parallel branches. Cost spike visible in your dashboard **before** the exception surfaces.
+
+**Cause:** `create_react_agent` and `StateGraph.compile()` default to `recursion_limit=25`. This counts *total supersteps*, **not loop iterations** — a complex conditional with many parallel branches can hit 25 without looping. Vague prompts never converge to a tool-stop condition. There is no default cost cap.
+
+**Diagnose first:**
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class StepLogger(BaseCallbackHandler):
+    def __init__(self):
+        self.step = 0
+    def on_chain_start(self, serialized, inputs, **kwargs):
+        self.step += 1
+        print(f"[step {self.step}] chain_start: {serialized.get('name')}")
+
+agent.invoke(inp, config={"configurable": {"thread_id": "debug"},
+                          "callbacks": [StepLogger()],
+                          "recursion_limit": 30})
+```
+
+Count the actual step count. If it is linear (5–10 steps), you probably need to raise the limit. If it is a loop (the same two node names alternate), you have a convergence bug.
+
+**Fix — cap and detect early:**
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(model=llm, tools=tools)
+
+# For interactive use: 5-10 is enough for good prompts; bigger is a bug.
+config = {"configurable": {"thread_id": tid}, "recursion_limit": 10}
+```
+
+**Fix — add a terminal edge on repeated tool calls:**
+
+```python
+def _should_stop(state):
+    recent = [m for m in state["messages"][-6:] if getattr(m, "tool_calls", None)]
+    if len(recent) >= 3 and all(
+        r.tool_calls[0]["name"] == recent[0].tool_calls[0]["name"] for r in recent
+    ):
+        return "end"  # same tool 3× in last 6 msgs → give up
+    return "continue"
+```
+
+Wire this into a conditional edge with `add_conditional_edges(node, _should_stop, {"continue": "agent", "end": END})`. Pair with a token-budget middleware that raises on per-session cost exceeded.
+
+---
+
+## E11 — `AgentExecutor` returns `"I couldn't find the answer"` on every tool call (no exception)
+
+**Pain:** P09
+
+**Where you see it:** Legacy code still using `AgentExecutor`. Tool raised an exception but the user-facing response is a generic apology. Nothing in logs.
+
+**Cause:** `AgentExecutor.invoke()` defaults `handle_parsing_errors=True` and catches **tool exceptions**, passing `str(exc)` as the next observation. If the exception serializes to an empty string (common for `HTTPError` with no body, or a `ValidationError` with no message), the loop continues without signal, runs out of iterations, and returns a generic failure.
+
+**Fix — inspect intermediate steps:**
+
+```python
+executor = AgentExecutor(
+    agent=agent,
+    tools=tools,
+    return_intermediate_steps=True,  # CRITICAL
+    handle_parsing_errors=False,     # re-raise so you see the real error
+)
+result = executor.invoke({"input": q})
+for step in result.get("intermediate_steps", []):
+    action, observation = step
+    print(action, "→", observation)
+```
+
+**Fix — migrate to LangGraph `create_react_agent`:**
+
+```python
+from langgraph.prebuilt import create_react_agent
+agent = create_react_agent(model=llm, tools=tools)
+# Raises tool exceptions by default. No silent swallowing.
+```
+
+LangGraph's `create_react_agent` uses provider-native tool calling (no free-text parsing) and does not catch tool exceptions silently. On a 0.3 → 1.0 migration this error usually vanishes by itself.
+
+---
+
+## E12 — Multi-turn chat forgets everything between calls, no exception
+
+**Pain:** P16
+
+**Where you see it:** Agent answers "what is my name?" correctly in turn 1, then forgets in turn 2. No traceback, no warning, no log.
+
+**Cause:** LangGraph checkpointers key state by `config["configurable"]["thread_id"]`. If you omit it, **every invocation gets a fresh state**. No warning. This is the #1 silent LangGraph bug.
+
+**Fix — require `thread_id` at your app boundary:**
+
+```python
+def invoke_agent(user_id: str, message: str):
+    cfg = {"configurable": {"thread_id": f"user:{user_id}"}}
+    return agent.invoke({"messages": [("user", message)]}, config=cfg)
+```
+
+**Fix — fail loud on missing `thread_id`:**
+
+```python
+from langchain_core.runnables import RunnableLambda
+
+def _assert_thread_id(state, config=None):
+    tid = (config or {}).get("configurable", {}).get("thread_id")
+    if not tid:
+        raise ValueError("thread_id is required on config['configurable']")
+    return state
+
+guarded = RunnableLambda(_assert_thread_id) | agent
+```
+
+Wire this as middleware (or the first node of your graph) so CI and staging catch the missing `thread_id` before production does.
+
+**Verify memory is working:**
+
+```python
+# Turn 1
+agent.invoke({"messages": [("user", "my name is Alex")]}, config=cfg)
+# Turn 2 — must remember "Alex"
+out = agent.invoke({"messages": [("user", "what is my name?")]}, config=cfg)
+assert "Alex" in out["messages"][-1].content
+```
+
+---
+
+## E13 — `TypeError: Object of type datetime is not JSON serializable` at `interrupt_before` / checkpoint save
+
+**Pain:** P17
+
+**Where you see it:** Graph runs fine until the first `interrupt_before=[node]` boundary or the first checkpoint save. Then crashes on state serialization.
+
+**Cause:** `InMemorySaver` / `PostgresSaver` / `SqliteSaver` serialize state as JSON on every superstep. Non-primitives — `datetime`, `bytes`, `Decimal`, `set`, custom classes, Pydantic models with non-primitive fields — break serialization. The error surfaces only at the serialization boundary (interrupt or checkpoint write), not when the offending value was added to state.
+
+**Fix — keep state JSON-primitive only:**
+
+```python
+from typing import Annotated, TypedDict
+from langgraph.graph.message import add_messages
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    created_at_iso: str          # NOT datetime
+    payload_b64: str             # NOT bytes
+    amount_cents: int            # NOT Decimal
+    tags: list[str]              # NOT set
+```
+
+Serialize at the boundary:
+
+```python
+from datetime import datetime, timezone
+
+def node_add_timestamp(state: State) -> State:
+    return {"created_at_iso": datetime.now(timezone.utc).isoformat()}
+```
+
+**Fix — for complex types, register a custom serde:**
+
+```python
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+saver = PostgresSaver(conn, serde=JsonPlusSerializer())  # handles Pydantic v2, datetime, Decimal
+```
+
+`JsonPlusSerializer` covers most common types but still rejects arbitrary classes. When in doubt: convert to primitives at the node boundary.
+
+**Test before prod:** Force a checkpoint save in CI with a representative state payload. `pickle` serialization "works locally" only because `InMemorySaver` in-process does not strictly enforce JSON-safety — but `PostgresSaver` does.
+
+---
+
+## E14 — Graph halts without reaching `END`; no exception, no log
+
+**Pain:** P56
+
+**Where you see it:** Graph invocation returns the input state unchanged, or a partial state. No error. `graph.get_state(cfg)` shows the graph as `done` but nodes you expected to run never executed.
+
+**Cause:** `add_conditional_edges(node, router, path_map)` where `router` returns a string **not** in `path_map` causes the graph to end without signal on some 1.0 versions. Typo in a router return value, a new condition added without updating `path_map`, or a default-case fall-through all trigger this.
+
+**Fix — always include a default route AND assert return value:**
+
+```python
+ROUTES = {"retrieve": "retrieve_node", "answer": "answer_node", "end": END}
+
+def router(state) -> str:
+    val = "end"
+    if not state.get("has_context"):
+        val = "retrieve"
+    elif state.get("needs_answer"):
+        val = "answer"
+    assert val in ROUTES, f"router returned {val!r}, not in {list(ROUTES)}"
+    return val
+
+graph.add_conditional_edges("planner", router, ROUTES)
+```
+
+**Fix — use `END` explicitly as a fallback, never omit it:**
+
+```python
+from langgraph.graph import END
+ROUTES = {"retrieve": "retrieve_node", END: END}  # always allow termination
+```
+
+**Debug:** Inspect the final state to confirm which nodes actually ran:
+
+```python
+state = graph.get_state(cfg)
+print("next:", state.next)          # what would run next
+print("checkpoint:", state.config)  # last checkpoint id
+print("values:", state.values)      # last seen state
+```
+
+If `state.next` is empty but the state does not look complete, a router sent the graph to nowhere.
+
+## Sources
+
+- Pain catalog: `docs/pain-catalog.md` (P09, P10, P16, P17, P55, P56)
+- [LangGraph concepts](https://langchain-ai.github.io/langgraph/concepts/)
+- [LangGraph persistence](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [`create_react_agent` reference](https://langchain-ai.github.io/langgraph/reference/prebuilt/)
+- [LangGraph state & reducers](https://langchain-ai.github.io/langgraph/concepts/low_level/#state)
+- [Recursion limit docs](https://langchain-ai.github.io/langgraph/concepts/low_level/#recursion-limit)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/import-migration.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/import-migration.md
@@ -1,0 +1,197 @@
+# Import & Migration Errors (0.2 / 0.3 → 1.0)
+
+Pain-catalog anchors: **P38, P39, P40, P41, P42, P66**.
+
+Every error below was raised by LangChain 0.2/0.3-era code running against pinned `langchain-core 1.0.x`. The top-level re-exports from the `langchain` meta-package were removed in 1.0. Provider integrations, agent factories, legacy chain classes, and `ConversationBufferMemory` now live in separate packages.
+
+Last verified against `langchain-core==1.0.0`, `langchain==1.0.0`, `langgraph==1.0.0`, `langchain-openai==1.0.0`, `langchain-anthropic==1.0.0`, `anthropic==0.42.0`.
+
+---
+
+## E01 — `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'`
+
+**Pain:** P38
+
+**Before:**
+
+```python
+from langchain.chat_models import ChatOpenAI  # 0.2 path
+from langchain.chat_models import ChatAnthropic  # 0.2 path
+```
+
+**Cause:** Provider integrations moved to `langchain-<provider>` packages in 0.3. The top-level re-exports from `langchain.chat_models` and `langchain.llms` were **removed** in 1.0.
+
+**After:**
+
+```python
+from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
+from langchain_google_genai import ChatGoogleGenerativeAI
+```
+
+**Codemod:** `python -m langchain_cli migrate path/to/src/` rewrites the imports. Run `pip install langchain-cli>=0.1` first. Re-run tests — imports will now succeed but you may hit E04 (`AIMessage.content` shape) and E05 (`list[Union]` structured output) next.
+
+**Install:** `pip install "langchain-openai>=1.0,<2.0" "langchain-anthropic>=1.0,<2.0" "langchain-google-genai>=1.0,<2.0"`.
+
+---
+
+## E02 — `AttributeError: module 'langchain' has no attribute 'LLMChain'`
+
+**Pain:** P39
+
+**Before:**
+
+```python
+from langchain.chains import LLMChain
+chain = LLMChain(llm=llm, prompt=prompt)
+result = chain.run({"input": text})
+```
+
+**Cause:** `LLMChain` (and `SimpleSequentialChain`, `SequentialChain`, `TransformChain`, etc.) were deprecated in 0.3 and **removed** in 1.0 in favor of LCEL composition. The 1.0 `langchain` package has no `chains` module.
+
+**After:**
+
+```python
+from langchain_core.output_parsers import StrOutputParser
+chain = prompt | llm | StrOutputParser()
+result = chain.invoke({"input": text})
+```
+
+**Notes:** If you need fallbacks, use `chain.with_fallbacks([backup])`. If you need retries, use `chain.with_retry(...)`. `.run(x)` became `.invoke({"input": x})`; single-positional-string input is gone.
+
+---
+
+## E03 — `ImportError: cannot import name 'ConversationBufferMemory'`
+
+**Pain:** P40
+
+**Before:**
+
+```python
+from langchain.memory import ConversationBufferMemory
+memory = ConversationBufferMemory(memory_key="history")
+```
+
+**Cause:** All `ConversationBufferMemory`, `ConversationSummaryMemory`, `ConversationTokenBufferMemory`, `VectorStoreRetrieverMemory` classes deprecated in 0.3, **removed** in 1.0. LangGraph checkpointing is the supported replacement for multi-turn chat memory.
+
+**After:**
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.prebuilt import create_react_agent
+
+checkpointer = InMemorySaver()  # or PostgresSaver / SqliteSaver
+agent = create_react_agent(model=llm, tools=tools, checkpointer=checkpointer)
+result = agent.invoke(
+    {"messages": [("user", "hi")]},
+    config={"configurable": {"thread_id": "user-42"}},
+)
+```
+
+**Notes:** `thread_id` is **required** — without it every invocation gets a fresh state (see E12). For process-restart persistence use `PostgresSaver` or `SqliteSaver`, not `InMemorySaver`.
+
+---
+
+## E04 — `ImportError: cannot import name 'initialize_agent'`
+
+**Pain:** P41
+
+**Before:**
+
+```python
+from langchain.agents import initialize_agent, AgentType
+agent = initialize_agent(
+    tools=tools,
+    llm=llm,
+    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+)
+```
+
+**Cause:** `initialize_agent`, `AgentType`, `create_openai_functions_agent`, `create_structured_chat_agent`, and most legacy agent factories are **removed** in 1.0. `AgentExecutor` is still importable but LangGraph's `create_react_agent` is the supported path for new code.
+
+**After:**
+
+```python
+from langgraph.prebuilt import create_react_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+agent = create_react_agent(
+    model=llm,
+    tools=tools,
+    checkpointer=InMemorySaver(),
+)
+```
+
+**Notes:** `create_react_agent` uses provider-native tool calling (no free-text ReAct parsing) and raises on tool errors by default, unlike legacy `AgentExecutor` which swallowed them as empty strings (E08). Default `recursion_limit=25` — see E13.
+
+---
+
+## E05 — `AttributeError: 'AgentAction' object has no attribute 'tool_name'` (or inverse `.tool`)
+
+**Pain:** P42
+
+**Before:**
+
+```python
+result = executor.invoke({"input": q})
+for action, observation in result["intermediate_steps"]:
+    print(action.tool, action.tool_input)  # 0.2 / 0.3 shape
+```
+
+**Cause:** Legacy `AgentAction` / `AgentFinish` tuple shape was replaced by `ToolCall` objects in 1.0. Fields renamed: `.tool` → `.tool_name`, `.tool_input` → `.args`, `.log` removed. LangGraph agents emit messages with `.tool_calls` instead of a separate `intermediate_steps` key.
+
+**After (LangGraph `create_react_agent`):**
+
+```python
+result = agent.invoke({"messages": [("user", q)]}, config=cfg)
+for msg in result["messages"]:
+    for tool_call in getattr(msg, "tool_calls", []) or []:
+        print(tool_call["name"], tool_call["args"])
+```
+
+**Notes:** When migrating, `grep -rn "intermediate_steps" src/` and `grep -rn "\.tool_input" src/` to find all call-sites. Both shapes compile, so type-checking will not catch this — only runtime AttributeError.
+
+---
+
+## E06 — `KeyError: 'input'` inside `tool_use` block parsing (after upgrading `langchain-anthropic`)
+
+**Pain:** P66
+
+**Before:** `langchain-anthropic==0.3.x` pinned alongside `langchain-anthropic==1.0`.
+
+**Cause:** `langchain-anthropic >= 1.0` **requires** `anthropic >= 0.40`. The Anthropic SDK's tool_use block schema changed; pinning to an old `anthropic` breaks `AIMessage.content` parsing for tool calls. Chat-only responses still work — tool calling is the first place it breaks.
+
+**After:**
+
+```bash
+pip install "langchain-anthropic>=1.0,<2.0" "anthropic>=0.42,<1.0"
+```
+
+Pin both in the same `pip install` or `pyproject.toml` bump — upgrading one without the other is the bug.
+
+**Notes:** Sanity-check with:
+
+```python
+import anthropic, langchain_anthropic
+print(anthropic.__version__, langchain_anthropic.__version__)
+# Must be anthropic >= 0.40 and langchain-anthropic >= 1.0
+```
+
+---
+
+## Codemod-driven migration checklist
+
+1. `pip install "langchain-cli>=0.1"` (dev dep).
+2. `python -m langchain_cli migrate .` — rewrites imports for E01.
+3. Manually handle E02/E03/E04 (the codemod does not rewrite `LLMChain`, memory, or agent construction).
+4. `grep -rn "intermediate_steps\|AgentAction\|AgentType\|initialize_agent\|LLMChain\|ConversationBuffer\|from langchain\.chat_models\|from langchain\.llms" src/` → every hit is a manual fix.
+5. Pin all three: `langchain-core`, `langchain`, `langgraph`, plus any provider packages, to the same 1.0.x major.
+6. `pytest -x` — expect E07-E14 from the other reference files next. That is normal on a 0.2/0.3 → 1.0 jump.
+
+## Sources
+
+- Pain catalog: `docs/pain-catalog.md` (P38, P39, P40, P41, P42, P66)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- [LangChain migration guide](https://python.langchain.com/docs/versions/migrating_chains/)
+- [`langchain-cli` migrate command](https://python.langchain.com/docs/versions/migrating/)
+- [LangGraph `create_react_agent`](https://langchain-ai.github.io/langgraph/reference/prebuilt/)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/triage-decision-tree.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/errors/triage-decision-tree.md
@@ -1,0 +1,140 @@
+# Triage Decision Tree
+
+Routing logic for LangChain 1.0 / LangGraph 1.0 tracebacks. Pipe your error in, walk the tree to the right reference file and entry code. Two minutes, no guessing.
+
+## ASCII flowchart
+
+```
+START: you have a traceback
+  │
+  ├── 1. Is the FIRST line of the traceback an ImportError or ModuleNotFoundError?
+  │   │
+  │   ├── "cannot import name 'ChatOpenAI' / 'ChatAnthropic' from 'langchain.chat_models'"
+  │   │     → errors/import-migration.md § E01 (P38)
+  │   │
+  │   ├── "cannot import name 'ConversationBufferMemory'"
+  │   │     → errors/import-migration.md § E03 (P40)
+  │   │
+  │   ├── "cannot import name 'initialize_agent'"
+  │   │     → errors/import-migration.md § E04 (P41)
+  │   │
+  │   ├── "No module named 'langchain_openai' / 'langchain_anthropic'"
+  │   │     → pip install "langchain-<provider>>=1.0,<2.0"
+  │   │
+  │   └── anything else starting with ImportError
+  │         → check package pins; `langchain-anthropic>=1.0` needs `anthropic>=0.40`
+  │           → errors/import-migration.md § E06 (P66)
+  │
+  ├── 2. Is it an AttributeError?
+  │   │
+  │   ├── "'list' object has no attribute 'lower' / 'strip' / 'split' / 'format'"
+  │   │     → errors/content-shape.md § E07 (P02)
+  │   │     FIX: use msg.text() or the block-iterator extractor
+  │   │
+  │   ├── "module 'langchain' has no attribute 'LLMChain'"
+  │   │     → errors/import-migration.md § E02 (P39)
+  │   │     FIX: prompt | llm | StrOutputParser()
+  │   │
+  │   ├── "'AgentAction' object has no attribute 'tool_name'" (or inverse)
+  │   │     → errors/import-migration.md § E05 (P42)
+  │   │     FIX: use .tool_name on new, .tool on old; migrate to LangGraph
+  │   │
+  │   └── anything else — likely shape drift between LangChain versions
+  │         → grep the attribute name in the `langchain-core` source
+  │
+  ├── 3. Is it a KeyError?
+  │   │
+  │   ├── Stack trace passes through runnables/passthrough.py or runnables/base.py
+  │   │     → errors/content-shape.md § E08 (P06)
+  │   │     FIX: add RunnableLambda debug probes; set_debug(True)
+  │   │
+  │   ├── Stack trace passes through prompts/chat.py or prompts/prompt.py
+  │   │     → errors/content-shape.md § E09 (P57)
+  │   │     FIX: MessagesPlaceholder or template_format="jinja2"
+  │   │
+  │   ├── KeyError: 'input' or 'content' inside tool_use block parsing (anthropic)
+  │   │     → errors/import-migration.md § E06 (P66)
+  │   │     FIX: bump anthropic to >=0.40 alongside langchain-anthropic>=1.0
+  │   │
+  │   └── anything else — inspect dict shape at each runnable stage
+  │
+  ├── 4. Is it a GraphRecursionError?
+  │   │
+  │   └── "Recursion limit of N reached without hitting a stop condition"
+  │         → errors/graph-traps.md § E10 (P10, P55)
+  │         FIX: recursion_limit=10, terminal edge on repeated tool calls
+  │
+  ├── 5. Is it a TypeError?
+  │   │
+  │   ├── "Object of type datetime / bytes / Decimal / set is not JSON serializable"
+  │   │     → errors/graph-traps.md § E13 (P17)
+  │   │     FIX: primitives-only state; JsonPlusSerializer for Pydantic
+  │   │
+  │   └── anything else involving async / coroutine
+  │         → likely sync invoke() inside async endpoint — use ainvoke()
+  │
+  ├── 6. No exception, but behavior is wrong?
+  │   │
+  │   ├── Agent forgets conversation between turns
+  │   │     → errors/graph-traps.md § E12 (P16)
+  │   │     FIX: require thread_id on every invocation
+  │   │
+  │   ├── Graph returns input unchanged, no nodes executed
+  │   │     → errors/graph-traps.md § E14 (P56)
+  │   │     FIX: assert router return is in path_map; include END explicitly
+  │   │
+  │   ├── Agent returns "I couldn't find the answer" on every call
+  │   │     → errors/graph-traps.md § E11 (P09)
+  │   │     FIX: return_intermediate_steps=True, handle_parsing_errors=False
+  │   │         or migrate to LangGraph create_react_agent
+  │   │
+  │   └── Token counts are zero during streaming
+  │         → use astream_events(version="v2") and read on_chat_model_stream
+  │
+  └── 7. Exception class not listed above?
+        │
+        ├── anthropic.BadRequestError / openai.BadRequestError
+        │     → check tool_choice / schema shape against provider docs
+        │
+        ├── pydantic.ValidationError
+        │     → model added extra fields (P53) — set ConfigDict(extra="ignore")
+        │     → or method="function_calling" dropped Optional[list[X]] (P03)
+        │
+        └── Other
+              → search docs/pain-catalog.md for the class name or message substring
+```
+
+## Quick-match table
+
+| First-line pattern of traceback | Entry | Reference |
+|---|---|---|
+| `ImportError: cannot import name 'ChatOpenAI'` | E01 | import-migration.md |
+| `AttributeError: module 'langchain' has no attribute 'LLMChain'` | E02 | import-migration.md |
+| `ImportError: cannot import name 'ConversationBufferMemory'` | E03 | import-migration.md |
+| `ImportError: cannot import name 'initialize_agent'` | E04 | import-migration.md |
+| `AttributeError: '<Agent...>' object has no attribute 'tool_name'` | E05 | import-migration.md |
+| `KeyError: 'input'` in tool_use block | E06 | import-migration.md |
+| `AttributeError: 'list' object has no attribute 'lower'` | E07 | content-shape.md |
+| `KeyError: '<var>'` in runnables/ | E08 | content-shape.md |
+| `KeyError: '<var>'` in prompts/ | E09 | content-shape.md |
+| `GraphRecursionError: Recursion limit of <N>` | E10 | graph-traps.md |
+| `AgentExecutor` returns "I couldn't find the answer" | E11 | graph-traps.md |
+| Multi-turn agent forgets context | E12 | graph-traps.md |
+| `TypeError: Object of type <...> is not JSON serializable` | E13 | graph-traps.md |
+| Graph halts without reaching `END` | E14 | graph-traps.md |
+
+## When the tree does not match
+
+1. Check `docs/pain-catalog.md` for the exception class name or a substring of the message.
+2. Search LangChain 1.0 / LangGraph 1.0 source on GitHub for the exact message literal:
+   - `langchain-ai/langchain` for core / prompts / runnables
+   - `langchain-ai/langgraph` for state / checkpointers / agents
+3. If the error only reproduces against a specific provider, check the provider integration package (`langchain-anthropic`, `langchain-openai`, etc.) release notes.
+4. Escalate to the main thread and file a pain-catalog extension request — do not silently add speculative fixes to this skill.
+
+## Sources
+
+- Pain catalog: `docs/pain-catalog.md`
+- [LangChain source](https://github.com/langchain-ai/langchain)
+- [LangGraph source](https://github.com/langchain-ai/langgraph)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-common-errors — One-Pager
+
+Paste-match catalog of real LangChain 1.0 / LangGraph 1.0 tracebacks — find the named cause and the named fix before you speculate.
+
+## The Problem
+
+Twelve-plus LangChain 1.0 and LangGraph 1.0 exceptions show up every week in production: `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'`, `AttributeError: 'list' object has no attribute 'lower'`, `GraphRecursionError: Recursion limit of 25 reached`, `TypeError: Object of type datetime is not JSON serializable`, `KeyError: 'question'` deep in LCEL internals, and more. Stack traces are ambiguous, docs sprawl across 0.2/0.3/1.0 eras, and engineers lose 30–90 minutes per incident re-deriving the fix each time.
+
+## The Solution
+
+This skill is a consolidated index of 14 LangChain 1.0 / LangGraph 1.0 errors grouped into 5 categories (imports, content-shape, chains, agents, graphs), with a triage decision tree that routes any paste-in traceback to the right reference file. Each catalog entry opens with the exact error message string, names the cause in one sentence with a pain-catalog code (P02, P06, P09, P10, P16, P17, P38, P39, P40, P41, P42, P55, P56, P57, P66), and gives a one-line fix plus a reference-file pointer for the deep walk-through.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Any Python engineer holding a LangChain 1.0 or LangGraph 1.0 traceback and looking for a named fix — not more speculative documentation |
+| **What** | 14-entry paste-match catalog, triage decision tree, 4 deep reference files (import-migration, content-shape, graph-traps, triage-decision-tree), and 2 worked walk-throughs (0.2 → 1.0 import migration and `GraphRecursionError` triage) |
+| **When** | During incident response, on a 0.3 → 1.0 upgrade when tests explode, or any time a stack trace mentions `langchain_`, `langgraph`, `OutputParserException`, `GraphRecursionError`, `AIMessage`, or `ChatPromptTemplate` |
+
+## Key Features
+
+1. **Exact-match catalog** — Every entry opens with the literal exception class and message string you see in your terminal, so Ctrl-F on the traceback lands on the fix in under 10 seconds
+2. **Triage decision tree** — Routes any traceback by first line (`ImportError` → import-migration, `AttributeError` on `.content` → content-shape, `GraphRecursionError` → graph-traps) so you never read the whole catalog
+3. **Pain-catalog anchored** — Every error cites a P## code from `docs/pain-catalog.md`, verifiable against LangChain 1.0.x and LangGraph 1.0.x pinned versions (2026-04-21)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.


### PR DESCRIPTION
## Summary

Handcrafted paste-match error catalog for LangChain 1.0 / LangGraph 1.0 — 14 named errors across 4 categories (import migration, content shape, chain composition, graph traps) with causes, fixes, and triage tree. Anchored to **P02, P06, P09, P10, P16, P17, P38, P39, P40, P41, P42, P55, P56, P57, P66**.

## Pain hook

Twelve-plus LangChain 1.0 / LangGraph 1.0 tracebacks repeat every week (`ImportError`, `AttributeError` on `AIMessage.content`, `GraphRecursionError`, silent `thread_id` memory loss) and engineers lose 30-90 minutes per incident re-deriving the fix. This skill is a paste-match catalog: Ctrl-F the traceback, land on the named cause (pain-catalog P##) and named fix in under 10 seconds. Body is a pure index; deep walk-throughs live in four references.

## Files

- `skills/langchain-common-errors/SKILL.md` (277 lines — well under 400-line target)
- `skills/langchain-common-errors/references/one-pager.md`
- `skills/langchain-common-errors/references/errors/import-migration.md`
- `skills/langchain-common-errors/references/errors/content-shape.md`
- `skills/langchain-common-errors/references/errors/graph-traps.md`
- `skills/langchain-common-errors/references/errors/triage-decision-tree.md`

## Validator

Grade **A (90/100)** at standard + enterprise, zero ERROR lines. (First attempt hit the 500-line cap; retry kept body as index-only with full detail in references.)

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude