### PR TITLE
feat(langchain-py-pack): add langchain-ci-integration (S13)

### DIFF
--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: langchain-ci-integration
+description: |
+  Wire LangChain 1.0 / LangGraph 1.0 tests into a GitHub Actions pipeline —
+  unit tests with FakeListChatModel, VCR-gated integration tests, warning-filter
+  policy, and eval-regression merge gates. Complements langchain-local-dev-loop
+  (F23) which covers the inner loop; THIS covers the CI wire-up. Use when setting
+  up GHA for a new LLM service, after a VCR cassette leak incident, or hardening
+  an existing pipeline.
+  Trigger with "langchain ci", "langchain github actions", "langchain test pipeline",
+  "vcr ci", "langchain eval gate", "pytest -W error langchain".
+allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pytest:*)
+version: 2.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, langchain, langgraph, python, langchain-1.0, ci, github-actions, testing]
+compatible-with: claude-code, codex
+---
+
+# LangChain CI Integration (Python)
+
+## Overview
+
+A PR passes every test on your laptop. You push. GHA runs `pytest` and aborts
+during collection — before a single test executes — with:
+
+```
+PytestUnraisableExceptionWarning: Exception ignored in: ...
+DeprecationWarning: langchain_community.llms ...
+```
+
+The org runs `pytest -W error` and a provider SDK emitted a `DeprecationWarning`
+at *import* time, which the warning filter promoted to an exception while pytest
+was still walking the test tree. This is **P45** and it blocks every PR for the
+team until someone pins a `filterwarnings` config.
+
+Meanwhile the integration suite has its own failure mode: a VCR cassette
+recorded three months ago at `temperature=0` against Anthropic is now flaking
+against a snapshot. `temperature=0` is not deterministic on Claude — it still
+nucleus-samples (**P05**) — so the cassette captured *one* valid completion, not
+*the* valid completion. And yesterday a reviewer caught
+`Authorization: Bearer sk-ant-...` in a cassette file that had been committed
+six weeks ago (**P44**) because `vcrpy` records all request headers by default.
+
+This skill covers the outer loop: the GitHub Actions workflow, the unit /
+integration / eval gate separation, VCR cassette hygiene, pytest warning
+policy, and a merge-blocking eval regression gate. The **inner** loop — fake
+model fixtures, VCR recording workflow, local determinism tricks — lives in
+`langchain-local-dev-loop` (F23); cross-reference it, do not duplicate it.
+Pin: `langchain-core 1.0.x`, `langgraph 1.0.x`, `actions/checkout@v4`,
+`actions/setup-python@v5`, `vcrpy 6.x`. Pain-catalog anchors: **P05, P43, P44, P45**.
+
+## Prerequisites
+
+- Python 3.10, 3.11, or 3.12 (matrix)
+- `langchain-core >= 1.0, < 2.0`, `langgraph >= 1.0, < 2.0`
+- `pytest >= 8`, `pytest-asyncio`, `vcrpy >= 6` (integration)
+- `langchain-local-dev-loop` (F23) applied locally — fixtures and recording workflow
+- GitHub repo with Actions enabled; secrets set for any live-API nightly job
+
+## Instructions
+
+### Step 1 — GHA workflow skeleton with four jobs
+
+Single workflow at `.github/workflows/tests.yml`. Matrix on unit only; keep
+integration and eval single-version to control cost.
+
+```yaml
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * *"  # nightly live-API re-record check (06:00 UTC)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+      - run: pip install -e ".[test]"
+      - run: pytest tests/unit/ -W error --timeout=30 -q
+
+  integration:
+    needs: unit
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-integration')
+    runs-on: ubuntu-latest
+    env:
+      RUN_INTEGRATION: "1"
+      VCR_MODE: "none"  # replay-only; nightly cron flips to "once"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: pip }
+      - run: pip install -e ".[test,integration]"
+      - run: pytest tests/integration/ -W error --timeout=60 -q
+
+  eval:
+    needs: unit
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }   # need base ref for delta comparison
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: pip }
+      - run: pip install -e ".[test,eval]"
+      - run: python scripts/run_eval.py --baseline origin/${{ github.base_ref }} --head HEAD --n 100
+      # run_eval.py posts a PR comment and exits nonzero on regression > threshold
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: pip }
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: python scripts/dryrun_load_chains.py   # catches ImportError migration regressions
+```
+
+See [GHA Workflow Reference](references/github-actions-workflow.md) for the full
+job definitions including the secret-injection pattern, the matrix caching
+nuance, and the `softprops/action-gh-release`-style PR comment action used by
+the eval job.
+
+### Step 2 — Unit job: `-W error` + `filterwarnings` to neutralize P45
+
+Root cause of the collection abort: pytest collects tests by importing them.
+Some provider SDKs emit `DeprecationWarning` on import. With `-W error` those
+become exceptions during collection. Fix at the *filter* level, not by dropping
+`-W error` (which would mask real warnings).
+
+In `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    # P45 — neutralize known import-time noise; scoped per module so new
+    # warnings from YOUR code still fail the build.
+    "ignore::DeprecationWarning:langchain_community.*",
+    "ignore::DeprecationWarning:pydantic.*",
+    "ignore:Pydantic serializer warnings:UserWarning",
+]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+
+The ordering matters — `"error"` first, specific `"ignore"` entries after, so
+the filters override the global promote-to-error. Keep the list **narrow**: a
+blanket `ignore::DeprecationWarning` hides regressions you need to see.
+
+Unit tests use `FakeListChatModel` fixtures from F23 (do not redefine them
+here). One CI-specific gotcha (**P43**): `FakeListChatModel` does not emit
+`response_metadata["token_usage"]`, so any callback that asserts on token counts
+will break. Either subclass the fake and inject `generation_info`, or gate the
+assertion:
+
+```python
+def test_chain_uses_tokens(patched_chat_model):
+    result = chain.invoke({"input": "hi"})
+    if patched_chat_model.__class__.__name__ == "FakeListChatModel":
+        pytest.skip("fake model doesn't emit token_usage (P43)")
+    assert result.response_metadata["token_usage"]["total_tokens"] > 0
+```
+
+Budget: unit job should finish in **<2 minutes** across the 3-version matrix.
+If it doesn't, something is calling out to a real provider — check with
+`pytest --collect-only -q | wc -l` and audit which tests lack fake-model
+fixtures.
+
+### Step 3 — Integration job: VCR replay + `filter_headers` (P44)
+
+Integration tests replay pre-recorded VCR cassettes. Three rules:
+
+1. Gate the job. `if: contains(github.event.pull_request.labels.*.name, 'run-integration')` or `env.RUN_INTEGRATION == "1"`, plus a nightly cron that flips to `VCR_MODE=once` and re-records against live APIs. PRs default to pure replay.
+2. Enforce `filter_headers` at the fixture level — not per-test. A single `conftest.py` prevents any contributor from recording a cassette with raw credentials.
+3. Pre-commit + CI both scan cassettes for leaked keys. Belt and suspenders.
+
+Fixture (lives in `tests/integration/conftest.py`, owned by this skill's
+pipeline concern — F23 owns the *recording* workflow):
+
+```python
+import vcr
+import pytest
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            "authorization",
+            "x-api-key",
+            "anthropic-version",
+            ("openai-organization", "REDACTED"),
+        ],
+        "filter_post_data_parameters": ["api_key"],
+        "record_mode": "none",  # CI default: replay only
+        "match_on": ["method", "scheme", "host", "port", "path", "query"],
+    }
+```
+
+Integration suite must finish in **<5 minutes** wall-clock on the runner, or
+you will start getting cancellation flakes from the `concurrency` block. If
+you exceed 5 minutes, split into a nightly-only long tier.
+
+See [Integration Gating](references/integration-gating.md) for the full
+live-vs-replay decision tree, cost-per-run budget worksheet, and the
+`VCR_MODE` flip pattern.
+
+### Step 4 — Eval-regression gate: merge-blocking PR comment
+
+The eval job runs the `langchain-eval-harness` harness (see that skill for the
+harness itself — this skill only covers the CI wire-up) against both the PR
+branch and the merge base. Post a comment; block merge on regression.
+
+`scripts/run_eval.py` is a thin CI wrapper: check out baseline and head via
+`git worktree`, run the harness at each ref, diff the results, post a PR
+comment, exit nonzero on regression. Full implementation in
+[Eval Regression Gate](references/eval-regression-gate.md).
+
+Thresholds:
+
+| Gate | Threshold | Rationale |
+|------|-----------|-----------|
+| Aggregate score | drop >2% | One-sigma noise on n=100 with well-behaved evals |
+| Per-example score | drop >5% on any single case | Catches quiet regressions masked by aggregate averaging |
+| Sample size floor | n ≥ 100 | Below this, aggregate delta is dominated by noise |
+
+The PR comment is a Markdown table with `before / after / Δ` per metric plus a
+**bold red** line if the gate failed. Required-status-check on the `eval` job
+completes the enforcement. See [Eval Regression Gate](references/eval-regression-gate.md)
+for the comment template and the noise-budget calculation.
+
+### Step 5 — Pre-commit hooks: secret scan + prompt lint
+
+Two layers: local (pre-commit) and CI (re-runs the same hooks as a final
+catch). Local alone is not sufficient — contributors can skip with `-n`. CI
+alone is slow. Run both.
+
+`.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: vcr-secret-scan
+        name: VCR cassette secret scan (P44)
+        entry: python scripts/scan_cassettes.py
+        language: system
+        files: "tests/integration/cassettes/.*\\.ya?ml$"
+        pass_filenames: true
+
+      - id: prompt-convention-lint
+        name: prompt-convention lint
+        entry: python scripts/lint_prompts.py
+        language: system
+        files: "prompts/.*\\.j2$|src/.*prompts?\\.py$"
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+```
+
+`scan_cassettes.py` greps for `sk-[A-Za-z0-9]{20,}`, `sk-ant-[A-Za-z0-9_-]{20,}`,
+`AIza[A-Za-z0-9_-]{35}` (Google), `xoxb-`, and `Bearer [A-Za-z0-9._-]{20,}`.
+Fail on any match. This is your last line of defense before **P44** ships to
+`main`. See [Pre-Commit Hooks](references/pre-commit-hooks.md) for the full
+pattern list, the prompt-convention lint rules (aligned with
+`claude-prompt-conventions`), and the `detect-secrets` baseline-rotation policy.
+
+### Step 6 — Dry-run chain loader: catch ImportError migration breaks
+
+LangChain 0.x → 1.0 moved integrations into provider packages. A chain that
+imports `from langchain.chat_models import ChatOpenAI` works in local dev if
+you still have the old compat shim installed, and explodes in CI. Dry-run-load
+every chain module at lint time:
+
+```python
+# scripts/dryrun_load_chains.py
+import importlib, pathlib, sys, traceback
+
+failures = []
+for py in pathlib.Path("src/chains").rglob("*.py"):
+    mod = str(py.with_suffix("")).replace("/", ".")
+    try:
+        importlib.import_module(mod)
+    except Exception:
+        failures.append((mod, traceback.format_exc()))
+
+if failures:
+    for mod, tb in failures:
+        print(f"::error::chain {mod} failed to import\n{tb}")
+    sys.exit(1)
+```
+
+Runs in the `lint` job. Costs ~5 seconds. Catches every `ImportError` and
+every top-level `NameError` from a bad rename before a single unit test fires.
+
+## Output
+
+- GHA workflow with four isolated jobs (unit / integration / eval / lint)
+- `pyproject.toml` `filterwarnings` config that survives `-W error` (P45)
+- VCR `conftest.py` fixture with enforced `filter_headers` (P44)
+- `run_eval.py` CI wrapper that posts PR comments and blocks merge on regression
+- `.pre-commit-config.yaml` with cassette secret scan + prompt lint + ruff
+- Dry-run chain loader that catches migration `ImportError`s
+
+### Gate policy
+
+| Gate | Required? | Target speed | On failure |
+|------|-----------|--------------|------------|
+| unit (3 Python versions) | yes, every PR | <2 min | block PR |
+| lint + dryrun-load | yes, every PR | <30 s | block PR |
+| integration (VCR replay) | on `run-integration` label or nightly | <5 min | block merge when run |
+| integration (live, nightly cron) | no | <15 min | open issue on fail |
+| eval regression (n≥100) | yes, every PR | <10 min | block merge if agg >2% or per-example >5% |
+| pre-commit (local) | yes | <10 s | reject commit |
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `PytestUnraisableExceptionWarning` during collection | `-W error` + SDK import-time `DeprecationWarning` (P45) | Add scoped `filterwarnings = ["ignore::DeprecationWarning:langchain_community.*"]` to `pyproject.toml` |
+| VCR replay mismatch after weeks of passing | Cassette recorded at `temp=0` on Anthropic (P05); model drift | Re-record on nightly cron with `VCR_MODE=once`; treat replay mismatches as eval-gate concerns, not unit failures |
+| `sk-ant-...` in cassette flagged by reviewer | `vcrpy` records all headers by default (P44) | Enforce `filter_headers` in `conftest.py`; add `scan_cassettes.py` to pre-commit AND CI |
+| Callback `AssertionError: 'token_usage' not in response_metadata` | `FakeListChatModel` doesn't emit metadata (P43) | Subclass the fake to inject `generation_info`, or `pytest.skip` on fake-model detection |
+| `ImportError: cannot import name 'ChatOpenAI' from 'langchain.chat_models'` in CI only | Legacy compat shim installed locally, not in CI | Add `dryrun_load_chains.py` to lint job; fail at lint, not at test |
+| Eval job times out at 10 min | n too large or harness not using `asyncio` concurrency | Cap at n=100 for PRs; run n=500 nightly; see F23 for async harness pattern |
+| Concurrency block cancels integration run | Long job + rapid pushes | Do not disable; keep integration <5 min or split long tier to nightly |
+
+## Examples
+
+### Wiring a new repo from scratch
+
+Copy the Step 1 workflow, the Step 2 `pyproject.toml` block, and the Step 5
+pre-commit config. Create `tests/unit/`, `tests/integration/cassettes/`,
+`scripts/run_eval.py`, `scripts/dryrun_load_chains.py`,
+`scripts/scan_cassettes.py`. Apply `langchain-local-dev-loop` (F23) first so
+fake-model fixtures exist before the unit job runs. Enable required status
+checks: `unit (3.10)`, `unit (3.11)`, `unit (3.12)`, `lint`, `eval`.
+Integration stays optional (label-gated).
+
+See [GHA Workflow Reference](references/github-actions-workflow.md) for the
+complete copy-pasteable workflow.
+
+### Hardening after a P44 cassette-leak incident
+
+Rotate every leaked key **first** (not a CI concern — incident response).
+Then: add `scan_cassettes.py` to pre-commit, re-scan the full history with
+`git log -p -- tests/integration/cassettes/`, rewrite history with
+`git-filter-repo` if keys hit `main`, enforce the `filter_headers` fixture
+going forward. See [Pre-Commit Hooks](references/pre-commit-hooks.md) for the
+full pattern list and the `detect-secrets` baseline-rotation playbook.
+
+### Wiring the eval harness into an existing repo
+
+The harness itself lives in `langchain-eval-harness`. THIS skill only supplies
+`run_eval.py` (the CI wrapper that reads the harness output, computes deltas,
+and posts PR comments) plus the gate thresholds. Drop in the Step 4 script,
+add the `eval` job to `.github/workflows/tests.yml`, make `eval` a required
+status check. See [Eval Regression Gate](references/eval-regression-gate.md)
+for the PR-comment Markdown template and the n≥100 noise-budget derivation.
+
+## Resources
+
+- [LangChain Python: Testing](https://python.langchain.com/docs/how_to/testing/)
+- [`FakeListChatModel` API](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.fake_chat_models.FakeListChatModel.html)
+- [vcrpy docs — filtering sensitive data](https://vcrpy.readthedocs.io/en/latest/advanced.html#filter-sensitive-data-from-the-request)
+- [GitHub Actions docs](https://docs.github.com/en/actions)
+- [pytest `filterwarnings`](https://docs.pytest.org/en/stable/how-to/capture-warnings.html)
+- Pair skill: `langchain-local-dev-loop` (F23) — fake fixtures, local recording
+- Pair skill: `langchain-eval-harness` — eval suite the gate runs against
+- Pack pain catalog: `docs/pain-catalog.md` (entries P05, P43, P44, P45)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/eval-regression-gate.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/eval-regression-gate.md
@@ -1,0 +1,174 @@
+# Eval Regression Gate
+
+Wire the `langchain-eval-harness` eval suite into PR CI as a merge-blocking gate. Posts a metric-delta comment on every PR; blocks merge when aggregate drops >2% or any per-example drops >5%. Minimum sample size n=100 for meaningful signal.
+
+## What this skill does NOT own
+
+This skill owns the **CI plumbing** — the GHA job, the PR comment, the threshold policy, the required-status-check wiring.
+
+The **harness itself** (LangSmith or local evaluators, metric definitions, example datasets, judge prompts) lives in `langchain-eval-harness`. Do not duplicate that content here.
+
+## Threshold policy
+
+| Signal | Threshold | What it catches | Action |
+|--------|-----------|-----------------|--------|
+| Aggregate score delta | < -2% | Systemic regressions across many examples | Block merge |
+| Any single-example delta | < -5% | Quiet regressions averaged away in the aggregate | Block merge |
+| Sample size | n ≥ 100 | Anything less is noise-dominated | Block job from running at n<100 |
+| Wall time | < 10 min | Budget ceiling; go async if near limit | Switch to `asyncio.gather` concurrency |
+
+**Why n ≥ 100.** With binary metrics (pass/fail) at p=0.8, the standard error of the mean at n=100 is ~4%. A 2% aggregate drop is at the edge of statistical signal but still discoverable with a one-sided test. Below n=30, the SE balloons past 7% and every PR looks like a regression.
+
+**Why -2% aggregate AND -5% per-example (both, not either).** The aggregate catches broad regressions. The per-example catches narrow ones — e.g., a prompt tweak that fixes 90 cases but breaks 5 specific edge cases. Each gate misses what the other catches.
+
+## The CI wrapper (`scripts/run_eval.py`)
+
+```python
+"""Run the eval harness at two refs, compare, post PR comment, exit nonzero on regression."""
+import argparse, json, os, subprocess, sys, pathlib, tempfile
+
+AGG_DROP_LIMIT = 0.02
+PER_EX_DROP_LIMIT = 0.05
+
+
+def run_eval_at(ref: str, n: int) -> dict:
+    """Check out `ref` in a worktree, run the harness, return results dict."""
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.check_call(["git", "worktree", "add", td, ref])
+        try:
+            out = subprocess.check_output(
+                ["python", "-m", "eval_harness", "--n", str(n), "--json"],
+                cwd=td,
+            )
+            return json.loads(out)
+        finally:
+            subprocess.check_call(["git", "worktree", "remove", td])
+
+
+def format_comment(base: dict, head: dict, agg_delta: float, per_ex_drops: list) -> str:
+    verdict = "PASS" if agg_delta >= -AGG_DROP_LIMIT and not per_ex_drops else "FAIL"
+    lines = [
+        f"## Eval regression gate: **{verdict}**",
+        "",
+        f"- Sample size: n={len(base['examples'])}",
+        f"- Baseline ref: `{base['ref']}`  |  Head ref: `{head['ref']}`",
+        "",
+        "| Metric | Baseline | Head | Δ |",
+        "|---|---|---|---|",
+    ]
+    for metric in base["aggregate_by_metric"]:
+        b = base["aggregate_by_metric"][metric]
+        h = head["aggregate_by_metric"][metric]
+        arrow = "↓" if h < b else ("↑" if h > b else "=")
+        lines.append(f"| {metric} | {b:.3f} | {h:.3f} | {arrow} {h-b:+.3f} |")
+    if per_ex_drops:
+        lines += ["", "### Per-example regressions (>5% drop):", ""]
+        for ex_id, drop in per_ex_drops:
+            lines.append(f"- `{ex_id}`: dropped {drop:.1%}")
+    return "\n".join(lines)
+
+
+def post_pr_comment(body: str) -> None:
+    pr = os.environ.get("PR_NUMBER")
+    if not pr:
+        print(body)  # fallback for local runs
+        return
+    subprocess.check_call([
+        "gh", "pr", "comment", pr, "--body", body,
+    ])
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--baseline", required=True)
+    p.add_argument("--head", required=True)
+    p.add_argument("--n", type=int, default=100)
+    args = p.parse_args()
+
+    if args.n < 100:
+        print(f"::error::n={args.n} is below statistical floor (100)", file=sys.stderr)
+        sys.exit(2)
+
+    base = run_eval_at(args.baseline, args.n)
+    head = run_eval_at(args.head, args.n)
+
+    agg_delta = head["aggregate"] - base["aggregate"]
+    per_ex_drops = []
+    for ex in base["examples"]:
+        eid = ex["id"]
+        if eid not in head["scores"]:
+            continue
+        drop = base["scores"][eid] - head["scores"][eid]
+        if drop > PER_EX_DROP_LIMIT:
+            per_ex_drops.append((eid, drop))
+
+    comment = format_comment(base, head, agg_delta, per_ex_drops)
+    post_pr_comment(comment)
+
+    if agg_delta < -AGG_DROP_LIMIT or per_ex_drops:
+        print("::error::eval regression gate failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## PR comment template (rendered example)
+
+```markdown
+## Eval regression gate: **FAIL**
+
+- Sample size: n=100
+- Baseline ref: `origin/main`  |  Head ref: `HEAD`
+
+| Metric | Baseline | Head | Δ |
+|---|---|---|---|
+| exact_match | 0.810 | 0.760 | ↓ -0.050 |
+| bleu | 0.620 | 0.610 | ↓ -0.010 |
+| judge_score | 4.200 | 4.150 | ↓ -0.050 |
+
+### Per-example regressions (>5% drop):
+
+- `multi-turn-007`: dropped 15.0%
+- `edge-case-042`: dropped 8.0%
+```
+
+## Required-status-check wiring
+
+GitHub Settings → Branches → Branch protection rule for `main`:
+
+- Check **Require status checks to pass before merging**
+- Add `eval regression (n=100)` to the required list
+- Also add `unit (py3.10)`, `unit (py3.11)`, `unit (py3.12)`, `lint + dryrun`
+
+With this config, `gh pr merge` refuses to merge until the eval job exits 0. Admin overrides are possible but logged.
+
+## When to tune thresholds
+
+Default -2% / -5% is tuned for **deterministic-ish** evals (exact match, BLEU against a reference, or a well-calibrated judge). Loosen if your eval is naturally noisy:
+
+| Eval type | Suggested aggregate limit | Suggested per-example limit |
+|-----------|---------------------------|------------------------------|
+| Exact-match / regex | -2% | -5% |
+| BLEU / ROUGE | -3% | -7% |
+| LLM-as-judge with a strong base model | -3% | -10% |
+| LLM-as-judge with a cheap base model | skip the per-example gate; aggregate -5% only |
+
+Do not loosen thresholds to quiet a flaky gate — that masks regressions. Fix the underlying noise (bigger n, better judge prompt, deterministic seeds where the provider supports them).
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Eval job always fails on first PR against a new branch | No baseline run on `origin/main` | Ensure `fetch-depth: 0` in checkout; cache `main` results |
+| Flaky pass/fail at the threshold boundary | n too small | Bump to n=200 for PRs; costs roughly 2× but SE shrinks √2 |
+| Job times out at 10 min wall clock | Serial eval loop | Switch harness to `asyncio.gather` with provider rate-limit semaphore |
+| PR comment not posted | `permissions: pull-requests: write` missing or `GH_TOKEN` env not set | Add `permissions` block to workflow; set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the step |
+| Per-example drops flagged but they are new examples added in the PR | Base ref does not have those example IDs | Filter `per_ex_drops` to only example IDs present in `base["scores"]` (the wrapper above does this) |
+
+## Cross-references
+
+- Eval harness definition, metric selection, judge prompts — `langchain-eval-harness`
+- Warning-filter policy that keeps `-W error` green during eval — [GHA Workflow Reference](github-actions-workflow.md)
+- Local eval debugging workflow — `langchain-local-dev-loop` (F23)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/github-actions-workflow.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/github-actions-workflow.md
@@ -1,0 +1,186 @@
+# GitHub Actions Workflow Reference
+
+Full, copy-pasteable `.github/workflows/tests.yml` with unit + integration + eval + lint jobs, caching strategy, secret injection, and matrix configuration. Pinned: `actions/checkout@v4`, `actions/setup-python@v5`.
+
+## Complete workflow
+
+```yaml
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Nightly live-API re-record check, 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      run_live:
+        description: "Run integration tests against LIVE provider APIs"
+        required: false
+        default: "false"
+
+concurrency:
+  # Cancel in-progress runs for the same ref when a new push arrives.
+  # Keep OFF for `main` pushes to preserve the nightly-cron trail.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+  pull-requests: write    # eval job posts comments
+  checks: write
+
+jobs:
+  unit:
+    name: unit (py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+
+      - name: Install
+        run: pip install -e ".[test]"
+
+      - name: Run unit tests (-W error)
+        run: pytest tests/unit/ -W error --timeout=30 -q --tb=short
+        env:
+          # Belt-and-suspenders: if anything tries to hit a real provider,
+          # it will fail fast with a clear auth error instead of hanging.
+          ANTHROPIC_API_KEY: "sk-ant-FAKE-UNIT-TEST-KEY"
+          OPENAI_API_KEY: "sk-FAKE-UNIT-TEST-KEY"
+          GOOGLE_API_KEY: "AIzaFAKE-UNIT-TEST-KEY"
+
+  integration:
+    name: integration (VCR ${{ env.VCR_MODE }})
+    needs: unit
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration')
+    runs-on: ubuntu-latest
+    env:
+      RUN_INTEGRATION: "1"
+      VCR_MODE: ${{ github.event_name == 'schedule' && 'once' || 'none' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+
+      - name: Install
+        run: pip install -e ".[test,integration]"
+
+      - name: Inject provider keys (nightly only)
+        if: github.event_name == 'schedule' || github.event.inputs.run_live == 'true'
+        run: |
+          echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_ENV"
+          echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
+          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" >> "$GITHUB_ENV"
+
+      - name: Run integration tests
+        run: pytest tests/integration/ -W error --timeout=60 -q
+
+      - name: Scan cassettes for leaked secrets (P44)
+        run: python scripts/scan_cassettes.py tests/integration/cassettes/
+
+      - name: Commit re-recorded cassettes (nightly only)
+        if: github.event_name == 'schedule'
+        run: |
+          if ! git diff --quiet tests/integration/cassettes/; then
+            git config user.name "ci-record-bot"
+            git config user.email "ci@example.com"
+            git add tests/integration/cassettes/
+            git commit -m "chore(ci): re-record VCR cassettes (nightly)"
+            git push
+          fi
+
+  eval:
+    name: eval regression (n=100)
+    needs: unit
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need base ref for delta comparison
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install -e ".[test,eval]"
+
+      - name: Run regression eval
+        run: python scripts/run_eval.py --baseline origin/${{ github.base_ref }} --head HEAD --n 100
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+  lint:
+    name: lint + dryrun
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: pip }
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: python scripts/dryrun_load_chains.py
+      - run: python scripts/scan_cassettes.py tests/integration/cassettes/
+```
+
+## Caching strategy
+
+- `cache: pip` with `cache-dependency-path` covering `pyproject.toml` and any `requirements*.txt`. The cache key rotates automatically when dependencies change.
+- Do **not** cache `~/.cache/langchain` — LangChain's internal cache can contain provider responses, which means a stale eval result could be reused across runs.
+- For `uv` users: swap `setup-python` + `pip install` for `astral-sh/setup-uv@v4` and `uv sync`. `uv` is ~3× faster on cold cache.
+
+## Matrix notes
+
+- Unit job runs on 3 Python versions to catch typing / syntax drift. Integration and eval stay single-version to control cost.
+- `fail-fast: false` so a Python-3.10-specific failure does not hide a Python-3.12 failure.
+- If you add Python 3.13 to the matrix, gate it behind `continue-on-error: true` until LangChain's minimum support lands.
+
+## Required status checks
+
+Configure in repo Settings → Branches → Branch protection rule for `main`:
+
+- `unit (py3.10)`, `unit (py3.11)`, `unit (py3.12)` — required
+- `lint + dryrun` — required
+- `eval regression (n=100)` — required
+- `integration (VCR none)` — **not** required (label-gated)
+
+## Common failure modes
+
+- `actions/setup-python@v5` cannot find the Python version → matrix has a typo (`3.12` vs `3.12.0`); use the `setup-python` MAJOR.MINOR format.
+- `pip` cache misses every run → `cache-dependency-path` does not match the actual files in repo. Confirm with `ls pyproject.toml requirements*.txt`.
+- Concurrency cancels the nightly cron → remove `main` from `cancel-in-progress`. The workflow above already does.
+- `permissions` block missing → `GITHUB_TOKEN` cannot post PR comments. Add `pull-requests: write`.
+
+## Cross-references
+
+- Unit-test fixtures — see `langchain-local-dev-loop` (F23)
+- VCR cassette *recording* workflow — see F23
+- Eval harness internals — see `langchain-eval-harness`
+- Prompt-convention lint rules — see `claude-prompt-conventions`

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/integration-gating.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/integration-gating.md
@@ -1,0 +1,101 @@
+# Integration Gating
+
+When to run integration tests live vs. via VCR replay, how to inject secrets, budgeting cost-per-run, and the scheduled re-record pattern. Pairs with the recording workflow in `langchain-local-dev-loop` (F23).
+
+## Three integration-test modes
+
+| Mode | When it runs | Secrets needed? | Cost | Purpose |
+|------|--------------|-----------------|------|---------|
+| **replay** (`VCR_MODE=none`) | Every PR with `run-integration` label | No | $0 | Regression guard on chain wiring, provider API shape |
+| **record-once** (`VCR_MODE=once`) | Nightly cron, manual dispatch | Yes (provider keys) | ~$0.05–0.50 per run | Detect provider drift; refresh cassettes |
+| **live** (`VCR_MODE=all`) | Never in CI automatically | Yes | Full API cost | Debug-only; use for incident response |
+
+**Default for PRs: replay.** Contributors without provider keys must be able to run integration locally against cassettes. If a contributor needs to change a prompt and therefore the cassette, they record locally (see F23) and commit the new cassette file.
+
+## Gating pattern
+
+```yaml
+integration:
+  if: >
+    github.event_name == 'schedule' ||
+    github.event_name == 'workflow_dispatch' ||
+    contains(github.event.pull_request.labels.*.name, 'run-integration')
+```
+
+Three triggers:
+
+1. **Nightly cron** — runs record-once mode, detects provider drift, auto-commits refreshed cassettes if tests still pass.
+2. **Manual dispatch** (`workflow_dispatch`) — for debugging a specific PR or validating a big refactor.
+3. **PR label** (`run-integration`) — contributor explicitly opts in. Replay mode, no keys needed.
+
+Default PR runs do **not** run integration at all — unit + lint + eval are the required gates.
+
+## Secret injection (live / record-once only)
+
+Store provider keys as repository secrets (Settings → Secrets and variables → Actions). Inject them at the job level only when needed:
+
+```yaml
+- name: Inject provider keys (nightly only)
+  if: github.event_name == 'schedule' || github.event.inputs.run_live == 'true'
+  run: |
+    echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_ENV"
+    echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
+```
+
+Do **not** inject keys into the replay job. If replay somehow hits the network, you want a 401, not a charge.
+
+For forked-PR safety: GitHub Actions does **not** expose secrets to workflows triggered by `pull_request` from forks. The label-gated integration job will silently run without keys in that case — and VCR replay mode works without keys, so this is fine. Live mode from a fork PR would require `pull_request_target`, which has security implications; do not enable it casually.
+
+## Cost budget
+
+Back-of-envelope for a 100-test integration suite running nightly in record-once mode:
+
+| Provider | Avg tokens/request | Cost/request | 100 tests |
+|----------|-------------------|--------------|-----------|
+| Claude Sonnet 4.6 | 1K in + 500 out | ~$0.013 | $1.30 |
+| GPT-4o | 1K in + 500 out | ~$0.008 | $0.80 |
+| Gemini 2.5 Pro | 1K in + 500 out | ~$0.005 | $0.50 |
+
+So a full nightly re-record is **~$2.60 per night** across three providers. $80/month. Flag this to whoever owns the GHA bill before turning on the cron.
+
+If budget is tight:
+
+- Run re-record weekly, not nightly (cut cost by 7×).
+- Sample — re-record 20 cassettes/night on rotation, not all 100.
+- Only re-record cassettes older than N days.
+
+## The record-once flip
+
+`VCR_MODE=once` means: for each test, if a cassette exists use it; if not, call live and record. This is the cheap nightly drift check: cassettes that still match their live counterpart do not re-record; cassettes that drifted fail, re-record, and commit. The follow-up PR review surfaces the drift for human review.
+
+Auto-commit only if *all* tests pass after re-record — otherwise you are laundering regressions through the nightly bot:
+
+```yaml
+- name: Commit re-recorded cassettes (nightly only)
+  if: github.event_name == 'schedule' && success()
+  run: |
+    if ! git diff --quiet tests/integration/cassettes/; then
+      git config user.name "ci-record-bot"
+      git config user.email "ci@example.com"
+      git add tests/integration/cassettes/
+      git commit -m "chore(ci): re-record VCR cassettes (nightly drift)"
+      git push
+    fi
+```
+
+The `success()` check is critical. A failing nightly should page, not self-heal.
+
+## P05 and the determinism mirage
+
+Anthropic `temperature=0` is **not** greedy decoding — it still nucleus-samples. So a cassette recorded at `temp=0` captures one of many valid completions. When the model drifts, replay-time comparison against that one captured completion will flake.
+
+Two mitigations, both cheap:
+
+1. Match VCR on `body` structural fields only (`method`, `scheme`, `host`, `port`, `path`, `query`) — not on response content. The default match config handles this.
+2. For tests that assert on *output content*, own a fake-model fixture instead (see F23). VCR is for testing provider-API shape and HTTP plumbing, not for asserting on prompt-output stability. That is the eval harness's job.
+
+## Cross-references
+
+- Recording cassettes locally — `langchain-local-dev-loop` (F23)
+- Secret-scan of committed cassettes — [Pre-Commit Hooks](pre-commit-hooks.md)
+- Eval-regression (the right tool for output-stability guarding) — [Eval Regression Gate](eval-regression-gate.md)

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/one-pager.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/one-pager.md
@@ -1,0 +1,29 @@
+# langchain-ci-integration — One-Pager
+
+Wire LangChain 1.0 / LangGraph 1.0 tests into a GitHub Actions pipeline with unit/integration/eval job separation, VCR cassette hygiene, and eval-regression merge gates.
+
+## The Problem
+
+A PR that passes locally fails in CI with `pytest` aborting during collection — the org runs `pytest -W error` and a provider SDK (e.g. `langchain_community.llms`) emits a `DeprecationWarning` on import (P45). Separately, the integration suite is flaky: a VCR cassette was recorded at `temperature=0` against Anthropic (still nucleus sampling per P05), drifted, and now mismatches on a snapshot assertion. The team also just discovered an `Authorization: Bearer sk-ant-...` header checked into a cassette file six weeks ago (P44). And the fake-model unit tests pass locally but fail in CI because a downstream callback asserts on `response_metadata["token_usage"]` which `FakeListChatModel` never emits (P43).
+
+## The Solution
+
+This skill wires four CI jobs that isolate failure modes: (1) a **unit** job using fake models + pinned `filterwarnings` to neutralize P45; (2) an **integration** job gated by label / cron / `RUN_INTEGRATION=1` that replays VCR cassettes with enforced `filter_headers` (P44); (3) an **eval-regression** job that runs the `langchain-eval-harness` harness on PR, posts a metric-delta comment, and blocks merge if aggregate regression >2% or per-example >5%; (4) a **pre-merge validator** that dry-run-loads all chains to catch `ImportError` migration breaks (complements `langchain-sdk-patterns`). Pre-commit hooks catch `sk-*` / `sk-ant-*` in cassettes before they ever reach the branch. Pinned to LangChain 1.0.x + LangGraph 1.0.x + GHA current (`actions/checkout@v4`, `actions/setup-python@v5`).
+
+## Who / What / When
+
+| Aspect | Details |
+|--------|---------|
+| **Who** | Python / DevOps engineers wiring a GitHub Actions (or equivalent) pipeline for a LangChain 1.0 / LangGraph 1.0 codebase — unit tests with fake models, gated integration tests with real API or VCR replay, eval regression merge gates |
+| **What** | GHA workflow (matrix over Python versions, `uv` install, pip cache), 4 CI jobs (unit / integration / eval / lint), gate-policy table, pre-commit secret-scan + prompt-convention lint, 4 references (gha-workflow / integration-gating / eval-regression-gate / pre-commit-hooks) |
+| **When** | Wiring a new repo, hardening an existing pipeline after a P44 cassette-leak incident, or after `langchain-local-dev-loop` (F23) makes the inner loop reliable and you need the outer loop |
+
+## Key Features
+
+1. **Four-job GHA workflow with targeted gates** — unit (<2 min, runs on every push), integration (<5 min, gated by `RUN_INTEGRATION=1` / label / nightly cron), eval (n≥100, blocks merge on regression >2% agg / >5% per-example), lint + dry-run chain loader
+2. **VCR cassette hygiene baked in** — `filter_headers=["authorization", "x-api-key", "anthropic-version"]` enforced at record time, pre-commit hook greps for `sk-*` / `sk-ant-*` / `AIza*`, CI re-verifies (P44)
+3. **`pytest -W error` survival kit** — `filterwarnings` config in `pyproject.toml` that neutralizes provider-SDK `DeprecationWarning` at collection time without masking real warnings (P45); pairs with F23's fake-model fixtures
+
+## Quick Start
+
+See [SKILL.md](../SKILL.md) for full instructions.

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/pre-commit-hooks.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/references/pre-commit-hooks.md
@@ -1,0 +1,210 @@
+# Pre-Commit Hooks
+
+Local + CI hooks that block cassette secret leaks (P44), enforce prompt conventions, and catch lint regressions before they reach review. Both layers are required — local alone can be skipped with `-n`; CI alone is slow.
+
+## `.pre-commit-config.yaml`
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: vcr-secret-scan
+        name: VCR cassette secret scan (P44)
+        entry: python scripts/scan_cassettes.py
+        language: system
+        files: "tests/integration/cassettes/.*\\.ya?ml$"
+        pass_filenames: true
+
+      - id: prompt-convention-lint
+        name: prompt-convention lint
+        entry: python scripts/lint_prompts.py
+        language: system
+        files: "prompts/.*\\.j2$|src/.*prompts?\\.py$"
+        pass_filenames: true
+
+      - id: dryrun-load-chains
+        name: dryrun load chain modules
+        entry: python scripts/dryrun_load_chains.py
+        language: system
+        pass_filenames: false
+        files: "src/chains/.*\\.py$"
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: "^tests/integration/cassettes/"
+```
+
+Note that `detect-secrets` excludes cassettes — our custom `scan_cassettes.py` is narrower and faster for that specific format. `detect-secrets` handles everything else.
+
+## `scripts/scan_cassettes.py`
+
+```python
+"""Grep VCR YAML cassettes for provider credentials (P44).
+
+Runs in: pre-commit (local), lint job (CI), integration job post-step (CI).
+"""
+import re
+import sys
+import pathlib
+
+# Ordered roughly by how much pain they cause.
+PATTERNS = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "Anthropic API key"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_\-]{20,}"), "OpenAI project key"),
+    (re.compile(r"sk-[A-Za-z0-9]{20,}"), "OpenAI API key"),
+    (re.compile(r"AIza[A-Za-z0-9_\-]{35}"), "Google API key"),
+    (re.compile(r"xoxb-[A-Za-z0-9\-]{40,}"), "Slack bot token"),
+    (re.compile(r"Bearer\s+[A-Za-z0-9._\-]{20,}"), "Bearer token"),
+    (re.compile(r"[Aa]uthorization:\s*[A-Za-z]+\s+[A-Za-z0-9._\-]{20,}"), "Authorization header"),
+]
+
+
+def scan(path: pathlib.Path) -> list[tuple[str, int, str]]:
+    hits = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as e:
+        print(f"::warning::could not read {path}: {e}", file=sys.stderr)
+        return hits
+    for lineno, line in enumerate(lines, 1):
+        for pat, label in PATTERNS:
+            if pat.search(line):
+                hits.append((str(path), lineno, label))
+                break
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    targets = []
+    for a in argv[1:]:
+        p = pathlib.Path(a)
+        if p.is_dir():
+            targets.extend(p.rglob("*.yaml"))
+            targets.extend(p.rglob("*.yml"))
+        elif p.is_file():
+            targets.append(p)
+    if not targets:
+        return 0
+
+    all_hits = []
+    for t in targets:
+        all_hits.extend(scan(t))
+
+    if all_hits:
+        print("::error::potential secret in VCR cassette (P44)")
+        for path, lineno, label in all_hits:
+            print(f"  {path}:{lineno}  ({label})")
+        print("Fix: add header/param to `filter_headers` / `filter_post_data_parameters`")
+        print("     in tests/integration/conftest.py, then re-record.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+```
+
+## `scripts/lint_prompts.py`
+
+Thin linter that enforces the prompt conventions from `claude-prompt-conventions`. Minimum rules:
+
+```python
+"""Lint prompt templates for convention violations.
+
+Pairs with `claude-prompt-conventions`. Keep rules narrow — block obvious
+mistakes, let review catch style preferences.
+"""
+import re
+import sys
+import pathlib
+
+RULES = [
+    # No f-strings with user-input variables (prompt-injection vector).
+    (re.compile(r'f"[^"]*\{(?!"|\w+\s*[:!\.])\w+\}"'),
+     "f-string with unquoted interpolation — consider prompt template"),
+    # System message should appear at position 0 (P58 — Claude silently ignores otherwise).
+    (re.compile(r'SystemMessage\([^)]*\)\s*,\s*HumanMessage.*SystemMessage',
+                re.DOTALL),
+     "multiple SystemMessages — Claude only honors the first (P58)"),
+    # Prefer named variables over positional {0} {1}.
+    (re.compile(r'\{[0-9]+\}'),
+     "positional template var — use named {var} instead"),
+]
+
+
+def lint(path: pathlib.Path) -> list[tuple[str, int, str]]:
+    hits = []
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    for lineno, line in enumerate(lines, 1):
+        for pat, msg in RULES:
+            if pat.search(line):
+                hits.append((str(path), lineno, msg))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    all_hits = []
+    for a in argv[1:]:
+        p = pathlib.Path(a)
+        if p.is_file():
+            all_hits.extend(lint(p))
+    for path, lineno, msg in all_hits:
+        print(f"::error file={path},line={lineno}::{msg}")
+    return 1 if all_hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+```
+
+## `detect-secrets` baseline rotation
+
+`.secrets.baseline` records **expected** secret-like strings (test fixtures, sample keys in docs) so the hook does not flag them on every run. Rotate:
+
+```bash
+# After adding legitimate new test fixtures:
+detect-secrets scan --baseline .secrets.baseline
+
+# Audit the baseline (interactive):
+detect-secrets audit .secrets.baseline
+```
+
+Commit the updated baseline. Never edit by hand — the hash chain breaks and the tool re-flags everything.
+
+## Installation snippet for contributors
+
+Add to `CONTRIBUTING.md`:
+
+```bash
+pip install pre-commit
+pre-commit install                    # install git hooks
+pre-commit run --all-files            # sanity check on first install
+```
+
+Optional but recommended: enable `pre-commit ci` (github.com/pre-commit-ci) as a redundant CI check so contributors who forgot `pre-commit install` still get blocked.
+
+## Incident response after a P44 leak
+
+If `sk-ant-...` or similar has hit `main`:
+
+1. **Rotate the key first.** Every leaked credential must be considered live until rotated. Anthropic console → API Keys → revoke.
+2. **Confirm blast radius.** `git log --all --oneline -- tests/integration/cassettes/ | head -20`. Grep every commit touching cassettes for the key pattern.
+3. **Rewrite history.** Use `git-filter-repo --replace-text leaked-patterns.txt` to scrub the key from every commit that ever had it. This is destructive and forces a force-push — coordinate with the team.
+4. **Force-push and instruct everyone** to re-clone (do not rebase — keys remain in the rebased history).
+5. **Prevent recurrence.** Land the `scan_cassettes.py` hook and the `filter_headers` conftest fixture in the same PR.
+
+## Cross-references
+
+- VCR `filter_headers` fixture setup — [Integration Gating](integration-gating.md)
+- Cassette recording workflow (local) — `langchain-local-dev-loop` (F23)
+- Prompt convention details — `claude-prompt-conventions`
+- `ruff` config — pair with `pyproject.toml` `[tool.ruff]` section (not owned by this skill)


### PR DESCRIPTION
## Summary

Handcrafted CI-integration skill — GHA workflow, VCR-gated integration, eval-regression merge gate, pre-commit hooks for secret + cassette hygiene. Complements F23 `langchain-local-dev-loop` (inner loop); S13 owns the CI wire-up. Anchored to pain-catalog **P05, P43, P44, P45**.

## Pain hook

Opens on a PR that is green locally but aborts during pytest collection in CI — `-W error` promoted a provider SDK's import-time `DeprecationWarning` to an exception (P45). Second hook threads P44 (a reviewer just caught `sk-ant-...` in a committed VCR cassette) and P05 (cassettes recorded at `temperature=0` on Anthropic flake because Claude still nucleus-samples).

## Files

- `skills/langchain-ci-integration/SKILL.md` (399 lines)
- `skills/langchain-ci-integration/references/one-pager.md`
- `skills/langchain-ci-integration/references/github-actions-workflow.md`
- `skills/langchain-ci-integration/references/integration-gating.md`
- `skills/langchain-ci-integration/references/eval-regression-gate.md`
- `skills/langchain-ci-integration/references/pre-commit-hooks.md`

## Validator

Grade **A (90/100)**, zero ERROR lines.

## Base

Targets \`feat/langchain-py-pack-foundation\` (#546).

Jeremy made me do it
-claude