### PR TITLE
fix(agents): quote phase_*.md descriptions (YAML mapping error)

### DIFF
--- a/workspace/lab/schema-optimization/agents/phase_1.md
+++ b/workspace/lab/schema-optimization/agents/phase_1.md
@@ -1,6 +1,6 @@
 ---
 name: phase-1-schema-analysis
-description: Phase 1 of BigQuery schema optimization pipeline: reads schema exports and produces initial analysis report with table counts, field types, naming patterns, and flagged issues. Outputs strict JSON for phase 2.
+description: "Phase 1 of BigQuery schema optimization pipeline: reads schema exports and produces initial analysis report with table counts, field types, naming patterns, and flagged issues. Outputs strict JSON for phase 2."
 ---
 
 # Phase 1 Agent: Initial Schema Analysis

--- a/workspace/lab/schema-optimization/agents/phase_2.md
+++ b/workspace/lab/schema-optimization/agents/phase_2.md
@@ -1,6 +1,6 @@
 ---
 name: phase-2-field-utilization
-description: Phase 2 of BigQuery schema optimization pipeline: analyzes field usage patterns to identify unused or low-utilization fields. Reads phase 1 output and produces utilization report as strict JSON for phase 3.
+description: "Phase 2 of BigQuery schema optimization pipeline: analyzes field usage patterns to identify unused or low-utilization fields. Reads phase 1 output and produces utilization report as strict JSON for phase 3."
 ---
 
 # Phase 2 Agent: Field Utilization Analysis

--- a/workspace/lab/schema-optimization/agents/phase_3.md
+++ b/workspace/lab/schema-optimization/agents/phase_3.md
@@ -1,6 +1,6 @@
 ---
 name: phase-3-impact-assessment
-description: Phase 3 of BigQuery schema optimization pipeline: evaluates the impact of proposed schema changes on systems, queries, and costs. Reads phase 1-2 outputs and produces impact assessment as strict JSON for phase 4.
+description: "Phase 3 of BigQuery schema optimization pipeline: evaluates the impact of proposed schema changes on systems, queries, and costs. Reads phase 1-2 outputs and produces impact assessment as strict JSON for phase 4."
 ---
 
 # Phase 3 Agent: Impact Assessment

--- a/workspace/lab/schema-optimization/agents/phase_4.md
+++ b/workspace/lab/schema-optimization/agents/phase_4.md
@@ -1,6 +1,6 @@
 ---
 name: phase-4-verification
-description: Phase 4 of BigQuery schema optimization pipeline: runs automated verification scripts to validate phase 2-3 conclusions with empirical data. Outputs verification results as strict JSON for phase 5.
+description: "Phase 4 of BigQuery schema optimization pipeline: runs automated verification scripts to validate phase 2-3 conclusions with empirical data. Outputs verification results as strict JSON for phase 5."
 ---
 
 # Phase 4 Agent: Verification with Script

--- a/workspace/lab/schema-optimization/agents/phase_5.md
+++ b/workspace/lab/schema-optimization/agents/phase_5.md
@@ -1,6 +1,6 @@
 ---
 name: phase-5-recommendations
-description: Phase 5 of BigQuery schema optimization pipeline: synthesizes all phase outputs into actionable recommendations with implementation plans. Produces final recommendations report.
+description: "Phase 5 of BigQuery schema optimization pipeline: synthesizes all phase outputs into actionable recommendations with implementation plans. Produces final recommendations report."
 ---
 
 # Phase 5 Agent: Final Recommendations


### PR DESCRIPTION
## Summary

Follow-up to #536 (which added frontmatter to 5 schema-optimization phase agents). The `description:` values contain unquoted colons ("Phase N of BigQuery schema optimization pipeline: ..."), which strict YAML parsers reject as a nested mapping.

The bug only surfaced *after* the expanded validator (from #578) started scanning `workspace/` — previously these files bypassed CI entirely.

Wrap each description in double quotes. No behavior change; agents are now loadable.

## Test plan

- [x] \`python3 scripts/validate-skills-schema.py --agents-only\` — 0 FATAL errors (was 5)
- [ ] CI passes

Jeremy made me do it
-claude