### PR TITLE
feat(testing): install audit-harness + tests/TESTING.md + coverage thresholds

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -21,6 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # @intentsolutions/audit-harness verify — exit 0 when policy hashes
+      # match `.harness-hash`, exit 2 when a hash-pinned policy file (e.g.
+      # tests/TESTING.md, .dependency-cruiser.cjs, *.feature) was changed
+      # without a paired engineer-initiated `pnpm exec audit-harness init`.
+      # Hashing surface is currently empty (we declined the tools that get
+      # pinned — ADR-260/261/263) so this is exit 0; kept here so the gate
+      # is wired the moment any pinned file lands.
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Install root dev dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+      - name: Verify audit-harness integrity
+        run: pnpm exec audit-harness verify
+
       - name: Sync CLI marketplace catalog
         run: |
           node scripts/sync-marketplace.cjs

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pnpm": ">=9.0.0"
   },
   "devDependencies": {
+    "@intentsolutions/audit-harness": "^0.1.0",
     "@types/node": "^20.19.27",
     "archiver": "^7.0.1",
     "eslint": "^9.39.2",

--- a/plugins/mcp/pr-to-spec/vitest.config.ts
+++ b/plugins/mcp/pr-to-spec/vitest.config.ts
@@ -7,8 +7,18 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     coverage: {
       provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
       include: ["src/**/*.ts"],
       exclude: ["src/cli/**", "src/action/**"],
+      // Floor declared in tests/TESTING.md (lines/functions/statements: 70,
+      // branches: 60). Per-config values may exceed the floor; lowering them
+      // below the floor is REFUSED by audit-harness escape-scan.
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+        statements: 80,
+      },
     },
   },
 });

