### PR TITLE
fix(agents): testing/code-cleanup frontmatter (#604 Phase 2A)

### DIFF
--- a/plugins/testing/code-cleanup/agents/async-pattern-fixer.md
+++ b/plugins/testing/code-cleanup/agents/async-pattern-fixer.md
@@ -1,6 +1,9 @@
 ---
 name: async-pattern-fixer
 description: "Use this agent when scanning for floating promises, async forEach antipatterns, missing await, unhandled rejections, and mixed async styles."
+model: inherit
+capabilities: ["floating-promise-detection", "async-foreach-audit", "missing-await-scan", "unhandled-rejection-check", "mixed-async-style-audit"]
+expertise_level: intermediate
 ---
 
 You are an expert **async pattern fixer** — a specialist in detecting dangerous asynchronous code patterns that are the #1 source of Node.js production bugs. Floating promises, unhandled rejections, and `forEach` + `async` antipatterns cause silent data loss, race conditions, and intermittent failures that are extremely difficult to reproduce. You NEVER auto-apply fixes because async changes can introduce subtle behavioral shifts and race conditions.

--- a/plugins/testing/code-cleanup/agents/circular-dep-untangler.md
+++ b/plugins/testing/code-cleanup/agents/circular-dep-untangler.md
@@ -1,6 +1,9 @@
 ---
 name: circular-dep-untangler
 description: "Use this agent when detecting and resolving circular module dependencies that cause initialization order issues, bundle bloat, and test difficulty."
+model: inherit
+capabilities: ["circular-dependency-detection", "module-graph-analysis", "initialization-order-audit", "dependency-refactoring"]
+expertise_level: intermediate
 ---
 
 You are an expert **circular dependency untangler** — a specialist in detecting module cycles and designing refactoring strategies to break them. You never auto-apply fixes because circular dependency resolution is an architectural decision that requires understanding module boundaries and ownership.

--- a/plugins/testing/code-cleanup/agents/dead-code-hunter.md
+++ b/plugins/testing/code-cleanup/agents/dead-code-hunter.md
@@ -1,6 +1,9 @@
 ---
 name: dead-code-hunter
 description: "Use this agent when scanning for unreachable code, unused exports/imports/variables, and dead feature flags. Includes confidence scoring and build verification."
+model: inherit
+capabilities: ["dead-code-detection", "unused-export-audit", "unreachable-branch-analysis", "dead-feature-flag-cleanup", "build-verification"]
+expertise_level: intermediate
 ---
 
 You are an expert **dead code hunter** — a specialist in identifying and safely removing code that is never executed, never imported, or never referenced. You prioritize precision over recall: every finding must include a confidence score, and you never remove code without build verification.

--- a/plugins/testing/code-cleanup/agents/defensive-code-cleaner.md
+++ b/plugins/testing/code-cleanup/agents/defensive-code-cleaner.md
@@ -1,6 +1,9 @@
 ---
 name: defensive-code-cleaner
 description: "Use this agent when identifying unnecessary null checks, impossible error handling, redundant validation, and dead catch blocks."
+model: inherit
+capabilities: ["unnecessary-null-check-detection", "impossible-error-path-cleanup", "redundant-validation-removal", "dead-catch-block-audit"]
+expertise_level: intermediate
 ---
 
 You are an expert **defensive code cleaner** — a specialist in identifying unnecessary defensive programming patterns that add complexity without protecting against real risks. You trace data flows to prove a check is unnecessary before flagging it. You NEVER auto-apply removals — every finding is flagged with an explanation of why the defense is unnecessary.

--- a/plugins/testing/code-cleanup/agents/dry-deduplicator.md
+++ b/plugins/testing/code-cleanup/agents/dry-deduplicator.md
@@ -1,6 +1,9 @@
 ---
 name: dry-deduplicator
 description: "Use this agent when detecting copy-pasted code blocks, duplicated logic across files, and repeated patterns that should be abstracted."
+model: inherit
+capabilities: ["code-duplication-detection", "pattern-extraction", "repeated-logic-refactoring", "cross-file-similarity-analysis"]
+expertise_level: intermediate
 ---
 
 You are an expert **DRY deduplicator** — a specialist in detecting duplicated code and recommending safe extractions. You have a strong bias against premature abstraction: **three similar lines is NOT duplication**. You only flag code when extraction genuinely reduces maintenance burden, and you NEVER auto-apply changes because deduplication is an architectural decision with high false-positive risk.

--- a/plugins/testing/code-cleanup/agents/legacy-code-remover.md
+++ b/plugins/testing/code-cleanup/agents/legacy-code-remover.md
@@ -1,6 +1,9 @@
 ---
 name: legacy-code-remover
 description: "Use this agent when modernizing deprecated API usage, old syntax patterns, compatibility shims, and unnecessary polyfills."
+model: inherit
+capabilities: ["deprecated-api-detection", "polyfill-audit", "syntax-modernization", "compatibility-shim-removal"]
+expertise_level: intermediate
 ---
 
 You are an expert **legacy code remover** — a specialist in identifying deprecated APIs, outdated syntax patterns, unnecessary polyfills, and compatibility shims that can be safely modernized. You always check the project's minimum platform targets before recommending changes.

--- a/plugins/testing/code-cleanup/agents/performance-optimizer.md
+++ b/plugins/testing/code-cleanup/agents/performance-optimizer.md
@@ -1,6 +1,9 @@
 ---
 name: performance-optimizer
 description: "Use this agent when scanning for N+1 queries, blocking I/O, bundle bloat, unnecessary re-renders, and inefficient algorithms."
+model: inherit
+capabilities: ["n-plus-one-detection", "blocking-io-audit", "bundle-size-analysis", "render-performance-review", "algorithm-complexity-audit"]
+expertise_level: intermediate
 ---
 
 You are an expert **performance optimizer** — a specialist in identifying code patterns that degrade runtime performance, increase bundle size, or waste compute resources. You flag issues with estimated impact and suggested fixes but NEVER auto-apply changes, because performance optimizations require benchmarking evidence and context about real-world usage patterns.

--- a/plugins/testing/code-cleanup/agents/security-scanner.md
+++ b/plugins/testing/code-cleanup/agents/security-scanner.md
@@ -1,6 +1,9 @@
 ---
 name: security-scanner
 description: "Use this agent when scanning for hardcoded secrets, weak cryptography, SQL/command injection vectors, and insecure defaults."
+model: inherit
+capabilities: ["secret-detection", "weak-crypto-audit", "injection-vector-scan", "insecure-defaults-check", "auth-pattern-review"]
+expertise_level: intermediate
 ---
 
 You are an expert **security scanner** — a specialist in identifying security vulnerabilities in source code. You focus on findings that are actionable and high-signal: hardcoded secrets, injection vectors, weak cryptography, and insecure configurations. You NEVER auto-apply fixes — all security findings are flagged for human review with severity ratings and remediation guidance.

--- a/plugins/testing/code-cleanup/agents/slop-remover.md
+++ b/plugins/testing/code-cleanup/agents/slop-remover.md
@@ -1,6 +1,9 @@
 ---
 name: slop-remover
 description: "Use this agent when scanning for AI-generated comment noise, low-value JSDoc, and filler text that restates obvious code."
+model: inherit
+capabilities: ["ai-noise-detection", "low-value-comment-removal", "filler-text-cleanup", "jsdoc-pruning"]
+expertise_level: intermediate
 ---
 
 You are an expert **AI slop remover** — a specialist in identifying and removing low-value comments that AI coding assistants generate. You distinguish between comments that add information and comments that merely restate what the code already says. You only touch comments — never modify actual code logic.

--- a/plugins/testing/code-cleanup/agents/type-consolidator.md
+++ b/plugins/testing/code-cleanup/agents/type-consolidator.md
@@ -1,6 +1,9 @@
 ---
 name: type-consolidator
 description: "Use this agent when merging duplicate type definitions, consolidating overlapping interfaces, and leveraging Pick/Omit/Partial."
+model: inherit
+capabilities: ["duplicate-type-detection", "interface-consolidation", "utility-type-refactoring", "type-hierarchy-flattening"]
+expertise_level: intermediate
 ---
 
 You are an expert **type consolidator** — a specialist in finding duplicate or near-duplicate type definitions and merging them into a single source of truth. You leverage TypeScript utility types (`Pick`, `Omit`, `Partial`, `Required`) to derive related types from a base definition instead of maintaining parallel copies.

--- a/plugins/testing/code-cleanup/agents/weak-type-eliminator.md
+++ b/plugins/testing/code-cleanup/agents/weak-type-eliminator.md
@@ -1,6 +1,9 @@
 ---
 name: weak-type-eliminator
 description: "Use this agent when replacing any, unknown, and overly broad generics with precise, compiler-verified types."
+model: inherit
+capabilities: ["any-type-elimination", "unknown-type-narrowing", "generic-tightening", "type-precision-analysis"]
+expertise_level: intermediate
 ---
 
 You are an expert **weak type eliminator** — a specialist in replacing `any`, implicit `any`, and overly broad type annotations with precise, compiler-verified types. You treat the type checker as your verification oracle: every change must compile cleanly.


### PR DESCRIPTION
## Campaign progress: 182 → 171 (–11)

Phase 2A batch 2 of #604. All 11 agents in `testing/code-cleanup` get production-grade frontmatter (capabilities + model + expertise_level).

These agents were already in good shape — their descriptions already used the "Use this agent when..." form from a prior pass. This PR just backfills the missing required fields.

## Per-agent capabilities

| Agent | Capabilities |
|---|---|
| `async-pattern-fixer` | floating-promise-detection, async-foreach-audit, missing-await-scan, unhandled-rejection-check, mixed-async-style-audit |
| `circular-dep-untangler` | circular-dependency-detection, module-graph-analysis, initialization-order-audit, dependency-refactoring |
| `dead-code-hunter` | dead-code-detection, unused-export-audit, unreachable-branch-analysis, dead-feature-flag-cleanup, build-verification |
| `defensive-code-cleaner` | unnecessary-null-check-detection, impossible-error-path-cleanup, redundant-validation-removal, dead-catch-block-audit |
| `dry-deduplicator` | code-duplication-detection, pattern-extraction, repeated-logic-refactoring, cross-file-similarity-analysis |
| `legacy-code-remover` | deprecated-api-detection, polyfill-audit, syntax-modernization, compatibility-shim-removal |
| `performance-optimizer` | n-plus-one-detection, blocking-io-audit, bundle-size-analysis, render-performance-review, algorithm-complexity-audit |
| `security-scanner` | secret-detection, weak-crypto-audit, injection-vector-scan, insecure-defaults-check, auth-pattern-review |
| `slop-remover` | ai-noise-detection, low-value-comment-removal, filler-text-cleanup, jsdoc-pruning |
| `type-consolidator` | duplicate-type-detection, interface-consolidation, utility-type-refactoring, type-hierarchy-flattening |
| `weak-type-eliminator` | any-type-elimination, unknown-type-narrowing, generic-tightening, type-precision-analysis |

Also added to every agent: `model: inherit`, `expertise_level: intermediate`.

**Body content unchanged** — each agent's cleanup methodology body is preserved.

## Verified

```
$ node packages/cli/dist/index.js validate --strict
  Frontmatter Errors: 182 → 171
  No code-cleanup agents in error list.
```

## Campaign tracker

| State | Your code | External | Total errors |
|---|---:|---:|---:|
| Main today | 89 | 88 | 182 |
| After #605 merges | 89 | 88 | 177 (Phase 1 clears 5) |
| After #606 merges | 77 | 88 | 170 |
| **After this merges** | **66** | **88** | **171 *(on this branch alone)*** |

## Reversal reminder

Not restoring `|| exit 1` yet — that's for the final campaign PR.

Jeremy made me do it
-claude