### PR TITLE
feat(langchain-py-pack): add langchain-deploy-integration (S14)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: langchain-deploy-integration
+description: |
+  Deploy a LangChain 1.0 / LangGraph 1.0 app to Cloud Run, Vercel, or LangServe
+  correctly — timeouts sized for chain length, cold-start mitigation, SSE
+  anti-buffering headers, Secret Manager over `.env`. Use when prepping first
+  prod deploy, debugging a stream that hangs behind a proxy, or diagnosing p99
+  latency spikes.
+  Trigger with "langchain deploy", "langchain cloud run", "langchain vercel python",
+  "langchain langserve", "langchain docker".
+allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(gcloud:*), Bash(vercel:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, deployment, cloud-run, vercel, langserve]
+compatible-with: claude-code, codex
+---
+
+# LangChain Deploy Integration (Python)
+
+## Overview
+
+An engineer ships a working LangGraph agent to Vercel. Every non-trivial request
+returns `FUNCTION_INVOCATION_TIMEOUT`. The Python runtime on Vercel defaults to
+a **10-second** cap (P35) — a three-tool agent with one RAG round easily runs
+20-40s. Local dev never exposed the wall because `uvicorn` on a laptop has no
+timeout. Two fixes apply together and each is load-bearing:
+
+```json
+// vercel.json — the baseline cap bump (Pro plan max is 60s, Enterprise 900s)
+{ "functions": { "api/chat.py": { "maxDuration": 60 } } }
+```
+
+```python
+# app/api/chat.py — stream the response so partial output arrives before the cap
+from fastapi.responses import StreamingResponse
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest):
+    async def gen():
+        async for chunk in chain.astream(req.input):
+            yield f"data: {chunk.model_dump_json()}\n\n"
+    return StreamingResponse(gen(), media_type="text/event-stream",
+                             headers={"X-Accel-Buffering": "no"})
+```
+
+The `maxDuration: 60` raises the Vercel-imposed wall; streaming reduces
+time-to-first-byte to under a second so the user sees progress even on a
+40-second completion. Once the Vercel cap is fixed, the next three walls are:
+Cloud Run cold starts (**5-15s** p99 on Python + LangChain — P36), `.env`
+secrets leaking via `docker exec <pod> env` (P37), and SSE streams hanging
+because Nginx / Cloud Run buffer the final chunk (P46).
+
+This skill walks through a production-grade multi-stage Dockerfile, Cloud Run
+flags for cold-start mitigation, Vercel `maxDuration` + streaming, LangServe
+route mounting with FastAPI lifespan, SSE anti-buffering headers, and Secret
+Manager via `pydantic.SecretStr`. Pin: `langchain-core 1.0.x`, `langgraph 1.0.x`,
+`langserve 1.0.x`. Pain-catalog anchors: **P35** (Vercel 10s default),
+**P36** (Cloud Run cold start), **P37** (`.env` leaks), **P46** (SSE buffering).
+
+## Prerequisites
+
+- Python 3.11+ (3.12 preferred for `uvicorn` startup speed)
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`, `langserve >= 1.0, < 2.0`
+- `fastapi >= 0.110`, `uvicorn[standard] >= 0.27`
+- Target platform: `gcloud` CLI (Cloud Run), `vercel` CLI (Vercel), or `docker` (generic)
+- For Cloud Run: a GCP project with Secret Manager API enabled
+- For Vercel: a project with `@vercel/python` runtime configured
+
+## Instructions
+
+### Step 1 — Multi-stage Dockerfile with slim runtime and `uvicorn`
+
+A multi-stage build keeps the runtime image under 400MB, which cuts Cloud Run
+cold starts by 2-3 seconds. Use `python:3.12-slim` as the final stage (not
+`python:3.12` — that base adds ~900MB for dev tooling that never runs in prod).
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim AS builder
+WORKDIR /build
+RUN pip install --no-cache-dir uv
+COPY pyproject.toml uv.lock ./
+RUN uv export --format requirements-txt --no-hashes > requirements.txt \
+ && pip wheel --wheel-dir=/wheels -r requirements.txt
+
+FROM python:3.12-slim AS runtime
+RUN useradd -m -u 10001 app
+WORKDIR /app
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir --no-index --find-links=/wheels /wheels/* \
+ && rm -rf /wheels
+COPY --chown=app:app app/ ./app/
+USER app
+EXPOSE 8080
+ENV PORT=8080 PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --workers 1"]
+```
+
+Single worker is correct — Cloud Run handles horizontal scale; in-process
+multi-worker just duplicates LangChain client memory. See [Dockerfile and
+Secrets](references/dockerfile-and-secrets.md) for the distroless variant
+and the `.dockerignore` hardening for `.env` files.
+
+### Step 2 — Deploy to Cloud Run with cold-start mitigation
+
+Python + LangChain + `tiktoken` + one embedding model imports take 5-15
+seconds (P36). At `--min-instances=0`, every scale-from-zero request eats that
+as user-facing latency. Paying for one always-on instance is usually cheaper
+than the lost requests.
+
+```bash
+gcloud run deploy langchain-api \
+  --source=. \
+  --region=us-central1 \
+  --min-instances=1 \
+  --max-instances=20 \
+  --cpu=2 --memory=2Gi \
+  --cpu-boost \
+  --no-cpu-throttling \
+  --timeout=3600 \
+  --concurrency=80 \
+  --set-secrets=ANTHROPIC_API_KEY=anthropic-key:latest,OPENAI_API_KEY=openai-key:latest \
+  --service-account=langchain-api@PROJECT.iam.gserviceaccount.com
+# --timeout=3600 is the Cloud Run per-request maximum (1 hour) — needed
+# because multi-tool LangGraph agents routinely run 1-5 minutes end-to-end.
+```
+
+The load-bearing flags: `--min-instances=1` kills cold-start p99 (one always-warm
+replica costs ~$15/mo and dominates p99 improvement); `--cpu-boost` doubles CPU
+for the first 10 seconds; `--no-cpu-throttling` (CPU-always-allocated billing)
+keeps `astream` running between keepalive pings so long LangGraph runs do not
+stall at tool boundaries; `--concurrency=80` matches typical I/O-bound
+workloads (drop to 10 if embedding large docs in-process).
+
+See [Cloud Run Deploy](references/cloud-run-deploy.md) for VPC egress, file
+secret mounts, revision traffic splitting, and the full cost model.
+
+### Step 3 — Vercel Python: `maxDuration: 60` + streaming to beat the cap
+
+On Vercel Hobby the max is **10s** by default (P35); Pro is **60s**, Enterprise
+**900s**. Always set `maxDuration` explicitly — the default is a trap.
+
+```json
+// vercel.json
+{
+  "functions": {
+    "api/chat.py": { "maxDuration": 60, "memory": 1024 }
+  }
+}
+```
+
+Streaming is not just a UX fix — it is the mitigation for bursts that still
+exceed `maxDuration`. Time-to-first-byte under a second keeps the proxy
+considering the request alive; partial content renders on the client; when
+the cap finally triggers, the user has already seen most of the answer. The
+Vercel entrypoint pattern mirrors the Overview snippet above — pair with the
+SSE headers from Step 5.
+
+Edge Runtime is **not** an option here — `@vercel/edge` is JavaScript-only.
+Anything that imports `langchain` must run on `@vercel/python` (serverless,
+Node-free Python container). See [Vercel Python Deploy](references/vercel-python-deploy.md)
+for env vars vs Vercel Secrets, cold-start profiling, and the serverless vs
+fluid-compute tradeoff.
+
+### Step 4 — LangServe: `add_routes` + FastAPI lifespan for pool cleanup
+
+LangServe ships typed HTTP routes over any `Runnable`. The `playground` path
+is invaluable in dev but **must be disabled in production** — it leaks chain
+topology to anyone who can hit the URL. Mount behind a FastAPI `lifespan`
+that closes `asyncpg` / `httpx` / Redis pools on revision retirement;
+`on_shutdown` fires too late on Cloud Run and connections leak across
+revisions.
+
+```python
+# app/main.py
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from langserve import add_routes
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.chain = build_chain()
+    yield
+    await db_pool.close()
+
+app = FastAPI(lifespan=lifespan)
+add_routes(app, build_chain(), path="/chat",
+           enable_feedback_endpoint=False,
+           playground_type="chat" if __debug__ else None)  # None = off in prod
+```
+
+See [LangServe Patterns](references/langserve-patterns.md) for typed input/output
+schemas, auth middleware, and coexisting with raw FastAPI handlers.
+
+### Step 5 — SSE anti-buffering: survive Nginx, Cloud Run, Cloudflare
+
+Nginx, Cloud Run's load balancer, and Cloudflare all buffer responses by
+default. On SSE, buffering means the client never sees the final `end` event
+and `LangGraph.astream` hangs forever (P46). Two headers plus one response
+flush fix it:
+
+```python
+from fastapi.responses import StreamingResponse
+
+def sse_headers() -> dict:
+    return {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        "X-Accel-Buffering": "no",          # disables Nginx buffering
+        "Connection": "keep-alive",
+    }
+
+@app.post("/api/chat/stream")
+async def stream(payload: dict):
+    async def gen():
+        async for event in graph.astream_events(payload, version="v2"):
+            yield f"data: {event['data']}\n\n".encode("utf-8")
+        yield b"event: end\ndata: [DONE]\n\n"
+    return StreamingResponse(gen(), headers=sse_headers())
+```
+
+Cross-reference: this is the same anti-buffering pattern used by
+`langchain-langgraph-streaming` (L29) — that skill covers the `astream_events`
+event shapes and client reconnection; this skill covers the proxy surface.
+If you see the stream work locally but hang in prod, the header is missing on
+the upstream response, not the client.
+
+### Step 6 — Secret Manager over `.env` with `pydantic.SecretStr`
+
+`python-dotenv` populates `os.environ`. Anyone with container access runs
+`docker exec <pod> env` and reads every API key in plain text (P37). Mount
+secrets from Secret Manager on Cloud Run, Vercel Secrets on Vercel; wrap in
+`pydantic.SecretStr` so `repr()`, logs, and tracebacks print `**********`
+instead of the value.
+
+```python
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
+    anthropic_api_key: SecretStr
+    openai_api_key: SecretStr
+
+settings = Settings()  # reads real env vars only; never .env in prod
+```
+
+Cloud Run: `--set-secrets=VAR=secret-name:latest` (Step 2). Vercel:
+`vercel env add ANTHROPIC_API_KEY production`. Never commit `.env`; add
+`.env*` to `.dockerignore` so it does not enter the build context.
+
+Cross-reference: this skill sets the deployment boundary. `langchain-security-basics`
+(P18) covers key-rotation cadence, PII log redaction, and the broader threat
+model — get the boundary right here, then layer on P18.
+
+## Output
+
+- Multi-stage Dockerfile, runtime image under 400MB, non-root user, `uvicorn` entrypoint
+- Cloud Run deployment with `--min-instances=1 --cpu-boost --no-cpu-throttling --timeout=3600 --concurrency=80`
+- `vercel.json` with `maxDuration: 60` plus streaming response for requests that may exceed the cap
+- LangServe `add_routes(app, chain, path="/chat")` behind a FastAPI `lifespan` that closes resource pools on revision retirement
+- SSE responses with `X-Accel-Buffering: no` and `Cache-Control: no-cache` so proxies do not buffer the final `end` event
+- Runtime secrets sourced from Secret Manager / Vercel Secrets and wrapped in `pydantic.SecretStr`; no `.env` in the image
+
+## Platform Decision Table
+
+| Platform | Max timeout | Cold start (p99) | SSE default | Cost baseline (1 agent, 1M req/mo) | Pick when |
+|----------|-------------|------------------|-------------|------------------------------------|-----------|
+| **Cloud Run** | 3600s | 5-15s (mitigable with min-instances) | Buffers without header override | ~$40-80/mo + min-instance | Long agents, heavy imports, VPC egress, GCP-native |
+| **Vercel Python** | 10s Hobby / 60s Pro / 900s Enterprise | 2-5s (warmed) | No buffering when streaming response | ~$20/mo Pro plan flat | Fast iteration, Next.js frontend colocation, short agents |
+| **Fly.io** | No hard cap (per-request soft) | 1-3s (always-on VM) | No default buffer | ~$30/mo for shared-cpu-1x + 1GB | Need persistent state, low cold start, non-serverless model |
+| **Railway** | 30 min default | 2-4s | No default buffer | ~$25/mo on Hobby replica | Prototype to production on one platform, Postgres bundled |
+| **Self-hosted (k8s + Nginx)** | Ingress-controlled | 0s (warm pod) | Buffers — requires `proxy_buffering off` | Variable, fixed infra cost | Compliance constraints, existing k8s, egress control |
+
+Cloud Run is the default for most LangChain production deployments — the 3600s
+timeout is the only mainstream serverless option long enough for multi-tool
+agents, and Secret Manager integration is native.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `FUNCTION_INVOCATION_TIMEOUT` (Vercel) | 10s Python default on Hobby, 60s on Pro (P35) | Set `maxDuration: 60` in `vercel.json`; stream the response |
+| `504 Gateway Timeout` from Cloud Run | Missing `--timeout=3600`; default is 300s | Redeploy with `--timeout=3600 --concurrency=80` |
+| p99 latency 10x p95 | Cold start from Python + LangChain imports (P36) | `--min-instances=1 --cpu-boost`, defer `tiktoken` import to request time |
+| Client hangs forever on SSE stream | Proxy buffering the final `end` event (P46) | Add `X-Accel-Buffering: no` and `Cache-Control: no-cache` headers |
+| `docker exec <pod> env` shows API keys | `python-dotenv` leaked `.env` into `os.environ` (P37) | Delete `.env` from image, use Secret Manager + `pydantic.SecretStr` |
+| `RuntimeError: Event loop is closed` on shutdown | `asyncpg` / `httpx` pool not closed before revision retirement | Move pool lifecycle into FastAPI `lifespan` context manager |
+| Stream works locally, stalls on Cloud Run | CPU throttling between keepalive pings | Deploy with `--no-cpu-throttling` (CPU-always-allocated) |
+| `ModuleNotFoundError` in Vercel build | `requirements.txt` not generated from `pyproject.toml` | Add build step: `uv export --format requirements-txt > requirements.txt` |
+
+## Examples
+
+### A: Cloud Run with min-instances, secret mounts, VPC egress
+
+One always-warm replica, two secrets from Secret Manager, egress routed
+through a VPC connector for private Postgres. See [Cloud Run Deploy](references/cloud-run-deploy.md)
+for the full flag set, revision traffic splitting, and the cost model.
+
+### B: Vercel with streaming and maxDuration
+
+`vercel.json` with `maxDuration: 60` plus the FastAPI streaming entrypoint
+from Step 3. The combination gives a 40-second completion a 60-second wall
+and <1s time-to-first-byte. See [Vercel Python Deploy](references/vercel-python-deploy.md)
+for Edge Runtime limits and the Vercel Secrets vs env var split.
+
+### C: LangServe behind FastAPI with lifespan
+
+Single `add_routes` call mounting `/chat` and `/chat/stream` with a shared
+connection pool closed via `lifespan`. Playground disabled in prod via the
+`__debug__` check. See [LangServe Patterns](references/langserve-patterns.md)
+for typed schemas, auth middleware, and raw-handler coexistence.
+
+## Resources
+
+- [Cloud Run: Configuring services](https://cloud.google.com/run/docs/configuring/services)
+- [Cloud Run: Always-on CPU (no CPU throttling)](https://cloud.google.com/run/docs/configuring/cpu-allocation)
+- [Vercel: Python runtime](https://vercel.com/docs/functions/runtimes/python)
+- [Vercel: `maxDuration` and streaming](https://vercel.com/docs/functions/configuring-functions/duration)
+- [LangServe: Getting started](https://python.langchain.com/docs/langserve/)
+- [FastAPI: Lifespan events](https://fastapi.tiangolo.com/advanced/events/)
+- [Pydantic: `SecretStr`](https://docs.pydantic.dev/latest/api/types/#pydantic.types.SecretStr)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P35, P36, P37, P46)
+- Related skills: `langchain-langgraph-streaming` (L29), `langchain-security-basics` (P18)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/cloud-run-deploy.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/cloud-run-deploy.md
@@ -1,0 +1,128 @@
+# Cloud Run Deploy Reference
+
+The complete flag set for a production LangChain service on Cloud Run, with
+rationale for each flag and the failure mode it prevents.
+
+## Baseline deploy command
+
+```bash
+gcloud run deploy langchain-api \
+  --source=. \
+  --region=us-central1 \
+  --min-instances=1 \
+  --max-instances=20 \
+  --cpu=2 --memory=2Gi \
+  --cpu-boost \
+  --no-cpu-throttling \
+  --timeout=3600 \
+  --concurrency=80 \
+  --execution-environment=gen2 \
+  --port=8080 \
+  --ingress=all \
+  --allow-unauthenticated \
+  --service-account=langchain-api@PROJECT.iam.gserviceaccount.com \
+  --set-env-vars=LANGCHAIN_TRACING_V2=true \
+  --set-secrets=ANTHROPIC_API_KEY=anthropic-key:latest,OPENAI_API_KEY=openai-key:latest
+```
+
+## Flag-by-flag rationale
+
+| Flag | Value | Why it matters |
+|------|-------|----------------|
+| `--min-instances` | `1` | Kills cold-start p99 (P36). One always-warm replica costs ~$15/mo on 2 vCPU / 2 GiB and dominates p99 improvement over any other tuning. |
+| `--max-instances` | `20` | Hard ceiling on autoscale. Set based on provider rate limits — each instance can hit the Anthropic tier-1 rate cap (50 req/min) independently. |
+| `--cpu` | `2` | Import time scales with CPU. `cpu=1` doubles cold start on LangChain imports. |
+| `--memory` | `2Gi` | Embedding models (even small ones) + tokenizer caches + request buffers. 1Gi OOMs on 10 concurrent embedding calls. |
+| `--cpu-boost` | flag | 2x CPU during first 10 seconds. Halves import time on cold start. Free when using `gen2`. |
+| `--no-cpu-throttling` | flag | CPU-always-allocated billing. Required so `astream` keeps executing between HTTP keepalive pings; without it, a long LangGraph run stalls at tool boundaries. |
+| `--timeout` | `3600` | Max request duration. Cloud Run max is 3600s (1h); use full value for agent runs. Defaults to 300s — too low for real agents. |
+| `--concurrency` | `80` | Per-instance concurrent request ceiling. LangChain is mostly I/O-bound (LLM calls), so 80 is typical. Drop to 10 if embedding large docs in-process. |
+| `--execution-environment` | `gen2` | Required for `--cpu-boost`. Slightly slower cold start than gen1 but supports mounts and network filesystems. |
+| `--ingress` | `all` | Public. Use `internal-and-cloud-load-balancing` for private APIs; requires a load balancer. |
+| `--service-account` | dedicated SA | Least-privilege. The SA needs `roles/secretmanager.secretAccessor` on each secret and `roles/cloudtrace.agent` for tracing. |
+
+## Secret mounts: env vs file
+
+Two ways to consume Secret Manager secrets:
+
+**Environment variables** (simplest, recommended for API keys):
+```bash
+--set-secrets=ANTHROPIC_API_KEY=anthropic-key:latest
+```
+Secret is read once at container start; not hot-reloaded on rotation.
+
+**Mounted as files** (required for multi-line secrets like certs or JSON creds):
+```bash
+--set-secrets=/var/secrets/gcp-credentials=gcp-sa-key:latest
+```
+File appears at the mount path; set `GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/gcp-credentials`.
+
+Rotation note: Cloud Run does not auto-redeploy on Secret Manager version
+changes. After `gcloud secrets versions add anthropic-key`, you must redeploy
+the service to pick up the new version. The `:latest` alias is evaluated at
+deploy time, not at request time.
+
+## VPC egress for private Postgres / Redis
+
+LangChain apps often need a private DB (pgvector, Redis cache). Cloud Run
+defaults to public egress only; route internal traffic via a VPC connector.
+
+```bash
+gcloud compute networks vpc-access connectors create lc-egress \
+  --region=us-central1 --network=default --range=10.8.0.0/28
+
+gcloud run deploy langchain-api \
+  --vpc-connector=projects/PROJECT/locations/us-central1/connectors/lc-egress \
+  --vpc-egress=private-ranges-only   # only 10.x / 172.16.x / 192.168.x go via VPC
+  # alternative: --vpc-egress=all-traffic   (everything through VPC, slower)
+```
+
+Use `private-ranges-only` unless you need all egress going through a NAT for
+IP allowlisting on external APIs — that path adds 20-40ms per call.
+
+## Revision traffic splitting
+
+Canary deploys without full cutover:
+
+```bash
+# Deploy new revision, send 0% traffic
+gcloud run deploy langchain-api --source=. --no-traffic --tag=canary
+
+# Route 10% of traffic to canary
+gcloud run services update-traffic langchain-api \
+  --to-revisions=LATEST=90,canary=10
+
+# Promote canary
+gcloud run services update-traffic langchain-api --to-latest
+```
+
+## Health checks and readiness
+
+Cloud Run pings `/` by default for startup. LangChain apps should expose a
+cheap `/healthz` that does **not** hit the model:
+
+```python
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok", "model": settings.model_id}
+```
+
+Configure with `--startup-probe=httpGet=/healthz,initialDelaySeconds=0,periodSeconds=1,timeoutSeconds=1,failureThreshold=20`.
+Do not probe model invocation — a slow model response will fail the probe and
+retart the instance.
+
+## Cost model
+
+Per-month baseline for one always-warm replica, 2 vCPU, 2 GiB, us-central1
+(2026 pricing):
+
+| Component | Cost |
+|-----------|------|
+| Always-allocated CPU (2 vCPU × 720 hrs) | ~$33 |
+| Always-allocated memory (2 GiB × 720 hrs) | ~$7 |
+| Requests (1M) | ~$0.40 |
+| Egress (10 GB) | ~$1.20 |
+| **Total baseline** | **~$42/mo** |
+
+Scaling to `--min-instances=0` drops this to ~$2/mo but you pay with 5-15s
+p99 cold start on the first request after idle. For production, pay the $40.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/dockerfile-and-secrets.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/dockerfile-and-secrets.md
@@ -1,0 +1,234 @@
+# Dockerfile and Secrets Reference
+
+A hardened multi-stage Dockerfile and the secret-management boundary between
+the platform (Secret Manager, Vercel Secrets) and the Python process
+(`pydantic.SecretStr`). Design goal: if someone gets `docker exec` on the
+running container, they see **no plaintext API keys** in `env` output (P37).
+
+## Multi-stage Dockerfile
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+ARG PY_VERSION=3.12
+
+# ---- builder: compile wheels from locked deps ----
+FROM python:${PY_VERSION}-slim AS builder
+WORKDIR /build
+RUN pip install --no-cache-dir uv
+COPY pyproject.toml uv.lock ./
+# Export to requirements.txt so the runtime layer doesn't need uv
+RUN uv export --format requirements-txt --no-hashes --no-dev > requirements.txt \
+ && pip wheel --wheel-dir=/wheels -r requirements.txt
+
+# ---- runtime: minimal, non-root ----
+FROM python:${PY_VERSION}-slim AS runtime
+# Security: non-root user with fixed UID so volume mounts have stable ownership
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin app
+WORKDIR /app
+
+# Install pre-built wheels only; no compiler in the runtime image
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir --no-index --find-links=/wheels /wheels/* \
+ && rm -rf /wheels /root/.cache
+
+# Copy app last so code changes don't bust the dep layer
+COPY --chown=app:app app/ ./app/
+
+# Runtime config
+USER app
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8080
+EXPOSE 8080
+
+# uvicorn with 1 worker — Cloud Run handles horizontal scale
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --workers 1"]
+```
+
+### Why each choice
+
+| Choice | Reason |
+|--------|--------|
+| `python:3.12-slim` | ~80 MB vs 900 MB for `python:3.12`. Kills cold start. |
+| Multi-stage | Compiler (`gcc`, `build-essential`) stays in builder; runtime has no toolchain. |
+| Non-root user (`--uid 10001`) | Defense in depth; some k8s policies refuse `uid=0` containers. |
+| `--no-cache-dir` on `pip install` | Saves ~50 MB on runtime image. |
+| Single `uvicorn --workers 1` | Cloud Run scales replicas; multi-worker in-process duplicates LangChain memory. |
+| `PYTHONUNBUFFERED=1` | Cloud Run / Vercel capture stdout for logs; buffered stdout hides crashes. |
+
+## `.dockerignore` — prevent secret leaks into build context
+
+```
+# Secrets — under no circumstances should these enter the image
+.env
+.env.*
+!.env.example
+secrets/
+*.pem
+*.key
+*.p12
+gcp-sa-*.json
+
+# Dev files that shouldn't ship
+.git
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+node_modules
+dist
+build
+```
+
+Build context is uploaded to the daemon wholesale — without
+`.dockerignore`, a committed `.env` ends up in the image even if `COPY`
+doesn't reference it (it's in the context tarball). CI should scan built
+images for `.env` files:
+
+```bash
+docker run --rm --entrypoint sh IMAGE -c 'find / -name ".env*" 2>/dev/null'
+# Expected output: nothing. Any hit = leak.
+```
+
+## Distroless variant (no shell, no debug tools)
+
+When you cannot allow a shell in production (CIS benchmark compliance):
+
+```dockerfile
+FROM gcr.io/distroless/python3-debian12:nonroot AS runtime
+WORKDIR /app
+COPY --from=builder /wheels /wheels
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --chown=nonroot:nonroot app/ ./app/
+USER nonroot
+ENV PORT=8080 PYTHONUNBUFFERED=1
+# Distroless has no /bin/sh — exec form only
+CMD ["-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+Tradeoff: you lose `docker exec <container> sh` for debugging. Plan your
+observability accordingly — structured logs + traces become mandatory.
+
+## Secret Manager on Cloud Run
+
+Three options, in order of preference:
+
+### 1. `--set-secrets=ENV_VAR=secret-name:latest` (simplest)
+
+```bash
+gcloud run deploy langchain-api \
+  --set-secrets=ANTHROPIC_API_KEY=anthropic-key:latest,OPENAI_API_KEY=openai-key:latest
+```
+
+Secret read once at container start, injected as an env var. Rotation
+requires a redeploy (Cloud Run does not auto-redeploy on secret version
+changes, and `:latest` is resolved at deploy time).
+
+### 2. Mount as a file (for multi-line secrets)
+
+```bash
+gcloud run deploy langchain-api \
+  --set-secrets=/var/secrets/gcp-key=gcp-sa-key:latest
+```
+
+In the app:
+```python
+import os
+os.environ.setdefault("GOOGLE_APPLICATION_CREDENTIALS", "/var/secrets/gcp-key")
+```
+
+### 3. Secret Manager client SDK (for hot rotation)
+
+If you need to pick up secret changes without redeploying, use the client SDK:
+
+```python
+from google.cloud import secretmanager
+from functools import lru_cache
+
+@lru_cache(maxsize=16)
+def get_secret(name: str, version: str = "latest") -> str:
+    client = secretmanager.SecretManagerServiceClient()
+    path = f"projects/PROJECT/secrets/{name}/versions/{version}"
+    return client.access_secret_version(request={"name": path}).payload.data.decode()
+```
+
+Clear cache on a signal or after N minutes to pick up rotations. Costs
+~$0.03 per 10k access calls — negligible for a cache-hit pattern.
+
+## `pydantic.SecretStr` — the process boundary
+
+Platform secrets land in `os.environ`; wrapping them in `SecretStr` prevents
+them from printing in logs, tracebacks, or `repr()` output.
+
+```python
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    # env_file=None forces env-only read; prevents reading a stray .env in prod
+    model_config = SettingsConfigDict(env_file=None, extra="ignore", case_sensitive=False)
+
+    anthropic_api_key: SecretStr
+    openai_api_key: SecretStr
+    langsmith_api_key: SecretStr | None = None
+    pg_url: SecretStr
+
+settings = Settings()
+
+# Usage: call .get_secret_value() only when handing to an SDK
+from langchain_anthropic import ChatAnthropic
+model = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    api_key=settings.anthropic_api_key.get_secret_value(),
+)
+
+# Accidental prints are safe:
+print(settings)
+# prints: anthropic_api_key=SecretStr('**********') ...
+```
+
+## The `.env` boundary
+
+Dev: `.env` file loaded by `python-dotenv` for convenience.
+
+Prod: **no `.env` file in the image**. Settings read from real env vars
+injected by the platform. Enforce with:
+
+```python
+# app/settings.py
+import os
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        # Only read .env locally; never in prod-like envs
+        env_file=".env" if os.getenv("ENV", "dev") == "dev" else None,
+        extra="ignore",
+    )
+```
+
+CI lint: grep the built image for `.env`:
+
+```yaml
+# .github/workflows/build.yml
+- run: |
+    docker build -t test-image .
+    docker run --rm --entrypoint find test-image / -name ".env*" -type f && {
+      echo "::error::.env file found in image"; exit 1
+    } || true
+```
+
+## Image size targets
+
+| Image | Target | Typical cold-start impact |
+|-------|--------|---------------------------|
+| `python:3.12` | 1000 MB | +3-5s |
+| `python:3.12-slim` + full deps | 400 MB | baseline |
+| `python:3.12-slim` + minimal deps | 250 MB | -1s |
+| `distroless/python3-debian12` | 180 MB | -2s |
+
+For LangChain apps the dep bloat dominates — `langchain-core`, provider
+SDKs, `tiktoken`, and one embedding library easily total 200+ MB. Slim
+runtime + no-dev wheels is the realistic target.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/langserve-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/langserve-patterns.md
@@ -1,0 +1,220 @@
+# LangServe Patterns Reference
+
+LangServe turns any `Runnable` into a typed FastAPI endpoint. The patterns
+below cover production mounting — typed schemas, playground gating, custom
+middleware, and coexisting with raw FastAPI handlers.
+
+## Minimal mount
+
+```python
+from fastapi import FastAPI
+from langserve import add_routes
+from app.chain import chain
+
+app = FastAPI()
+add_routes(app, chain, path="/chat")
+```
+
+This exposes:
+
+- `POST /chat/invoke` — single-shot `chain.invoke(input)`
+- `POST /chat/batch` — `chain.batch([inputs])`
+- `POST /chat/stream` — `chain.stream(input)` as SSE
+- `POST /chat/stream_events` — `chain.astream_events(input, version="v2")` as SSE
+- `GET /chat/playground` — browser playground UI (dev only)
+- `GET /chat/input_schema` — JSON Schema for input
+- `GET /chat/output_schema` — JSON Schema for output
+
+## Production mount with lifespan and playground gating
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from langserve import add_routes
+from app.chain import build_chain, close_pools
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.chain = build_chain()
+    yield
+    await close_pools()
+
+app = FastAPI(lifespan=lifespan)
+
+IS_PROD = __debug__ is False  # set PYTHONOPTIMIZE=1 in prod
+add_routes(
+    app,
+    app.state.chain if False else build_chain(),  # see note below
+    path="/chat",
+    playground_type="chat" if not IS_PROD else None,  # None disables in prod
+    enable_feedback_endpoint=False,  # don't expose until LangSmith auth wired
+    enabled_endpoints=("invoke", "batch", "stream", "stream_events"),
+)
+```
+
+Note: `add_routes` binds the Runnable eagerly. If you need request-scoped
+chain instances (rare — usually chain state is immutable), use a factory
+wrapper that builds per request. For most apps, build once at startup.
+
+## Typed input and output schemas
+
+LangServe uses Pydantic to validate request bodies. Explicit schemas produce
+better client SDKs and OpenAPI docs:
+
+```python
+from pydantic import BaseModel, Field
+from langchain_core.runnables import RunnablePassthrough
+
+class ChatInput(BaseModel):
+    question: str = Field(..., min_length=1, max_length=2000)
+    session_id: str = Field(..., pattern=r"^[a-zA-Z0-9_-]{1,64}$")
+    temperature: float = Field(0.0, ge=0.0, le=2.0)
+
+class ChatOutput(BaseModel):
+    answer: str
+    tokens_in: int
+    tokens_out: int
+
+typed_chain = (
+    RunnablePassthrough()
+    .with_types(input_type=ChatInput, output_type=ChatOutput)
+    | chain
+)
+
+add_routes(app, typed_chain, path="/chat")
+```
+
+The generated `/chat/input_schema` endpoint now returns a schema that
+front-end teams can codegen TypeScript types from.
+
+## Custom middleware: auth, rate limit, request ID
+
+LangServe mounts are plain FastAPI routes — standard middleware applies:
+
+```python
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+import uuid
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        rid = request.headers.get("x-request-id") or str(uuid.uuid4())
+        request.state.request_id = rid
+        response = await call_next(request)
+        response.headers["x-request-id"] = rid
+        return response
+
+app.add_middleware(RequestIDMiddleware)
+```
+
+For auth, use FastAPI `Depends` on a custom route that wraps the chain, or
+insert a global dependency on `/chat/*`:
+
+```python
+from fastapi import Depends, HTTPException, Security
+from fastapi.security import APIKeyHeader
+
+api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
+
+async def require_api_key(key: str = Security(api_key_header)):
+    if key != settings.api_key.get_secret_value():
+        raise HTTPException(401, "invalid or missing x-api-key")
+
+# Apply to all LangServe routes
+app = FastAPI(dependencies=[Depends(require_api_key)])
+add_routes(app, chain, path="/chat")
+```
+
+## Per-request configurable fields
+
+Expose chain config without rebuilding the chain:
+
+```python
+from langchain_core.runnables import ConfigurableField
+
+chain = (
+    prompt
+    | model.configurable_fields(
+        temperature=ConfigurableField(id="temperature"),
+        model_name=ConfigurableField(id="model_name"),
+    )
+    | parser
+)
+
+add_routes(app, chain, path="/chat",
+           per_req_config_modifier=lambda config, request: {
+               **config,
+               "configurable": {"temperature": request.headers.get("x-temp", 0.0)},
+           })
+```
+
+## Coexisting with raw FastAPI handlers
+
+LangServe mounts on a path prefix; other routes work normally:
+
+```python
+app = FastAPI(lifespan=lifespan)
+
+# LangServe mounts
+add_routes(app, chat_chain, path="/chat")
+add_routes(app, embed_chain, path="/embed")
+
+# Raw FastAPI handlers
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+@app.post("/api/webhook")
+async def webhook(payload: dict):
+    # custom logic, not a Runnable
+    return {"received": True}
+```
+
+## Disabling the playground in production
+
+The playground is extremely useful in dev but leaks chain topology —
+it returns the Runnable graph, input/output schemas, and will happily run
+any input that validates against the schema. Two ways to disable:
+
+```python
+# Option 1: None removes the playground route
+add_routes(app, chain, path="/chat", playground_type=None)
+
+# Option 2: gate by env / debug flag
+add_routes(app, chain, path="/chat",
+           playground_type="chat" if settings.env == "dev" else None)
+```
+
+Also disable `enable_feedback_endpoint=False` in prod unless LangSmith auth
+is wired — by default, anyone can POST feedback to any run.
+
+## SSE headers on LangServe stream routes
+
+LangServe's `/stream` and `/stream_events` routes already set `Content-Type:
+text/event-stream`. You still need `X-Accel-Buffering: no` to defeat Nginx
+and Cloud Run buffering (P46). Add via middleware:
+
+```python
+class SSEHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        if response.media_type == "text/event-stream":
+            response.headers["x-accel-buffering"] = "no"
+            response.headers["cache-control"] = "no-cache, no-transform"
+        return response
+
+app.add_middleware(SSEHeadersMiddleware)
+```
+
+## Versioning a LangServe API
+
+Mount each version on its own path. Chains evolve; client deprecation takes
+time. Two paths, two chain versions:
+
+```python
+add_routes(app, chain_v1, path="/v1/chat")
+add_routes(app, chain_v2, path="/v2/chat")
+```
+
+Put the version in the path, not a header — CDN caching and client libraries
+handle path versioning better.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-deploy-integration — One-Pager
+
+Deploy a LangChain 1.0 / LangGraph 1.0 app to Cloud Run, Vercel, or LangServe correctly — timeouts sized for chain length, cold-start mitigation, SSE anti-buffering, Secret Manager over `.env`.
+
+## The Problem
+
+An engineer ships a working LangGraph agent to Vercel and sees `FUNCTION_INVOCATION_TIMEOUT` on every non-trivial request — the Vercel Python runtime defaults to a **10-second** timeout while a three-tool agent easily runs 20-40s (P35). Moving to Cloud Run escapes the wall but introduces a **5-15s cold start** from Python + LangChain + tiktoken + embedding imports, which makes p99 latency 10x p95 (P36). The SSE stream that worked locally hangs forever in production because Nginx and Cloud Run buffer the final `end` chunk (P46). Meanwhile `.env` files copied into the container leak every API key to anyone who can run `docker exec <pod> env` (P37).
+
+## The Solution
+
+This skill walks a multi-stage Dockerfile (slim runtime, `uvicorn`, non-root user) into Cloud Run with `--min-instances=1 --cpu-boost --timeout=3600 --concurrency=80` and CPU-always-allocated billing; a Vercel `vercel.json` with `maxDuration: 60` plus a streaming response that beats the wall-clock cap; a LangServe `add_routes(app, chain, path="/chat")` + FastAPI `lifespan` for connection-pool cleanup; SSE anti-buffering headers (`X-Accel-Buffering: no`, `Cache-Control: no-cache`) to survive reverse proxies; and Secret Manager / `pydantic.SecretStr` for runtime credentials instead of `.env`. Includes a platform decision table (Cloud Run / Vercel Python / Fly.io / Railway / self-hosted) covering timeout cap, cold-start profile, SSE behavior, and per-month cost for a baseline agent.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers shipping a working LangChain 1.0 / LangGraph 1.0 app to prod on Cloud Run, Vercel, Fly.io, LangServe, or FastAPI behind any reverse proxy |
+| **What** | Multi-stage Dockerfile template, `gcloud run deploy` flag set, `vercel.json` with streaming, LangServe + FastAPI lifespan, SSE anti-buffering headers, Secret Manager pattern with `SecretStr`, platform decision table, 4 references (cloud-run, vercel-python, langserve-patterns, dockerfile-and-secrets) |
+| **When** | Prepping first prod deploy, debugging a stream that hangs behind a proxy, diagnosing p99 latency spikes, or rotating `.env` secrets into a real secret store |
+
+## Key Features
+
+1. **Timeouts sized for chain length, not HTTP defaults** — Vercel `maxDuration: 60` (vs 10s default) plus streaming-as-mitigation; Cloud Run `--timeout=3600 --concurrency=80` so a LangGraph agent with four tool rounds does not trip `FUNCTION_INVOCATION_TIMEOUT` or a 504
+2. **Cold-start mitigation playbook** — `--min-instances=1 --cpu-boost`, CPU-always-allocated billing so background `astream` completes, slim base image, deferred imports of `tiktoken` and embedding models so the 5-15s Python + LangChain load does not land in p99 user latency
+3. **SSE-safe proxy configuration** — `X-Accel-Buffering: no`, `Cache-Control: no-cache`, `Content-Type: text/event-stream`, disabled response buffering on Cloud Run / Nginx / Cloudflare so the final `end` event actually reaches the client and `LangGraph.astream` does not hang
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/vercel-python-deploy.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/references/vercel-python-deploy.md
@@ -1,0 +1,179 @@
+# Vercel Python Deploy Reference
+
+Vercel's Python runtime has three gotchas that catch every LangChain deploy:
+the 10-second default timeout (P35), the Edge Runtime mirage (you cannot use
+it), and the `requirements.txt` build step (Vercel does not read `pyproject.toml`).
+
+## `vercel.json` schema
+
+```json
+{
+  "functions": {
+    "api/chat.py": {
+      "maxDuration": 60,
+      "memory": 1024,
+      "runtime": "python3.12"
+    },
+    "api/embed.py": {
+      "maxDuration": 300,
+      "memory": 3008
+    }
+  },
+  "headers": [
+    {
+      "source": "/api/chat/stream",
+      "headers": [
+        { "key": "X-Accel-Buffering", "value": "no" },
+        { "key": "Cache-Control", "value": "no-cache, no-transform" }
+      ]
+    }
+  ]
+}
+```
+
+## `maxDuration` per plan tier
+
+| Plan | Max | Default |
+|------|-----|---------|
+| **Hobby** | 10s | 10s |
+| **Pro** | 60s | 10s |
+| **Enterprise** | 900s | 10s |
+
+The default is always 10s regardless of plan tier. Set `maxDuration`
+explicitly or watch `FUNCTION_INVOCATION_TIMEOUT` in your logs.
+
+## Streaming as the mitigation when `maxDuration` is not enough
+
+Even on Enterprise's 900s cap, a runaway agent can hit it. Streaming does two
+things:
+
+1. **Time-to-first-byte under 1 second** — the Vercel proxy considers the
+   request alive as soon as the first chunk ships; long completions no longer
+   trigger the stall detector.
+2. **User sees partial output** — when the cap finally triggers, the client
+   has already rendered 80% of the answer; the UX degrades gracefully.
+
+```python
+# api/chat.py
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.chain import build_chain
+
+app = FastAPI()
+chain = build_chain()  # module-level so warm invocations reuse it
+
+@app.post("/api/chat")
+async def chat(payload: dict):
+    async def gen():
+        async for chunk in chain.astream(payload["input"]):
+            yield f"data: {chunk.model_dump_json()}\n\n"
+        yield "data: [DONE]\n\n"
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
+    )
+```
+
+## Edge Runtime: not an option for LangChain
+
+Vercel's Edge Runtime runs on V8 / workerd and does **not** support Python —
+the `@vercel/edge` runtime is for TypeScript / JavaScript only. Anything that
+imports `langchain`, `langgraph`, `openai`, or `anthropic` must run on
+`@vercel/python` (serverless, Node.js-free Python container).
+
+If you need edge-like cold start, look at Vercel's Fluid Compute (beta) or
+move to Cloud Run with `--min-instances=1`.
+
+## Cold start profile
+
+Vercel Python cold start is usually 2-5 seconds for a LangChain app. The
+dominant costs are:
+
+- `import langchain_core` / `langchain_anthropic` / `langchain_openai` — ~1.5s
+- `import tiktoken` (forces BPE merge table load) — ~0.8s
+- `import langgraph` — ~0.4s
+- Any embedding model instantiation (even lazy) — ~1-3s
+
+Defer `tiktoken` and embedding model loading to request time when possible —
+serverless only pays the import cost on cold start, but a deferred import
+lets you warm critical paths first.
+
+```python
+# at module level: cheap imports only
+from fastapi import FastAPI
+from langchain_core.messages import HumanMessage
+
+app = FastAPI()
+
+# deferred: don't import at cold-start time
+_chain = None
+def get_chain():
+    global _chain
+    if _chain is None:
+        from app.chain import build_chain  # 1.5s import deferred
+        _chain = build_chain()
+    return _chain
+```
+
+## `requirements.txt` build step
+
+Vercel's Python runtime reads `requirements.txt`, not `pyproject.toml`.
+If you use `uv` or `poetry`, add a build step:
+
+```json
+{
+  "buildCommand": "pip install uv && uv export --format requirements-txt --no-hashes > requirements.txt"
+}
+```
+
+Alternative: commit `requirements.txt` and gate it in CI to match `uv.lock`.
+
+## Vercel Secrets vs env vars
+
+Two ways to pass secrets:
+
+**Environment variables** (`vercel env add`):
+```bash
+vercel env add ANTHROPIC_API_KEY production
+# enter value when prompted
+```
+Stored encrypted at rest, exposed as `os.environ["ANTHROPIC_API_KEY"]` at runtime.
+
+**Vercel Secrets** (legacy, deprecated for new projects):
+Older alias system. Use env vars for new projects — simpler and equivalent.
+
+Never commit `.env` and add `.env*` to `.vercelignore`:
+```
+.env
+.env.*
+!.env.example
+```
+
+## Memory tiers
+
+| Memory | Use case | Cost multiplier |
+|--------|----------|-----------------|
+| 128-512 MB | Tiny agents, no local embedding | 1x |
+| 1024 MB | Standard LangChain app | 2x |
+| 3008 MB | In-process FAISS / Chroma / embedding | 6x |
+
+Memory and CPU scale together on Vercel — a 3008 MB function has more CPU
+than a 128 MB one. If cold start matters, pay for more memory.
+
+## Serverless vs Fluid Compute
+
+Vercel's Fluid Compute (beta as of late 2026) runs long-lived Python workers
+that handle multiple requests. It fixes the cold-start problem but is
+pre-GA; production deploys should stick to standard serverless and use
+`--min-instances=1` on Cloud Run if cold start is the blocker.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `FUNCTION_INVOCATION_TIMEOUT` | 10s default (P35) | Set `maxDuration: 60` |
+| `500 Module not found` | Missing `requirements.txt` | Add build step or commit file |
+| `MemoryError` or OOM kill | 1024 MB not enough for embedding | Bump to 3008 MB |
+| Stream truncates mid-response | Proxy buffering | Add `X-Accel-Buffering: no` header |
+| `.env` values in prod | Committed to repo | Add `.env*` to `.vercelignore` |


### PR DESCRIPTION
## Summary

Handcrafted deployment skill for LangChain 1.0 / LangGraph 1.0 — Cloud Run, Vercel Python, LangServe, multi-stage Dockerfile, Secret Manager. Anchored to pain-catalog **P35, P36, P37, P46**.

## Pain hook

Engineer ships a working LangGraph agent to Vercel and every non-trivial request returns `FUNCTION_INVOCATION_TIMEOUT` because the Python runtime defaults to a 10-second cap (P35) — fix is `maxDuration: 60` in `vercel.json` plus streaming so bursts that still exceed the wall degrade gracefully. Same playbook extends to Cloud Run's 5-15s cold start (P36), `.env` leaks via `docker exec <pod> env` (P37), and SSE streams buffered dead by proxies (P46).

## Files

- `skills/langchain-deploy-integration/SKILL.md` (325 lines)
- `skills/langchain-deploy-integration/references/one-pager.md`
- `skills/langchain-deploy-integration/references/cloud-run-deploy.md`
- `skills/langchain-deploy-integration/references/vercel-python-deploy.md`
- `skills/langchain-deploy-integration/references/langserve-patterns.md`
- `skills/langchain-deploy-integration/references/dockerfile-and-secrets.md`

## Validator

Grade **A (90/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude