### PR TITLE
feat(langchain-py-pack): add langchain-local-dev-loop (F23)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: langchain-local-dev-loop
+description: |
+  Build a fast, deterministic local test loop for LangChain 1.0 / LangGraph 1.0
+  — FakeListChatModel fixtures, pytest config, VCR cassettes with key redaction,
+  warning-filter policy. Use when adding tests to a new chain, fixing a flaky
+  test, or making integration tests reproducible.
+  Trigger with "langchain pytest", "FakeListChatModel", "VCR langchain",
+  "langchain test fixtures", "langchain integration test".
+allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(python:*), Bash(pip:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, testing, pytest, vcr]
+compatible-with: claude-code, codex
+---
+
+# LangChain Local Dev Loop (Python)
+
+## Overview
+
+An engineer writes the most natural assertion possible:
+
+```python
+def test_summarize():
+    out = chain.invoke({"text": "..."})
+    assert out.content == "expected summary"
+```
+
+It passes locally against Claude at `temperature=0`. It fails in CI on the third
+run with a one-token delta in the output. That is P05: Anthropic's `temperature=0`
+is not greedy — it still samples. Tests against live Claude are not deterministic,
+period.
+
+So the engineer swaps in `FakeListChatModel(responses=["expected summary"])` and
+the assertion passes. Then the downstream callback that logs cost blows up in CI
+with `KeyError: 'token_usage'` — because `FakeListChatModel` does not emit
+`response_metadata["token_usage"]` (P43). Production code reads that key, so
+either the fake has to synthesize it or the test has to skip the callback.
+
+Meanwhile, the first integration test under VCR records a cassette that ships
+`Authorization: Bearer sk-ant-api03-...` in the repo (P44). PR review catches it;
+the reviewer revokes the key; the dev loop is hosed for an afternoon.
+
+And none of this matters if pytest cannot even collect the suite because
+`import langchain_community` emits a `DeprecationWarning` that `-W error` promotes
+to failure (P45).
+
+This skill installs the four layers that make the whole loop fast and safe:
+`FakeListChatModel` / `FakeListLLM` with a metadata-emitting subclass (fixes P43);
+VCR with `filter_headers` plus a pre-commit hook (fixes P44); pytest
+`filterwarnings` policy in `pyproject.toml` (fixes P45); and an env-var-gated
+integration marker so the default `pytest` run never touches live APIs.
+
+**Speed targets:** unit tests with `FakeListChatModel` run in **< 100ms** per
+test; VCR-replayed integration tests run in **500ms – 2s** per test; live
+integration tests (the `RUN_INTEGRATION=1` gate) run only in nightly or
+manual workflows.
+
+**Pin:** `langchain-core 1.0.x`, `langgraph 1.0.x`, `pytest` current, `vcrpy`
+current. Pain-catalog anchors: P05, P43, P44, P45.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install langchain-core>=1.0,<2.0 langgraph>=1.0,<2.0 pytest vcrpy pytest-recording`
+- For integration tests: at least one provider key (`ANTHROPIC_API_KEY`, etc.)
+- Project uses `pyproject.toml` (PEP 621) for pytest config
+
+## Instructions
+
+### Step 1 — Deterministic unit tests with `FakeListChatModel`
+
+Use `FakeListChatModel` from `langchain_core.language_models.fake` for chat
+chains and `FakeListLLM` for legacy completion LLMs. Responses cycle through
+the list.
+
+```python
+from langchain_core.language_models.fake import FakeListChatModel
+from langchain_core.prompts import ChatPromptTemplate
+
+def test_classifier_picks_positive():
+    fake = FakeListChatModel(responses=["positive"])
+    prompt = ChatPromptTemplate.from_messages([("user", "Classify: {text}")])
+    chain = prompt | fake
+    out = chain.invoke({"text": "I love it"})
+    assert out.content == "positive"
+```
+
+This is deterministic, runs in single-digit milliseconds, and has zero provider
+dependency. Use it for every chain assertion that does not specifically require
+real model behavior.
+
+### Step 2 — Subclass `FakeListChatModel` to emit `response_metadata` (P43 fix)
+
+The stock fake emits no `response_metadata["token_usage"]`. If your chain has a
+callback that records cost, the callback crashes under the fake. Subclass and
+synthesize the metadata instead of mocking around the callback:
+
+```python
+from langchain_core.language_models.fake import FakeListChatModel
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.messages import AIMessage
+
+class FakeChatWithUsage(FakeListChatModel):
+    """FakeListChatModel that emits response_metadata['token_usage'] so
+    downstream callbacks reading token usage do not crash under test."""
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        response = self.responses[self.i % len(self.responses)]
+        self.i += 1
+        message = AIMessage(
+            content=response,
+            response_metadata={
+                "token_usage": {
+                    "input_tokens": 10,
+                    "output_tokens": len(response.split()),
+                    "total_tokens": 10 + len(response.split()),
+                },
+                "model_name": "fake-chat",
+            },
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": len(response.split()),
+                "total_tokens": 10 + len(response.split()),
+            },
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+```
+
+Use `FakeChatWithUsage` whenever a chain's observability / cost path is in the
+assertion surface. See [Fake Model Fixtures](references/fake-model-fixtures.md)
+for agent, retriever, and embedder fakes.
+
+### Step 3 — pytest fixtures that wire the fake into chains
+
+Put fixtures in `tests/conftest.py` so they are shared across the suite:
+
+```python
+# tests/conftest.py
+import pytest
+from langchain_core.prompts import ChatPromptTemplate
+from tests.fakes import FakeChatWithUsage
+
+@pytest.fixture
+def fake_chat():
+    """Reusable fake chat model. Override responses per-test via
+    monkeypatch.setattr(fake_chat, 'responses', [...])."""
+    return FakeChatWithUsage(responses=["ok"])
+
+@pytest.fixture
+def summarize_chain(fake_chat):
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "Summarize the user's text in one line."),
+        ("user", "{text}"),
+    ])
+    return prompt | fake_chat
+```
+
+Per-test response override:
+
+```python
+def test_summary_shape(summarize_chain, fake_chat):
+    fake_chat.responses = ["short summary"]
+    out = summarize_chain.invoke({"text": "long input"})
+    assert out.content == "short summary"
+```
+
+### Step 4 — VCR cassettes for integration tests with key redaction (P44 fix)
+
+Unit tests should never touch the network. Integration tests do, exactly once —
+to record a cassette — and every subsequent run replays from the cassette file.
+`vcrpy` records headers by default, which means `Authorization: Bearer sk-...`
+lands in the fixture unless you filter it.
+
+Configure VCR in `tests/conftest.py`:
+
+```python
+# tests/conftest.py (continued)
+import pytest
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            "authorization",
+            "x-api-key",
+            "anthropic-version",
+            "openai-organization",
+            "cookie",
+        ],
+        "filter_query_parameters": ["api_key"],
+        # Block accidental re-recording in CI:
+        "record_mode": "none",
+    }
+```
+
+Use `pytest-recording`:
+
+```python
+import pytest
+
+@pytest.mark.vcr  # cassette at tests/cassettes/<test_name>.yaml
+@pytest.mark.integration
+def test_live_claude_short_answer():
+    from langchain_anthropic import ChatAnthropic
+    chat = ChatAnthropic(model="claude-sonnet-4-6", temperature=0, timeout=30)
+    out = chat.invoke("Say 'ok' and nothing else.")
+    assert "ok" in out.content.lower()
+```
+
+To record (once, locally, with a real key): `pytest --record-mode=once tests/`.
+Every other run replays — cassettes are committed, real API is never hit again.
+
+**Pre-commit hook to block key leaks:**
+
+```bash
+# .git/hooks/pre-commit or .pre-commit-config.yaml entry
+#!/usr/bin/env bash
+set -e
+if git diff --cached --name-only | grep -q '^tests/cassettes/'; then
+    if git diff --cached -U0 -- 'tests/cassettes/' | \
+       grep -E '(sk-ant-[a-zA-Z0-9_-]+|sk-[a-zA-Z0-9]{20,}|Bearer\s+[a-zA-Z0-9_-]{20,})'; then
+        echo "ERROR: API key pattern found in staged cassette." >&2
+        exit 1
+    fi
+fi
+```
+
+See [VCR Cassette Hygiene](references/vcr-cassette-hygiene.md) for the full
+pre-commit config, record-new-episodes flow, shared-cassette patterns, and the
+PR review checklist.
+
+### Step 5 — Pytest warnings + markers in `pyproject.toml` (P45 fix)
+
+`langchain_community` and some provider SDKs emit `DeprecationWarning` at import
+time. If the suite runs `-W error`, collection fails before any test does. Set
+the policy once in `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["tests"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "-W", "error",
+]
+markers = [
+    "integration: hits real APIs or replays VCR cassettes (set RUN_INTEGRATION=1)",
+    "slow: takes > 1s per test",
+    "smoke: minimal healthcheck run in CI",
+]
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning:langchain_community.*",
+    "ignore::DeprecationWarning:pydantic.*",
+    "ignore::PendingDeprecationWarning:langchain_core.*",
+]
+```
+
+See [Pytest Config](references/pytest-config.md) for the full skeleton
+including coverage config and parallel execution notes.
+
+### Step 6 — Integration-test gating via env var
+
+Default `pytest` must never hit real APIs. Gate on `RUN_INTEGRATION=1`:
+
+```python
+# tests/conftest.py (continued)
+import os
+import pytest
+
+def pytest_collection_modifyitems(config, items):
+    if os.getenv("RUN_INTEGRATION") == "1":
+        return
+    skip_integration = pytest.mark.skip(reason="set RUN_INTEGRATION=1 to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)
+```
+
+CI default: `pytest` (unit only). Nightly / manual: `RUN_INTEGRATION=1 pytest -m integration`.
+
+### Step 7 — LangGraph tests: per-test `thread_id` + state assertions
+
+LangGraph state is scoped to a `thread_id`. Tests that share a `thread_id` leak
+state between each other. Give every test a fresh `thread_id` and a fresh
+`MemorySaver`:
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+import uuid, pytest
+
+@pytest.fixture
+def graph_config():
+    return {"configurable": {"thread_id": str(uuid.uuid4())}}
+
+@pytest.fixture
+def checkpointed_graph(fake_chat):
+    from my_app.graphs import build_graph
+    return build_graph(fake_chat).compile(checkpointer=MemorySaver())
+
+def test_node_emits_plan(checkpointed_graph, graph_config, fake_chat):
+    fake_chat.responses = ["step 1\nstep 2\nstep 3"]
+    result = checkpointed_graph.invoke({"goal": "deploy"}, graph_config)
+    # Assert state shape per node, not just the final output:
+    assert result["plan"] == ["step 1", "step 2", "step 3"]
+    # Time-travel: inspect every checkpoint for debugging
+    history = list(checkpointed_graph.get_state_history(graph_config))
+    assert history[-1].values == {"goal": "deploy"}  # initial state
+```
+
+Subgraph isolation testing cross-references `langchain-langgraph-subgraphs`
+(pain P21 — parent cannot read child state unless the key is in the parent
+schema). See [LangGraph Test Patterns](references/langgraph-test-patterns.md)
+for the subgraph-shared-state test recipe.
+
+## Output
+
+- `tests/fakes.py` with `FakeChatWithUsage` subclass that emits `response_metadata`
+- `tests/conftest.py` with fake-model fixtures, VCR config, and `RUN_INTEGRATION` gate
+- `pyproject.toml` `[tool.pytest.ini_options]` block with markers and `filterwarnings`
+- `tests/cassettes/` committed with filtered headers (no `Authorization` / `x-api-key`)
+- Pre-commit hook grepping cassettes for `sk-` / `sk-ant-` / `Bearer` patterns
+- LangGraph tests with per-test `thread_id` and `MemorySaver` — no cross-test leakage
+
+## Test-type matrix
+
+| Type | Model | Network | Target speed | Determinism | Use case |
+|------|-------|---------|--------------|-------------|----------|
+| Unit | `FakeListChatModel` / `FakeChatWithUsage` | none | **< 100ms** | total | Chain shape, parser, routing logic |
+| Integration (VCR) | real model, replayed cassette | replay only | **500ms – 2s** | total (once recorded) | End-to-end chain behavior, provider-specific edge cases |
+| Integration (live) | real model | live API | 2s – 30s | probabilistic (P05) | Nightly smoke, recording new cassettes, provider regression |
+| Smoke | real model, minimal prompt | live API | < 5s | probabilistic | CI healthcheck — 1 test per provider, gated on `RUN_INTEGRATION=1` |
+| Load | real model | live API | minutes | probabilistic | Throughput / retry-storm reproduction, never in PR CI |
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `AssertionError` on content despite `temperature=0` | Anthropic `temperature=0` still samples (P05) | Switch to `FakeListChatModel` or VCR replay |
+| `KeyError: 'token_usage'` under fake model | `FakeListChatModel` emits no `response_metadata` (P43) | Use `FakeChatWithUsage` subclass from Step 2 |
+| PR review flags `Authorization: Bearer sk-...` in cassette | VCR recorded headers by default (P44) | Set `filter_headers` before recording; re-record; add pre-commit grep hook |
+| `pytest` fails at collection with `DeprecationWarning` | `-W error` + SDK import warnings (P45) | Add `filterwarnings = ["ignore::DeprecationWarning:langchain_community.*"]` |
+| `vcr.errors.CannotOverwriteExistingCassetteException` | Test changed request shape but cassette is stale | `pytest --record-mode=new_episodes` locally, inspect diff, commit |
+| LangGraph test pollutes next test's state | Shared `thread_id` + shared `MemorySaver` | Per-test `thread_id=uuid.uuid4()`, per-test `MemorySaver()` |
+
+## Examples
+
+### A flaky chain assertion, fixed in three commits
+
+1. **Commit 1 — failing test** uses real `ChatAnthropic`, passes locally, fails
+   1-in-5 in CI at `temperature=0` (P05).
+2. **Commit 2 — swap to fake model** uses `FakeListChatModel`, passes
+   deterministically, but the cost-logging callback crashes (P43).
+3. **Commit 3 — fake with metadata** uses `FakeChatWithUsage`, the callback
+   reads `response_metadata["token_usage"]` cleanly, the test is green and
+   runs in 40ms.
+
+See [Fake Model Fixtures](references/fake-model-fixtures.md) for the full
+worked example including agent and retriever fakes.
+
+### Recording a cassette without leaking a key
+
+```bash
+# 1. Ensure conftest.py has filter_headers configured FIRST
+# 2. Record with real key present in the environment
+ANTHROPIC_API_KEY=sk-ant-... pytest --record-mode=once tests/integration/test_summarize.py
+# 3. Verify no leak
+grep -E 'sk-|Bearer' tests/cassettes/*.yaml && echo "LEAK" || echo "clean"
+# 4. Commit cassettes/ — pre-commit hook runs the same grep as a hard gate
+git add tests/cassettes/ && git commit -m "test: record summarize cassette"
+```
+
+See [VCR Cassette Hygiene](references/vcr-cassette-hygiene.md) for
+record-new-episodes mode, rerecord-on-mismatch, and the PR review checklist.
+
+### LangGraph time-travel debugging on a failing test
+
+When a graph test fails mid-graph, `get_state_history(config)` returns every
+checkpoint — you can replay from any point by passing its `config.checkpoint_id`
+back into `graph.invoke`. See
+[LangGraph Test Patterns](references/langgraph-test-patterns.md) for the full
+time-travel debugging recipe and the subgraph-shared-state test pattern
+(cross-ref `langchain-langgraph-subgraphs` / pain L30).
+
+## Resources
+
+- [LangChain Python: testing guide](https://python.langchain.com/docs/contributing/testing/)
+- [`FakeListChatModel` API](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.fake.FakeListChatModel.html)
+- [`vcrpy` documentation](https://vcrpy.readthedocs.io/)
+- [`pytest-recording`](https://pytest-vcr.readthedocs.io/)
+- [LangGraph `MemorySaver` + `get_state_history`](https://langchain-ai.github.io/langgraph/how-tos/time-travel/)
+- [Pytest `filterwarnings`](https://docs.pytest.org/en/stable/how-to/capture-warnings.html)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P05, P43, P44, P45)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/fake-model-fixtures.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/fake-model-fixtures.md
@@ -1,0 +1,192 @@
+# Fake Model Fixtures Reference
+
+Deterministic, network-free stand-ins for chat models, completion LLMs,
+embedders, retrievers, and agents. Copy-paste ready. Pinned to
+`langchain-core 1.0.x`.
+
+## The three stock fakes
+
+| Class | Module | Emits |
+|-------|--------|-------|
+| `FakeListChatModel` | `langchain_core.language_models.fake` | `AIMessage(content=str)` cycled from `responses=[...]` |
+| `FakeListLLM` | `langchain_core.language_models.fake` | `str` cycled from `responses=[...]` |
+| `FakeStreamingListLLM` | `langchain_core.language_models.fake` | Streaming `str` chunks |
+
+All three implement `Runnable` — they slot directly into LCEL `prompt | model`
+chains without any adapter.
+
+## Chat model fake with `response_metadata` (P43 fix)
+
+The stock `FakeListChatModel` does **not** emit `response_metadata["token_usage"]`.
+Downstream callbacks that log cost or enforce budgets crash with `KeyError`.
+Subclass and synthesize the metadata instead of mocking the callback:
+
+```python
+# tests/fakes.py
+from langchain_core.language_models.fake import FakeListChatModel
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.messages import AIMessage
+
+
+class FakeChatWithUsage(FakeListChatModel):
+    """FakeListChatModel that synthesizes response_metadata and usage_metadata
+    so downstream callbacks reading token usage do not KeyError under test.
+
+    Token counts are approximations: input=10, output=len(response.split()).
+    Override in a subclass if your assertion surface is the exact count.
+    """
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        response = self.responses[self.i % len(self.responses)]
+        self.i += 1
+        out_tokens = max(1, len(response.split()))
+        message = AIMessage(
+            content=response,
+            response_metadata={
+                "token_usage": {
+                    "input_tokens": 10,
+                    "output_tokens": out_tokens,
+                    "total_tokens": 10 + out_tokens,
+                },
+                "model_name": "fake-chat",
+                "finish_reason": "stop",
+            },
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": out_tokens,
+                "total_tokens": 10 + out_tokens,
+            },
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+```
+
+### When to use which
+
+| Chain surface under test | Fake to use |
+|--------------------------|-------------|
+| Prompt → model → parser (output-only assertion) | `FakeListChatModel` |
+| Prompt → model → callback that reads `response_metadata` | `FakeChatWithUsage` |
+| Streaming endpoint, counting chunks | `FakeStreamingListLLM` (wrap as chat if needed) |
+| Legacy `LLMChain` / completion-style | `FakeListLLM` |
+
+## Agent fake — canned tool calls
+
+`create_tool_calling_agent` expects the model to emit `tool_calls` on the
+`AIMessage`. The stock fakes do not. Subclass to emit tool calls:
+
+```python
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.language_models.fake import FakeListChatModel
+
+
+class FakeAgentModel(FakeListChatModel):
+    """Emits one tool call per `responses` entry when entry is a dict;
+    plain strings are treated as final text responses."""
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        item = self.responses[self.i % len(self.responses)]
+        self.i += 1
+        if isinstance(item, dict):
+            # item = {"tool": "search", "args": {"q": "..."}}
+            msg = AIMessage(
+                content="",
+                tool_calls=[{
+                    "name": item["tool"],
+                    "args": item["args"],
+                    "id": f"call_{self.i}",
+                }],
+            )
+        else:
+            msg = AIMessage(content=item)
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+```
+
+Usage:
+
+```python
+fake = FakeAgentModel(responses=[
+    {"tool": "search", "args": {"q": "weather"}},
+    "The weather is 72°F.",
+])
+```
+
+## Retriever fake
+
+```python
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.documents import Document
+from typing import List
+
+
+class FakeRetriever(BaseRetriever):
+    docs: List[Document] = []
+
+    def _get_relevant_documents(self, query, *, run_manager):
+        return list(self.docs)
+
+
+# In conftest.py:
+import pytest
+
+@pytest.fixture
+def fake_retriever():
+    return FakeRetriever(docs=[
+        Document(page_content="doc 1 content", metadata={"source": "a.md"}),
+        Document(page_content="doc 2 content", metadata={"source": "b.md"}),
+    ])
+```
+
+## Embedder fake
+
+```python
+from langchain_core.embeddings import Embeddings
+import hashlib
+
+
+class FakeEmbeddings(Embeddings):
+    """Stable, deterministic embeddings derived from a hash of the text.
+    Same text → same vector every run. Not useful for similarity semantics;
+    use only for plumbing tests."""
+
+    def __init__(self, dims: int = 384):
+        self.dims = dims
+
+    def _vec(self, text: str):
+        h = hashlib.sha256(text.encode()).digest()
+        return [(h[i % len(h)] / 255.0) for i in range(self.dims)]
+
+    def embed_documents(self, texts):
+        return [self._vec(t) for t in texts]
+
+    def embed_query(self, text):
+        return self._vec(text)
+```
+
+## Per-test response override pattern
+
+Fixtures return a fake with a default response list; tests override via
+attribute assignment. This avoids re-building the chain per test:
+
+```python
+def test_short_answer(summarize_chain, fake_chat):
+    fake_chat.responses = ["short"]
+    assert summarize_chain.invoke({"text": "long"}).content == "short"
+
+def test_long_answer(summarize_chain, fake_chat):
+    fake_chat.responses = ["a much longer summary here"]
+    assert "summary" in summarize_chain.invoke({"text": "long"}).content
+```
+
+## Reset between tests
+
+`FakeListChatModel.i` is an instance counter — it survives across test
+invocations on a session-scoped fixture. Either use function-scoped fixtures
+(default) or reset explicitly:
+
+```python
+@pytest.fixture(autouse=True)
+def _reset_fake(fake_chat):
+    fake_chat.i = 0
+    yield
+```

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/langgraph-test-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/langgraph-test-patterns.md
@@ -1,0 +1,185 @@
+# LangGraph Test Patterns Reference
+
+LangGraph 1.0 tests need three things the chain tests don't:
+
+1. A fresh `thread_id` per test (state is scoped to threads)
+2. A fresh checkpointer per test (or explicit reset)
+3. Per-node state assertions, not just final-output assertions
+
+## Per-test `thread_id` + `MemorySaver`
+
+```python
+import uuid
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+@pytest.fixture
+def graph_config():
+    """Fresh thread_id per test — prevents state leakage between tests."""
+    return {"configurable": {"thread_id": str(uuid.uuid4())}}
+
+@pytest.fixture
+def checkpointer():
+    """Per-test MemorySaver — prevents test N from seeing test N-1's checkpoints."""
+    return MemorySaver()
+
+@pytest.fixture
+def compiled_graph(fake_chat, checkpointer):
+    from my_app.graphs import build_graph
+    return build_graph(fake_chat).compile(checkpointer=checkpointer)
+```
+
+Using a session-scoped `MemorySaver` or a shared `thread_id` guarantees flaky
+tests — the third test sees state from the first two. Always per-test.
+
+## State assertions per node
+
+The naive graph test asserts on the final output dict only. That hides bugs in
+intermediate nodes. Assert the shape at each node:
+
+```python
+def test_plan_then_execute(compiled_graph, graph_config, fake_chat):
+    fake_chat.responses = [
+        "step 1\nstep 2\nstep 3",  # plan node
+        "done",                    # execute node
+    ]
+    result = compiled_graph.invoke({"goal": "deploy"}, graph_config)
+
+    assert result["plan"] == ["step 1", "step 2", "step 3"]
+    assert result["status"] == "done"
+
+    # State history — every checkpoint the graph created:
+    history = list(compiled_graph.get_state_history(graph_config))
+    # Order: newest first
+    assert history[0].values["status"] == "done"
+    assert history[-1].values == {"goal": "deploy"}
+    # Every node wrote a checkpoint:
+    assert len(history) >= 3  # start + plan + execute
+```
+
+## Time-travel debugging on a failing test
+
+When an intermediate node produces the wrong shape, `get_state_history` gives
+you every checkpoint. Replay from any of them:
+
+```python
+def test_debug_failing_node(compiled_graph, graph_config, fake_chat):
+    fake_chat.responses = ["bad plan output", "done"]
+    compiled_graph.invoke({"goal": "deploy"}, graph_config)
+
+    history = list(compiled_graph.get_state_history(graph_config))
+    # Find the checkpoint right before the failing node ran:
+    pre_failure = next(h for h in history if h.next == ("plan",))
+
+    # Replay with a corrected input:
+    fake_chat.responses = ["step 1\nstep 2\nstep 3", "done"]
+    new_result = compiled_graph.invoke(None, pre_failure.config)
+    assert new_result["plan"] == ["step 1", "step 2", "step 3"]
+```
+
+`pre_failure.config` carries the `checkpoint_id`; `invoke(None, config)`
+resumes from that checkpoint. This is the fastest way to bisect a multi-node
+graph without rerunning earlier nodes.
+
+## Subgraph isolation tests (cross-ref `langchain-langgraph-subgraphs`, P21)
+
+Parent graphs cannot see subgraph state unless the key is declared in the
+parent's state schema (pain L30). Test this explicitly:
+
+```python
+from langgraph.graph import StateGraph
+from typing import TypedDict
+
+class ParentState(TypedDict):
+    goal: str
+    subgraph_result: str  # MUST be declared for the parent to see it
+
+class ChildState(TypedDict):
+    goal: str
+    subgraph_result: str
+    internal_scratch: str  # lives only in child, never visible to parent
+
+def test_subgraph_state_contract(compiled_parent_graph, graph_config):
+    """Assert the parent sees exactly the keys the schema declares — no more."""
+    result = compiled_parent_graph.invoke({"goal": "x"}, graph_config)
+    assert "subgraph_result" in result
+    assert "internal_scratch" not in result  # opaque by design
+```
+
+If you forget to add `subgraph_result` to `ParentState`, the parent's
+`get_state` returns without it silently — this test catches that regression.
+See the pack's `langchain-langgraph-subgraphs` skill for the full
+state-contract playbook (pain anchor L30 / P21).
+
+## Testing streaming graphs
+
+`graph.stream(...)` yields one event per node per step. Assert on the event
+sequence:
+
+```python
+async def test_streaming_plan_then_execute(compiled_graph, graph_config, fake_chat):
+    fake_chat.responses = ["step 1\nstep 2", "done"]
+    events = []
+    async for event in compiled_graph.astream(
+        {"goal": "deploy"},
+        graph_config,
+        stream_mode="updates",
+    ):
+        events.append(event)
+
+    # One update per node:
+    assert any("plan" in e for e in events)
+    assert any("execute" in e for e in events)
+```
+
+For `stream_mode="values"` you get the full state after each step; for
+`"updates"` you get the delta only.
+
+## Interrupts and human-in-the-loop (HITL)
+
+Graphs with `interrupt_before=["human_review"]` pause before a node. Tests
+need to step through manually:
+
+```python
+def test_interrupt_before_review(compiled_graph_with_interrupt, graph_config, fake_chat):
+    fake_chat.responses = ["plan A"]
+    # First invoke stops at the interrupt:
+    compiled_graph_with_interrupt.invoke({"goal": "x"}, graph_config)
+
+    state = compiled_graph_with_interrupt.get_state(graph_config)
+    assert state.next == ("human_review",)
+
+    # Simulate human approval by updating state, then resume:
+    compiled_graph_with_interrupt.update_state(
+        graph_config,
+        {"approved": True},
+        as_node="human_review",
+    )
+    final = compiled_graph_with_interrupt.invoke(None, graph_config)
+    assert final["status"] == "approved"
+```
+
+## Performance expectations
+
+| Graph shape | Fake model | Target |
+|-------------|------------|--------|
+| 3-node linear | `FakeChatWithUsage` | < 50ms |
+| 5-node with one subgraph | `FakeChatWithUsage` | < 150ms |
+| With VCR replay (integration) | real model, replayed | 500ms - 2s |
+| With interrupt + resume | fake | < 100ms |
+
+If a fake-model graph test exceeds 200ms, check for accidental sleeps,
+real-network calls, or a non-fake embedder still hitting a local vector DB
+cold-start.
+
+## Gotchas
+
+- `MemorySaver` is in-memory — does not persist across test processes.
+  Fine for unit tests. For integration tests that must survive a restart,
+  use `SqliteSaver` with a per-test file path in `tmp_path`.
+- `update_state` with `as_node="X"` writes a checkpoint *as if* node X had
+  run. Forgetting `as_node=` writes as an anonymous update and the graph
+  resumes from the wrong step.
+- Tests that use `graph.stream` must either `await` an async stream or call
+  `list(graph.stream(...))` on sync — easy to mix up and get a coroutine
+  back instead of events.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-local-dev-loop — One-Pager
+
+Build a fast, deterministic local test loop for LangChain 1.0 / LangGraph 1.0 — `FakeListChatModel` fixtures, pytest config, VCR cassettes with key redaction, warning-filter policy.
+
+## The Problem
+
+An engineer writes `assert chain.invoke(input).content == "expected"` — it passes locally at `temperature=0` against Claude but fails intermittently in CI, because Anthropic's `temperature=0` still samples (P05). They switch to `FakeListChatModel` — now downstream token callbacks blow up with `KeyError: 'token_usage'` because the fake model emits no `response_metadata` (P43). They record a VCR cassette for an integration smoke test, and PR review flags `Authorization: Bearer sk-ant-...` committed into the fixture file (P44). On top of that, pytest collection itself fails before any test runs because `langchain_community` imports emit `DeprecationWarning` and the suite runs `-W error` (P45).
+
+## The Solution
+
+This skill installs a four-layer local dev loop: (1) `FakeListChatModel` and `FakeListLLM` for deterministic unit tests, with a subclass that synthesizes `response_metadata` so downstream token counters keep working; (2) pytest fixtures that wire the fake model into chains, agents, retrievers, and embedders; (3) VCR cassettes for integration tests with `filter_headers=["authorization","x-api-key","anthropic-version"]` and a pre-commit hook grepping for `sk-*` / `sk-ant-*`; (4) `pyproject.toml` `filterwarnings` policy plus an `@pytest.mark.integration` gate that defaults-skips unless `RUN_INTEGRATION=1`. LangGraph tests use `MemorySaver` with a fixed `thread_id` per test and assert state shape per node. Pinned to LangChain 1.0.x / LangGraph 1.0.x / pytest current / vcrpy current.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers and researchers adding tests to a LangChain 1.0 / LangGraph 1.0 codebase — unit, integration, smoke, or load |
+| **What** | Fake-model fixtures (with metadata subclass), VCR cassette policy + key-leak pre-commit hook, `pyproject.toml` pytest/markers/filterwarnings skeleton, LangGraph per-test `thread_id` pattern, 4 references (fake-model-fixtures, vcr-cassette-hygiene, pytest-config, langgraph-test-patterns) |
+| **When** | Adding tests to a new chain or graph; fixing a flaky test caused by provider non-determinism; making an integration test reproducible without real API calls; wiring CI for deterministic runs |
+
+## Key Features
+
+1. **`FakeListChatModel` + metadata-emitting subclass** — Deterministic responses cycled from a `responses=[...]` list; subclass overrides `_generate` to inject `generation_info={"token_usage": {...}}` so downstream callbacks reading `response_metadata["token_usage"]` keep working (P43 fix)
+2. **VCR cassette hygiene** — `filter_headers` config removes `authorization` / `x-api-key` / `anthropic-version` before any cassette is written, paired with a pre-commit hook that greps cassette files for `sk-` / `sk-ant-` and blocks the commit on a match (P44 fix)
+3. **`pyproject.toml` pytest skeleton** — `filterwarnings = ["ignore::DeprecationWarning:langchain_community.*"]` (P45 fix), `markers = ["integration: requires RUN_INTEGRATION=1"]`, env-var gate that defaults-skips integration tests unless `RUN_INTEGRATION=1`, per-provider `testpaths`
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/pytest-config.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/pytest-config.md
@@ -1,0 +1,165 @@
+# Pytest Config Reference
+
+Single-source `pyproject.toml` skeleton for LangChain 1.0 / LangGraph 1.0
+projects. Covers warning policy (P45 fix), markers, integration gating,
+coverage, and parallel execution.
+
+## Minimum viable `[tool.pytest.ini_options]`
+
+```toml
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = [
+    "-ra",                  # summary of all non-passing results
+    "--strict-markers",     # unknown @pytest.mark.xyz → error
+    "--strict-config",      # unknown config key → error
+    "--tb=short",
+    "-W", "error",          # warnings → failures; overrides via filterwarnings
+]
+
+markers = [
+    "integration: hits real APIs or replays VCR cassettes (set RUN_INTEGRATION=1 to run)",
+    "smoke: minimal healthcheck tests, run in every CI job",
+    "slow: takes > 1s per test; skipped in quick runs via -m 'not slow'",
+    "vcr: uses pytest-recording cassette replay",
+]
+
+filterwarnings = [
+    "error",                                               # treat warnings as errors
+    "ignore::DeprecationWarning:langchain_community.*",    # P45: noisy import-time DW
+    "ignore::DeprecationWarning:pydantic.*",               # pydantic v1 compat warnings
+    "ignore::PendingDeprecationWarning:langchain_core.*",
+    "ignore::UserWarning:langsmith.*",                     # telemetry warnings
+    "ignore:Pydantic serializer warnings:UserWarning",
+]
+```
+
+## Why `filterwarnings = ["error", ...]` and not `addopts = ["-W", "error"]`
+
+Both exist; they interact. Prefer `filterwarnings` because:
+
+- `filterwarnings` is applied per-test (scoped properly)
+- `-W error` in `addopts` fires at import / collection time, before filters
+  attach — so any warning emitted during `collect` bypasses your ignores and
+  crashes the suite (P45 symptom)
+
+If you truly want warnings-as-errors at collection too, include `"error"` as
+the *first* entry of `filterwarnings`, then the specific `ignore::...` rules
+after it. Pytest evaluates rules top-to-bottom; specific overrides global.
+
+## Integration gate — conftest.py
+
+```python
+# tests/conftest.py
+import os
+import pytest
+
+def pytest_collection_modifyitems(config, items):
+    """Skip @pytest.mark.integration unless RUN_INTEGRATION=1 is set."""
+    if os.getenv("RUN_INTEGRATION") == "1":
+        return
+    skip = pytest.mark.skip(reason="set RUN_INTEGRATION=1 to run integration tests")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip)
+```
+
+Usage:
+
+```bash
+pytest                                   # unit only (default, fast)
+RUN_INTEGRATION=1 pytest -m integration  # integration only (VCR or live)
+pytest -m "not slow"                     # everything except slow tests
+pytest -m smoke                          # quickest subset for CI health
+```
+
+## Coverage config (optional but recommended)
+
+```toml
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = ["tests/*", "src/*/migrations/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+fail_under = 80
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+```
+
+Run with: `pytest --cov=src --cov-report=term-missing`
+
+## Parallel execution
+
+`pytest-xdist` runs tests across workers. Works cleanly with `FakeListChatModel`
+because fakes are stateless per fixture. Does **not** work with shared VCR
+cassettes (file-write contention on record; file-read concurrency is fine on
+replay if `record_mode=none`).
+
+```toml
+[tool.pytest.ini_options]
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "-n", "auto",  # enable xdist with worker-per-CPU
+]
+```
+
+Exclude integration from xdist if cassettes collide:
+
+```bash
+pytest -n auto -m "not integration"
+RUN_INTEGRATION=1 pytest -n 0 -m integration
+```
+
+## CI matrix pattern
+
+```yaml
+# .github/workflows/test.yml
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -e ".[test]"
+      - run: pytest -n auto -m "not integration"
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -e ".[test]"
+      - run: RUN_INTEGRATION=1 pytest -m integration
+        env:
+          # Cassettes replay, no live keys needed.
+          # Live nightly job uses secrets: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+## Common pytest flags for LangChain projects
+
+| Flag | Use |
+|------|-----|
+| `--record-mode=none` | Force replay (CI default) |
+| `--record-mode=once` | Record missing cassettes (local only) |
+| `--block-network` (pytest-recording) | Fail any test that makes a real HTTP call — safety net |
+| `-x` | Stop on first failure — great for debugging a cascade |
+| `--lf` | Last-failed only — iterate fast after a regression |
+| `-k "summarize"` | Substring-match test names |
+
+## Gotchas
+
+- `strict-markers` will fail the suite if a dev adds `@pytest.mark.newthing`
+  without declaring it. That is the point — forces marker discipline.
+- `pythonpath = ["src"]` lets you `import my_app` without an editable install.
+  Remove it if you install with `pip install -e .`.
+- `filterwarnings` is evaluated first-match; order matters. Put `"error"`
+  first, then specific `ignore::...` rules.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/vcr-cassette-hygiene.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/references/vcr-cassette-hygiene.md
@@ -1,0 +1,140 @@
+# VCR Cassette Hygiene Reference
+
+Recording real API calls once and replaying forever is the fastest integration
+test pattern we have. It is also the fastest way to leak an API key into a
+public repo if you let `vcrpy` record headers by default. This reference is
+the full playbook.
+
+## The leak (P44)
+
+`vcrpy` records request headers unless you tell it not to. Anthropic and OpenAI
+send the key in `Authorization: Bearer ...` or `x-api-key: ...`. The cassette
+is a YAML file committed with the test. PR review is the last line of defense
+before the key hits a public branch — which is too late, because even a deleted
+commit on a public repo is scraped by credential harvesters within minutes.
+
+**The key is compromised the moment the commit is pushed.** Revoke immediately.
+
+## Baseline `vcr_config` (safe defaults)
+
+```python
+# tests/conftest.py
+import pytest
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        # Strip every header that carries a credential:
+        "filter_headers": [
+            "authorization",
+            "x-api-key",
+            "anthropic-version",
+            "anthropic-beta",
+            "openai-organization",
+            "openai-project",
+            "x-goog-api-key",
+            "cookie",
+            "set-cookie",
+        ],
+        # Strip query-string credentials (Google's ?key= pattern):
+        "filter_query_parameters": ["api_key", "key", "access_token"],
+        # Strip request-body fields that some providers accept in the body:
+        "filter_post_data_parameters": ["api_key"],
+        # Default: replay only. Recording requires --record-mode=once on CLI.
+        "record_mode": "none",
+        # Body matching is strong; headers vary run-to-run on the LLM side:
+        "match_on": ["method", "scheme", "host", "port", "path", "query", "body"],
+    }
+```
+
+## Recording flow (once, locally, with a real key)
+
+```bash
+# Preconditions:
+# 1. conftest.py has filter_headers configured
+# 2. .env or shell has ANTHROPIC_API_KEY / OPENAI_API_KEY etc.
+
+# Record:
+pytest --record-mode=once tests/integration/test_summarize.py
+
+# Post-record audit — hard-grep for common key prefixes:
+grep -REn '(sk-ant-[a-zA-Z0-9_-]+|sk-[a-zA-Z0-9]{20,}|Bearer\s+[a-zA-Z0-9_-]{20,}|AIza[0-9A-Za-z-_]{35})' tests/cassettes/
+# Expected output: no matches. Any match → STOP, revoke key, re-record.
+
+# Commit:
+git add tests/cassettes/
+git commit -m "test: record summarize cassette"
+```
+
+## Record modes (when to use each)
+
+| Mode | Behavior | When |
+|------|----------|------|
+| `none` | Replay only. Missing cassette → test fails. | **Default in CI.** |
+| `once` | Record if cassette missing, else replay. | First recording, local only. |
+| `new_episodes` | Replay existing, record new interactions. | Adding a follow-up request to an existing cassette. |
+| `all` | Re-record everything. | Provider changed the response shape. |
+
+Never set `record_mode=all` in `vcr_config` — it will silently overwrite
+cassettes and rotate in a fresh real key every CI run.
+
+## Pre-commit hook — hard-gate against leaks
+
+`.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: cassette-no-keys
+        name: Block API keys in VCR cassettes
+        entry: bash scripts/check-cassettes.sh
+        language: system
+        files: ^tests/cassettes/.*\.(yaml|yml)$
+```
+
+`scripts/check-cassettes.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -e
+LEAKED=$(git diff --cached -U0 -- 'tests/cassettes/' | \
+    grep -E '(sk-ant-[a-zA-Z0-9_-]+|sk-[a-zA-Z0-9]{20,}|Bearer\s+[a-zA-Z0-9_-]{20,}|AIza[0-9A-Za-z-_]{35})' || true)
+if [ -n "$LEAKED" ]; then
+    echo "ERROR: API key pattern in staged cassette:" >&2
+    echo "$LEAKED" >&2
+    exit 1
+fi
+```
+
+## Per-test vs shared cassettes
+
+- **Per-test (`pytest-recording` default)** — one `.yaml` per test function,
+  stored at `tests/cassettes/<test_module>/<test_name>.yaml`. Cheap to
+  regenerate individual tests. Preferred.
+- **Shared** — multiple tests replay from one cassette. Brittle; one
+  test-order change invalidates everything. Use only for expensive
+  setup-shaped cassettes (auth exchange, initial embedding batch).
+
+## Cassette drift — when replay fails
+
+```
+vcr.errors.CannotOverwriteExistingCassetteException:
+  Can't overwrite existing cassette at ... in your current record mode ('none').
+```
+
+The test's request shape changed. Decide:
+
+1. **Intentional change** → `pytest --record-mode=new_episodes` locally,
+   inspect diff, commit.
+2. **Unintentional (code regression)** → fix the request-building code;
+   cassette is correct.
+
+## PR review checklist for cassettes
+
+- [ ] `filter_headers` includes `authorization`, `x-api-key`, every provider-specific key header
+- [ ] `grep -E '(sk-|Bearer |AIza)' tests/cassettes/` returns zero matches
+- [ ] Pre-commit hook `cassette-no-keys` is installed and passing
+- [ ] `record_mode` default is `none` (no silent re-records)
+- [ ] Cassette file sizes are reasonable (< 100KB each — a 10MB cassette usually means response body was not trimmed)
+- [ ] Reviewer has confirmed at least one cassette replays by checking out the branch and running `pytest -m integration`


### PR DESCRIPTION
## Summary

Handcrafted Flagship skill for fast, deterministic local testing of LangChain 1.0 / LangGraph 1.0 codebases — `FakeListChatModel` fixtures, pytest config, VCR cassette hygiene, warning-filter policy, LangGraph test patterns. Anchored to pain-catalog **P05, P43, P44, P45**.

## Pain hook

Engineer writes `assert chain.invoke(input).content == "expected"` — passes locally at `temperature=0` against Claude but fails intermittently in CI because Anthropic's `temperature=0` still samples (P05), then the first VCR cassette ships `Authorization: Bearer sk-ant-...` into the repo (P44). Skill fixes both paths: `FakeChatWithUsage` subclass synthesizing `response_metadata` (P43), `filter_headers` + pre-commit grep hook for cassettes (P44), and `pyproject.toml` `filterwarnings` policy so pytest collection does not fail on SDK `DeprecationWarning`s under `-W error` (P45).

## Files

- `skills/langchain-local-dev-loop/SKILL.md`
- `skills/langchain-local-dev-loop/references/one-pager.md`
- `skills/langchain-local-dev-loop/references/fake-model-fixtures.md`
- `skills/langchain-local-dev-loop/references/vcr-cassette-hygiene.md`
- `skills/langchain-local-dev-loop/references/pytest-config.md`
- `skills/langchain-local-dev-loop/references/langgraph-test-patterns.md`

## Validator

Grade **A (93/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude