### PR TITLE
chore(migration): compatible-with → compatibility (ai-ml category, 34 skills)

### DIFF
--- a/plugins/ai-ml/ai-ethics-validator/skills/validating-ai-ethics-and-fairness/SKILL.md
+++ b/plugins/ai-ml/ai-ethics-validator/skills/validating-ai-ethics-and-fairness/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: validating-ai-ethics-and-fairness
-description: |
-  Validate AI/ML models and datasets for bias, fairness, and ethical concerns.
-  Use when auditing AI systems for ethical compliance, fairness assessment, or bias detection.
-  Trigger with phrases like "evaluate model fairness", "check for bias", or "validate AI ethics".
-  
+description: 'Validate AI/ML models and datasets for bias, fairness, and ethical concerns.
+
+  Use when auditing AI systems for ethical compliance, fairness assessment, or bias
+  detection.
+
+  Trigger with phrases like "evaluate model fairness", "check for bias", or "validate
+  AI ethics".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(python:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, compliance, audit]
+tags:
+- ai
+- compliance
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # AI Ethics Validator
 

--- a/plugins/ai-ml/ai-sdk-agents/skills/orchestrating-multi-agent-systems/SKILL.md
+++ b/plugins/ai-ml/ai-sdk-agents/skills/orchestrating-multi-agent-systems/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: orchestrating-multi-agent-systems
-description: |
-  Execute orchestrate multi-agent systems with handoffs, routing, and workflows across AI providers.
-  Use when building complex AI systems requiring agent collaboration, task delegation, or workflow coordination.
-  Trigger with phrases like "create multi-agent system", "orchestrate agents", or "coordinate agent workflows".
-  
+description: 'Execute orchestrate multi-agent systems with handoffs, routing, and
+  workflows across AI providers.
+
+  Use when building complex AI systems requiring agent collaboration, task delegation,
+  or workflow coordination.
+
+  Trigger with phrases like "create multi-agent system", "orchestrate agents", or
+  "coordinate agent workflows".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, workflow, agent-orchestration]
+tags:
+- ai
+- workflow
+- agent-orchestration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Orchestrating Multi-Agent Systems
 

--- a/plugins/ai-ml/anomaly-detection-system/skills/detecting-data-anomalies/SKILL.md
+++ b/plugins/ai-ml/anomaly-detection-system/skills/detecting-data-anomalies/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: detecting-data-anomalies
-description: |
-  Process identify anomalies and outliers in datasets using machine learning algorithms.
-  Use when analyzing data for unusual patterns, outliers, or unexpected deviations from normal behavior.
-  Trigger with phrases like "detect anomalies", "find outliers", or "identify unusual patterns".
-  
+description: 'Process identify anomalies and outliers in datasets using machine learning
+  algorithms.
+
+  Use when analyzing data for unusual patterns, outliers, or unexpected deviations
+  from normal behavior.
+
+  Trigger with phrases like "detect anomalies", "find outliers", or "identify unusual
+  patterns".
+
+  '
 allowed-tools: Read, Bash(python:*), Grep, Glob
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, detecting-data]
+tags:
+- ai
+- ml
+- detecting-data
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Detecting Data Anomalies
 

--- a/plugins/ai-ml/automl-pipeline-builder/skills/building-automl-pipelines/SKILL.md
+++ b/plugins/ai-ml/automl-pipeline-builder/skills/building-automl-pipelines/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: building-automl-pipelines
-description: |
-  Build automated machine learning pipelines with feature engineering, model selection, and hyperparameter tuning.
+description: 'Build automated machine learning pipelines with feature engineering,
+  model selection, and hyperparameter tuning.
+
   Use when automating ML workflows from data preparation through model deployment.
-  Trigger with phrases like "build automl pipeline", "automate ml workflow", or "create automated training pipeline".
-  
+
+  Trigger with phrases like "build automl pipeline", "automate ml workflow", or "create
+  automated training pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(python:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, deployment, ml]
+tags:
+- ai
+- deployment
+- ml
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Building Automl Pipelines
 

--- a/plugins/ai-ml/classification-model-builder/skills/building-classification-models/SKILL.md
+++ b/plugins/ai-ml/classification-model-builder/skills/building-classification-models/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: building-classification-models
-description: |
-  Build and evaluate classification models for supervised learning tasks with labeled data. Use when requesting "build a classifier", "create classification model", or "train classifier". Trigger with relevant phrases based on skill purpose.
+description: 'Build and evaluate classification models for supervised learning tasks
+  with labeled data. Use when requesting "build a classifier", "create classification
+  model", or "train classifier". Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, classification-models]
+tags:
+- ai
+- classification-models
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Classification Model Builder
 

--- a/plugins/ai-ml/clustering-algorithm-runner/skills/running-clustering-algorithms/SKILL.md
+++ b/plugins/ai-ml/clustering-algorithm-runner/skills/running-clustering-algorithms/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: running-clustering-algorithms
-description: |
-  Analyze datasets by running clustering algorithms (K-means, DBSCAN, hierarchical) to identify data groups. Use when requesting "run clustering", "cluster analysis", or "group data points". Trigger with relevant phrases based on skill purpose.
+description: 'Analyze datasets by running clustering algorithms (K-means, DBSCAN,
+  hierarchical) to identify data groups. Use when requesting "run clustering", "cluster
+  analysis", or "group data points". Trigger with relevant phrases based on skill
+  purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, clustering-algorithms]
+tags:
+- ai
+- clustering-algorithms
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clustering Algorithm Runner
 

--- a/plugins/ai-ml/computer-vision-processor/skills/processing-computer-vision-tasks/SKILL.md
+++ b/plugins/ai-ml/computer-vision-processor/skills/processing-computer-vision-tasks/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: processing-computer-vision-tasks
-description: |
-  Process images using object detection, classification, and segmentation. Use when requesting "analyze image", "object detection", "image classification", or "computer vision". Trigger with relevant phrases based on skill purpose.
+description: 'Process images using object detection, classification, and segmentation.
+  Use when requesting "analyze image", "object detection", "image classification",
+  or "computer vision". Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, processing-computer]
+tags:
+- ai
+- processing-computer
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Computer Vision Processor
 

--- a/plugins/ai-ml/data-preprocessing-pipeline/skills/preprocessing-data-with-automated-pipelines/SKILL.md
+++ b/plugins/ai-ml/data-preprocessing-pipeline/skills/preprocessing-data-with-automated-pipelines/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: preprocessing-data-with-automated-pipelines
-description: |
-  Process automate data cleaning, transformation, and validation for ML tasks. Use when requesting "preprocess data", "clean data", "ETL pipeline", or "data transformation". Trigger with relevant phrases based on skill purpose.
+description: 'Process automate data cleaning, transformation, and validation for ML
+  tasks. Use when requesting "preprocess data", "clean data", "ETL pipeline", or "data
+  transformation". Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, etl]
+tags:
+- ai
+- ml
+- etl
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Data Preprocessing Pipeline
 

--- a/plugins/ai-ml/data-visualization-creator/skills/creating-data-visualizations/SKILL.md
+++ b/plugins/ai-ml/data-visualization-creator/skills/creating-data-visualizations/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: creating-data-visualizations
-description: |
-  Generate plots, charts, and graphs from data with automatic visualization type selection. Use when requesting "visualization", "plot", "chart", or "graph". Trigger with phrases like 'generate', 'create', or 'scaffold'.
+description: 'Generate plots, charts, and graphs from data with automatic visualization
+  type selection. Use when requesting "visualization", "plot", "chart", or "graph".
+  Trigger with phrases like ''generate'', ''create'', or ''scaffold''.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, data-visualizations]
+tags:
+- ai
+- data-visualizations
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Data Visualization Creator
 

--- a/plugins/ai-ml/dataset-splitter/skills/splitting-datasets/SKILL.md
+++ b/plugins/ai-ml/dataset-splitter/skills/splitting-datasets/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: splitting-datasets
-description: |
-  Process split datasets into training, validation, and testing sets for ML model development. Use when requesting "split dataset", "train-test split", or "data partitioning". Trigger with relevant phrases based on skill purpose.
+description: 'Process split datasets into training, validation, and testing sets for
+  ML model development. Use when requesting "split dataset", "train-test split", or
+  "data partitioning". Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, testing, ml]
+tags:
+- ai
+- testing
+- ml
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Dataset Splitter
 

--- a/plugins/ai-ml/deep-learning-optimizer/skills/optimizing-deep-learning-models/SKILL.md
+++ b/plugins/ai-ml/deep-learning-optimizer/skills/optimizing-deep-learning-models/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: optimizing-deep-learning-models
-description: |
-  Optimize deep learning models using Adam, SGD, and learning rate scheduling to improve accuracy and reduce training time. Use when asked to "optimize deep learning model" or "improve model performance". Trigger with phrases like 'optimize', 'performance', or 'speed up'.
+description: 'Optimize deep learning models using Adam, SGD, and learning rate scheduling
+  to improve accuracy and reduce training time. Use when asked to "optimize deep learning
+  model" or "improve model performance". Trigger with phrases like ''optimize'', ''performance'',
+  or ''speed up''.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, performance, optimizing-deep]
+tags:
+- ai
+- performance
+- optimizing-deep
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deep Learning Optimizer
 

--- a/plugins/ai-ml/experiment-tracking-setup/skills/setting-up-experiment-tracking/SKILL.md
+++ b/plugins/ai-ml/experiment-tracking-setup/skills/setting-up-experiment-tracking/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: setting-up-experiment-tracking
-description: |
-  Implement machine learning experiment tracking using MLflow or Weights & Biases. Configures environment and provides code for logging parameters, metrics, and artifacts. Use when asked to "setup experiment tracking" or "initialize MLflow". Trigger with relevant phrases based on skill purpose.
+description: 'Implement machine learning experiment tracking using MLflow or Weights
+  & Biases. Configures environment and provides code for logging parameters, metrics,
+  and artifacts. Use when asked to "setup experiment tracking" or "initialize MLflow".
+  Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, logging]
+tags:
+- ai
+- ml
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Experiment Tracking Setup
 

--- a/plugins/ai-ml/feature-engineering-toolkit/skills/engineering-features-for-machine-learning/SKILL.md
+++ b/plugins/ai-ml/feature-engineering-toolkit/skills/engineering-features-for-machine-learning/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: engineering-features-for-machine-learning
-description: |
-  Execute create, select, and transform features to improve machine learning model performance. Handles feature scaling, encoding, and importance analysis. Use when asked to "engineer features" or "select features". Trigger with relevant phrases based on skill purpose.
+description: 'Execute create, select, and transform features to improve machine learning
+  model performance. Handles feature scaling, encoding, and importance analysis. Use
+  when asked to "engineer features" or "select features". Trigger with relevant phrases
+  based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, performance, scaling]
+tags:
+- ai
+- ml
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Feature Engineering Toolkit
 

--- a/plugins/ai-ml/hyperparameter-tuner/skills/tuning-hyperparameters/SKILL.md
+++ b/plugins/ai-ml/hyperparameter-tuner/skills/tuning-hyperparameters/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: tuning-hyperparameters
-description: |
-  Optimize machine learning model hyperparameters using grid search, random search, or Bayesian optimization. Finds best parameter configurations to maximize performance. Use when asked to "tune hyperparameters" or "optimize model". Trigger with relevant phrases based on skill purpose.
+description: 'Optimize machine learning model hyperparameters using grid search, random
+  search, or Bayesian optimization. Finds best parameter configurations to maximize
+  performance. Use when asked to "tune hyperparameters" or "optimize model". Trigger
+  with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, performance]
+tags:
+- ai
+- ml
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Hyperparameter Tuner
 

--- a/plugins/ai-ml/jeremy-adk-orchestrator/skills/adk-deployment-specialist/SKILL.md
+++ b/plugins/ai-ml/jeremy-adk-orchestrator/skills/adk-deployment-specialist/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: adk-deployment-specialist
-description: |
-  Deploy and orchestrate Vertex AI ADK agents using A2A protocol. Manages AgentCard discovery, task submission, Code Execution Sandbox, and Memory Bank. Use when asked to "deploy ADK agent" or "orchestrate agents". Trigger with phrases like 'deploy', 'infrastructure', or 'CI/CD'.
+description: 'Deploy and orchestrate Vertex AI ADK agents using A2A protocol. Manages
+  AgentCard discovery, task submission, Code Execution Sandbox, and Memory Bank. Use
+  when asked to "deploy ADK agent" or "orchestrate agents". Trigger with phrases like
+  ''deploy'', ''infrastructure'', or ''CI/CD''.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
 effort: high
-argument-hint: "<agent-name or project-id>"
-tags: [ai, deployment, ci-cd]
+argument-hint: <agent-name or project-id>
+tags:
+- ai
+- deployment
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Adk Deployment Specialist
 

--- a/plugins/ai-ml/jeremy-adk-software-engineer/skills/adk-engineer/SKILL.md
+++ b/plugins/ai-ml/jeremy-adk-software-engineer/skills/adk-engineer/SKILL.md
@@ -1,14 +1,21 @@
 ---
 name: adk-engineer
-description: |
-  Execute software engineer specializing in creating production-ready ADK agents with best practices, code structure, testing, and deployment automation. Use when asked to "build ADK agent", "create agent code", or "engineer ADK application". Trigger with relevant phrases based on skill purpose.
+description: 'Execute software engineer specializing in creating production-ready
+  ADK agents with best practices, code structure, testing, and deployment automation.
+  Use when asked to "build ADK agent", "create agent code", or "engineer ADK application".
+  Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 effort: high
-compatible-with: claude-code, codex, openclaw
-tags: [ai, deployment, testing]
+tags:
+- ai
+- deployment
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # ADK Engineer
 

--- a/plugins/ai-ml/jeremy-gcp-starter-examples/skills/gcp-examples-expert/SKILL.md
+++ b/plugins/ai-ml/jeremy-gcp-starter-examples/skills/gcp-examples-expert/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: gcp-examples-expert
-description: |
-  Generate production-ready Google Cloud code examples from official repositories including ADK samples, Genkit templates, Vertex AI notebooks, and Gemini patterns. Use when asked to "show ADK example" or "provide GCP starter kit". Trigger with relevant phrases based on skill purpose.
+description: 'Generate production-ready Google Cloud code examples from official repositories
+  including ADK samples, Genkit templates, Vertex AI notebooks, and Gemini patterns.
+  Use when asked to "show ADK example" or "provide GCP starter kit". Trigger with
+  relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 effort: medium
-argument-hint: "[framework or use-case]"
-compatible-with: claude-code, codex, openclaw
-tags: [ai, gcp, gcp-examples]
+argument-hint: '[framework or use-case]'
+tags:
+- ai
+- gcp
+- gcp-examples
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # GCP Examples Expert
 

--- a/plugins/ai-ml/jeremy-genkit-pro/skills/genkit-production-expert/SKILL.md
+++ b/plugins/ai-ml/jeremy-genkit-pro/skills/genkit-production-expert/SKILL.md
@@ -1,14 +1,22 @@
 ---
 name: genkit-production-expert
-description: |
-  Build production Firebase Genkit applications including RAG systems, multi-step flows, and tool calling for Node.js/Python/Go. Deploy to Firebase Functions or Cloud Run with AI monitoring. Use when asked to "create genkit flow" or "implement RAG". Trigger with relevant phrases based on skill purpose.
+description: 'Build production Firebase Genkit applications including RAG systems,
+  multi-step flows, and tool calling for Node.js/Python/Go. Deploy to Firebase Functions
+  or Cloud Run with AI monitoring. Use when asked to "create genkit flow" or "implement
+  RAG". Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 effort: medium
-compatible-with: claude-code, codex, openclaw
-tags: [ai, deployment, monitoring, python]
+tags:
+- ai
+- deployment
+- monitoring
+- python
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Genkit Production Expert
 

--- a/plugins/ai-ml/jeremy-vertex-engine/skills/vertex-engine-inspector/SKILL.md
+++ b/plugins/ai-ml/jeremy-vertex-engine/skills/vertex-engine-inspector/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: vertex-engine-inspector
-description: |
-  Inspect and validate Vertex AI Agent Engine deployments including Code Execution Sandbox, Memory Bank, A2A protocol compliance, and security posture. Generates production readiness scores. Use when asked to inspect, validate, or audit an Agent Engine deployment. Trigger with "inspect agent engine", "validate agent engine deployment", "check agent engine config", "audit agent engine security", "agent engine readiness check", "vertex engine health", or "reasoning engine status".
+description: 'Inspect and validate Vertex AI Agent Engine deployments including Code
+  Execution Sandbox, Memory Bank, A2A protocol compliance, and security posture. Generates
+  production readiness scores. Use when asked to inspect, validate, or audit an Agent
+  Engine deployment. Trigger with "inspect agent engine", "validate agent engine deployment",
+  "check agent engine config", "audit agent engine security", "agent engine readiness
+  check", "vertex engine health", or "reasoning engine status".
+
+  '
 allowed-tools: Read, Grep, Glob, Bash(cmd:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-argument-hint: "<project-id> <agent-engine-id> [location]"
+argument-hint: <project-id> <agent-engine-id> [location]
 effort: high
-tags: [ai, deployment, security, compliance]
+tags:
+- ai
+- deployment
+- security
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vertex Engine Inspector
 

--- a/plugins/ai-ml/jeremy-vertex-validator/skills/validator-expert/SKILL.md
+++ b/plugins/ai-ml/jeremy-vertex-validator/skills/validator-expert/SKILL.md
@@ -1,24 +1,40 @@
 ---
 name: validator-expert
-description: |
-  Validate production readiness of Vertex AI Agent Engine deployments across
+description: 'Validate production readiness of Vertex AI Agent Engine deployments
+  across
+
   security, monitoring, performance, compliance, and best practices. Generates
+
   weighted scores (0-100%) with actionable remediation plans. Use when asked to
+
   validate a deployment, run a production readiness check, audit security posture,
+
   or verify compliance for Vertex AI agents. Trigger with "validate deployment",
+
   "production readiness", "security audit", "compliance check", "is this agent
+
   ready for prod", "check my ADK agent", "review before deploy", or
+
   "production readiness check". Make sure to use this skill whenever validating
+
   ADK agents for Agent Engine.
-allowed-tools: "Read,Grep,Glob,Bash(gcloud:*),Bash(python:*),Bash(pylint:*),Bash(flake8:*),Bash(mypy:*),Bash(bandit:*),Bash(pytest:*)"
+
+  '
+allowed-tools: Read,Grep,Glob,Bash(gcloud:*),Bash(python:*),Bash(pylint:*),Bash(flake8:*),Bash(mypy:*),Bash(bandit:*),Bash(pytest:*)
 version: 2.1.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [vertex-ai, security, compliance, validation, production-readiness, gcp]
+tags:
+- vertex-ai
+- security
+- compliance
+- validation
+- production-readiness
+- gcp
 model: inherit
 effort: high
-argument-hint: "[project-id]"
+argument-hint: '[project-id]'
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Validator Expert
 

--- a/plugins/ai-ml/local-tts/skills/local-tts/SKILL.md
+++ b/plugins/ai-ml/local-tts/skills/local-tts/SKILL.md
@@ -1,21 +1,35 @@
 ---
 name: local-tts
-description: |
-  Generate speech locally from text using VoxCPM2 (2B params, Apache-2.0). 30 languages,
+description: 'Generate speech locally from text using VoxCPM2 (2B params, Apache-2.0).
+  30 languages,
+
   voice design (describe a voice), voice cloning (from 3-10s reference). Runs 100%
+
   offline on Apple Silicon via Metal (MPS). Zero API calls, zero cost.
+
   Use when user asks to "say" or "speak" something, wants a voiceover, wants to clone
+
   a voice, or wants to generate audio from text. Trigger phrases: "say this",
+
   "read out loud", "clone my voice", "generate voiceover", "text to speech", "TTS".
+
+  '
 allowed-tools: Read, Bash(python3:*), Bash(file:*), Bash(ls:*)
 version: 1.0.0
 author: Bubble Invest <contact@bubbleinvest.com>
 license: Apache-2.0
-compatible-with: claude-code
-tags: [tts, voice, audio, voice-cloning, voice-design, offline, apple-silicon, narration]
+tags:
+- tts
+- voice
+- audio
+- voice-cloning
+- voice-design
+- offline
+- apple-silicon
+- narration
 user-invocable: true
+compatibility: Designed for Claude Code
 ---
-
 # Local TTS — Offline Text-to-Speech
 
 Generate speech from text using VoxCPM2 locally. 30 languages, voice design, voice cloning. Runs on Apple Silicon via Metal. Apache-2.0, zero cost.

--- a/plugins/ai-ml/ml-model-trainer/skills/training-machine-learning-models/SKILL.md
+++ b/plugins/ai-ml/ml-model-trainer/skills/training-machine-learning-models/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: training-machine-learning-models
-description: |
-  Build train machine learning models with automated workflows. Analyzes datasets, selects model types (classification, regression), configures parameters, trains with cross-validation, and saves model artifacts. Use when asked to "train model" or "evalua... Trigger with relevant phrases based on skill purpose.
+description: 'Build train machine learning models with automated workflows. Analyzes
+  datasets, selects model types (classification, regression), configures parameters,
+  trains with cross-validation, and saves model artifacts. Use when asked to "train
+  model" or "evalua... Trigger with relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, workflow]
+tags:
+- ai
+- ml
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ml Model Trainer
 

--- a/plugins/ai-ml/model-deployment-helper/skills/deploying-machine-learning-models/SKILL.md
+++ b/plugins/ai-ml/model-deployment-helper/skills/deploying-machine-learning-models/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: deploying-machine-learning-models
-description: |
-  Deploy this skill enables AI assistant to deploy machine learning models to production environments. it automates the deployment workflow, implements best practices for serving models, optimizes performance, and handles potential errors. use this skill when th... Use when deploying or managing infrastructure. Trigger with phrases like 'deploy', 'infrastructure', or 'CI/CD'.
+description: 'Deploy this skill enables AI assistant to deploy machine learning models
+  to production environments. it automates the deployment workflow, implements best
+  practices for serving models, optimizes performance, and handles potential errors.
+  use this skill when th... Use when deploying or managing infrastructure. Trigger
+  with phrases like ''deploy'', ''infrastructure'', or ''CI/CD''.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, deployment, ci-cd, ml]
+tags:
+- ai
+- deployment
+- ci-cd
+- ml
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Model Deployment Helper
 

--- a/plugins/ai-ml/model-evaluation-suite/skills/evaluating-machine-learning-models/SKILL.md
+++ b/plugins/ai-ml/model-evaluation-suite/skills/evaluating-machine-learning-models/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: evaluating-machine-learning-models
-description: |
-  Build this skill allows AI assistant to evaluate machine learning models using a comprehensive suite of metrics. it should be used when the user requests model performance analysis, validation, or testing. AI assistant can use this skill to assess model accuracy, p... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Build this skill allows AI assistant to evaluate machine learning models
+  using a comprehensive suite of metrics. it should be used when the user requests
+  model performance analysis, validation, or testing. AI assistant can use this skill
+  to assess model accuracy, p... Use when appropriate context detected. Trigger with
+  relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, testing, ml, performance]
+tags:
+- ai
+- testing
+- ml
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Model Evaluation Suite
 

--- a/plugins/ai-ml/model-explainability-tool/skills/explaining-machine-learning-models/SKILL.md
+++ b/plugins/ai-ml/model-explainability-tool/skills/explaining-machine-learning-models/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: explaining-machine-learning-models
-description: |
-  Build this skill enables AI assistant to provide interpretability and explainability for machine learning models. it is triggered when the user requests explanations for model predictions, insights into feature importance, or help understanding model behavior... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Build this skill enables AI assistant to provide interpretability and
+  explainability for machine learning models. it is triggered when the user requests
+  explanations for model predictions, insights into feature importance, or help understanding
+  model behavior... Use when appropriate context detected. Trigger with relevant phrases
+  based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, explaining-machine]
+tags:
+- ai
+- ml
+- explaining-machine
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Model Explainability Tool
 

--- a/plugins/ai-ml/model-versioning-tracker/skills/tracking-model-versions/SKILL.md
+++ b/plugins/ai-ml/model-versioning-tracker/skills/tracking-model-versions/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: tracking-model-versions
-description: |
-  Build this skill enables AI assistant to track and manage ai/ml model versions using the model-versioning-tracker plugin. it should be used when the user asks to manage model versions, track model lineage, log model performance, or implement version control f... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Build this skill enables AI assistant to track and manage ai/ml model
+  versions using the model-versioning-tracker plugin. it should be used when the user
+  asks to manage model versions, track model lineage, log model performance, or implement
+  version control f... Use when appropriate context detected. Trigger with relevant
+  phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, performance, tracking-model]
+tags:
+- ai
+- performance
+- tracking-model
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Model Versioning Tracker
 

--- a/plugins/ai-ml/neural-network-builder/skills/building-neural-networks/SKILL.md
+++ b/plugins/ai-ml/neural-network-builder/skills/building-neural-networks/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: building-neural-networks
-description: |
-  Execute this skill allows AI assistant to construct and configure neural network architectures using the neural-network-builder plugin. it should be used when the user requests the creation of a new neural network, modification of an existing one, or assistance... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Execute this skill allows AI assistant to construct and configure neural
+  network architectures using the neural-network-builder plugin. it should be used
+  when the user requests the creation of a new neural network, modification of an
+  existing one, or assistance... Use when appropriate context detected. Trigger with
+  relevant phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, neural-networks]
+tags:
+- ai
+- neural-networks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Neural Network Builder
 

--- a/plugins/ai-ml/nlp-text-analyzer/skills/analyzing-text-with-nlp/SKILL.md
+++ b/plugins/ai-ml/nlp-text-analyzer/skills/analyzing-text-with-nlp/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: analyzing-text-with-nlp
-description: |
-  Execute this skill enables AI assistant to perform natural language processing and text analysis using the nlp-text-analyzer plugin. it should be used when the user requests analysis of text, including sentiment analysis, keyword extraction, topic modeling, or ... Use when analyzing code or data. Trigger with phrases like 'analyze', 'review', or 'examine'.
+description: 'Execute this skill enables AI assistant to perform natural language
+  processing and text analysis using the nlp-text-analyzer plugin. it should be used
+  when the user requests analysis of text, including sentiment analysis, keyword extraction,
+  topic modeling, or ... Use when analyzing code or data. Trigger with phrases like
+  ''analyze'', ''review'', or ''examine''.
+
+  '
 allowed-tools: Read, Bash(cmd:*), Grep, Glob
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, analyzing-text]
+tags:
+- ai
+- analyzing-text
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Nlp Text Analyzer
 

--- a/plugins/ai-ml/ollama-local-ai/skills/ollama-setup/SKILL.md
+++ b/plugins/ai-ml/ollama-local-ai/skills/ollama-setup/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: ollama-setup
-description: |
-  Configure auto-configure Ollama when user needs local LLM deployment, free AI alternatives,
+description: 'Configure auto-configure Ollama when user needs local LLM deployment,
+  free AI alternatives,
+
   or wants to eliminate hosted API costs. Trigger phrases: "install ollama",
-  "local AI", "free LLM", "self-hosted AI", "replace OpenAI", "no API costs". Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+
+  "local AI", "free LLM", "self-hosted AI", "replace OpenAI", "no API costs". Use
+  when appropriate context detected. Trigger with relevant phrases based on skill
+  purpose.
+
+  '
 allowed-tools: Read, Write, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, deployment, api, llm]
+tags:
+- ai
+- deployment
+- api
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ollama Setup
 

--- a/plugins/ai-ml/recommendation-engine/skills/building-recommendation-systems/SKILL.md
+++ b/plugins/ai-ml/recommendation-engine/skills/building-recommendation-systems/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: building-recommendation-systems
-description: |
-  Execute this skill empowers AI assistant to construct recommendation systems using collaborative filtering, content-based filtering, or hybrid approaches. it analyzes user preferences, item features, and interaction data to generate personalized recommendations... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Execute this skill empowers AI assistant to construct recommendation
+  systems using collaborative filtering, content-based filtering, or hybrid approaches.
+  it analyzes user preferences, item features, and interaction data to generate personalized
+  recommendations... Use when appropriate context detected. Trigger with relevant
+  phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, recommendation-systems]
+tags:
+- ai
+- recommendation-systems
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Recommendation Engine
 

--- a/plugins/ai-ml/regression-analysis-tool/skills/performing-regression-analysis/SKILL.md
+++ b/plugins/ai-ml/regression-analysis-tool/skills/performing-regression-analysis/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: performing-regression-analysis
-description: |
-  Execute this skill empowers AI assistant to perform regression analysis and modeling using the regression-analysis-tool plugin. it analyzes datasets, generates appropriate regression models (linear, polynomial, etc.), validates the models, and provides performa... Use when analyzing code or data. Trigger with phrases like 'analyze', 'review', or 'examine'.
+description: 'Execute this skill empowers AI assistant to perform regression analysis
+  and modeling using the regression-analysis-tool plugin. it analyzes datasets, generates
+  appropriate regression models (linear, polynomial, etc.), validates the models,
+  and provides performa... Use when analyzing code or data. Trigger with phrases like
+  ''analyze'', ''review'', or ''examine''.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, performing-regression]
+tags:
+- ai
+- performing-regression
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Regression Analysis Tool
 

--- a/plugins/ai-ml/sentiment-analysis-tool/skills/analyzing-text-sentiment/SKILL.md
+++ b/plugins/ai-ml/sentiment-analysis-tool/skills/analyzing-text-sentiment/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: analyzing-text-sentiment
-description: |
-  Execute this skill enables AI assistant to analyze the sentiment of text data. it identifies the emotional tone expressed in text, classifying it as positive, negative, or neutral. use this skill when a user requests sentiment analysis, opinion mining, or emoti... Use when analyzing code or data. Trigger with phrases like 'analyze', 'review', or 'examine'.
+description: 'Execute this skill enables AI assistant to analyze the sentiment of
+  text data. it identifies the emotional tone expressed in text, classifying it as
+  positive, negative, or neutral. use this skill when a user requests sentiment analysis,
+  opinion mining, or emoti... Use when analyzing code or data. Trigger with phrases
+  like ''analyze'', ''review'', or ''examine''.
+
+  '
 allowed-tools: Read, Write, Bash(cmd:*), Grep
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, analyzing-text]
+tags:
+- ai
+- analyzing-text
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentiment Analysis Tool
 

--- a/plugins/ai-ml/time-series-forecaster/skills/forecasting-time-series-data/SKILL.md
+++ b/plugins/ai-ml/time-series-forecaster/skills/forecasting-time-series-data/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: forecasting-time-series-data
-description: |
-  Process this skill enables AI assistant to forecast future values based on historical time series data. it analyzes time-dependent data to identify trends, seasonality, and other patterns. use this skill when the user asks to predict future values of a time ser... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Process this skill enables AI assistant to forecast future values based
+  on historical time series data. it analyzes time-dependent data to identify trends,
+  seasonality, and other patterns. use this skill when the user asks to predict future
+  values of a time ser... Use when appropriate context detected. Trigger with relevant
+  phrases based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, forecasting-time]
+tags:
+- ai
+- forecasting-time
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Time Series Forecaster
 

--- a/plugins/ai-ml/transfer-learning-adapter/skills/adapting-transfer-learning-models/SKILL.md
+++ b/plugins/ai-ml/transfer-learning-adapter/skills/adapting-transfer-learning-models/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: adapting-transfer-learning-models
-description: |
-  Build this skill automates the adaptation of pre-trained machine learning models using transfer learning techniques. it is triggered when the user requests assistance with fine-tuning a model, adapting a pre-trained model to a new dataset, or performing... Use when appropriate context detected. Trigger with relevant phrases based on skill purpose.
+description: 'Build this skill automates the adaptation of pre-trained machine learning
+  models using transfer learning techniques. it is triggered when the user requests
+  assistance with fine-tuning a model, adapting a pre-trained model to a new dataset,
+  or performing... Use when appropriate context detected. Trigger with relevant phrases
+  based on skill purpose.
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
-compatible-with: claude-code, codex, openclaw
-tags: [ai, ml, adapting-transfer]
+tags:
+- ai
+- ml
+- adapting-transfer
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Transfer Learning Adapter
 


### PR DESCRIPTION
## Summary

First chunk of issue #613 — bulk migration of the deprecated \`compatible-with\` CSV-platform-list field to the spec-aligned \`compatibility\` free-text field per [agentskills.io/specification](https://agentskills.io/specification).

**Pure schema migration. No content changes.** Generated by the existing idempotent migration tool the repo CLAUDE.md already documents:

\`\`\`bash
python3 scripts/batch-remediate.py --migrate-compatible-with --root plugins/ai-ml/
\`\`\`

Translation pattern:
- \`compatible-with: claude-code, codex, openclaw\` → \`compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw\`
- \`compatible-with: claude-code\` → \`compatibility: Designed for Claude Code\`

### Side effect

\`yaml.safe_dump\` round-trips the entire frontmatter — so \`description: |\` literal blocks come out as single-quoted scalars. **The rendered description text is unchanged; only the YAML representation differs.** This matches \`batch-remediate.py\`'s documented behavior.

### Sequencing

This is **PR 1 of ~10–15** staged by category. Categories sized by \`compatible-with\` count:

| Category | Skills | Status |
|---|---|---|
| ai-ml | 34 | this PR |
| business-tools | 40 | next |
| devops | 36 | queued |
| productivity | 31 | queued |
| security | 27 | queued |
| testing | 26 | queued |
| database | 26 | queued |
| crypto | 25 | queued |
| api-development | 25 | queued |
| performance | 24 | queued |
| skill-enhancers / community / mcp / examples / design / packages / ai-agency / jeremy-* | 36 total | bundled later |
| **saas-packs** | 2,575 | sub-chunked further |

## Test plan

- [x] \`grep -rl "^compatible-with:" plugins/ai-ml/\` returns 0 results post-migration
- [x] Spot-check: \`plugins/ai-ml/ai-ethics-validator/skills/validating-ai-ethics-and-fairness/SKILL.md\` validates at marketplace tier with grade A (96/100), zero errors
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes (no link breakage from frontmatter restructure)

Refs #613

jeremy made me do it
-claude