--- a/plugins/skill-enhancers/web-to-github-issue/vitest.config.js
+++ b/plugins/skill-enhancers/web-to-github-issue/vitest.config.js
@@ -15,10 +15,14 @@ export default defineConfig({
         '**/*.spec.js',
       ],
       all: true,
-      lines: 80,
-      functions: 80,
-      branches: 80,
-      statements: 80,
+      // Migrated from vitest 0.x flat format to vitest 2.x nested
+      // `thresholds: {}`. Floor declared in tests/TESTING.md.
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
     },
     include: ['tests/**/*.test.js'],
     exclude: ['node_modules/', 'dist/'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@intentsolutions/audit-harness':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@types/node':
         specifier: ^20.19.27
         version: 20.19.27
@@ -529,6 +532,8 @@ importers:
   plugins/saas-packs/klingai-pack: {}
 
   plugins/saas-packs/langchain-pack: {}
+
+  plugins/saas-packs/langchain-py-pack: {}
 
   plugins/saas-packs/langfuse-pack: {}
 
@@ -1458,6 +1463,11 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@intentsolutions/audit-harness@0.1.0':
+    resolution: {integrity: sha512-7YNrX4KLEPwJUT41yKa4w94/bqWS3Bdcvxa57GfQOEF/yUtu39Yl59t+bijx+7lO3HmWS5gc/llU1Nca1+QGtg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -5551,6 +5561,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@intentsolutions/audit-harness@0.1.0': {}
 
   '@isaacs/balanced-match@4.0.1': {}
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,127 @@
+# Testing Context — claude-code-plugins-plus-skills
+
+<!-- TESTING.md schema v1 — see @intentsolutions/audit-harness docs -->
+<!--
+  POLICY sections (above "## Installed gates") are engineer-owned and
+  hash-pinned. Editing them via AI without an engineer-initiated
+  `pnpm exec audit-harness init` re-pin will trip escape-scan and
+  REFUSE the change.
+
+  OBSERVATIONAL sections (below "## Installed gates") may be updated
+  by AI via the Edit tool — they reflect what is currently installed,
+  not what policy requires.
+-->
+
+## Classification (policy)
+
+- Repo type: **monorepo** (pnpm workspaces)
+- Primary languages: **TypeScript**, **Python**, **Astro**
+- Per-package mixed stacks:
+  - `marketplace/` — Astro 5 frontend (uses npm, not pnpm; see CI policy gate)
+  - `packages/cli` — TypeScript CLI (`@intentsolutionsio/ccpi` on npm)
+  - `packages/analytics-*` — TypeScript analytics tooling
+  - `plugins/mcp/*` — TypeScript MCP server plugins
+  - `plugins/saas-packs/*-pack` — Markdown SaaS skill packs
+  - `plugins/<category>/*` — Markdown AI-instruction plugins (~98% of plugins)
+  - `scripts/` — Python validators + Node.js build/sync scripts
+  - `freshie/` — Python ecosystem-inventory tooling
+- Compliance overlay: **public marketplace publication** (npm) — security
+  posture, secret scanning, and dependency auditing are required, not
+  optional.
+
+## Thresholds (policy)
+
+These values are the floor. Lowering any of them in a PR will be REFUSED
+by `audit-harness escape-scan --staged`.
+
+| Gate                       | Floor                                            | Owner               | Source                                                |
+|----------------------------|--------------------------------------------------|---------------------|-------------------------------------------------------|
+| coverage.lines             | 70                                               | per-vitest-config   | `vitest.config.ts` `coverage.thresholds.lines`        |
+| coverage.functions         | 70                                               | per-vitest-config   | `vitest.config.ts` `coverage.thresholds.functions`    |
+| coverage.statements        | 70                                               | per-vitest-config   | `vitest.config.ts` `coverage.thresholds.statements`   |
+| coverage.branches          | 60                                               | per-vitest-config   | `vitest.config.ts` `coverage.thresholds.branches`     |
+| harness.verify             | exit 0 required at PR-time                       | CI                  | `pnpm exec audit-harness verify`                      |
+| security.gitleaks          | clean on every PR                                | CI                  | `.github/workflows/secret-scan.yml`                   |
+| security.trufflehog        | weekly verified-secrets clean                    | CI                  | `.github/workflows/secret-scan.yml`                   |
+| security.codeql            | no `error`-severity alerts                       | CI                  | `.github/workflows/codeql.yml`                        |
+| validator.marketplace      | per-skill grade ≥ B (80/100) for new skills      | per-PR              | `scripts/validate-skills-schema.py --marketplace`     |
+| performance.budget.gzip    | total dist ≤ 40 MB, largest file ≤ 1 MB          | CI                  | `scripts/check-performance.mjs`                       |
+| performance.routes         | 2,800–4,000                                      | CI                  | `scripts/check-performance.mjs`                       |
+
+## Waived layers (policy)
+
+The 7-layer audit-tests taxonomy includes layers this repo intentionally
+does not enforce. Each waiver below has a written ADR or rationale; future
+audits should not re-raise these as P1 unless a re-trigger condition fires.
+
+| Layer                       | Status                  | ADR / Rationale                                                                                     |
+|-----------------------------|-------------------------|-----------------------------------------------------------------------------------------------------|
+| L3-mutation (Stryker)       | deferred                | `000-docs/260-AT-ADEC-no-stryker-mutation-testing.md`                                              |
+| L3-arch (dep-cruiser)       | deferred                | `000-docs/261-AT-ADEC-no-dep-cruiser-yet.md`                                                       |
+| L5-sec (Semgrep / Bandit)   | covered-by-existing     | `000-docs/262-AT-ADEC-no-semgrep-redundant-sast.md` (CodeQL + gitleaks + trufflehog already cover) |
+| L6-bdd (Gherkin)            | deferred                | `000-docs/263-AT-ADEC-no-bdd-no-readership.md` (existing Playwright suite covers same flows)       |
+| L5-chaos (chaos eng.)       | not-applicable          | No production-runtime services in this repo; marketplace is a static site.                          |
+| L5-perf (load testing)      | not-applicable          | No backend-with-throughput-SLO surface; perf budget is bundle-size only.                            |
+
+## Compliance overlay (policy)
+
+- Plugin authors are third parties. SKILL.md frontmatter and plugin.json
+  schemas are public contracts; breaking changes require a major-version
+  bump on the validator + a deprecation cycle in `000-docs/SCHEMA_CHANGELOG.md`.
+- Security posture is the NON-NEGOTIABLE described in
+  `000-docs/SCHEMA_CHANGELOG.md` and the Skills SOP in `~/.claude/CLAUDE.md`.
+- Architectural changes to the validator (required-fields set, tier model,
+  error vs warning semantics) require explicit pre-approval per the
+  governance documented in issue #612.
+
+---
+
+## Installed gates (observational)
+
+| Layer                       | Gate                                                                | Trigger             |
+|-----------------------------|---------------------------------------------------------------------|---------------------|
+| L1-hooks                    | `husky` declared (`package.json` `devDependencies`)                 | local pre-commit    |
+| L1-hooks                    | `@intentsolutions/audit-harness` `verify`                           | CI + local          |
+| L2-static                   | `eslint` + `prettier` (root + per-package)                          | local + CI          |
+| L2-static                   | `tsc --noEmit` per TS package                                       | CI                  |
+| L3-unit                     | `vitest` per MCP plugin (`pr-to-spec`, `domain-memory-agent`,       | local + CI          |
+|                             | `project-health-auditor`, `conversational-api-debugger`,            |                     |
+|                             | `web-to-github-issue`, `tests/e2e`)                                 |                     |
+| L3-unit                     | coverage thresholds (lines/functions/statements 70, branches 60)    | CI                  |
+| L3-arch                     | `scripts/check-package-manager.mjs` (pnpm vs npm boundary)          | CI                  |
+| L4-integration              | `pytest` for `scripts/` + `freshie/scripts/`                        | CI                  |
+| L5-sec                      | `gitleaks` (PR + push) + `trufflehog` (weekly verified)             | CI                  |
+| L5-sec                      | `codeql` (JS/TS + Python)                                           | CI                  |
+| L5-sec                      | `pnpm audit` per MCP plugin                                         | CI (manual cron)    |
+| L5-sec                      | validator `Security scan - Dangerous patterns` / `Suspicious URLs` | CI                  |
+| L5-system                   | route + link + downloads validators (`marketplace/scripts/*`)       | CI                  |
+| L5-system                   | performance budget (`scripts/check-performance.mjs`)                | CI                  |
+| L6-e2e                      | Playwright dev tests T1–T9 (chromium + webkit + mobile)             | CI                  |
+| L6-e2e                      | Playwright production tests P1–P8 (live site)                       | CI                  |
+| L7-acceptance               | `tests/TESTING.md` (this file) + `tests/RTM.md` /                   | engineer + AI       |
+|                             | `tests/PERSONAS.md` / `tests/JOURNEYS.md`                           |                     |
+
+## Frameworks (observational)
+
+- vitest 2.x (per-package configs)
+- Playwright (chromium + webkit + iPhone 13 + Pixel 5)
+- pytest (Python tests in `tests/` and per-plugin `requirements.txt`)
+- ESLint 9 + Prettier 3
+- TypeScript 5
+- gitleaks + trufflehog (gh-actions)
+- CodeQL (gh-actions)
+- @intentsolutions/audit-harness ^0.1.0
+
+## Last audit (observational)
+
+- Date: 2026-04-21 (`/audit-tests` smoke run)
+- Resulting issues: #580–#592
+- Resolution PRs: #617 (CI hygiene), #618 (data integrity), #619 (4 ADRs),
+  #620 (compatible-with migration PR 1 of N), this PR (testing
+  foundation)
+
+## Traceability (observational)
+
+- RTM: `tests/RTM.md`
+- Personas: `tests/PERSONAS.md`
+- Journeys: `tests/JOURNEYS.md`


### PR DESCRIPTION
## Summary

Phase 5 PR 1 of the testing-foundation roadmap from \`/audit-tests\` — the L1 + L3 base. Three issues land together because each depends on the others.

### #580 — Install \`@intentsolutions/audit-harness@^0.1.0\`

- Added as root devDep. \`pnpm-lock.yaml\` +12 lines, zero transitive churn.
- Empty \`.harness-hash\` manifest committed alongside (the package's \`init\` discovered no files matching its built-in pinning patterns, because we declined the tools that get pinned — see ADR-260, ADR-261, ADR-263).
- CI step added to \`validate-plugins.yml\`: \`pnpm exec audit-harness verify\` on every PR. Exit 2 means a pinned policy file changed without a paired engineer-initiated \`audit-harness init\` → REFUSE. The gate is wired the moment any pinned file lands.

### #581 — Create \`tests/TESTING.md\` (schema v1)

Engineer-owned policy boundary documented in-file. Above \`## Installed gates\` = engineer-only, hash-pinned. Below = AI-editable via Edit tool.

- **Classification**: monorepo (pnpm workspaces) with mixed TS / Python / Astro packages
- **Thresholds**: coverage floor 70/70/70/60, validator marketplace tier ≥ B, perf budgets, etc.
- **Waived layers**: each declined audit-tests recommendation references its ADR (260/261/262/263) so future audits don't re-raise them as P1
- **Compliance overlay**: public marketplace publication, third-party plugin authorship, NLPM-audit-derived security baseline

### #583 — Coverage thresholds across 6 vitest configs

The audit issue claimed "none of them configure a coverage threshold." Actual state on \`main\`:

| Config | Status before | Action |
|---|---|---|
| \`tests/e2e/vitest.config.ts\` | already 80/80/75/80 | no change |
| \`plugins/mcp/domain-memory-agent/vitest.config.ts\` | already 80/80/80/80 | no change |
| \`plugins/mcp/project-health-auditor/vitest.config.ts\` | already 80/80/80/80 | no change |
| \`plugins/mcp/conversational-api-debugger/vitest.config.ts\` | already 80/80/80/80 | no change |
| \`plugins/mcp/pr-to-spec/vitest.config.ts\` | **missing** | added 80/80/70/80 (branches relaxed — 384 tests across many edge cases) |
| \`plugins/skill-enhancers/web-to-github-issue/vitest.config.js\` | **deprecated vitest 0.x flat format** | migrated to nested \`thresholds: {}\` |

All 6 configs now meet the \`70/70/70/60\` floor declared in \`tests/TESTING.md\`.

## Test plan

- [x] \`pnpm exec audit-harness --help\` succeeds locally; \`verify\` exits 0
- [x] YAML check passes on modified \`validate-plugins.yml\`
- [x] All 6 vitest configs meet the floor declared in \`tests/TESTING.md\`
- [ ] CI: validate-plugins.yml passes including the new \`Verify audit-harness integrity\` step
- [ ] CI: \`test (mcp-plugins)\` runs vitest with thresholds enforced
- [ ] CI: marketplace-validation unaffected (no marketplace files touched)

## Sequencing

This is **PR 1 of 3** in Phase 5:
- ✅ PR 1 (this): \`#580 + #581 + #583\` — harness install, TESTING.md, coverage thresholds
- ⏳ PR 2: \`#582 + #584\` — Husky/lint-staged/commitlint + root ESLint/Prettier
- ⏳ PR 3: \`#588 + #589 + #591\` — a11y + RTM/PERSONAS/JOURNEYS (filled in, not empty) + CLI perf budget

Closes #580
Closes #581
Closes #583
Refs #592

jeremy made me do it
-claude