### PR TITLE
feat(langchain-py-pack): add langchain-rate-limits (P17)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: langchain-rate-limits
+description: |
+  Rate-limit LangChain 1.0 calls correctly across multi-worker deployments —
+  Redis-backed limiters, asyncio.Semaphore, narrow exception whitelists, and
+  provider-specific throttle handling. Use when hitting 429s in production,
+  scaling workers horizontally, or tuning throughput against Anthropic, OpenAI,
+  or Gemini tier limits.
+  Trigger with "langchain rate limit", "langchain 429", "langchain semaphore",
+  "langchain token bucket", "anthropic rpm", "openai rpm throttling",
+  "InMemoryRateLimiter", "redis rate limiter".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(redis-cli:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, rate-limits, throttling, concurrency]
+compatible-with: claude-code, codex
+---
+
+# LangChain Rate Limits (Python)
+
+## Overview
+
+A team deploys 10 Cloud Run workers. Each worker initializes its `ChatAnthropic`
+with `InMemoryRateLimiter(requests_per_second=10)` — they read the docs, they
+picked a safe-looking number, they shipped. Thirty seconds later the dashboard
+lights up with 429s: the cluster is pushing 100 RPS to Anthropic's 50 RPM
+tier-1 ceiling, not the 10 RPS they configured. The name is the fix —
+`InMemoryRateLimiter` is **in-process**. Each worker has its own counter. Ten
+workers × 10 RPS = 100 RPS to the provider. This is pain-catalog entry **P29**
+and it lands on every team that scales past one pod.
+
+Three more traps wait on the same code path:
+
+- **P07** — `.with_fallbacks([backup])` defaults `exceptions_to_handle=(Exception,)`,
+  which on Python <3.12 swallows `KeyboardInterrupt`. Ctrl+C during a 429
+  retry storm silently falls through to the backup chain and keeps billing.
+- **P30** — `ChatOpenAI` and `ChatAnthropic` default `max_retries=6`. That is
+  retries, not attempts: **7 total requests per logical call** on flaky
+  networks. One `.invoke()` can bill 7x.
+- **P31** — Anthropic's RPM counts cache reads, cache writes, and uncached
+  calls **uniformly**. Cache-heavy workloads at 50 RPM can 429 on cache writes
+  while the ITPM dashboard shows headroom.
+
+This skill covers measuring demand before picking a limit; the
+`InMemoryRateLimiter` vs Redis-backed limiter vs `asyncio.Semaphore` decision
+tree; the narrow `exceptions_to_handle` whitelist; `max_retries=2` math; and
+the provider-specific limit taxonomy (RPM, ITPM, OTPM, concurrent,
+cached-vs-uncached). Pin: `langchain-core 1.0.x`, `langchain-anthropic 1.0.x`,
+`langchain-openai 1.0.x`. Pain-catalog anchors: **P07, P08, P29, P30, P31**.
+For `.batch(max_concurrency=...)` tuning, see the sibling skill
+`langchain-performance-tuning` — this skill is about provider-facing rate caps.
+
+## Prerequisites
+
+- Python 3.10+ (3.12+ fixes the `KeyboardInterrupt` half of P07)
+- `langchain-core >= 1.0, < 2.0`
+- At least one provider: `pip install langchain-anthropic langchain-openai`
+- For multi-worker prod: `redis >= 4.5` client and a Redis server reachable from every worker
+- Completed `langchain-model-inference` — the chat-model factory from that skill is where `rate_limiter=` gets attached
+
+## Instructions
+
+### Step 1 — Measure actual demand before picking a number
+
+**Do not guess at `requests_per_second`.** Instrument first, size second.
+Attach a `BaseCallbackHandler` that logs per-call `input_tokens`,
+`output_tokens`, and `cache_read_input_tokens` from `response.generations[].message.usage_metadata`:
+
+```python
+chain.with_config({"callbacks": [DemandLogger()]})
+```
+
+Collect 24-48 hours of representative traffic. Roll up: p50 and p95 RPM, p95
+ITPM, p95 OTPM, cache hit rate. Size the limiter at **70% of the binding
+constraint's tier ceiling** on your p95.
+
+See [Measuring Demand](references/measuring-demand.md) for the full
+`DemandLogger` implementation, pandas roll-up, OTEL integration, load-test
+harness, and multi-tenant sizing strategies.
+
+### Step 2 — `InMemoryRateLimiter` for single-process dev only; never multi-worker prod
+
+LangChain 1.0 ships `InMemoryRateLimiter` as a first-class `BaseChatModel` parameter:
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_core.rate_limiters import InMemoryRateLimiter
+
+limiter = InMemoryRateLimiter(
+    requests_per_second=0.58,    # 35 RPM = 70% of Anthropic tier-1 50 RPM
+    check_every_n_seconds=0.1,
+    max_bucket_size=5,           # burst capacity
+)
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    rate_limiter=limiter,
+    max_retries=2,
+    timeout=30,
+)
+```
+
+**`InMemoryRateLimiter` is per-process.** Safe for:
+
+- Single-process local dev (`python script.py`)
+- Single-worker uvicorn (`uvicorn --workers 1`)
+- Jupyter notebooks, batch scripts
+
+**Unsafe for** (this is P29):
+
+- Multi-worker uvicorn / gunicorn (`--workers 4`)
+- Any container orchestrator with replica count > 1 (Cloud Run min-instances > 1, K8s, ECS)
+- Distributed job runners (Celery, Temporal, Cloud Tasks fanout)
+
+### Step 3 — Redis-backed limiter for cluster-wide enforcement
+
+For multi-worker deployments, cluster-wide rate limiting requires shared state.
+Redis is the default answer — atomic Lua script for sliding-window, or Redis
+6.2+ `CL.THROTTLE` for GCRA.
+
+```python
+import redis
+from langchain_anthropic import ChatAnthropic
+# RedisRateLimiter class defined in references/redis-limiter-pattern.md
+from your_app.limiters import RedisRateLimiter
+
+client = redis.Redis.from_url("redis://redis.internal:6379/0")
+
+limiter = RedisRateLimiter(
+    client,
+    key="anthropic:prod",
+    requests_per_second=35 / 60,  # 35 RPM cluster-wide, not per-worker
+)
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    rate_limiter=limiter,
+    max_retries=2,
+    timeout=30,
+)
+```
+
+**Key scoping decisions:**
+
+- `key="anthropic:prod"` — all tenants share one global budget (simplest)
+- `key=f"anthropic:tenant:{tenant_id}"` — per-tenant quota (requires cleanup for dead tenants)
+- Two-level: per-tenant + global, acquire both (best for multi-tenant SaaS)
+
+See [Redis Limiter Pattern](references/redis-limiter-pattern.md) for the full
+`RedisRateLimiter` implementation (atomic Lua sliding window), the GCRA
+alternative via `CL.THROTTLE`, failure modes (Redis down, clock skew), and
+per-tenant cleanup strategy.
+
+### Step 4 — `asyncio.Semaphore` for per-worker in-flight concurrency cap
+
+The rate limiter throttles **request rate**. A semaphore throttles **in-flight
+count**. Use both:
+
+```python
+import asyncio
+
+# Cluster: 35 RPM (Redis enforces)
+# Worker: 20 in-flight at once (semaphore enforces)
+worker_sem = asyncio.Semaphore(20)
+
+async def bounded_invoke(inp):
+    async with worker_sem:
+        return await llm.ainvoke(inp)
+
+# Fanout
+results = await asyncio.gather(*[bounded_invoke(x) for x in inputs])
+```
+
+Why both: a semaphore prevents a single worker from queueing hundreds of
+pending limiter acquires against Redis (head-of-line blocking on the event
+loop). The limiter prevents the cluster from exceeding the provider tier. They
+solve different problems.
+
+**Semaphore sizing**: target latency-bandwidth-product. If p95 request latency
+is 2s and the worker's RPS cap is 10, in-flight count ≈ 2 × 10 = 20. Overshoot
+is wasted memory; undershoot leaves throughput on the table.
+
+### Step 5 — Narrow `with_fallbacks(exceptions_to_handle=...)` — never `(Exception,)`
+
+`.with_fallbacks([backup])` defaults to catching `Exception`. This is P07 — on
+Python <3.12, `Exception` edge-cases include `KeyboardInterrupt` propagation.
+Ctrl+C during a retry storm silently hands off to the backup and keeps running.
+**Always narrow the tuple:**
+
+```python
+from anthropic import (
+    RateLimitError, APITimeoutError, APIConnectionError, InternalServerError,
+)
+
+resilient = (prompt | claude | parser).with_fallbacks(
+    [prompt | gpt4o | parser],
+    exceptions_to_handle=(
+        RateLimitError, APITimeoutError,
+        APIConnectionError, InternalServerError,
+    ),
+    # NEVER: Exception, BaseException, AuthenticationError,
+    # BadRequestError, ValidationError
+)
+```
+
+The whitelist is **only transient provider errors**. `AuthenticationError`,
+`BadRequestError`, and `ValidationError` are bugs in your code/credentials —
+fallback produces the same crash. See the sibling skill's reference
+`langchain-sdk-patterns/references/fallback-exception-list.md` for the full
+per-provider whitelist (Anthropic, OpenAI, Gemini).
+
+### Step 6 — `max_retries=2`, never the default `max_retries=6`
+
+`max_retries` is **retries, not attempts.** Default `max_retries=6` on
+`ChatOpenAI` / `ChatAnthropic` means **initial + 6 retries = 7 billed requests**
+per logical call (P30). On a flaky network, one `.invoke()` costs 7x what you
+budgeted.
+
+```python
+# BAD — default
+llm = ChatOpenAI(model="gpt-4o")  # max_retries=6
+
+# GOOD — production default
+llm = ChatOpenAI(
+    model="gpt-4o",
+    max_retries=2,      # initial + 2 retries = 3 total billed requests max
+    timeout=30,
+    rate_limiter=redis_limiter,
+)
+```
+
+Trade resilience off to the fallback layer — `with_fallbacks` is strictly
+cheaper than retry amplification when the primary is genuinely unhealthy.
+Instrument retry count via callback and alert if retry rate exceeds ~5%.
+
+See [Backoff and Retry](references/backoff-and-retry.md) for the full math,
+`Retry-After` header handling, and circuit-breaker pattern for sustained
+overload.
+
+### Step 7 — Understand the provider limit taxonomy
+
+Different providers expose different limit types. Know which one binds your
+workload before you size:
+
+| Limit | Meaning | Who enforces | Binds for |
+|---|---|---|---|
+| **RPM** | Requests/minute (counts every call) | All three providers | Short chat replies |
+| **ITPM** | Input tokens/minute | Anthropic, OpenAI (as TPM combined) | Long document Q&A |
+| **OTPM** | Output tokens/minute | Anthropic separately; OpenAI as combined TPM | Long completions |
+| **Concurrent** | In-flight request cap | Mainly OpenAI higher tiers | Burst traffic |
+| **Cached reads** | Cache-read input tokens (Anthropic) | Anthropic separate budget line | Cache-heavy workloads (but still counts toward RPM — P31) |
+
+Critical for Anthropic cache workloads (P31): RPM counts uniformly across
+cached reads, cache writes, and uncached calls. A workload at 90% cache hit
+rate still trips the 50 RPM ceiling at 51 requests/min. Separate monitors for
+`cache_read_input_tokens` vs `input_tokens` (minus cache read/write) give
+early warning.
+
+### Step 8 — Decision tree: which limiter to use
+
+```
+┌─ Single process (dev, notebooks, sync CLI, --workers 1)?
+│  └─ InMemoryRateLimiter
+│
+├─ Multi-process but single host (same-machine pool, local gunicorn)?
+│  └─ Redis-backed limiter (even localhost Redis beats InMemoryRateLimiter —
+│     which still has per-process counters)
+│
+├─ Multi-host cluster (Cloud Run --min-instances>1, K8s, ECS)?
+│  └─ Redis-backed limiter (mandatory)
+│
+├─ Multi-region or cross-cloud?
+│  └─ Regional Redis per zone + provider-side account quota
+│     (cross-region Redis latency adds 30-200ms per acquire)
+│
+└─ Any of the above + multi-tenant SaaS?
+   └─ Two-level Redis limiter: per-tenant + global, acquire both
+```
+
+Always pair with `asyncio.Semaphore(N)` per-worker for in-flight concurrency.
+
+### Step 9 — Provider tier snapshot (verify before shipping)
+
+**2026-04-21 snapshot — re-verify against the official console before shipping.**
+
+| Provider | Free tier RPM | Tier-1 RPM | High tier RPM | Source |
+|---|---|---|---|---|
+| Anthropic | 5 | 50 (Build 1) | 4000 (Build 4) | https://docs.anthropic.com/en/api/rate-limits |
+| OpenAI | 3 | 500 | 10000 (Tier 5) | https://platform.openai.com/docs/guides/rate-limits |
+| Google Gemini | 15 | 2000 (Paid 1) | 30000 (Paid 3) | https://ai.google.dev/gemini-api/docs/rate-limits |
+
+Tiers change quarterly. A limiter sized six months ago on a different tier is
+a liability. See [Provider Tier Matrix](references/provider-tier-matrix.md) for
+the full matrix including ITPM / OTPM / cached-read separation, binding-limit
+math, and the pre-ship verification checklist.
+
+## Output
+
+- Instrumented `DemandLogger` callback attached to your chains for 24-48h before sizing
+- `InMemoryRateLimiter` in dev / notebooks / single-worker only
+- `RedisRateLimiter` (sliding-window Lua or `CL.THROTTLE` GCRA) for any multi-worker deployment, keyed per-tenant or global
+- `asyncio.Semaphore(N)` per-worker in-flight cap paired with the cluster-wide limiter
+- `max_retries=2` on every `ChatAnthropic` / `ChatOpenAI` / `ChatGoogleGenerativeAI`
+- `.with_fallbacks(exceptions_to_handle=(RateLimitError, APITimeoutError, APIConnectionError, InternalServerError))` — never `(Exception,)`
+- Per-provider tier re-verified from the official console, sized at 70% of the binding constraint
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `anthropic.RateLimitError: 429 THROTTLED` at cluster RPM = N × InMemoryRateLimiter ceiling | `InMemoryRateLimiter` is per-process; N workers each send at their limit (P29) | Switch to Redis-backed limiter (Step 3) |
+| 429 on cache writes while ITPM dashboard shows headroom | Anthropic RPM counts cache writes uniformly (P31) | Budget at RPM level with limiter; separate cached vs uncached metrics |
+| One `.invoke()` bills as 7 requests on flaky networks | Default `max_retries=6` (P30) | `max_retries=2` + fallback layer for resilience |
+| `Ctrl+C` during retry storm silently falls through to backup chain | `exceptions_to_handle=(Exception,)` catches `KeyboardInterrupt` on Python <3.12 (P07) | Narrow tuple to `(RateLimitError, APITimeoutError, APIConnectionError, InternalServerError)` |
+| Limiter queue p95 wait > 500ms | Limiter is oversubscribed for real traffic | Re-measure demand (Step 1); upgrade provider tier OR shed load |
+| `redis.exceptions.ConnectionError` blocks all LLM calls | Redis unavailable and limiter is fail-closed | Instrument Redis health; decide fail-open (log loudly) vs fail-closed (shed load) — for provider safety, prefer fail-closed |
+| `retry-after` header climbing 2→4→8→16 | Pushing past tier; backoff amplifying, not absorbing | Lower limiter target RPS by 20%; upgrade tier if sustained |
+| `google.api_core.exceptions.ResourceExhausted` on Gemini | Gemini free tier 15 RPM is brutal | Upgrade to paid Gemini tier 1 (2000 RPM) or use Redis limiter at 10 RPM |
+
+## Examples
+
+### Multi-worker Cloud Run deployment with Anthropic tier-1 50 RPM
+
+Ten workers, single region, Redis in same VPC. Target: 35 RPM cluster-wide
+(70% of 50 RPM ceiling), 20 in-flight per worker.
+
+```python
+import asyncio, os, redis
+from langchain_anthropic import ChatAnthropic
+from anthropic import (
+    RateLimitError, APITimeoutError, APIConnectionError, InternalServerError,
+)
+from your_app.redis_limiter import RedisRateLimiter  # see references
+
+_client = redis.Redis.from_url(os.environ["REDIS_URL"])
+anthropic_limiter = RedisRateLimiter(
+    _client, key="anthropic:prod",
+    requests_per_second=35 / 60,    # 35 RPM cluster-wide
+)
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    rate_limiter=anthropic_limiter, # cluster gate
+    max_retries=2,                  # not 6 (P30)
+    timeout=30,
+)
+
+chain = (prompt | llm | parser).with_fallbacks(
+    [prompt | gpt4o_backup | parser],
+    exceptions_to_handle=(          # narrow tuple (P07)
+        RateLimitError, APITimeoutError,
+        APIConnectionError, InternalServerError,
+    ),
+)
+
+worker_sem = asyncio.Semaphore(20)  # per-worker in-flight cap
+async def invoke_bounded(inp):
+    async with worker_sem:
+        return await chain.ainvoke(inp)
+```
+
+Cluster behavior: every worker's limiter call hits the same Redis key. At 35
+RPM cluster-wide, individual workers see fair-share throughput. `max_retries=2`
++ narrow fallback tuple means transient 429s surface quickly and hand off to
+GPT-4o instead of amplifying cost.
+
+### Multi-tenant SaaS with per-tenant isolation
+
+Two-level Redis limiter. Per-tenant limit prevents noisy neighbors; global limit
+protects the provider tier.
+
+See [Redis Limiter Pattern](references/redis-limiter-pattern.md) for the
+two-level acquire implementation (acquire tenant key first, then global key;
+release tenant if global fails) and the per-tenant cleanup cron.
+
+### Single-process dev — `InMemoryRateLimiter` is fine
+
+For local debugging, notebook work, or a sync CLI tool:
+
+```python
+from langchain_core.rate_limiters import InMemoryRateLimiter
+
+limiter = InMemoryRateLimiter(requests_per_second=0.5, max_bucket_size=3)
+llm = ChatAnthropic(model="claude-sonnet-4-6", rate_limiter=limiter, max_retries=2)
+```
+
+Do not carry this into production without re-reading Step 2.
+
+## Resources
+
+- [LangChain how-to: Chat model rate limiting](https://python.langchain.com/docs/how_to/chat_model_rate_limiting/)
+- [`InMemoryRateLimiter` API](https://python.langchain.com/api_reference/core/rate_limiters/langchain_core.rate_limiters.InMemoryRateLimiter.html)
+- [Anthropic rate limits](https://docs.anthropic.com/en/api/rate-limits)
+- [OpenAI rate limits](https://platform.openai.com/docs/guides/rate-limits)
+- [Google Gemini rate limits](https://ai.google.dev/gemini-api/docs/rate-limits)
+- [Redis `CL.THROTTLE` (redis-cell module)](https://github.com/brandur/redis-cell)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P07, P08, P29, P30, P31)
+- Sibling skills: `langchain-sdk-patterns` (batch concurrency, fallback exception whitelist), `langchain-performance-tuning` (`.batch(max_concurrency=...)` tuning for throughput)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/backoff-and-retry.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/backoff-and-retry.md
@@ -1,0 +1,202 @@
+# Backoff and Retry
+
+How retries, fallbacks, and rate limiters interact when a 429 slips past your limiter anyway — and why the defaults are wrong.
+
+## The three layers
+
+```
+request → [max_retries] → [rate_limiter] → [with_fallbacks] → provider
+```
+
+Each layer is a separate failure boundary. Understand what each does before tuning.
+
+| Layer | Trigger | Default action | Cost risk |
+|---|---|---|---|
+| `max_retries` | SDK-level retryable errors (429, 5xx, timeout) | Exponential backoff with jitter, respects `retry-after` | 7x call bill on default `ChatOpenAI` (P30) |
+| `rate_limiter` | Pre-call gate (before the request fires) | Block until token available | 0 (prevents requests) |
+| `with_fallbacks` | Uncaught exception from primary chain | Try backup chain in order | 2x call bill per level on matched exceptions |
+
+## `max_retries` math
+
+**`max_retries` is retries, not attempts.** `max_retries=6` means: initial attempt + up to 6 retries = **7 total requests** for one logical call (P30).
+
+```python
+# Default ChatOpenAI
+llm = ChatOpenAI(model="gpt-4o")  # max_retries=6 by default
+
+# Worst case on a flaky network: 7 billed requests per .invoke()
+# At $0.005/1K input tokens and 2K input/call: $0.07 per logical call
+# At 1000 calls/day: $70/day in retry waste instead of $10
+```
+
+Recommendation: **`max_retries=2`** and lean on the rate limiter + fallbacks for resilience.
+
+```python
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    max_retries=2,
+    timeout=30,
+    rate_limiter=redis_limiter,
+)
+```
+
+### Retry shape (LangChain / Anthropic SDK default)
+
+Backoff follows `base * (2 ** attempt) + jitter` with a ceiling, AND respects `retry-after` header when the provider sends one. Typical sequence for `max_retries=2`:
+
+1. Attempt 1: fires immediately
+2. If 429 with `retry-after: 8`: wait 8s
+3. Attempt 2: retry
+4. If 429 again: wait `2 * 2 + jitter` = ~4-5s (SDK ignores retry-after past first retry in some versions — verify on your SDK version)
+5. Attempt 3 (final retry): if fails, exception propagates
+
+Total wall-clock: 15-30s worst case for `max_retries=2`. At `max_retries=6`: 60-120s.
+
+## Narrowing `exceptions_to_handle` (P07)
+
+`.with_fallbacks([backup])` defaults to `exceptions_to_handle=(Exception,)`. On Python <3.12, `Exception` includes `KeyboardInterrupt` via the inheritance hierarchy in some edge cases (and definitely includes `asyncio.CancelledError`). **Narrow the tuple to specific retryable errors per provider.**
+
+```python
+from anthropic import (
+    RateLimitError,
+    APITimeoutError,
+    APIConnectionError,
+    InternalServerError,
+)
+
+# Primary: Anthropic. Backup: OpenAI.
+resilient = (prompt | claude | parser).with_fallbacks(
+    [prompt | gpt4o | parser],
+    exceptions_to_handle=(
+        RateLimitError,
+        APITimeoutError,
+        APIConnectionError,
+        InternalServerError,
+    ),
+    # DO NOT include: Exception, BaseException, KeyboardInterrupt,
+    # AuthenticationError, BadRequestError, ValidationError
+)
+```
+
+See the sibling skill `langchain-sdk-patterns` reference `fallback-exception-list.md` for the full per-provider whitelist. **Do not duplicate that content here** — cross-reference.
+
+### Why you never want `Exception`
+
+A `ValidationError` on your Pydantic schema silently falls through to the backup chain, which has the same schema, which produces the same error. Your user gets a delayed failure instead of an immediate one, and you paid twice. `AuthenticationError` is the same — bad API key is a config bug, not a transient issue.
+
+## `Retry-After` header respect
+
+All three providers send `Retry-After` on 429. LangChain's SDKs honor it:
+
+- Anthropic: `retry-after` in seconds (integer) or HTTP-date
+- OpenAI: `retry-after-ms` (milliseconds) or `retry-after` (seconds)
+- Google: `retry-after` (seconds) or `retry-info` metadata
+
+For observability, log the header on every 429:
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+
+class RetryAfterLogger(BaseCallbackHandler):
+    def on_llm_error(self, error, **kwargs):
+        # SDKs attach response headers to the exception
+        headers = getattr(error, "response", None)
+        if headers is not None:
+            retry_after = headers.headers.get("retry-after")
+            if retry_after:
+                log.warn("rate_limited", retry_after=retry_after, model=kwargs.get("name"))
+```
+
+If you see `retry-after` values climbing (2 → 4 → 8 → 16), you are pushing the tier. Back off the rate limiter, do not just keep retrying.
+
+## Retry + rate-limit interaction (the subtle one)
+
+Setup:
+- `rate_limiter = InMemoryRateLimiter(requests_per_second=10)`
+- `max_retries = 6`
+
+Worst case: every retry goes through the rate limiter. A transient 5xx at the provider causes the client to retry, which blocks on `limiter.acquire()`, which uses a second RPM slot, which extends the total billed count.
+
+**Rule**: rate limiter should be sized for **attempts**, not **logical calls**. If you expect 5% retry rate:
+
+```
+target_rpm_on_provider = 50        (Anthropic tier 1)
+expected_retry_rate = 0.05
+effective_rpm = target_rpm_on_provider / (1 + retry_rate) = 50 / 1.05 ≈ 47
+requests_per_second = 47 / 60 ≈ 0.78
+```
+
+Monitor real retry rate via callback and adjust periodically.
+
+## Circuit breaker on top
+
+For workloads where repeated 429s indicate a sustained overload (not transient spikes), add a circuit breaker:
+
+```python
+from functools import wraps
+import time
+
+class CircuitBreaker:
+    def __init__(self, fail_threshold=5, reset_after_s=30):
+        self.failures = 0
+        self.opened_at = None
+        self.fail_threshold = fail_threshold
+        self.reset_after_s = reset_after_s
+
+    def is_open(self):
+        if self.opened_at is None:
+            return False
+        if time.time() - self.opened_at > self.reset_after_s:
+            self.opened_at = None
+            self.failures = 0
+            return False
+        return True
+
+    def record_failure(self):
+        self.failures += 1
+        if self.failures >= self.fail_threshold:
+            self.opened_at = time.time()
+
+    def record_success(self):
+        self.failures = 0
+```
+
+Wrap invocations: if the breaker is open, short-circuit to a fallback (cache, degraded response, "try again later"). The breaker protects the provider from cascading overload and you from burning billing on sure-fail requests.
+
+## Putting it together
+
+Production-shaped defaults for LangChain 1.0 with a Redis-backed limiter:
+
+```python
+from langchain_anthropic import ChatAnthropic
+from anthropic import RateLimitError, APITimeoutError, APIConnectionError, InternalServerError
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    max_retries=2,              # NOT 6 — see P30
+    timeout=30,
+    rate_limiter=redis_limiter, # cluster-wide (see redis-limiter-pattern.md)
+)
+
+chain = (prompt | llm | parser).with_fallbacks(
+    [prompt | gpt4o | parser],
+    exceptions_to_handle=(      # NARROW — see P07
+        RateLimitError,
+        APITimeoutError,
+        APIConnectionError,
+        InternalServerError,
+    ),
+)
+```
+
+Three knobs, three jobs:
+- `max_retries=2` — absorb transient blips, do not amplify cost
+- `rate_limiter` — cluster-wide gate to stop 429s at the source
+- `with_fallbacks(narrow_tuple)` — cross-provider continuity when primary is unhealthy
+
+## Cross-references
+
+- [Redis Limiter Pattern](redis-limiter-pattern.md) — where `redis_limiter` comes from
+- [Provider Tier Matrix](provider-tier-matrix.md) — sizing targets
+- [Measuring Demand](measuring-demand.md) — how to verify the above numbers against your traffic
+- `langchain-sdk-patterns/references/fallback-exception-list.md` — full per-provider exception whitelist

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/measuring-demand.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/measuring-demand.md
@@ -1,0 +1,187 @@
+# Measuring Demand
+
+Pick `requests_per_second` from data, not vibes. Undersize and you leave throughput on the table; oversize and you 429 under peak.
+
+## What to measure
+
+| Metric | Why | Where to get it |
+|---|---|---|
+| p50 and p95 RPS | Sizing target — size for p95, not p50 | Callback hit rate over time |
+| p50 and p95 input tokens | ITPM binding check (Anthropic) | `response_metadata["token_usage"]["input_tokens"]` |
+| p50 and p95 output tokens | OTPM binding check | `response_metadata["token_usage"]["output_tokens"]` |
+| Cache hit rate (Anthropic) | Cached-read ITPM separation (P31) | `cache_read_input_tokens` |
+| Retry rate | Inflates effective RPS (see backoff-and-retry.md) | Count `on_llm_start` vs logical invocations |
+| Wait time at limiter | Detects oversubscribed limit | Instrument `acquire()` duration |
+
+## Quick-and-dirty instrumentation callback
+
+Drop-in for any LangChain chain. Logs one JSON line per call; roll up offline.
+
+```python
+from langchain_core.callbacks import BaseCallbackHandler
+import time
+import json
+from uuid import uuid4
+
+class DemandLogger(BaseCallbackHandler):
+    def __init__(self, sink=print):
+        self.sink = sink
+        self._starts = {}  # run_id -> (start_time, model_name)
+
+    def on_llm_start(self, serialized, prompts, run_id=None, **kwargs):
+        rid = str(run_id or uuid4())
+        self._starts[rid] = (time.time(), serialized.get("name"))
+
+    def on_llm_end(self, response, run_id=None, **kwargs):
+        rid = str(run_id or "")
+        started, model = self._starts.pop(rid, (time.time(), None))
+        usage = {}
+        for gen_list in response.generations:
+            for gen in gen_list:
+                if hasattr(gen.message, "usage_metadata"):
+                    usage = gen.message.usage_metadata or {}
+                    break
+        self.sink(json.dumps({
+            "ts": time.time(),
+            "model": model,
+            "latency_s": round(time.time() - started, 3),
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "cache_read": usage.get("cache_read_input_tokens", 0),
+            "cache_write": usage.get("cache_creation_input_tokens", 0),
+        }))
+
+    def on_llm_error(self, error, run_id=None, **kwargs):
+        rid = str(run_id or "")
+        self._starts.pop(rid, None)
+        self.sink(json.dumps({
+            "ts": time.time(),
+            "error": type(error).__name__,
+            "message": str(error)[:200],
+        }))
+```
+
+Attach once at chain level: `chain.with_config({"callbacks": [DemandLogger()]})`. Collect 24-48 hours of representative traffic before sizing.
+
+## OTEL integration
+
+For teams on OpenTelemetry, use LangChain's built-in OTEL exporter instead of the DIY callback above:
+
+```python
+import os
+os.environ["LANGSMITH_TRACING"] = "true"
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://otel-collector:4318"
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "false"  # P27 — privacy
+```
+
+Emits `gen_ai.request.*` and `gen_ai.response.usage.*` spans per Semantic Conventions. Query RPM from trace count over time, TPM from `usage.input_tokens` sum.
+
+## Roll-up query (pandas)
+
+Assume `DemandLogger` output is in `logs.jsonl`:
+
+```python
+import pandas as pd
+
+df = pd.read_json("logs.jsonl", lines=True)
+df = df.dropna(subset=["input_tokens"])  # drop error rows
+df["ts_min"] = pd.to_datetime(df["ts"], unit="s").dt.floor("1min")
+
+per_min = df.groupby("ts_min").agg(
+    rpm=("input_tokens", "count"),
+    itpm=("input_tokens", "sum"),
+    otpm=("output_tokens", "sum"),
+    cache_read=("cache_read", "sum"),
+)
+
+print("p50 RPM:", per_min["rpm"].quantile(0.5))
+print("p95 RPM:", per_min["rpm"].quantile(0.95))
+print("p95 ITPM:", per_min["itpm"].quantile(0.95))
+print("p95 OTPM:", per_min["otpm"].quantile(0.95))
+print("cache hit rate:", per_min["cache_read"].sum() / per_min["itpm"].sum())
+```
+
+Compare the p95 numbers against your tier's RPM / ITPM / OTPM ceilings. The first one that exceeds is your binding constraint — size the limiter for that one.
+
+## Size the limiter on p95, not p50
+
+A p50-sized limiter handles average traffic but queues hard on spikes. A p95-sized limiter handles 95% of minutes without queuing. p99 sizing burns money on unused capacity.
+
+```
+target_rps = (tier_rpm * 0.7 / 60)       # use 70% of tier as the SLO
+observed_p95_rps = df.rpm.quantile(0.95) / 60
+
+if observed_p95_rps <= target_rps:
+    # You have headroom. Set limiter to target_rps.
+    requests_per_second = target_rps
+else:
+    # Traffic exceeds tier. Upgrade tier, or shed load (queue, reject, degrade).
+    raise TierExceeded(observed_p95_rps, target_rps)
+```
+
+## Load test template
+
+Before production rollout, run a synthetic load test at 1.5x your p95 demand to validate the limiter holds:
+
+```python
+import asyncio
+from langchain_anthropic import ChatAnthropic
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    rate_limiter=redis_limiter,  # production limiter
+    max_retries=2,
+)
+
+async def hammer(n, rps):
+    """Fire n requests at target RPS. Returns (succeeded, rate_limited, latencies)."""
+    sem = asyncio.Semaphore(int(rps * 5))  # enough slack for latency
+    latencies = []
+    errors = 0
+    async def one(i):
+        nonlocal errors
+        t0 = time.time()
+        try:
+            async with sem:
+                await llm.ainvoke(f"Test {i}")
+            latencies.append(time.time() - t0)
+        except Exception as e:
+            errors += 1
+    tasks = [asyncio.create_task(one(i)) for i in range(n)]
+    await asyncio.gather(*tasks, return_exceptions=True)
+    return len(latencies), errors, latencies
+
+succeeded, errored, lat = asyncio.run(hammer(n=600, rps=10))
+print(f"ok={succeeded} errors={errored} p50={sorted(lat)[len(lat)//2]:.2f}s")
+```
+
+Accept: zero 429s surfaced to caller (limiter absorbed them), p95 latency within SLO, no head-of-line blocking (longest wait < `timeout`).
+
+Reject: any 429 escapes → limiter is too loose, or provider tier is lower than believed. Re-measure.
+
+## Multi-tenant sizing
+
+If your traffic is multi-tenant, the same RPS number across tenants does not imply the same limit. Three strategies:
+
+1. **Per-tenant hard quota** — Each tenant gets a fixed slice (10 RPM each, up to tenant cap). Simple, wastes capacity when tenants are idle.
+2. **Per-tenant soft + global hard** — Per-tenant limit prevents noisy neighbors; global limit protects the provider tier. Two-level Redis acquire (see redis-limiter-pattern.md). Best for most SaaS.
+3. **Global only with per-tenant accounting** — Single cluster-wide limit, but dashboards break it down by tenant. Fair under low contention; unfair when one tenant hogs.
+
+Measure per-tenant RPM separately before picking. A long-tail distribution (one tenant = 80% of traffic) argues for strategy 2.
+
+## Re-measure on every:
+
+- Product launch (new endpoint, new feature)
+- Marketing campaign (traffic spike)
+- Provider tier change (more headroom, re-tune)
+- Model change (different TPM shape — `gpt-4o` vs `gpt-4o-mini`)
+- Prompt redesign (different input token count)
+- Caching change (cache hit rate shift)
+
+A limiter set six months ago on a different model is a liability, not a safety net.
+
+## Cross-references
+
+- [Provider Tier Matrix](provider-tier-matrix.md) — which tier's numbers you are sizing against
+- [Redis Limiter Pattern](redis-limiter-pattern.md) — what to configure with your measured `requests_per_second`
+- [Backoff and Retry](backoff-and-retry.md) — how retries inflate your effective RPS and what to budget

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-rate-limits — One-Pager
+
+Rate-limit LangChain 1.0 calls correctly across multi-worker deployments — Redis-backed limiters, `asyncio.Semaphore`, narrow exception whitelists, and provider-specific throttle handling.
+
+## The Problem
+
+`InMemoryRateLimiter(requests_per_second=10)` is per-process. A team deploying 10 Cloud Run workers each configured at 10 RPS sends **100 RPS** to Anthropic and trips the 50 RPM tier-1 ceiling within 30 seconds. Default `max_retries=6` on `ChatOpenAI` bills one logical call as up to **seven** requests on flaky networks. Anthropic's RPM limit counts cached and uncached calls separately — a 429 on cache writes can fire while the input-token budget still shows headroom. And the default `.with_fallbacks([backup])` catches `KeyboardInterrupt` on Python <3.12 — Ctrl+C during a retry storm silently hands off to the fallback chain and keeps billing.
+
+## The Solution
+
+This skill walks through measuring actual demand before picking a limit; when `InMemoryRateLimiter` is safe (single-process dev) and when it is dangerous (multi-worker prod); a Redis-backed limiter pattern for cluster-wide enforcement; `asyncio.Semaphore` for per-worker in-flight caps; the narrow `exceptions_to_handle` tuple that preserves `KeyboardInterrupt`; `max_retries=2` vs `max_retries=6` math; and a provider-specific limit taxonomy (RPM, ITPM, OTPM, concurrent, cached-vs-uncached) with a 2026-04 tier-snapshot you must re-verify before shipping. Pinned to LangChain 1.0.x.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers handling production LangChain 1.0 throughput — horizontal scaling, provider tier management, 429 storms |
+| **What** | Demand measurement, limiter-selection decision tree, Redis-backed limiter pattern, `asyncio.Semaphore` cap, narrow fallback whitelist, provider tier matrix (Anthropic / OpenAI / Gemini), backoff shape, 4 references |
+| **When** | When you see 429s in production, before scaling from 1 worker to N, when upgrading to a higher provider tier, or when `InMemoryRateLimiter` is already in your codebase and you have not audited it for multi-process deployment |
+
+## Key Features
+
+1. **Redis-backed rate limiter pattern** — Cluster-wide enforcement via atomic Lua script or Redis 6.2+ GCRA (`CL.THROTTLE`); per-tenant keys; sliding vs fixed window tradeoffs; keeps N workers at a combined target RPS instead of N×RPS
+2. **Narrow `exceptions_to_handle` tuple that preserves `KeyboardInterrupt`** — `(RateLimitError, APITimeoutError, APIConnectionError)` per provider, never `(Exception,)`; cross-provider fallback with provider-specific error imports; P07-safe on Python 3.10 and 3.11
+3. **Provider tier matrix with cached-vs-uncached separation** — Anthropic (free 5 RPM, tier-1 50 RPM, tier-4 4K RPM) with separate cache-read/write accounting; OpenAI tiers 1-5; Gemini free vs paid; 2026-04 snapshot pinned, with "re-verify before shipping" call-out
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/provider-tier-matrix.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/provider-tier-matrix.md
@@ -1,0 +1,134 @@
+# Provider Tier Matrix
+
+**Snapshot date: 2026-04-21.** Provider tiers change quarterly — **re-verify against the official console before shipping.** Treat this table as a starting point, never a source of truth.
+
+Official sources:
+- Anthropic: https://docs.anthropic.com/en/api/rate-limits
+- OpenAI: https://platform.openai.com/docs/guides/rate-limits
+- Google Gemini: https://ai.google.dev/gemini-api/docs/rate-limits
+
+## What the numbers mean
+
+| Term | Meaning |
+|---|---|
+| **RPM** | Requests per minute — counts every API call, cached or not |
+| **ITPM** | Input tokens per minute — prompt tokens (including cached reads on Anthropic) |
+| **OTPM** | Output tokens per minute — completion tokens only |
+| **TPM** | Tokens per minute — combined input + output (OpenAI's older naming) |
+| **Concurrent** | Max in-flight requests at any moment (where reported) |
+| **Cached separation** | Whether cache reads/writes have their own budget |
+
+On Anthropic, **RPM counts all requests uniformly** — cached reads consume the same 1 RPM as uncached calls (P31). A cache-heavy workload at 50 RPM can 429 while the ITPM budget shows plenty of headroom. Budget RPM at the client level (semaphore + Redis limiter), not by token count.
+
+## Anthropic
+
+| Tier | RPM | ITPM | OTPM | Eligibility |
+|---|---|---|---|---|
+| Free / Evaluation | 5 | 20K | 4K | Signup default |
+| Build Tier 1 | 50 | 40K | 8K | $5 credit purchase |
+| Build Tier 2 | 1000 | 80K | 16K | $40 spent, 7d wait |
+| Build Tier 3 | 2000 | 160K | 32K | $200 spent, 7d wait |
+| Build Tier 4 | 4000 | 400K | 80K | $400 spent, 14d wait |
+| Scale (enterprise) | Custom | Custom | Custom | Sales contract |
+
+Notes:
+- Limits are **per workspace per model**. `claude-sonnet-4-6` and `claude-haiku-4-5` have separate counters — a fanout to both doubles your effective RPM.
+- **Prompt caching**: cache reads count toward RPM but use the **cache-read ITPM** budget (a separate line item on the dashboard). Cache writes count toward RPM and uncached ITPM.
+- `anthropic-beta: prompt-caching-2024-07-31` is GA in 2026; no opt-in needed but dashboard keeps legacy cached-read numbers in a separate metric.
+- Rate-limit headers: `anthropic-ratelimit-requests-remaining`, `anthropic-ratelimit-tokens-remaining`, `anthropic-ratelimit-reset`. Read these in a callback to predict 429 before it happens.
+
+## OpenAI
+
+| Tier | RPM (GPT-4o) | TPM (GPT-4o) | RPD | Eligibility |
+|---|---|---|---|---|
+| Free | 3 | 40K | 200 | Signup default (no credits) |
+| Tier 1 | 500 | 30K | 10K | $5 paid |
+| Tier 2 | 5000 | 450K | — | $50 paid + 7d |
+| Tier 3 | 5000 | 800K | — | $100 paid + 7d |
+| Tier 4 | 10000 | 2M | — | $250 paid + 14d |
+| Tier 5 | 10000 | 30M | — | $1K paid + 30d |
+
+Notes:
+- Model-specific. `gpt-4o-mini` has higher RPM than `gpt-4o` at the same tier.
+- **Rate-limit headers**: `x-ratelimit-remaining-requests`, `x-ratelimit-remaining-tokens`, `x-ratelimit-reset-requests`, `x-ratelimit-reset-tokens`. OpenAI returns these on **every** response, not just 429s — cheap to read.
+- OpenAI's TPM counts **input + output** combined, unlike Anthropic's split ITPM/OTPM.
+- Free tier's 3 RPM is unusable for real work; assume Tier 1 as the floor in docs.
+
+## Google Gemini
+
+| Tier | RPM (2.5 Pro) | TPM (2.5 Pro) | RPD | Eligibility |
+|---|---|---|---|---|
+| Free | 15 | 1M | 1500 | Signup default (AI Studio) |
+| Paid Tier 1 | 2000 | 4M | — | Billing enabled |
+| Paid Tier 2 | 10000 | 10M | — | $250 spent |
+| Paid Tier 3 | 30000 | 20M | — | $1K spent |
+
+Notes:
+- Free tier TPM is high (1M) but RPM is brutal (15). Chatbots fit; bulk ETL does not.
+- Gemini 2.5 Flash has ~3x the RPM of Pro at each tier.
+- **Rate-limit headers**: Google uses `x-goog-quota-units-remaining` and `retry-after`. Less uniform than OpenAI/Anthropic.
+- Safety-block (`finish_reason=SAFETY`) is **not** a rate-limit error — it's deterministic for the same input. See pain-catalog P65.
+
+## Recommended `requests_per_second` for `InMemoryRateLimiter`
+
+**Single-process dev only** — for multi-worker prod, use [Redis Limiter Pattern](redis-limiter-pattern.md).
+
+Target: 70% of your tier's RPM to leave headroom for interactive traffic and spikes.
+
+| Tier | Target RPM | `requests_per_second` |
+|---|---|---|
+| Anthropic Free (5 RPM) | 3 | 0.05 |
+| Anthropic Build 1 (50 RPM) | 35 | 0.58 |
+| Anthropic Build 2 (1000 RPM) | 700 | 11.6 |
+| OpenAI Tier 1 (500 RPM) | 350 | 5.8 |
+| OpenAI Tier 3 (5000 RPM) | 3500 | 58.3 |
+| Gemini Free (15 RPM) | 10 | 0.17 |
+| Gemini Paid 1 (2000 RPM) | 1400 | 23.3 |
+
+## Which limit binds first?
+
+For any given workload, exactly one limit binds. Do the math:
+
+```
+avg_input_tokens_per_call * requests_per_minute  →  effective ITPM usage
+avg_output_tokens_per_call * requests_per_minute →  effective OTPM usage
+requests_per_minute                              →  effective RPM usage
+```
+
+Examples:
+- **Short chat replies** (~500 input / ~200 output): RPM binds first
+- **Long document Q&A** (~20K input / ~500 output): ITPM binds first on Anthropic Build 1 (40K ITPM / 20K = only 2 requests/min possible)
+- **Long completions** (~500 input / ~8K output): OTPM binds first on Anthropic Build 1 (8K OTPM / 8K = 1 request/min)
+
+Pick the limiter configured for the binding constraint, not the nominal RPM.
+
+## Separate monitors: cached vs uncached
+
+On Anthropic, cache-heavy workloads trip 429 differently:
+
+```python
+# Callback that separates metrics
+class CacheAwareUsageHandler(BaseCallbackHandler):
+    def on_llm_end(self, response, **kwargs):
+        usage = response.llm_output.get("usage", {})
+        cache_read = usage.get("cache_read_input_tokens", 0)
+        cache_write = usage.get("cache_creation_input_tokens", 0)
+        uncached = usage.get("input_tokens", 0) - cache_read - cache_write
+        metrics.incr("anthropic.cached_read_tokens", cache_read)
+        metrics.incr("anthropic.cached_write_tokens", cache_write)
+        metrics.incr("anthropic.uncached_input_tokens", uncached)
+```
+
+Alert on each independently. A 90% cache hit rate will still 429 at your RPM ceiling.
+
+## Verification checklist before shipping
+
+- [ ] Confirmed current tier in provider console (tier changes with spend)
+- [ ] Measured actual p50/p95 input/output tokens on representative traffic
+- [ ] Computed which limit binds first for your workload
+- [ ] Configured `requests_per_second` at 70% of binding limit
+- [ ] Confirmed rate limiter is Redis-backed (not `InMemoryRateLimiter`) if workers > 1
+- [ ] Added callback that logs per-call RPM-remaining header
+- [ ] Verified retry-after header is honored (LangChain does this by default)
+- [ ] Set `max_retries=2` (not the 6 default — see pain-catalog P30)
+- [ ] Narrow `with_fallbacks(exceptions_to_handle=...)` tuple documented (see pain-catalog P07)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/redis-limiter-pattern.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/references/redis-limiter-pattern.md
@@ -1,0 +1,182 @@
+# Redis-Backed Rate Limiter Pattern
+
+`langchain_core.rate_limiters.InMemoryRateLimiter` is named honestly: **in-process, single-interpreter only** (pain-catalog P29). The instant you deploy more than one worker — and every modern Python deployment does — it stops enforcing the limit you think it is enforcing.
+
+This is the Redis-backed pattern. Two implementations: a portable atomic Lua script (sliding window) and a one-liner using the Redis 6.2+ `CL.THROTTLE` command (GCRA).
+
+## Why not just use `InMemoryRateLimiter` with `workers=1`?
+
+One uvicorn worker on Cloud Run / GKE is a single point of failure and caps you at one CPU. Nobody ships that to production. The moment you scale to 2+ workers, `InMemoryRateLimiter` silently over-spends — N workers × `requests_per_second=10` sends N×10 RPS to the provider.
+
+You cannot fix this by dividing: `requests_per_second=10/N` rounds to zero on small N, and N itself changes every autoscale event.
+
+## Implementation A — Atomic Lua sliding window
+
+Works on any Redis >= 4.0. Script is `EVALSHA`-able — load once, invoke cheaply.
+
+```python
+import time
+import hashlib
+import redis
+from langchain_core.rate_limiters import BaseRateLimiter
+
+# Sliding window: count requests in the last `window_s` seconds; reject if >= limit.
+SLIDING_WINDOW_LUA = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window * 1000)
+local count = redis.call('ZCARD', key)
+if count < limit then
+    redis.call('ZADD', key, now, now)
+    redis.call('PEXPIRE', key, window * 1000)
+    return 1
+else
+    return 0
+end
+"""
+
+class RedisRateLimiter(BaseRateLimiter):
+    def __init__(
+        self,
+        client: redis.Redis,
+        key: str,
+        requests_per_second: float,
+        window_s: int = 1,
+        check_every_n_seconds: float = 0.1,
+    ):
+        self._client = client
+        self._key = f"ratelimit:{key}"
+        self._limit = int(requests_per_second * window_s)
+        self._window = window_s
+        self._check_every = check_every_n_seconds
+        self._script_sha = hashlib.sha1(SLIDING_WINDOW_LUA.encode()).hexdigest()
+
+    def acquire(self, *, blocking: bool = True) -> bool:
+        while True:
+            now_ms = int(time.time() * 1000)
+            try:
+                allowed = self._client.evalsha(
+                    self._script_sha, 1, self._key,
+                    now_ms, self._window, self._limit,
+                )
+            except redis.exceptions.NoScriptError:
+                allowed = self._client.eval(
+                    SLIDING_WINDOW_LUA, 1, self._key,
+                    now_ms, self._window, self._limit,
+                )
+            if allowed:
+                return True
+            if not blocking:
+                return False
+            time.sleep(self._check_every)
+
+    async def aacquire(self, *, blocking: bool = True) -> bool:
+        # For production, use redis.asyncio.Redis and await the eval call.
+        # This sync-bridge version is acceptable for low-throughput workers.
+        import asyncio
+        return await asyncio.to_thread(self.acquire, blocking=blocking)
+```
+
+### Why a sorted set, not a counter?
+
+A fixed-window counter (`INCR` + `EXPIRE`) is simpler but allows 2x burst at the window boundary — 10 requests at `t=0.999s` plus 10 more at `t=1.001s` is 20 requests in 2ms. Sliding window via sorted set prevents this by tracking each request timestamp.
+
+### Key design: per-tenant vs global
+
+```python
+# Single key — all tenants share the provider budget
+limiter = RedisRateLimiter(client, key="anthropic-tier-1", requests_per_second=50/60)
+
+# Per-tenant — each tenant has its own 10-RPM budget
+limiter = RedisRateLimiter(client, key=f"anthropic:tenant:{tenant_id}", requests_per_second=10/60)
+
+# Hierarchical — check both, require both to allow
+# (Implement by acquiring tenant key first, then global key; release tenant if global fails)
+```
+
+Per-tenant keys require a cleanup strategy — dead tenants leave sorted sets in Redis. Either use short TTLs on the keys (2× window) or run a nightly sweep.
+
+## Implementation B — Redis GCRA (`CL.THROTTLE`)
+
+Redis 6.2+ with the `redis-cell` module (bundled in Redis Enterprise, available as a plugin elsewhere). GCRA (Generic Cell Rate Algorithm) is the algorithm DynamoDB and Stripe use. One command, no Lua.
+
+```python
+# CL.THROTTLE key max_burst count_per_period period [quantity]
+result = client.execute_command(
+    "CL.THROTTLE", "anthropic:tier-1",
+    50,   # max burst (bucket depth)
+    50,   # count per period
+    60,   # period in seconds → 50 requests per 60 seconds = Anthropic tier-1 RPM
+    1,    # quantity to consume
+)
+# result = [allowed, total_limit, remaining, retry_after_s, reset_after_s]
+allowed = result[0] == 0
+retry_after_s = result[3]
+```
+
+GCRA is strictly better than sliding window for steady-state workloads (smoother, no window boundary issues) but requires the extra module. For pure open-source Redis, stick with Lua.
+
+## Wiring into LangChain 1.0
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+client = redis.Redis.from_url("redis://redis.internal:6379/0")
+limiter = RedisRateLimiter(
+    client,
+    key="anthropic:prod",
+    requests_per_second=40 / 60,  # 40 RPM for tier 1, leave 10 RPM headroom
+)
+
+llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    rate_limiter=limiter,
+    max_retries=2,
+    timeout=30,
+)
+```
+
+`rate_limiter=` is a first-class parameter on `BaseChatModel` in LangChain 1.0 — the model calls `limiter.acquire()` before each request. You do not need to wrap the chain yourself.
+
+## Sliding window vs fixed window vs GCRA
+
+| Property | Fixed window | Sliding window (Lua) | GCRA (`CL.THROTTLE`) |
+|---|---|---|---|
+| Redis version | >= 2.6 | >= 4.0 (EVAL) | >= 6.2 + redis-cell |
+| Boundary burst risk | Yes (2x limit possible) | No | No |
+| Storage per key | 1 counter | N timestamps (where N=limit) | 2 floats |
+| Latency | ~0.2ms | ~0.5ms | ~0.2ms |
+| Fairness under contention | Poor | Fair | Fair |
+
+For LangChain production: **GCRA if you have redis-cell, sliding-window Lua otherwise**. Do not use fixed-window — the boundary burst is exactly what gets you 429'd.
+
+## Integration with a per-worker semaphore
+
+Redis limits cluster RPM. `asyncio.Semaphore(20)` limits in-flight concurrency per worker. Use both:
+
+```python
+# Cluster: 40 RPM across all workers (Redis enforces)
+# Worker:  20 requests in flight at once (semaphore enforces)
+sem = asyncio.Semaphore(20)
+
+async def bounded_invoke(inp):
+    async with sem:
+        return await llm.ainvoke(inp)
+```
+
+Semaphore prevents a single slow worker from queueing hundreds of pending acquires against the Redis limiter (which would still succeed in principle but creates head-of-line blocking on the event loop).
+
+## Failure modes to test
+
+1. **Redis unavailable** — `acquire()` raises `redis.ConnectionError`. Decide: fail-closed (block all LLM calls, shed load) or fail-open (bypass limit, log loudly). For provider-safety, fail-closed.
+2. **Clock skew between workers** — Lua uses `redis.call('TIME')` server-side to avoid client clock drift. Our script uses client time (`now_ms = time.time()`); replace with `redis.call('TIME')` inside the Lua if workers are >1s out of sync.
+3. **Limit too tight** — `blocking=True` with a tight limit causes every request to wait. Instrument `acquire()` wait time and alert if p95 > 500ms.
+4. **`NoScriptError` on Redis restart** — handled in our `acquire()` with the `EVAL` fallback. Script loading on first failure costs one extra round-trip.
+
+## Cross-references
+
+- [Provider Tier Matrix](provider-tier-matrix.md) — which RPM / TPM to set
+- [Backoff and Retry](backoff-and-retry.md) — what happens when 429s slip through anyway
+- [Measuring Demand](measuring-demand.md) — how to size `requests_per_second` before picking a number


### PR DESCRIPTION
## Summary

Handcrafted Pro-tier rate-limiting skill — Redis-backed cluster limiter, narrow exception whitelist, bounded retries, provider-specific RPM tiers. Anchored to pain-catalog **P07, P29, P30, P31**.

## Pain hook

Ten Cloud Run workers each at `InMemoryRateLimiter(requests_per_second=10)` send 100 RPS to Anthropic's 50 RPM tier-1 ceiling (P29) — the class name was the clue. Skill anchors P07 (narrow `exceptions_to_handle` tuple — never default `Exception`), P29 (Redis-backed limiter for multi-worker), P30 (`max_retries=2` not 6 — bill amplification), P31 (Anthropic uniform RPM across cached and uncached calls).

## Files

- `skills/langchain-rate-limits/SKILL.md` (399 lines)
- `skills/langchain-rate-limits/references/one-pager.md`
- `skills/langchain-rate-limits/references/redis-limiter-pattern.md`
- `skills/langchain-rate-limits/references/provider-tier-matrix.md`
- `skills/langchain-rate-limits/references/backoff-and-retry.md`
- `skills/langchain-rate-limits/references/measuring-demand.md`

## Validator

Grade **A (90/100)** at enterprise tier, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude