### PR TITLE
docs(adr): decline 4 audit-tests recommendations with documented rationale

### DIFF
--- a/000-docs/260-AT-ADEC-no-stryker-mutation-testing.md
+++ b/000-docs/260-AT-ADEC-no-stryker-mutation-testing.md
@@ -1,0 +1,128 @@
+# ADR-260: Defer Stryker mutation testing for MCP plugin packages
+
+| Field        | Value                                                                              |
+|--------------|------------------------------------------------------------------------------------|
+| Status       | Accepted (decline)                                                                 |
+| Date         | 2026-04-29                                                                         |
+| Decider      | Jeremy Longshore (Tons of Skills / Intent Solutions)                               |
+| Driver       | `/audit-tests` smoke run (2026-04-21), recommendation tracked as issue #585        |
+| Supersedes   | —                                                                                  |
+| Superseded by| —                                                                                  |
+| Related      | #592 (audit-tests roadmap meta), #583 (coverage thresholds — installed)            |
+
+## Context
+
+`/audit-tests` recommended installing Stryker mutation testing across the four
+MCP plugin packages with vitest configs (`pr-to-spec`, `domain-memory-agent`,
+`project-health-auditor`, `conversational-api-debugger`). The recommendation
+was reasonable on its own merits — mutation testing answers a strictly
+stronger question than coverage ("did the assertion verify behavior?" vs.
+"was the line executed?") — and the audit's matrix marked it as P1 for
+service/api packages.
+
+The proposed install was substantial:
+
+- Per-package `stryker.conf.json` with vitest runner + per-test coverage
+  analysis
+- Per-package `test:mutation` script in `package.json`
+- Root `test:mutation:all` aggregator
+- Weekly `mutation-test.yml` GitHub Actions workflow with 60-minute timeout,
+  4-package matrix, artifact upload
+- Per-module thresholds in `tests/TESTING.md`
+- Hash-pinning the new policy via `audit-harness init`
+
+Wall-clock cost on CI per run: approximately 5–20 minutes per package (the
+overhead is roughly 5–15× the baseline test run, multiplied across four
+packages even with concurrency).
+
+## Decision
+
+**Decline now. Revisit only when triggered by evidence.**
+
+Do not install Stryker for the MCP plugin packages at this time. Do not add
+the proposed weekly workflow, per-package configs, or thresholds in
+`tests/TESTING.md`. The ratchet stays on coverage (#583) and the existing
+vitest assertion suite.
+
+This decision applies to **this repo only** — Stryker is a perfectly
+reasonable choice for repos that meet the trigger criteria below.
+
+## Rationale
+
+The senior-tech-lead read on this audit recommendation:
+
+1. **Mutation testing is most valuable when assertions are suspect.** Our
+   MCP plugin tests are not the "happy-path-without-asserting" pattern that
+   mutation testing is designed to catch. They use exact-match assertions
+   on parsed output, and `pr-to-spec` in particular has 384 vitest tests
+   that exercise schema validation, error paths, and edge cases. If those
+   tests had no assertions, mutation would be the right alarm; they have
+   assertions, so mutation here would mostly confirm what we already know.
+2. **No regression has been caught (or missed) that mutation testing would
+   have surfaced.** The signal we'd be paying for has not, to date, had
+   detectable demand. We have not had a "tests passed but production broke"
+   incident traceable to a non-asserting test. Adopting tooling for a
+   demand that hasn't materialized creates carrying cost without obvious
+   payback.
+3. **CI minute and reviewer-attention budgets are real costs.** Five to
+   twenty minutes per package per weekly run, plus dispatch overhead, plus
+   investigating "survived" mutations in logging/telemetry code (the known
+   noisy class). For a small contributor base, the per-finding investigation
+   cost is high relative to the per-finding signal.
+4. **Coverage thresholds (#583) are the load-bearing wall right now.** Until
+   coverage is enforced and stable for at least one full release cycle,
+   stacking mutation on top adds complexity without certainty that the
+   underlying coverage signal is trustworthy. Stryker's own docs say the
+   same: stand up coverage first, then mutation, not in parallel.
+
+This is a "not yet" rather than "not ever." Mutation testing remains in the
+toolkit; it just isn't paying for itself today.
+
+## Consequences
+
+**Accepted:**
+- The repo will rely on coverage thresholds + assertion-grade tests as its
+  unit-level safety net. Tests that "execute without asserting" can pass CI
+  if a contributor writes them.
+- We accept that some classes of regression — particularly silent mutations
+  in arithmetic, comparison operators, and boolean expressions where the
+  test only checks "did it return something?" — would not be caught.
+
+**Mitigated:**
+- Code review remains the human gate against the no-assertion test
+  pattern. This is a small contributor base; the review pass is realistic.
+- The `audit-tests` skill flags this as an absent layer, so the gap is
+  visible at every audit, not silent.
+
+**Triggers to revisit (any one is enough):**
+- A regression incident traceable to a non-asserting unit test.
+- The contributor base expands beyond ~3 active engineers (review can no
+  longer be relied on for assertion-quality vetting).
+- We add a security-critical or money-critical surface (auth, payments,
+  cryptography) where the cost of a silent regression dominates the
+  CI-minutes cost.
+- A future audit shows coverage staying flat while bugs continue to ship —
+  evidence that coverage alone has hit its useful ceiling.
+
+When any trigger fires, the install path is the one issue #585 already
+documents. Re-open #585 (or open a successor) and reference this ADR.
+
+## Alternatives considered
+
+- **Install per the audit's recommendation.** Rejected: see Rationale.
+- **Install on a single highest-leverage package** (e.g. `pr-to-spec` only).
+  Rejected for now: same ceiling on demand evidence; partial install creates
+  asymmetric expectations across packages. Reasonable to revisit if a
+  trigger above fires for one specific package.
+- **Defer to a property-based testing layer instead** (fast-check, hypothesis).
+  Tracked as a possible future, not in scope here. Property-based tests
+  would address the "assertion-quality" question from a different angle and
+  may be a better fit for some of the parsing-heavy modules.
+
+## References
+
+- Audit recommendation: GitHub issue #585
+- Audit-tests roadmap meta-tracker: #592
+- Coverage thresholds (the prerequisite that landed): #583
+- `tests/TESTING.md` (`Installed gates` section will explicitly mark
+  L3-mutation as deferred-by-ADR-260, not absent-by-oversight)

--- a/000-docs/261-AT-ADEC-no-dep-cruiser-yet.md
+++ b/000-docs/261-AT-ADEC-no-dep-cruiser-yet.md
@@ -1,0 +1,134 @@
+# ADR-261: Defer dependency-cruiser architecture rules until policy is written
+
+| Field        | Value                                                                              |
+|--------------|------------------------------------------------------------------------------------|
+| Status       | Accepted (decline)                                                                 |
+| Date         | 2026-04-29                                                                         |
+| Decider      | Jeremy Longshore (Tons of Skills / Intent Solutions)                               |
+| Driver       | `/audit-tests` smoke run (2026-04-21), recommendation tracked as issue #586        |
+| Supersedes   | —                                                                                  |
+| Superseded by| —                                                                                  |
+| Related      | #592 (audit-tests roadmap meta), #580 (audit-harness install)                      |
+
+## Context
+
+`/audit-tests` recommended installing `dependency-cruiser` to enforce
+architectural rules (forbidden imports, no circular deps, no test files in
+production, no cross-plugin imports) as fitness functions wired into CI and
+hash-pinned via `audit-harness`.
+
+The recommendation came with a fully-written `.dependency-cruiser.cjs` config
+covering six rules:
+
+- `no-cli-importing-marketplace`
+- `no-marketplace-importing-cli`
+- `no-cross-plugin-imports`
+- `no-test-files-in-prod`
+- `no-circular`
+- `no-orphans` (warn-only)
+
+Plus root scripts (`arch:check`, `arch:graph`), CI wiring, and a hash-pin
+step.
+
+## Decision
+
+**Decline now. Write the architecture policy first, then revisit.**
+
+Do not install `dependency-cruiser` at this time. Do not add the proposed
+`.dependency-cruiser.cjs`, scripts, or CI step.
+
+This decision applies to **this repo only** — `dependency-cruiser` is a
+sound choice for repos with a written architecture policy that already
+constrains imports.
+
+## Rationale
+
+The senior-tech-lead read on this audit recommendation:
+
+1. **Architecture rules without a written policy create noise, not signal.**
+   The proposed config encodes assumptions ("CLI must not import marketplace,"
+   "MCP plugins must not cross-import") that have not been written down as a
+   policy this repo subscribes to. If the rules pre-exist the policy, the
+   first PR that hits a rule has no documented authority to point at — only
+   a CI check that says "no." That breeds rule-bypass culture (`// dep-cruise
+   ignore`) faster than it breeds compliance.
+2. **Tools should follow policy, not generate it.** A reasonable order of
+   operations is: write a one-page architecture-rules ADR documenting which
+   imports are forbidden and why → land it on `main` → install
+   `dependency-cruiser` to enforce it → hash-pin both. The opposite
+   order — install the tool, draft rules to fill it — produces tooling for
+   its own sake.
+3. **Two of the rules in the proposed config are speculative for this repo.**
+   `no-cli-importing-marketplace` and `no-marketplace-importing-cli` describe
+   a separation that is already enforced by the package-manager policy
+   (pnpm at root, npm in `marketplace/`). Encoding them in
+   dependency-cruiser duplicates an existing gate. `no-cross-plugin-imports`
+   is the most interesting candidate but needs the policy written first
+   (under what conditions, if any, may shared utility code live across
+   plugins?).
+4. **`no-orphans` would generate hundreds of warnings on day one.** The
+   `scripts/` tree alone has 70+ scripts that are run from CLI invocations
+   and CI but are not "imported" anywhere. The rule needs a curated allow-list
+   that we don't yet have. Shipping it now would mean either suppressing the
+   warnings (training contributors to ignore the warning) or burning a
+   sprint cleaning up flagged files we may not actually want to delete.
+5. **Code review currently catches the cases the rules would catch.** The
+   contributor base is small enough that a "do not import marketplace from
+   the CLI" PR comment would land before merge. This is not a permanent
+   answer; it is the right answer until the contributor base grows.
+
+## Consequences
+
+**Accepted:**
+- The repo will rely on code review and the existing package-manager policy
+  to prevent the import patterns dependency-cruiser would catch.
+- A contributor could land an unintended cross-plugin import in code review;
+  it would be caught by post-merge review or at the next audit, not at
+  PR-open time.
+- Circular dependencies, in particular, are not gated. If one is introduced,
+  it would surface as a bundle-tree-shaking issue or a runtime "cannot
+  read X of undefined" — a slower failure mode.
+
+**Mitigated:**
+- The `audit-tests` skill flags this as an absent layer, so the gap is
+  visible at every audit.
+- The package-manager policy gate (`scripts/check-package-manager.mjs`)
+  already enforces the `pnpm` / `npm` boundary; it covers the highest-value
+  case from the proposed config without dependency-cruiser overhead.
+
+**Triggers to revisit (any one is enough):**
+- An architecture-rules ADR is written and merged. At that point install
+  dependency-cruiser to enforce it.
+- A circular import causes a debugging incident.
+- An unintended cross-plugin import lands and survives review.
+- The contributor base expands beyond ~3 active engineers.
+- A future audit shows architectural drift that code review missed.
+
+When any trigger fires, the install path is the one issue #586 already
+documents. Write the policy ADR first; install the tool to enforce it;
+re-open #586 (or open a successor) and reference this ADR.
+
+## Alternatives considered
+
+- **Install per the audit's recommendation, then write policy after.**
+  Rejected: rules-first-policy-second is the wrong order. Tools should
+  enforce policy, not generate it.
+- **Install only the `no-circular` rule** (the only universally-applicable
+  rule in the proposed config). Marginal benefit, full toolchain cost.
+  Reasonable as a future minimal-install if a circular import becomes a
+  real-world incident.
+- **Use ESLint's `no-restricted-imports`** instead of dependency-cruiser.
+  Same problem (tool ahead of policy); ESLint is also far less expressive
+  than dependency-cruiser for this class of rule.
+- **Defer indefinitely.** Rejected: keeping a written ADR in `000-docs/`
+  with explicit triggers gives a clean re-entry path; "defer indefinitely"
+  is what the team does when nobody wrote it down.
+
+## References
+
+- Audit recommendation: GitHub issue #586
+- Audit-tests roadmap meta-tracker: #592
+- Existing package-manager gate: `scripts/check-package-manager.mjs` and
+  `pnpm-workspace.yaml`
+- `tests/TESTING.md` (`Installed gates` section will explicitly mark
+  L3-arch as deferred-by-ADR-261, not absent-by-oversight)

--- a/000-docs/262-AT-ADEC-no-semgrep-redundant-sast.md
+++ b/000-docs/262-AT-ADEC-no-semgrep-redundant-sast.md
@@ -1,0 +1,174 @@
+# ADR-262: Decline Semgrep — redundant against existing CodeQL + gitleaks + trufflehog stack
+
+| Field        | Value                                                                              |
+|--------------|------------------------------------------------------------------------------------|
+| Status       | Accepted (decline)                                                                 |
+| Date         | 2026-04-29                                                                         |
+| Decider      | Jeremy Longshore (Tons of Skills / Intent Solutions)                               |
+| Driver       | `/audit-tests` smoke run (2026-04-21), recommendation tracked as issue #587        |
+| Supersedes   | —                                                                                  |
+| Superseded by| —                                                                                  |
+| Related      | #592 (audit-tests roadmap meta), NLPM external audit response (2026-04-21)         |
+
+## Context
+
+`/audit-tests` recommended adding Semgrep SAST plus Bandit (Python SAST) to
+complement the existing CodeQL workflow, plus re-enabling the
+`security-audit.yml` cron so `pnpm audit` runs weekly with
+`--audit-level high`.
+
+The proposed install was substantial:
+
+- New `.github/workflows/semgrep.yml` running on PR, push, weekly cron, and
+  manual dispatch — with a wide ruleset (`p/ci`, `p/security-audit`,
+  `p/nodejs`, `p/typescript`, `p/python`, `p/owasp-top-ten`, `p/secrets`,
+  `p/supply-chain`)
+- New `.github/workflows/python-sast.yml` running Bandit on every Python
+  change
+- New `.semgrep/mcp-plugins.yml` with two custom rules (`mcp-no-raw-exec`,
+  `mcp-plugin-json-required-fields`)
+- Re-enable `security-audit.yml` cron and tighten `pnpm audit` to fail on
+  high severity
+
+This is genuinely valuable on a repo with no SAST. **But this repo already
+has a substantial security stack**, hardened during the NLPM external audit
+response on 2026-04-21:
+
+- **CodeQL** for JavaScript/TypeScript + Python (`.github/workflows/codeql.yml`)
+- **gitleaks** on every PR and push (`.github/workflows/secret-scan.yml`)
+- **trufflehog** weekly verified-secrets scan (`.github/workflows/secret-scan.yml`)
+- **`pnpm audit`** wired to dependency changes (in `security-audit.yml`)
+- **Validator-driven** dangerous-pattern, suspicious-URL, and credential-shape
+  scans (in `validate-plugins.yml` — `Security scan - Dangerous patterns`,
+  `Security scan - Suspicious URLs`, `Security scan - Informational sweep`)
+- **Plugin-level** `npm audit` per MCP plugin (in `validate-plugins.yml`)
+
+The question is not "should we have SAST?" — we have it. The question is
+"does layering Semgrep on top yield meaningfully more catches than the
+existing stack already provides?"
+
+## Decision
+
+**Decline. Existing security stack is sufficient until evidence of a gap.**
+
+Do not add `.github/workflows/semgrep.yml`, `.github/workflows/python-sast.yml`,
+or `.semgrep/`. Do not duplicate the `pnpm audit` cron in `security-audit.yml`.
+
+This decision applies to **this repo only** — Semgrep is a perfectly
+reasonable choice for repos that don't already have CodeQL + gitleaks +
+trufflehog covering the same ground.
+
+## Rationale
+
+The senior-tech-lead read on this audit recommendation:
+
+1. **CodeQL and Semgrep overlap at the OSS level we'd actually run.** The
+   audit issue acknowledges this directly ("CodeQL and Semgrep overlap but
+   are not redundant"), then stacks both anyway. The pitched differentiation
+   is "Semgrep is faster and has community rules" — but the speed argument
+   is moot when CodeQL already runs in our CI without blocking PRs, and the
+   community-rules argument matters most when we have specific custom
+   patterns to enforce. We do not currently have a documented set of
+   repo-specific SAST rules that CodeQL is missing. Without that list, we'd
+   be adopting Semgrep on a hope-it-finds-something basis.
+2. **Secret scanning is comprehensively covered.** The NLPM external audit
+   on 2026-04-21 hardened our secret-scanning surface (gitleaks PR-and-push,
+   trufflehog weekly verified). Adding Semgrep `p/secrets` on top duplicates
+   coverage and produces parallel findings that have to be reconciled
+   manually.
+3. **Bandit on the Python tree would generate noise without payback.**
+   The Python code in this repo is concentrated in `scripts/` (CI helpers,
+   validators, freshie inventory) and `freshie/scripts/`. These are
+   trusted-author scripts, not user-input handlers. Bandit's strongest
+   findings target shell-out, deserialization, and crypto-misuse patterns —
+   none of which match what our Python scripts do. The expected
+   signal-to-noise ratio is low.
+4. **Custom Semgrep rules require maintenance.** The proposed
+   `mcp-no-raw-exec` and `mcp-plugin-json-required-fields` rules are real
+   ideas, but the second one duplicates a check the existing universal
+   validator already performs (`scripts/validate-skills-schema.py` enforces
+   `plugin.json` allowed fields). Maintaining the same constraint in two
+   places (validator + Semgrep) is exactly the kind of duplication that
+   produces drift — a future contributor edits the validator and not the
+   Semgrep rule, or vice versa, and now the policy is ambiguous.
+5. **`pnpm audit` cron and `--audit-level high`** *is* a reasonable change
+   from the audit issue and worth applying — but as a **separate** small
+   PR scoped to `security-audit.yml`, not as part of a Semgrep install.
+   Treat that as a follow-up; do not bundle it under the Semgrep
+   recommendation.
+
+This is not "we don't need SAST" — we have SAST. It's "we don't need
+*more* SAST until evidence shows the existing layer is missing something."
+
+## Consequences
+
+**Accepted:**
+- The repo will not run Semgrep. Some classes of OWASP Top 10 patterns that
+  CodeQL's queries don't surface might go uncaught.
+- The Python tree will not run Bandit. If a contributor adds a deserialization
+  call or shell-out without review, it is not gated by a SAST tool — only by
+  code review and the validator's `Security scan - Dangerous patterns`
+  step.
+- Custom MCP-plugin rules (the two proposed) are not enforced in CI. The
+  `mcp-no-raw-exec` rule in particular is worth re-considering as a focused
+  addition (see Triggers below).
+
+**Mitigated:**
+- CodeQL covers JavaScript / TypeScript / Python at the depth-of-analysis
+  level Semgrep OSS does not match.
+- gitleaks + trufflehog cover the secret-scanning gap explicitly.
+- The validator's `Security scan - Dangerous patterns` step in
+  `validate-plugins.yml` catches `rm -rf /`, `eval(`, IP-address-curl, and
+  `base64 -d` patterns at PR time.
+- The `audit-tests` skill flags this as an absent layer, so the gap is
+  visible at every audit.
+
+**Follow-up (separate PR, not blocked by this ADR):**
+- Re-enable the `security-audit.yml` cron (currently commented out).
+- Tighten `pnpm audit || true` to `pnpm audit --audit-level high`. This is
+  a worthwhile bug fix on its own; track separately as a small PR.
+
+**Triggers to revisit (any one is enough):**
+- A specific class of vulnerability lands that CodeQL did not catch and
+  Semgrep would have. (Concrete evidence of a gap, not speculation.)
+- A custom MCP-plugin pattern emerges that the validator can't express but
+  Semgrep can — e.g., a taint-tracking question across two files. At that
+  point a focused, repo-specific Semgrep install (custom rules only, no
+  community packs) is the right shape, not the broad-stroke install the
+  issue proposes.
+- The Python tree grows beyond utility scripts to include user-input or
+  network-handling code. Bandit becomes appropriate.
+- A regulatory or compliance requirement names Semgrep specifically.
+
+When any trigger fires, scope the re-introduction to the specific gap,
+not the full eight-pack the audit recommended.
+
+## Alternatives considered
+
+- **Install per the audit's recommendation.** Rejected: see Rationale.
+- **Install Semgrep with custom rules only** (skip the community packs).
+  Reasonable as a focused future install if a specific gap appears. Not
+  the right shape today because we do not yet have a documented list of
+  rules to enforce.
+- **Replace CodeQL with Semgrep.** Rejected: CodeQL has deeper interprocedural
+  taint analysis and is integrated with GitHub Advanced Security. We get
+  more for our minute on CodeQL than on Semgrep at the OSS level.
+- **Add only Bandit for Python.** Rejected for now: low expected
+  signal-to-noise on this repo's Python tree. Reconsider if the Python
+  surface area changes shape.
+
+## References
+
+- Audit recommendation: GitHub issue #587
+- Audit-tests roadmap meta-tracker: #592
+- NLPM audit response (auto-memory): `project_nlpm_audit.md` —
+  documented the existing gitleaks + trufflehog hardening
+- Existing security workflows:
+  - `.github/workflows/codeql.yml`
+  - `.github/workflows/secret-scan.yml` (gitleaks + trufflehog)
+  - `.github/workflows/security-audit.yml` (pnpm audit, cron disabled)
+  - `.github/workflows/validate-plugins.yml` (dangerous-patterns,
+    suspicious-URLs, credential-shapes, npm audit per plugin)
+- `tests/TESTING.md` (`Installed gates` section will explicitly mark
+  L5-sec as covered-by-CodeQL+gitleaks+trufflehog,
+  Semgrep-deferred-by-ADR-262)

--- a/000-docs/263-AT-ADEC-no-bdd-no-readership.md
+++ b/000-docs/263-AT-ADEC-no-bdd-no-readership.md
@@ -1,0 +1,147 @@
+# ADR-263: Decline BDD/Gherkin — no non-engineer readership for scenarios
+
+| Field        | Value                                                                              |
+|--------------|------------------------------------------------------------------------------------|
+| Status       | Accepted (decline)                                                                 |
+| Date         | 2026-04-29                                                                         |
+| Decider      | Jeremy Longshore (Tons of Skills / Intent Solutions)                               |
+| Driver       | `/audit-tests` smoke run (2026-04-21), recommendation tracked as issue #590        |
+| Supersedes   | —                                                                                  |
+| Superseded by| —                                                                                  |
+| Related      | #592 (audit-tests roadmap meta), #589 (RTM/PERSONAS/JOURNEYS — installed)          |
+
+## Context
+
+`/audit-tests` recommended scaffolding three `.feature` files with
+Playwright-BDD glue:
+
+- `marketplace/features/plugin-install.feature`
+- `marketplace/features/plugin-authoring.feature`
+- `marketplace/features/cli-user.feature`
+
+…plus `playwright-bdd.config.ts`, per-feature step files, and hash-pinning via
+`audit-harness init`.
+
+The audit issue itself flags BDD as **P2, not P1**, and acknowledges the
+right preconditions for value:
+
+- "Non-engineers want to read and write test scenarios"
+- "The business rules are genuinely separable from the UI code"
+- "An external stakeholder needs to approve 'what ships' in plain English"
+
+…then notes that for this repo: "the marketplace is engineer-authored and
+engineer-consumed; the business rules are relatively thin; there is no
+external stakeholder signing off features in Gherkin."
+
+The audit's own assessment is the right one. This ADR records the decision
+to act on that assessment instead of installing BDD anyway.
+
+## Decision
+
+**Decline. Use existing Playwright `test()` blocks; revisit when readership
+exists.**
+
+Do not install playwright-bdd. Do not create `marketplace/features/`,
+step files, or the BDD config. Do not hash-pin Gherkin files we do not
+have a non-engineer audience for.
+
+This decision applies to **this repo only** — BDD is the right shape for
+products with PM/QA/BA stakeholders writing or reviewing scenarios.
+
+## Rationale
+
+The senior-tech-lead read on this audit recommendation:
+
+1. **BDD's value is non-engineer readership.** The whole point of Gherkin is
+   that a PM, BA, or QA engineer can read a `.feature` file and say "yes,
+   that's what we want to ship" or "no, that's wrong." If the only readers
+   are engineers, Gherkin is a more verbose way to write a Playwright test —
+   strictly more characters per scenario, with a translation layer (steps)
+   to maintain. That is a net cost without a counterbalancing benefit.
+2. **Existing Playwright tests already cover these flows.** The repo has
+   T1–T9 dev tests (homepage search, search results, mobile viewport,
+   install CTA, playbooks nav, explore flows, cowork page/integration) and
+   P1–P8 production tests. The "plugin install" flow the audit proposes as
+   a feature file is **already covered** by T4 (install CTA) and P1 (core
+   page smoke tests). Adding a BDD layer would duplicate coverage in a
+   different syntax, not add new coverage.
+3. **The CLI flow does not need a feature file.** The audit proposes
+   `cli-user.feature` covering `ccpi --version` and `ccpi --help`. The
+   existing `cli-smoke-tests` job in `validate-plugins.yml` covers exactly
+   this. Re-stating it as Gherkin produces zero new signal.
+4. **The "plugin authoring" feature file would test the validator, not the
+   product.** The audit proposes scenarios checking that
+   `ccpi validate --strict` exits 0 on valid plugins and non-zero on
+   invalid ones. That belongs in the validator's own test suite (or in
+   `cli-smoke-tests`), not in a top-level `.feature` file. Putting validator
+   tests in BDD form imposes the readership tax for tests no
+   non-engineer will read.
+5. **Hash-pinning Gherkin without a non-engineer reviewer is theater.** The
+   audit issue notes "don't hash-pin until the features are reviewed by a
+   non-engineer." If we don't have a non-engineer reviewer in the loop, the
+   pin protects nothing — engineers edit, engineers re-pin, the
+   constraint is loose by design.
+6. **RTM / PERSONAS / JOURNEYS (#589) is the right primitive for this repo.**
+   The persona-coverage and journey-mapping artifacts are engineer-readable
+   traceability docs that pair Playwright tests to user flows without
+   Gherkin's translation layer. We landed (or will land) those under a
+   different track. They do the traceability work BDD would do, sized for
+   our actual readership.
+
+## Consequences
+
+**Accepted:**
+- The repo will not have `.feature` files. The `audit-tests` skill flags
+  this as an absent layer, but the gap is visible at every audit, not silent.
+- New contributors expecting Gherkin scenarios will find Playwright `test()`
+  blocks instead. The codebase convention is "tests in TypeScript Playwright,
+  trace to PERSONAS/JOURNEYS for the user-flow context."
+
+**Mitigated:**
+- The existing T1–T9 + P1–P8 Playwright test suite covers the same flows
+  the audit proposed feature files for.
+- `cli-smoke-tests` already exercises the CLI surface that
+  `cli-user.feature` would have covered.
+- RTM / PERSONAS / JOURNEYS (#589) provide engineer-readable user-flow
+  traceability without Gherkin's overhead.
+
+**Triggers to revisit (any one is enough):**
+- A non-engineer (PM, BA, QA, customer-success lead) joins the team and
+  needs to read or write product scenarios.
+- A regulated or compliance-driven feature lands where an external auditor
+  needs Gherkin-style behavior specs to sign off on "what shipped."
+- A plugin-marketplace product surface emerges where the business rules
+  separate cleanly from UI code and need stakeholder review (e.g., a
+  paid-tier plugin gating mechanism with billing rules).
+- The contributor base expands such that authoring/reviewing
+  Playwright-in-TypeScript is a barrier to a stakeholder's review.
+
+When any trigger fires, the install path is the one issue #590 already
+documents. Re-open #590 (or open a successor) and reference this ADR.
+
+## Alternatives considered
+
+- **Install per the audit's recommendation.** Rejected: see Rationale.
+- **Install playwright-bdd with one feature file** (the most consumer-facing
+  flow, `plugin-install.feature`), as a "toe in the water." Rejected: even
+  one `.feature` file requires the BDD config, the step glue infrastructure,
+  the hash-pin, and the maintenance overhead. The cost floor is roughly the
+  same whether you ship one feature or ten. Without a reader, even one is
+  too many.
+- **Convert existing Playwright tests to BDD.** Rejected: would force a
+  syntax migration on a passing suite for zero added benefit. T1–T9 / P1–P8
+  are working; rewriting them in Gherkin is purely additive cost.
+
+## References
+
+- Audit recommendation: GitHub issue #590
+- Audit-tests roadmap meta-tracker: #592
+- Existing Playwright suite: `marketplace/tests/T*.spec.ts` (dev) and
+  `marketplace/tests/production/P*.spec.ts` (production)
+- CLI smoke tests: `cli-smoke-tests` job in
+  `.github/workflows/validate-plugins.yml`
+- RTM / PERSONAS / JOURNEYS: `tests/RTM.md`, `tests/PERSONAS.md`,
+  `tests/JOURNEYS.md` (landed under #589)
+- `tests/TESTING.md` (`Installed gates` section will explicitly mark
+  L6-bdd as deferred-by-ADR-263, not absent-by-oversight; existing
+  Playwright suite remains the L6 implementation)


### PR DESCRIPTION
## Summary

`/audit-tests` recommended 11 installs across the 7-layer testing taxonomy. Four of those are better declined-with-explanation than installed. This PR adds 4 ADRs to \`000-docs/\` documenting the decline + revisit triggers, and (when merged) closes the corresponding issues.

| ADR | Issue | Decline |
|---|---|---|
| **ADR-260** | #585 | **Stryker mutation testing** — Mutation testing's value is on suspect-assertion suites; ours use exact-match assertions and no regression has surfaced that mutation would catch. CI cost (5–20 min/pkg weekly) outweighs current signal demand. |
| **ADR-261** | #586 | **dependency-cruiser architecture rules** — Tools should follow policy, not generate it. Write architecture-rules ADR first, then install. Existing package-manager gate covers the highest-value case. |
| **ADR-262** | #587 | **Semgrep SAST** — Existing CodeQL + gitleaks + trufflehog + pnpm audit + validator scans cover the same ground at greater depth than Semgrep OSS would add. NLPM audit hardened this on 2026-04-21. |
| **ADR-263** | #590 | **BDD / Gherkin** — BDD's value is non-engineer readership. Engineer-authored, engineer-consumed repo. Existing T1–T9 + P1–P8 Playwright suite covers the proposed feature flows. RTM/PERSONAS/JOURNEYS (#589) handles the traceability. |

Each ADR documents specific revisit triggers so the decision is reviewable and bounded — these are "not yet" decisions with explicit re-entry paths, not permanent declines.

The pnpm-audit cron tightening + \`--audit-level high\` change buried in #587 is **worthwhile and stands alone** — tracked as a separate small PR (not bundled here).

## Test plan

- [x] All 4 ADRs land at \`000-docs/26{0..3}-AT-ADEC-*.md\` per filing standard
- [x] Force-added to git per the SCHEMA_CHANGELOG.md precedent (000-docs/ is gitignored by default)
- [ ] Each ADR cross-referenced from its corresponding GitHub issue close-comment
- [ ] tests/TESTING.md \`Installed gates\` section will reference the relevant ADR for each declined layer (handled in the Phase 5 testing-foundation PR, not this one)

Closes #585
Closes #586
Closes #587
Closes #590
Refs #592 (audit-tests roadmap meta-tracker)

jeremy made me do it
-claude