### PR TITLE
fix(agents): fullstack-starter-pack frontmatter (#604 Phase 2A)

### DIFF
--- a/plugins/packages/fullstack-starter-pack/agents/api-builder.md
+++ b/plugins/packages/fullstack-starter-pack/agents/api-builder.md
@@ -1,7 +1,9 @@
 ---
 name: api-builder
-description: >
-  API design specialist for RESTful and GraphQL APIs with best practices
+description: "Use this agent when designing RESTful or GraphQL APIs, reviewing endpoint schemas, implementing API versioning strategies, defining authentication flows, or generating OpenAPI documentation."
+model: inherit
+capabilities: ["rest-api-design", "graphql-schema-design", "api-versioning", "endpoint-documentation", "api-security-patterns", "openapi-specification"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 20-40 minutes per API design review
 ---

--- a/plugins/packages/fullstack-starter-pack/agents/backend-architect.md
+++ b/plugins/packages/fullstack-starter-pack/agents/backend-architect.md
@@ -1,7 +1,10 @@
 ---
 name: backend-architect
-description: >
-  System architecture specialist for scalable backend design and patterns
+description: "Use this agent when designing scalable backend systems, choosing monolithic vs microservices, planning distributed systems, or reviewing system-level architecture decisions."
+model: inherit
+capabilities: ["system-architecture-design", "scalability-patterns", "microservices-decomposition", "distributed-systems", "technology-selection", "high-availability-planning"]
+expertise_level: advanced
+activation_priority: high
 difficulty: advanced
 estimated_time: 30-60 minutes per architecture review
 ---

--- a/plugins/packages/fullstack-starter-pack/agents/database-designer.md
+++ b/plugins/packages/fullstack-starter-pack/agents/database-designer.md
@@ -1,6 +1,9 @@
 ---
 name: database-designer
-description: Database schema design specialist for SQL and NoSQL modeling
+description: "Use this agent when designing database schemas, choosing between SQL and NoSQL datastores, modeling entity relationships, planning indexes, or optimizing data-access patterns for specific workloads."
+model: inherit
+capabilities: ["schema-design", "sql-data-modeling", "nosql-data-modeling", "relationship-design", "index-strategy", "query-optimization"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 30-45 minutes per schema design
 ---

--- a/plugins/packages/fullstack-starter-pack/agents/deployment-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/agents/deployment-specialist.md
@@ -1,8 +1,9 @@
 ---
 name: deployment-specialist
-description: >
-  CI/CD and deployment specialist for Docker, cloud platforms, and
-  automation
+description: "Use this agent when setting up CI/CD pipelines, writing Dockerfiles, planning cloud deployment (AWS/GCP/Azure), or implementing zero-downtime release patterns."
+model: inherit
+capabilities: ["ci-cd-pipeline-design", "containerization", "cloud-deployment", "infrastructure-automation", "zero-downtime-releases", "production-monitoring-setup"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 30-60 minutes per deployment setup
 ---

--- a/plugins/packages/fullstack-starter-pack/agents/react-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/agents/react-specialist.md
@@ -1,7 +1,9 @@
 ---
 name: react-specialist
-description: >
-  Modern React specialist for hooks, server components, and performance
+description: "Use this agent when building React 18+ apps, reviewing component architecture, implementing server components, or optimizing hook-based performance and concurrent features."
+model: inherit
+capabilities: ["react-18-concurrent-features", "hooks-architecture", "server-components", "performance-optimization", "nextjs-integration", "component-design-patterns"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 20-40 minutes per component review
 ---

--- a/plugins/packages/fullstack-starter-pack/agents/ui-ux-expert.md
+++ b/plugins/packages/fullstack-starter-pack/agents/ui-ux-expert.md
@@ -1,8 +1,9 @@
 ---
 name: ui-ux-expert
-description: >
-  UI/UX specialist for accessibility, responsive design, and user
-  experience
+description: "Use this agent when designing user interfaces, auditing accessibility against WCAG 2.1, reviewing responsive layouts across breakpoints, or optimizing user experience flows in web applications."
+model: inherit
+capabilities: ["wcag-accessibility-audit", "responsive-design-review", "user-experience-analysis", "design-system-architecture", "interaction-design"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 15-30 minutes per design review
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/react-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/react-specialist.md
@@ -1,7 +1,9 @@
 ---
 name: react-specialist
-description: >
-  Modern React specialist for hooks, server components, and performance
+description: "Use this agent when building React 18+ apps, reviewing component architecture, implementing server components, or optimizing hook-based performance and concurrent features."
+model: inherit
+capabilities: ["react-18-concurrent-features", "hooks-architecture", "server-components", "performance-optimization", "nextjs-integration", "component-design-patterns"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 20-40 minutes per component review
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/ui-ux-expert.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/ui-ux-expert.md
@@ -1,8 +1,9 @@
 ---
 name: ui-ux-expert
-description: >
-  UI/UX specialist for accessibility, responsive design, and user
-  experience
+description: "Use this agent when designing user interfaces, auditing accessibility against WCAG 2.1, reviewing responsive layouts across breakpoints, or optimizing user experience flows in web applications."
+model: inherit
+capabilities: ["wcag-accessibility-audit", "responsive-design-review", "user-experience-analysis", "design-system-architecture", "interaction-design"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 15-30 minutes per design review
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/api-builder.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/api-builder.md
@@ -1,7 +1,9 @@
 ---
 name: api-builder
-description: >
-  API design specialist for RESTful and GraphQL APIs with best practices
+description: "Use this agent when designing RESTful or GraphQL APIs, reviewing endpoint schemas, implementing API versioning strategies, defining authentication flows, or generating OpenAPI documentation."
+model: inherit
+capabilities: ["rest-api-design", "graphql-schema-design", "api-versioning", "endpoint-documentation", "api-security-patterns", "openapi-specification"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 20-40 minutes per API design review
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/backend-architect.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/backend-architect.md
@@ -1,7 +1,10 @@
 ---
 name: backend-architect
-description: >
-  System architecture specialist for scalable backend design and patterns
+description: "Use this agent when designing scalable backend systems, choosing monolithic vs microservices, planning distributed systems, or reviewing system-level architecture decisions."
+model: inherit
+capabilities: ["system-architecture-design", "scalability-patterns", "microservices-decomposition", "distributed-systems", "technology-selection", "high-availability-planning"]
+expertise_level: advanced
+activation_priority: high
 difficulty: advanced
 estimated_time: 30-60 minutes per architecture review
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/03-database/agents/database-designer.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/03-database/agents/database-designer.md
@@ -1,6 +1,9 @@
 ---
 name: database-designer
-description: Database schema design specialist for SQL and NoSQL modeling
+description: "Use this agent when designing database schemas, choosing between SQL and NoSQL datastores, modeling entity relationships, planning indexes, or optimizing data-access patterns for specific workloads."
+model: inherit
+capabilities: ["schema-design", "sql-data-modeling", "nosql-data-modeling", "relationship-design", "index-strategy", "query-optimization"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 30-45 minutes per schema design
 ---

--- a/plugins/packages/fullstack-starter-pack/plugins/04-integration/agents/deployment-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/04-integration/agents/deployment-specialist.md
@@ -1,8 +1,9 @@
 ---
 name: deployment-specialist
-description: >
-  CI/CD and deployment specialist for Docker, cloud platforms, and
-  automation
+description: "Use this agent when setting up CI/CD pipelines, writing Dockerfiles, planning cloud deployment (AWS/GCP/Azure), or implementing zero-downtime release patterns."
+model: inherit
+capabilities: ["ci-cd-pipeline-design", "containerization", "cloud-deployment", "infrastructure-automation", "zero-downtime-releases", "production-monitoring-setup"]
+expertise_level: intermediate
 difficulty: intermediate
 estimated_time: 30-60 minutes per deployment setup
 ---


### PR DESCRIPTION
## Campaign progress: 182 → 170 (–12)

Phase 2A batch 1 of #604 — brings all 6 fullstack-starter-pack agents to production-grade frontmatter. 12 files changed (6 top-level + 6 byte-identical nested mirrors across `01-frontend/02-backend/03-database/04-integration`).

## Changes

Per-agent, frontmatter-only (body content unchanged — each agent carries 500–670 lines of domain reference material):

| Agent | New capabilities |
|---|---|
| `ui-ux-expert` | wcag-accessibility-audit, responsive-design-review, user-experience-analysis, design-system-architecture, interaction-design |
| `react-specialist` | react-18-concurrent-features, hooks-architecture, server-components, performance-optimization, nextjs-integration, component-design-patterns |
| `api-builder` | rest-api-design, graphql-schema-design, api-versioning, endpoint-documentation, api-security-patterns, openapi-specification |
| `backend-architect` | system-architecture-design, scalability-patterns, microservices-decomposition, distributed-systems, technology-selection, high-availability-planning |
| `database-designer` | schema-design, sql-data-modeling, nosql-data-modeling, relationship-design, index-strategy, query-optimization |
| `deployment-specialist` | ci-cd-pipeline-design, containerization, cloud-deployment, infrastructure-automation, zero-downtime-releases, production-monitoring-setup |

Plus for every agent:
- `description` reshaped to "Use this agent when..." form per `agent-creator` skill's canonical spec, kept under the 200-char ccpi limit
- `model: inherit` added (lets orchestrator model selection propagate)
- `expertise_level` (`intermediate`/`advanced`) matching the pack's existing `difficulty` field
- Existing pack-specific fields (`difficulty`, `estimated_time`) preserved — not our scope to remove

## Verification

```
$ node packages/cli/dist/index.js validate --strict
  Frontmatter Errors: 182 → 170
  No fullstack-starter-pack agents in error list.
```

## Body content not changed

Each of these agents is a 500–670-line domain guide (React 18+ deep-dive, RESTful/GraphQL patterns, backend architecture playbook, etc.). Those bodies are already substantive; rewriting them into the `agent-creator` skill's template structure (Role/Responsibilities/Process/Output Format/Edge Cases) would be a much larger scope and isn't required by `ccpi validate --strict`. If a refresh is wanted, it's a separate PR per agent. This one is surgical: just the frontmatter that was actually flagged as broken.

## Campaign status after this PR

| Bucket | Total | Before | Remaining |
|---|---:|---:|---:|
| Your code (●) | 89 | 89 | 77 |
| External (○) | 88 | 88 | 88 |
| Class B (invalid category) | 4 | 4 | 4 *(cleared by #605 once that merges)* |
| Class C (description length) | 1 | 1 | 1 *(cleared by #605)* |
| **Total ccpi errors** | **182** | 182 | **170** |

## Next Phase 2A candidates

Planning to tackle, in descending size:
1. `plugins/testing/code-cleanup` (11 agents, highly consistent cleanup-pattern capabilities)
2. `plugins/packages/creator-studio-pack` (10)
3. `plugins/packages/ai-ml-engineering-pack` (8)
4. `plugins/packages/devops-automation-pack` + `plugins/packages/security-pro-pack` (5 + 5)
5. Remaining small plugins (~30 across many plugins) as one PR

## Reversal reminder

This PR does NOT restore `|| exit 1` on `ccpi validate --strict`. That's reserved for the final Phase 2A + 2B PR that clears the last error. Keep the mitigation in place until then per #604.

Jeremy made me do it
-claude