### PR TITLE
feat(langchain-py-pack): add langchain-core-workflow (S06)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: langchain-core-workflow
+description: |
+  Compose LangChain 1.0 chains with RunnableParallel, RunnableBranch,
+  RunnablePassthrough.assign, and RunnableLambda — correct input/output shapes,
+  debug probes, and typed composition that catches dict-shape bugs before
+  invocation. Use when wiring multi-step chains, parallel retrievals,
+  conditional routing, or threading state through a chain for RAG,
+  classification, or extraction pipelines.
+  Trigger with "runnable parallel", "runnable branch", "langchain rag
+  composition", "passthrough assign", "langchain lcel", "runnable lambda",
+  "debug probe".
+allowed-tools: Read, Write, Edit, Bash(python:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, lcel, runnables, rag]
+compatible-with: claude-code, codex
+---
+
+# LangChain Core Workflow (Python)
+
+## Overview
+
+An engineer wires a four-stage LCEL chain: classify the question, retrieve
+context, format the prompt, invoke the LLM. It looks clean:
+
+```python
+chain = (
+    RunnablePassthrough.assign(category=classifier)
+    | RunnablePassthrough.assign(docs=retriever)
+    | prompt
+    | llm
+    | StrOutputParser()
+)
+
+chain.invoke({"question": "What's our refund policy?"})
+```
+
+The call returns this:
+
+```
+Traceback (most recent call last):
+  ...
+  File ".../runnables/base.py", line 3421, in _call_with_config
+    output = call_func_with_variable_args(func, input, ...)
+  File ".../prompts/chat.py", line 1021, in _format_messages
+    return await ... await self.ainvoke({**kwargs})
+KeyError: 'question'
+```
+
+Nothing in that stack says **which stage produced the wrong dict shape**. The
+`RunnablePassthrough.assign(docs=retriever)` call silently rebuilt the dict
+and — because `retriever` was itself a `Runnable[str, list[Document]]` that
+took the `question` *string*, not the dict — a mis-piped intermediate value
+overwrote the `question` key. The prompt template expected `{question}` and
+blew up. This is P06 in the pack's pain catalog: `.pipe()` on mismatched dict
+shape raises `KeyError` deep in runnable internals with no hint at the
+offending stage.
+
+The fix is **two patterns you install once and never remove**:
+
+1. **Debug probes** — a `RunnableLambda` that logs dict keys between every two
+   stages. <1ms overhead per invocation. Surfaces the exact stage that mutates
+   the shape.
+2. **Typed composition** — annotate each chain with `RunnableSerializable[InputT, OutputT]`
+   plus pydantic `BaseModel` types so mypy flags the mismatch at lint time
+   instead of at `.invoke()`.
+
+Meanwhile, a second trap waits for anyone tempted to wrap tool-using chains
+in the legacy `AgentExecutor`: it silently swallows intermediate tool errors
+as empty-string observations and the agent cheerfully answers "I couldn't
+find the answer" (P09). For agent loops in LangChain 1.0, skip `AgentExecutor`
+and use LangGraph's `create_react_agent` — errors raise, not vanish. This
+skill cross-references `langchain-langgraph-agents` (L26) for that path.
+
+Composition primitives covered — with input/output shapes and use cases — are
+`RunnableParallel` (fan-out, 2–3× wall-clock win on 2 independent retrievals),
+`RunnableBranch` (conditional routing with mandatory default), `RunnablePassthrough.assign`
+(merge computed fields without losing input), and `RunnableLambda` (arbitrary
+Python, used here for debug probes and shape assertions). Pin: `langchain-core 1.0.x`.
+Pain-catalog anchors: P06, P09.
+
+## Prerequisites
+
+- Python 3.10+
+- `langchain-core >= 1.0, < 2.0`
+- `pydantic >= 2.0` for typed composition
+- At least one chat provider installed (see `langchain-model-inference`)
+- Familiarity with the composition primitives introduced in `langchain-sdk-patterns`
+
+## Instructions
+
+### Step 1 — Fan-out with `RunnableParallel` for independent sub-tasks
+
+`RunnableParallel({"a": chain_a, "b": chain_b})` forwards the same input to
+both branches and runs them concurrently, merging results into a dict.
+Wall-clock collapses to the slower branch — 2–3× speedup on two parallel
+retrievals is typical (dense vector search + BM25, or tool-use + analysis).
+
+```python
+from langchain_core.runnables import RunnableParallel, RunnablePassthrough
+
+# Hybrid retrieval: dense vector search and BM25 at the same time
+hybrid = RunnableParallel(
+    dense=dense_retriever,     # Runnable[str, list[Document]]
+    bm25=bm25_retriever,       # Runnable[str, list[Document]]
+    query=RunnablePassthrough() # keep the original string for downstream stages
+)
+
+# Output: {"dense": [...], "bm25": [...], "query": "..."}
+result = hybrid.invoke("refund policy for damaged goods")
+```
+
+Input shape: whatever the sub-chains accept (all must accept the same shape).
+Output shape: `dict` with one key per sub-chain. If one branch takes 5× longer,
+your total latency is that branch — not the sum. See
+[Parallel vs Sequential](references/parallel-vs-sequential.md) for the async
+`.abatch()` variant, shared-state gotchas, and a benchmarking template.
+
+### Step 2 — Route on input with `RunnableBranch`
+
+`RunnableBranch((cond, runnable), ..., default)` dispatches per-input to the
+first matching branch. **The default is mandatory** — without one you get a
+silent fallthrough on unmatched inputs.
+
+```python
+from langchain_core.runnables import RunnableBranch
+
+router = RunnableBranch(
+    (lambda x: x["category"] == "refund", refund_chain),
+    (lambda x: x["category"] == "shipping", shipping_chain),
+    (lambda x: len(x["question"]) > 2000, long_form_chain),
+    general_chain,  # default — required
+)
+```
+
+Classifier-gated routes are the common case: a cheap small-model classifier
+runs first, its label goes into the dict via `RunnablePassthrough.assign`, and
+`RunnableBranch` dispatches. See [Branch Routing Patterns](references/branch-routing-patterns.md)
+for the signature, classifier-gated route recipe, fallback route pattern, and
+pytest patterns for each branch in isolation.
+
+### Step 3 — Thread state with `RunnablePassthrough.assign`
+
+`.assign(field=...)` merges a computed field into the input dict without
+losing any existing keys. This is the primary pattern for staged context
+assembly in RAG:
+
+```python
+from langchain_core.runnables import RunnablePassthrough
+
+def format_docs(docs: list) -> str:
+    return "\n\n".join(d.page_content for d in docs)
+
+# At each step, the dict grows: {question} -> {question, docs} -> {question, docs, context}
+staged = (
+    RunnablePassthrough.assign(docs=retriever)         # adds "docs"
+    | RunnablePassthrough.assign(context=lambda x: format_docs(x["docs"]))  # adds "context"
+)
+
+staged.invoke({"question": "..."})
+# {"question": "...", "docs": [...], "context": "..."}
+```
+
+The input dict passes through unchanged; the new field is the only mutation.
+This is the safest shape-preserving primitive in LCEL — use it whenever a
+downstream stage needs both the original input and a computed value. See
+[Passthrough Assign Patterns](references/passthrough-assign-patterns.md) for
+staged context assembly, the `itemgetter` variant for pulling a single field
+into a typed chain, and anti-patterns that re-shadow input keys.
+
+### Step 4 — Use `RunnableLambda` for debug probes (and little else)
+
+`RunnableLambda(fn)` wraps any Python callable into a runnable. Its best use
+is **debug probes** — log intermediate values without breaking the pipe:
+
+```python
+from langchain_core.runnables import RunnableLambda
+
+def probe(stage: str):
+    """<1ms overhead per invocation. Returns input unchanged."""
+    def _probe(x):
+        keys = list(x.keys()) if isinstance(x, dict) else type(x).__name__
+        print(f"[probe:{stage}] keys={keys}")
+        return x
+    return RunnableLambda(_probe)
+
+chain = (
+    probe("input")
+    | RunnablePassthrough.assign(category=classifier)
+    | probe("after-classify")
+    | RunnablePassthrough.assign(docs=retriever)
+    | probe("after-retrieve")
+    | prompt
+    | probe("after-prompt")
+    | llm
+    | StrOutputParser()
+)
+```
+
+When P06's `KeyError` strikes, the last probe that printed tells you exactly
+which stage produced the wrong shape. Remove the probes (or gate them on an
+env var) after debugging. For production chains that stay observable, prefer
+`langchain.debug = True` or LangSmith tracing over `print` probes.
+
+See [Debug Probes](references/debug-probes.md) for a shape-assertion decorator,
+the `langchain.debug` flag, verbose mode, and a probe that raises instead of
+prints (useful in CI).
+
+Avoid `RunnableLambda` for real logic — it loses LangSmith tracing fidelity
+(input/output become opaque blobs) and a >3-line lambda is a sign you want a
+concrete `Runnable` subclass. See the anti-pattern note in
+`langchain-sdk-patterns/references/runnable-composition-matrix.md`.
+
+### Step 5 — Type chains with `RunnableSerializable[InputT, OutputT]`
+
+The root fix for P06 is static typing at chain boundaries. `RunnableSerializable`
+carries input and output type parameters; pair it with pydantic `BaseModel`s
+and mypy catches dict-shape mismatches at lint time:
+
+```python
+from pydantic import BaseModel
+from langchain_core.runnables import RunnableSerializable
+
+class RAGInput(BaseModel):
+    question: str
+    user_id: str
+
+class RAGOutput(BaseModel):
+    answer: str
+    citations: list[str]
+
+def build_rag_chain() -> RunnableSerializable[RAGInput, RAGOutput]:
+    return (
+        RunnablePassthrough.assign(docs=retriever)
+        | RunnablePassthrough.assign(context=lambda x: format_docs(x["docs"]))
+        | prompt
+        | llm.with_structured_output(RAGOutput)
+    )
+
+rag: RunnableSerializable[RAGInput, RAGOutput] = build_rag_chain()
+```
+
+Call `rag.input_schema.model_json_schema()` to dump the runtime-enforced
+schema for tests or assertions. Combined with the debug probes from Step 4,
+this is the typed-composition pattern that retires P06 in new code.
+
+### Step 6 — RAG composition example (end-to-end)
+
+```python
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnablePassthrough, RunnableParallel
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "Answer from the context. If not in context, say so."),
+    ("human", "Context:\n{{ context }}\n\nQuestion: {{ question }}"),
+], template_format="jinja2")
+
+# Hybrid retrieval (parallel) + staged context assembly
+rag_chain = (
+    RunnableParallel(
+        dense=dense_retriever,
+        bm25=bm25_retriever,
+        question=RunnablePassthrough(),
+    )
+    | RunnablePassthrough.assign(
+        context=lambda x: format_hybrid(x["dense"], x["bm25"])
+    )
+    | prompt
+    | llm
+    | StrOutputParser()
+)
+
+answer = rag_chain.invoke("What's the return window for electronics?")
+```
+
+This is the reference composition — parallel dual-retrieval (2–3× speedup vs
+sequential), staged context assembly via `.assign`, jinja2 prompt templating
+(escapes literal `{` from retrieved docs, see `langchain-sdk-patterns`), and
+a simple string output. Add debug probes from Step 4 during development.
+
+### Step 7 — For agent loops, skip `AgentExecutor`
+
+Legacy `AgentExecutor` silently catches tool exceptions and feeds the error
+message back as an empty-string observation — the agent then answers "I
+couldn't find the answer" with no trace of the underlying failure (P09). In
+LangChain 1.0, use LangGraph's `create_react_agent` instead: tool errors
+raise by default, intermediate steps are inspectable, and recursion limits
+are explicit.
+
+See the pack's `langchain-langgraph-agents` skill (L26) for the agent
+migration path. The composition primitives in this skill (`RunnableParallel`,
+`RunnableBranch`, `.assign`) remain the right tools for the non-agent parts
+of any LangGraph workflow — they compose inside a LangGraph node.
+
+## Composition Pattern Table
+
+| Pattern | Input shape | Output shape | Typical use |
+|---|---|---|---|
+| `a \| b \| c` (RunnableSequence) | `a.input` | `c.output` | Linear pipeline: prompt → llm → parser |
+| `RunnableParallel(x=ch1, y=ch2)` | forwarded to both | `{"x": ch1.output, "y": ch2.output}` | Fan-out: hybrid retrieval, tool-use + analysis |
+| `RunnableBranch((cond, ch), ..., default)` | anything cond accepts | `ch.output` or `default.output` | Classifier-gated routing, per-input dispatch |
+| `RunnablePassthrough()` | any | same as input | Keep original value alongside a transform in a parallel |
+| `RunnablePassthrough.assign(k=ch)` | `dict` | input dict with `"k"` added (ch.output) | Staged context assembly, threading state |
+| `RunnableLambda(fn)` | `fn`'s arg | `fn`'s return | Debug probes, shape assertions — avoid for real logic |
+
+## Output
+
+- Multi-step chains composed from `RunnableParallel`, `RunnableBranch`, `RunnablePassthrough.assign`, and `RunnableLambda` with declared input/output shapes
+- Debug-probe pattern (<1ms per invocation) that surfaces the exact stage producing a wrong dict shape when P06 strikes
+- Typed-composition pattern (`RunnableSerializable[InputT, OutputT]` + pydantic `BaseModel`) that catches P06 at lint time before invocation
+- RAG composition recipe: hybrid parallel retrieval + staged context assembly + prompt + llm + parser, 2–3× wall-clock win on dual retrieval
+- Cross-reference to `langchain-langgraph-agents` (L26) for agent loops that avoid P09's silent-error trap
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `KeyError: 'question'` deep in runnable internals, no stage named in stack | `RunnablePassthrough.assign` or an upstream runnable rebuilt the dict in a way a downstream stage does not expect (P06) | Insert `RunnableLambda` debug probes between stages; annotate with `RunnableSerializable[InputT, OutputT]` + pydantic for lint-time catch |
+| Agent returns "I couldn't find the answer" with no error in logs | Legacy `AgentExecutor` swallows tool exceptions as empty-string observations (P09) | Migrate to LangGraph `create_react_agent`; see `langchain-langgraph-agents` (L26) |
+| `RunnableBranch` returns wrong branch's output for unmatched input | No default branch supplied; LCEL fell through to the last-declared pair | Always pass a default as the final positional arg to `RunnableBranch((cond, ch), ..., default_ch)` |
+| `.assign` computed field shadows input key | `RunnablePassthrough.assign(question=...)` overwrote the original `question` | Name computed fields distinctly from input keys; use `itemgetter` to extract when you need the original |
+| `RunnableLambda` call shows as opaque blob in LangSmith | Lambda's input/output are not traced at block-level | Replace with a concrete `Runnable` subclass or use `.assign(key=...)` with a named function |
+| `RunnableParallel` branches race on shared mutable state | A lambda closed over a non-thread-safe object | Keep parallel branches side-effect-free; materialize shared state before the parallel block |
+
+## Examples
+
+### Hybrid retrieval with parallel branches
+
+Two retrievers run concurrently on the same query — dense vector search via
+an embedding model and BM25 via rank-bm25. `RunnableParallel` merges the
+results; a downstream `.assign` step formats the union. Wall-clock is the
+slower retriever, not the sum — typically a 2–3× win over sequential dense
+then BM25.
+
+See [Parallel vs Sequential](references/parallel-vs-sequential.md) for the
+benchmarking template and async variant.
+
+### Classifier-gated routing for a customer support chain
+
+A cheap small-model classifier runs first and tags the input dict with a
+`category`. `RunnableBranch` dispatches refunds, shipping, and general
+questions to specialist chains. The default branch handles unmatched inputs
+with a disclaimer prompt.
+
+See [Branch Routing Patterns](references/branch-routing-patterns.md) for the
+classifier-gated recipe and pytest isolation patterns.
+
+### Staged context assembly for RAG with citations
+
+`RunnablePassthrough.assign(docs=retriever)` then
+`.assign(context=format_docs)` builds the prompt context without dropping the
+original `question`. A final `.assign(citations=lambda x: [d.metadata["url"] for d in x["docs"]])`
+threads citations through to the structured output.
+
+See [Passthrough Assign Patterns](references/passthrough-assign-patterns.md)
+for the staged pattern and the anti-pattern around key shadowing.
+
+### Debug probe that raises in CI
+
+In development, probes `print`. In CI, they assert on expected keys and raise
+on mismatch — catching P06 during test runs instead of at production invoke.
+
+See [Debug Probes](references/debug-probes.md) for the shape-assertion
+decorator and the `langchain.debug` flag.
+
+## Resources
+
+- [LangChain Python: Runnable interface](https://python.langchain.com/docs/concepts/runnables/)
+- [LangChain Python: RunnableParallel](https://python.langchain.com/docs/how_to/parallel/)
+- [LangChain Python: RunnableBranch](https://python.langchain.com/docs/how_to/routing/)
+- [LangChain Python: RunnablePassthrough](https://python.langchain.com/docs/how_to/passthrough/)
+- [LangChain Python: debug mode](https://python.langchain.com/docs/how_to/debugging/)
+- [LangChain 1.0 release notes](https://blog.langchain.com/langchain-langgraph-1dot0/)
+- Pair skill: `langchain-sdk-patterns` (composition primitives, fallbacks, concurrency)
+- Agent alternative: `langchain-langgraph-agents` (L26) — avoids P09
+- Pack pain catalog: `docs/pain-catalog.md` (entries P06, P09)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/branch-routing-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/branch-routing-patterns.md
@@ -1,0 +1,145 @@
+# Branch Routing Patterns
+
+`RunnableBranch` dispatches an input to the first branch whose condition
+returns truthy. It is the LCEL equivalent of `if/elif/else` — with one
+important rule: **always supply a default**. The signature is:
+
+```python
+RunnableBranch(
+    (cond_1, runnable_1),
+    (cond_2, runnable_2),
+    ...,
+    default_runnable,
+)
+```
+
+Conditions are callables taking the chain input and returning bool. They run
+top-to-bottom; the first match wins and evaluation short-circuits. The final
+positional arg is the default branch — it runs when no condition matches.
+
+## Classifier-gated routing
+
+The common case: a small cheap model tags the input with a category, then
+`RunnableBranch` dispatches to a specialist chain per category.
+
+```python
+from langchain_core.runnables import RunnableBranch, RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+
+classifier_prompt = ChatPromptTemplate.from_messages([
+    ("system", "Classify the ticket as one of: refund, shipping, technical, other."),
+    ("human", "{{ question }}"),
+], template_format="jinja2")
+
+classifier = classifier_prompt | haiku_llm | StrOutputParser()
+
+router = RunnableBranch(
+    (lambda x: x["category"] == "refund", refund_chain),
+    (lambda x: x["category"] == "shipping", shipping_chain),
+    (lambda x: x["category"] == "technical", technical_chain),
+    general_chain,  # default — required
+)
+
+full = (
+    RunnablePassthrough.assign(category=classifier)
+    | router
+)
+```
+
+Why two stages rather than a branch-on-raw-input: keeping classification in
+its own `.assign` step means (a) the classifier result is visible in traces
+and debug probes, (b) you can swap classifiers without touching the router,
+and (c) tests can pin the category directly.
+
+## Fallback route on unmatched input
+
+The default branch is **not** an error handler — it is the "none of the above"
+path. For real input, the default might be a general-purpose chain with a
+disclaimer prompt:
+
+```python
+disclaimer_prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a general assistant. If the question needs a specialist, say so."),
+    ("human", "{{ question }}"),
+], template_format="jinja2")
+
+general_chain = disclaimer_prompt | llm | StrOutputParser()
+```
+
+For explicit error handling on a missing category, raise inside the default:
+
+```python
+def raise_unmatched(x):
+    raise ValueError(f"no route for category={x.get('category')!r}")
+
+router = RunnableBranch(
+    (lambda x: x["category"] == "refund", refund_chain),
+    RunnableLambda(raise_unmatched),   # fail loudly instead of silent fallthrough
+)
+```
+
+This is the pattern to use in CI or staging — surface unmatched inputs
+instead of quietly serving them with a default chain.
+
+## Condition patterns
+
+Conditions can be any callable that returns a boolean-ish value. Common shapes:
+
+| Condition | Use |
+|---|---|
+| `lambda x: x["category"] == "refund"` | Direct key match |
+| `lambda x: len(x["question"]) > 2000` | Input-size routing (long form → bigger model) |
+| `lambda x: x.get("user_tier") == "enterprise"` | Tier-gated features |
+| `lambda x: any(w in x["q"].lower() for w in URGENT_WORDS)` | Keyword short-circuit |
+| `predicate_chain` (a `Runnable[I, bool]`) | Async/LLM-based predicate |
+
+A `Runnable` predicate lets the branch use the same input pipeline as the
+target runnables — useful for predicates that need an LLM judgment, but slower
+than a pure-Python lambda. Prefer lambdas for hot paths.
+
+## Common mistakes
+
+**Omitting the default.** Older LCEL code sometimes passes only `(cond, runnable)`
+tuples with no trailing default arg. Without a default, unmatched inputs fall
+through to the last-declared pair — a silent correctness bug.
+
+**Condition mutating the input.** Conditions run on every branch evaluation.
+If a condition has side effects (logging counters, cache writes), you will
+see duplicated side effects when conditions run top-to-bottom.
+
+**Non-exhaustive conditions on enum categories.** If your classifier can emit
+`"refund"`, `"shipping"`, `"technical"`, and `"other"`, but your branch only
+handles the first three, `"other"` silently hits the default. Enumerate all
+categories or add a `raise_unmatched` default.
+
+**Conditions that read missing keys.** `lambda x: x["category"]` raises
+`KeyError` if classification is skipped. Use `.get()` with a default:
+`lambda x: x.get("category") == "refund"`.
+
+## Testing branches in isolation
+
+Each branch is a `Runnable` — test it directly without going through the
+router. This is the biggest win of `RunnableBranch` over inline if/elif
+Python:
+
+```python
+def test_refund_chain_handles_basic_case():
+    result = refund_chain.invoke({"question": "I want my money back"})
+    assert "refund" in result.lower()
+
+def test_router_dispatches_refund_to_refund_chain(monkeypatch):
+    # Pin classifier output without calling the LLM
+    monkeypatch.setattr("mymodule.classifier", RunnableLambda(lambda x: "refund"))
+    result = full.invoke({"question": "return this"})
+    # assert target chain ran
+```
+
+For the router itself, test each condition by invoking with a pinned input
+that matches exactly one branch. Run a separate test for the default path —
+assert it fires on a category your router does not handle.
+
+## Resources
+
+- [LangChain Python: dynamic routing](https://python.langchain.com/docs/how_to/routing/)
+- [`RunnableBranch` API reference](https://python.langchain.com/api_reference/core/runnables/langchain_core.runnables.branch.RunnableBranch.html)
+- Pack pain catalog: P56 (LangGraph conditional edges — sibling footgun)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/debug-probes.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/debug-probes.md
@@ -1,0 +1,190 @@
+# Debug Probes
+
+P06's cryptic `KeyError` costs hours when probes are not installed. This
+reference covers three tools for making LCEL chains observable: inline
+`RunnableLambda` probes, `langchain.debug` global flag, and a shape-assertion
+decorator for CI.
+
+## The inline probe
+
+A `RunnableLambda` that logs input and returns it unchanged. <1ms overhead
+per invocation. Drop it between any two stages.
+
+```python
+from langchain_core.runnables import RunnableLambda
+
+def probe(stage: str, *, logger=print):
+    """Observability probe. Logs shape, returns input unchanged."""
+    def _probe(x):
+        if isinstance(x, dict):
+            logger(f"[probe:{stage}] keys={list(x.keys())}")
+        else:
+            logger(f"[probe:{stage}] type={type(x).__name__}")
+        return x
+    return RunnableLambda(_probe)
+```
+
+Wire it into a chain:
+
+```python
+chain = (
+    probe("input")
+    | RunnablePassthrough.assign(category=classifier)
+    | probe("after-classify")
+    | RunnablePassthrough.assign(docs=retriever)
+    | probe("after-retrieve")
+    | prompt
+    | probe("after-prompt")
+    | llm
+    | StrOutputParser()
+)
+
+chain.invoke({"question": "What's our refund policy?"})
+# [probe:input] keys=['question']
+# [probe:after-classify] keys=['question', 'category']
+# [probe:after-retrieve] keys=['question', 'category', 'docs']
+# [probe:after-prompt] type=ChatPromptValue
+```
+
+When P06 strikes, the **last probe that printed** names the stage before the
+crash. That stage is where the dict shape changed unexpectedly.
+
+## Gating probes on an env var
+
+You do not want probes printing in production. Gate them:
+
+```python
+import os, logging
+
+log = logging.getLogger(__name__)
+
+def probe(stage: str):
+    if os.environ.get("LCEL_DEBUG") != "1":
+        return RunnableLambda(lambda x: x)  # no-op passthrough
+    def _probe(x):
+        if isinstance(x, dict):
+            log.debug("probe=%s keys=%s", stage, list(x.keys()))
+        else:
+            log.debug("probe=%s type=%s", stage, type(x).__name__)
+        return x
+    return RunnableLambda(_probe)
+```
+
+Set `LCEL_DEBUG=1` during development, leave it unset in prod. The no-op
+probe adds a negligible frame but preserves the chain shape for consistent
+behavior.
+
+## Shape-assertion decorator
+
+In CI, probes should **raise** instead of print — turning P06 into a test
+failure with a clear message instead of a production mystery:
+
+```python
+from langchain_core.runnables import RunnableLambda
+
+def assert_shape(stage: str, required_keys: set[str]):
+    """Probe that raises if required keys are missing. For CI."""
+    def _assert(x):
+        if not isinstance(x, dict):
+            raise TypeError(f"[{stage}] expected dict, got {type(x).__name__}")
+        missing = required_keys - set(x.keys())
+        if missing:
+            raise KeyError(f"[{stage}] missing keys: {missing}; have {set(x.keys())}")
+        return x
+    return RunnableLambda(_assert)
+
+# Usage in tests
+test_chain = (
+    assert_shape("input", {"question"})
+    | RunnablePassthrough.assign(category=classifier)
+    | assert_shape("after-classify", {"question", "category"})
+    | rest_of_chain
+)
+```
+
+Name the expected shape at each boundary. A missing key surfaces at that
+boundary, not 200 lines into `_call_with_config`.
+
+## `langchain.debug` — the global flag
+
+LangChain ships a global debug mode that logs every runnable's input and
+output:
+
+```python
+import langchain
+langchain.debug = True
+
+chain.invoke({"question": "..."})
+# Logs each step with full input/output
+```
+
+Useful for **one-off** debugging but verbose — it will dump the full prompt
+string, the LLM response, and every intermediate object. Turn it off after
+you find the bug.
+
+Alternatively, `langchain.verbose = True` is a lighter logger that shows
+chain entry/exit without full payloads.
+
+## Structured logging — replace `print` with `structlog`
+
+For long-running services, prefer structured logging to `print`:
+
+```python
+import structlog
+logger = structlog.get_logger()
+
+def probe(stage: str):
+    def _probe(x):
+        keys = list(x.keys()) if isinstance(x, dict) else None
+        logger.debug("lcel.probe", stage=stage, keys=keys, type=type(x).__name__)
+        return x
+    return RunnableLambda(_probe)
+```
+
+This writes JSON lines that LangSmith, Datadog, or your log aggregator can
+filter by stage.
+
+## LangSmith — the production answer
+
+Once you are past "debug with prints", use [LangSmith](https://smith.langchain.com):
+
+```python
+import os
+os.environ["LANGCHAIN_TRACING_V2"] = "true"
+os.environ["LANGCHAIN_API_KEY"] = "ls__..."
+```
+
+Every runnable's input, output, latency, and token count show up in the
+LangSmith UI. The tradeoff: `RunnableLambda` calls render as opaque blobs
+(they do not expose internal structure the way `RunnableSequence` does), so
+for observability-first code, prefer composition primitives over lambdas —
+see `runnable-composition-matrix.md` in `langchain-sdk-patterns`.
+
+## Probe decision table
+
+| Situation | Use |
+|---|---|
+| Active development, fast iteration | Inline `print` probes |
+| CI test runs | `assert_shape` probes that raise |
+| Staging / production (persistent) | `structlog` probes + LangSmith |
+| One-off "where did this break?" debug | `langchain.debug = True` |
+| Chain works but answers are wrong | LangSmith trace replay |
+
+## Minimal probe — the one-liner
+
+If you want a single-line copy-paste:
+
+```python
+probe = RunnableLambda(lambda x: (print(f"[probe] {list(x.keys()) if isinstance(x, dict) else type(x).__name__}"), x)[1])
+
+chain = probe | step_1 | probe | step_2 | probe | step_3
+```
+
+Ugly, fast, effective — a one-time debug tool. Replace with the named probe
+factory once you know which stage is broken.
+
+## Resources
+
+- [LangChain Python: debugging](https://python.langchain.com/docs/how_to/debugging/)
+- [LangSmith tracing setup](https://docs.smith.langchain.com/tracing)
+- Pack pain catalog: P06 (the reason this reference exists)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-core-workflow — One-Pager
+
+Compose LangChain 1.0 chains with `RunnableParallel`, `RunnableBranch`, `RunnablePassthrough.assign`, and `RunnableLambda` — correct input/output shapes, debug probes, and typed composition that catches dict-shape bugs before invocation.
+
+## The Problem
+
+An engineer wires a four-stage chain: classify → retrieve → format → generate. `.invoke({"question": "..."})` returns `KeyError: 'question'` from deep inside runnable internals. The stack trace names `_call_with_config` and a transformer class but **never** the stage that produced the wrong dict shape. Swapping `RunnablePassthrough()` for `RunnablePassthrough.assign(context=retriever)` changes the schema in a way that downstream `prompt.invoke(dict_in)` cannot tolerate, but LCEL gives no pre-invocation check (P06). Meanwhile, legacy `AgentExecutor` silently turns tool exceptions into empty-string observations and the agent answers "I couldn't find that" — no error surfaces (P09).
+
+## The Solution
+
+Add a `RunnableLambda` debug probe between every two stages (overhead <1ms per invocation) that prints or logs the dict's keys. For new code, annotate chains with `RunnableSerializable[InputT, OutputT]` plus pydantic `BaseModel` input/output types — mypy and pytest catch P06 at lint time, not at `.invoke()`. Fan-out independent retrievals with `RunnableParallel` for a 2–3× wall-clock win on 2 parallel calls. Route on input shape with `RunnableBranch` (always supply a default). Thread state through the chain with `RunnablePassthrough.assign(field=...)`. For agent loops, skip `AgentExecutor` entirely and use LangGraph's `create_react_agent` — tool errors raise, not vanish.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python engineers wiring multi-step LCEL chains — RAG composition, classification + extraction pipelines, parallel retrieval/tool-use stages, conditional routing |
+| **What** | `RunnableParallel` / `RunnableBranch` / `RunnablePassthrough.assign` / `RunnableLambda` patterns, debug-probe recipe, typed composition with `RunnableSerializable[I, O]`, 4 deep references |
+| **When** | After `langchain-sdk-patterns` (composition primitives) and `langchain-model-inference` (chat models), before any multi-stage chain ships — P06's cryptic `KeyError` burns hours if the debug probes are not in from the start |
+
+## Key Features
+
+1. **Debug-probe pattern** — A one-line `RunnableLambda(lambda x: (print(f"[probe] keys={list(x.keys())}"), x)[1])` insertable between any two stages, <1ms overhead, surfaces the exact stage that changes the dict shape (P06 fix)
+2. **Typed composition with `RunnableSerializable[InputT, OutputT]`** — Annotate chain boundaries with pydantic `BaseModel` types so mypy flags shape mismatches before invocation; pairs with `chain.input_schema.model_json_schema()` for runtime assertion
+3. **RAG composition recipe** — End-to-end pattern (retriever + context formatter + prompt + llm + parser) with `RunnablePassthrough.assign(context=retriever)` that preserves the input `question` field through to the prompt, plus a parallel variant for hybrid dense + BM25 retrieval
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/parallel-vs-sequential.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/parallel-vs-sequential.md
@@ -1,0 +1,140 @@
+# Parallel vs Sequential — RunnableParallel Deep Dive
+
+`RunnableParallel({"a": chain_a, "b": chain_b})` runs sub-chains concurrently
+and merges their outputs into a dict. In practice, it is the single biggest
+latency win in an LCEL pipeline after correct `.batch(max_concurrency=...)`.
+This reference covers when parallel wins, async semantics, shared-state
+gotchas, and a benchmarking template.
+
+## When parallel wins
+
+| Scenario | Speedup | Why |
+|---|---|---|
+| 2 independent retrievers (dense + BM25) | 2–3× | Both hit the network; wall-clock = slower one |
+| Tool-use call + analysis summary | ~2× | Tool and LLM are both I/O-bound and independent |
+| 3 sub-chains (summary + entities + sentiment) | 2.5–3× | Same input fans out, unrelated downstream |
+| Local CPU transform + remote LLM call | ~1.0× | CPU work is cheap; LLM dominates anyway |
+| Two chained retrievers (A then B needs A's output) | N/A | Not parallel — this is sequential by contract |
+
+Parallel wins when branches are **I/O-bound, independent, and of comparable
+latency**. Two 500ms network calls in parallel take ~500ms. If one branch is
+2s and the other is 50ms, parallel gives 2s — no worse than sequential's 2.05s,
+but not the dramatic win of balanced branches.
+
+## Sync vs async
+
+`RunnableParallel` uses `asyncio.gather` under the hood when called via
+`.ainvoke` / `.abatch`. The sync `.invoke` uses a thread pool, which:
+
+- Works correctly for network-bound branches (they release the GIL)
+- Does **not** parallelize CPU-bound Python work (GIL contention)
+- Has ~5–15ms thread-pool overhead per branch
+
+For production async services (FastAPI, LangGraph nodes), use `.ainvoke` /
+`.abatch`. The thread-pool path is acceptable for scripts and eval harnesses.
+
+```python
+# Sync — thread pool, fine for scripts
+result = hybrid.invoke("query")
+
+# Async — asyncio.gather, use in async services
+result = await hybrid.ainvoke("query")
+```
+
+## Shared state gotchas
+
+Branches in a `RunnableParallel` run concurrently. If they close over shared
+mutable state, you will get races. Symptoms include intermittent `KeyError`,
+corrupted lists, and "flaky" unit tests.
+
+```python
+# BAD — shared mutable list
+results_log = []
+def logged_retrieve(q):
+    docs = retriever.invoke(q)
+    results_log.append(docs)   # race with other branch
+    return docs
+
+parallel = RunnableParallel(
+    a=RunnableLambda(logged_retrieve),
+    b=RunnableLambda(logged_retrieve),
+)
+```
+
+Rules:
+
+1. **Branches are side-effect-free.** Do logging/metrics after the parallel block.
+2. **Materialize shared inputs before the parallel.** Pass a frozen snapshot.
+3. **Use `contextvars` for per-request state**, not module-level globals.
+4. **No generators**. Parallel branches that yield are hostile to `asyncio.gather`.
+
+## Benchmarking template
+
+Measuring a real speedup matters — parallel is not automatic. Use this
+template to compare serial vs parallel for a given pair of sub-chains:
+
+```python
+import asyncio, time
+from langchain_core.runnables import RunnableParallel
+
+async def bench(inputs: list[str], n: int = 20):
+    # Serial baseline
+    t0 = time.perf_counter()
+    for x in inputs[:n]:
+        await chain_a.ainvoke(x)
+        await chain_b.ainvoke(x)
+    serial = time.perf_counter() - t0
+
+    # Parallel
+    parallel = RunnableParallel(a=chain_a, b=chain_b)
+    t0 = time.perf_counter()
+    for x in inputs[:n]:
+        await parallel.ainvoke(x)
+    par = time.perf_counter() - t0
+
+    print(f"serial: {serial:.2f}s  parallel: {par:.2f}s  speedup: {serial/par:.2f}x")
+
+asyncio.run(bench(queries))
+```
+
+Report the ratio, not the absolute — absolute times vary with provider load.
+Speedup below 1.3× means one branch dominates; below 1.1× means you added
+overhead without winning anything.
+
+## Fan-out + batch — the two-dimensional pattern
+
+`RunnableParallel` runs N branches for a single input. `.batch(inputs,
+max_concurrency=K)` runs K inputs at once through the whole chain. Combined,
+you get `N × K` in-flight calls:
+
+```python
+parallel = RunnableParallel(a=chain_a, b=chain_b)  # N=2 branches
+results = await parallel.abatch(
+    big_input_list,
+    config={"max_concurrency": 10},                # K=10 inputs
+)
+# 2 × 10 = up to 20 provider calls in flight
+```
+
+Watch provider rate limits — the effective concurrency is the product. Tune
+`max_concurrency` downward when `N` is large; see
+`langchain-sdk-patterns/references/batch-concurrency-tuning.md` for
+per-provider ceilings.
+
+## When to use sequential
+
+Not every pair should be parallel. Use sequential (`|`) when:
+
+- Branch B's input depends on branch A's output
+- Branches write to the same downstream state (avoid races)
+- One branch is ~10× slower (parallel wins nothing, but adds overhead)
+- You need early-exit semantics (`RunnableBranch` is a better fit)
+
+The rule of thumb from `runnable-composition-matrix.md` stands: linear flow
+goes through `|`, independent sub-tasks go through `RunnableParallel`.
+
+## Resources
+
+- [LangChain Python: parallel execution](https://python.langchain.com/docs/how_to/parallel/)
+- [asyncio.gather semantics](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather)
+- Pack pain catalog: P08 (batch concurrency), P06 (dict-shape divergence)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/passthrough-assign-patterns.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/references/passthrough-assign-patterns.md
@@ -1,0 +1,174 @@
+# Passthrough Assign Patterns
+
+`RunnablePassthrough.assign(field=ch)` merges a computed field into the input
+dict without losing any existing keys. It is the primary pattern for
+**threading state** through a chain — the input dict grows as it flows,
+every earlier key stays reachable by later stages.
+
+This reference covers staged context assembly for RAG, the `itemgetter`
+variant for typed sub-chains, and anti-patterns around key shadowing.
+
+## The core shape
+
+```python
+RunnablePassthrough.assign(key=runnable)
+# Input:  {"a": 1, "b": 2}
+# Output: {"a": 1, "b": 2, "key": runnable.invoke({"a": 1, "b": 2})}
+```
+
+The `runnable` receives the **full input dict** and its output is assigned
+to the new key. This is different from `RunnableParallel`, which replaces
+the dict with one keyed only by the parallel branches.
+
+## Staged context assembly for RAG
+
+The canonical RAG pipeline stages context in three assigns:
+
+```python
+from langchain_core.runnables import RunnablePassthrough
+
+def format_docs(docs: list) -> str:
+    return "\n\n".join(f"[{i+1}] {d.page_content}" for i, d in enumerate(docs))
+
+def extract_citations(docs: list) -> list[str]:
+    return [d.metadata.get("url", "") for d in docs]
+
+rag_context = (
+    RunnablePassthrough.assign(docs=retriever)
+    | RunnablePassthrough.assign(
+        context=lambda x: format_docs(x["docs"]),
+        citations=lambda x: extract_citations(x["docs"]),
+    )
+)
+
+rag_context.invoke({"question": "..."})
+# {"question": "...", "docs": [...], "context": "...", "citations": [...]}
+```
+
+Note that `.assign` accepts **multiple kwargs at once** — both computed fields
+run after the previous stage and both see the full input including `docs`.
+Use this when two computed fields derive from the same upstream value.
+
+## `itemgetter` for pulling a field into a typed sub-chain
+
+When a sub-chain expects a concrete input type (string, list), not the whole
+dict, use `itemgetter` to extract the field. This is the pattern to pass a
+dict's `question` to a retriever that takes a string:
+
+```python
+from operator import itemgetter
+from langchain_core.runnables import RunnablePassthrough
+
+question_only = itemgetter("question") | retriever  # Runnable[dict, list[Document]]
+
+chain = RunnablePassthrough.assign(docs=question_only)
+```
+
+Without `itemgetter`, you would pass the full dict to `retriever.invoke`,
+which would try to embed the dict and crash (P06 exactly — `retriever` expects
+`str`, sees `dict`). This is the cleanest shape-matching primitive in LCEL
+for pulling typed fields into typed sub-chains.
+
+## Preserving input alongside transforms in `RunnableParallel`
+
+`RunnablePassthrough()` (the bare call, no `.assign`) is the identity
+runnable — input passes through unchanged. Inside a `RunnableParallel`, this
+keeps the original value alongside computed values:
+
+```python
+from langchain_core.runnables import RunnableParallel, RunnablePassthrough
+
+enriched = RunnableParallel(
+    summary=summary_chain,
+    entities=entity_chain,
+    original=RunnablePassthrough(),  # keep the input around
+)
+# Output: {"summary": "...", "entities": [...], "original": "<input>"}
+```
+
+Use this when a downstream stage needs both a transform and the raw input.
+The common case is a prompt that quotes the user's original question
+alongside an LLM-generated classification.
+
+## Lambda assigns — short, readable, no-LLM
+
+`.assign(field=lambda x: ...)` wraps the lambda in a `RunnableLambda`
+automatically. This is the clean way to add computed fields from pure-Python
+logic:
+
+```python
+from datetime import datetime
+
+annotated = RunnablePassthrough.assign(
+    timestamp=lambda x: datetime.utcnow().isoformat(),
+    word_count=lambda x: len(x["question"].split()),
+    is_urgent=lambda x: "urgent" in x["question"].lower(),
+)
+```
+
+Keep the lambdas short (1 line). If the logic is >3 lines, extract to a
+named function and pass the function — it traces better and tests are easier.
+
+## Anti-pattern: shadowing input keys
+
+```python
+# BAD — overwrites the original "question" with a paraphrase
+bad = RunnablePassthrough.assign(
+    question=paraphrase_chain,   # shadowed!
+)
+```
+
+Downstream stages that expected the original `question` now see the
+paraphrased version. This is a silent correctness bug — the chain runs fine,
+but your citations no longer match what the user asked.
+
+**Rule:** name computed fields distinctly from input keys. If you genuinely
+need to replace a field, do it via a full `RunnableLambda` that signals
+intent, not via a sneaky `.assign` that looks like augmentation.
+
+## Anti-pattern: chained `.assign` with circular dependencies
+
+```python
+# BAD — "context" is computed from "docs", but "docs" is computed from "context"
+broken = (
+    RunnablePassthrough.assign(docs=lambda x: retrieve(x["context"]))
+    | RunnablePassthrough.assign(context=lambda x: format_docs(x["docs"]))
+)
+```
+
+At the first `.assign`, `x["context"]` does not exist — `KeyError`. Order
+matters. Make the dependency graph explicit: compute upstream first, merge
+into dict, then compute downstream.
+
+## Combining with `RunnableBranch` for computed routes
+
+A clean pattern: use `.assign` to compute a category, then `RunnableBranch`
+to route on it:
+
+```python
+routed = (
+    RunnablePassthrough.assign(category=classifier)
+    | RunnableBranch(
+        (lambda x: x["category"] == "refund", refund_chain),
+        (lambda x: x["category"] == "shipping", shipping_chain),
+        general_chain,
+    )
+)
+```
+
+The branch runnables all receive the dict with `category` included — they
+can use it for further conditional logic, or ignore it.
+
+## Shape cheat sheet
+
+| Before | After `.assign(k=ch)` |
+|---|---|
+| `{"a": 1}` | `{"a": 1, "k": ch.invoke({"a": 1})}` |
+| `{"a": 1, "k": "old"}` | `{"a": 1, "k": ch.invoke({"a": 1, "k": "old"})}` (shadowed!) |
+| `"not a dict"` | `TypeError` — `.assign` requires dict input |
+
+## Resources
+
+- [LangChain Python: passthrough](https://python.langchain.com/docs/how_to/passthrough/)
+- [`RunnablePassthrough` API reference](https://python.langchain.com/api_reference/core/runnables/langchain_core.runnables.passthrough.RunnablePassthrough.html)
+- Pack pain catalog: P06 (dict-shape divergence — shadowing is a common cause)


### PR DESCRIPTION
## Summary

Handcrafted Core-Workflows skill covering LangChain 1.0 composition primitives — `RunnableParallel`, `RunnableBranch`, `RunnablePassthrough.assign`, `RunnableLambda` — with debug probes and typed composition. Anchored to pain-catalog **P06, P09**.

## Pain hook

Overview opens with the four-stage chain crashing at `KeyError: 'question'` deep in `_call_with_config` with no hint which stage mutated the dict (P06). Fix is two patterns installed once: `RunnableLambda` debug probes between stages (<1ms overhead) that surface the offending stage, and `RunnableSerializable[InputT, OutputT]` + pydantic types that catch shape mismatches at lint time — plus a cross-reference to LangGraph's `create_react_agent` to sidestep `AgentExecutor`'s silent error-swallowing (P09).

## Files

- `skills/langchain-core-workflow/SKILL.md` (379 lines)
- `skills/langchain-core-workflow/references/one-pager.md`
- `skills/langchain-core-workflow/references/parallel-vs-sequential.md`
- `skills/langchain-core-workflow/references/branch-routing-patterns.md`
- `skills/langchain-core-workflow/references/passthrough-assign-patterns.md`
- `skills/langchain-core-workflow/references/debug-probes.md`

## Validator

Grade **A (92/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude