### PR TITLE
fix(commands): frontmatter cleanup Phase 1 — 5 trivial fixes (#604)

### DIFF
--- a/plugins/ai-agency/shipwright/commands/shipwright-build.md
+++ b/plugins/ai-agency/shipwright/commands/shipwright-build.md
@@ -1,7 +1,7 @@
 ---
 name: shipwright-build
 description: Build a new app from a plain-English description
-category: ai-agency
+category: deployment
 ---
 
 # /shipwright-build

--- a/plugins/ai-agency/shipwright/commands/shipwright-enhance.md
+++ b/plugins/ai-agency/shipwright/commands/shipwright-enhance.md
@@ -1,7 +1,7 @@
 ---
 name: shipwright-enhance
 description: Add features to an existing Shipwright project
-category: ai-agency
+category: deployment
 ---
 
 # /shipwright-enhance

--- a/plugins/ai-agency/shipwright/commands/shipwright-projects.md
+++ b/plugins/ai-agency/shipwright/commands/shipwright-projects.md
@@ -1,7 +1,7 @@
 ---
 name: shipwright-projects
 description: List and manage existing Shipwright projects
-category: ai-agency
+category: deployment
 ---
 
 # /shipwright-projects

--- a/plugins/ai-agency/shipwright/commands/shipwright-stacks.md
+++ b/plugins/ai-agency/shipwright/commands/shipwright-stacks.md
@@ -1,7 +1,7 @@
 ---
 name: shipwright-stacks
 description: List supported Shipwright tech stacks
-category: ai-agency
+category: deployment
 ---
 
 # /shipwright-stacks

--- a/plugins/devops/backup-strategy-implementor/commands/backup-strategy.md
+++ b/plugins/devops/backup-strategy-implementor/commands/backup-strategy.md
@@ -1,6 +1,6 @@
 ---
 name: backup-strategy
-description: Design and implement a comprehensive backup strategy for your infrastructure, including schedules, retention policies, storage tiers, and recovery procedures.
+description: Design a backup strategy with schedules, retention, storage tiers, and recovery.
 ---
 # Backup Strategy Implementor
 


### PR DESCRIPTION
## Campaign progress: 182 → 177 errors

Phase 1 of #604. Clears the two "trivial" error classes — all that remains after this merges is the 177-agent `capabilities` batch (Phase 2+).

| Class | Before | After |
|---|---:|---:|
| A — agents missing `capabilities` | 177 | 177 (next) |
| B — invalid `category` | 4 | **0 ✓** |
| C — description > 80 chars | 1 | **0 ✓** |

## Changes

| File | Change |
|---|---|
| `plugins/ai-agency/shipwright/commands/shipwright-build.md` | `category: ai-agency` → `deployment` |
| `plugins/ai-agency/shipwright/commands/shipwright-enhance.md` | `category: ai-agency` → `deployment` |
| `plugins/ai-agency/shipwright/commands/shipwright-projects.md` | `category: ai-agency` → `deployment` |
| `plugins/ai-agency/shipwright/commands/shipwright-stacks.md` | `category: ai-agency` → `deployment` |
| `plugins/devops/backup-strategy-implementor/commands/backup-strategy.md` | Description trimmed 158 → 80 chars (limit) |

### Rationale: shipwright → `deployment`

ccpi's allowed category list: `git, deployment, security, testing, documentation, database, api, frontend, backend, devops, forecasting, analytics, migration, monitoring, other`. Shipwright's pipeline builds and ships apps end-to-end; `deployment` carries more semantic signal than the alternative (`other`). Alternative future fix: extend ccpi's allowlist if `ai-agency` becomes legitimate — that's a design decision, not a cleanup concern.

### Rationale: backup-strategy description trim

Before (158 chars):
> "Design and implement a comprehensive backup strategy for your infrastructure, including schedules, retention policies, storage tiers, and recovery procedures."

After (80 chars — exactly at the limit):
> "Design a backup strategy with schedules, retention, storage tiers, and recovery."

## Verified locally

```
$ node packages/cli/dist/index.js validate --strict
  Frontmatter Summary:
    Total: 532
    Errors: 177  (was 182)
```

None of the 5 files appear in the remaining error list.

## Non-changes

- 5 files, 5 single-line edits
- Zero behavior change — the commands still do exactly what they did; just spec-compliant frontmatter
- Mitigation in `validate-plugins.yml` (`|| true` on ccpi validate --strict) stays in place until Phase 2+ clears the remaining 177 per #604

## Reversal reminder

This PR does NOT restore `|| exit 1` on the ccpi validate step. That reversal belongs in the final PR of #604 (the one that clears the last `capabilities` error). Keep the mitigation comment in `validate-plugins.yml` as the durable reminder.

Jeremy made me do it
-claude