### PR TITLE
feat(langchain-py-pack): add langchain-webhooks-events (F22)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: langchain-webhooks-events
+description: |
+  Dispatch LangChain 1.0 chain/agent events to external systems — webhooks, Kafka,
+  Redis Streams, SNS — via async fire-and-forget callbacks, subgraph-aware wiring,
+  and HMAC-signed delivery with idempotency keys. Use when firing webhooks on tool
+  calls, pushing telemetry to Kafka / Redis Streams, or fanning progress to multiple
+  subscribers without blocking the chain.
+  Trigger with "langchain webhook", "langchain event dispatch", "langchain callback kafka",
+  "langchain pubsub", "langchain per-tool webhook", "BaseCallbackHandler webhook",
+  "on_tool_end webhook", "langchain analytics event".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, webhooks, async, events, callbacks]
+compatible-with: claude-code, codex
+---
+
+# LangChain Webhooks and Event Dispatch (Python)
+
+## Overview
+
+A team wires per-tool webhook dispatch from their LangChain agent via FastAPI
+`BackgroundTasks` — analytics is always N seconds late because `BackgroundTasks`
+fire **after** the HTTP response closes, not during the stream (P60). Worse:
+the `BaseCallbackHandler` they attached via `.with_config(callbacks=[h])`
+fires on the outer agent but is dark on the subagent's tool calls — custom
+callbacks are **not** inherited by LangGraph subgraphs (P28), they must be
+passed via `config["callbacks"]` at invoke time.
+
+Pain-catalog anchors handled here:
+
+- P28 — Callbacks via `with_config` don't propagate to subgraphs
+- P46 — SSE streams dropped by buffering proxies (see `langchain-langgraph-streaming`)
+- P47 — `astream_events(v2)` emits thousands of events; never forward raw
+- P48 — Sync `invoke()` inside async endpoint blocks the event loop
+- P60 — `BackgroundTasks` fire post-response; wrong for per-event dispatch
+
+This skill walks through an async `AsyncCallbackHandler` with fire-and-forget
+dispatch, per-target sinks for HTTP / Kafka / Redis Streams / SNS, HMAC-signed
+delivery with 1s/5s/30s retry and DLQ, idempotency keys = `run_id + event_type
++ step_index`, and `config["callbacks"]` wiring that makes subagent calls visible.
+Typical webhook latency budget: <500ms per event. Pin: `langchain-core 1.0.x`,
+`langgraph 1.0.x`. Scope: server-to-server dispatch only — UI streaming is in
+`langchain-langgraph-streaming`.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- `httpx >= 0.27` for async HTTP (or `aiohttp`)
+- One of: `aiokafka`, `redis[hiredis] >= 5`, `aioboto3` (per target)
+- An event sink — a webhook endpoint, Kafka topic, Redis Stream, or SNS topic
+- A shared secret (for HMAC) stored in your secret manager, not env
+
+## Instructions
+
+### Step 1 — Write an async handler that fire-and-forget dispatches
+
+Sync dispatch from a callback blocks the chain — a slow HTTP POST during
+`on_tool_end` serializes all downstream tokens behind it (P48). Use
+`asyncio.create_task(...)` so the dispatch runs alongside the chain:
+
+```python
+import asyncio
+import uuid
+from typing import Any
+from langchain_core.callbacks import AsyncCallbackHandler
+
+class EventDispatchHandler(AsyncCallbackHandler):
+    """Fire-and-forget dispatch to external sinks.
+
+    IMPORTANT: subclass AsyncCallbackHandler (not BaseCallbackHandler) so
+    on_* methods are awaited. Mixing sync and async handlers is a silent
+    footgun — sync on_* blocks the event loop (P48).
+    """
+
+    def __init__(self, sink, *, run_id: str | None = None):
+        self.sink = sink                      # dispatch target — Step 3
+        self.run_id = run_id or str(uuid.uuid4())
+        self._tasks: set[asyncio.Task] = set()
+
+    def _dispatch(self, event_type: str, payload: dict, step_index: int) -> None:
+        # Fire-and-forget. Keep a strong reference so the task isn't GC'd
+        # mid-flight (asyncio quirk — orphan tasks get garbage-collected).
+        task = asyncio.create_task(
+            self.sink.send(
+                idempotency_key=f"{self.run_id}:{event_type}:{step_index}",
+                event_type=event_type,
+                payload=payload,
+            )
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def on_tool_end(self, output: Any, *, run_id, parent_run_id=None, **kwargs):
+        # 4000 char cap — keep payload under typical webhook body limits
+        # while preserving enough context for downstream analytics.
+        MAX_OUTPUT_CHARS = 4000
+        self._dispatch(
+            "tool_end",
+            {"output": str(output)[:MAX_OUTPUT_CHARS], "run_id": str(run_id)},
+            step_index=kwargs.get("tags", []).__len__() or 0,
+        )
+
+    async def on_chain_end(self, outputs: dict, *, run_id, **kwargs):
+        # Only named chains — skip the unnamed LCEL inner nodes (P47)
+        name = kwargs.get("name")
+        if not name or name.startswith("RunnableLambda"):
+            return
+        self._dispatch("chain_end", {"name": name, "run_id": str(run_id)}, step_index=0)
+
+    async def drain(self, timeout: float = 5.0) -> None:
+        """Call before process exit so in-flight dispatches complete."""
+        if self._tasks:
+            await asyncio.wait(self._tasks, timeout=timeout)
+```
+
+See [Async Callback Handler](references/async-callback-handler.md) for the full
+handler — `on_llm_end`, filtering, sync-vs-async decision.
+
+### Step 2 — Pass callbacks via `config` so subgraphs inherit them
+
+P28: `Runnable.with_config(callbacks=[h])` binds at definition and is **not**
+inherited by LangGraph subgraphs. Pass callbacks via `config` at invocation:
+
+```python
+# WRONG — subagent tool calls never fire the handler
+agent_with_handler = agent.with_config({"callbacks": [handler]})
+await agent_with_handler.ainvoke({"messages": [...]})
+
+# RIGHT — callbacks in config propagate into subgraphs
+await agent.ainvoke(
+    {"messages": [...]},
+    config={"callbacks": [handler], "configurable": {"thread_id": "t1"}},
+)
+```
+
+Validate propagation with a probe that counts events by `kwargs["name"]` and
+asserts the subagent's name appears. See [Subgraph Propagation](references/subgraph-propagation.md).
+
+### Step 3 — Pick a dispatch target by delivery semantics
+
+Match the event to the transport:
+
+| Target | Delivery | Typical latency | Use when | Failure mode |
+|---|---|---|---|---|
+| HTTP webhook | At-least-once (with retry) | 50-500ms | Partner integrations, Zapier/Make, customer-owned endpoints | Endpoint 5xx → retry 1s/5s/30s → DLQ |
+| Kafka (aiokafka) | At-least-once (idempotent producer) | 5-20ms intra-region | High-volume telemetry, analytics fan-in | Broker unavailable → retry + local buffer |
+| Redis Streams (`XADD`) | At-least-once (consumer groups) | 1-5ms | Near-realtime worker queues, progress fan-out | Redis down → retry or spill to disk |
+| SNS | At-most-once (best-effort) | 10-100ms | Fan-out to multiple SQS/Lambda subscribers | Best-effort only; accept loss or front with SQS FIFO |
+
+Handler stays provider-agnostic; only the `sink` changes. A minimal HTTP sink:
+
+```python
+import hashlib, hmac, json, os
+import httpx
+
+WEBHOOK_URL = os.environ["WEBHOOK_URL"]
+SIGNING_SECRET = os.environ["WEBHOOK_SIGNING_SECRET"].encode()
+
+class WebhookSink:
+    # 256-bit HMAC — industry-standard signature strength (GitHub, Stripe use same)
+    SIG_ALG = hashlib.sha256
+    # Retry schedule: 1s absorbs transient blips, 5s absorbs brief 503s,
+    # 30s absorbs autoscaler / cold-start incidents. Beyond 30s = stale event.
+    RETRY_DELAYS = (1, 5, 30)
+    REQUEST_TIMEOUT_S = 5.0
+
+    def __init__(self, client: httpx.AsyncClient):
+        self.client = client
+
+    async def send(self, *, idempotency_key: str, event_type: str, payload: dict) -> None:
+        body = json.dumps({"event": event_type, "data": payload}, sort_keys=True).encode()
+        sig = hmac.new(SIGNING_SECRET, body, self.SIG_ALG).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotency_key,
+            "X-Signature-256": f"sha256={sig}",
+        }
+        for delay in self.RETRY_DELAYS:
+            try:
+                resp = await self.client.post(WEBHOOK_URL, content=body, headers=headers, timeout=self.REQUEST_TIMEOUT_S)
+                if 200 <= resp.status_code < 300:
+                    return
+                if resp.status_code < 500 and resp.status_code != 429:
+                    return  # 4xx (except 429) is not retryable
+            except (httpx.TimeoutException, httpx.TransportError):
+                pass
+            await asyncio.sleep(delay)
+        await self._dead_letter(idempotency_key, event_type, payload)
+```
+
+See [Dispatch Targets](references/dispatch-targets.md) for Kafka / Redis Streams
+/ SNS sinks and per-target DLQ patterns.
+
+### Step 4 — Filter events so you don't saturate the downstream
+
+`astream_events(version="v2")` emits thousands of events per invocation (P47).
+Never forward raw — dispatch only what the downstream consumes:
+
+| Callback method | Typical decision | Why |
+|---|---|---|
+| `on_llm_start` | Skip | Prompt content often contains PII; low value without masking |
+| `on_llm_new_token` | **Skip for dispatch** (UI only) | 1 event per token; N/A to analytics |
+| `on_llm_end` | Dispatch for named chains only | Token usage, final response — high value, low volume |
+| `on_chain_start` | Skip (P47 noise) | LCEL emits one per inner runnable |
+| `on_chain_end` | Dispatch for named subgraphs only | Stage completion — what analytics cares about |
+| `on_tool_start` | Optional (dispatch for audit log) | Matters for compliance / tool-use audit |
+| `on_tool_end` | **Dispatch always** | The key analytics signal in agent flows |
+| `on_agent_action` | Dispatch | Cleaner signal than `on_tool_start` in agent graphs |
+| `on_agent_finish` | Dispatch | Terminal event for the run |
+
+Rule of thumb: dispatch `on_tool_end` + named `on_chain_end` + `on_llm_end`.
+Everything else is noise.
+
+### Step 5 — Build idempotency keys and a retry budget
+
+At-least-once transports mean duplicates. Build the key deterministically:
+
+```python
+# run_id — unique per chain invocation (propagates into subgraphs)
+# event_type — on_tool_end / on_chain_end / on_llm_end
+# step_index — monotonic per-run counter you maintain in the handler
+
+idempotency_key = f"{run_id}:{event_type}:{step_index}"
+```
+
+Retry budget: **1s → 5s → 30s** (~36s total) then DLQ. Retry on 5xx / 429 /
+network only — 4xx (except 429) goes straight to DLQ. DLQ is a Redis Stream
+or S3 prefix keyed by `YYYY/MM/DD/run_id/idempotency_key.json`; alarm on depth
+growth. See [Idempotency and Retry](references/idempotency-and-retry.md) for
+HMAC verify, at-least-once vs at-most-once, and 24h de-dup window sizing.
+
+### Step 6 — Never dispatch from `BackgroundTasks` (P60)
+
+FastAPI `BackgroundTasks` run *after* the response closes — exactly wrong for
+per-event dispatch. Events must go out *during* the chain:
+
+```python
+# WRONG — events fire all at once after the stream ends
+@app.post("/chat")
+async def chat(req: Request, bg: BackgroundTasks):
+    bg.add_task(agent.ainvoke, {"messages": [...]})  # late + no streaming
+    return {"status": "accepted"}
+
+# RIGHT — handler fires during the chain, each on_tool_end dispatches immediately
+@app.post("/chat")
+async def chat(req: ChatReq):
+    handler = EventDispatchHandler(sink=webhook_sink, run_id=req.run_id)
+    try:
+        result = await agent.ainvoke(
+            {"messages": req.messages},
+            config={"callbacks": [handler], "configurable": {"thread_id": req.thread_id}},
+        )
+    finally:
+        await handler.drain(timeout=5.0)  # flush in-flight dispatches
+    return {"result": result}
+```
+
+`drain()` awaits in-flight `asyncio.create_task()` dispatches up to 5s so
+events aren't lost when the pod scales down mid-request.
+
+## Output
+
+- Async `BaseCallbackHandler` subclass with `asyncio.create_task()` fire-and-forget
+- Callbacks wired via `config["callbacks"]` at invoke time (subgraph-safe)
+- Per-target sink abstraction: HTTP / Kafka / Redis Streams / SNS
+- HMAC-signed webhook payloads with 1s/5s/30s retry and DLQ fallback
+- Idempotency key = `run_id + event_type + step_index`
+- Event-taxonomy filter: dispatch `on_tool_end` + named `on_chain_end` + `on_llm_end`
+- `drain()` on shutdown to flush in-flight dispatches
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Handler fires on outer agent but not subagent | Bound via `with_config` at definition (P28) | Pass via `config["callbacks"]` at `invoke(...)` time |
+| Webhook analytics lags generation duration | `BackgroundTasks` fire post-response (P60) | Dispatch from the callback handler, never from `BackgroundTasks` |
+| Browser / Kafka saturates on long generations | Forwarded `astream_events(v2)` raw (P47) | Filter events server-side; dispatch only `on_tool_end`/`on_chain_end`/`on_llm_end` |
+| SSE stream hangs, no end event | Proxy buffering (P46) | Set `X-Accel-Buffering: no` — see `langchain-langgraph-streaming` |
+| Event loop freezes on slow webhook | Sync POST in callback (P48) | Subclass `AsyncCallbackHandler`; use `asyncio.create_task()` |
+| Duplicate events downstream | At-least-once dispatch + retry | Receiver dedupes on `Idempotency-Key` header with 24h cache |
+| Orphan `asyncio.create_task` never runs | GC collected the task | Hold a strong reference in `self._tasks` and discard on completion |
+| Events lost on pod shutdown | In-flight tasks cancelled | Call `await handler.drain(timeout=5.0)` in endpoint `finally` block |
+| 4xx webhook errors retrying 3x | Retry logic retrying everything | Retry only on 5xx / 429 / network; 4xx goes straight to DLQ |
+| Signature verification fails on receiver | Body re-serialized with different key order | Sign the exact bytes you send; use `sort_keys=True` in `json.dumps` |
+
+## Examples
+
+### Named subgraph dispatch with a LangGraph agent
+
+Planner subagent runs `search_docs` → `summarize`; outer agent needs a webhook
+on `summarize` completion. Full wiring in [Subgraph Propagation](references/subgraph-propagation.md).
+
+### Fan-out: webhook + Kafka + Redis Streams in one invocation
+
+`CompositeSink` dispatches to multiple child sinks via
+`asyncio.gather(..., return_exceptions=True)` — one sink's failure doesn't block
+others. See [Dispatch Targets](references/dispatch-targets.md).
+
+### HMAC-signed webhook receiver with de-dup
+
+Verify `X-Signature-256`, SETNX `Idempotency-Key` against Redis with 24h TTL,
+200 on both replay and first-seen. See [Idempotency and Retry](references/idempotency-and-retry.md).
+
+## Resources
+
+- [LangChain callbacks concepts](https://python.langchain.com/docs/concepts/callbacks/)
+- [`BaseCallbackHandler` / `AsyncCallbackHandler` API](https://python.langchain.com/api_reference/core/callbacks/langchain_core.callbacks.base.BaseCallbackHandler.html)
+- [`astream_events` v2 events reference](https://python.langchain.com/docs/how_to/streaming/#using-stream-events)
+- [LangGraph streaming concepts](https://langchain-ai.github.io/langgraph/concepts/streaming/)
+- [FastAPI BackgroundTasks — note the "after response" semantics](https://fastapi.tiangolo.com/tutorial/background-tasks/)
+- [aiokafka producer idempotence](https://aiokafka.readthedocs.io/en/stable/producer.html)
+- [Redis Streams `XADD` / consumer groups](https://redis.io/docs/latest/commands/xadd/)
+- Cross-reference in this pack: `langchain-langgraph-streaming` (UI streaming), `langchain-debug-bundle` (callback-propagation debugging)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P28, P46, P47, P48, P60)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/async-callback-handler.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/async-callback-handler.md
@@ -1,0 +1,236 @@
+# Async Callback Handler — Fire-and-Forget Dispatch
+
+A production-shaped `AsyncCallbackHandler` that dispatches LangChain 1.0 events
+to an external sink without blocking the chain. Covers the sync-vs-async
+decision, event filtering, task lifetime (the GC footgun), and graceful drain.
+
+## Sync vs async handler — pick one, not both
+
+LangChain 1.0 exposes two base classes:
+
+| Class | When to use | Blocking behavior |
+|---|---|---|
+| `BaseCallbackHandler` (sync) | Only if every `on_*` method is CPU-only and fast (<1ms) | Blocks the chain step-by-step |
+| `AsyncCallbackHandler` (async) | **Default for dispatch handlers** — any I/O | Awaited inline; must `asyncio.create_task` to fan out |
+
+**Never mix** — if your handler subclasses `BaseCallbackHandler` but the
+`on_*` methods are `async def`, LangChain will not await them. They become
+fire-and-forget by accident, and exceptions get swallowed. Subclass
+`AsyncCallbackHandler` explicitly when you need async I/O.
+
+## The full handler
+
+```python
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable
+from typing import Any, Protocol
+from langchain_core.callbacks import AsyncCallbackHandler
+
+logger = logging.getLogger(__name__)
+
+class Sink(Protocol):
+    async def send(
+        self,
+        *,
+        idempotency_key: str,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None: ...
+
+class EventDispatchHandler(AsyncCallbackHandler):
+    """Fire-and-forget event dispatch for LangChain 1.0.
+
+    Usage:
+        handler = EventDispatchHandler(sink=webhook_sink, run_id=req.id)
+        try:
+            result = await agent.ainvoke(
+                {"messages": msgs},
+                config={"callbacks": [handler]},  # P28 — pass via config
+            )
+        finally:
+            await handler.drain(timeout=5.0)
+    """
+
+    def __init__(
+        self,
+        sink: Sink,
+        *,
+        run_id: str | None = None,
+        dispatch_on_tool_start: bool = False,
+        dispatch_on_llm_end: bool = True,
+    ):
+        self.sink = sink
+        self.run_id = run_id or str(uuid.uuid4())
+        self._step = 0
+        self._tasks: set[asyncio.Task] = set()
+        self._opts = {
+            "tool_start": dispatch_on_tool_start,
+            "llm_end": dispatch_on_llm_end,
+        }
+
+    def _next_step(self) -> int:
+        self._step += 1
+        return self._step
+
+    def _dispatch(self, event_type: str, payload: dict) -> None:
+        step = self._next_step()
+        key = f"{self.run_id}:{event_type}:{step}"
+        task = asyncio.create_task(self._safe_send(key, event_type, payload))
+        # Footgun: asyncio drops weak references to orphan tasks. Hold strong
+        # refs in the set so the GC doesn't cancel dispatch mid-flight.
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _safe_send(self, key: str, event_type: str, payload: dict) -> None:
+        try:
+            await self.sink.send(idempotency_key=key, event_type=event_type, payload=payload)
+        except Exception:  # noqa: BLE001 — dispatch errors must not kill the chain
+            logger.exception("event dispatch failed key=%s", key)
+
+    # --- Callback hooks ---
+
+    async def on_tool_start(self, serialized, input_str, *, run_id, **kwargs):
+        if not self._opts["tool_start"]:
+            return
+        self._dispatch(
+            "tool_start",
+            {
+                "tool": (serialized or {}).get("name"),
+                "input": input_str[:2000],
+                "run_id": str(run_id),
+            },
+        )
+
+    async def on_tool_end(self, output, *, run_id, **kwargs):
+        self._dispatch(
+            "tool_end",
+            {
+                "output": str(output)[:4000],
+                "run_id": str(run_id),
+            },
+        )
+
+    async def on_tool_error(self, error: BaseException, *, run_id, **kwargs):
+        self._dispatch(
+            "tool_error",
+            {
+                "error": f"{type(error).__name__}: {error}",
+                "run_id": str(run_id),
+            },
+        )
+
+    async def on_chain_end(self, outputs, *, run_id, **kwargs):
+        # Skip unnamed / LCEL-internal nodes — P47 noise.
+        name = kwargs.get("name")
+        if not name or name.startswith(("RunnableLambda", "RunnableParallel", "RunnableSequence")):
+            return
+        self._dispatch("chain_end", {"name": name, "run_id": str(run_id)})
+
+    async def on_llm_end(self, response, *, run_id, **kwargs):
+        if not self._opts["llm_end"]:
+            return
+        usage = {}
+        try:
+            # LangChain 1.0 — AIMessage.usage_metadata
+            gen = response.generations[0][0]
+            msg = gen.message
+            if getattr(msg, "usage_metadata", None):
+                usage = dict(msg.usage_metadata)
+        except (AttributeError, IndexError):
+            pass
+        self._dispatch("llm_end", {"usage": usage, "run_id": str(run_id)})
+
+    # --- Graceful shutdown ---
+
+    async def drain(self, timeout: float = 5.0) -> None:
+        """Await in-flight dispatches. Call in endpoint finally block."""
+        if not self._tasks:
+            return
+        done, pending = await asyncio.wait(self._tasks, timeout=timeout)
+        if pending:
+            logger.warning("drain timeout: %d dispatches still in flight", len(pending))
+            for t in pending:
+                t.cancel()
+```
+
+## Why the strong-reference set (`self._tasks`)
+
+CPython's asyncio keeps only weak references to tasks created by
+`asyncio.create_task`. An orphan task — no strong reference from anywhere —
+can be garbage-collected mid-flight, silently cancelling the dispatch. Every
+real handler keeps the task in a set and removes it on completion:
+
+```python
+task = asyncio.create_task(coro)
+self._tasks.add(task)
+task.add_done_callback(self._tasks.discard)
+```
+
+Missing this is the most common reason "sometimes the webhook fires, sometimes
+it doesn't" in load testing.
+
+## Step-index monotonicity
+
+`step_index` in the idempotency key is a per-handler-instance counter. It
+guarantees uniqueness within a run, which is all the receiver needs. Do NOT use
+the LangChain `run_id` alone — the same `run_id` will fire multiple `on_tool_end`
+events if the chain calls the same tool twice, and identical keys mean the
+receiver will dedupe legitimate second calls.
+
+## Event filter tuning
+
+The three flags (`dispatch_on_tool_start`, `dispatch_on_llm_end`, and implicit
+"dispatch on_tool_end / on_chain_end for named only") cover 90% of cases.
+If you need a custom filter, override `_dispatch` to accept a predicate:
+
+```python
+def _dispatch(self, event_type, payload):
+    if self.filter and not self.filter(event_type, payload):
+        return
+    ...
+```
+
+## When to prefer `astream_events` over a callback handler
+
+Callbacks fire in the same task as the chain step. `astream_events(version="v2")`
+decouples: the chain pushes events onto an async queue, your consumer reads in a
+separate task. Prefer `astream_events` when:
+
+- The dispatch logic needs its own concurrency limit (semaphore) across events
+- You want to batch-dispatch (e.g., accumulate 10 events then POST)
+- You need to replay events from a recorded stream
+
+Stick with callbacks when:
+
+- You want subgraph propagation automatically (callbacks pass via `config`)
+- The dispatch is per-event fire-and-forget (no batching)
+- You want to use the same handler in tests via `FakeListChatModel`
+
+## Testing the handler
+
+```python
+import pytest
+from unittest.mock import AsyncMock
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_tool_end():
+    sink = AsyncMock()
+    handler = EventDispatchHandler(sink=sink, run_id="r1")
+
+    await handler.on_tool_end(output="ok", run_id="tool-1")
+    await handler.drain()
+
+    sink.send.assert_awaited_once()
+    call = sink.send.call_args.kwargs
+    assert call["idempotency_key"] == "r1:tool_end:1"
+    assert call["event_type"] == "tool_end"
+    assert call["payload"]["output"] == "ok"
+```
+
+## Cross-references
+
+- [Dispatch Targets](dispatch-targets.md) — what `sink` looks like for each transport
+- [Subgraph Propagation](subgraph-propagation.md) — why `config["callbacks"]` is required (P28)
+- [Idempotency and Retry](idempotency-and-retry.md) — receiver-side de-dup and replay semantics

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/dispatch-targets.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/dispatch-targets.md
@@ -1,0 +1,242 @@
+# Dispatch Targets — HTTP / Kafka / Redis Streams / SNS
+
+Per-transport implementation of the `Sink` protocol. Each target has different
+delivery guarantees, latency, and failure modes. Pick based on who is consuming,
+not on what's most familiar.
+
+## Target matrix
+
+| Target | Delivery guarantee | Typical latency | Ordering | Back-pressure | Failure mode |
+|---|---|---|---|---|---|
+| **HTTP webhook** | At-least-once (with receiver idempotency) | 50-500ms | No | None (remote) | 5xx/timeout → retry 1s/5s/30s → DLQ |
+| **Kafka (aiokafka)** | At-least-once (`enable.idempotence=true`) | 5-20ms intra-region | Per-partition | Broker-driven (acks=all) | Broker unavailable → local buffer + retry |
+| **Redis Streams** | At-least-once (consumer groups + ACK) | 1-5ms intra-region | FIFO per stream | Stream length cap | Redis down → retry or spill |
+| **SNS** | **At-most-once** (best-effort) | 10-100ms | No | None | Delivery loss tolerated; front with SQS FIFO for exactly-once |
+
+Rule: customer-facing integrations get webhooks; internal telemetry gets Kafka
+or Redis Streams; SNS is fan-out only when occasional loss is acceptable.
+
+## HTTP webhook sink
+
+The reference implementation from SKILL.md Step 3, expanded with DLQ and
+pluggable retry schedule:
+
+```python
+import asyncio, hashlib, hmac, json, logging, os
+from typing import Any
+import httpx
+
+log = logging.getLogger(__name__)
+
+class WebhookSink:
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        signing_secret: bytes,
+        dlq,                               # any DLQ sink — see below
+        retry_delays: tuple[int, ...] = (1, 5, 30),
+        request_timeout: float = 5.0,
+    ):
+        self.client = client
+        self.url = url
+        self.secret = signing_secret
+        self.dlq = dlq
+        self.retry_delays = retry_delays
+        self.timeout = request_timeout
+
+    async def send(self, *, idempotency_key: str, event_type: str, payload: dict[str, Any]) -> None:
+        body = json.dumps({"event": event_type, "data": payload}, sort_keys=True).encode()
+        sig = hmac.new(self.secret, body, hashlib.sha256).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotency_key,
+            "X-Signature-256": f"sha256={sig}",
+            "X-Event-Type": event_type,
+        }
+
+        attempt = 0
+        for delay in (0, *self.retry_delays):
+            if delay:
+                await asyncio.sleep(delay)
+            attempt += 1
+            try:
+                resp = await self.client.post(self.url, content=body, headers=headers, timeout=self.timeout)
+                if 200 <= resp.status_code < 300:
+                    return
+                # 4xx (non-429) is not retryable — payload is wrong
+                if 400 <= resp.status_code < 500 and resp.status_code != 429:
+                    log.warning("webhook %s rejected: %s", idempotency_key, resp.status_code)
+                    break
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                log.info("webhook %s attempt %d failed: %s", idempotency_key, attempt, exc)
+
+        await self.dlq.send(idempotency_key=idempotency_key, event_type=event_type, payload=payload)
+```
+
+Client-side: share a single `httpx.AsyncClient` across the whole process
+(connection pool reuse is critical at high RPS). Set `limits=httpx.Limits(max_keepalive_connections=100, max_connections=200)`.
+
+## Kafka sink (aiokafka)
+
+```python
+import json
+from aiokafka import AIOKafkaProducer
+
+class KafkaSink:
+    def __init__(self, producer: AIOKafkaProducer, topic: str):
+        self.producer = producer
+        self.topic = topic
+
+    async def send(self, *, idempotency_key, event_type, payload):
+        value = json.dumps({"event": event_type, "data": payload}, sort_keys=True).encode()
+        # Partition key on run_id so events from the same run land on one partition → ordered
+        run_id = idempotency_key.split(":", 1)[0].encode()
+        await self.producer.send_and_wait(
+            self.topic,
+            value=value,
+            key=run_id,
+            headers=[("idempotency-key", idempotency_key.encode()),
+                     ("event-type", event_type.encode())],
+        )
+```
+
+Producer config for idempotent at-least-once:
+
+```python
+producer = AIOKafkaProducer(
+    bootstrap_servers="kafka:9092",
+    enable_idempotence=True,   # producer-side dedup within a session
+    acks="all",                # wait for all in-sync replicas
+    max_in_flight_requests_per_connection=5,  # required for idempotence
+    compression_type="lz4",
+)
+```
+
+On broker unavailability, `send_and_wait` raises. Catch and route to DLQ, or
+buffer locally (bounded deque) and retry in a background task.
+
+## Redis Streams sink
+
+```python
+import json
+from redis.asyncio import Redis
+
+class RedisStreamSink:
+    def __init__(self, redis: Redis, stream: str, maxlen: int = 100_000):
+        self.redis = redis
+        self.stream = stream
+        self.maxlen = maxlen
+
+    async def send(self, *, idempotency_key, event_type, payload):
+        await self.redis.xadd(
+            self.stream,
+            {
+                "idempotency_key": idempotency_key,
+                "event_type": event_type,
+                "payload": json.dumps(payload),
+            },
+            maxlen=self.maxlen,
+            approximate=True,   # ~10% faster, bounded memory
+        )
+```
+
+Consumers use `XREADGROUP` + `XACK` for at-least-once delivery. If a consumer
+crashes before `XACK`, another consumer picks up via `XPENDING`/`XCLAIM`.
+
+## SNS sink (fan-out only)
+
+```python
+import json
+
+class SNSSink:
+    def __init__(self, sns_client, topic_arn: str):
+        self.sns = sns_client
+        self.topic_arn = topic_arn
+
+    async def send(self, *, idempotency_key, event_type, payload):
+        # SNS is best-effort. No DLQ on the publisher side — subscribers must
+        # own their DLQ (e.g., SQS FIFO with a redrive policy).
+        await self.sns.publish(
+            TopicArn=self.topic_arn,
+            Message=json.dumps({"event": event_type, "data": payload}),
+            MessageAttributes={
+                "idempotency-key": {"DataType": "String", "StringValue": idempotency_key},
+                "event-type": {"DataType": "String", "StringValue": event_type},
+            },
+        )
+```
+
+For exactly-once-style delivery, SNS → SQS FIFO with content-based dedup on
+`idempotency_key`. Do not reach for SNS if you cannot tolerate any loss.
+
+## Composite fan-out sink
+
+Dispatch to multiple sinks from one handler:
+
+```python
+import asyncio
+
+class CompositeSink:
+    def __init__(self, *sinks):
+        self.sinks = sinks
+
+    async def send(self, **kwargs):
+        # gather with return_exceptions — one sink's failure must not block others
+        results = await asyncio.gather(
+            *(s.send(**kwargs) for s in self.sinks),
+            return_exceptions=True,
+        )
+        for sink, result in zip(self.sinks, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning("sink %s failed: %s", type(sink).__name__, result)
+```
+
+`asyncio.gather(return_exceptions=True)` is the key — without it, the first
+failure cancels the rest.
+
+## Dead letter queue patterns
+
+**Redis Stream DLQ** (simplest — co-located with primary Redis):
+
+```python
+class RedisDLQ:
+    def __init__(self, redis: Redis, stream: str = "webhooks:dlq"):
+        self.redis = redis
+        self.stream = stream
+
+    async def send(self, *, idempotency_key, event_type, payload):
+        await self.redis.xadd(self.stream, {
+            "idempotency_key": idempotency_key,
+            "event_type": event_type,
+            "payload": json.dumps(payload),
+        })
+```
+
+**S3/GCS DLQ** (durable; replay-from-archive):
+
+```python
+# Key: YYYY/MM/DD/run_id/idempotency_key.json
+key = f"{date.today():%Y/%m/%d}/{run_id}/{idempotency_key}.json"
+await s3.put_object(Bucket=bucket, Key=key, Body=json.dumps(payload).encode())
+```
+
+Alarm on DLQ depth growth (Redis: `XLEN dlq_stream`; S3: CloudWatch object-count
+metric). A healthy system has DLQ growth ~0.
+
+## Per-target tuning notes
+
+- **HTTP**: set per-host connection limits in `httpx.Limits`. A single slow receiver
+  should not starve other dispatches
+- **Kafka**: prefer `send_and_wait` over fire-and-forget `send` on the producer
+  inside a callback — you want to know if the broker ack'd
+- **Redis Streams**: `maxlen=N approximate=True` bounds memory. For unbounded retention,
+  pair with a consumer that persists to durable storage
+- **SNS**: tag messages with `MessageDeduplicationId = idempotency_key` on FIFO topics
+  (standard topics don't support this)
+
+## Cross-references
+
+- [Async Callback Handler](async-callback-handler.md) — the handler that calls these sinks
+- [Idempotency and Retry](idempotency-and-retry.md) — key construction, receiver de-dup
+- [Subgraph Propagation](subgraph-propagation.md) — ensuring subagent events reach these sinks

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/idempotency-and-retry.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/idempotency-and-retry.md
@@ -1,0 +1,221 @@
+# Idempotency and Retry — Keys, Signing, Receiver De-dup
+
+At-least-once transports mean receivers see duplicates. Without idempotency,
+duplicates get processed twice — double-charged analytics, double-triggered
+downstream jobs, double-sent notifications. This reference defines the key
+scheme, HMAC signing, retry budget, and receiver-side de-dup.
+
+## Idempotency key scheme
+
+```
+idempotency_key = f"{run_id}:{event_type}:{step_index}"
+```
+
+| Component | Source | Purpose |
+|---|---|---|
+| `run_id` | `str(uuid.uuid4())` generated at handler init | Uniquely identifies the chain invocation; propagates into subgraphs |
+| `event_type` | `tool_end` / `chain_end` / `llm_end` / `tool_error` | Distinguishes events of different types within the same run |
+| `step_index` | Monotonic counter inside the handler instance | Unique ordinal within `(run_id, event_type)` |
+
+Properties:
+
+- **Deterministic for retries.** Re-dispatching the exact same event from the
+  same `_safe_send` call produces the exact same key — receiver dedupes.
+- **Unique across legitimate re-invocations.** If the same tool fires twice in
+  a chain, `step_index` differs — both events reach the receiver.
+- **Run-scoped.** A fresh invocation of the same chain gets a new `run_id` —
+  no collision with prior runs.
+
+**Anti-pattern:** using the LangChain `run_id` kwarg directly. Tools that are
+called multiple times in one run fire `on_tool_end` with different `run_id`
+values — which is fine — but if you aggregate them into a single event or
+collapse them, the receiver dedupes legitimate work away.
+
+## HMAC-SHA256 signing
+
+Sender:
+
+```python
+import hashlib, hmac, json
+
+body = json.dumps({"event": event_type, "data": payload}, sort_keys=True).encode()
+sig = hmac.new(secret, body, hashlib.sha256).hexdigest()
+headers["X-Signature-256"] = f"sha256={sig}"
+```
+
+`sort_keys=True` is non-negotiable — without it, Python dict ordering changes
+the bytes you sign, and the receiver's independent re-serialization won't
+match.
+
+Receiver (FastAPI example):
+
+```python
+from fastapi import FastAPI, Request, HTTPException, Header
+
+@app.post("/webhooks/langchain")
+async def receive(
+    request: Request,
+    x_signature_256: str = Header(...),
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+):
+    body = await request.body()
+    expected = "sha256=" + hmac.new(SECRET, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_signature_256):
+        raise HTTPException(status_code=401, detail="bad signature")
+
+    # De-dup — see below
+    if not await mark_seen(idempotency_key, ttl=86400):
+        return {"status": "duplicate"}
+
+    await process(json.loads(body))
+    return {"status": "ok"}
+```
+
+`hmac.compare_digest` is timing-safe — do not use `==` for signature comparison
+(timing attacks can leak the signature byte-by-byte).
+
+## Retry budget: 1s / 5s / 30s
+
+Sender-side retry schedule:
+
+| Attempt | Delay before | Cumulative wall clock |
+|---|---|---|
+| 1 (initial) | 0s | 0s |
+| 2 | 1s | 1s |
+| 3 | 5s | 6s |
+| 4 | 30s | 36s |
+| DLQ | — | 36s total |
+
+Rationale:
+
+- **1s**: absorbs most transient network blips (TCP re-establish, DNS TTL flip)
+- **5s**: absorbs brief provider-side 503s and autoscaler cold-boots
+- **30s**: absorbs longer incidents; beyond this, retry is futile in the
+  critical path — the event is stale
+- **DLQ at 36s**: bounded total latency. Anything longer belongs in async
+  replay, not the hot path
+
+Retry only on:
+
+| Status / error | Retry? | Reason |
+|---|---|---|
+| 200-299 | No | Success |
+| 400-403, 405-428, 430-499 | **No** — DLQ immediately | Client error; retry won't help |
+| 404 | No — DLQ | Receiver doesn't know the endpoint; config issue |
+| 408 (timeout) | Yes | Transient |
+| 429 (rate limit) | Yes — honor `Retry-After` if present | Back off |
+| 500-599 | Yes | Transient server error |
+| Connection/timeout/DNS | Yes | Network |
+
+## At-least-once vs at-most-once
+
+| Model | Guarantee | Cost |
+|---|---|---|
+| **At-least-once** | Every event reaches receiver ≥ 1 time | Receiver must dedupe |
+| **At-most-once** | Every event reaches receiver ≤ 1 time | Tolerable loss; simpler receiver |
+| **Exactly-once** | Every event reaches receiver = 1 time | Requires transactional sink + dedup store; rare in practice |
+
+Pick:
+
+- **At-least-once**: HTTP webhooks, Kafka, Redis Streams. Default.
+- **At-most-once**: SNS fan-out where loss < duplicate cost (e.g., rough-cut
+  UI counters). Skip retry, skip DLQ.
+- **Exactly-once approximation**: at-least-once + receiver idempotency with
+  a de-dup store. Good enough for 99.9% of cases.
+
+## Receiver de-dup with Redis SETNX
+
+```python
+from redis.asyncio import Redis
+
+async def mark_seen(redis: Redis, key: str, *, ttl: int = 86400) -> bool:
+    """Returns True if the key was NEW (process this event),
+    False if DUPLICATE (skip)."""
+    # SET key val EX ttl NX — atomic set-if-not-exists with expiry
+    return await redis.set(f"idemp:{key}", "1", ex=ttl, nx=True) is True
+```
+
+TTL sizing:
+
+| Event cadence | Safe TTL | Why |
+|---|---|---|
+| Sub-minute (per-tool-end) | 24h | Retry budget (36s) << TTL; plenty of margin |
+| Sub-hour (per-run-end) | 7d | Covers long outages |
+| Daily (summary events) | 30d | Covers weekly sender outages |
+
+Do not set TTL shorter than 2x your retry budget — a delayed retry after DLQ
+replay could arrive after the de-dup entry expires, causing a false-new.
+
+## Replay from DLQ
+
+DLQ entries are not junk — they are events worth eventually delivering. Pattern:
+
+1. Operator verifies the receiver is healthy again
+2. Run a one-shot `replay_dlq.py` script that reads the DLQ and re-sends with
+   the original `idempotency_key`
+3. Receiver dedupes any that already landed during normal retry
+4. DLQ entry marked as replayed (move to `replayed/` prefix in S3, XDEL from
+   Redis Stream)
+
+Never re-use a fresh idempotency key on replay — you lose the dedup guarantee.
+
+## Sender-side circuit breaker
+
+If the DLQ is filling faster than 10 events/sec sustained for 60s, trip a
+circuit breaker: stop dispatching to that sink for 5 minutes, route directly
+to DLQ. Prevents a dying receiver from consuming all your retry budget and
+slowing the chain:
+
+```python
+from circuitbreaker import circuit
+
+class CBWebhookSink(WebhookSink):
+    @circuit(failure_threshold=10, recovery_timeout=300, name="webhook")
+    async def _send_primary(self, **kwargs):
+        return await super().send(**kwargs)
+
+    async def send(self, **kwargs):
+        try:
+            return await self._send_primary(**kwargs)
+        except CircuitBreakerError:
+            await self.dlq.send(**kwargs)
+```
+
+## Testing
+
+Property-based test for idempotency key:
+
+```python
+from hypothesis import given, strategies as st
+
+@given(
+    run_id=st.uuids().map(str),
+    event_type=st.sampled_from(["tool_end", "chain_end", "llm_end"]),
+    step_index=st.integers(min_value=1, max_value=10_000),
+)
+def test_idempotency_key_format(run_id, event_type, step_index):
+    key = f"{run_id}:{event_type}:{step_index}"
+    parts = key.split(":")
+    assert len(parts) == 3
+    assert parts[0] == run_id
+    assert parts[1] == event_type
+    assert int(parts[2]) == step_index
+```
+
+Integration test for receiver de-dup:
+
+```python
+@pytest.mark.asyncio
+async def test_duplicate_event_is_not_reprocessed(client, redis):
+    headers = _sign({"event": "tool_end", "data": {"x": 1}}, key="k1")
+    r1 = await client.post("/webhooks/langchain", headers=headers, json={...})
+    r2 = await client.post("/webhooks/langchain", headers=headers, json={...})
+    assert r1.json() == {"status": "ok"}
+    assert r2.json() == {"status": "duplicate"}
+```
+
+## Cross-references
+
+- [Async Callback Handler](async-callback-handler.md) — key generation in the handler
+- [Dispatch Targets](dispatch-targets.md) — per-target retry behavior and DLQ
+- [Subgraph Propagation](subgraph-propagation.md) — `run_id` continuity across subgraphs

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-webhooks-events — One-Pager
+
+Dispatch LangChain 1.0 chain/agent events to external systems — webhooks, Kafka, Redis Streams, SNS — without blocking the chain or losing visibility into subagent tool calls.
+
+## The Problem
+
+Teams wire per-token webhook dispatch via FastAPI `BackgroundTasks` and wonder why their analytics pipeline is always N seconds late — `BackgroundTasks` run **after** the response closes (P60), not during the stream. Others attach a `BaseCallbackHandler` to the top-level agent and never see a single event from the subagent's tool calls — custom callbacks are **not** inherited by subgraphs; they must be passed via `config["callbacks"]` at invocation, not via `Runnable.with_config` at definition (P28). Meanwhile `astream_events(v2)` emits thousands of events per invocation (P47) — forwarding every one raw to Kafka saturates the topic, and the first sync `chain.invoke()` inside an async endpoint blocks the entire event loop (P48).
+
+## The Solution
+
+This skill teaches an async `BaseCallbackHandler` that fires-and-forgets dispatch via `asyncio.create_task()` inside `on_tool_end` / `on_llm_end`, never blocking the chain. Callbacks are passed via `config["callbacks"]` at invoke time so they propagate into subgraphs. An event taxonomy tells you which `on_*` events to forward (the interesting ones: `on_tool_end`, `on_chain_end` for named subgraphs) and which to drop (`on_chain_start` noise, P47). A target-matrix covers HTTP webhooks, Kafka, Redis Streams, and SNS — each with delivery guarantees, typical latency, and dead-letter patterns. Idempotency keys are built from `run_id + event_type + step_index`, HMAC-signed for webhooks, retried with 1s/5s/30s exponential backoff before the final DLQ write. Pinned to LangChain 1.0.x with four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers wiring LangChain chains into real-time systems — per-tool webhooks, per-run telemetry to Kafka/Redis, fan-out to analytics and downstream workers |
+| **What** | Async `BaseCallbackHandler` with fire-and-forget dispatch, subgraph-aware callback wiring, event-taxonomy filter, per-target dispatch matrix (HTTP/Kafka/Redis/SNS), idempotency key scheme, HMAC-signed webhooks with 1s/5s/30s retry + DLQ, 4 references |
+| **When** | Firing webhooks mid-chain (per-tool, per-stage), pushing telemetry to Kafka/Redis Streams, dispatching events to multiple subscribers without blocking the stream, debugging subagent silence, replacing broken `BackgroundTasks` dispatch |
+
+## Key Features
+
+1. **Async fire-and-forget handler** — `BaseCallbackHandler` subclass uses `asyncio.create_task()` inside `on_tool_end` so dispatch never blocks the chain's forward progress; typical webhook latency budget kept under 500ms per event
+2. **Subgraph-aware propagation** — Callbacks passed via `config["callbacks"]` at `invoke(...)` time (not `with_config`) so they fire from child subgraphs and tool-calling subagents (P28), plus a debug probe to prove propagation is working
+3. **Per-target dispatch matrix** — HTTP webhook (at-least-once, HMAC-signed, 1s/5s/30s retry), Kafka (at-least-once, idempotent producer), Redis Streams (at-least-once with consumer groups), SNS (best-effort fan-out) — each with failure mode, DLQ pattern, and idempotency-key convention (`run_id + event_type + step_index`)
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions. Cross-reference `langchain-langgraph-streaming` (in this pack) for browser-facing SSE — this skill is for server-to-server dispatch only.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/subgraph-propagation.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/references/subgraph-propagation.md
@@ -1,0 +1,192 @@
+# Subgraph Propagation — Why `config["callbacks"]` is Required
+
+P28 is the silent bug that destroys observability: a `BaseCallbackHandler`
+attached via `Runnable.with_config(callbacks=[handler])` is **not** inherited
+by LangGraph subgraphs. The outer agent fires callbacks; the inner subagent's
+tool calls are completely dark. This reference explains why and gives a
+repeatable fix + propagation probe.
+
+## The mechanism
+
+LangChain 1.0 has two ways to attach callbacks to a `Runnable`:
+
+| Method | When bound | Inherited by subgraphs? |
+|---|---|---|
+| `runnable.with_config({"callbacks": [h]})` | At definition | **No** — captured in the parent runnable's config, not the invocation config |
+| `runnable.invoke(x, config={"callbacks": [h]})` | At invocation | **Yes** — config flows through every child `Runnable.invoke` call |
+
+LangGraph creates a child `Runnable` per node and subgraph. The child receives
+the config from the parent's invocation context. Callbacks bound at
+*definition* time are trapped in the parent's scope. Callbacks passed in
+config flow down.
+
+## The wrong pattern (P28)
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+inner_agent = create_react_agent(model=llm, tools=[search_tool])
+outer_graph = (
+    StateGraph(State)
+    .add_node("plan", planner)
+    .add_node("execute", inner_agent)   # subgraph
+    .add_edge("plan", "execute")
+    .compile()
+)
+
+# WRONG — handler bound at definition; does NOT propagate
+agent_with_cb = outer_graph.with_config({"callbacks": [dispatch_handler]})
+await agent_with_cb.ainvoke({"messages": [...]})
+# Result: dispatch fires on 'plan' and 'execute' entry,
+# but NOT on search_tool invocation inside inner_agent. Dark.
+```
+
+## The right pattern
+
+```python
+await outer_graph.ainvoke(
+    {"messages": [...]},
+    config={
+        "callbacks": [dispatch_handler],
+        "configurable": {"thread_id": "t1"},
+    },
+)
+# Result: dispatch fires on every tool call everywhere in the graph —
+# including deeply nested subgraphs and their tools.
+```
+
+The rule: **every invocation site that might hit a subgraph must pass
+callbacks through config**. There is no way to "register" a callback once and
+have it apply to nested invocations.
+
+## Propagation probe
+
+Before shipping, verify the callbacks reach every level:
+
+```python
+from collections import Counter
+from langchain_core.callbacks import AsyncCallbackHandler
+
+class EventCounter(AsyncCallbackHandler):
+    """Counts events by the runnable name that emitted them.
+    Useful for asserting subgraph propagation in tests."""
+    def __init__(self):
+        self.counts: Counter[str] = Counter()
+
+    async def on_chain_start(self, serialized, inputs, *, run_id, **kwargs):
+        name = kwargs.get("name") or (serialized or {}).get("name") or "<anon>"
+        self.counts[f"chain_start:{name}"] += 1
+
+    async def on_tool_start(self, serialized, input_str, *, run_id, **kwargs):
+        name = (serialized or {}).get("name") or "<anon>"
+        self.counts[f"tool_start:{name}"] += 1
+
+# Test:
+counter = EventCounter()
+await outer_graph.ainvoke(
+    {"messages": [HumanMessage("find the user and summarize")]},
+    config={"callbacks": [counter]},
+)
+
+# If subgraph propagation works, you see both outer and inner names:
+assert "chain_start:plan" in counter.counts
+assert "chain_start:execute" in counter.counts   # subgraph entry
+assert "tool_start:search_tool" in counter.counts  # tool inside subgraph
+```
+
+If `tool_start:search_tool` is **missing**, callbacks are not propagating —
+you bound them at definition, not invocation.
+
+## Per-subgraph event filtering
+
+Once callbacks propagate, you often want different dispatch rules for the
+outer graph vs subgraphs. Use the `kwargs["name"]` or the `tags` list:
+
+```python
+class ScopedDispatchHandler(AsyncCallbackHandler):
+    """Dispatch only events from named subgraphs we care about."""
+
+    SUBGRAPH_ALLOWLIST = {"execute", "retrieval", "synthesis"}
+
+    async def on_chain_end(self, outputs, *, run_id, **kwargs):
+        name = kwargs.get("name", "")
+        if name not in self.SUBGRAPH_ALLOWLIST:
+            return
+        self._dispatch("chain_end", {"name": name, "run_id": str(run_id)})
+```
+
+Alternative: tag the subgraph nodes explicitly when building the graph, then
+filter on tags:
+
+```python
+graph.add_node("execute", inner_agent, metadata={"tags": ["subgraph", "customer-visible"]})
+
+# In handler:
+tags = kwargs.get("tags", []) or []
+if "customer-visible" not in tags:
+    return
+```
+
+Tags are more stable than names because node names can change without breaking
+downstream filtering code.
+
+## run_id continuity across subgraphs
+
+Every callback receives a `run_id` kwarg. In subgraphs, the child's `run_id`
+differs from the parent's — but the `parent_run_id` kwarg links them.
+
+```python
+async def on_tool_end(self, output, *, run_id, parent_run_id=None, **kwargs):
+    # Build a call tree for debugging:
+    self.call_tree[run_id] = parent_run_id
+```
+
+Your idempotency key uses the handler's *init-time* `run_id` (the logical chain
+invocation id), not the per-callback `run_id`. The per-callback `run_id` is
+for correlating events within a single invocation.
+
+## Callbacks + `astream_events` interaction
+
+If you use both `astream_events(version="v2")` AND a callback handler, the
+handler fires during event emission. Both mechanisms see the same events.
+Typical pattern:
+
+- Callback handler → dispatch to external sinks (webhooks, Kafka)
+- `astream_events` consumer → forward filtered events to SSE stream for UI
+
+Do not use one for both purposes — the coupling makes testing hard and the
+event shapes differ.
+
+## Debugging a dark subagent
+
+Symptoms:
+- Handler fires on outer nodes, silent on inner nodes
+- No exceptions, no warnings — just no events
+- `langchain.debug=True` output shows the inner runnable executing
+
+Steps:
+
+1. Check invoke site — is config passed?
+   ```python
+   await graph.ainvoke(x, config={"callbacks": [h]})  # right
+   await graph.with_config({"callbacks": [h]}).ainvoke(x)  # wrong
+   ```
+2. Install the `EventCounter` probe above and assert inner names appear.
+3. If step 2 passes but your dispatch handler still misses events — check
+   event filtering. You may be filtering out the inner events by name /
+   runnable type (`on_chain_start` for `RunnableLambda` is often silenced).
+4. If none of the above — check that you're subclassing `AsyncCallbackHandler`
+   (not `BaseCallbackHandler`) and that your handler methods are `async def`.
+   Mixing sync/async leads to silent skips.
+
+## Cross-ref to debug-bundle skill
+
+The pack's `langchain-debug-bundle` skill has the full P28 triage flowchart,
+including LangSmith/OTEL correlation patterns. Use this reference for dispatch
+propagation, that skill for observability propagation.
+
+## Cross-references
+
+- [Async Callback Handler](async-callback-handler.md) — the handler subclass this relies on
+- [Dispatch Targets](dispatch-targets.md) — where events go once they reach the handler
+- [Idempotency and Retry](idempotency-and-retry.md) — how `run_id` fits into idempotency keys


### PR DESCRIPTION
## Summary

Handcrafted Flagship skill covering event dispatch from LangChain 1.0 chains to external systems (webhooks, Kafka, Redis Streams) — async callback handler, fire-and-forget, HMAC + idempotency, subgraph propagation. Anchored to pain-catalog **P28, P46, P47, P48, P60**.

## Pain hook

Team fires per-tool webhooks from FastAPI `BackgroundTasks` wondering why analytics lags N seconds (P60 — tasks fire post-response) and why their subagent's tool calls are dark (P28 — callbacks bound via `.with_config` don't propagate to subgraphs). Fix: async `AsyncCallbackHandler` with `asyncio.create_task()` fire-and-forget dispatch passed via `config["callbacks"]` at invoke time, HMAC-signed with `run_id + event_type + step_index` idempotency keys and 1s/5s/30s retry before DLQ.

## Files

- `skills/langchain-webhooks-events/SKILL.md` (318 lines)
- `skills/langchain-webhooks-events/references/one-pager.md`
- `skills/langchain-webhooks-events/references/async-callback-handler.md`
- `skills/langchain-webhooks-events/references/dispatch-targets.md`
- `skills/langchain-webhooks-events/references/idempotency-and-retry.md`
- `skills/langchain-webhooks-events/references/subgraph-propagation.md`

## Validator

Grade **A (93/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude