### PR TITLE
feat(langchain-py-pack): add langchain-reference-architecture (F21)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: langchain-reference-architecture
+description: |
+  A reference layered architecture for production LangChain 1.0 / LangGraph 1.0
+  services — LLM factory with version-safe defaults, chain/graph registry,
+  retriever and tool DI, Pydantic-validated config, per-request tenant scoping,
+  middleware ordering, checkpointer selection per environment. Use when starting
+  a new service, refactoring a tangled chain, or onboarding a team to existing code.
+  Trigger with "langchain architecture", "langchain llm factory",
+  "langchain chain registry", "langchain dependency injection",
+  "langchain project structure".
+allowed-tools: Read, Write, Edit
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, architecture, reference-architecture, patterns]
+compatible-with: claude-code, codex
+---
+
+# LangChain Reference Architecture (Python)
+
+## Overview
+
+Eight months into a LangChain service, a code review surfaces the mess.
+Twelve chain definitions live inlined inside FastAPI route handlers. Three
+retrievers are constructed at module-global scope, one bound to
+`tenant_id="acme"` because that was the first tenant in the pilot —
+that retriever now returns Acme's documents to every other tenant, a P33
+leak that has been live in production for six weeks.
+`max_retries=6` is hardcoded at four separate call sites. A
+`RunnableWithMessageHistory` backed by the default
+`InMemoryChatMessageHistory` loses every conversation on pod restart
+(P22) — which is most days, because Cloud Run scales to zero.
+Config is read from `os.environ` in three modules with three different
+fallback strategies. There is no place to put a new provider without
+touching seven files, and nobody remembers why the retriever is built
+at import time.
+
+The fix is not "rename a variable." The fix is an architecture that made
+every one of those mistakes hard to write. This skill is the target
+layered architecture:
+
+- `app/` — FastAPI routes. Thin. Parses HTTP, calls into `services`,
+  serializes response. No chain logic, no vendor clients, no env vars.
+- `services/` — chain and graph definitions. Take dependencies through
+  constructor args, not module-level imports.
+- `adapters/` — vendor clients, LLM factory, retriever factory, tool
+  factory. This is where `langchain-anthropic` is imported. Nowhere else.
+- `config/` — one Pydantic `Settings` class. `SecretStr` for keys,
+  `Literal["dev","staging","prod"]` for env names, `.env` file loader.
+- `domain/` — Pydantic models, typed LangGraph state, enums. No I/O.
+
+Five layers, five imports deep at most. Dependency direction is
+**strictly downward**. `app` imports `services`; `services` imports
+`adapters`; `adapters` imports `config` and `domain`. Never the reverse.
+Import-linter enforces this in CI. Pain-catalog anchors: P22 (in-memory
+history loses messages — architectural fix is persistent history
+injected via DI) and P33 (per-tenant vector stores leak if retriever
+bound at import — architectural fix is per-request factory). Adjacent:
+P10 (recursion limits), P24 (middleware order), P28 (callback
+inheritance). Pin: `langchain-core 1.0.x`, `langgraph 1.0.x`,
+`langchain-anthropic 1.0.x`, `langchain-openai 1.0.x`, `pydantic 2.x`,
+`import-linter 2.x`.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- `pydantic >= 2.5` and `pydantic-settings >= 2.1`
+- `import-linter >= 2.0` for layer enforcement in CI
+- Provider package(s): `langchain-anthropic`, `langchain-openai`, etc.
+- For staging/prod checkpointer: `langgraph-checkpoint-postgres` and a Postgres instance
+- Cross-reference: sibling skill `langchain-model-inference` for the LLM factory's version-safe defaults
+
+## Instructions
+
+### Step 1 — Adopt the 5-layer directory layout
+
+```
+src/my_service/
+├── app/                         # Layer 1: HTTP boundary (FastAPI)
+│   ├── __init__.py
+│   ├── main.py                  # FastAPI instance, DI wiring, lifespan
+│   ├── routes/
+│   │   ├── support.py           # POST /support → services.support.run(...)
+│   │   └── health.py
+│   └── deps.py                  # FastAPI Depends() providers
+├── services/                    # Layer 2: chain and graph definitions
+│   ├── __init__.py
+│   ├── registry.py              # name → builder lookup
+│   ├── support/
+│   │   ├── chain.py             # SupportChain(llm, retriever, memory)
+│   │   └── graph.py             # SupportGraph (LangGraph StateGraph)
+│   └── triage/
+│       └── chain.py
+├── adapters/                    # Layer 3: vendor integrations
+│   ├── __init__.py
+│   ├── llm_factory.py           # chat_model(provider, **kwargs) → BaseChatModel
+│   ├── retriever_factory.py     # retriever_for(tenant_id) → Retriever
+│   ├── tool_factory.py          # tools_for(tenant_id) → list[BaseTool]
+│   ├── checkpointer.py          # checkpointer_for(env) → BaseCheckpointSaver
+│   └── history.py               # history_for(session_id, tenant_id) → BaseChatMessageHistory
+├── config/                      # Layer 4: configuration
+│   ├── __init__.py
+│   └── settings.py              # Pydantic Settings
+└── domain/                      # Layer 5: pure models, no I/O
+    ├── __init__.py
+    ├── state.py                 # TypedDict / Pydantic for LangGraph state
+    └── models.py                # request/response schemas
+tests/
+├── unit/                        # fake adapters, assert service logic
+├── integration/                 # real adapters against ephemeral infra
+└── contract/                    # schema snapshots (e.g., tool specs)
+pyproject.toml                   # includes [tool.importlinter] contracts
+```
+
+Typical depth is 5 layers. See [Directory Layout](references/directory-layout.md) for the full tree with file-naming conventions.
+
+### Step 2 — Centralize LLM defaults in an `adapters/llm_factory.py`
+
+Chains depend on the `BaseChatModel` protocol, not a concrete class. The factory is the one place version-safe defaults live:
+
+```python
+# src/my_service/adapters/llm_factory.py
+from langchain_core.language_models import BaseChatModel
+from langchain_anthropic import ChatAnthropic
+from langchain_openai import ChatOpenAI
+
+_SAFE_DEFAULTS = {"timeout": 30, "max_retries": 2}
+
+def chat_model(provider: str, **overrides) -> BaseChatModel:
+    defaults = {**_SAFE_DEFAULTS, **overrides}  # caller wins
+    if provider == "anthropic":
+        return ChatAnthropic(model="claude-sonnet-4-6", **defaults)
+    if provider == "openai":
+        return ChatOpenAI(model="gpt-4o", **defaults)
+    raise ValueError(f"Unknown provider: {provider!r}")
+```
+
+The `max_retries=6` scatter in the mess-case becomes `max_retries=2` in exactly one file. Services that want a longer timeout pass `timeout=60` — but they never set `max_retries=6` by accident. Cross-reference `langchain-model-inference` Step 3 for the factory pattern's provenance; see [LLM Factory Pattern](references/llm-factory-pattern.md) for per-provider variants and caching.
+
+### Step 3 — Replace scattered imports with a chain/graph registry
+
+```python
+# src/my_service/services/registry.py
+from typing import Callable, Protocol
+from langchain_core.runnables import Runnable
+
+class ChainBuilder(Protocol):
+    def __call__(self, *, tenant_id: str) -> Runnable: ...
+
+_BUILDERS: dict[str, ChainBuilder] = {}
+
+def register(name: str):
+    def decorator(fn: ChainBuilder) -> ChainBuilder:
+        _BUILDERS[name] = fn
+        return fn
+    return decorator
+
+def get(name: str, *, tenant_id: str) -> Runnable:
+    try:
+        return _BUILDERS[name](tenant_id=tenant_id)
+    except KeyError:
+        raise KeyError(f"No chain registered under {name!r}. Known: {list(_BUILDERS)}")
+```
+
+Each service module registers itself:
+
+```python
+# src/my_service/services/support/chain.py
+from my_service.services.registry import register
+from my_service.adapters.llm_factory import chat_model
+from my_service.adapters.retriever_factory import retriever_for
+
+@register("support_agent")
+def build_support_agent(*, tenant_id: str):
+    llm = chat_model("anthropic")
+    retriever = retriever_for(tenant_id=tenant_id)
+    # ... compose chain ...
+    return chain
+```
+
+Routes become one line: `chain = registry.get("support_agent", tenant=req.tenant_id)`. There is one place to look, not twelve.
+
+### Step 4 — Build retrievers and tools per-request, keyed by tenant (P33)
+
+This is the P33 architectural fix. The factory takes `tenant_id` as a runtime argument. Nothing is bound at import:
+
+```python
+# src/my_service/adapters/retriever_factory.py
+from functools import lru_cache
+from langchain_core.retrievers import BaseRetriever
+from langchain_pinecone import PineconeVectorStore
+from my_service.config.settings import get_settings
+
+@lru_cache(maxsize=256)  # cache the *store*, not the retriever
+def _store_for(tenant_id: str) -> PineconeVectorStore:
+    s = get_settings()
+    return PineconeVectorStore(
+        index_name=s.pinecone_index,
+        namespace=f"tenant:{tenant_id}",  # per-tenant namespace
+        embedding=...,
+    )
+
+def retriever_for(*, tenant_id: str, k: int = 6) -> BaseRetriever:
+    # Retriever construction <5ms because store is cached — do it per-request.
+    return _store_for(tenant_id).as_retriever(search_kwargs={"k": k})
+```
+
+The retriever is cheap to build (<5ms typical) so per-request construction is fine. Unit test with two tenants and assert non-overlap. See [Dependency Rules](references/dependency-rules.md) for the import-linter contract that forbids `services/*.py` from importing `langchain_pinecone` directly.
+
+### Step 5 — Collapse config to one Pydantic `Settings`
+
+```python
+# src/my_service/config/settings.py
+from functools import lru_cache
+from typing import Literal
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="MYSVC_")
+
+    env: Literal["dev", "staging", "prod"] = "dev"
+    anthropic_api_key: SecretStr
+    openai_api_key: SecretStr
+    pinecone_api_key: SecretStr
+    pinecone_index: str
+    postgres_dsn: SecretStr | None = None  # required when env != "dev"
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()  # reads env/.env at first call, caches
+```
+
+`SecretStr` prevents keys from leaking into logs. `Literal[...]` catches typos (`env="staing"`) at validation time, not at deploy time.
+
+### Step 6 — Compose middleware in one place, in the right order
+
+Middleware order is a correctness concern (P24 — redaction before caching, or cached responses leak PII across tenants). Wire the stack once in `adapters/` and hand the composed runnable to every service:
+
+```python
+# src/my_service/adapters/middleware.py
+from langchain_core.runnables import Runnable
+
+def wrap(model: Runnable) -> Runnable:
+    # Order matters: redact -> cache -> retry -> model
+    # Cross-reference L31 (langchain-middleware-patterns) for the full rationale.
+    return (
+        model
+        .with_config(tags=["mysvc"])
+        # | redaction_middleware()
+        # | cache_middleware()
+        # | retry_middleware()
+    )
+```
+
+Cross-reference `langchain-middleware-patterns` (L31) for the middleware stack rationale and P25 (retry double-counting tokens).
+
+### Step 7 — Pick the checkpointer per environment
+
+This is the P22 architectural fix. `MemorySaver` is fine for dev; it is not an option for staging or prod:
+
+```python
+# src/my_service/adapters/checkpointer.py
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import MemorySaver
+
+def checkpointer_for(env: str) -> BaseCheckpointSaver:
+    if env == "dev":
+        return MemorySaver()
+    # Staging/prod: Postgres-backed. Async variant for FastAPI.
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from my_service.config.settings import get_settings
+    dsn = get_settings().postgres_dsn
+    assert dsn is not None, "POSTGRES_DSN required outside dev"
+    return AsyncPostgresSaver.from_conn_string(dsn.get_secret_value())
+```
+
+Same for chat history when you use `RunnableWithMessageHistory` instead of a graph: `InMemoryChatMessageHistory` in dev, `PostgresChatMessageHistory` or `RedisChatMessageHistory` in staging/prod. See [Per-Env Checkpointer](references/per-env-checkpointer.md) for the `MemorySaver` / `SqliteSaver` / `PostgresSaver` / `AsyncPostgresSaver` decision matrix and the migration script between them. Cross-reference `langchain-langgraph-checkpointing` (L27) for checkpoint schema details.
+
+### Step 8 — Test strategy: fakes in unit, real adapters in integration
+
+The factory boundary is also the fake boundary. Unit tests inject a `FakeListChatModel` where production injects `ChatAnthropic`:
+
+```python
+# tests/unit/test_support_chain.py
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from my_service.services.support.chain import build_support_agent
+
+def test_support_agent_returns_expected_shape(monkeypatch):
+    monkeypatch.setattr(
+        "my_service.services.support.chain.chat_model",
+        lambda provider, **kw: FakeListChatModel(responses=["fixed answer"]),
+    )
+    chain = build_support_agent(tenant_id="acme")
+    assert chain.invoke({"input": "hi"}).content == "fixed answer"
+```
+
+Integration tests use the real adapters against ephemeral Postgres and a sandbox Pinecone namespace. Contract tests snapshot tool JSON schemas so a silent `bind_tools` change fails CI.
+
+### Step 9 — Enforce the layer graph in CI with import-linter
+
+```toml
+# pyproject.toml
+[tool.importlinter]
+root_package = "my_service"
+
+[[tool.importlinter.contracts]]
+name = "Layered architecture"
+type = "layers"
+layers = [
+    "my_service.app",
+    "my_service.services",
+    "my_service.adapters",
+    "my_service.config",
+    "my_service.domain",
+]
+
+[[tool.importlinter.contracts]]
+name = "Services do not import vendor SDKs"
+type = "forbidden"
+source_modules = ["my_service.services"]
+forbidden_modules = [
+    "langchain_anthropic",
+    "langchain_openai",
+    "langchain_pinecone",
+]
+```
+
+CI runs `lint-imports`. A PR that puts `from langchain_anthropic import ChatAnthropic` inside `services/support/chain.py` fails — forcing the author to go through `adapters/llm_factory.chat_model("anthropic")` instead.
+
+## Output
+
+- 5-layer directory tree with `app / services / adapters / config / domain`
+- `adapters/llm_factory.py` as the single source of version-safe defaults
+- `services/registry.py` with `register(...)` / `get(name, tenant=...)` lookup
+- Per-request retriever and tool factories keyed by `tenant_id` (P33 closed)
+- One Pydantic `Settings` with `SecretStr` keys and `Literal[...]` env names
+- Middleware composition order documented and wired once in `adapters`
+- Per-env checkpointer: `MemorySaver` dev, `AsyncPostgresSaver` staging/prod (P22 closed)
+- Test strategy: fakes at the factory boundary in unit, real adapters in integration
+- `import-linter` contracts enforced in CI
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `KeyError: "No chain registered under 'support_agent'"` | Registry imported before service module registered | Import `services.support.chain` from `services/__init__.py` or `app.main` startup |
+| Retriever returns wrong tenant's documents (P33) | Retriever bound at module-import scope with hardcoded tenant | Construct `retriever_for(tenant_id=...)` per request; retriever build <5ms with cached store |
+| Chat history empty after pod restart (P22) | `RunnableWithMessageHistory` backed by `InMemoryChatMessageHistory` in staging/prod | Switch to `PostgresChatMessageHistory` / `RedisChatMessageHistory` via `history_for(env=...)` factory |
+| `pydantic.ValidationError` on `env="staing"` typo | `Literal["dev","staging","prod"]` caught at `Settings` init | Fix env var before deploy; this is the intended behavior |
+| `import-linter` failure `services imports langchain_anthropic` | Vendor SDK imported in services layer | Route through `adapters.llm_factory.chat_model("anthropic")` |
+| `GraphRecursionError` on vague prompts (P10) | `create_react_agent` default `recursion_limit=25` | Set `recursion_limit=5-10` at graph compile time in the service |
+| Cached response contains another tenant's PII (P24) | Middleware order was cache before redaction | Compose in `adapters/middleware.py` as redact → cache → model |
+| Subgraph traces missing (P28) | Parent callbacks not inherited into subgraphs | Pass `config={"callbacks": [...]}` explicitly when invoking subgraph |
+| `AssertionError: POSTGRES_DSN required outside dev` | `Settings.postgres_dsn` None in staging | Fail fast at startup; do not fall back to `MemorySaver` silently |
+
+## Examples
+
+### Onboarding a new tenant
+
+Because retrievers are built per request from `tenant_id`, onboarding a new tenant is a data concern (create Pinecone namespace, seed documents), not a code concern. No file in `services/` changes. No redeploy is required to add `tenant_id="zeta"`.
+
+### Adding a new provider
+
+`adapters/llm_factory.py` grows one `elif` branch. `config/settings.py` grows one `SecretStr` field. No service module changes — they all depend on `BaseChatModel`, not `ChatAnthropic`. Cross-reference `langchain-model-inference` for the list of provider packages and their 1.0 import paths.
+
+### Refactoring the 8-month-old mess
+
+The migration is layer by layer, bottom up:
+
+1. Extract `config/settings.py` first — it has no dependencies and unlocks the rest
+2. Extract `adapters/llm_factory.py` and replace scattered `ChatAnthropic(...)` calls
+3. Extract `adapters/retriever_factory.py` with `tenant_id` as a runtime arg — this is the P33 fix
+4. Introduce `services/registry.py` and move one chain at a time from routes into registered builders
+5. Turn on `import-linter` in CI with `ignore_imports` for routes that have not migrated yet; remove ignores as you go
+6. Swap `MemorySaver` for `AsyncPostgresSaver` in staging last — it is the lowest-risk step once factories exist
+
+## Resources
+
+- [LangChain 1.0 — Concepts](https://python.langchain.com/docs/concepts/)
+- [LangGraph — Persistence and checkpointers](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
+- [import-linter — Layer contracts](https://import-linter.readthedocs.io/en/stable/contract_types.html#layers)
+- [FastAPI — Dependency injection](https://fastapi.tiangolo.com/tutorial/dependencies/)
+- Pack pain catalog: `docs/pain-catalog.md` (entries P10, P22, P24, P28, P33)
+- Sibling skills in this pack (same `plugins/saas-packs/langchain-py-pack/skills/` directory):
+  - `langchain-model-inference` — LLM factory defaults provenance
+  - `langchain-embeddings-search` — retriever and vector-store selection
+  - `langchain-sdk-patterns` — composition patterns referenced by service builders

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/dependency-rules.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/dependency-rules.md
@@ -1,0 +1,165 @@
+# Dependency Rules
+
+The architecture is only useful if the layer graph is actually enforced. `import-linter` is a Python static analyzer that reads `pyproject.toml` and fails CI when imports cross forbidden edges. Run it on every PR.
+
+## The Layer Graph
+
+```
+app          (FastAPI routes — HTTP boundary)
+ │
+ ▼
+services     (chain/graph definitions)
+ │
+ ▼
+adapters     (LLM factory, retriever factory, vendor SDKs)
+ │
+ ├──▶ config   (Pydantic Settings)
+ │
+ └──▶ domain  (pure Pydantic models, enums, typed state)
+```
+
+Rules:
+
+1. Each layer may import the layer below it, or any layer lower.
+2. No layer may import a layer above it.
+3. No vendor SDK (`langchain_anthropic`, `langchain_openai`, `langchain_pinecone`, etc.) may be imported outside `adapters/`.
+4. `domain/` imports nothing outside `pydantic` and the standard library. No I/O. No LangChain.
+5. `config/` imports nothing from `domain`, `adapters`, `services`, or `app`.
+
+## `import-linter` Configuration
+
+Full config in `pyproject.toml`:
+
+```toml
+[tool.importlinter]
+root_package = "my_service"
+
+# Contract 1: strict layering
+[[tool.importlinter.contracts]]
+name = "Layered architecture"
+type = "layers"
+layers = [
+    "my_service.app",
+    "my_service.services",
+    "my_service.adapters",
+    "my_service.config",
+    "my_service.domain",
+]
+
+# Contract 2: services do not import vendor SDKs directly
+[[tool.importlinter.contracts]]
+name = "Services go through adapters for vendors"
+type = "forbidden"
+source_modules = ["my_service.services"]
+forbidden_modules = [
+    "langchain_anthropic",
+    "langchain_openai",
+    "langchain_google_genai",
+    "langchain_pinecone",
+    "langchain_community.vectorstores",
+]
+
+# Contract 3: domain stays pure
+[[tool.importlinter.contracts]]
+name = "Domain has no external deps"
+type = "forbidden"
+source_modules = ["my_service.domain"]
+forbidden_modules = [
+    "langchain_core",
+    "langgraph",
+    "fastapi",
+    "sqlalchemy",
+]
+ignore_imports = [
+    # Allow Pydantic and typing
+]
+
+# Contract 4: app layer only imports services, not adapters
+[[tool.importlinter.contracts]]
+name = "Routes don't reach into adapters"
+type = "forbidden"
+source_modules = ["my_service.app.routes"]
+forbidden_modules = [
+    "my_service.adapters",
+    "langchain_core",
+]
+```
+
+## Run in CI
+
+`.github/workflows/ci.yml`:
+
+```yaml
+- name: Install import-linter
+  run: pip install "import-linter>=2.0"
+
+- name: Enforce layer graph
+  run: lint-imports --config pyproject.toml
+```
+
+Expected output on a clean repo:
+
+```
+$ lint-imports
+=================
+Import Linter
+=================
+
+Using config file: pyproject.toml
+
+Contracts
+---------
+Analyzed 47 files, 123 dependencies.
+-----------------------------------
+
+Layered architecture KEPT
+Services go through adapters for vendors KEPT
+Domain has no external deps KEPT
+Routes don't reach into adapters KEPT
+
+Contracts: 4 kept, 0 broken.
+```
+
+Expected output when a PR violates the graph:
+
+```
+Services go through adapters for vendors BROKEN
+
+my_service.services.support.chain is not allowed to import langchain_anthropic:
+-   my_service.services.support.chain -> langchain_anthropic (l. 3)
+```
+
+## Testing Injection Boundaries
+
+The layer graph defines **where** fakes plug in. For each adapter:
+
+| Adapter | Fake injection pattern |
+|---------|------------------------|
+| `llm_factory.chat_model` | `monkeypatch.setattr` in unit tests; real client in integration |
+| `retriever_factory.retriever_for` | Hand-built `FakeRetriever` from `langchain_core.retrievers`; real Pinecone in integration |
+| `tool_factory.tools_for` | List of `@tool`-decorated test fns; real integrations in integration |
+| `checkpointer.checkpointer_for` | `MemorySaver()` regardless of env; Postgres fixtures in integration |
+| `history.history_for` | `InMemoryChatMessageHistory()` regardless of env |
+
+Unit test example for tenant isolation (the P33 test):
+
+```python
+# tests/unit/test_retriever_factory.py
+def test_tenants_do_not_share_namespace():
+    r1 = retriever_for(tenant_id="acme")
+    r2 = retriever_for(tenant_id="zeta")
+    # Different namespaces on the underlying store
+    assert r1.vectorstore._index_name == r2.vectorstore._index_name  # same index
+    assert r1.vectorstore._namespace == "tenant:acme"
+    assert r2.vectorstore._namespace == "tenant:zeta"
+    assert r1.vectorstore._namespace != r2.vectorstore._namespace
+```
+
+A regression that binds `tenant_id` at import time fails this test because both retrievers would share the pre-bound namespace.
+
+## What This Buys You
+
+- A PR that adds `from langchain_anthropic import ChatAnthropic` to a route fails CI, not production
+- A service module importing a vendor SDK fails CI, not production
+- A domain model growing an `sqlalchemy` dep fails CI before the coupling rots everything
+- Refactoring is safe: if the dependency direction is preserved, behavior is preserved

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/directory-layout.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/directory-layout.md
@@ -1,0 +1,110 @@
+# Directory Layout
+
+The target tree for a LangChain 1.0 / LangGraph 1.0 service. Five layers, strict downward dependency, tests mirror the production tree.
+
+## Full Tree
+
+```
+my_service/
+├── src/
+│   └── my_service/
+│       ├── __init__.py
+│       │
+│       ├── app/                              # Layer 1 — HTTP boundary
+│       │   ├── __init__.py
+│       │   ├── main.py                       # FastAPI() instance, lifespan, routers
+│       │   ├── deps.py                       # FastAPI Depends() providers
+│       │   ├── middleware.py                 # HTTP middleware (auth, request_id)
+│       │   └── routes/
+│       │       ├── __init__.py
+│       │       ├── health.py                 # GET /healthz, /readyz
+│       │       ├── support.py                # POST /support
+│       │       └── triage.py                 # POST /triage
+│       │
+│       ├── services/                         # Layer 2 — chains and graphs
+│       │   ├── __init__.py                   # imports each service to register it
+│       │   ├── registry.py                   # @register / get(name, tenant=...)
+│       │   ├── support/
+│       │   │   ├── __init__.py
+│       │   │   ├── chain.py                  # LCEL pipeline
+│       │   │   └── graph.py                  # LangGraph StateGraph
+│       │   └── triage/
+│       │       ├── __init__.py
+│       │       └── chain.py
+│       │
+│       ├── adapters/                         # Layer 3 — vendor integrations
+│       │   ├── __init__.py
+│       │   ├── llm_factory.py                # chat_model(provider, **kw)
+│       │   ├── retriever_factory.py          # retriever_for(tenant_id=...)
+│       │   ├── tool_factory.py               # tools_for(tenant_id=...)
+│       │   ├── checkpointer.py               # checkpointer_for(env=...)
+│       │   ├── history.py                    # history_for(session_id, tenant_id)
+│       │   ├── middleware.py                 # LangChain middleware stack
+│       │   └── telemetry.py                  # LangSmith / OTEL bootstrap
+│       │
+│       ├── config/                           # Layer 4 — configuration
+│       │   ├── __init__.py
+│       │   └── settings.py                   # Pydantic Settings class
+│       │
+│       └── domain/                           # Layer 5 — pure models
+│           ├── __init__.py
+│           ├── state.py                      # LangGraph TypedDict state
+│           ├── models.py                     # request/response Pydantic models
+│           └── enums.py
+│
+├── tests/
+│   ├── unit/
+│   │   ├── test_support_chain.py             # injects FakeListChatModel
+│   │   └── test_retriever_factory.py         # asserts tenant isolation
+│   ├── integration/
+│   │   ├── test_postgres_checkpointer.py     # ephemeral PG
+│   │   └── test_pinecone_namespace.py        # sandbox namespace
+│   └── contract/
+│       └── test_tool_schemas.py              # snapshots bind_tools JSON
+│
+├── .env.example                              # template; never commit real .env
+├── pyproject.toml                            # [tool.importlinter] contracts here
+├── README.md
+└── Dockerfile
+```
+
+## File-Naming Conventions
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `*_factory.py` | Adapter that constructs a vendor-bound object per request or per env | `retriever_factory.py` |
+| `*/chain.py` | LCEL (`Runnable`) composition | `services/support/chain.py` |
+| `*/graph.py` | LangGraph `StateGraph` | `services/support/graph.py` |
+| `registry.py` | Name → builder lookup inside a layer | `services/registry.py` |
+| `settings.py` | Exactly one Pydantic `BaseSettings` subclass | `config/settings.py` |
+| `state.py` | TypedDict or Pydantic model for LangGraph state | `domain/state.py` |
+| `deps.py` | FastAPI `Depends()` providers only | `app/deps.py` |
+
+## Where Each SKILL Component Lives
+
+| Component from SKILL.md Step | File |
+|------------------------------|------|
+| LLM factory (Step 2) | `adapters/llm_factory.py` |
+| Chain/graph registry (Step 3) | `services/registry.py` |
+| Retriever factory (Step 4) | `adapters/retriever_factory.py` |
+| Tool factory (Step 4) | `adapters/tool_factory.py` |
+| Pydantic `Settings` (Step 5) | `config/settings.py` |
+| Middleware stack (Step 6) | `adapters/middleware.py` |
+| Checkpointer selection (Step 7) | `adapters/checkpointer.py` |
+| Chat history selection (Step 7) | `adapters/history.py` |
+| Fakes and injection points (Step 8) | `tests/unit/conftest.py` |
+| `import-linter` contracts (Step 9) | `pyproject.toml` |
+
+## Depth Discipline
+
+Typical production depth is 5 layers from route to domain model:
+
+```
+app.routes.support.run
+  -> services.registry.get
+    -> services.support.chain.build_support_agent
+      -> adapters.llm_factory.chat_model
+        -> langchain_anthropic.ChatAnthropic  # only here
+```
+
+If a stack trace shows a 7th frame inside `langchain_*` called from inside `app/`, the layer boundary was violated. Import-linter (Step 9 in SKILL.md) catches this at PR time, not at incident time.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/llm-factory-pattern.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/llm-factory-pattern.md
@@ -1,0 +1,139 @@
+# LLM Factory Pattern
+
+The `adapters/llm_factory.py` module is the single source of version-safe defaults. Every chain in `services/` depends on the `BaseChatModel` **protocol**, not on `ChatAnthropic` or `ChatOpenAI` directly.
+
+## Why a Factory
+
+Without one, `max_retries=6` (the `ChatOpenAI` default) leaks into four call sites. Timeouts are missing on three of the four because the author forgot. Swapping providers requires a grep-and-replace. Unit tests spin up real API clients.
+
+With one:
+
+- Safe defaults (`timeout=30`, `max_retries=2`) live in exactly one file
+- Services take `BaseChatModel` as a constructor arg — test fakes and prod clients are interchangeable
+- Adding a provider is one branch in one file
+
+## Minimal Factory
+
+```python
+# src/my_service/adapters/llm_factory.py
+from typing import Any
+from langchain_core.language_models import BaseChatModel
+from langchain_anthropic import ChatAnthropic
+from langchain_openai import ChatOpenAI
+
+_SAFE_DEFAULTS: dict[str, Any] = {
+    "timeout": 30,         # seconds; default None hangs forever on provider stall
+    "max_retries": 2,      # retries, not attempts — see pain catalog P30
+}
+
+_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-4o",
+    "gemini": "gemini-2.5-pro",
+}
+
+def chat_model(provider: str, **overrides: Any) -> BaseChatModel:
+    defaults = {**_SAFE_DEFAULTS, **overrides}  # caller's kwargs win
+    model = defaults.pop("model", _MODELS.get(provider))
+    if model is None:
+        raise ValueError(f"No default model for provider {provider!r}")
+
+    if provider == "anthropic":
+        return ChatAnthropic(model=model, **defaults)
+    if provider == "openai":
+        return ChatOpenAI(model=model, **defaults)
+    if provider == "gemini":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(model=model, **defaults)
+    raise ValueError(f"Unknown provider: {provider!r}")
+```
+
+## Per-Provider Variants
+
+Some providers need extra config that does not fit `_SAFE_DEFAULTS`:
+
+```python
+def _anthropic(**kw) -> BaseChatModel:
+    return ChatAnthropic(
+        model=kw.pop("model", "claude-sonnet-4-6"),
+        default_headers={"anthropic-beta": "tools-2024-05-16"} if kw.pop("beta_tools", False) else None,
+        **kw,
+    )
+
+def _openai(**kw) -> BaseChatModel:
+    return ChatOpenAI(
+        model=kw.pop("model", "gpt-4o"),
+        # OpenAI-specific: response_format requires json_schema method
+        **kw,
+    )
+```
+
+The factory dispatcher calls `_anthropic` / `_openai` — services still only see `BaseChatModel`.
+
+## Caching
+
+For stateless chat models, caching the instance is safe and saves the per-request construction cost:
+
+```python
+from functools import lru_cache
+
+@lru_cache(maxsize=16)  # keyed by provider + frozen kwargs
+def _cached(provider: str, frozen: frozenset) -> BaseChatModel:
+    return chat_model(provider, **dict(frozen))
+
+def chat_model_cached(provider: str, **kw) -> BaseChatModel:
+    return _cached(provider, frozenset(kw.items()))
+```
+
+Do **not** cache retrievers this way — they need per-tenant keys, which is why the retriever factory is separate (see SKILL.md Step 4 and P33).
+
+## Service Consumption
+
+Chains take `BaseChatModel`, never `ChatAnthropic`:
+
+```python
+# src/my_service/services/support/chain.py
+from langchain_core.language_models import BaseChatModel
+from langchain_core.prompts import ChatPromptTemplate
+
+def build_support_agent_with_llm(llm: BaseChatModel):
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a support agent."),
+        ("human", "{input}"),
+    ])
+    return prompt | llm
+```
+
+Construction wiring:
+
+```python
+# src/my_service/services/support/chain.py (registration wrapper)
+from my_service.adapters.llm_factory import chat_model
+from my_service.services.registry import register
+
+@register("support_agent")
+def build(*, tenant_id: str):
+    return build_support_agent_with_llm(chat_model("anthropic"))
+```
+
+## Test Injection
+
+Unit tests bypass `chat_model` via `monkeypatch`:
+
+```python
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+def test_agent_calls_llm_once(monkeypatch):
+    fake = FakeListChatModel(responses=["ok"])
+    monkeypatch.setattr(
+        "my_service.services.support.chain.chat_model",
+        lambda provider, **kw: fake,
+    )
+    # ... exercise chain, assert on fake.invocations ...
+```
+
+Because the service imports `chat_model` by name, not the concrete class, this one-line patch replaces the entire LLM boundary. No `responses`-mock HTTP matcher required.
+
+## Relation to `langchain-model-inference`
+
+This pattern's version-safe defaults (`timeout=30`, `max_retries=2`), the `BaseChatModel` protocol-first design, and the provider-dispatch factory come straight from the sibling skill `langchain-model-inference` Step 3. This skill's contribution is treating that factory as the **architectural seam** between layers — the single place vendor SDKs are imported.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-reference-architecture — One-Pager
+
+A reference layered architecture for production LangChain 1.0 / LangGraph 1.0 services that prevents the chain-in-route-handler, import-time-retriever, and per-env-checkpointer tangles that strangle 8-month-old codebases.
+
+## The Problem
+
+By month eight, a LangChain service that started as a single FastAPI route has accumulated twelve chain definitions inlined in handlers, three retrievers constructed at module-import scope, `max_retries=6` hardcoded in four places, no tenant scoping, a `RunnableWithMessageHistory` backed by `InMemoryChatMessageHistory` that loses every conversation on pod restart (P22), and a retriever that was bound to `tenant_id="acme"` at import and now returns Acme's documents to every other tenant (P33). A code review turns up the P33 leak on a Friday. The fix is not "move one line" — the fix is an architecture that made the wrong thing hard to write in the first place.
+
+## The Solution
+
+Five layers with a strict dependency direction — `app/` (FastAPI routes) → `services/` (chain and graph definitions) → `adapters/` (LLM factory, retriever factory, vendor clients) → `config/` (Pydantic `Settings`) → `domain/` (Pydantic models, typed state). Chains take their dependencies through constructor arguments, not imports. An LLM factory is the single source of version-safe defaults (timeout 30s, max_retries 2, cache). A chain/graph registry replaces scattered import sites with `registry.get("support_agent", tenant=...)`. Retriever and tool factories are keyed by request — not module — scope, so P33 cannot happen. Config is one Pydantic `Settings` class with `SecretStr` for keys and `Literal[...]` for env names. Middleware composition order (redact → cache → model, per L31) is wired once in the DI layer. Checkpointer selection is per env: `MemorySaver` in dev, `PostgresSaver` in staging and prod. Import-linter enforces the layer graph in CI.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Tech leads and architects designing a new LangChain 1.0 / LangGraph 1.0 service, or refactoring a tangled chain, or onboarding a team to existing code |
+| **What** | Layered directory tree, LLM factory, chain/graph registry, per-request retriever and tool factories, Pydantic `Settings` module, middleware composition order, per-env checkpointer selection, import-linter config, testing strategy, 4 deep references |
+| **When** | At project kickoff (before file 3), or at the code review that surfaces P22 / P33 / scattered `max_retries=6`, or during onboarding — this skill is the paper map that prevents the 30-file mess |
+
+## Key Features
+
+1. **5-layer dependency rule enforced by import-linter** — `app` → `services` → `adapters` → `config` → `domain`, never the reverse; CI fails the PR if a route imports a vendor client directly, so the tangles never accumulate
+2. **LLM factory + chain/graph registry** — Single source of version-safe defaults (`timeout=30`, `max_retries=2`) reused by every chain; registry exposes `registry.get("support_agent", tenant=...)` so there is one place to look, not twelve
+3. **Per-request retriever/tool factories + per-env checkpointer** — Retriever construction time stays under 5ms so per-request construction is cheap; P33 is architecturally impossible because no retriever is ever bound at import; `MemorySaver` in dev, `PostgresSaver` in staging/prod means P22 is impossible in the environments that matter
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/per-env-checkpointer.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/references/per-env-checkpointer.md
@@ -1,0 +1,148 @@
+# Per-Environment Checkpointer
+
+LangGraph checkpointers persist graph state so a workflow survives process restart, pod rescheduling, and human-in-the-loop resumption. Picking the right one per env is not optional — `MemorySaver` in staging or prod is P22 (history lost on restart) waiting to happen.
+
+## Decision Matrix
+
+| Env | Recommended saver | Storage | Why |
+|-----|-------------------|---------|-----|
+| `dev` (local) | `MemorySaver` | In-process dict | Zero setup, fast iteration, restart-tolerance not needed |
+| `dev` (shared) | `SqliteSaver` | `checkpoints.db` file | Survives `pytest` restarts; single-writer OK |
+| `test` / `ci` | `SqliteSaver` (in-memory URI) | `:memory:` | Same API as prod, resets per test |
+| `staging` | `PostgresSaver` or `AsyncPostgresSaver` | Managed Postgres | Matches prod, catches schema drift early |
+| `prod` (sync) | `PostgresSaver` | Managed Postgres | Battle-tested, supports human-in-the-loop `interrupt` |
+| `prod` (async, FastAPI) | `AsyncPostgresSaver` | Managed Postgres | Non-blocking in async event loop |
+| `prod` (horizontal scale) | `AsyncPostgresSaver` + advisory locks | Managed Postgres | One thread per thread_id; lock prevents concurrent writes |
+
+Redis savers exist (community packages) but are typically a worse fit — Postgres gives you durability + queryability for the audit trail you will want.
+
+## Factory
+
+```python
+# src/my_service/adapters/checkpointer.py
+from __future__ import annotations
+from typing import Literal
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import MemorySaver
+
+Env = Literal["dev", "staging", "prod", "test"]
+
+def checkpointer_for(env: Env) -> BaseCheckpointSaver:
+    if env in ("dev", "test"):
+        return MemorySaver()
+    # staging and prod: Postgres. Async variant for FastAPI.
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from my_service.config.settings import get_settings
+
+    dsn = get_settings().postgres_dsn
+    assert dsn is not None, f"POSTGRES_DSN required when env={env!r}"
+    return AsyncPostgresSaver.from_conn_string(dsn.get_secret_value())
+```
+
+## Wire Into a Graph
+
+```python
+# src/my_service/services/support/graph.py
+from langgraph.graph import StateGraph, END
+from my_service.adapters.checkpointer import checkpointer_for
+from my_service.config.settings import get_settings
+
+def build_support_graph():
+    builder = StateGraph(SupportState)
+    # ... add nodes, edges ...
+    builder.set_entry_point("triage")
+    builder.add_edge("respond", END)
+
+    saver = checkpointer_for(get_settings().env)
+    return builder.compile(checkpointer=saver)
+```
+
+## First-Run Schema Setup
+
+`PostgresSaver` and `AsyncPostgresSaver` need tables. Call `setup()` on startup once per environment:
+
+```python
+# src/my_service/app/main.py
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from my_service.adapters.checkpointer import checkpointer_for
+from my_service.config.settings import get_settings
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    saver = checkpointer_for(get_settings().env)
+    if hasattr(saver, "setup"):
+        await saver.setup()  # idempotent; creates tables if missing
+    app.state.checkpointer = saver
+    yield
+
+app = FastAPI(lifespan=lifespan)
+```
+
+Running `setup()` every boot is safe — it is idempotent. For tighter control, run it as a migration step before deploy.
+
+## Migrating Between Savers
+
+When moving `dev` → `staging` → `prod`, the checkpoint **schema** is stable (LangGraph manages it). The **data** is not portable between savers (nor should it be — dev state should not follow you into prod). The migration is:
+
+1. Point staging at its own Postgres. Run `setup()`. Deploy.
+2. Smoke-test: start a graph in staging, restart the pod, confirm `get_state(config)` returns the interrupted state.
+3. Repeat for prod with a separate DSN.
+
+If you need to move **user data** (not checkpoints) between tenants or envs, that is a domain-level job — export via the graph's state snapshot, not by copying checkpointer tables.
+
+## Connection Pooling
+
+In async prod deployments, pass a pool explicitly rather than using `from_conn_string`:
+
+```python
+from psycopg_pool import AsyncConnectionPool
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+pool = AsyncConnectionPool(
+    conninfo=dsn,
+    min_size=2,
+    max_size=10,
+    kwargs={"autocommit": True, "prepare_threshold": 0},
+    open=False,
+)
+await pool.open()
+saver = AsyncPostgresSaver(pool)
+```
+
+`prepare_threshold=0` avoids Postgres prepared-statement caching issues behind pgbouncer in transaction mode.
+
+## Thread and Checkpoint IDs
+
+Every `invoke` / `astream` takes `config={"configurable": {"thread_id": "..."}}`. In a multi-tenant service, namespace the thread:
+
+```python
+thread_id = f"tenant:{tenant_id}:session:{session_id}"
+```
+
+This keeps tenant data partitionable in the checkpoints table — useful for data deletion on churn (GDPR) and for blast-radius containment if a tenant's data is compromised.
+
+## Relation to `RunnableWithMessageHistory`
+
+If you are not using LangGraph, the equivalent P22 fix is swapping `InMemoryChatMessageHistory` for a persistent backend in `adapters/history.py`:
+
+```python
+# src/my_service/adapters/history.py
+def history_for(session_id: str, tenant_id: str) -> BaseChatMessageHistory:
+    env = get_settings().env
+    if env == "dev":
+        return InMemoryChatMessageHistory()
+    from langchain_postgres import PostgresChatMessageHistory
+    return PostgresChatMessageHistory(
+        table_name="chat_history",
+        session_id=f"tenant:{tenant_id}:session:{session_id}",
+        sync_connection=..., # from settings
+    )
+```
+
+Same decision matrix applies. Same P22 protection.
+
+## Cross-Reference
+
+- Sibling skill `langchain-langgraph-checkpointing` (L27) — when it lands — owns the deep dive on checkpoint schema, state snapshots, and resumption patterns. This reference covers only the selection-per-env decision.
+- Pain catalog entry **P22** — in-memory history on process restart.


### PR DESCRIPTION
## Summary

Handcrafted Flagship architecture skill — 5-layer reference architecture (`app → services → adapters → config → domain`) for production LangChain 1.0 / LangGraph 1.0 services, enforced by `import-linter`. LLM factory, tenant-keyed retriever factory, per-env checkpointer. Anchored to pain-catalog **P22, P33**.

## Pain hook

An 8-month-old LangChain service accumulates 12 chain definitions inlined in route handlers, retrievers constructed at module scope (one bound to `tenant_id="acme"` leaking docs to every other tenant — P33), `max_retries=6` hardcoded four places, and `InMemoryChatMessageHistory` that drops all conversations on pod restart (P22). The fix is a strict 5-layer architecture enforced by `import-linter`, with an LLM factory, tenant-keyed per-request retriever factory, and per-env checkpointer selection so P22 and P33 become architecturally impossible.

## Files

- `skills/langchain-reference-architecture/SKILL.md` (391 lines)
- `skills/langchain-reference-architecture/references/one-pager.md`
- `skills/langchain-reference-architecture/references/directory-layout.md`
- `skills/langchain-reference-architecture/references/llm-factory-pattern.md`
- `skills/langchain-reference-architecture/references/dependency-rules.md`
- `skills/langchain-reference-architecture/references/per-env-checkpointer.md`

## Validator

Grade **A (94/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude