### PR TITLE
ci: trust Gemini workspace + install bun for mcp-plugins tests

### DIFF
--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -96,6 +96,12 @@ jobs:
           GITHUB_TOKEN: '${{ github.token }}'
           PULL_REQUEST_NUMBER: '${{ steps.pr.outputs.number }}'
           REPOSITORY: '${{ github.repository }}'
+          # Trust the GitHub Actions workspace so the CLI runs in headless mode
+          # without prompting. Per Gemini docs: in CI we either set this env or
+          # pass --skip-trust. We control the runner + checkout, so the trust
+          # signal is correct here. (See issue #614 for the failure mode.)
+          # https://geminicli.com/docs/cli/trusted-folders/#headless-and-automated-environments
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           # Temporary: surfaces Gemini CLI stdout/stderr in run logs so we can
           # see exactly what the CLI reports when talking to the MCP server.
           # Remove once reviews are confirmed posting reliably.

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -246,6 +246,16 @@ jobs:
         if: matrix.test-type == 'mcp-plugins'
         uses: pnpm/action-setup@v4
 
+      # plugins/mcp/slack-channel uses `bun test` as its test runner.
+      # Other MCP plugins use vitest. Installing bun lets the per-plugin
+      # test loop run slack-channel's bun-native tests without forcing a
+      # framework migration. (See issue #615.)
+      - name: Setup Bun
+        if: matrix.test-type == 'mcp-plugins'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         if: matrix.test-type == 'mcp-plugins'
         run: pnpm install --frozen-lockfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ plugins/mcp/[plugin-name]/
 
 `plugin.json` only allows these fields: `name`, `version`, `description`, `author`, `repository`, `homepage`, `license`, `keywords`. CI rejects any others.
 
-### SKILL.md Frontmatter (IS Enterprise Standard, Schema v3.3.0)
+### SKILL.md Frontmatter (IS Enterprise Standard, Schema v3.3.1)
 
 **Required at marketplace tier — all 8 fields must be present:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,10 @@ Validate your skills with:
 python3 scripts/validate-skills-schema.py --skills-only
 ```
 
+### Modifying the validator itself
+
+If your PR changes `scripts/validate-skills-schema.py`, the master spec at `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`, or the SKILL.md frontmatter rules in this doc, **read [`000-docs/SCHEMA_CHANGELOG.md`](000-docs/SCHEMA_CHANGELOG.md) first** — the NON-NEGOTIABLES section at the top documents which directions of change are out of bounds without explicit pre-approval (see issue #612 for the postmortem). Bug fixes that bring the validator into spec compliance are fine to apply directly; architectural changes (required-field set, tier model, error vs. warning semantics) need approval before the change lands.
+
 ## Validation Requirements
 
 CI runs the following checks on every PR:


### PR DESCRIPTION
## Summary

- **#614**: Gemini PR Review failed on every PR with *"Gemini CLI is not running in a trusted directory."* gemini-cli enforced workspace-trust as a security feature; in CI we control the runner + checkout, so setting `GEMINI_CLI_TRUST_WORKSPACE=true` per Gemini's headless-CI guidance is the documented fix. Restores the wait-for-Gemini-review policy bypassed via `--admin` in #611.
- **#615**: `test (mcp-plugins)` matrix job failed at `plugins/mcp/slack-channel` because that plugin's `package.json` uses `bun test` as its runner, but the runner only had pnpm/node. Added `oven-sh/setup-bun@v2` before the install step. No framework migration; other plugins unaffected.
- **#612 (refs)**: added a "Modifying the validator" callout to `CONTRIBUTING.md` pointing at `000-docs/SCHEMA_CHANGELOG.md` NON-NEGOTIABLES + issue #612 — the third guard location the issue's "done when" listed. Also picks up a stale `Schema v3.3.0 → v3.3.1` reference in `CLAUDE.md` left over from PR #611.

## Test plan

- [ ] CI: `Gemini PR Review` check completes and posts a review on this PR (vs. failing at startup at ~29s)
- [ ] CI: `test (mcp-plugins)` job passes — slack-channel test count visible in logs alongside pr-to-spec / project-health-auditor
- [ ] CI: `test (python-tests)` and `test (validation-scripts)` matrix legs unaffected (bun setup is gated on `mcp-plugins`)
- [ ] No regression on Slack notification step in gemini-code-review.yml

Closes #614
Closes #615
Refs #612

jeremy made me do it
-claude