### PR TITLE
feat(langchain-py-pack): add langchain-enterprise-rbac (P19)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: langchain-enterprise-rbac
+description: |
+  Enforce tenant isolation and role-based access across LangChain 1.0 chains and
+  LangGraph 1.0 agents — per-request retriever construction, tenant-scoped rate
+  limits, role-scoped tool allowlists, and structured audit logs. Use when
+  building multi-tenant saas, passing soc2 review, or debugging cross-tenant
+  leak. Trigger with "langchain multi-tenant", "langchain tenant isolation",
+  "langchain rbac", "langchain row-level security", "langchain audit log".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, multi-tenant, rbac, enterprise, security]
+compatible-with: claude-code, codex
+---
+
+# LangChain Enterprise RBAC (Python)
+
+## Overview
+
+A B2B SaaS team shipped their first RAG feature for two tenants. The factory
+code looked innocent: build `PineconeVectorStore` once at module import with
+`namespace="acme-corp"` (the first tenant), convert it to a retriever, store
+it in a module global, reuse on every request. Six weeks later tenant "Initech"
+went live. Their first search returned three documents from Acme Corp.
+
+The singleton retriever had captured the Acme namespace at process start.
+`RunnableConfig.configurable["tenant_id"]` was being passed in — but the
+retriever never read it, because the filter was baked in. Every request for
+every tenant hit the same Pinecone namespace. Security review caught it three
+days later and put a hold on the SOC2 renewal. This is pain-catalog entry
+**P33**, the single most common cause of cross-tenant leak in LangChain 1.0
+production.
+
+This skill fixes it with four workstreams:
+
+- **P33 — retriever-per-request factory** — build the retriever inside the
+  chain or agent invocation, keyed by `tenant_id` from `RunnableConfig`. Never
+  at module scope. Unit-test with two tenants and assert non-overlap.
+- **Role-scoped tool allowlist** — build the agent per-request with only the
+  tools the current user's role permits. Forbidden tools are not passed to
+  `create_agent` at all, so the model cannot call them even if it tries.
+- **Per-tenant rate limit + budget** — scope the `InMemoryRateLimiter` (or a
+  Redis-backed equivalent) by `tenant_id`, and check a per-tenant USD budget
+  before invoking the model.
+- **Structured audit log** — JSON log with `user_id`, `tenant_id`,
+  `chain_name`, `tools_called`, `cost_usd`, `outcome`, emitted in both success
+  and failure paths. Ships to SIEM or BigQuery.
+
+Two failure patterns anchor this skill: **import-time retriever binding (P33)**
+and **missing audit log on tool failure** (the `try` block logs on success but
+the `except` branch re-raises without emitting, so incident response has no
+record of denied tool calls). Pinned: `langchain-core 1.0.x`,
+`langgraph 1.0.x`, `langchain-anthropic 1.0.x`, `langchain-openai 1.0.x`,
+`langchain-postgres 0.0.15+` (for PGVector RLS), `pinecone-client 5.x`,
+`chromadb 0.5.x`. Pain-catalog anchors: **P33 primary**, P18, P24, P31, P37.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- At least one vector-store backend: `pinecone-client`, `langchain-postgres`
+  (PGVector), `chromadb`, or `faiss-cpu` (single-tenant only — see §Step 2)
+- A structured logging sink: stdout JSON for local, Cloud Logging / Datadog /
+  Splunk HEC / BigQuery streaming insert for production
+- A tenant authorization claim in every request (JWT `tid` claim, session
+  cookie, or header — the auth boundary is out of scope for this skill but
+  assumed correct)
+
+## Instructions
+
+### Step 1 — Build the retriever per-request, never at import
+
+Move retriever construction inside the chain or agent invocation, keyed by
+`config["configurable"]["tenant_id"]`.
+
+```python
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_pinecone import PineconeVectorStore
+
+# WRONG — retriever bound at import time with first tenant's namespace.
+# RETRIEVER = PineconeVectorStore(index_name="rag", namespace="acme-corp",
+#     embedding=emb).as_retriever(search_kwargs={"k": 4})
+
+# RIGHT — factory called per-request, reads tenant from RunnableConfig.
+def retriever_for(config: RunnableConfig):
+    tenant_id = config["configurable"]["tenant_id"]  # required, no default
+    if not tenant_id:
+        raise PermissionError("tenant_id missing from RunnableConfig")
+    store = PineconeVectorStore(
+        index_name="rag",
+        namespace=tenant_id,   # P33 fix — namespace per-invocation
+        embedding=emb,
+    )
+    return store.as_retriever(search_kwargs={"k": 4})
+
+def retrieve(inputs: dict, config: RunnableConfig):
+    return retriever_for(config).invoke(inputs["query"])
+
+chain = RunnableLambda(retrieve) | prompt | model
+result = chain.invoke({"query": "..."},
+    config={"configurable": {"tenant_id": "initech"}})
+```
+
+No default on `tenant_id` — a missing tenant must be a hard error, not a silent
+fallback. See [Retriever-per-request](references/retriever-per-request.md) for
+factory lifecycle and PGVector RLS / Chroma / FAISS adapters.
+
+### Step 2 — Pick a vector-store isolation primitive
+
+| Store | Isolation primitive | Per-tenant latency | Max tenants | Safety notes |
+|---|---|---|---|---|
+| **Pinecone** | `namespace=tenant_id` per query | ~40ms p50 (shared index) | 100,000+ per index | Namespace is the documented isolation boundary; still apply metadata `{"tenant_id": tid}` as defense in depth |
+| **PGVector** | Postgres row-level security (RLS) on `tenant_id` column | ~20ms p50 (HNSW index) | Bounded by Postgres row count | Use `SET LOCAL app.tenant_id = :tid` per transaction; RLS policy `USING (tenant_id = current_setting('app.tenant_id'))` |
+| **Chroma** | Collection-per-tenant (`get_or_create_collection(name=tid)`) | ~30ms p50 | ~1,000 before metadata overhead | Good isolation at small scale; collection creation is synchronous — provision lazily but cache the handle per-request |
+| **FAISS** | In-process index-per-tenant | ~5ms p50 (in-memory) | 10-50 practical limit | Poor fit for multi-tenant SaaS — cannot shard across processes, reloads on every deploy, no durable filter. Use for single-tenant evaluation only |
+
+Pinecone scales highest. PGVector with RLS is the strongest primitive when
+isolation must be auditable at the database layer (RLS is enforced by the
+server even if application code is bypassed). Chroma is fine for ≤1,000
+tenants. FAISS is not a multi-tenant production choice — document so future
+engineers do not adopt it. See
+[Vector-store isolation](references/vector-store-isolation.md) for the PGVector
+RLS DDL and Chroma lifecycle.
+
+### Step 3 — Build the agent per-request with a role-scoped tool allowlist
+
+Never bind every tool to every agent and trust the model to pick the right one.
+Build the agent inside the request handler with only the tools the user's role
+permits.
+
+```python
+from langgraph.prebuilt import create_agent
+
+# Map role -> allowed tool names. Owned by IAM config, not the skill.
+ROLE_TOOLS: dict[str, set[str]] = {
+    "viewer": {"search_docs"},
+    "editor": {"search_docs", "create_note"},
+    "admin":  {"search_docs", "create_note", "delete_note", "export_audit"},
+}
+ALL_TOOLS = {t.name: t for t in [search_docs, create_note, delete_note, export_audit]}
+
+def agent_for(user_role: str, tenant_id: str):
+    allowed = ROLE_TOOLS.get(user_role, set())
+    tools = [ALL_TOOLS[n] for n in allowed if n in ALL_TOOLS]
+    # Forbidden tools are not passed in — the model never sees them.
+    return create_agent(model, tools=tools)
+
+agent = agent_for(user_role="viewer", tenant_id="initech")
+# viewer has no delete_note -> the agent cannot call it.
+```
+
+Add a denylist for dangerous argument patterns (SQL with `DROP` / `TRUNCATE`,
+shell with `rm -rf` / `sudo`, URLs to internal metadata endpoints) via a
+`pre_model_hook` or tool wrapper — allowlist bounds *which* tools run,
+denylist bounds *what arguments* they accept. See
+[Role-scoped tool allowlist](references/role-scoped-tool-allowlist.md).
+
+### Step 4 — Scope rate limits and budgets by tenant
+
+Per-tenant limits prevent one tenant's runaway job from exhausting shared model
+capacity. Rate-limit detail is covered in `langchain-rate-limits`; cost-budget
+detail in `langchain-cost-tuning`. The only RBAC-specific requirement here:
+**limiter key must include `tenant_id`** — never a process-global singleton.
+
+```python
+# Sketch only — see langchain-rate-limits for production implementation.
+_limiters: dict[str, InMemoryRateLimiter] = {}
+
+def limiter_for(tenant_id: str) -> InMemoryRateLimiter:
+    if tenant_id not in _limiters:
+        # Tier lookup — different plans get different budgets.
+        rps = TENANT_TIER_LIMITS.get(tenant_id, 1.0)  # 1.0 rps = free-tier default
+        _limiters[tenant_id] = InMemoryRateLimiter(requests_per_second=rps)
+    return _limiters[tenant_id]
+```
+
+For multi-process deployments use a Redis-backed limiter — `InMemoryRateLimiter`
+is per-process only, so 1 rps × 8 workers = 8 rps aggregate.
+
+### Step 5 — Emit a structured audit log on every invocation
+
+The audit log is the record of truth during an incident. Emit on both success
+and failure paths. The common bug is logging in the `try` block only — when a
+tool raises, the `except` branch re-raises without emitting, so the incident
+responder has no record of the denied call.
+
+```python
+import json
+import time
+import uuid
+from contextlib import contextmanager
+
+@contextmanager
+def audit(ctx: dict):
+    started = time.monotonic()
+    trace_id = str(uuid.uuid4())
+    record = {**ctx, "trace_id": trace_id, "outcome": "pending"}
+    try:
+        yield record
+        record["outcome"] = record.get("outcome", "success")
+    except Exception as exc:
+        record["outcome"] = "error"
+        record["error_class"] = type(exc).__name__
+        record["error_message"] = str(exc)[:500]  # truncate — no PII leakage
+        raise
+    finally:
+        record["latency_ms"] = int((time.monotonic() - started) * 1000)  # 1000 ms per second
+        print(json.dumps(record))  # or a SIEM / BigQuery client
+
+ctx = {
+    "user_id": "u_42",
+    "tenant_id": "initech",
+    "chain_name": "rag-qa-v3",
+    "role": "viewer",
+}
+with audit(ctx) as record:
+    result = chain.invoke(inputs, config={"configurable": ctx})
+    record["tools_called"] = [m.name for m in result.get("tool_calls", [])]
+    record["input_tokens"]  = result["usage"]["input_tokens"]
+    record["output_tokens"] = result["usage"]["output_tokens"]
+    record["cost_usd"]      = cost_of(result["usage"])
+```
+
+The `try / finally` pattern guarantees emission even when the chain raises.
+Required fields: `user_id`, `tenant_id`, `chain_name`, `outcome`, `latency_ms`,
+`trace_id`. Recommended: `tools_called`, `input_tokens`, `output_tokens`,
+`cost_usd`, `role`. See [Audit-log schema](references/audit-log-schema.md) for
+the full catalog, JSON example, SIEM / BigQuery ingestion, and query recipes.
+
+### Step 6 — Two-tenant regression test for cross-tenant leak
+
+The test that would have caught P33 on day one. Seed two tenants with distinct
+documents, run a golden query as each, assert non-overlap on retrieved IDs.
+
+```python
+import pytest
+
+@pytest.fixture
+def two_tenant_store():
+    seed("acme",    ["acme-doc-1",    "acme-doc-2"])
+    seed("initech", ["initech-doc-1", "initech-doc-2"])
+    yield
+    cleanup(["acme", "initech"])
+
+def test_tenant_isolation(two_tenant_store):
+    acme_hits    = chain.invoke({"query": "q"}, config={"configurable": {"tenant_id": "acme"}})
+    initech_hits = chain.invoke({"query": "q"}, config={"configurable": {"tenant_id": "initech"}})
+    acme_ids    = {d.id for d in acme_hits["documents"]}
+    initech_ids = {d.id for d in initech_hits["documents"]}
+    assert acme_ids.isdisjoint(initech_ids), \
+        f"CROSS-TENANT LEAK: overlap={acme_ids & initech_ids}"
+    assert all("acme"    in doc_id for doc_id in acme_ids)
+    assert all("initech" in doc_id for doc_id in initech_ids)
+```
+
+Run in CI on every PR. A regression to import-time retriever binding fails
+immediately. See
+[Multi-tenant regression tests](references/multi-tenant-regression-tests.md)
+for fixtures covering tool-allowlist violation, audit-log completeness, and
+rate-limiter scoping.
+
+## Output
+
+- Retriever factory keyed by `RunnableConfig.configurable["tenant_id"]`
+- Vector-store choice made against the 4-row isolation table, not by defaults
+- Agent constructed per-request with a role-scoped tool allowlist (not a
+  deny-all at tool-call time)
+- Rate limiter and cost budget keyed by `tenant_id`, never a process global
+- Structured audit log emitted on both success and failure paths with
+  required fields (`user_id`, `tenant_id`, `chain_name`, `outcome`,
+  `latency_ms`, `trace_id`)
+- Two-tenant pytest fixture in CI that asserts cross-tenant non-overlap
+
+## Error Handling
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| Tenant A's docs returned to Tenant B after deploy | Singleton retriever bound at import (P33) | Move to per-request factory keyed by `config["configurable"]["tenant_id"]` (Step 1) |
+| `KeyError: 'tenant_id'` in retriever factory | Caller forgot to pass `configurable` | Fail fast with `PermissionError`; never default to a tenant |
+| `permission denied for relation documents` on PGVector | RLS policy enabled but session variable not set | `SET LOCAL app.tenant_id = :tid` inside the transaction |
+| Agent calls a tool the user's role should not have | Every tool bound at agent construction | Build agent per-request with only role-permitted tools (Step 3) |
+| Audit log missing entries for errored invocations | Log emitted inside `try` only, not `finally` | Move emit to `finally` block (Step 5) |
+| Shared rate limit trips all tenants when one misbehaves | Process-global `InMemoryRateLimiter` | Key limiter by `tenant_id`; use Redis-backed for multi-process (Step 4) |
+| Cross-tenant leak regression ships to prod | No two-tenant CI test | Add the Step 6 fixture; run on every PR |
+| Audit log contains raw PII from prompts | Logging `inputs` verbatim | Log field names / token counts / IDs only; never log raw message content |
+
+## Examples
+
+### Full multi-tenant RAG agent, end-to-end
+
+Combines all six steps: retriever-per-request, Pinecone namespace isolation,
+role-scoped tools, per-tenant rate limit, audit-log context manager, regression
+test. Assembly is ~80 lines. See
+[Retriever-per-request](references/retriever-per-request.md).
+
+### Migrating from a shared singleton to per-request
+
+Wrap the old singleton, add the factory alongside, route by feature flag, ship
+the regression test first, flip the flag, delete the singleton. Typical
+migration window: 1-2 sprints. See
+[Multi-tenant regression tests](references/multi-tenant-regression-tests.md).
+
+### Exporting audit log to BigQuery for compliance queries
+
+Stream each record to BigQuery per the
+[Audit-log schema](references/audit-log-schema.md). Recipes: "tool calls by
+user X in last 24h", "tenants with >1% error rate", "highest-spend tenants".
+
+## Resources
+
+- [LangChain Python: `RunnableConfig`](https://python.langchain.com/docs/concepts/runnables/#runnableconfig)
+- [LangChain Python: Multiple retrievers](https://python.langchain.com/docs/how_to/multiple_queries/)
+- [LangGraph: `create_agent`](https://langchain-ai.github.io/langgraph/agents/agents/)
+- [Pinecone: Namespaces](https://docs.pinecone.io/guides/indexes/use-namespaces)
+- [PGVector: Row-level security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html)
+- [SOC2 CC6.1 — logical access controls](https://www.aicpa-cima.com/)
+- Pack pain catalog: `docs/pain-catalog.md` (primary P33; adjacent P18, P24, P31, P37)
+- Sibling skills: `langchain-rate-limits` (per-tenant limiters), `langchain-cost-tuning` (per-tenant budgets), `langchain-security-basics` (input redaction upstream of audit log)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/audit-log-schema.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/audit-log-schema.md
@@ -1,0 +1,202 @@
+# Audit-log Schema
+
+The audit log is the record of truth during an incident. One JSON record per chain / agent invocation, emitted on both success and failure paths.
+
+## Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `trace_id` | string (UUID v4) | Unique per invocation; joins to OTel spans when instrumented |
+| `tenant_id` | string | From `RunnableConfig.configurable.tenant_id`; non-null |
+| `user_id` | string | Application user identifier; non-null |
+| `chain_name` | string | Human-readable; e.g. `"rag-qa-v3"`, `"support-agent"` |
+| `outcome` | enum | One of `success`, `error`, `tool_denied`, `rate_limited`, `budget_exceeded` |
+| `latency_ms` | integer | Wall-clock, including retries |
+| `timestamp` | string (ISO 8601) | UTC, millisecond precision |
+
+## Optional fields (recommended)
+
+| Field | Type | Notes |
+|---|---|---|
+| `role` | string | Caller role at invocation time; useful for tool allowlist audits |
+| `tools_called` | string[] | Tool names invoked during the run; empty array for pure chains |
+| `tool_denied` | object | `{name, reason}` when `outcome == "tool_denied"` |
+| `input_tokens` | integer | Prompt tokens |
+| `output_tokens` | integer | Completion tokens |
+| `cache_read_tokens` | integer | Anthropic cache read hits (P14) |
+| `cost_usd` | float | Computed from usage × per-model rate card |
+| `model` | string | e.g. `claude-sonnet-4-6`, `gpt-4o` |
+| `error_class` | string | Python exception class when `outcome == "error"` |
+| `error_message` | string | Truncated to 500 chars; never logs raw prompt content |
+| `parent_trace_id` | string | For agent → sub-agent invocations |
+| `retrieval_ids` | string[] | Document IDs returned by the retriever; for cross-tenant leak forensics |
+
+## Fields that must NEVER appear
+
+- Raw prompt content (use upstream redaction; see pain-catalog P24)
+- Raw tool arguments (log the tool name + arg keys, not values)
+- API keys, JWTs, session cookies (even if they appeared in the prompt)
+- PII not already authorized for retention (emails, SSNs, payment data)
+
+If the chain operates on PII, apply redaction middleware **before** the audit sink — otherwise the log becomes a new PII store to defend.
+
+## JSON example
+
+```json
+{
+  "trace_id": "0f9e5c83-7e54-4a6c-ae9a-3f2c1b1a0d11",
+  "tenant_id": "initech",
+  "user_id": "u_42",
+  "role": "viewer",
+  "chain_name": "rag-qa-v3",
+  "outcome": "success",
+  "latency_ms": 842,
+  "timestamp": "2026-04-21T14:05:22.107Z",
+  "tools_called": ["search_docs"],
+  "input_tokens": 1532,
+  "output_tokens": 284,
+  "cache_read_tokens": 1200,
+  "cost_usd": 0.0041,
+  "model": "claude-sonnet-4-6",
+  "retrieval_ids": ["initech-doc-34", "initech-doc-77", "initech-doc-91"]
+}
+```
+
+## The `try / finally` emit contract
+
+```python
+import json, time, uuid
+from contextlib import contextmanager
+
+@contextmanager
+def audit(ctx: dict):
+    started = time.monotonic()
+    record = {
+        "trace_id": str(uuid.uuid4()),
+        "timestamp": _utc_iso_now(),
+        "outcome": "pending",
+        **ctx,
+    }
+    try:
+        yield record
+        record.setdefault("outcome", "success")
+    except PermissionError as exc:
+        record["outcome"] = "tool_denied"
+        record["tool_denied"] = {"reason": str(exc)[:200]}
+        raise
+    except RateLimitError:
+        record["outcome"] = "rate_limited"
+        raise
+    except BudgetExceededError:
+        record["outcome"] = "budget_exceeded"
+        raise
+    except Exception as exc:
+        record["outcome"] = "error"
+        record["error_class"] = type(exc).__name__
+        record["error_message"] = str(exc)[:500]
+        raise
+    finally:
+        record["latency_ms"] = int((time.monotonic() - started) * 1000)
+        _sink(json.dumps(record))
+```
+
+The `finally` block guarantees emission even when the chain raises. The exception-specific handlers classify the outcome before re-raising.
+
+## Sink choice
+
+| Sink | Pros | Cons |
+|---|---|---|
+| **stdout + Cloud Logging** | Zero extra deps; works in Cloud Run / GKE; 10GB free tier | Index cost at volume; 30-day default retention |
+| **BigQuery streaming insert** | SQL queries for compliance; 180-day retention tier; cheap at scale | Latency (2-10s to queryability); quota on streaming inserts |
+| **Splunk HEC** | Security-team standard; mature alerting | Vendor cost per ingest GB |
+| **Datadog Logs** | Correlates with APM traces via `trace_id` | Vendor cost; retention tiering |
+| **Kafka → Sink of choice** | Decouples chain latency from log sink | Adds infra |
+
+For most teams starting out: stdout JSON → log aggregator → nightly export to BigQuery for 180-day retention. Splunk / Datadog if the security team already runs one.
+
+## BigQuery DDL
+
+```sql
+CREATE TABLE `project.audit.langchain_invocations` (
+  trace_id          STRING  NOT NULL,
+  tenant_id         STRING  NOT NULL,
+  user_id           STRING  NOT NULL,
+  role              STRING,
+  chain_name        STRING  NOT NULL,
+  outcome           STRING  NOT NULL,
+  latency_ms        INT64   NOT NULL,
+  timestamp         TIMESTAMP NOT NULL,
+  tools_called      ARRAY<STRING>,
+  input_tokens      INT64,
+  output_tokens     INT64,
+  cache_read_tokens INT64,
+  cost_usd          FLOAT64,
+  model             STRING,
+  error_class       STRING,
+  error_message     STRING,
+  retrieval_ids     ARRAY<STRING>,
+  parent_trace_id   STRING,
+)
+PARTITION BY DATE(timestamp)
+CLUSTER BY tenant_id, chain_name;
+```
+
+Partition by date for retention / query cost. Cluster by `tenant_id` so tenant-scoped queries scan only their slice.
+
+## Query recipes
+
+### Every tool call by user X in the last 24h
+
+```sql
+SELECT timestamp, chain_name, tools_called, outcome
+FROM `project.audit.langchain_invocations`
+WHERE user_id = 'u_42'
+  AND timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+  AND ARRAY_LENGTH(tools_called) > 0
+ORDER BY timestamp DESC;
+```
+
+### Tenants with >1% error rate in the last hour
+
+```sql
+SELECT
+  tenant_id,
+  COUNTIF(outcome = 'error') / COUNT(*) AS error_rate,
+  COUNT(*) AS n
+FROM `project.audit.langchain_invocations`
+WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+GROUP BY tenant_id
+HAVING error_rate > 0.01 AND n > 100
+ORDER BY error_rate DESC;
+```
+
+### Highest-spend tenants this month
+
+```sql
+SELECT tenant_id, SUM(cost_usd) AS spend_usd
+FROM `project.audit.langchain_invocations`
+WHERE DATE(timestamp) >= DATE_TRUNC(CURRENT_DATE(), MONTH)
+GROUP BY tenant_id
+ORDER BY spend_usd DESC
+LIMIT 20;
+```
+
+### Cross-tenant leak detection (retrieval_ids from wrong tenant)
+
+```sql
+-- Flags invocations where a retrieved doc's ID prefix disagrees with the tenant_id.
+-- Assumes your document IDs encode tenant (e.g. "initech-doc-77").
+SELECT trace_id, tenant_id, retrieval_ids
+FROM `project.audit.langchain_invocations`,
+     UNNEST(retrieval_ids) AS doc_id
+WHERE NOT STARTS_WITH(doc_id, CONCAT(tenant_id, '-'))
+  AND timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR);
+```
+
+A non-empty result on this query is a P33 incident — page on it.
+
+## Related
+
+- [Retriever-per-request](retriever-per-request.md) — so `retrieval_ids` are always tenant-scoped
+- [Role-scoped tool allowlist](role-scoped-tool-allowlist.md) — `tool_denied` outcome source
+- [Multi-tenant regression tests](multi-tenant-regression-tests.md) — tests that assert audit-log completeness

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/multi-tenant-regression-tests.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/multi-tenant-regression-tests.md
@@ -1,0 +1,175 @@
+# Multi-tenant Regression Tests
+
+The tests that would have caught **P33** on day one. Run them in CI on every PR that touches the chain / agent / retriever factory. A regression back to import-time retriever binding fails the suite immediately.
+
+## Fixture: two tenants with distinct documents
+
+```python
+import pytest
+from langchain_pinecone import PineconeVectorStore
+
+@pytest.fixture(scope="module")
+def two_tenant_store(pinecone_test_index):
+    """Seeds Tenant A and Tenant B with distinct documents in separate namespaces."""
+    acme = PineconeVectorStore(index_name=pinecone_test_index, namespace="acme", embedding=emb)
+    initech = PineconeVectorStore(index_name=pinecone_test_index, namespace="initech", embedding=emb)
+
+    acme.add_texts(
+        ["Acme revenue Q3 was $42M", "Acme CEO is Wile E. Coyote"],
+        ids=["acme-doc-1", "acme-doc-2"],
+        metadatas=[{"tenant_id": "acme"}] * 2,
+    )
+    initech.add_texts(
+        ["Initech revenue Q3 was $17M", "Initech CEO is Bill Lumbergh"],
+        ids=["initech-doc-1", "initech-doc-2"],
+        metadatas=[{"tenant_id": "initech"}] * 2,
+    )
+    yield
+    # Cleanup — delete the test namespaces so the next run starts clean.
+    acme.delete(delete_all=True)
+    initech.delete(delete_all=True)
+```
+
+## The golden-query isolation test
+
+```python
+GOLDEN_QUERIES = [
+    "what was Q3 revenue?",
+    "who is the CEO?",
+    "give me any document",
+]
+
+@pytest.mark.parametrize("query", GOLDEN_QUERIES)
+def test_tenant_isolation(two_tenant_store, query):
+    acme_result = chain.invoke(
+        {"query": query},
+        config={"configurable": {"tenant_id": "acme", "user_id": "t_u1"}},
+    )
+    initech_result = chain.invoke(
+        {"query": query},
+        config={"configurable": {"tenant_id": "initech", "user_id": "t_u1"}},
+    )
+
+    acme_ids    = {d.id for d in acme_result["documents"]}
+    initech_ids = {d.id for d in initech_result["documents"]}
+
+    # Hard assertion — no overlap, ever.
+    overlap = acme_ids & initech_ids
+    assert not overlap, f"CROSS-TENANT LEAK for query {query!r}: overlap={overlap}"
+
+    # Positive assertion — each tenant sees only its own.
+    assert all(i.startswith("acme-")    for i in acme_ids)
+    assert all(i.startswith("initech-") for i in initech_ids)
+```
+
+The `overlap` set being non-empty is a P33 incident in CI. Fail the build.
+
+## Test: missing tenant_id must raise
+
+```python
+def test_missing_tenant_raises_permission_error():
+    with pytest.raises(PermissionError, match="tenant_id"):
+        chain.invoke({"query": "anything"}, config={"configurable": {}})
+
+def test_none_tenant_raises_permission_error():
+    with pytest.raises(PermissionError, match="tenant_id"):
+        chain.invoke({"query": "anything"}, config={"configurable": {"tenant_id": None}})
+
+def test_empty_string_tenant_raises_permission_error():
+    with pytest.raises(PermissionError, match="tenant_id"):
+        chain.invoke({"query": "anything"}, config={"configurable": {"tenant_id": ""}})
+```
+
+The bug pattern this catches: a silent default like `tenant_id = config.get("tenant_id", "public")` that looks harmless but creates a shared namespace.
+
+## Test: tool allowlist strictly enforced
+
+```python
+def test_viewer_agent_has_no_write_tools():
+    agent = agent_for(user_role="viewer")
+    tool_names = {t.name for t in agent.get_tools()}
+    assert "delete_note" not in tool_names
+    assert "create_note" not in tool_names
+    assert tool_names == {"search_docs"}
+
+def test_admin_agent_has_all_tools():
+    agent = agent_for(user_role="admin")
+    tool_names = {t.name for t in agent.get_tools()}
+    assert tool_names == {"search_docs", "create_note", "delete_note", "export_audit"}
+
+def test_unknown_role_raises():
+    with pytest.raises(PermissionError, match="no tool access"):
+        agent_for(user_role="nonexistent_role")
+```
+
+## Test: audit log emits on failure path
+
+```python
+def test_audit_log_emitted_on_exception(capsys):
+    with pytest.raises(ValueError):
+        with audit({"user_id": "u_1", "tenant_id": "t_1", "chain_name": "test"}):
+            raise ValueError("boom")
+
+    captured = capsys.readouterr()
+    record = json.loads(captured.out.strip())
+    assert record["outcome"] == "error"
+    assert record["error_class"] == "ValueError"
+    assert record["latency_ms"] >= 0
+    assert "trace_id" in record
+
+def test_audit_log_emitted_on_tool_denied(capsys):
+    with pytest.raises(PermissionError):
+        with audit({"user_id": "u_1", "tenant_id": "t_1", "chain_name": "test"}):
+            raise PermissionError("SQL DROP forbidden")
+
+    record = json.loads(capsys.readouterr().out.strip())
+    assert record["outcome"] == "tool_denied"
+```
+
+The bug pattern this catches: audit logging inside the `try` block without a `finally` clause. The error path silently omits the record, so incident responders cannot see denied calls.
+
+## Test: rate limiter is per-tenant, not global
+
+```python
+def test_rate_limiter_is_per_tenant():
+    l1 = limiter_for("acme")
+    l2 = limiter_for("initech")
+    assert l1 is not l2, "limiter is a process-global singleton — tenants share quota"
+
+def test_same_tenant_reuses_limiter():
+    l1a = limiter_for("acme")
+    l1b = limiter_for("acme")
+    assert l1a is l1b, "limiter should be cached per tenant_id"
+```
+
+## Running in CI
+
+```yaml
+# .github/workflows/rbac-regression.yml (excerpt)
+- name: Run RBAC regression suite
+  env:
+    PINECONE_API_KEY: ${{ secrets.PINECONE_TEST_KEY }}
+    PINECONE_TEST_INDEX: ${{ vars.PINECONE_TEST_INDEX }}
+  run: pytest tests/rbac/ -v --tb=short
+```
+
+Gate merges on this suite. Tag every RBAC-relevant test with `@pytest.mark.rbac` so you can also run `pytest -m rbac` locally.
+
+## Mutation-testing angle
+
+For extra assurance, run `mutmut` on the retriever factory and the allowlist code. The isolation tests should fail on every meaningful mutation — if they don't, your test coverage has a blind spot.
+
+## What the tests do not cover
+
+- Live rate-limiter behavior under load (needs a load test, not a unit test)
+- Cloud-side RLS enforcement (needs an integration test against a real Postgres)
+- Network-level tenant isolation (firewall / VPC concerns, out of scope)
+
+These belong in a separate integration / security-review checklist, not the unit suite.
+
+## Related
+
+- [Retriever-per-request](retriever-per-request.md) — the factory these tests exercise
+- [Role-scoped tool allowlist](role-scoped-tool-allowlist.md) — allowlist tests
+- [Audit-log schema](audit-log-schema.md) — audit emission tests
+- [Vector-store isolation](vector-store-isolation.md) — PGVector RLS integration test pattern

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/one-pager.md
@@ -1,0 +1,30 @@
+# langchain-enterprise-rbac — One-Pager
+
+Enforce tenant isolation and role-based access across LangChain 1.0 chains and LangGraph 1.0 agents — retriever-per-request, tenant-scoped rate limits, role-scoped tool allowlists, and structured audit logs.
+
+## The Problem
+
+A B2B SaaS team wired up a RAG pipeline for their first two tenants: build the `PineconeVectorStore` at import time with `namespace="acme-corp"` (the first tenant onboarded), then convert it to a retriever with `.as_retriever(search_kwargs={"k": 4})`. Ship. Six weeks later tenant "Initech" onboarded; their first query returned three Acme Corp documents. The singleton retriever had cached the Acme namespace at process start — every request, regardless of the `tenant_id` in `RunnableConfig`, hit the same Pinecone namespace. Security review caught it three days later and issued a hold on the SOC2 renewal. This is pain-catalog entry P33, and it is the #1 cause of cross-tenant data leaks in LangChain 1.0 production. The sibling failure mode is missing audit logs on tool failures — when the tool raises, the invocation never reaches the cost/compliance sink, and you cannot prove who ran what during an incident.
+
+## The Solution
+
+This skill builds a retriever-per-request factory keyed by `config["configurable"]["tenant_id"]` so the filter / namespace / collection is bound at invocation time, not import time; maps the factory onto Pinecone (namespace), PGVector (row-level security), Chroma (collection-per-tenant), and FAISS (store-per-tenant, noted as a poor fit above 50 tenants); builds agents with role-scoped tool allowlists per-request; emits structured audit logs on both success and failure paths; and ships a two-tenant pytest regression fixture that asserts non-overlap on golden queries. Pinned to LangChain 1.0.x / LangGraph 1.0.x with five deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Backend engineers building multi-tenant LangChain 1.0 / LangGraph 1.0 SaaS, SRE / platform engineers enforcing tenant isolation, security engineers preparing for SOC2 / ISO 27001 review |
+| **What** | Retriever-per-request factory pattern, vector-store multi-tenant comparison (Pinecone / PGVector RLS / Chroma / FAISS), role-scoped tool allowlist, per-tenant rate limit and budget hooks, structured audit-log schema, two-tenant pytest regression fixture |
+| **When** | Before the second tenant onboards; during SOC2 / ISO 27001 prep; after any cross-tenant leak incident; when adding a new tool that accepts external arguments; when migrating from a single-tenant vector store to a shared one |
+
+## Key Features
+
+1. **Retriever-per-request factory (P33 fix)** — Factory function builds a fresh `VectorStoreRetriever` per invocation, reading `tenant_id` from `RunnableConfig.configurable`; never caches the retriever at module scope; supports Pinecone namespace, PGVector `session.execute("SET LOCAL app.tenant_id = :tid")`, and Chroma collection-per-tenant with a single interface
+2. **Role-scoped tool allowlist per-request** — Agent is constructed per-request with only the tools the current user's role permits; forbidden tools are not passed to `create_agent()` at all, so the model cannot call them even if it tries; includes a denylist for dangerous argument patterns (e.g. SQL with `DROP`, shell with `rm -rf`)
+3. **Structured audit log on every invocation** — JSON log with `user_id`, `tenant_id`, `chain_name`, `tools_called`, `input_tokens`, `output_tokens`, `cost_usd`, `outcome` (success / error / tool_denied), `latency_ms`, `trace_id`; emitted in both the success path and the exception path via a `try / finally`; shipped to SIEM or BigQuery for query recipes like "show me every tool call by user X in the last 24h"
+4. **Two-tenant regression test fixture** — `pytest` fixture seeds Tenant A and Tenant B with distinct documents; golden query asserts Tenant A's retriever never returns Tenant B's documents and vice versa; catches P33 on import-time binding regression
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/retriever-per-request.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/retriever-per-request.md
@@ -1,0 +1,144 @@
+# Retriever-per-request Factory Pattern
+
+The canonical fix for **P33** (per-tenant vector stores leak if retriever bound at process start). Every tenant-scoped retrieval path in LangChain 1.0 / LangGraph 1.0 should follow this pattern.
+
+## Why not at import time
+
+A module-scope `RETRIEVER = vectorstore.as_retriever(...)` captures whatever filter / namespace / collection is in scope when the module first loads. That value is **cached for the process lifetime**. The retriever has no awareness of `RunnableConfig.configurable["tenant_id"]` and no reason to re-read it — it is a plain object with pre-baked state.
+
+Result: every tenant gets the same retrieval. The first tenant onboarded wins; everyone else leaks into their namespace. P33 is triggered by the pattern, not by any specific vector store, so it applies equally to Pinecone, Chroma, PGVector, and FAISS.
+
+## The factory
+
+```python
+from typing import Callable
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+
+def make_retriever_factory(
+    build: Callable[[str], BaseRetriever],
+) -> Callable[[RunnableConfig], BaseRetriever]:
+    """Returns a function that builds a retriever per-request from config.
+
+    The `build` argument is the store-specific constructor. Keep this
+    factory generic so the caller chooses their store.
+    """
+    def factory(config: RunnableConfig) -> BaseRetriever:
+        try:
+            tenant_id = config["configurable"]["tenant_id"]
+        except KeyError as exc:
+            raise PermissionError("tenant_id missing from RunnableConfig") from exc
+        if not tenant_id or not isinstance(tenant_id, str):
+            raise PermissionError(f"invalid tenant_id: {tenant_id!r}")
+        return build(tenant_id)
+    return factory
+```
+
+`PermissionError` on missing tenant — never `KeyError`, never a silent default. A caller that forgets to pass `configurable` must fail loudly.
+
+## Store-specific `build` functions
+
+### Pinecone (namespace-per-tenant)
+
+```python
+from langchain_pinecone import PineconeVectorStore
+
+def build_pinecone(tenant_id: str) -> BaseRetriever:
+    store = PineconeVectorStore(
+        index_name="rag",
+        namespace=tenant_id,
+        embedding=emb,
+    )
+    # Defense in depth — also filter on metadata in case namespace config
+    # drifts or a write path forgot to set namespace.
+    return store.as_retriever(
+        search_kwargs={"k": 4, "filter": {"tenant_id": tenant_id}},
+    )
+```
+
+### PGVector (row-level security)
+
+```python
+from sqlalchemy import text
+from langchain_postgres import PGVector
+
+def build_pgvector(tenant_id: str) -> BaseRetriever:
+    store = PGVector(
+        embeddings=emb,
+        collection_name="rag",
+        connection=engine,
+    )
+    # Set the tenant session variable per-transaction. The RLS policy on
+    # the documents table reads it. If it's missing, RLS denies all rows.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.tenant_id = :tid"), {"tid": tenant_id})
+    return store.as_retriever(search_kwargs={"k": 4})
+```
+
+See [Vector-store isolation](vector-store-isolation.md) for the RLS policy DDL.
+
+### Chroma (collection-per-tenant)
+
+```python
+import chromadb
+from langchain_chroma import Chroma
+
+def build_chroma(tenant_id: str) -> BaseRetriever:
+    client = chromadb.PersistentClient(path="/var/chroma")
+    # get_or_create is idempotent; safe to call per-request.
+    collection = client.get_or_create_collection(name=f"rag-{tenant_id}")
+    store = Chroma(client=client, collection_name=collection.name, embedding_function=emb)
+    return store.as_retriever(search_kwargs={"k": 4})
+```
+
+### FAISS (single-tenant only)
+
+```python
+# FAISS is in-process only. If you must use it multi-tenant, load a separate
+# index file per tenant — but you pay the file-load cost on cold cache, and
+# you cannot share memory across processes. Not recommended beyond ~50 tenants.
+def build_faiss(tenant_id: str) -> BaseRetriever:
+    path = f"/var/faiss/{tenant_id}.index"
+    store = FAISS.load_local(path, emb, allow_dangerous_deserialization=False)
+    return store.as_retriever(search_kwargs={"k": 4})
+```
+
+## Wiring the factory into a chain
+
+```python
+factory = make_retriever_factory(build_pinecone)
+
+def retrieve(inputs: dict, config: RunnableConfig):
+    return factory(config).invoke(inputs["query"])
+
+chain = RunnableLambda(retrieve) | prompt | model
+
+chain.invoke(
+    {"query": "when was the contract signed?"},
+    config={"configurable": {"tenant_id": "initech", "user_id": "u_42"}},
+)
+```
+
+The retriever is rebuilt on every `invoke`. For high-QPS endpoints where the cost of rebuilding matters, cache the **client** (the Pinecone / Chroma / Postgres connection) but rebuild the per-tenant view each request — never cache the retriever itself.
+
+## Lifecycle checklist
+
+1. Retriever is constructed **inside** the request handler, not at module scope
+2. Factory reads `tenant_id` from `RunnableConfig.configurable`, not from env / globals
+3. Missing `tenant_id` raises `PermissionError`, not a `KeyError` or silent default
+4. Vector-store client (connection pool, Pinecone client, Chroma client) is cached; the retriever view is not
+5. Two-tenant regression test runs in CI and asserts non-overlap (see [Multi-tenant regression tests](multi-tenant-regression-tests.md))
+6. On deploy, the first request for each tenant triggers a fresh build — no state carries over from a previous deploy
+
+## Common anti-patterns
+
+- `@lru_cache` on the factory — defeats the whole point, caches first tenant
+- Default `tenant_id="public"` — silent escape hatch for forgotten configs
+- Building the retriever in a FastAPI lifespan handler — runs once at startup, same as import
+- Reading tenant from an env var instead of `RunnableConfig` — breaks when the process serves multiple tenants
+
+## Related
+
+- [Vector-store isolation](vector-store-isolation.md) — Pinecone / PGVector RLS / Chroma / FAISS detail
+- [Multi-tenant regression tests](multi-tenant-regression-tests.md) — pytest fixtures that catch P33
+- [Audit-log schema](audit-log-schema.md) — log every retrieval with tenant_id for forensics

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/role-scoped-tool-allowlist.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/role-scoped-tool-allowlist.md
@@ -1,0 +1,119 @@
+# Role-scoped Tool Allowlist
+
+Bind only the tools the current user's role is permitted to call. Forbidden tools must not be passed to `create_agent` — the model never sees them in its tool catalog, so it cannot call them.
+
+## Why allowlist at bind time, not at tool-call time
+
+Three common patterns fail in production:
+
+1. **Bind everything, reject at tool execution** — the model still attempts the call, burns tokens generating arguments, and the rejection surfaces as a confusing error. P32 (tool allowlist not enforced when agents synthesize tool names from strings) bites here.
+2. **Check role inside each tool's implementation** — duplicates the allowlist across N tools; drift is inevitable when a new tool is added.
+3. **Wrap each tool with a decorator that reads role from global state** — global state in an async server means race conditions and wrong-tenant tools.
+
+The structural fix: make the allowlist a property of how the agent is built, not how each tool behaves. The agent built for a viewer has a strictly smaller tool catalog than the agent built for an admin.
+
+## The allowlist map
+
+```python
+ROLE_TOOLS: dict[str, set[str]] = {
+    "viewer": {"search_docs"},
+    "editor": {"search_docs", "create_note"},
+    "admin":  {"search_docs", "create_note", "delete_note", "export_audit"},
+}
+```
+
+Source this from your IAM system — Okta groups, Auth0 roles, a custom claim — not from a hardcoded dict in the chain code. The example above is for illustration.
+
+## Building the agent per-request
+
+```python
+from langgraph.prebuilt import create_agent
+
+ALL_TOOLS = {t.name: t for t in [search_docs, create_note, delete_note, export_audit]}
+
+def agent_for(user_role: str):
+    allowed_names = ROLE_TOOLS.get(user_role, set())
+    if not allowed_names:
+        raise PermissionError(f"role {user_role!r} has no tool access")
+    tools = [ALL_TOOLS[n] for n in allowed_names if n in ALL_TOOLS]
+    return create_agent(model, tools=tools)
+```
+
+Call `agent_for(user_role)` inside the request handler, not at import. The cost of `create_agent` is small (a handful of ms); the safety of a per-request build is large.
+
+## Denylist for dangerous argument patterns
+
+The allowlist bounds *which* tools run. The denylist bounds *what arguments* those tools accept. Patterns to reject via a pre-execution hook or a tool wrapper:
+
+| Tool shape | Deny pattern | Why |
+|---|---|---|
+| SQL query | `\b(DROP|TRUNCATE|ALTER)\b` case-insensitive | Writes / schema changes from a read tool |
+| Shell / subprocess | `rm -rf`, `sudo`, `> /dev/`, backticks | Destructive commands |
+| HTTP fetch | `169.254.169.254`, `localhost`, `127.0.0.1`, `.internal` | Cloud metadata / SSRF |
+| File read | `../`, absolute paths outside a whitelist | Path traversal |
+| Python eval | Any use at all in a production tool | RCE surface; use JSON tool args instead |
+
+Apply the denylist at the tool wrapper layer, not inside the tool:
+
+```python
+import re
+from langchain_core.tools import tool
+
+SQL_DENY = re.compile(r"\b(DROP|TRUNCATE|ALTER|GRANT|REVOKE)\b", re.IGNORECASE)
+
+def wrap_sql_tool(raw_tool):
+    @tool(name=raw_tool.name, description=raw_tool.description)
+    def safe(query: str) -> str:
+        if SQL_DENY.search(query):
+            raise PermissionError(f"forbidden SQL keyword in query")
+        return raw_tool.invoke({"query": query})
+    return safe
+```
+
+The raise surfaces to the audit log via the `try / finally` pattern (see [Audit-log schema](audit-log-schema.md)) with `outcome: "tool_denied"` and the offending pattern.
+
+## Pre-model hook for per-turn enforcement
+
+LangGraph `create_agent` accepts a `pre_model_hook` — a chance to inspect state before each model call. Use it to enforce that the tool catalog hasn't been mutated and to strip any tool messages from prior turns that violated a since-revoked permission.
+
+```python
+def pre_model_hook(state):
+    # Filter out tool results for tools the current role can no longer access.
+    # Useful when a long-running session has a role change mid-flight.
+    role = state.get("user_role")
+    allowed = ROLE_TOOLS.get(role, set())
+    messages = [
+        m for m in state["messages"]
+        if not (m.type == "tool" and m.name not in allowed)
+    ]
+    return {"messages": messages}
+
+agent = create_agent(model, tools=tools, pre_model_hook=pre_model_hook)
+```
+
+## Testing the allowlist
+
+```python
+def test_viewer_cannot_delete():
+    agent = agent_for(user_role="viewer")
+    # The delete_note tool is simply not in the agent's catalog.
+    assert "delete_note" not in [t.name for t in agent.get_tools()]
+
+def test_sql_deny_pattern():
+    wrapped = wrap_sql_tool(raw_sql_tool)
+    with pytest.raises(PermissionError, match="forbidden SQL"):
+        wrapped.invoke({"query": "DROP TABLE users"})
+```
+
+## Anti-patterns
+
+- Building the agent once at module scope, mutating its tool list per request — race condition, tools bleed across requests
+- Trusting the model's own "role" awareness — models comply most of the time, not all of the time; never a security boundary
+- Logging the denylist hit but still executing the tool — negates the protection
+- Regex-only denylists for shell commands — bash parsing is non-regular, use shlex and allowlist the binary instead
+
+## Related
+
+- [Retriever-per-request](retriever-per-request.md) — same per-request pattern for retrievers
+- [Audit-log schema](audit-log-schema.md) — `outcome: "tool_denied"` entries for every deny
+- [Multi-tenant regression tests](multi-tenant-regression-tests.md) — test fixtures for allowlist / denylist

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/vector-store-isolation.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/references/vector-store-isolation.md
@@ -1,0 +1,175 @@
+# Vector-store Isolation Primitives
+
+Each vector store offers a different isolation primitive. Pick one by scale and by the audit posture your security team requires.
+
+## Comparison
+
+| Store | Isolation primitive | p50 query latency | Max practical tenants | Audit posture |
+|---|---|---|---|---|
+| **Pinecone** | Namespace per tenant | ~40ms (shared index) | 100,000+ per index | Namespace is the isolation boundary; log both namespace and metadata for defense in depth |
+| **PGVector** | Row-level security on `tenant_id` | ~20ms (HNSW) | Millions of rows, 1000s of tenants | Strongest — RLS enforced by Postgres server, not app code |
+| **Chroma** | Collection per tenant | ~30ms | ~1,000 before metadata overhead | App-layer boundary; no server-side enforcement |
+| **FAISS** | In-process index per tenant | ~5ms (in-memory) | 10-50 | No multi-process story; not suitable for SaaS |
+
+Pinecone handles the highest scale. PGVector is the strongest when your security team needs isolation to be enforced at the database server. Chroma is appropriate for small B2B SaaS (≤1,000 tenants). FAISS is a development tool — document it so future engineers do not adopt it for production.
+
+## Pinecone — namespace per tenant
+
+```python
+from langchain_pinecone import PineconeVectorStore
+
+# Write path — always include namespace.
+store = PineconeVectorStore(
+    index_name="rag",
+    namespace=tenant_id,          # REQUIRED — never omit
+    embedding=emb,
+)
+store.add_texts(
+    ["document content"],
+    ids=[f"{tenant_id}-doc-1"],    # prefix IDs with tenant for leak forensics
+    metadatas=[{"tenant_id": tenant_id}],  # defense in depth
+)
+
+# Read path — namespace + metadata filter together.
+retriever = store.as_retriever(
+    search_kwargs={
+        "k": 4,
+        "filter": {"tenant_id": tenant_id},  # redundant with namespace; belt-and-braces
+    },
+)
+```
+
+Why the redundant metadata filter: if a write path ever forgets to set `namespace` (the default is `""`, which silently succeeds), the misfiled vectors sit in the default namespace where every tenant's query with the metadata filter will exclude them. Without the filter, a query with `namespace=""` would pull them.
+
+**Namespace lifecycle:** Pinecone namespaces are created on first write; no explicit provisioning step. Deletion: `store.delete(delete_all=True)` removes all vectors in the namespace. For tenant offboarding, this is the cleanup call.
+
+## PGVector — row-level security
+
+PGVector with RLS is the strongest isolation primitive because the database server enforces it. Even if application code has a bug, the server refuses to return rows from other tenants.
+
+### Schema and RLS policy
+
+```sql
+-- Table — add tenant_id column.
+CREATE TABLE documents (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  embedding VECTOR(1536) NOT NULL,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX documents_embedding_hnsw
+  ON documents USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX documents_tenant_id ON documents (tenant_id);
+
+-- Enable RLS.
+ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+
+-- Policy — reads and writes only for the current session's tenant.
+CREATE POLICY tenant_isolation ON documents
+  USING (tenant_id = current_setting('app.tenant_id', true))
+  WITH CHECK (tenant_id = current_setting('app.tenant_id', true));
+
+-- Grant to the app role — RLS still applies.
+GRANT SELECT, INSERT, UPDATE, DELETE ON documents TO langchain_app;
+```
+
+### Setting the session variable per transaction
+
+```python
+from sqlalchemy import text
+
+def run_with_tenant(tenant_id: str, work):
+    with engine.begin() as conn:
+        # SET LOCAL is transaction-scoped — auto-reset on commit/rollback.
+        conn.execute(text("SET LOCAL app.tenant_id = :tid"), {"tid": tenant_id})
+        return work(conn)
+```
+
+The `SET LOCAL` form is critical. `SET` without `LOCAL` persists for the whole session, which means connection pooling will bleed tenants into each other. Always `SET LOCAL`.
+
+### Testing RLS enforcement
+
+```python
+def test_rls_blocks_cross_tenant_read():
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.tenant_id = 'initech'"))
+        rows = conn.execute(text(
+            "SELECT id FROM documents WHERE content LIKE '%Acme%'"
+        )).all()
+    # Even though Acme documents exist, RLS filters them out.
+    assert rows == []
+
+def test_rls_blocks_write_to_other_tenant():
+    with pytest.raises(Exception, match="violates row-level security"):
+        with engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.tenant_id = 'initech'"))
+            conn.execute(text(
+                "INSERT INTO documents (id, tenant_id, content, embedding) "
+                "VALUES ('x', 'acme', 'stolen', '[0,0,0,...]'::vector)"
+            ))
+```
+
+A malicious or buggy write attempting to impersonate another tenant is blocked by the `WITH CHECK` clause.
+
+## Chroma — collection per tenant
+
+```python
+import chromadb
+from langchain_chroma import Chroma
+
+client = chromadb.PersistentClient(path="/var/chroma")
+
+def chroma_for(tenant_id: str) -> Chroma:
+    # get_or_create is idempotent — safe per-request.
+    collection = client.get_or_create_collection(name=f"rag-{tenant_id}")
+    return Chroma(
+        client=client,
+        collection_name=collection.name,
+        embedding_function=emb,
+    )
+```
+
+Pros: simple mental model (one collection = one tenant), no shared index to reason about.
+
+Cons: collection creation is synchronous and adds ~100ms on first write per tenant; metadata overhead grows with collection count; at ~1,000 collections query planning slows.
+
+**Offboarding:** `client.delete_collection(name=f"rag-{tenant_id}")` — synchronous and final.
+
+## FAISS — not recommended for multi-tenant
+
+FAISS is in-process. Each worker loads its own index from disk. Implications:
+
+- No shared memory across processes — 10 workers × 500MB index = 5GB RAM
+- Cold start on every deploy
+- No transactional isolation — a write during read is undefined
+- Tenant offboarding requires deleting a file on disk, then signaling every worker to reload
+
+Use FAISS for local development and single-tenant on-prem deployments. For multi-tenant SaaS, use one of the three above.
+
+## Cross-cutting concerns
+
+### Backups and retention
+
+Pinecone, PGVector, and Chroma back up per-tenant differently:
+
+- **Pinecone** — collections (backups) are index-scoped; you cannot back up a single tenant, only the whole index
+- **PGVector** — standard Postgres backup (`pg_dump`) captures all tenants; for per-tenant export use `COPY ... WHERE tenant_id = $1`
+- **Chroma** — one collection per tenant means per-tenant backup is `client.get_collection(name=...).get(include=["documents", "metadatas", "embeddings"])`
+
+### Index growth pressure
+
+At scale you will want to shard further — e.g. one Pinecone index per tier (enterprise customers in their own dedicated index). Design the retriever factory to accept an `(index_name, namespace)` pair so sharding doesn't require a rewrite.
+
+### Migration between stores
+
+When migrating FAISS → Pinecone or Chroma → PGVector, run the [regression tests](multi-tenant-regression-tests.md) against both stores in parallel for at least one full week. Diff the retrieved doc IDs per tenant per query; investigate any delta before cutting over.
+
+## Related
+
+- [Retriever-per-request](retriever-per-request.md) — factory implementations for all four stores
+- [Multi-tenant regression tests](multi-tenant-regression-tests.md) — RLS integration test included
+- [Audit-log schema](audit-log-schema.md) — `retrieval_ids` field enables cross-tenant leak detection queries


### PR DESCRIPTION
## Summary

Handcrafted Pro-tier multi-tenant skill — tenant isolation, retriever-per-request factory, role-scoped tool allowlists, audit log schema, cross-tenant regression tests, vector-store isolation matrix. Anchored to pain-catalog **P33**.

## Pain hook

A B2B SaaS team bound their `PineconeVectorStore` retriever at module import with the first tenant's namespace; six weeks later the second tenant's first query returned three Acme Corp docs, and security review put a hold on SOC2 renewal (P33). Skill replaces the singleton with a per-request factory keyed by `config["configurable"]["tenant_id"]` and ships a two-tenant pytest fixture that fails CI the moment anyone regresses back to import-time binding.

## Files

- `skills/langchain-enterprise-rbac/SKILL.md` (303 lines)
- `skills/langchain-enterprise-rbac/references/one-pager.md`
- `skills/langchain-enterprise-rbac/references/retriever-per-request.md`
- `skills/langchain-enterprise-rbac/references/role-scoped-tool-allowlist.md`
- `skills/langchain-enterprise-rbac/references/audit-log-schema.md`
- `skills/langchain-enterprise-rbac/references/multi-tenant-regression-tests.md`
- `skills/langchain-enterprise-rbac/references/vector-store-isolation.md`

## Validator

Grade **A (92/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude