### PR TITLE
feat(langchain-py-pack): add langchain-otel-observability (L33)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: langchain-otel-observability
+description: |
+  Wire LangChain 1.0 / LangGraph 1.0 traces into an OpenTelemetry-native backend
+  (Jaeger, Honeycomb, Grafana Tempo, Datadog) with LLM-specific SLOs, safe
+  prompt-content policy, and subgraph-aware span propagation. Use when LangSmith
+  is not the right fit (existing OTEL stack, compliance, multi-cloud) or
+  alongside LangSmith for deep-system traces.
+  Trigger with "langchain OTEL", "langchain opentelemetry", "langchain jaeger",
+  "langchain honeycomb", "langchain SLO", "LLM span", "langchain tempo",
+  "langchain datadog tracing".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, observability, opentelemetry, jaeger, honeycomb]
+compatible-with: claude-code, codex
+---
+
+# LangChain OTEL Observability (Python)
+
+## Overview
+
+An engineer wires OpenTelemetry expecting to see prompts and responses in
+Honeycomb. The traces land — but only timing, model name, and token counts
+appear. The prompt body is blank. This is **not** a bug: it's the OTEL GenAI
+semantic-conventions privacy-safe default (P27), where
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is off. The instinct is to
+flip it on and move on. On a multi-tenant workload that flip is a leak — the
+next engineer to search traces for Tenant A sees Tenant B's PII in the results,
+because redaction was supposed to happen upstream and never did.
+
+A second trap lives inside LangGraph. A `BaseCallbackHandler` attached to the
+parent runnable never fires on inner agent tool calls, because LangGraph
+creates a child runtime per subgraph and callbacks do not inherit (P28). Spans
+inside subgraphs appear orphaned in the waterfall — or they do not appear at
+all — and SLO dashboards under-count latency on the exact calls that matter
+most: the nested agent loops.
+
+This skill wires LangChain 1.0 / LangGraph 1.0 into an OTEL-native backend
+(Jaeger, Honeycomb, Grafana Tempo, Datadog) with a correct content-capture
+policy, subgraph-aware span propagation, and five LLM-specific SLOs (p95 / p99
+latency, error rate, cost-per-request, TTFT) with burn-rate alerts. Pin:
+`langchain-core 1.0.x`, `langgraph 1.0.x`,
+`opentelemetry-instrumentation-langchain >= 0.33`, OTEL GenAI semconv as of
+2026-04. Pain-catalog anchors: P27, P28 (and cross-references P04, P34, P37).
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- An OTEL-native backend picked: Jaeger (dev), Honeycomb / Tempo / Datadog (prod)
+- For multi-tenant: upstream redaction middleware already in place (see
+  `langchain-security-basics` and `langchain-middleware-patterns`)
+- Access to set env vars at deploy time (`OTLP_ENDPOINT`, API keys)
+
+## Instructions
+
+### Step 1 — Install the SDK and instrumentor, configure the exporter
+
+```bash
+pip install \
+  opentelemetry-api \
+  opentelemetry-sdk \
+  opentelemetry-exporter-otlp-proto-http \
+  "opentelemetry-instrumentation-langchain>=0.33"
+```
+
+```python
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+
+resource = Resource.create({
+    "service.name": "my-langchain-app",
+    "service.version": "1.0.0",
+    "deployment.environment": os.getenv("ENV", "dev"),
+})
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(BatchSpanProcessor(
+    OTLPSpanExporter(
+        endpoint=os.environ["OTLP_ENDPOINT"],       # per-backend; see matrix
+        headers=_parse_headers(os.getenv("OTLP_HEADERS", "")),
+    ),
+    max_queue_size=2048,        # spans buffered before drop; raise for high volume
+    max_export_batch_size=512,  # batched export keeps per-span overhead under 1ms
+))
+trace.set_tracer_provider(provider)
+
+LangchainInstrumentor().instrument()   # emits gen_ai.* attrs on every run
+```
+
+`BatchSpanProcessor` keeps per-span overhead well under 1 ms. Use
+`SimpleSpanProcessor` only in local dev — it blocks the call path per span.
+
+Per-backend `OTLP_ENDPOINT` and header config lives in
+[Backend Setup Matrix](references/backend-setup-matrix.md) — Jaeger,
+Honeycomb, Grafana Tempo, Datadog.
+
+### Step 2 — Verify the GenAI attribute schema
+
+Trigger one call and inspect what landed in the backend. LangChain 1.0 emits
+these `gen_ai.*` attributes natively on every chat-model span:
+
+| Attribute | Example |
+|-----------|---------|
+| `gen_ai.system` | `anthropic` |
+| `gen_ai.request.model` | `claude-sonnet-4-6` |
+| `gen_ai.request.temperature` | `0.0` |
+| `gen_ai.usage.input_tokens` | `1234` |
+| `gen_ai.usage.output_tokens` | `567` |
+| `gen_ai.response.finish_reasons` | `["stop"]` |
+
+Missing anything? Likely a stale instrumentor version or an outdated provider
+package. The full emitted-vs-custom matrix plus LangGraph's span taxonomy
+(`LangGraph.invoke` → `LangGraph.node.*` → `LangGraph.subgraph.*`) is in
+[GenAI Semantic Conventions](references/genai-semantic-conventions.md).
+
+### Step 3 — Decide on prompt-content capture (critical — do not skip)
+
+The engineer's instinct is to flip the capture flag to see prompts. Before
+flipping it, classify the workload into one of these buckets:
+
+| Workload | Flag | Notes |
+|----------|------|-------|
+| Dev / staging with synthetic inputs | `true` | Fine. Do not copy these traces to prod. |
+| Single-tenant internal tool | `true` | Fine if RBAC on backend is tight. |
+| Single-tenant product, signed compliance artifacts | `true` | BAA / DPIA in place; retention policy matches log retention. |
+| Multi-tenant SaaS, **no upstream redaction** | **`false`** | Hard no. Fix redaction first. |
+| Multi-tenant SaaS, **with upstream redaction** | `true` | Safe — the span sees the already-redacted text. |
+| Healthcare / finance / legal without legal sign-off | **`false`** | Hard no. |
+
+```bash
+# trusted single-tenant ONLY
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+export TRACELOOP_TRACE_CONTENT=true   # OpenLLMetry alias; set both to be safe
+```
+
+Leave unset (default) anywhere else. To capture bodies in a multi-tenant
+system, wire redaction middleware upstream of the model call first — see
+[Prompt Content Policy](references/prompt-content-policy.md) and cross-reference
+pack siblings `langchain-security-basics` (PII redaction middleware pattern,
+P34) and `langchain-middleware-patterns` (middleware order: redact → cache →
+model, P24). **Failure pattern P27** — prompts missing from traces because
+capture was never opted in — is the #1 first-day OTEL complaint; make the
+decision explicit instead of surprise-flipping the flag in prod.
+
+### Step 4 — Propagate callbacks through subgraphs (P28)
+
+LangGraph creates a child runtime per subgraph. Callbacks bound at the parent
+definition time do **not** inherit:
+
+```python
+# WRONG — subagent spans orphaned or missing (P28)
+agent = create_react_agent(model=llm, tools=tools).with_config(
+    callbacks=[my_handler]  # bound at definition time; children do not see it
+)
+agent.invoke({"messages": [...]})
+
+# RIGHT — pass callbacks at invocation via config; they propagate down
+agent.invoke(
+    {"messages": [...]},
+    config={"callbacks": [my_handler]}  # invocation-time; inherited by children
+)
+```
+
+The same rule applies to custom attribute handlers (e.g. the
+`CostAttributeHandler` in the semantic-conventions reference that stamps
+`gen_ai.usage.cost_usd` on each model span). Attach via
+`config["callbacks"]`, never via `.with_config()`. **Failure pattern P28
+symptom:** SLO dashboards show low latency because the slow nested spans are
+missing entirely, not because the nested calls are fast.
+
+### Step 5 — Define LLM SLOs and dashboards
+
+Five SLIs matter from day one. All five derive from `gen_ai.*` span attributes
+— no second pipeline required:
+
+| SLI | Target example | Why |
+|-----|----------------|-----|
+| **p95 latency** (top-level chat) | `< 5 s` for chat UI | Provider variance dominates |
+| **p99 latency** | `< 15 s` | Tail matters on chat; agents with tools live here |
+| **Error rate** | `< 0.5%` | Includes 429s + `finish_reason IN ("length","content_filter")` |
+| **Cost per request** (p95) | `< $0.05` | Catches `haiku`→`opus` regressions |
+| **TTFT p95** (streaming) | `< 2 s` | Perceived latency, not total duration |
+
+Concrete Honeycomb / PromQL / Datadog queries for each SLI, plus multi-window
+multi-burn-rate alerts (14.4× / 1h fast burn, 6× / 6h slow burn), are in
+[LLM SLO Dashboards](references/llm-slo-dashboards.md).
+
+### Step 6 — Tune sampling
+
+Defaults are wrong for two ends of the volume spectrum:
+
+```python
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+# Low/medium volume — keep everything for debuggability
+# (< ~100 req/s) — SDK default 100% is fine
+
+# High volume — head-sample, but carve out errors + slow spans via tail sampling
+# at the OTEL Collector (see references/llm-slo-dashboards.md)
+provider = TracerProvider(
+    resource=resource,
+    sampler=TraceIdRatioBased(0.10),  # 10% head sample
+)
+```
+
+**Watch out:** head sampling at 10% means 90% of p99 outliers are discarded
+before they reach the backend — p99 metrics become noisy and biased toward
+the median. For tail-latency SLOs, move sampling to a Collector with
+`tailsamplingprocessor` so errors and slow spans (`latency > 5000ms`) are
+always kept while the rest is probabilistically sampled at 10%. Typical trace
+overhead with `BatchSpanProcessor` at the 512-span batch size: **under 1 ms
+per span**; recommended sampling rate for high-volume production is **1-10%**.
+
+## Output
+
+- OTEL exporter wired to a chosen backend (Jaeger / Honeycomb / Tempo / Datadog)
+- `opentelemetry-instrumentation-langchain` emitting `gen_ai.*` attrs on every
+  LangChain and LangGraph span
+- Explicit prompt-content capture decision recorded against a workload bucket,
+  with the multi-tenant guardrail enforced upstream
+- Callbacks propagated via `config["callbacks"]` at invocation time so
+  subgraph spans nest correctly under their parent node
+- Five LLM SLOs (p95 / p99 latency, error rate, cost-per-request, TTFT) with
+  dashboards and MWMBR burn-rate alerts
+- Sampling strategy matched to workload volume and SLO precision needs
+
+## Error Handling
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Traces land but prompt and completion bodies are empty | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` unset (P27 — privacy-safe default) | Set to `true` **only** for the workload buckets in Step 3; for multi-tenant, wire upstream redaction first |
+| Subgraph / tool-call spans orphaned or missing | Callbacks bound via `.with_config()` at definition time (P28) | Pass via `config["callbacks"]` at invocation time so children inherit |
+| `gen_ai.usage.cache_read_input_tokens` resets every call | Per-call usage, aggregation is your job (P04) | Custom callback summing across calls keyed by `session.id`; see `langchain-model-inference` |
+| p99 dashboard looks noisy and median-biased | 10% head sampling drops outliers before backend | Move to Collector `tailsamplingprocessor` — always keep errors and `latency > 5000ms` |
+| Traces never appear | `OTLPSpanExporter` endpoint wrong protocol (gRPC on 4317 vs HTTP on 4318) | Verify with `curl -v $OTLP_ENDPOINT`; swap to the `proto-grpc` exporter package if your backend expects gRPC |
+| Cost attribute missing from spans | LangChain 1.0 does not emit `gen_ai.usage.cost_usd` natively | Add a `BaseCallbackHandler` that computes from tokens × pricing; see semantic-conventions reference |
+| PR review flags `sk-...` in trace attributes | Secrets in prompts captured via `gen_ai.prompt.content` (P37-adjacent) | Upstream redactor must strip API-key patterns before model call; audit via 0.1% sampler |
+| Exporter dropping spans silently | Queue overflow at high volume | Increase `max_queue_size` to 4096+; add Collector between SDK and backend |
+
+## Examples
+
+### Running Jaeger locally for dev-loop tracing
+
+Spin up Jaeger in Docker, point the SDK at `http://localhost:4318/v1/traces`,
+leave content capture on (it's dev, inputs are synthetic). You get a generic
+span waterfall — no LLM-specific UX, but good for verifying the instrumentor
+emits what you expect before paying for a SaaS backend.
+
+See [Backend Setup Matrix](references/backend-setup-matrix.md) for the
+`docker run` command and SDK config.
+
+### Investigating an agent latency incident in Honeycomb
+
+Honeycomb's BubbleUp over `gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+and tool call count is the fastest path from "p95 spiked at 14:00" to "one
+specific tool took 20 s because the vectorstore was slow." Requires
+content-capture-off by default so you can turn the team loose on search
+without PII-leak worries.
+
+See [LLM SLO Dashboards](references/llm-slo-dashboards.md) for the exact
+Honeycomb query shape.
+
+### Dual-exporting during a LangSmith → Tempo migration
+
+Register two `BatchSpanProcessor`s — one to LangSmith's OTLP endpoint, one to
+Tempo. Run both for two weeks, compare waterfalls, cut over. LangSmith handles
+LLM-specific analytics; Tempo handles unified trace search across LLM and
+non-LLM services in your Grafana stack.
+
+See [Backend Setup Matrix](references/backend-setup-matrix.md) dual-export
+section.
+
+## Resources
+
+- [OTEL GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OTEL Python SDK](https://opentelemetry.io/docs/languages/python/)
+- [OpenLLMetry LangChain instrumentation](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-langchain)
+- [Honeycomb OTLP ingest](https://docs.honeycomb.io/getting-data-in/otlp/)
+- [Grafana Tempo](https://grafana.com/docs/tempo/latest/)
+- [Datadog OTLP](https://docs.datadoghq.com/opentelemetry/)
+- [Google SRE — Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/)
+- Pack cross-references: `langchain-security-basics` (redaction, P34),
+  `langchain-middleware-patterns` (order: redact → cache → model, P24),
+  `langchain-model-inference` (cost callback pattern, P04)
+- Pack pain catalog: `docs/pain-catalog.md` — P27 (content-capture default),
+  P28 (subgraph callback propagation), P04 (cache token aggregation),
+  P34 (prompt injection), P37 (secrets in env / prompts)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/backend-setup-matrix.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/backend-setup-matrix.md
@@ -1,0 +1,184 @@
+# OTEL Backend Setup Matrix
+
+Four OTEL-native backends where LangChain 1.0 traces can land. Pick one; you can
+dual-export during migration. All four speak OTLP (gRPC on 4317, HTTP on 4318),
+so the exporter config is a URL swap — the rest of the skill applies unchanged.
+
+## Comparison matrix
+
+| Backend | Hosting | Cost | LLM-specific UX | Sampling default | Best for |
+|---------|---------|------|-----------------|------------------|----------|
+| **Jaeger** | Self-hosted (Docker, Helm) | Free (infra only) | None — generic span viewer | 100% (configure at SDK) | Dev/staging, on-prem compliance, teams with existing Jaeger |
+| **Honeycomb** | SaaS | Free tier 20M events/mo; paid from $130/mo | BubbleUp over `gen_ai.*` attrs; heatmaps of latency per model | Dynamic (head + tail) | Teams wanting fast LLM-specific slicing without building dashboards |
+| **Grafana Tempo** | Self-hosted or Grafana Cloud | Tempo free self-hosted; Cloud free tier 50GB | Pairs with Prometheus for cost metrics; TraceQL queries | 10-100% (SDK + collector) | Teams already on Grafana stack wanting unified logs/metrics/traces |
+| **Datadog** | SaaS | ~$31/host/mo APM + LLM Observability add-on (priced per trace) | Native LLM Observability product with token cost, eval scores | 100% (Datadog-side tail) | Enterprise teams standardized on Datadog APM |
+
+## Shared: install the OTEL Python SDK
+
+```bash
+pip install \
+  opentelemetry-api \
+  opentelemetry-sdk \
+  opentelemetry-exporter-otlp-proto-http \
+  opentelemetry-instrumentation-langchain
+```
+
+`opentelemetry-instrumentation-langchain` (from the OpenLLMetry project by
+Traceloop) emits OTEL GenAI semantic conventions automatically on every
+LangChain / LangGraph invocation. LangChain-core has a built-in OTEL emitter
+too; the Traceloop package is currently the richer path and is what the rest
+of this skill assumes. Pin `opentelemetry-instrumentation-langchain >= 0.33`.
+
+## Shared: base SDK setup
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+
+resource = Resource.create({
+    "service.name": "my-langchain-app",
+    "service.version": "1.0.0",
+    "deployment.environment": "prod",
+})
+
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(BatchSpanProcessor(
+    OTLPSpanExporter(endpoint=OTLP_ENDPOINT, headers=OTLP_HEADERS),
+    max_queue_size=2048,
+    max_export_batch_size=512,
+))
+trace.set_tracer_provider(provider)
+
+LangchainInstrumentor().instrument()
+```
+
+`BatchSpanProcessor` adds well under 1ms per span at the default batch size.
+Use `SimpleSpanProcessor` only in dev — it blocks the event loop per span.
+
+---
+
+## Jaeger (self-hosted)
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 -p 4318:4318 \
+  jaegertracing/all-in-one:1.62
+```
+
+```python
+OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
+OTLP_HEADERS = {}
+```
+
+UI at `http://localhost:16686`. No LLM-specific view — you get a generic span
+waterfall. Query by service name and filter tags like `gen_ai.system=anthropic`.
+Free and easy for local dev; for production deploy via the `jaegertracing/jaeger`
+Helm chart with Cassandra or Elasticsearch backing storage.
+
+**Sampling:** Jaeger honors the SDK sampler. For high-volume prod (>100 req/s),
+set the SDK to `TraceIdRatioBased(0.1)` (10%) to keep storage manageable. See
+[LLM SLO Dashboards](llm-slo-dashboards.md) for why head sampling is risky for
+tail-latency SLOs and how to compensate.
+
+---
+
+## Honeycomb (SaaS)
+
+```python
+import os
+OTLP_ENDPOINT = "https://api.honeycomb.io/v1/traces"
+OTLP_HEADERS = {
+    "x-honeycomb-team": os.environ["HONEYCOMB_API_KEY"],
+    "x-honeycomb-dataset": "langchain-prod",
+}
+```
+
+Honeycomb's **BubbleUp** over `gen_ai.*` attributes is the killer feature: you
+select a slow outlier and Honeycomb surfaces which model, which prompt length,
+which tool count correlates with slowness — in seconds, no pre-built dashboard
+needed. Free tier is 20M events/month; a busy chat app at ~200k req/day and
+15 spans/req uses ~90M/month, so budget accordingly.
+
+**Sampling:** Honeycomb has native dynamic sampling (head + tail). Use
+`opentelemetry-exporter-otlp` with 100% SDK sampling and configure dynamic
+sampling server-side via Refinery if volume requires it.
+
+---
+
+## Grafana Tempo (self-hosted / Grafana Cloud)
+
+```python
+# Grafana Cloud
+OTLP_ENDPOINT = "https://tempo-prod-XX-prod-us-east-0.grafana.net/otlp/v1/traces"
+OTLP_HEADERS = {
+    "Authorization": f"Basic {os.environ['GRAFANA_OTLP_TOKEN']}",
+}
+
+# Self-hosted Tempo
+OTLP_ENDPOINT = "http://tempo.monitoring.svc.cluster.local:4318/v1/traces"
+OTLP_HEADERS = {}
+```
+
+Tempo stores traces only; for LLM SLO dashboards you emit metrics via
+`opentelemetry-exporter-prometheus` alongside, then query in Grafana with
+TraceQL for spans + PromQL for metrics. See [LLM SLO Dashboards](llm-slo-dashboards.md)
+for the PromQL examples.
+
+**Sampling:** Configure in the SDK or upstream via the OTEL Collector's
+`tailsamplingprocessor`. Tail sampling that keeps all spans where
+`gen_ai.usage.output_tokens > 1000` OR status is error gives you outlier
+coverage without full 100% storage cost.
+
+---
+
+## Datadog (SaaS)
+
+Datadog supports OTLP ingest directly from v7.40+ Agent, or via the Datadog
+Collector. LLM Observability is a separate paid add-on that surfaces
+LangChain spans with token costs and eval scoring.
+
+```python
+OTLP_ENDPOINT = "http://datadog-agent.monitoring.svc.cluster.local:4318/v1/traces"
+OTLP_HEADERS = {}
+```
+
+The agent forwards to Datadog with the site-specific endpoint baked in. For
+Datadog-less setups, use the direct OTLP endpoint:
+
+```python
+OTLP_ENDPOINT = "https://trace.agent.datadoghq.com/api/v0.2/traces"
+OTLP_HEADERS = {"DD-API-KEY": os.environ["DD_API_KEY"]}
+```
+
+**Sampling:** Datadog does tail sampling server-side. Send 100% from SDK; they
+sample at ingest. Costs grow quickly with span volume — a busy agent workload
+at 1M spans/day can run $500+/month on APM alone, before LLM Observability.
+
+---
+
+## Dual-exporting during migration
+
+To validate a backend swap before cutover, register two processors:
+
+```python
+provider.add_span_processor(BatchSpanProcessor(jaeger_exporter))
+provider.add_span_processor(BatchSpanProcessor(honeycomb_exporter))
+```
+
+Both exporters see every span. Compare waterfall correctness across backends
+for two weeks, then remove the retiring one. Watch the collector's exporter
+failure metrics — a silently failing second exporter will look like it's working
+in your new backend.
+
+## Sources
+
+- OTEL Python SDK — https://opentelemetry.io/docs/languages/python/
+- OpenLLMetry — https://github.com/traceloop/openllmetry
+- Jaeger — https://www.jaegertracing.io/docs/1.62/
+- Honeycomb OTLP — https://docs.honeycomb.io/getting-data-in/otlp/
+- Grafana Tempo — https://grafana.com/docs/tempo/latest/
+- Datadog OTLP — https://docs.datadoghq.com/opentelemetry/

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/genai-semantic-conventions.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/genai-semantic-conventions.md
@@ -1,0 +1,146 @@
+# OTEL GenAI Semantic Conventions for LangChain
+
+The OpenTelemetry **GenAI semantic conventions** define a standard attribute
+schema for LLM spans so that backends can render model, token, and cost
+information uniformly. LangChain 1.0 via `opentelemetry-instrumentation-langchain`
+emits most of these natively; a handful require custom instrumentation.
+
+Spec: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+## Attribute schema (what LangChain emits)
+
+### Required on every LLM span
+
+| Attribute | Type | Example | Emitted by LangChain 1.0 |
+|-----------|------|---------|--------------------------|
+| `gen_ai.system` | string | `anthropic`, `openai`, `google.gemini`, `cohere` | Yes — auto-detected from provider class |
+| `gen_ai.operation.name` | string | `chat`, `text_completion`, `embeddings` | Yes |
+| `gen_ai.request.model` | string | `claude-sonnet-4-6`, `gpt-4o` | Yes — from `model` kwarg |
+
+### Request parameters
+
+| Attribute | Type | Example | Emitted by LangChain 1.0 |
+|-----------|------|---------|--------------------------|
+| `gen_ai.request.temperature` | double | `0.7` | Yes |
+| `gen_ai.request.top_p` | double | `0.95` | Yes |
+| `gen_ai.request.max_tokens` | int | `4096` | Yes |
+| `gen_ai.request.frequency_penalty` | double | `0.0` | OpenAI only |
+| `gen_ai.request.presence_penalty` | double | `0.0` | OpenAI only |
+| `gen_ai.request.stop_sequences` | string[] | `["\\n\\nHuman:"]` | Yes |
+
+### Response metadata
+
+| Attribute | Type | Example | Emitted by LangChain 1.0 |
+|-----------|------|---------|--------------------------|
+| `gen_ai.response.model` | string | `claude-sonnet-4-6-20250514` | Yes |
+| `gen_ai.response.id` | string | `msg_01Abc...` | Yes |
+| `gen_ai.response.finish_reasons` | string[] | `["stop", "tool_calls"]` | Yes |
+
+### Token usage
+
+| Attribute | Type | Example | Emitted by LangChain 1.0 |
+|-----------|------|---------|--------------------------|
+| `gen_ai.usage.input_tokens` | int | `1234` | Yes |
+| `gen_ai.usage.output_tokens` | int | `567` | Yes |
+| `gen_ai.usage.cache_read_input_tokens` | int | `100` | Anthropic only — needs aggregation (see P04) |
+| `gen_ai.usage.cache_creation_input_tokens` | int | `50` | Anthropic only |
+| `gen_ai.usage.reasoning_tokens` | int | `89` | OpenAI o1 series only |
+
+### Prompt / completion content (opt-in, see prompt-content-policy.md)
+
+| Attribute | Type | Emitted when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` |
+|-----------|------|--------|
+| `gen_ai.prompt.<n>.role` | string | `system`, `user`, `assistant`, `tool` |
+| `gen_ai.prompt.<n>.content` | string | **PII / PHI risk — see policy** |
+| `gen_ai.completion.<n>.role` | string | `assistant` |
+| `gen_ai.completion.<n>.content` | string | **PII / PHI risk** |
+| `gen_ai.completion.<n>.finish_reason` | string | `stop`, `length`, `tool_calls` |
+
+## LangChain span taxonomy
+
+`opentelemetry-instrumentation-langchain` creates spans on every `Runnable`.
+Span names follow `<component>.<method>` conventions:
+
+| Span name | Component | Extra attributes |
+|-----------|-----------|------------------|
+| `ChatAnthropic.chat` / `ChatOpenAI.chat` | Chat model | All `gen_ai.*` above |
+| `Runnable.invoke` / `Runnable.stream` | LCEL wrapper | `langchain.runnable.name` |
+| `Tool.<name>` | Tool invocation | `gen_ai.tool.name`, `gen_ai.tool.call_id`, `gen_ai.tool.arguments` (if content capture on) |
+| `Retriever.get_relevant_documents` | Retriever | `langchain.retriever.source`, `langchain.retriever.k` |
+| `VectorStore.similarity_search` | Vector store | `db.system` (e.g. `pinecone`, `chroma`), `db.operation` |
+| `ChatPromptTemplate.format_messages` | Prompt template | `langchain.prompt.template_format` (`f-string` / `jinja2`) |
+
+### LangGraph spans
+
+LangGraph adds a parent-child relationship per node:
+
+| Span name | Parent | When |
+|-----------|--------|------|
+| `LangGraph.invoke` | Root | Every graph invocation |
+| `LangGraph.node.<node_name>` | `LangGraph.invoke` | Each node execution |
+| `LangGraph.subgraph.<subgraph_name>` | `LangGraph.node.*` | Each subgraph call |
+| Model / tool spans | `LangGraph.node.*` | Nested under the node that called them |
+
+**P28 failure mode:** If callbacks are not propagated via `config["callbacks"]`,
+spans inside subgraphs are **not** children of `LangGraph.subgraph.*`. They
+either do not appear or appear as orphaned root spans. See SKILL.md Step 4.
+
+## What's missing and needs custom instrumentation
+
+LangChain 1.0 does not emit these natively. If you need them, add a
+`BaseCallbackHandler` that sets them in `on_llm_end`:
+
+1. **Cost** — `gen_ai.usage.cost_usd` (custom attribute, not yet standardized).
+   Calculate from `input_tokens * input_price + output_tokens * output_price`.
+2. **TTFT (time to first token)** — emit a span event `first_token` inside
+   `on_llm_new_token`. Backends (Honeycomb, Datadog) can query the delta from
+   span start.
+3. **Evaluation scores** — if you run an LLM-as-judge post-hoc, attach
+   `gen_ai.evaluation.<metric>` attributes on the original span via span
+   links rather than overwriting.
+
+### Cost attribute example
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+from opentelemetry import trace
+
+PRICING = {  # USD per 1M tokens; keep in sync with provider pricing pages
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+}
+
+class CostAttributeHandler(BaseCallbackHandler):
+    def on_llm_end(self, response, **kwargs):
+        span = trace.get_current_span()
+        if not span.is_recording():
+            return
+        model = kwargs.get("invocation_params", {}).get("model", "")
+        usage = response.llm_output.get("token_usage", {})
+        price = PRICING.get(model)
+        if not price:
+            return
+        cost = (
+            usage.get("prompt_tokens", 0) * price["input"] / 1_000_000
+            + usage.get("completion_tokens", 0) * price["output"] / 1_000_000
+        )
+        span.set_attribute("gen_ai.usage.cost_usd", cost)
+```
+
+Attach to every invocation via `config["callbacks"]=[CostAttributeHandler()]`
+(do not use `.with_config()` — P28).
+
+## Attribute hygiene
+
+- Keep attribute values under 1KB. Spans with huge strings balloon backend
+  storage costs and trigger exporter drops.
+- Never put user IDs in free-form attributes — use `enduser.id` (standard
+  OTEL resource attribute) so RBAC / redaction rules can target it.
+- Session / thread ID from LangGraph should map to `session.id` (standard
+  attribute) so traces from the same conversation cluster in the UI.
+
+## Sources
+
+- OTEL GenAI conventions — https://opentelemetry.io/docs/specs/semconv/gen-ai/
+- OTEL resource conventions — https://opentelemetry.io/docs/specs/semconv/resource/
+- OpenLLMetry LangChain instrumentation — https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-langchain

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/llm-slo-dashboards.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/llm-slo-dashboards.md
@@ -1,0 +1,185 @@
+# LLM SLO Dashboards and Burn-Rate Alerts
+
+Five SLIs that matter for an LLM service plus concrete query examples for
+Honeycomb, Grafana (Prometheus + Tempo), and Datadog. All five come from
+`gen_ai.*` attributes on LangChain spans — you do not need a second pipeline.
+
+## The five SLIs
+
+| SLI | Definition | Why it matters for LLM |
+|-----|------------|------------------------|
+| **p95 latency (chat)** | 95th percentile end-to-end duration of top-level `LangGraph.invoke` or `Runnable.invoke` | Provider variance is the dominant factor; track per-model so one slow provider does not mask the others |
+| **p99 latency (chat)** | 99th percentile of same | Tail latency dominates user perception on chat UIs; agents with many tool calls often live here |
+| **error rate** | `errors / total` over a rolling window; `errors` includes `span.status.code = ERROR` plus `gen_ai.response.finish_reason IN ("length", "content_filter")` | Provider 429s, context-length overflow, and safety filters are all "errors" from the user's seat |
+| **cost per request** | Sum of `gen_ai.usage.cost_usd` per top-level request | The only SLI that catches silent regression from someone swapping `haiku` → `opus` |
+| **time to first token (TTFT)** | Delta from span start to `first_token` span event | For streaming UIs — perceived latency comes from TTFT, not total duration |
+
+## Honeycomb queries
+
+Honeycomb ingests all `gen_ai.*` as first-class columns. Use the Query Builder
+or Honeycomb Query Language (triggered from API / Terraform).
+
+### p95 latency per model
+```
+VISUALIZE: P95(duration_ms)
+GROUP BY: gen_ai.request.model
+WHERE: name = "LangGraph.invoke"
+```
+
+### Error rate
+```
+VISUALIZE: RATE_MAX(error), COUNT
+GROUP BY: gen_ai.request.model, gen_ai.response.finish_reason
+WHERE: name = "LangGraph.invoke"
+```
+
+### Cost per request (p50, p95)
+```
+VISUALIZE: P50(gen_ai.usage.cost_usd), P95(gen_ai.usage.cost_usd)
+GROUP BY: gen_ai.request.model
+WHERE: parent_id = "" (top-level spans only)
+```
+
+### TTFT (requires span event instrumentation — see genai-semantic-conventions.md)
+```
+VISUALIZE: P95(meta.span_events["first_token"].time - start_time)
+GROUP BY: gen_ai.request.model
+WHERE: gen_ai.request.stream = true
+```
+
+## Grafana / Prometheus PromQL
+
+If you're on Grafana + Tempo + Prometheus, emit Prometheus metrics in parallel
+to traces via an `opentelemetry-exporter-prometheus` pipeline. Histogram metric
+`llm_request_duration_seconds` with labels `model`, `provider`, `status`:
+
+### p95 latency per model (5-minute window)
+```promql
+histogram_quantile(0.95,
+  sum(rate(llm_request_duration_seconds_bucket[5m])) by (le, model)
+)
+```
+
+### p99 latency per model (5-minute window)
+```promql
+histogram_quantile(0.99,
+  sum(rate(llm_request_duration_seconds_bucket[5m])) by (le, model)
+)
+```
+
+### Error rate (5-minute rolling)
+```promql
+sum(rate(llm_requests_total{status="error"}[5m])) by (model)
+/
+sum(rate(llm_requests_total[5m])) by (model)
+```
+
+### Cost per minute (billing-accurate if cost attribute is set)
+```promql
+sum(rate(llm_cost_usd_total[1m])) by (model, tenant_id) * 60
+```
+
+### TTFT p95 (requires separate `llm_ttft_seconds` histogram from callback)
+```promql
+histogram_quantile(0.95,
+  sum(rate(llm_ttft_seconds_bucket[5m])) by (le, model)
+)
+```
+
+## Datadog LLM Observability queries
+
+Datadog's LLM Observability product pre-computes these. If you are on APM only
+(no LLM add-on), query the raw spans:
+
+### p95 latency
+```
+@operation_name:LangGraph.invoke
+| measure @duration p95 by @gen_ai.request.model
+```
+
+### Error rate
+```
+@operation_name:LangGraph.invoke @status:error
+/
+@operation_name:LangGraph.invoke
+```
+
+### Cost (requires custom metric from callback)
+```
+avg:llm.cost{*} by {gen_ai.request.model}.as_count()
+```
+
+## Burn-rate alerts
+
+A burn rate alert fires when you're consuming your error budget faster than the
+SLO allows. Standard multi-window multi-burn-rate (MWMBR) pattern from Google
+SRE. Example for a 99.5% latency SLO over a 30-day window (error budget = 0.5%,
+3.6 hours/month):
+
+### Fast burn (page-worthy) — 14.4× burn, 1hr window
+```promql
+(
+  sum(rate(llm_request_duration_seconds_count{le="5"}[1h]))
+  /
+  sum(rate(llm_request_duration_seconds_count[1h]))
+) < (1 - 14.4 * 0.005)
+```
+Meaning: if we keep this p95-over-5s rate for a month, we burn 48% of budget.
+
+### Slow burn (ticket-worthy) — 6× burn, 6hr window
+```promql
+(
+  sum(rate(llm_request_duration_seconds_count{le="5"}[6h]))
+  /
+  sum(rate(llm_request_duration_seconds_count[6h]))
+) < (1 - 6 * 0.005)
+```
+
+### Cost burn — fires when projected monthly cost exceeds budget
+```promql
+sum(increase(llm_cost_usd_total[1d])) * 30 > 5000  # $5k/month budget
+```
+
+## Dashboard layout (recommended)
+
+Four panels, top to bottom:
+
+1. **Latency SLI** — p50, p95, p99 over time, grouped by model. Include SLO
+   threshold as a horizontal line.
+2. **Error rate SLI** — stacked area by `finish_reason` (`stop` is success,
+   everything else adds to error rate).
+3. **Cost panel** — sum of `gen_ai.usage.cost_usd` per hour, stacked by model
+   and tenant. Annotate with cost budget.
+4. **Volume panel** — request rate by model + TTFT p95 if streaming.
+
+## Sampling caveat for tail-latency SLOs
+
+Head sampling at 10% means 90% of p99 outliers are discarded before they reach
+the backend. Your dashboard's p99 becomes noisy and biased toward the median.
+Fix with tail sampling at the OTEL Collector:
+
+```yaml
+# otel-collector.yaml — tail-sample keeps all error and all slow spans
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    policies:
+      - name: errors-keep-all
+        type: status_code
+        status_code: {status_codes: [ERROR]}
+      - name: slow-keep-all
+        type: latency
+        latency: {threshold_ms: 5000}
+      - name: fast-sample-10pct
+        type: probabilistic
+        probabilistic: {sampling_percentage: 10}
+```
+
+Tail sampling needs a collector in front of your backend; direct-to-backend
+exporters can only head-sample.
+
+## Sources
+
+- Google SRE Workbook: Alerting on SLOs — https://sre.google/workbook/alerting-on-slos/
+- Honeycomb query language — https://docs.honeycomb.io/reference/api/query-specification/
+- OTEL Collector tail sampling — https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-otel-observability — One-Pager
+
+Wire LangChain 1.0 / LangGraph 1.0 traces into OpenTelemetry-native backends (Jaeger, Honeycomb, Grafana Tempo, Datadog) with LLM-specific SLOs, safe prompt-content policy, and subgraph-aware span propagation.
+
+## The Problem
+
+An engineer wires OTEL expecting to see prompts and responses in Honeycomb; only timing, model name, and token counts appear — the prompt body is blank (P27). This is a privacy-safe default: `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is off. Flipping it on in a multi-tenant workload leaks Tenant A's PII into Tenant B's traces the instant an engineer searches them. Meanwhile, a `BaseCallbackHandler` attached to the parent runnable never fires on inner agent tool calls because LangGraph creates a child runtime per subgraph and callbacks do not inherit (P28) — subagent spans appear orphaned in the waterfall, or they do not appear at all, and your SLO dashboards under-count latency on the exact calls that matter most.
+
+## The Solution
+
+This skill walks through OTEL exporter setup for four backends (Jaeger, Honeycomb, Grafana Tempo, Datadog) with per-backend endpoint and sampling config; the OTEL GenAI semantic conventions (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) that LangChain 1.0 emits natively vs what needs custom instrumentation; a prompt-content policy tying the capture toggle to compliance posture (GDPR, HIPAA, SOC2) with explicit multi-tenant guardrails; subgraph span propagation via `config["callbacks"]` that ensures nested graphs create child spans correctly; LLM SLO definitions (p95 / p99 latency, error rate, cost-per-request, time-to-first-token) with dashboards and burn-rate alerts. Pinned to LangChain 1.0.x and current OTEL GenAI semantic conventions, with four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Platform/SRE engineers and senior backend wiring LangChain into an existing OTEL stack (Jaeger, Honeycomb, Tempo, Datadog). Not for LangSmith-first teams — see `langchain-observability` for that |
+| **What** | OTEL exporter install + per-backend setup; GenAI semconv attribute schema; prompt-content policy with multi-tenant guardrail; subgraph callback propagation; LLM SLO dashboards + burn-rate alerts; backend comparison matrix; 4 references |
+| **When** | Compliance or architecture rules out LangSmith as sole sink; you already run Jaeger/Honeycomb/Tempo/Datadog for the rest of the stack; you need LLM spans in the same waterfall as DB and HTTP spans for incident forensics |
+
+## Key Features
+
+1. **Backend matrix across four OTEL-native sinks** — Jaeger (self-hosted, free, no cost visualization), Honeycomb (SaaS, BubbleUp on LLM attrs, generous free tier), Grafana Tempo (self-hosted, pairs with Prometheus for cost metrics), Datadog (SaaS, APM integration, expensive at scale); each with endpoint, auth, and sampling knobs
+2. **Prompt-content policy with multi-tenant guardrail** — `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` only on trusted single-tenant workloads; in multi-tenant you MUST run redaction middleware upstream (cross-references `langchain-security-basics`); ties capture toggle to GDPR / HIPAA / SOC2 posture
+3. **Subgraph-aware span propagation (P28 fix)** — Pass callbacks via `config["callbacks"]` at invocation time, not via `Runnable.with_config()` which binds at definition time; verified pattern for nested LangGraph subagents; failure mode (orphaned spans, under-counted latency) is named and measurable
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/prompt-content-policy.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/references/prompt-content-policy.md
@@ -1,0 +1,156 @@
+# Prompt-Content Policy for OTEL Traces
+
+OTEL GenAI's privacy-safe default (P27) is that prompt and completion bodies are
+**not** exported. The engineer's instinct on day one is to flip
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` and move on — and this
+is the single most common data-exfiltration risk when adding observability to
+an LLM service.
+
+This reference is the decision framework: when is capture safe, when is it
+actually dangerous, and how to wire redaction upstream.
+
+## The default (what you get without any config)
+
+```
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT  (unset or "false")
+```
+
+Trace attributes present:
+- `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.id`
+- `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
+- Request params (temperature, max_tokens, stop_sequences)
+- `gen_ai.response.finish_reasons`
+- Tool names (but not arguments)
+
+Trace attributes **missing**:
+- `gen_ai.prompt.<n>.content`
+- `gen_ai.completion.<n>.content`
+- `gen_ai.tool.arguments`
+
+For latency + cost + error-rate dashboards this is sufficient. Turn capture on
+only if you have a concrete reason the bodies are needed.
+
+## When capture is safe
+
+Single-tenant, trusted-operator workloads with one or more of:
+
+1. **Internal-only service** with no end-user data flowing through prompts —
+   for example an agent that operates on your public corpus.
+2. **Dev / staging environment** with synthetic or scrubbed inputs. Never copy
+   staging traces into prod backends where search rules differ.
+3. **SaaS product with explicit user consent** (in ToS) to trace for support;
+   the backend has RBAC so only on-call engineers can view; automatic retention
+   of ≤14 days; tenant-scoped redaction already applied upstream by middleware.
+4. **Regulated workload with legal blessing** — e.g. HIPAA BAA in place with
+   backend vendor, signed DPIA for GDPR, documented SOC2 controls mapping the
+   trace store to the same severity as application logs.
+
+## When capture is dangerous
+
+Any of these makes `CAPTURE_MESSAGE_CONTENT=true` a breach waiting to happen:
+
+1. **Multi-tenant without upstream redaction** — Tenant A's prompt lands in a
+   span that Tenant A's customer-success engineer queries; the engineer is
+   inside Tenant B's account context; you just leaked B's data into A's ticket.
+2. **Healthcare, finance, legal prompts** without explicit BAA / DPIA and a
+   trace backend that meets the corresponding control framework.
+3. **Prompts that contain pasted secrets** — users paste API keys, connection
+   strings, private keys into chat assistants constantly. Capture-on means
+   those land in your trace store forever (retention typically ≥30 days).
+4. **Shared-developer backend** where debugging engineers from many products
+   can query across datasets — one engineer's SELECT is another product's
+   compliance incident.
+
+## The guardrail: redact-before-observe
+
+The correct architecture:
+
+```
+User input
+   → redaction middleware  (strip PII/PHI, replace secrets with placeholders)
+   → cache middleware      (hash the redacted text, not raw)
+   → chat model            (prompt with redacted content)
+   → OTEL span             (captures the already-redacted content — safe)
+```
+
+Redaction must happen **upstream of the model call** so the span, which
+instruments the model call, only sees redacted content. Cross-reference
+`langchain-security-basics` (redaction middleware patterns, P34 cross-ref) and
+`langchain-middleware-patterns` (middleware order; redact → cache → model).
+
+### Minimal redaction middleware sketch
+
+```python
+from langchain_core.runnables import RunnableLambda
+from langchain_core.messages import HumanMessage, AIMessage
+import re
+
+PII_PATTERNS = [
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "[SSN]"),
+    (re.compile(r"sk-[A-Za-z0-9]{32,}"), "[API_KEY]"),
+    (re.compile(r"sk-ant-[A-Za-z0-9-]{32,}"), "[ANTHROPIC_KEY]"),
+    (re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+"), "[EMAIL]"),
+    # Add patterns for your domain — credit cards, phone, addresses, IDs.
+]
+
+def redact_text(text: str) -> str:
+    for pattern, replacement in PII_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+def redact_messages(msgs: list) -> list:
+    redacted = []
+    for m in msgs:
+        if isinstance(m, (HumanMessage, AIMessage)) and isinstance(m.content, str):
+            redacted.append(type(m)(content=redact_text(m.content)))
+        else:
+            redacted.append(m)
+    return redacted
+
+redact = RunnableLambda(redact_messages)
+chain = redact | prompt | llm
+```
+
+For production, use a named-entity recognition (NER) service — `presidio-analyzer`
+is open source, or a commercial DLP (AWS Macie, GCP DLP). Regex-only redaction
+misses a lot.
+
+## Environment variable matrix
+
+Set per-environment, not per-process. The exporter reads env at init.
+
+| Env var | Value | Effect |
+|---------|-------|--------|
+| (unset) | — | Default: no content in traces |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `false` | Explicit: no content |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `true` | Capture prompt + completion content |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `NO_CONTENT` | Alias for false (some versions) |
+| `TRACELOOP_TRACE_CONTENT` | `false` | OpenLLMetry-specific alias; either knob works |
+
+Verify which knob your version honors — OpenLLMetry releases have changed the
+primary knob name. Set both to be safe.
+
+## Compliance posture mapping
+
+| Framework | Policy |
+|-----------|--------|
+| **GDPR** | Prompt body may contain personal data. Without a documented lawful basis, keep content capture off in production. If on, document retention, subject-access workflow, and DPIA. |
+| **HIPAA** | Prompts may contain PHI. Require a BAA with the trace backend vendor; same vendor can store logs but not always traces — verify. Off by default; turn on only with legal sign-off. |
+| **SOC2** | Trace store counts as a system containing customer data — it must appear in your data-flow diagram and access-control matrix. Off by default; turn on behind RBAC. |
+| **PCI-DSS** | Card data in prompts must never enter the trace store. Mandatory upstream redaction; fail closed (crash the request) if the redactor is down. |
+| **Internal-only / no regulated data** | On is fine. Document the decision. |
+
+## Audit pattern
+
+Run a periodic sampler that checks 0.1% of recent trace spans for regex hits on
+raw PII patterns (SSN, credit card, API key prefix). If any fire, your
+redactor has a gap. This is an O(1) ops task with a cron + Honeycomb/Datadog
+query; the pattern pays for itself the first time it catches a leak.
+
+## Sources
+
+- OTEL GenAI semconv — content capture flag — https://opentelemetry.io/docs/specs/semconv/gen-ai/
+- Presidio (open-source PII detection) — https://microsoft.github.io/presidio/
+- OpenLLMetry capture toggle — https://www.traceloop.com/docs/openllmetry/privacy
+- Pack cross-reference — `langchain-security-basics`, `langchain-middleware-patterns`
+- Pain catalog — P27 (default-off), P34 (prompt injection), P37 (secrets hygiene)


### PR DESCRIPTION
## Summary

Handcrafted OTEL-native observability skill — wires LangChain 1.0 / LangGraph 1.0 traces into Jaeger / Honeycomb / Grafana Tempo / Datadog with LLM-specific SLO dashboards, safe prompt-content policy, and subgraph-aware span propagation. Anchored to pain-catalog **P27, P28**.

## Pain hook

**P27** — engineer opens Honeycomb expecting prompts and sees only timing because `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is off-by-default, and the instinct to flip it on becomes a multi-tenant leak when redaction middleware is missing upstream. **P28** — callbacks attached via `.with_config()` at parent definition time never fire inside LangGraph subgraphs, so subagent spans orphan and SLO dashboards silently under-count tail latency on the exact nested calls that matter most.

## Files

- `skills/langchain-otel-observability/SKILL.md`
- `skills/langchain-otel-observability/references/one-pager.md`
- `skills/langchain-otel-observability/references/backend-setup-matrix.md`
- `skills/langchain-otel-observability/references/genai-semantic-conventions.md`
- `skills/langchain-otel-observability/references/llm-slo-dashboards.md`
- `skills/langchain-otel-observability/references/prompt-content-policy.md`

## Validator

Grade **A (91/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude