### PR TITLE
feat(langchain-py-pack): add langchain-incident-runbook (S11)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: langchain-incident-runbook
+description: |
+  Triage LangChain 1.0 / LangGraph 1.0 production incidents — LLM-specific SLOs,
+  provider outage runbook, latency spike decision tree, cost-overrun response,
+  agent loop containment. Use during an on-call page, in a post-mortem, or writing
+  the team's first LLM runbook.
+  Trigger with "langchain incident", "llm on-call", "langchain slo",
+  "langchain outage", "langchain cost spike", "langchain agent loop".
+allowed-tools: Read
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, sre, incident-response, slo, on-call]
+compatible-with: claude-code, codex
+---
+
+# LangChain Incident Runbook
+
+## Overview
+
+3:07am. PagerDuty: "LangChain p95 latency > 10s for 5 minutes." You open LangSmith,
+filter by `service="triage-agent"` over the last 15 minutes, and the first trace
+is 43 seconds long — an agent is on step 24 of 25 iterations, bouncing between
+the same two tools on a vague user prompt ("help me with my account"). The cost
+dashboard shows **$400 spent in the last 10 minutes**, up from a $6/hour baseline.
+This is P10: `create_react_agent` defaults to `recursion_limit=25` with no cost
+cap; vague prompts never converge; the spend hits before `GraphRecursionError`
+surfaces. First move is not to push a code fix — it is to flip
+`recursion_limit=5` via config reload and add a middleware token-budget cap per
+session, then deal with the stuck sessions.
+
+Or: same alert, different signature. p95 is healthy at 1.8s, but p99 is 12s and
+spiky. The spikes correlate with instance starts in Cloud Run. P36: Python +
+LangChain + embedding preloads = 5–15s cold start; Cloud Run scales to zero by
+default, so first-request p99 is 10x p95. First move is `--min-instances=1`
+(or a keepalive pinger), not more CPU.
+
+The shape of the page decides the first move. This runbook gives you:
+
+1. The LLM-specific SLO set most teams do not have: **p95 TTFT <1s, p99 total
+   latency <10s, error-rate <0.5%, cost-per-req <$0.05** — with Prometheus
+   burn-rate recording rules that page on user-visible regression.
+2. A triage decision tree with three root paths (latency / cost / error-rate),
+   each with a 3-step diagnostic and first-response action.
+3. Provider outage runbook wired to `.with_fallbacks(backup)` so failover is a
+   config flip, not a code change.
+4. Agent-loop containment via `recursion_limit` tuning and middleware
+   token-budget caps so runaway agents stop burning cost **before** the
+   `GraphRecursionError`.
+5. Post-incident debug bundle (cross-ref `langchain-debug-bundle`) and write-up
+   template.
+
+Pinned: `langchain-core 1.0.x`, `langgraph 1.0.x`, `langsmith 0.3+`. Primary pain
+anchors: **P10** (agent runaway), **P36** (cold start). Adjacent: P29 (per-process
+rate limiter), P30 (`max_retries=6` means 7 attempts), P31 (Anthropic cache RPM).
+
+## Prerequisites
+
+- LangSmith workspace with tracing enabled (free tier is fine for runbook work)
+- Prometheus + Alertmanager or equivalent (Datadog, Grafana Cloud) — burn-rate rules assume PromQL
+- `langchain-observability` skill applied — metrics are grounded in what LangSmith callbacks emit
+- A `backup` model factory from `langchain-rate-limits` — the failover playbook assumes `.with_fallbacks()` is already wired
+- On-call rotation + PagerDuty (or equivalent) integrated with the alert pipeline
+
+## Instructions
+
+### Step 1 — Define the LLM-specific SLO set
+
+HTTP-style SLOs miss what users actually feel. Define four, publish them, wire
+burn-rate alerts to the symptom.
+
+| SLO | Threshold | Alert condition | First-response action |
+|---|---|---|---|
+| **p95 TTFT** (time to first streamed token) | <1s | burn-rate > 2% over 5min | Check streaming is enabled; check provider status; check cold start (P36) |
+| **p99 total latency** | <10s | burn-rate > 5% over 5min | Check agent loop depth (P10); cold start (P36); provider latency |
+| **Error rate** (5xx + uncaught exceptions) | <0.5% | burn-rate > 1% over 5min | Check provider 429/500; auth token; schema drift on structured output |
+| **Cost per request** | <$0.05 (tier-dependent) | p95 spend/req > $0.20 over 15min | Check agent recursion (P10); retry rate (P30); token-use per req |
+
+Prometheus recording rule pattern for p99 latency burn-rate (replicate for TTFT,
+error-rate, and cost):
+
+```yaml
+groups:
+  - name: langchain_slo
+    interval: 30s
+    rules:
+      - record: langchain:p99_latency_5m
+        expr: histogram_quantile(0.99, sum(rate(langchain_request_duration_seconds_bucket[5m])) by (le, service))
+      - alert: LangChainP99LatencyBurn
+        expr: langchain:p99_latency_5m > 10
+        for: 5m
+        labels: { severity: page, team: llm }
+        annotations:
+          summary: "LangChain p99 > 10s for {{ $labels.service }}"
+          runbook: "https://runbooks/langchain-incident-runbook#latency"
+```
+
+See [LLM SLOs](references/llm-slos.md) for the canonical set (free / paid /
+enterprise tiers), burn-rate recipes (fast + slow), and a TTFT-specific rule
+that requires streaming to be instrumented.
+
+### Step 2 — Triage decision tree: which root path?
+
+The alert name tells you the root path. Do not mix diagnostics across paths —
+the first-response action differs.
+
+```
+Alert fired
+  ├── Latency (p95/p99 breach, TTFT breach)
+  │     ├── 1. Provider status page (Anthropic, OpenAI) green? → if red, Step 3
+  │     ├── 2. Cold start pattern? (p99 >> p95, correlates with instance starts) → P36
+  │     └── 3. Streaming configured? (TTFT only makes sense with .stream/.astream)
+  │
+  ├── Cost (spend/req or absolute spend/hour breach)
+  │     ├── 1. Agent recursion depth? (LangSmith: max steps per trace) → P10
+  │     ├── 2. Retry rate elevated? (callback log: attempt count / logical call) → P30
+  │     └── 3. Token-use per req regression? (input + output tokens from callbacks)
+  │
+  └── Error rate (5xx + uncaught exceptions)
+        ├── 1. Provider 429/500 spike? (distinguish client 4xx from provider 5xx)
+        ├── 2. Auth? (API key rotation, expired token, org quota exhausted)
+        └── 3. Schema drift on structured output? (Pydantic ValidationError in traces)
+```
+
+For each leaf, [Latency Triage](references/latency-triage.md) and
+[Cost Overrun Response](references/cost-overrun-response.md) give the LangSmith
+filter query, the exact metric to inspect, and the remediation.
+
+### Step 3 — Provider outage: detect, circuit-break, fail over
+
+Detection precedes failover. Do not flip fallbacks on an application bug.
+
+1. **Detect** via three signals — all three should agree before declaring a
+   provider outage:
+   - Vendor status page watcher (`status.anthropic.com`, `status.openai.com`) —
+     poll every 30s, surface into Slack
+   - In-app canary probe — a 1-req/min call to each configured provider with a
+     trivial prompt, tracked as a separate SLO
+   - Error-rate spike on the primary provider in your own metrics (distinguishes
+     a real outage from your app's bug)
+2. **Circuit-break** the primary: a `CircuitBreaker` middleware (see
+   `langchain-middleware-patterns` if available, or a simple
+   `aiobreaker`-backed runnable) opens after N consecutive `APIError` /
+   `APITimeoutError` within a window. Once open, calls skip the primary and go
+   straight to the backup. This bounds the latency cost of a down provider.
+3. **Fail over** via `.with_fallbacks(backup)` — the fallback chain is already
+   wired (see `langchain-rate-limits`). During an outage, either flip a feature
+   flag that swaps the default factory, or temporarily set the primary's
+   `max_retries=0` so the chain reaches the fallback immediately.
+4. **Comms**: post a user-facing status page entry ("Degraded performance on
+   feature X — monitoring upstream provider") and an internal Slack update with
+   the canary graph attached. [Provider Outage Playbook](references/provider-outage-playbook.md)
+   has the full comms template and the circuit-breaker middleware snippet.
+
+### Step 4 — Agent loop containment: stop the bleed before GraphRecursionError
+
+P10 is the most common cost-spike cause. `create_react_agent` defaults to
+`recursion_limit=25`, meaning 25 model calls per user turn — with Claude Sonnet
+at ~$3/MTok input, a 10k-token tool-call loop burns real money per minute.
+
+Three containment layers, applied in order:
+
+1. **Set `recursion_limit` per agent depth** — interactive chat agents rarely
+   need more than 5–8 steps; background research agents can justify 15; never
+   leave the default 25 in production.
+
+   ```python
+   from langgraph.prebuilt import create_react_agent
+
+   agent = create_react_agent(
+       llm, tools,
+       recursion_limit=8,  # P10 — was default 25
+   )
+   ```
+
+2. **Middleware token-budget cap per session** — a callback that tracks
+   cumulative input + output tokens for a session id and raises a custom
+   `BudgetExceeded` exception once the cap is hit. The agent terminates
+   cleanly; the user sees a polite "I could not finish this task in budget,
+   try rephrasing" instead of a spinning UI until `GraphRecursionError`.
+3. **Circuit on repeated tool calls** — a LangGraph edge that routes to `END`
+   when the same tool has been called with the same args twice in a row. This
+   is a cheap heuristic for "the agent is stuck in a loop."
+
+[Cost Overrun Response](references/cost-overrun-response.md) has the middleware
+implementation, the repeat-tool edge pattern, and a per-tenant budget
+enforcement example.
+
+### Step 5 — Post-incident: bundle, write up, communicate
+
+Within 30 minutes of all-clear:
+
+1. **Debug bundle** — capture the failing LangSmith trace URL(s), the
+   Prometheus dashboard screenshot at the breach window, the agent's config
+   (recursion_limit, model id, max_retries), and the provider's status page
+   state at incident time. Cross-reference `langchain-debug-bundle` if present.
+2. **Write-up template** — timeline (detection → triage → mitigation →
+   all-clear), root cause in one sentence with pain-catalog anchor (e.g.
+   "P10: recursion_limit=25 default, vague prompt, no token cap"), permanent
+   fix ticket link, follow-up SLO tuning.
+3. **Comms** — close the user-facing status page entry, post a short Slack
+   summary (one-paragraph timeline + link to write-up), schedule the
+   post-mortem review in the next weekly SRE sync.
+
+## Output
+
+- LLM SLO set (TTFT, p99 latency, error-rate, cost-per-req) published and
+  alerted via Prometheus burn-rate rules
+- Triage decision tree posted in the runbook with three root paths (latency /
+  cost / error-rate) and first-response actions per leaf
+- Provider outage playbook with circuit breaker + `.with_fallbacks(backup)`
+  wired to a feature flag for one-flip failover
+- `recursion_limit` set per agent depth (never default 25 in prod); middleware
+  token-budget cap per session
+- Post-incident debug-bundle template + write-up template wired to the
+  on-call workflow
+
+## Error Handling
+
+| Symptom | Likely cause | First-response action |
+|---|---|---|
+| p95 latency breach, TTFT degraded | Streaming disabled, or provider-side latency | Verify `.stream()`/`.astream()` used; check provider status page |
+| p99 >> p95, correlates with instance starts | Cloud Run cold start (P36) | `--min-instances=1`, CPU-always-allocated billing, preload imports |
+| Cost-per-req spike, agent traces show 20+ steps | `recursion_limit=25` default + vague prompt (P10) | `recursion_limit=5–8`, add middleware token-budget cap |
+| Cost spike, callback log shows 7 attempts per logical call | `max_retries=6` inflates cost 7x (P30) | `max_retries=2` + circuit breaker; log retries via callbacks |
+| 429 storm despite `requests_per_second=10` on each of N workers | `InMemoryRateLimiter` is per-process (P29) | Switch to `RedisRateLimiter` or provider-side quota |
+| Anthropic 429 while token budget has headroom | Cache RPM throttled separately (P31) | Client-side semaphore on RPM, not token count; monitor cached-read vs uncached separately |
+| Error-rate spike, all on primary provider | Provider outage | Canary probe confirms; flip failover to `.with_fallbacks(backup)` via flag |
+| `ValidationError` surge on structured output | Schema drift — model added fields | `ConfigDict(extra="ignore")` on the Pydantic schema (see `langchain-sdk-patterns`) |
+| Agent never terminates, no `GraphRecursionError` yet | Stuck in tool-call loop | Add "repeated tool call" edge routing to `END`; raise `BudgetExceeded` from middleware |
+
+## Examples
+
+### On-call page: cost spike from agent runaway
+
+PagerDuty: "cost-per-req > $0.20 for 15 minutes." LangSmith filtered to the
+last 15 minutes shows average trace depth = 22 steps (baseline 4). Single
+tenant, single conversation pattern — a user who asked an open-ended question
+the agent cannot resolve. First-response action: flip `recursion_limit=5` via
+config reload (no deploy), add session to the blocklist in middleware, post
+internal Slack with the trace URL.
+
+See [Cost Overrun Response](references/cost-overrun-response.md) for the
+middleware token-budget implementation and the per-tenant budget pattern.
+
+### On-call page: p99 latency spike during traffic ramp
+
+p95 healthy at 1.8s, p99 at 12s, spikes correlate with Cloud Run instance
+starts — classic P36. First-response action: `gcloud run services update
+<svc> --min-instances=1`, verify heavy imports are at module top level,
+schedule follow-up ticket to move embedding preload to a warm-up hook.
+
+See [Latency Triage](references/latency-triage.md) for the cold-start
+detection recipe and the p95-vs-p99 attribution decision tree.
+
+### On-call page: provider outage mid-day
+
+Anthropic status page goes red. Canary probe error-rate jumps from 0% to 100%
+on Anthropic, stays at 0% on OpenAI. Flip the failover flag — the
+`.with_fallbacks(backup=ChatOpenAI(...))` chain (already wired via
+`langchain-rate-limits`) takes over. Post user-facing status entry, monitor
+cost (OpenAI pricing differs — watch cost-per-req SLO), revert when upstream
+recovers.
+
+See [Provider Outage Playbook](references/provider-outage-playbook.md) for the
+circuit-breaker middleware, the canary probe snippet, and the user-comms
+template.
+
+## Resources
+
+- [LangChain Python: LangSmith tracing](https://docs.smith.langchain.com/)
+- [LangGraph: `create_react_agent` and `recursion_limit`](https://langchain-ai.github.io/langgraph/reference/prebuilt/)
+- [Google Cloud Run: cold start mitigation](https://cloud.google.com/run/docs/tips/general#avoiding_cold_starts)
+- [Google SRE: burn-rate alerting](https://sre.google/workbook/alerting-on-slos/)
+- [Anthropic status page](https://status.anthropic.com/)
+- [OpenAI status page](https://status.openai.com/)
+- Pack pain catalog: `docs/pain-catalog.md` (primary: P10, P36; adjacent: P29, P30, P31)
+- Related skills: `langchain-debug-bundle` (post-incident capture), `langchain-observability` (SLO metrics source), `langchain-rate-limits` (`.with_fallbacks` chain), `langchain-cost-tuning` (token budget caps), `langchain-deploy-integration` (cold-start fix)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/cost-overrun-response.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/cost-overrun-response.md
@@ -1,0 +1,210 @@
+# Cost Overrun Response — Agent Recursion Cap, Retry Throttle, Per-Tenant Budget
+
+Cost spikes are acute incidents. Unlike latency, they have no natural
+self-recovery — if an agent is looping at $400/10min, it will still be looping
+at $4,000/hour unless someone stops it. First-response actions here are about
+**bleed containment**, not root cause.
+
+## Decision tree
+
+```
+Cost-per-req spike alert
+  ├── LangSmith: avg trace depth > 15? → Agent runaway (P10)
+  │     → Flip recursion_limit=5 via config reload
+  │     → Add session to middleware blocklist
+  │     → See Step A below
+  │
+  ├── Callback log: attempts/logical_call > 2? → Retry amplification (P30)
+  │     → Lower max_retries to 2
+  │     → Check what error is triggering retries (probably 429 — see P31)
+  │     → See Step B below
+  │
+  └── Token-use-per-req spike? → Prompt or output regression
+        → Find the changed prompt via git log since last deploy
+        → Check if a user pasted a giant document (move to file upload)
+        → See Step C below
+```
+
+## Step A — Agent recursion containment (P10)
+
+### Immediate stop
+
+Flip the `recursion_limit` via whatever config-reload path you have — feature
+flag, env var hot-reload, or restart:
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(
+    llm, tools,
+    recursion_limit=5,  # emergency cap — was 8 or 25
+)
+```
+
+If you do not have config reload, a deploy is required. In that case, apply
+Step A2 first and deploy in parallel.
+
+### Step A2 — Middleware token-budget cap
+
+A callback handler that tracks cumulative input + output tokens per session
+and raises a custom `BudgetExceeded` exception when the cap is hit. This stops
+any agent, not just the specific one you are debugging.
+
+```python
+from langchain_core.callbacks import AsyncCallbackHandler
+from contextvars import ContextVar
+
+SESSION_TOKENS: ContextVar[int] = ContextVar("SESSION_TOKENS", default=0)
+
+class BudgetExceeded(Exception):
+    pass
+
+class TokenBudgetHandler(AsyncCallbackHandler):
+    def __init__(self, cap: int = 50_000):
+        self.cap = cap
+
+    async def on_llm_end(self, response, **kwargs):
+        usage = response.llm_output.get("token_usage", {})
+        total = usage.get("total_tokens", 0)
+        running = SESSION_TOKENS.get() + total
+        SESSION_TOKENS.set(running)
+        if running > self.cap:
+            raise BudgetExceeded(f"Session exceeded {self.cap} tokens (used {running})")
+```
+
+Attach to the chain via `with_config({"callbacks": [TokenBudgetHandler(50_000)]})`.
+Wire `BudgetExceeded` to return a graceful user-facing message, not a 500.
+
+### Step A3 — Repeat-tool circuit (LangGraph edge)
+
+A cheap heuristic for "agent is stuck in a loop":
+
+```python
+from langgraph.graph import StateGraph, END
+
+def should_continue(state):
+    history = state.get("messages", [])
+    tool_calls = [m for m in history[-6:] if m.type == "tool"]
+    if len(tool_calls) >= 2:
+        # Same tool with same args twice in a row?
+        if tool_calls[-1].name == tool_calls[-2].name and \
+           tool_calls[-1].args == tool_calls[-2].args:
+            return END
+    return "continue"
+
+graph.add_conditional_edges("agent", should_continue)
+```
+
+This catches loops long before `recursion_limit` does, typically within 2–3
+steps.
+
+## Step B — Retry amplification (P30)
+
+`max_retries=6` on `ChatOpenAI` means **7** requests per logical call (initial
++ 6 retries). Under a rate-limit regime, each 429 triggers retries, which each
+hit 429, which each retry — cost multiplies 7x for no successful output.
+
+### Fix
+
+```python
+# BAD — default cost amplification
+llm = ChatOpenAI(model="gpt-4o", max_retries=6)
+
+# GOOD — bounded retry + circuit breaker
+llm = ChatOpenAI(model="gpt-4o", max_retries=2)
+```
+
+Pair with a circuit breaker (see `provider-outage-playbook.md`) so sustained
+429s short-circuit instead of every request paying 3x.
+
+### Observability for retries
+
+The provider SDK does not log each retry by default. Add a callback:
+
+```python
+class RetryLogger(AsyncCallbackHandler):
+    async def on_retry(self, retry_state, **kwargs):
+        logger.warning(
+            "retry",
+            attempt=retry_state.attempt_number,
+            wait=retry_state.next_action.sleep,
+        )
+```
+
+Emit a Prometheus counter `langchain_retries_total{provider, reason}` so you
+can alert on retry-rate elevation before it becomes a cost alert.
+
+## Step C — Token-use regression
+
+If cost-per-req is up but trace depth and retry rate are normal, check the
+token usage directly:
+
+```
+LangSmith filter:
+  - service = "my-service"
+  - window = last_1h
+  - baseline = 24h_ago_1h
+  - compare: avg(input_tokens), avg(output_tokens)
+```
+
+If input tokens are up: a user is pasting a giant document, or a retriever
+is returning more chunks (k increased accidentally), or a prompt template was
+modified to include more few-shot examples.
+
+If output tokens are up: `max_tokens` was removed or raised, or the prompt
+changed to encourage longer responses, or the model was swapped (e.g. Sonnet
+→ Opus has different verbosity).
+
+### Mitigations
+
+- **`max_tokens` cap:** set explicitly on every model factory; do not leave
+  unset. 1024 is a sane default for chat; 4096 for structured generation.
+- **Retriever `k`:** audit every retriever for hardcoded `k` vs config-driven;
+  a change from `k=4` to `k=10` doubles input cost for RAG chains.
+- **Paste detection:** if users paste >10k-char bodies, route to a file-upload
+  path that does chunking + retrieval, not a direct prompt inclusion.
+
+## Per-tenant budget enforcement
+
+For multi-tenant SaaS, per-tenant caps prevent one customer from burning the
+monthly budget. Track in a fast store (Redis) keyed by tenant:
+
+```python
+import redis.asyncio as redis
+
+class TenantBudgetHandler(AsyncCallbackHandler):
+    def __init__(self, r: redis.Redis, daily_cap_usd: float = 5.0):
+        self.r = r
+        self.daily_cap = daily_cap_usd
+
+    async def on_llm_end(self, response, *, tags, **kwargs):
+        tenant_id = next((t[7:] for t in tags if t.startswith("tenant:")), None)
+        if not tenant_id:
+            return
+        cost = compute_cost(response)  # dollars
+        key = f"budget:{tenant_id}:{today()}"
+        total = await self.r.incrbyfloat(key, cost)
+        await self.r.expire(key, 86_400)
+        if total > self.daily_cap:
+            raise BudgetExceeded(f"Tenant {tenant_id} exceeded daily cap")
+```
+
+Tag runs with the tenant id: `chain.with_config({"tags": [f"tenant:{tid}"]})`.
+
+## Alert thresholds
+
+- **Page:** cost-per-req p95 > 4x baseline for 15min
+- **Page:** absolute spend/hour > 2x forecast for 1h
+- **Ticket:** token-use-per-req up 20% over 7-day baseline (gradual regression)
+- **Ticket:** retry rate > 5% of total requests (P30 warning signal)
+
+## Post-mitigation check
+
+After the spike stops:
+
+1. Confirm LangSmith shows trace depth back at baseline.
+2. Confirm cost-per-req SLO back under threshold for a full window.
+3. File the permanent fix ticket (e.g. "move `recursion_limit=5` from hotfix
+   config to code default").
+4. Add a regression test: an agent invocation with a known vague prompt must
+   terminate within `recursion_limit` steps.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/latency-triage.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/latency-triage.md
@@ -1,0 +1,119 @@
+# Latency Triage — p95 vs p99, Cold Start Detection, Provider vs App Attribution
+
+When a latency alert fires, the first decision is **which percentile** moved.
+p95 and p99 degradations have different root causes and different fixes.
+Fixing the wrong one wastes the incident window.
+
+## Shape-reading: what the percentile tells you
+
+| Shape | Likely cause | First check |
+|---|---|---|
+| p95 up, p99 up proportionally, TTFT up | Provider-side latency, or network | Provider status page; provider-side request-start logs if available |
+| p95 stable, p99 spiky, spikes align with instance starts | **Cold start** (P36) | `kubectl get pods` / `gcloud run services describe` — count pod starts in window |
+| p95 up, p99 up, TTFT unchanged | Output-length regression — model is generating more tokens | LangSmith: compare avg output tokens in window vs baseline |
+| TTFT up, total latency unchanged | Provider-side queuing or prompt-caching miss | Anthropic: check cache hit rate; OpenAI: check `usage.prompt_tokens_details.cached_tokens` |
+| p95 stable, p99 up, spikes on long-running sessions | Agent recursion depth increased (P10 adjacent) | LangSmith: step-count histogram per trace |
+| All percentiles up on a single pod/instance | Bad deploy or resource exhaustion on that instance | Per-instance latency breakdown; recycle the instance |
+
+## Cold-start detection (P36)
+
+Cloud Run, Lambda, Vercel — any platform that scales to zero — produces a
+p99 that is 10x p95 because the first request after a cold start pays the full
+Python import + LangChain initialization tax (5–15s for a typical stack with
+embeddings + FAISS preloaded at module level).
+
+**Detection query (LangSmith or equivalent):**
+
+```
+# Pseudo-query: correlate p99 spikes with instance age < 30s
+- filter: latency > 10s AND service = "my-service"
+- join: container_start_timestamp (from platform metrics)
+- group by: latency_bucket, instance_age_bucket
+```
+
+If the histogram shows 90% of >10s traces happening on instances <30s old, it
+is a cold start. The fix is **not** more CPU — it is `--min-instances=1`
+(Cloud Run), `provisioned_concurrency` (Lambda), or a keepalive pinger (every
+5min, to keep at least one warm instance).
+
+**Quick Cloud Run fix:**
+
+```bash
+gcloud run services update my-langchain-service \
+  --min-instances=1 \
+  --cpu-always-allocated
+```
+
+CPU-always-allocated changes billing (you pay when the instance is idle) but
+halves cold-start time on many stacks because module-level imports stay warm
+in memory during idle periods.
+
+**Module-level preload:** any heavy import (SentenceTransformers, FAISS index
+load, ChatAnthropic construction) at module top level is paid at cold start,
+not first request. Move them inside a `startup` hook if your framework has
+one, or keep them at module level and accept the cold-start cost — but do not
+put them inside the request handler, which makes **every** request pay the
+cost.
+
+## Streaming diagnosis
+
+TTFT only has a value if you are streaming. If your app is using
+`.invoke()` instead of `.stream()` / `.astream()`, TTFT and total latency
+are the same number and the TTFT SLO is meaningless.
+
+**Check:** in LangSmith, inspect a slow trace — if the model span has a single
+output event at the end, you are not streaming. If it has incremental output
+events, you are.
+
+**Fix for FastAPI + LangChain:**
+
+```python
+from fastapi.responses import StreamingResponse
+
+@app.post("/chat")
+async def chat(body: ChatRequest):
+    return StreamingResponse(
+        (chunk.content async for chunk in chain.astream(body.input)),
+        media_type="text/plain",
+    )
+```
+
+Streaming also helps bypass Vercel's 10s function timeout (P35 adjacent) — the
+first byte going out the door resets the connection-idle clock on most
+platforms.
+
+## Provider-side vs app-side attribution
+
+The fastest way to split provider latency from your own:
+
+1. In LangSmith, open the slow trace.
+2. Check the model span duration — that is **provider wall-clock time** (request
+   sent → final token received at your process).
+3. Subtract from the total trace duration — that is **your app overhead**
+   (routing, retriever, tool calls between model steps, serialization).
+
+If the model span alone is 8s, the provider is slow — no amount of app-side
+tuning will fix it. Check provider status, consider failing over.
+
+If the model span is 800ms but the trace is 8s, you have app overhead — a slow
+retriever, an N+1 tool call, a synchronous DB query in a `RunnableLambda`. Run
+`langchain-debug-bundle` if available.
+
+## When to page vs when to wait
+
+- **Page immediately:** p95 TTFT burn-rate > 2% in 5min (fast burn) AND
+  provider status page is green → your bug.
+- **Page immediately:** p99 > 10s AND sustained 15min → user-visible
+  degradation even if intermittent.
+- **Wait, file a ticket:** p99 spiky but p95 healthy, matches cold-start
+  pattern → fix with `--min-instances=1` at next deploy window unless traffic
+  is ramping.
+- **Wait, file a ticket:** slow-burn alerts (1h window) → likely a gradual
+  regression, not an outage; triage in business hours.
+
+## Recovery verification
+
+After applying a fix (min-instances=1, streaming enabled, etc.), wait at
+least **one full p99 window** before declaring all-clear. If your window is
+5min, that means 5 minutes of clean metrics. Do not close the incident on
+"looks better" — close on "SLO back under threshold for N minutes."

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/llm-slos.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/llm-slos.md
@@ -1,0 +1,119 @@
+# LLM SLOs — Canonical Set and Burn-Rate Recipes
+
+The four SLOs that map to what LLM users actually feel. HTTP-style SLOs (2xx
+ratio, p95 response time) miss TTFT entirely and confuse "provider was up" with
+"user got a useful answer."
+
+## The Four SLOs
+
+| SLO | Definition | Free tier target | Paid target | Enterprise target |
+|---|---|---|---|---|
+| **p95 TTFT** | Time from request accepted to first streamed token emitted | <2s | <1s | <500ms |
+| **p99 total latency** | Request accepted to final token (or error) | <15s | <10s | <5s |
+| **Error rate** | 5xx + uncaught exceptions / total requests | <1% | <0.5% | <0.1% |
+| **Cost per request** | Sum of input + output token cost / request | <$0.15 | <$0.05 | <$0.02 |
+
+TTFT only makes sense if you are streaming. If your app is batch-only, replace
+TTFT with p50 total latency at a tighter threshold (<2s paid, <1s enterprise).
+
+## Why these four, not HTTP SLOs
+
+- **HTTP 200s lie.** A request that returns 200 with a `ValidationError`
+  serialized into the JSON body is a success to a load balancer and a failure
+  to a user. Error-rate must include app-layer exceptions, not just HTTP codes.
+- **p95 response time hides TTFT.** A 3s response with streaming feels instant;
+  a 3s response without streaming feels broken. TTFT is the real latency SLO
+  for streamed apps.
+- **Cost is a user-facing concern.** If cost-per-req triples overnight, you
+  cannot just absorb it — that is an incident. Cost-per-req belongs in the
+  on-call SLO set, not a finance dashboard.
+
+## Recording rules (Prometheus)
+
+Assumes metrics are emitted via the LangSmith callback or equivalent — check
+`langchain-observability` for the metric-emission pattern.
+
+```yaml
+groups:
+  - name: langchain_slo
+    interval: 30s
+    rules:
+      # p99 total latency over 5m
+      - record: langchain:p99_latency_5m
+        expr: histogram_quantile(0.99, sum(rate(langchain_request_duration_seconds_bucket[5m])) by (le, service))
+
+      # p95 TTFT over 5m
+      - record: langchain:p95_ttft_5m
+        expr: histogram_quantile(0.95, sum(rate(langchain_ttft_seconds_bucket[5m])) by (le, service))
+
+      # Error rate (5xx + exceptions) over 5m
+      - record: langchain:error_rate_5m
+        expr: |
+          sum(rate(langchain_requests_total{status=~"5..|error"}[5m])) by (service)
+            / sum(rate(langchain_requests_total[5m])) by (service)
+
+      # Cost per request over 15m (dollars)
+      - record: langchain:cost_per_req_15m
+        expr: |
+          sum(rate(langchain_request_cost_usd_sum[15m])) by (service)
+            / sum(rate(langchain_request_cost_usd_count[15m])) by (service)
+```
+
+## Burn-rate alerts (fast + slow)
+
+Google SRE's multi-window multi-burn-rate pattern: a **fast burn** alert fires
+on rapid degradation (5min window) so you wake up during real incidents; a
+**slow burn** alert (1h window) catches gradual regressions without paging on
+a transient blip.
+
+```yaml
+  - name: langchain_slo_alerts
+    rules:
+      # Fast burn: 2% of monthly error budget in 5 minutes
+      - alert: LangChainP99LatencyFastBurn
+        expr: langchain:p99_latency_5m > 10
+        for: 5m
+        labels: { severity: page, team: llm }
+        annotations:
+          summary: "LangChain p99 > 10s (fast burn) on {{ $labels.service }}"
+          runbook: "https://runbooks/langchain-incident-runbook#latency"
+
+      # Slow burn: 10% over 1 hour
+      - alert: LangChainP99LatencySlowBurn
+        expr: avg_over_time(langchain:p99_latency_5m[1h]) > 10
+        for: 1h
+        labels: { severity: ticket, team: llm }
+
+      # Cost spike — fast only, because cost spikes are acute
+      - alert: LangChainCostPerReqSpike
+        expr: langchain:cost_per_req_15m > 0.20
+        for: 15m
+        labels: { severity: page, team: llm }
+        annotations:
+          runbook: "https://runbooks/langchain-incident-runbook#cost"
+
+      # Error rate
+      - alert: LangChainErrorRateFastBurn
+        expr: langchain:error_rate_5m > 0.02
+        for: 5m
+        labels: { severity: page, team: llm }
+```
+
+## Per-tier SLO gotchas
+
+- **TTFT requires streaming to be instrumented.** If your callback does not
+  record a `first_token_timestamp`, you will alert on "no TTFT samples" which
+  is indistinguishable from "TTFT great." Make the metric have a sane default
+  and alert on `absent()`.
+- **Cost-per-req needs input + output tokens.** Callbacks that only record
+  input tokens undercount by 2–10x depending on the chain.
+- **Error rate must exclude 429s your retry succeeded on.** Otherwise every
+  provider rate-limit blip pages on-call. Record two separate metrics: raw 4xx
+  for capacity planning, and "unretried failures" for SLO.
+
+## When to tune the SLO
+
+If you are burning the budget cleanly every month on p99 latency but users are
+not complaining, the SLO is too tight — loosen it. If users complain without
+any SLO breach, the SLO is missing a dimension (usually TTFT or schema-validity
+rate). SLOs are contracts with users, not with Prometheus.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-incident-runbook — One-Pager
+
+Triage a LangChain 1.0 / LangGraph 1.0 production incident at 3am without guessing — LLM-specific SLOs, a latency/cost/error-rate decision tree, and concrete remediations per symptom.
+
+## The Problem
+
+PagerDuty fires at 3:07am: "LangChain p95 latency > 10s for 5 minutes." You open LangSmith and see an agent running 25 iterations against `recursion_limit=25` default — the cost dashboard shows $400 in the last 10 minutes and climbing (P10). Or the p99 pattern shows a clean 800ms baseline with occasional 12s spikes — classic Cloud Run cold start on a Python + LangChain service with scale-to-zero, where p99 is 10x p95 (P36). Most teams do not have LLM-specific SLOs defined — they monitor HTTP status like a REST API, miss time-to-first-token entirely, and discover cost-per-request only when the monthly bill lands. There is no standard runbook: latency triage, cost-spike response, and provider-outage failover all require different first moves, and choosing wrong burns budget or makes the outage worse.
+
+## The Solution
+
+A triage decision tree with three root paths — latency / cost / error-rate — each with a 3-step diagnostic sequence and a first-response action. Canonical LLM SLO set (p95 TTFT <1s, p99 total <10s, error-rate <0.5%, cost-per-req <$0.05) with Prometheus burn-rate recording rules so you page on symptoms that map to user experience, not provider 200s. Provider-outage playbook wired to `.with_fallbacks(backup)` so failover is one config flip, not a code change. Agent-loop containment via `recursion_limit` tuning and middleware token-budget caps so runaway agents stop burning cost before the `GraphRecursionError`. Post-incident template with LangSmith trace URL, debug-bundle cross-ref, and user-facing status page entry. Pinned to LangChain 1.0.x / LangGraph 1.0.x, four deep references.
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | On-call engineers responding to a LangChain/LangGraph production incident, SREs defining LLM SLOs for the first time, team leads writing the first LLM runbook |
+| **What** | LLM SLO set + Prometheus burn-rate rules, triage decision tree (latency/cost/error-rate), provider outage playbook with `.with_fallbacks` failover, agent-loop containment via `recursion_limit` + middleware budgets, post-incident template, 4 references (llm-slos, latency-triage, cost-overrun-response, provider-outage-playbook) |
+| **When** | During an active on-call page, in a post-mortem write-up, or writing your team's first LLM runbook — before the first 3am incident, not after |
+
+## Key Features
+
+1. **LLM-specific SLO set with burn-rate alerting** — p95 TTFT <1s, p99 total latency <10s, error-rate <0.5%, cost-per-req <$0.05, wired to Prometheus recording rules that page on 2%/5min (fast burn) and 10%/1h (slow burn), so alerts fire on user-visible regression, not provider-side 200s
+2. **Triage decision tree with three root paths** — Latency spike → check provider status + cold starts (P36) + streaming; cost spike → check agent recursion (P10) + retry rate (P30) + token-use per req; error-rate spike → check provider 429/500 + auth + schema drift. Each path has a 3-step diagnostic with concrete LangSmith filters and a first-response action
+3. **Provider outage playbook with one-flip failover** — Status page watchers (Anthropic, OpenAI), in-app canary probe, `ChatAnthropic`/`ChatOpenAI` circuit breaker, failover to `.with_fallbacks(backup)` from `langchain-rate-limits`. Includes user-comms template for the status page and internal Slack channel
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/provider-outage-playbook.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/references/provider-outage-playbook.md
@@ -1,0 +1,218 @@
+# Provider Outage Playbook — Detect, Circuit-Break, Fail Over, Communicate
+
+Provider outages (Anthropic, OpenAI, Azure OpenAI) are the easiest LLM
+incidents to handle **if** you prepared failover ahead of time, and the
+hardest to handle if you did not. This playbook assumes
+`.with_fallbacks(backup)` is already wired (see `langchain-rate-limits`) —
+during the incident, the work is detection, confirmation, and comms.
+
+## Detection — three signals must agree
+
+Do not declare a provider outage on one signal. Provider-side error rates
+look similar to your app's bugs, your canary looks similar to a deploy issue,
+and vendor status pages lag real incidents by 10–30 minutes.
+
+### Signal 1: vendor status page watcher
+
+Poll each provider's status page every 30s, surface into a Slack channel:
+
+```python
+import httpx
+
+PROVIDERS = {
+    "anthropic": "https://status.anthropic.com/api/v2/status.json",
+    "openai": "https://status.openai.com/api/v2/status.json",
+}
+
+async def watch_status():
+    async with httpx.AsyncClient(timeout=5) as client:
+        for name, url in PROVIDERS.items():
+            try:
+                r = await client.get(url)
+                indicator = r.json()["status"]["indicator"]
+                if indicator != "none":
+                    await slack_post(
+                        f"Provider {name} status: {indicator}",
+                        channel="#llm-oncall",
+                    )
+            except Exception as e:
+                logger.warning(f"status check failed: {name}: {e}")
+```
+
+Run on a cron (every 30–60s). The `indicator` values are `none`, `minor`,
+`major`, `critical`.
+
+### Signal 2: in-app canary probe
+
+A 1-req/min call to each configured provider with a trivial prompt. This
+catches outages the vendor has not posted yet (early-incident gap), and
+catches "working for them, broken for you" cases (network, auth, region).
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_openai import ChatOpenAI
+
+CANARIES = {
+    "anthropic": ChatAnthropic(model="claude-haiku-4-5", timeout=10, max_retries=0),
+    "openai": ChatOpenAI(model="gpt-4o-mini", timeout=10, max_retries=0),
+}
+
+async def run_canaries():
+    for name, llm in CANARIES.items():
+        start = time.monotonic()
+        try:
+            await llm.ainvoke("say ok")
+            status = "ok"
+        except Exception as e:
+            status = f"fail:{type(e).__name__}"
+        dur = time.monotonic() - start
+        canary_latency.labels(provider=name).observe(dur)
+        canary_status.labels(provider=name, status=status).inc()
+```
+
+`max_retries=0` is deliberate — the canary should fail fast, not mask the
+outage with retries.
+
+### Signal 3: app-side error-rate spike on the primary
+
+From your own metrics: `rate(langchain_requests_total{provider="anthropic", status="error"}[5m])`.
+If this jumps but the canary is green and the status page is green, it is
+your app's bug, not an outage.
+
+### Confirmation matrix
+
+| Status page | Canary | App errors | Verdict |
+|---|---|---|---|
+| Red | Fail | Spiking | Confirmed outage — fail over |
+| Green | Fail | Spiking | Likely outage (vendor lag) — fail over, watch status page |
+| Red | Pass | Baseline | Status page lag on a past incident — do not fail over |
+| Green | Pass | Spiking | Your app's bug — do not fail over, debug |
+| Green | Pass | Baseline | Healthy |
+
+## Circuit breaker
+
+Bounds the latency cost of a dead provider. After N consecutive failures in a
+window, the breaker opens — new requests bypass the primary and go straight
+to the fallback. After a timeout, the breaker half-opens for one probe; if it
+passes, close, else stay open.
+
+Minimal implementation with `aiobreaker`:
+
+```python
+from aiobreaker import CircuitBreaker
+from datetime import timedelta
+from langchain_core.runnables import RunnableLambda
+from anthropic import APIError, APITimeoutError, RateLimitError
+
+breaker = CircuitBreaker(
+    fail_max=5,
+    timeout_duration=timedelta(seconds=30),
+)
+
+async def breaker_call(llm, msg):
+    return await breaker.call_async(llm.ainvoke, msg)
+
+primary_with_breaker = RunnableLambda(lambda x: breaker_call(primary_llm, x))
+resilient = primary_with_breaker.with_fallbacks(
+    [backup_llm],
+    exceptions_to_handle=(RateLimitError, APIError, APITimeoutError),
+)
+```
+
+Tune `fail_max` high enough to absorb a single bad request (5 is reasonable);
+`timeout_duration` low enough to probe recovery quickly (30s for critical
+services, 2min for background jobs).
+
+## Failover — one flip, not a code change
+
+If `.with_fallbacks(backup)` is already wired, the primary is already trying
+the backup on `RateLimitError`/`APIError`/`APITimeoutError`. During an outage,
+the primary wastes latency (timeout duration) on every call before failing
+over. Two ways to bypass that:
+
+1. **Feature flag swap** — a flag that makes the factory return the backup as
+   primary. Fastest path if you have a flag framework.
+
+   ```python
+   def make_llm():
+       if feature_flag("llm_failover_to_openai"):
+           return ChatOpenAI(model="gpt-4o")
+       return ChatAnthropic(model="claude-sonnet-4-6")
+   ```
+
+2. **`max_retries=0` on primary** — during outage, set the primary's
+   `max_retries=0` via config reload. The primary fails on first attempt,
+   `.with_fallbacks` kicks in immediately, and you save the retry-backoff
+   latency.
+
+## User-facing comms
+
+### Status page template (public)
+
+```
+[Monitoring] Degraded performance — {feature name}
+Posted: {timestamp}
+
+We are currently experiencing degraded performance on {feature name} due to
+an upstream AI provider incident. Requests may be slower than usual or return
+errors. We have failed over to a backup provider and are monitoring the
+situation.
+
+Updates will be posted here.
+```
+
+Update as it resolves:
+
+```
+[Resolved] Degraded performance — {feature name}
+Posted: {timestamp}
+
+The upstream provider incident has been resolved and we have returned to
+normal operation. Total duration: {N} minutes. No action required.
+```
+
+### Internal Slack update (on-call channel)
+
+```
+:rotating_light: LLM provider outage — Anthropic
+Detected: {timestamp}
+Confirmation: status page red + canary failing + app error rate {N}%
+Mitigation: failover to OpenAI via feature flag llm_failover_to_openai
+Cost impact: OpenAI pricing differs — watch cost-per-req SLO
+Next update: in 30 minutes, or on resolution
+IC: @{your name}
+Trace sample: {langsmith url}
+```
+
+## Post-outage checklist
+
+- [ ] Flip the failover flag back when status page returns to green AND canary
+      passes for 5+ minutes (do not flip on status-page-only — vendors often
+      close incidents optimistically).
+- [ ] Close user-facing status page entry.
+- [ ] Post internal all-clear in Slack with total duration and cost delta
+      (backup provider may have been more/less expensive).
+- [ ] File post-mortem ticket. Check: did the breaker open correctly? Did the
+      canary fire early enough? Did comms land in under 15min?
+- [ ] Update the canary threshold if it did not fire early enough.
+
+## What does NOT belong in the outage playbook
+
+- **Rollbacks.** A provider outage is not your code's fault; a rollback does
+  nothing.
+- **Scale-up.** More instances do not help when the upstream is the
+  bottleneck.
+- **Cache purges.** Caches protect you during outages — do not invalidate them.
+- **New features.** Do not deploy during an active incident except for the
+  failover flip itself.
+
+## Provider-specific notes
+
+- **Anthropic** publishes regional status (us-east, eu-west). Check the
+  endpoint the outage affects — your app may be fine if it uses a different
+  region.
+- **OpenAI** status page aggregates multiple products (API, ChatGPT, image).
+  The "API" component is the one that affects LangChain.
+- **Azure OpenAI** has per-deployment quotas that look like outages. If your
+  deployment is at 0 RPM but the Azure status page is green, your quota was
+  exhausted or revoked — not an outage.


### PR DESCRIPTION
## Summary

Handcrafted Operations skill — LLM-specific SLOs, latency triage, cost-overrun response, provider-outage playbook for on-call engineers responding to a LangChain 1.0 / LangGraph 1.0 production incident. Anchored to pain-catalog **P10, P36** (plus P29/P30/P31 adjacent).

## Pain hook

3am PagerDuty fires "LangChain p95 > 10s," LangSmith shows a react agent at step 24 of default `recursion_limit=25` burning \$400/10min on a vague prompt (P10). Or p99 is 10x p95 because Python + LangChain = 5-15s Cloud Run cold start with scale-to-zero (P36) — and the on-call has no runbook to separate the two.

## Files

- `skills/langchain-incident-runbook/SKILL.md` (279 lines)
- `skills/langchain-incident-runbook/references/one-pager.md`
- `skills/langchain-incident-runbook/references/llm-slos.md`
- `skills/langchain-incident-runbook/references/latency-triage.md`
- `skills/langchain-incident-runbook/references/cost-overrun-response.md`
- `skills/langchain-incident-runbook/references/provider-outage-playbook.md`

## Validator

Grade **A (93/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude