### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 2/6, 438 skills)

### DIFF
--- a/plugins/saas-packs/clerk-pack/skills/clerk-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-ci-integration
-description: |
-  Configure Clerk CI/CD integration with GitHub Actions and testing.
+description: 'Configure Clerk CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Clerk tests into your build process.
+
   Trigger with phrases like "clerk CI", "clerk GitHub Actions",
+
   "clerk automated tests", "CI clerk", "clerk pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, testing, ci-cd]
+tags:
+- saas
+- clerk
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk CI Integration
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-common-errors/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-common-errors
-description: |
-  Troubleshoot common Clerk errors and issues.
+description: 'Troubleshoot common Clerk errors and issues.
+
   Use when encountering authentication errors, SDK issues,
+
   or configuration problems with Clerk.
+
   Trigger with phrases like "clerk error", "clerk not working",
+
   "clerk authentication failed", "clerk issue", "fix clerk".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, authentication]
+tags:
+- saas
+- clerk
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Common Errors
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-core-workflow-a
-description: |
-  Implement user sign-up and sign-in flows with Clerk.
+description: 'Implement user sign-up and sign-in flows with Clerk.
+
   Use when building authentication UI, customizing sign-in experience,
+
   or implementing OAuth social login.
+
   Trigger with phrases like "clerk sign-in", "clerk sign-up",
+
   "clerk login flow", "clerk OAuth", "clerk social login".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, authentication]
+tags:
+- saas
+- clerk
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Core Workflow A: Sign-Up & Sign-In
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clerk-core-workflow-b
-description: |
-  Implement session management and middleware with Clerk.
+description: 'Implement session management and middleware with Clerk.
+
   Use when managing user sessions, configuring route protection,
+
   or implementing token refresh and custom JWT templates.
+
   Trigger with phrases like "clerk session", "clerk middleware",
+
   "clerk route protection", "clerk token", "clerk JWT".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, clerk-core, sessions, middleware]
+tags:
+- saas
+- clerk
+- clerk-core
+- sessions
+- middleware
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Core Workflow B: Session & Middleware
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-cost-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-cost-tuning
-description: |
-  Optimize Clerk costs and understand pricing.
+description: 'Optimize Clerk costs and understand pricing.
+
   Use when planning budget, reducing costs,
+
   or understanding Clerk pricing model.
+
   Trigger with phrases like "clerk cost", "clerk pricing",
+
   "reduce clerk cost", "clerk billing", "clerk budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, cost-optimization]
+tags:
+- saas
+- clerk
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Cost Tuning
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-data-handling/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-data-handling
-description: |
-  Handle user data, privacy, and GDPR compliance with Clerk.
+description: 'Handle user data, privacy, and GDPR compliance with Clerk.
+
   Use when implementing data export, user deletion,
+
   or privacy compliance features.
+
   Trigger with phrases like "clerk user data", "clerk GDPR",
+
   "clerk privacy", "clerk data export", "clerk delete user".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, compliance]
+tags:
+- saas
+- clerk
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Data Handling
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-debug-bundle
-description: |
-  Collect comprehensive debug information for Clerk issues.
+description: 'Collect comprehensive debug information for Clerk issues.
+
   Use when troubleshooting complex problems, preparing support tickets,
+
   or diagnosing intermittent issues.
+
   Trigger with phrases like "clerk debug", "clerk diagnostics",
+
   "clerk support ticket", "clerk troubleshooting".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, debugging]
+tags:
+- saas
+- clerk
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Debug Bundle
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-deploy-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-deploy-integration
-description: |
-  Configure Clerk for deployment on various platforms.
+description: 'Configure Clerk for deployment on various platforms.
+
   Use when deploying to Vercel, Netlify, Railway, or other platforms,
+
   or when setting up production environment.
+
   Trigger with phrases like "deploy clerk", "clerk Vercel",
+
   "clerk Netlify", "clerk production deploy", "clerk Railway".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(netlify:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, deployment, etl]
+tags:
+- saas
+- clerk
+- deployment
+- etl
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Deploy Integration
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: clerk-enterprise-rbac
-description: |
-  Configure enterprise SSO, role-based access control, and organization management.
+description: 'Configure enterprise SSO, role-based access control, and organization
+  management.
+
   Use when implementing SSO integration, configuring role-based permissions,
+
   or setting up organization-level controls.
+
   Trigger with phrases like "clerk SSO", "clerk RBAC",
+
   "clerk enterprise", "clerk roles", "clerk permissions", "clerk organizations".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, rbac, enterprise, organizations]
+tags:
+- saas
+- clerk
+- rbac
+- enterprise
+- organizations
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Enterprise RBAC
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-hello-world/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clerk-hello-world
-description: |
-  Create your first authenticated request with Clerk.
+description: 'Create your first authenticated request with Clerk.
+
   Use when making initial API calls, testing authentication,
+
   or verifying Clerk integration works correctly.
+
   Trigger with phrases like "clerk hello world", "first clerk request",
+
   "test clerk auth", "verify clerk setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, api, testing, authentication]
+tags:
+- saas
+- clerk
+- api
+- testing
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Hello World
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-incident-runbook/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clerk-incident-runbook
-description: |
-  Manage incident response for Clerk authentication issues.
+description: 'Manage incident response for Clerk authentication issues.
+
   Use when handling auth outages, security incidents,
+
   or production authentication problems.
+
   Trigger with phrases like "clerk incident", "clerk outage",
+
   "clerk down", "auth not working", "clerk emergency".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, security, authentication, incident-response]
+tags:
+- saas
+- clerk
+- security
+- authentication
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Incident Runbook
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-install-auth/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-install-auth
-description: |
-  Install and configure Clerk SDK/CLI authentication.
+description: 'Install and configure Clerk SDK/CLI authentication.
+
   Use when setting up a new Clerk integration, configuring API keys,
+
   or initializing Clerk in your project.
+
   Trigger with phrases like "install clerk", "setup clerk",
+
   "clerk auth", "configure clerk API key", "add clerk to project".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, api, authentication]
+tags:
+- saas
+- clerk
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Install & Auth
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clerk-local-dev-loop
-description: |
-  Set up local development workflow with Clerk.
+description: 'Set up local development workflow with Clerk.
+
   Use when configuring development environment, testing auth locally,
+
   or setting up hot reload with Clerk.
+
   Trigger with phrases like "clerk local dev", "clerk development",
+
   "test clerk locally", "clerk dev environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, testing, authentication, workflow]
+tags:
+- saas
+- clerk
+- testing
+- authentication
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Local Dev Loop
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-migration-deep-dive
-description: |
-  Migrate from other authentication providers to Clerk.
+description: 'Migrate from other authentication providers to Clerk.
+
   Use when migrating from Auth0, Firebase, Supabase Auth, NextAuth,
+
   or custom authentication solutions.
+
   Trigger with phrases like "migrate to clerk", "clerk migration",
+
   "switch to clerk", "auth0 to clerk", "firebase auth to clerk".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, migration, authentication]
+tags:
+- saas
+- clerk
+- migration
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Migration Deep Dive
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-multi-env-setup
-description: |
-  Configure Clerk for multiple environments (dev, staging, production).
+description: 'Configure Clerk for multiple environments (dev, staging, production).
+
   Use when setting up environment-specific configurations,
+
   managing multiple Clerk instances, or implementing environment promotion.
+
   Trigger with phrases like "clerk environments", "clerk staging",
+
   "clerk dev prod", "clerk multi-environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, clerk-multi]
+tags:
+- saas
+- clerk
+- clerk-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Multi-Environment Setup
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-observability/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clerk-observability
-description: |
-  Implement monitoring, logging, and observability for Clerk authentication.
+description: 'Implement monitoring, logging, and observability for Clerk authentication.
+
   Use when setting up monitoring, debugging auth issues in production,
+
   or implementing audit logging.
+
   Trigger with phrases like "clerk monitoring", "clerk logging",
+
   "clerk observability", "clerk metrics", "clerk audit log".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, monitoring, observability, debugging]
+tags:
+- saas
+- clerk
+- monitoring
+- observability
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Observability
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-performance-tuning
-description: |
-  Optimize Clerk authentication performance.
+description: 'Optimize Clerk authentication performance.
+
   Use when improving auth response times, reducing latency,
+
   or optimizing Clerk SDK usage.
+
   Trigger with phrases like "clerk performance", "clerk optimization",
+
   "clerk slow", "clerk latency", "optimize clerk".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, performance, authentication]
+tags:
+- saas
+- clerk
+- performance
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Performance Tuning
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-prod-checklist
-description: |
-  Production readiness checklist for Clerk deployment.
+description: 'Production readiness checklist for Clerk deployment.
+
   Use when preparing to deploy, reviewing production configuration,
+
   or auditing Clerk implementation before launch.
+
   Trigger with phrases like "clerk production", "clerk deploy checklist",
+
   "clerk go-live", "clerk launch ready".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, deployment, audit]
+tags:
+- saas
+- clerk
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Production Checklist
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-rate-limits/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-rate-limits
-description: |
-  Understand and manage Clerk rate limits and quotas.
+description: 'Understand and manage Clerk rate limits and quotas.
+
   Use when hitting rate limits, optimizing API usage,
+
   or planning for high-traffic scenarios.
+
   Trigger with phrases like "clerk rate limit", "clerk quota",
+
   "clerk API limits", "clerk throttling".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, api]
+tags:
+- saas
+- clerk
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Rate Limits
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-reference-architecture
-description: |
-  Reference architecture patterns for Clerk authentication.
+description: 'Reference architecture patterns for Clerk authentication.
+
   Use when designing application architecture, planning auth flows,
+
   or implementing enterprise-grade authentication.
+
   Trigger with phrases like "clerk architecture", "clerk design",
+
   "clerk system design", "clerk integration patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, authentication]
+tags:
+- saas
+- clerk
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Reference Architecture
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-sdk-patterns
-description: |
-  Common Clerk SDK patterns and best practices.
+description: 'Common Clerk SDK patterns and best practices.
+
   Use when implementing authentication flows, accessing user data,
+
   or integrating Clerk SDK methods in your application.
+
   Trigger with phrases like "clerk SDK", "clerk patterns",
+
   "clerk best practices", "clerk API usage".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, api, authentication]
+tags:
+- saas
+- clerk
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk SDK Patterns
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-security-basics/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-security-basics/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-security-basics
-description: |
-  Implement security best practices with Clerk authentication.
+description: 'Implement security best practices with Clerk authentication.
+
   Use when securing your application, reviewing auth implementation,
+
   or hardening Clerk configuration.
+
   Trigger with phrases like "clerk security", "secure clerk",
+
   "clerk best practices", "clerk hardening".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, security, authentication]
+tags:
+- saas
+- clerk
+- security
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Security Basics
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-upgrade-migration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clerk-upgrade-migration
-description: |
-  Manage Clerk SDK version upgrades and handle breaking changes.
+description: 'Manage Clerk SDK version upgrades and handle breaking changes.
+
   Use when upgrading Clerk packages, migrating to new SDK versions,
+
   or handling deprecation warnings.
+
   Trigger with phrases like "upgrade clerk", "clerk migration",
+
   "update clerk SDK", "clerk breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, migration]
+tags:
+- saas
+- clerk
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Upgrade & Migration
 

--- a/plugins/saas-packs/clerk-pack/skills/clerk-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clerk-webhooks-events
-description: |
-  Configure Clerk webhooks and handle authentication events.
+description: 'Configure Clerk webhooks and handle authentication events.
+
   Use when setting up user sync, handling auth events,
+
   or integrating Clerk with external systems via Svix webhooks.
+
   Trigger with phrases like "clerk webhooks", "clerk events",
+
   "clerk user sync", "clerk svix", "clerk event handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clerk, authentication, webhooks]
+tags:
+- saas
+- clerk
+- authentication
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clerk Webhooks & Events
 

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-ci-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-ci-integration
-description: |
-  Run ClickHouse integration tests in CI with GitHub Actions and Docker containers.
+description: 'Run ClickHouse integration tests in CI with GitHub Actions and Docker
+  containers.
+
   Use when setting up automated testing against a real ClickHouse instance,
+
   configuring CI pipelines, or implementing schema validation in CI.
+
   Trigger: "clickhouse CI", "clickhouse GitHub Actions", "clickhouse integration tests",
+
   "test clickhouse in CI", "clickhouse automated testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse CI Integration
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-common-errors/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-common-errors/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: clickhouse-common-errors
-description: |
-  Diagnose and fix the top 15 ClickHouse errors — query failures, insert problems,
-  memory limits, and merge issues.
-  Use when encountering ClickHouse exceptions, debugging failed queries,
-  or troubleshooting server-side errors.
-  Trigger: "clickhouse error", "fix clickhouse", "clickhouse not working",
-  "debug clickhouse", "clickhouse exception", "clickhouse syntax error".
+description: "Diagnose and fix the top 15 ClickHouse errors \u2014 query failures,\
+  \ insert problems,\nmemory limits, and merge issues.\nUse when encountering ClickHouse\
+  \ exceptions, debugging failed queries,\nor troubleshooting server-side errors.\n\
+  Trigger: \"clickhouse error\", \"fix clickhouse\", \"clickhouse not working\",\n\
+  \"debug clickhouse\", \"clickhouse exception\", \"clickhouse syntax error\".\n"
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Common Errors
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-core-workflow-a
-description: |
-  Design ClickHouse schemas with MergeTree engines, ORDER BY keys, and partitioning.
+description: 'Design ClickHouse schemas with MergeTree engines, ORDER BY keys, and
+  partitioning.
+
   Use when creating new tables, choosing engines, designing sort keys,
+
   or modeling data for analytical workloads.
+
   Trigger: "clickhouse schema design", "clickhouse table design",
+
   "clickhouse ORDER BY", "clickhouse partitioning", "MergeTree table".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Schema Design (Core Workflow A)
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clickhouse-core-workflow-b
-description: |
-  Insert, query, and aggregate data in ClickHouse with real SQL patterns.
+description: 'Insert, query, and aggregate data in ClickHouse with real SQL patterns.
+
   Use when writing analytical queries, inserting data at scale,
+
   building dashboards, or implementing materialized views.
+
   Trigger: "clickhouse query", "clickhouse insert", "clickhouse aggregate",
+
   "clickhouse materialized view", "clickhouse SQL".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Insert & Query (Core Workflow B)
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-cost-tuning/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: clickhouse-cost-tuning
-description: |
-  Optimize ClickHouse Cloud costs — compute scaling, storage tiering, compression,
-  and query efficiency for lower bills.
-  Use when analyzing ClickHouse Cloud bills, reducing storage costs,
-  or optimizing compute utilization.
-  Trigger: "clickhouse cost", "clickhouse billing", "reduce clickhouse spend",
-  "clickhouse pricing", "clickhouse expensive", "clickhouse storage cost".
+description: "Optimize ClickHouse Cloud costs \u2014 compute scaling, storage tiering,\
+  \ compression,\nand query efficiency for lower bills.\nUse when analyzing ClickHouse\
+  \ Cloud bills, reducing storage costs,\nor optimizing compute utilization.\nTrigger:\
+  \ \"clickhouse cost\", \"clickhouse billing\", \"reduce clickhouse spend\",\n\"\
+  clickhouse pricing\", \"clickhouse expensive\", \"clickhouse storage cost\".\n"
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-data-handling/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-data-handling/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: clickhouse-data-handling
-description: |
-  Handle data lifecycle in ClickHouse — TTL expiration, data deletion (GDPR),
-  column-level encryption, and audit logging with real ClickHouse SQL.
-  Use when implementing data retention, GDPR deletion requests,
-  or managing sensitive data in ClickHouse.
-  Trigger: "clickhouse data retention", "clickhouse TTL", "clickhouse GDPR",
-  "delete data clickhouse", "clickhouse data lifecycle", "clickhouse PII".
+description: "Handle data lifecycle in ClickHouse \u2014 TTL expiration, data deletion\
+  \ (GDPR),\ncolumn-level encryption, and audit logging with real ClickHouse SQL.\n\
+  Use when implementing data retention, GDPR deletion requests,\nor managing sensitive\
+  \ data in ClickHouse.\nTrigger: \"clickhouse data retention\", \"clickhouse TTL\"\
+  , \"clickhouse GDPR\",\n\"delete data clickhouse\", \"clickhouse data lifecycle\"\
+  , \"clickhouse PII\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Data Handling
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-debug-bundle/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: clickhouse-debug-bundle
-description: |
-  Collect ClickHouse diagnostic data — system tables, query logs, merge status,
-  and server metrics for support tickets and troubleshooting.
-  Use when investigating persistent issues, preparing debug artifacts,
-  or collecting evidence for ClickHouse support.
-  Trigger: "clickhouse debug", "clickhouse diagnostics", "clickhouse support bundle",
-  "collect clickhouse logs", "clickhouse system tables".
+description: "Collect ClickHouse diagnostic data \u2014 system tables, query logs,\
+  \ merge status,\nand server metrics for support tickets and troubleshooting.\nUse\
+  \ when investigating persistent issues, preparing debug artifacts,\nor collecting\
+  \ evidence for ClickHouse support.\nTrigger: \"clickhouse debug\", \"clickhouse\
+  \ diagnostics\", \"clickhouse support bundle\",\n\"collect clickhouse logs\", \"\
+  clickhouse system tables\".\n"
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-deploy-integration/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: clickhouse-deploy-integration
-description: |
-  Deploy ClickHouse-backed applications to Vercel, Fly.io, and Cloud Run with
+description: 'Deploy ClickHouse-backed applications to Vercel, Fly.io, and Cloud Run
+  with
+
   connection pooling, secrets, and health checks.
+
   Use when deploying applications that connect to ClickHouse Cloud,
+
   configuring platform secrets, or setting up deployment pipelines.
+
   Trigger: "deploy clickhouse app", "clickhouse Vercel", "clickhouse Cloud Run",
+
   "clickhouse production deploy", "clickhouse Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-enterprise-rbac/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: clickhouse-enterprise-rbac
-description: |
-  Configure ClickHouse enterprise RBAC — SQL-based users, roles, row policies,
-  column-level grants, and quota management.
-  Use when setting up multi-user access control, implementing tenant isolation,
-  or configuring enterprise security for ClickHouse.
-  Trigger: "clickhouse RBAC", "clickhouse roles", "clickhouse permissions",
-  "clickhouse row policy", "clickhouse enterprise access", "clickhouse GRANT".
+description: "Configure ClickHouse enterprise RBAC \u2014 SQL-based users, roles,\
+  \ row policies,\ncolumn-level grants, and quota management.\nUse when setting up\
+  \ multi-user access control, implementing tenant isolation,\nor configuring enterprise\
+  \ security for ClickHouse.\nTrigger: \"clickhouse RBAC\", \"clickhouse roles\",\
+  \ \"clickhouse permissions\",\n\"clickhouse row policy\", \"clickhouse enterprise\
+  \ access\", \"clickhouse GRANT\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-hello-world/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-hello-world
-description: |
-  Create your first ClickHouse table, insert data, and run analytical queries.
+description: 'Create your first ClickHouse table, insert data, and run analytical
+  queries.
+
   Use when starting a new ClickHouse project, learning MergeTree basics,
+
   or testing your ClickHouse connection with real operations.
+
   Trigger: "clickhouse hello world", "first clickhouse table",
+
   "clickhouse quick start", "create clickhouse table", "clickhouse example".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Hello World
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-incident-runbook/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: clickhouse-incident-runbook
-description: |
-  ClickHouse incident response — triage, diagnose, and remediate server issues
-  using system tables, kill stuck queries, and execute recovery procedures.
-  Use when ClickHouse is slow, unresponsive, or producing errors in production.
-  Trigger: "clickhouse incident", "clickhouse outage", "clickhouse down",
-  "clickhouse emergency", "clickhouse on-call", "clickhouse broken".
+description: "ClickHouse incident response \u2014 triage, diagnose, and remediate\
+  \ server issues\nusing system tables, kill stuck queries, and execute recovery procedures.\n\
+  Use when ClickHouse is slow, unresponsive, or producing errors in production.\n\
+  Trigger: \"clickhouse incident\", \"clickhouse outage\", \"clickhouse down\",\n\"\
+  clickhouse emergency\", \"clickhouse on-call\", \"clickhouse broken\".\n"
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-install-auth/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-install-auth
-description: |
-  Install @clickhouse/client and configure authentication to ClickHouse Cloud or self-hosted.
+description: 'Install @clickhouse/client and configure authentication to ClickHouse
+  Cloud or self-hosted.
+
   Use when setting up a new ClickHouse project, configuring connection strings,
+
   or initializing the official Node.js client.
+
   Trigger: "install clickhouse", "setup clickhouse client", "clickhouse auth",
+
   "connect to clickhouse", "clickhouse credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-local-dev-loop/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: clickhouse-local-dev-loop
-description: |
-  Run ClickHouse locally with Docker, configure test fixtures, and iterate fast.
+description: 'Run ClickHouse locally with Docker, configure test fixtures, and iterate
+  fast.
+
   Use when setting up a local ClickHouse dev environment, writing integration tests,
+
   or running ClickHouse in Docker Compose.
+
   Trigger: "clickhouse local dev", "clickhouse docker", "clickhouse dev environment",
+
   "run clickhouse locally", "clickhouse docker compose".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Bash(docker-compose:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Bash(docker-compose:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-migration-deep-dive/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: clickhouse-migration-deep-dive
-description: |
-  Execute ClickHouse schema migrations — ALTER TABLE operations, data migration
-  between engines, versioned migration runners, and zero-downtime schema changes.
-  Use when modifying ClickHouse schemas, migrating data between tables,
-  or implementing versioned migration workflows.
-  Trigger: "clickhouse migration", "clickhouse ALTER TABLE", "clickhouse schema change",
-  "migrate clickhouse", "clickhouse add column", "clickhouse schema migration".
+description: "Execute ClickHouse schema migrations \u2014 ALTER TABLE operations,\
+  \ data migration\nbetween engines, versioned migration runners, and zero-downtime\
+  \ schema changes.\nUse when modifying ClickHouse schemas, migrating data between\
+  \ tables,\nor implementing versioned migration workflows.\nTrigger: \"clickhouse\
+  \ migration\", \"clickhouse ALTER TABLE\", \"clickhouse schema change\",\n\"migrate\
+  \ clickhouse\", \"clickhouse add column\", \"clickhouse schema migration\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-multi-env-setup/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: clickhouse-multi-env-setup
-description: |
-  Configure ClickHouse across dev, staging, and production with environment-specific
+description: 'Configure ClickHouse across dev, staging, and production with environment-specific
+
   settings, secrets management, and infrastructure-as-code patterns.
+
   Use when setting up per-environment ClickHouse instances, managing connection
+
   configs, or deploying to multiple environments.
+
   Trigger: "clickhouse environments", "clickhouse dev staging prod",
+
   "clickhouse multi-env", "clickhouse environment config", "clickhouse staging setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-observability/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-observability/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: clickhouse-observability
-description: |
-  Monitor ClickHouse with Prometheus metrics, Grafana dashboards, system table queries,
+description: 'Monitor ClickHouse with Prometheus metrics, Grafana dashboards, system
+  table queries,
+
   and alerting for query performance, merge health, and resource usage.
+
   Use when setting up ClickHouse monitoring, building Grafana dashboards,
+
   or configuring alerts for production ClickHouse deployments.
+
   Trigger: "clickhouse monitoring", "clickhouse metrics", "clickhouse Grafana",
+
   "clickhouse observability", "monitor clickhouse", "clickhouse Prometheus".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Observability
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-performance-tuning/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: clickhouse-performance-tuning
-description: |
-  Optimize ClickHouse query performance with indexing, projections, settings tuning,
+description: 'Optimize ClickHouse query performance with indexing, projections, settings
+  tuning,
+
   and query analysis using system tables.
+
   Use when queries are slow, investigating performance bottlenecks,
+
   or tuning ClickHouse server settings.
-  Trigger: "clickhouse performance", "optimize clickhouse query", "clickhouse slow query",
+
+  Trigger: "clickhouse performance", "optimize clickhouse query", "clickhouse slow
+  query",
+
   "clickhouse indexing", "clickhouse tuning", "clickhouse projections".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-prod-checklist/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: clickhouse-prod-checklist
-description: |
-  Production readiness checklist for ClickHouse — server tuning, backup, monitoring,
-  and deployment verification.
-  Use when launching a ClickHouse deployment, doing go-live reviews,
-  or auditing production readiness.
-  Trigger: "clickhouse production", "clickhouse go-live", "clickhouse launch checklist",
-  "production clickhouse", "clickhouse prod ready".
+description: "Production readiness checklist for ClickHouse \u2014 server tuning,\
+  \ backup, monitoring,\nand deployment verification.\nUse when launching a ClickHouse\
+  \ deployment, doing go-live reviews,\nor auditing production readiness.\nTrigger:\
+  \ \"clickhouse production\", \"clickhouse go-live\", \"clickhouse launch checklist\"\
+  ,\n\"production clickhouse\", \"clickhouse prod ready\".\n"
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-rate-limits/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-rate-limits/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-rate-limits
-description: |
-  Configure ClickHouse query concurrency, memory quotas, and connection limits.
+description: 'Configure ClickHouse query concurrency, memory quotas, and connection
+  limits.
+
   Use when hitting "too many simultaneous queries", managing concurrent users,
+
   or tuning server-side resource limits.
+
   Trigger: "clickhouse rate limit", "clickhouse concurrency", "clickhouse quota",
+
   "too many simultaneous queries", "clickhouse connection limit".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Rate Limits & Concurrency
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-reference-architecture/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: clickhouse-reference-architecture
-description: |
-  Production reference architecture for ClickHouse-backed applications —
-  project layout, data flow, multi-tenant patterns, and operational topology.
-  Use when designing new ClickHouse systems, reviewing architecture,
-  or establishing standards for ClickHouse integrations.
-  Trigger: "clickhouse architecture", "clickhouse project structure",
-  "clickhouse design", "clickhouse multi-tenant", "clickhouse reference".
+description: "Production reference architecture for ClickHouse-backed applications\
+  \ \u2014\nproject layout, data flow, multi-tenant patterns, and operational topology.\n\
+  Use when designing new ClickHouse systems, reviewing architecture,\nor establishing\
+  \ standards for ClickHouse integrations.\nTrigger: \"clickhouse architecture\",\
+  \ \"clickhouse project structure\",\n\"clickhouse design\", \"clickhouse multi-tenant\"\
+  , \"clickhouse reference\".\n"
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-sdk-patterns/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: clickhouse-sdk-patterns
-description: |
-  Production-ready patterns for @clickhouse/client — streaming inserts, typed queries,
-  error handling, and connection management.
-  Use when building robust ClickHouse integrations, implementing streaming,
-  or establishing team coding standards.
-  Trigger: "clickhouse SDK patterns", "clickhouse client patterns",
-  "clickhouse best practices", "clickhouse streaming insert".
+description: "Production-ready patterns for @clickhouse/client \u2014 streaming inserts,\
+  \ typed queries,\nerror handling, and connection management.\nUse when building\
+  \ robust ClickHouse integrations, implementing streaming,\nor establishing team\
+  \ coding standards.\nTrigger: \"clickhouse SDK patterns\", \"clickhouse client patterns\"\
+  ,\n\"clickhouse best practices\", \"clickhouse streaming insert\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-security-basics/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-security-basics/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-security-basics
-description: |
-  Secure ClickHouse with user management, network restrictions, TLS, and audit logging.
+description: 'Secure ClickHouse with user management, network restrictions, TLS, and
+  audit logging.
+
   Use when hardening a ClickHouse deployment, creating restricted users,
+
   or configuring network-level access controls.
+
   Trigger: "clickhouse security", "clickhouse user management", "secure clickhouse",
+
   "clickhouse TLS", "clickhouse access control", "clickhouse firewall".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Security Basics
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-upgrade-migration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clickhouse-upgrade-migration
-description: |
-  Upgrade ClickHouse server versions and @clickhouse/client SDK safely.
+description: 'Upgrade ClickHouse server versions and @clickhouse/client SDK safely.
+
   Use when upgrading ClickHouse, handling breaking changes between versions,
+
   or migrating from older client libraries.
-  Trigger: "upgrade clickhouse", "clickhouse version upgrade", "update clickhouse client",
+
+  Trigger: "upgrade clickhouse", "clickhouse version upgrade", "update clickhouse
+  client",
+
   "clickhouse breaking changes", "new clickhouse version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/clickhouse-pack/skills/clickhouse-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clickhouse-pack/skills/clickhouse-webhooks-events/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: clickhouse-webhooks-events
-description: |
-  Ingest data into ClickHouse from webhooks, Kafka, and streaming sources
+description: 'Ingest data into ClickHouse from webhooks, Kafka, and streaming sources
+
   with batching, dedup, and exactly-once patterns.
+
   Use when building data ingestion pipelines, consuming webhook payloads,
+
   or integrating Kafka topics into ClickHouse.
+
   Trigger: "clickhouse ingestion", "clickhouse webhook", "clickhouse Kafka",
+
   "stream data to clickhouse", "clickhouse data pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, database, analytics, clickhouse, olap]
-compatible-with: claude-code
+tags:
+- saas
+- database
+- analytics
+- clickhouse
+- olap
+compatibility: Designed for Claude Code
 ---
-
 # ClickHouse Data Ingestion
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-ci-integration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-ci-integration
-description: |
-  Set up CI/CD pipelines for ClickUp API integrations with GitHub Actions,
+description: 'Set up CI/CD pipelines for ClickUp API integrations with GitHub Actions,
+
   automated testing, and task status sync.
+
   Trigger: "clickup CI", "clickup GitHub Actions", "clickup automated tests",
+
   "CI clickup integration", "clickup pipeline", "clickup CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp CI Integration
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-common-errors/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: clickup-common-errors
-description: |
-  Diagnose and fix ClickUp API v2 errors by HTTP status and error code.
+description: 'Diagnose and fix ClickUp API v2 errors by HTTP status and error code.
+
   Use when encountering ClickUp API errors, debugging failed requests,
+
   or troubleshooting OAUTH_* error codes, 401s, 429s, and 500s.
+
   Trigger: "clickup error", "fix clickup", "clickup not working",
+
   "clickup 401", "clickup 429", "OAUTH error", "debug clickup API".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Common Errors
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: clickup-core-workflow-a
-description: |
-  Manage ClickUp tasks via API v2: create, read, update, delete tasks with
+description: 'Manage ClickUp tasks via API v2: create, read, update, delete tasks
+  with
+
   assignees, priorities, due dates, subtasks, and statuses.
+
   Trigger: "clickup task", "create clickup task", "update task status",
+
   "manage clickup tasks", "clickup CRUD", "clickup task management".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Core Workflow A — Task Management
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clickup-core-workflow-b
-description: |
-  Manage ClickUp workspaces, spaces, folders, lists, and views via API v2.
+description: 'Manage ClickUp workspaces, spaces, folders, lists, and views via API
+  v2.
+
   Use when creating project structures, organizing spaces and lists,
+
   or managing the ClickUp hierarchy programmatically.
+
   Trigger: "clickup space", "clickup folder", "clickup list", "clickup views",
+
   "create clickup space", "organize clickup workspace", "clickup hierarchy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Core Workflow B — Spaces, Folders, Lists & Views
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-cost-tuning/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-cost-tuning
-description: |
-  Optimize ClickUp API usage costs through plan selection, request reduction,
+description: 'Optimize ClickUp API usage costs through plan selection, request reduction,
+
   caching, and usage monitoring.
+
   Trigger: "clickup cost", "clickup billing", "reduce clickup usage",
+
   "clickup pricing", "clickup plan comparison", "clickup API usage".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-data-handling/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-data-handling/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-data-handling
-description: |
-  Handle ClickUp data exports, PII redaction, GDPR compliance, and
+description: 'Handle ClickUp data exports, PII redaction, GDPR compliance, and
+
   data retention for ClickUp API integrations.
+
   Trigger: "clickup data", "clickup PII", "clickup GDPR", "clickup data retention",
+
   "clickup privacy", "clickup CCPA", "clickup data export".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Data Handling
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: clickup-debug-bundle
-description: |
-  Collect ClickUp API diagnostic information for troubleshooting and support.
+description: 'Collect ClickUp API diagnostic information for troubleshooting and support.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting API connectivity and rate limit diagnostics.
+
   Trigger: "clickup debug", "clickup diagnostics", "clickup support bundle",
+
   "collect clickup logs", "clickup health check".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-deploy-integration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-deploy-integration
-description: |
-  Deploy ClickUp API integrations to Vercel, Fly.io, and Cloud Run with
+description: 'Deploy ClickUp API integrations to Vercel, Fly.io, and Cloud Run with
+
   secure secrets management and health checks.
+
   Trigger: "deploy clickup", "clickup Vercel", "clickup production deploy",
+
   "clickup Cloud Run", "clickup Fly.io", "clickup hosting".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-enterprise-rbac/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-enterprise-rbac
-description: |
-  Implement ClickUp Enterprise SSO, OAuth 2.0 multi-workspace access,
+description: 'Implement ClickUp Enterprise SSO, OAuth 2.0 multi-workspace access,
+
   role-based permissions, and organization management via API v2.
+
   Trigger: "clickup SSO", "clickup RBAC", "clickup enterprise",
+
   "clickup roles", "clickup permissions", "clickup OAuth app", "clickup multi-workspace".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-hello-world/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clickup-hello-world
-description: |
-  Make your first ClickUp API v2 calls: list workspaces, spaces, and create a task.
+description: 'Make your first ClickUp API v2 calls: list workspaces, spaces, and create
+  a task.
+
   Use when starting a new ClickUp integration, testing your setup,
+
   or learning the ClickUp hierarchy (Workspace, Space, Folder, List, Task).
+
   Trigger: "clickup hello world", "clickup first call", "clickup quick start",
+
   "test clickup API", "create clickup task".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Hello World
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-incident-runbook/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-incident-runbook
-description: |
-  Execute ClickUp API incident response: triage, diagnosis, mitigation,
+description: 'Execute ClickUp API incident response: triage, diagnosis, mitigation,
+
   and postmortem for API failures and integration outages.
+
   Trigger: "clickup incident", "clickup outage", "clickup down",
+
   "clickup on-call", "clickup emergency", "clickup API broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-install-auth/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: clickup-install-auth
-description: |
-  Set up ClickUp API v2 authentication with personal tokens or OAuth 2.0.
+description: 'Set up ClickUp API v2 authentication with personal tokens or OAuth 2.0.
+
   Use when configuring a new ClickUp integration, setting up API access,
+
   or initializing OAuth flows for multi-user apps.
+
   Trigger: "install clickup", "setup clickup auth", "clickup API token",
+
   "clickup OAuth", "configure clickup credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-local-dev-loop/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-local-dev-loop
-description: |
-  Set up local development for ClickUp API integrations with testing,
+description: 'Set up local development for ClickUp API integrations with testing,
+
   mocking, and hot reload.
+
   Trigger: "clickup dev setup", "clickup local development", "clickup dev environment",
+
   "develop with clickup", "clickup testing setup", "mock clickup API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clickup-migration-deep-dive
-description: |
-  Migrate to ClickUp from other project management tools (Jira, Asana, Trello)
+description: 'Migrate to ClickUp from other project management tools (Jira, Asana,
+  Trello)
+
   or migrate data between ClickUp workspaces using API v2.
+
   Trigger: "migrate to clickup", "clickup migration", "jira to clickup",
+
   "asana to clickup", "trello to clickup", "clickup data migration",
+
   "move tasks to clickup", "clickup import".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-multi-env-setup/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-multi-env-setup
-description: |
-  Configure ClickUp API access across dev, staging, and production environments
+description: 'Configure ClickUp API access across dev, staging, and production environments
+
   with per-environment tokens and workspace isolation.
+
   Trigger: "clickup environments", "clickup staging", "clickup dev prod",
+
   "clickup environment setup", "clickup config by env", "clickup multi-env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-observability/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-observability/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-observability
-description: |
-  Monitor ClickUp API integrations with metrics, tracing, structured logging,
+description: 'Monitor ClickUp API integrations with metrics, tracing, structured logging,
+
   and alerting using Prometheus, OpenTelemetry, and Grafana.
+
   Trigger: "clickup monitoring", "clickup metrics", "clickup observability",
+
   "monitor clickup", "clickup alerts", "clickup tracing", "clickup dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Observability
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-performance-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: clickup-performance-tuning
-description: |
-  Optimize ClickUp API v2 performance with caching, pagination, connection pooling,
+description: 'Optimize ClickUp API v2 performance with caching, pagination, connection
+  pooling,
+
   and request batching patterns.
+
   Trigger: "clickup performance", "optimize clickup", "clickup latency",
+
   "clickup caching", "clickup slow", "clickup batch requests", "clickup pagination".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-prod-checklist/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-prod-checklist
-description: |
-  Production readiness checklist for ClickUp API v2 integrations covering
+description: 'Production readiness checklist for ClickUp API v2 integrations covering
+
   auth, rate limits, error handling, monitoring, and rollback.
+
   Trigger: "clickup production", "clickup go-live", "clickup launch checklist",
+
   "clickup prod ready", "deploy clickup to production".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-rate-limits/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: clickup-rate-limits
-description: |
-  Handle ClickUp API rate limits with backoff, queuing, and header monitoring.
+description: 'Handle ClickUp API rate limits with backoff, queuing, and header monitoring.
+
   Use when hitting 429 errors, implementing retry logic, or optimizing
-  API throughput against ClickUp's per-plan rate limits.
+
+  API throughput against ClickUp''s per-plan rate limits.
+
   Trigger: "clickup rate limit", "clickup 429", "clickup throttling",
+
   "clickup retry", "clickup backoff", "clickup request queue".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-reference-architecture/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: clickup-reference-architecture
-description: |
-  Production architecture for ClickUp API v2 integrations with layered design,
+description: 'Production architecture for ClickUp API v2 integrations with layered
+  design,
+
   custom fields, time tracking, goals, and two-way sync patterns.
+
   Trigger: "clickup architecture", "clickup design", "clickup project structure",
+
   "clickup custom fields", "clickup time tracking", "clickup goals API".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-sdk-patterns/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clickup-sdk-patterns
-description: |
-  Production-ready ClickUp API v2 client patterns with typed wrappers,
+description: 'Production-ready ClickUp API v2 client patterns with typed wrappers,
+
   error handling, caching, and multi-tenant support.
+
   Trigger: "clickup client wrapper", "clickup SDK patterns", "clickup best practices",
+
   "clickup typescript client", "clickup API wrapper", "production clickup code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-security-basics/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clickup-security-basics
-description: |
-  Secure ClickUp API tokens, implement least-privilege access, and audit usage.
+description: 'Secure ClickUp API tokens, implement least-privilege access, and audit
+  usage.
+
   Use when securing API keys, rotating tokens, configuring per-environment
+
   credentials, or auditing ClickUp API access patterns.
+
   Trigger: "clickup security", "clickup secrets", "secure clickup token",
+
   "clickup API key rotation", "clickup access audit".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Security Basics
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clickup-upgrade-migration
-description: |
-  Migrate between ClickUp API versions (v2 to v3) and handle breaking changes.
+description: 'Migrate between ClickUp API versions (v2 to v3) and handle breaking
+  changes.
+
   Use when upgrading API versions, adapting to endpoint changes,
+
   or migrating between ClickUp plan tiers.
+
   Trigger: "upgrade clickup API", "clickup v2 to v3", "clickup breaking changes",
+
   "clickup API migration", "clickup deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/clickup-pack/skills/clickup-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clickup-pack/skills/clickup-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: clickup-webhooks-events
-description: |
-  Create and manage ClickUp webhooks for real-time event notifications.
+description: 'Create and manage ClickUp webhooks for real-time event notifications.
+
   Use when setting up webhook listeners for task/list/space events,
+
   implementing two-way sync, or handling ClickUp event payloads.
+
   Trigger: "clickup webhook", "clickup events", "clickup notifications",
+
   "clickup real-time", "clickup event listener", "clickup webhook create".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, clickup]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- clickup
+compatibility: Designed for Claude Code
 ---
-
 # ClickUp Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-ci-integration/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-ci-integration
-description: |
-  Configure CodeRabbit as a CI gate with GitHub Actions, branch protection, and review enforcement.
+description: 'Configure CodeRabbit as a CI gate with GitHub Actions, branch protection,
+  and review enforcement.
+
   Use when setting up CodeRabbit as a required check, gating merges on review approval,
+
   or integrating CodeRabbit status into your CI pipeline.
+
   Trigger with phrases like "coderabbit CI", "coderabbit GitHub Actions",
+
   "coderabbit required check", "coderabbit merge gate", "coderabbit CI pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, ci-cd, github-actions]
+tags:
+- saas
+- coderabbit
+- ci-cd
+- github-actions
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit CI Integration
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-common-errors/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: coderabbit-common-errors
-description: |
-  Diagnose and fix CodeRabbit common errors and configuration issues.
+description: 'Diagnose and fix CodeRabbit common errors and configuration issues.
+
   Use when CodeRabbit is not reviewing PRs, posting duplicate comments,
+
   ignoring configuration, or behaving unexpectedly.
+
   Trigger with phrases like "coderabbit error", "fix coderabbit",
+
   "coderabbit not working", "debug coderabbit", "coderabbit broken".
+
+  '
 allowed-tools: Read, Grep, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, debugging, troubleshooting]
+tags:
+- saas
+- coderabbit
+- debugging
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Common Errors
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: coderabbit-core-workflow-a
-description: |
-  Execute CodeRabbit primary workflow: automated PR code review with configuration.
+description: 'Execute CodeRabbit primary workflow: automated PR code review with configuration.
+
   Use when setting up automated code reviews on pull requests,
+
   configuring review behavior, or establishing the core CodeRabbit review loop.
+
   Trigger with phrases like "coderabbit review workflow", "coderabbit PR review",
+
   "coderabbit auto review", "configure coderabbit reviews".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, workflow, code-review]
+tags:
+- saas
+- coderabbit
+- workflow
+- code-review
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Core Workflow A: Automated PR Review
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-core-workflow-b
-description: |
-  Tune CodeRabbit review configuration: learnings, code guidelines, and noise reduction.
+description: 'Tune CodeRabbit review configuration: learnings, code guidelines, and
+  noise reduction.
+
   Use when fine-tuning review quality, training CodeRabbit with team preferences,
+
   adding code guidelines, or reducing false positives.
+
   Trigger with phrases like "coderabbit tune reviews", "coderabbit learnings",
+
   "coderabbit guidelines", "reduce coderabbit noise", "coderabbit false positives".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, workflow, tuning, learnings]
+tags:
+- saas
+- coderabbit
+- workflow
+- tuning
+- learnings
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Core Workflow B: Learnings & Tuning
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-cost-tuning
-description: |
-  Optimize CodeRabbit costs through seat management, repo selection, and review scope tuning.
+description: 'Optimize CodeRabbit costs through seat management, repo selection, and
+  review scope tuning.
+
   Use when analyzing CodeRabbit billing, reducing per-seat costs,
+
   or implementing usage monitoring and budget optimization.
+
   Trigger with phrases like "coderabbit cost", "coderabbit billing",
-  "reduce coderabbit costs", "coderabbit pricing", "coderabbit expensive", "coderabbit budget".
+
+  "reduce coderabbit costs", "coderabbit pricing", "coderabbit expensive", "coderabbit
+  budget".
+
+  '
 allowed-tools: Read, Grep, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, cost-optimization, billing]
+tags:
+- saas
+- coderabbit
+- cost-optimization
+- billing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Cost Tuning
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-data-handling/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-data-handling/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-data-handling
-description: |
-  Implement CodeRabbit PII handling, data retention, and GDPR/CCPA compliance patterns.
-  Use when handling sensitive data, implementing data redaction, configuring retention policies,
+description: 'Implement CodeRabbit PII handling, data retention, and GDPR/CCPA compliance
+  patterns.
+
+  Use when handling sensitive data, implementing data redaction, configuring retention
+  policies,
+
   or ensuring compliance with privacy regulations for CodeRabbit integrations.
+
   Trigger with phrases like "coderabbit data", "coderabbit PII",
-  "coderabbit GDPR", "coderabbit data retention", "coderabbit privacy", "coderabbit CCPA".
+
+  "coderabbit GDPR", "coderabbit data retention", "coderabbit privacy", "coderabbit
+  CCPA".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, compliance]
+tags:
+- saas
+- coderabbit
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Data Handling
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: coderabbit-debug-bundle
-description: |
-  Collect CodeRabbit debug evidence for support tickets and troubleshooting.
+description: 'Collect CodeRabbit debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for CodeRabbit problems.
+
   Trigger with phrases like "coderabbit debug", "coderabbit support bundle",
+
   "coderabbit diagnostic", "coderabbit not working evidence".
+
+  '
 allowed-tools: Read, Bash(gh:*), Bash(git:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, debugging, support]
+tags:
+- saas
+- coderabbit
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Debug Bundle
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-deploy-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-deploy-integration
-description: |
-  Roll out CodeRabbit across an organization: multi-repo deployment, org-level config, and team onboarding.
+description: 'Roll out CodeRabbit across an organization: multi-repo deployment, org-level
+  config, and team onboarding.
+
   Use when deploying CodeRabbit org-wide, creating shared configurations,
+
   or onboarding development teams to AI code review.
+
   Trigger with phrases like "deploy coderabbit", "coderabbit org rollout",
+
   "coderabbit multi-repo", "coderabbit onboarding", "coderabbit team setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, deployment, onboarding]
+tags:
+- saas
+- coderabbit
+- deployment
+- onboarding
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Deploy Integration
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-enterprise-rbac/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: coderabbit-enterprise-rbac
-description: |
-  Configure CodeRabbit enterprise access control, seat management, and organization policies.
+description: 'Configure CodeRabbit enterprise access control, seat management, and
+  organization policies.
+
   Use when managing who gets AI reviews, configuring organization-level defaults,
+
   or implementing access policies for CodeRabbit across teams.
+
   Trigger with phrases like "coderabbit SSO", "coderabbit RBAC",
-  "coderabbit enterprise", "coderabbit roles", "coderabbit permissions", "coderabbit seats".
+
+  "coderabbit enterprise", "coderabbit roles", "coderabbit permissions", "coderabbit
+  seats".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, enterprise, rbac, access-control]
+tags:
+- saas
+- coderabbit
+- enterprise
+- rbac
+- access-control
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Enterprise RBAC
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-hello-world/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-hello-world
-description: |
-  Create a minimal working CodeRabbit configuration and trigger your first AI review.
+description: 'Create a minimal working CodeRabbit configuration and trigger your first
+  AI review.
+
   Use when starting with CodeRabbit, testing your setup,
+
   or learning basic .coderabbit.yaml patterns.
+
   Trigger with phrases like "coderabbit hello world", "coderabbit example",
+
   "coderabbit quick start", "first coderabbit review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, quickstart, testing]
+tags:
+- saas
+- coderabbit
+- quickstart
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Hello World
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-incident-runbook/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-incident-runbook
-description: |
-  Execute CodeRabbit incident response procedures when reviews stop working or block PRs.
+description: 'Execute CodeRabbit incident response procedures when reviews stop working
+  or block PRs.
+
   Use when CodeRabbit is down, reviews are not posting, PRs are blocked by stale checks,
+
   or CodeRabbit is producing incorrect reviews.
+
   Trigger with phrases like "coderabbit incident", "coderabbit outage",
-  "coderabbit down", "coderabbit broken", "coderabbit emergency", "coderabbit not reviewing".
+
+  "coderabbit down", "coderabbit broken", "coderabbit emergency", "coderabbit not
+  reviewing".
+
+  '
 allowed-tools: Read, Grep, Bash(gh:*), Bash(curl:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, incident-response, runbook]
+tags:
+- saas
+- coderabbit
+- incident-response
+- runbook
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Incident Runbook
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-install-auth/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-install-auth
-description: |
-  Install and configure CodeRabbit AI code review on GitHub or GitLab repositories.
+description: 'Install and configure CodeRabbit AI code review on GitHub or GitLab
+  repositories.
+
   Use when setting up CodeRabbit for the first time, installing the GitHub App,
+
   configuring the CLI, or connecting CodeRabbit to your repositories.
+
   Trigger with phrases like "install coderabbit", "setup coderabbit",
+
   "coderabbit auth", "configure coderabbit", "add coderabbit to repo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, authentication, setup]
+tags:
+- saas
+- coderabbit
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Install & Auth
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-local-dev-loop/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-local-dev-loop
-description: |
-  Configure CodeRabbit CLI for local pre-commit code reviews and fast iteration.
+description: 'Configure CodeRabbit CLI for local pre-commit code reviews and fast
+  iteration.
+
   Use when setting up local development with CodeRabbit CLI reviews,
+
   integrating AI review into your commit workflow, or testing config changes.
+
   Trigger with phrases like "coderabbit dev setup", "coderabbit local development",
+
   "coderabbit CLI workflow", "coderabbit pre-commit review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(cr:*), Bash(git:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, cli, workflow, development]
+tags:
+- saas
+- coderabbit
+- cli
+- workflow
+- development
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Local Dev Loop
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-migration-deep-dive/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-migration-deep-dive
-description: |
-  Migrate to CodeRabbit from other code review tools or roll out across a large organization.
+description: 'Migrate to CodeRabbit from other code review tools or roll out across
+  a large organization.
+
   Use when switching from another AI review tool, migrating from manual-only reviews,
+
   or planning a phased CodeRabbit adoption strategy.
+
   Trigger with phrases like "migrate to coderabbit", "coderabbit migration",
-  "switch to coderabbit", "coderabbit from reviewbot", "adopt coderabbit", "replace code review tool".
+
+  "switch to coderabbit", "coderabbit from reviewbot", "adopt coderabbit", "replace
+  code review tool".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, migration, adoption]
+tags:
+- saas
+- coderabbit
+- migration
+- adoption
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Migration Deep Dive
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-multi-env-setup/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: coderabbit-multi-env-setup
-description: |
-  Configure CodeRabbit review behavior per branch and environment using path instructions and base branches.
-  Use when setting different review profiles per branch, configuring stricter reviews for release branches,
+description: 'Configure CodeRabbit review behavior per branch and environment using
+  path instructions and base branches.
+
+  Use when setting different review profiles per branch, configuring stricter reviews
+  for release branches,
+
   or customizing CodeRabbit behavior across dev/staging/prod workflows.
+
   Trigger with phrases like "coderabbit environments", "coderabbit staging",
-  "coderabbit per-branch config", "coderabbit release review", "coderabbit environment setup".
+
+  "coderabbit per-branch config", "coderabbit release review", "coderabbit environment
+  setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, environments, branching]
+tags:
+- saas
+- coderabbit
+- environments
+- branching
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Multi-Environment Setup
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-observability/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-observability/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: coderabbit-observability
-description: |
-  Monitor CodeRabbit review effectiveness with metrics, dashboards, and alerts.
+description: 'Monitor CodeRabbit review effectiveness with metrics, dashboards, and
+  alerts.
+
   Use when tracking review coverage, measuring comment acceptance rates,
+
   or building dashboards for CodeRabbit adoption across your organization.
+
   Trigger with phrases like "coderabbit monitoring", "coderabbit metrics",
-  "coderabbit observability", "monitor coderabbit", "coderabbit alerts", "coderabbit dashboard".
+
+  "coderabbit observability", "monitor coderabbit", "coderabbit alerts", "coderabbit
+  dashboard".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, monitoring, observability, metrics]
+tags:
+- saas
+- coderabbit
+- monitoring
+- observability
+- metrics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Observability
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-performance-tuning
-description: |
-  Optimize CodeRabbit review speed, relevance, and signal-to-noise ratio.
+description: 'Optimize CodeRabbit review speed, relevance, and signal-to-noise ratio.
+
   Use when reviews take too long, contain too many irrelevant comments,
+
   or when teams are experiencing review fatigue.
+
   Trigger with phrases like "coderabbit performance", "optimize coderabbit",
-  "coderabbit slow", "coderabbit noise", "coderabbit too many comments", "coderabbit relevance".
+
+  "coderabbit slow", "coderabbit noise", "coderabbit too many comments", "coderabbit
+  relevance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, performance, tuning]
+tags:
+- saas
+- coderabbit
+- performance
+- tuning
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Performance Tuning
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-prod-checklist
-description: |
-  Execute CodeRabbit production readiness checklist for org-wide deployment.
+description: 'Execute CodeRabbit production readiness checklist for org-wide deployment.
+
   Use when preparing to enforce CodeRabbit reviews, going live with required checks,
+
   or auditing CodeRabbit configuration before making it a merge gate.
+
   Trigger with phrases like "coderabbit production", "coderabbit go-live",
+
   "coderabbit launch checklist", "coderabbit readiness", "coderabbit pre-launch".
+
+  '
 allowed-tools: Read, Bash(gh:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, deployment, production, checklist]
+tags:
+- saas
+- coderabbit
+- deployment
+- production
+- checklist
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Production Checklist
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-rate-limits/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-rate-limits/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-rate-limits
-description: |
-  Understand and handle CodeRabbit and GitHub API rate limits for review automation.
+description: 'Understand and handle CodeRabbit and GitHub API rate limits for review
+  automation.
+
   Use when hitting rate limits on @coderabbitai commands, automating review queries,
+
   or building scripts that interact with CodeRabbit via the GitHub API.
+
   Trigger with phrases like "coderabbit rate limit", "coderabbit throttling",
+
   "coderabbit too many requests", "github api rate limit coderabbit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, rate-limits, github-api]
+tags:
+- saas
+- coderabbit
+- rate-limits
+- github-api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Rate Limits
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-reference-architecture/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-reference-architecture
-description: |
-  Implement CodeRabbit reference architecture with production-grade .coderabbit.yaml configuration.
+description: 'Implement CodeRabbit reference architecture with production-grade .coderabbit.yaml
+  configuration.
+
   Use when designing review configuration for a new project, establishing team standards,
+
   or building a comprehensive review setup from scratch.
+
   Trigger with phrases like "coderabbit architecture", "coderabbit best practices",
-  "coderabbit project structure", "coderabbit reference config", "coderabbit full setup".
+
+  "coderabbit project structure", "coderabbit reference config", "coderabbit full
+  setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, reference-architecture, best-practices]
+tags:
+- saas
+- coderabbit
+- reference-architecture
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Reference Architecture
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-sdk-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: coderabbit-sdk-patterns
-description: |
-  Apply production-ready CodeRabbit automation patterns using GitHub API and PR comments.
+description: 'Apply production-ready CodeRabbit automation patterns using GitHub API
+  and PR comments.
+
   Use when building automation around CodeRabbit reviews, processing review feedback
+
   programmatically, or integrating CodeRabbit into custom workflows.
+
   Trigger with phrases like "coderabbit automation", "coderabbit API patterns",
+
   "automate coderabbit", "coderabbit github api", "process coderabbit reviews".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, automation, github-api, typescript]
+tags:
+- saas
+- coderabbit
+- automation
+- github-api
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit SDK Patterns
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-security-basics/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-security-basics/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: coderabbit-security-basics
-description: |
-  Configure CodeRabbit for security-focused code review with secret detection and vulnerability scanning.
+description: 'Configure CodeRabbit for security-focused code review with secret detection
+  and vulnerability scanning.
+
   Use when setting up security review rules, configuring secret detection in PRs,
+
   or hardening CodeRabbit configuration for compliance requirements.
+
   Trigger with phrases like "coderabbit security", "coderabbit secrets",
-  "secure coderabbit", "coderabbit vulnerability detection", "coderabbit security review".
+
+  "secure coderabbit", "coderabbit vulnerability detection", "coderabbit security
+  review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, security, secrets, compliance]
+tags:
+- saas
+- coderabbit
+- security
+- secrets
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Security Basics
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: coderabbit-upgrade-migration
-description: |
-  Update CodeRabbit configuration for new features, migrate between plans, and adopt new capabilities.
+description: 'Update CodeRabbit configuration for new features, migrate between plans,
+  and adopt new capabilities.
+
   Use when CodeRabbit releases new features, upgrading from Free to Pro plan,
+
   or updating .coderabbit.yaml schema for new options.
+
   Trigger with phrases like "upgrade coderabbit", "coderabbit new features",
+
   "update coderabbit config", "coderabbit plan upgrade", "coderabbit changelog".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, migration, upgrade]
+tags:
+- saas
+- coderabbit
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Upgrade & Migration
 

--- a/plugins/saas-packs/coderabbit-pack/skills/coderabbit-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/coderabbit-pack/skills/coderabbit-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: coderabbit-webhooks-events
-description: |
-  Implement CodeRabbit webhook signature validation and event handling.
+description: 'Implement CodeRabbit webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling CodeRabbit event notifications securely.
+
   Trigger with phrases like "coderabbit webhook", "coderabbit events",
+
   "coderabbit webhook signature", "handle coderabbit events", "coderabbit notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, coderabbit, webhooks]
+tags:
+- saas
+- coderabbit
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # CodeRabbit Webhooks & Events
 

--- a/plugins/saas-packs/cohere-pack/skills/cohere-ci-integration/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-ci-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-ci-integration
-description: |
-  Configure CI/CD for Cohere integrations with GitHub Actions and automated testing.
+description: 'Configure CI/CD for Cohere integrations with GitHub Actions and automated
+  testing.
+
   Use when setting up automated testing for Chat/Embed/Rerank,
+
   configuring CI pipelines, or testing Cohere-powered applications.
+
   Trigger with phrases like "cohere CI", "cohere GitHub Actions",
+
   "cohere automated tests", "CI cohere", "cohere pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere CI Integration
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-common-errors/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-common-errors
-description: |
-  Diagnose and fix Cohere API v2 errors and exceptions.
+description: 'Diagnose and fix Cohere API v2 errors and exceptions.
+
   Use when encountering Cohere errors, debugging failed requests,
+
   or troubleshooting CohereError, CohereTimeoutError, rate limits.
+
   Trigger with phrases like "cohere error", "fix cohere",
+
   "cohere not working", "debug cohere", "cohere 429", "cohere 400".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Common Errors
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-core-workflow-a
-description: |
-  Build a complete RAG pipeline with Cohere Chat, Embed, and Rerank.
+description: 'Build a complete RAG pipeline with Cohere Chat, Embed, and Rerank.
+
   Use when implementing retrieval-augmented generation, building
+
   grounded Q&A systems, or combining search with LLM generation.
+
   Trigger with phrases like "cohere RAG", "cohere retrieval",
+
   "cohere grounded generation", "cohere search and answer".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere RAG Pipeline (Core Workflow A)
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-core-workflow-b
-description: |
-  Build tool-use agents and function calling with Cohere API v2.
+description: 'Build tool-use agents and function calling with Cohere API v2.
+
   Use when implementing multi-step agents, function calling,
+
   or building autonomous tool-using workflows with Cohere.
+
   Trigger with phrases like "cohere tool use", "cohere agents",
+
   "cohere function calling", "cohere multi-step".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Tool Use & Agents (Core Workflow B)
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-cost-tuning
-description: |
-  Optimize Cohere costs through model selection, token budgets, and usage monitoring.
+description: 'Optimize Cohere costs through model selection, token budgets, and usage
+  monitoring.
+
   Use when analyzing Cohere billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "cohere cost", "cohere billing",
+
   "reduce cohere costs", "cohere pricing", "cohere expensive", "cohere budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-data-handling/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-data-handling/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-data-handling
-description: |
-  Implement data privacy for Cohere API calls with PII redaction and compliance.
+description: 'Implement data privacy for Cohere API calls with PII redaction and compliance.
+
   Use when handling sensitive data, implementing PII redaction before API calls,
+
   or ensuring GDPR/CCPA compliance with Cohere integrations.
+
   Trigger with phrases like "cohere data", "cohere PII",
+
   "cohere GDPR", "cohere data retention", "cohere privacy", "cohere redact".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Data Handling
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-debug-bundle
-description: |
-  Collect Cohere debug evidence for support tickets and troubleshooting.
+description: 'Collect Cohere debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Cohere API problems.
+
   Trigger with phrases like "cohere debug", "cohere support bundle",
+
   "collect cohere logs", "cohere diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-deploy-integration
-description: |
-  Deploy Cohere-powered applications to Vercel, Fly.io, and Cloud Run.
+description: 'Deploy Cohere-powered applications to Vercel, Fly.io, and Cloud Run.
+
   Use when deploying Cohere API v2 apps to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy cohere", "cohere Vercel",
+
   "cohere production deploy", "cohere Cloud Run", "cohere Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-enterprise-rbac/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-enterprise-rbac
-description: |
-  Configure Cohere enterprise API key management, role-based access, and org controls.
+description: 'Configure Cohere enterprise API key management, role-based access, and
+  org controls.
+
   Use when implementing multi-team API key management, per-team usage limits,
+
   or setting up organization-level controls for Cohere.
+
   Trigger with phrases like "cohere enterprise", "cohere RBAC",
+
   "cohere team keys", "cohere org management", "cohere access control".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-hello-world/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-hello-world
-description: |
-  Create a minimal working Cohere example with Chat, Embed, and Rerank.
+description: 'Create a minimal working Cohere example with Chat, Embed, and Rerank.
+
   Use when starting a new Cohere integration, testing your setup,
+
   or learning basic Cohere API v2 patterns.
+
   Trigger with phrases like "cohere hello world", "cohere example",
+
   "cohere quick start", "simple cohere code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Hello World
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-incident-runbook
-description: |
-  Execute Cohere incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Cohere incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Cohere API outages, investigating errors,
+
   or running post-incident reviews for Cohere integration failures.
+
   Trigger with phrases like "cohere incident", "cohere outage",
+
   "cohere down", "cohere on-call", "cohere emergency", "cohere broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-install-auth/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-install-auth
-description: |
-  Install and configure Cohere SDK authentication with API v2.
+description: 'Install and configure Cohere SDK authentication with API v2.
+
   Use when setting up a new Cohere integration, configuring API keys,
+
   or initializing the CohereClientV2 in your project.
+
   Trigger with phrases like "install cohere", "setup cohere",
+
   "cohere auth", "configure cohere API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-local-dev-loop
-description: |
-  Configure Cohere local development with mocking, testing, and hot reload.
+description: 'Configure Cohere local development with mocking, testing, and hot reload.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Cohere API v2.
+
   Trigger with phrases like "cohere dev setup", "cohere local development",
+
   "cohere dev environment", "develop with cohere", "mock cohere".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-migration-deep-dive/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-migration-deep-dive
-description: |
-  Migrate from OpenAI/Anthropic/other LLM providers to Cohere, or vice versa.
+description: 'Migrate from OpenAI/Anthropic/other LLM providers to Cohere, or vice
+  versa.
+
   Use when switching LLM providers, migrating embeddings between models,
+
   or re-platforming existing AI integrations to Cohere API v2.
+
   Trigger with phrases like "migrate to cohere", "switch from openai to cohere",
+
   "cohere migration", "replace openai with cohere", "cohere replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-multi-env-setup/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-multi-env-setup
-description: |
-  Configure Cohere across development, staging, and production environments.
+description: 'Configure Cohere across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment
+
   API keys, model selection, and rate limit strategies.
+
   Trigger with phrases like "cohere environments", "cohere staging",
+
   "cohere dev prod", "cohere environment setup", "cohere config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-observability/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-observability
-description: |
-  Set up comprehensive observability for Cohere API v2 with metrics, traces, and alerts.
+description: 'Set up comprehensive observability for Cohere API v2 with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for Chat/Embed/Rerank operations,
+
   setting up dashboards, or configuring alerts for Cohere integrations.
+
   Trigger with phrases like "cohere monitoring", "cohere metrics",
+
   "cohere observability", "monitor cohere", "cohere alerts", "cohere tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Observability
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-performance-tuning
-description: |
-  Optimize Cohere API performance with caching, batching, model selection, and streaming.
+description: 'Optimize Cohere API performance with caching, batching, model selection,
+  and streaming.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Cohere Chat, Embed, and Rerank.
+
   Trigger with phrases like "cohere performance", "optimize cohere",
+
   "cohere latency", "cohere caching", "cohere slow", "cohere batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-prod-checklist
-description: |
-  Execute Cohere production deployment checklist and rollback procedures.
+description: 'Execute Cohere production deployment checklist and rollback procedures.
+
   Use when deploying Cohere integrations to production, preparing for launch,
+
   or implementing go-live procedures for Cohere-powered apps.
+
   Trigger with phrases like "cohere production", "deploy cohere",
+
   "cohere go-live", "cohere launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-rate-limits/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-rate-limits
-description: |
-  Implement Cohere rate limiting, backoff, and request queuing patterns.
+description: 'Implement Cohere rate limiting, backoff, and request queuing patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Cohere.
+
   Trigger with phrases like "cohere rate limit", "cohere throttling",
+
   "cohere 429", "cohere retry", "cohere backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-reference-architecture
-description: |
-  Implement Cohere reference architecture with layered project layout for RAG and agents.
+description: 'Implement Cohere reference architecture with layered project layout
+  for RAG and agents.
+
   Use when designing new Cohere integrations, reviewing project structure,
+
   or establishing architecture standards for Cohere API v2 applications.
+
   Trigger with phrases like "cohere architecture", "cohere project structure",
+
   "cohere layout", "organize cohere app", "cohere design pattern".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-sdk-patterns
-description: |
-  Apply production-ready Cohere SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Cohere SDK patterns for TypeScript and Python.
+
   Use when implementing Cohere integrations, refactoring SDK usage,
+
   or establishing team coding standards for Cohere API v2.
+
   Trigger with phrases like "cohere SDK patterns", "cohere best practices",
+
   "cohere code patterns", "idiomatic cohere", "cohere wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-security-basics/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-security-basics/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-security-basics
-description: |
-  Apply Cohere security best practices for API key management and access control.
+description: 'Apply Cohere security best practices for API key management and access
+  control.
+
   Use when securing API keys, implementing key rotation,
+
   or auditing Cohere security configuration.
+
   Trigger with phrases like "cohere security", "cohere secrets",
+
   "secure cohere", "cohere API key security", "cohere key rotation".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Security Basics
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: cohere-upgrade-migration
-description: |
-  Migrate from Cohere API v1 to v2 and upgrade SDK versions.
+description: 'Migrate from Cohere API v1 to v2 and upgrade SDK versions.
+
   Use when upgrading cohere-ai SDK, migrating from CohereClient to CohereClientV2,
+
   or handling breaking changes between API versions.
+
   Trigger with phrases like "upgrade cohere", "cohere migration",
+
   "cohere v1 to v2", "update cohere SDK", "cohere breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/cohere-pack/skills/cohere-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/cohere-pack/skills/cohere-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: cohere-webhooks-events
-description: |
-  Implement Cohere streaming event handling, SSE patterns, and connector webhooks.
+description: 'Implement Cohere streaming event handling, SSE patterns, and connector
+  webhooks.
+
   Use when building streaming UIs, handling chat/tool events,
+
   or registering Cohere connectors for RAG.
+
   Trigger with phrases like "cohere streaming", "cohere events",
+
   "cohere SSE", "cohere connectors", "cohere webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, nlp, cohere]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- nlp
+- cohere
+compatibility: Designed for Claude Code
 ---
-
 # Cohere Streaming Events & Connectors
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-ci-integration/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-ci-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-ci-integration
-description: |
-  Integrate CoreWeave deployments into CI/CD pipelines with GitHub Actions.
+description: 'Integrate CoreWeave deployments into CI/CD pipelines with GitHub Actions.
+
   Use when automating container builds, deploying inference services from CI,
+
   or validating GPU manifests in pull requests.
+
   Trigger with phrases like "coreweave CI", "coreweave github actions",
+
   "coreweave pipeline", "automate coreweave deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave CI Integration
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-common-errors/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-common-errors
-description: |
-  Diagnose and fix CoreWeave GPU scheduling, pod, and networking errors.
+description: 'Diagnose and fix CoreWeave GPU scheduling, pod, and networking errors.
+
   Use when pods are stuck Pending, GPUs are not allocated,
+
   or experiencing CUDA and NCCL errors.
+
   Trigger with phrases like "coreweave error", "coreweave pod pending",
+
   "coreweave gpu not found", "coreweave debug", "fix coreweave".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: coreweave-core-workflow-a
-description: |
-  Deploy KServe InferenceService on CoreWeave with autoscaling and GPU scheduling.
+description: 'Deploy KServe InferenceService on CoreWeave with autoscaling and GPU
+  scheduling.
+
   Use when serving ML models with KServe, configuring scale-to-zero,
+
   or deploying production inference endpoints on CoreWeave.
+
   Trigger with phrases like "coreweave inference service", "coreweave kserve",
+
   "coreweave model serving", "deploy model on coreweave".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Core Workflow: KServe Inference
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-core-workflow-b
-description: |
-  Run distributed GPU training jobs on CoreWeave with multi-node PyTorch.
+description: 'Run distributed GPU training jobs on CoreWeave with multi-node PyTorch.
+
   Use when training models across multiple GPUs, setting up distributed training,
+
   or running fine-tuning jobs on CoreWeave H100 clusters.
+
   Trigger with phrases like "coreweave training", "coreweave multi-gpu",
+
   "distributed training coreweave", "fine-tune on coreweave".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Core Workflow: GPU Training
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-cost-tuning
-description: |
-  Optimize CoreWeave GPU cloud costs with right-sizing and scheduling.
+description: 'Optimize CoreWeave GPU cloud costs with right-sizing and scheduling.
+
   Use when reducing GPU spend, selecting cost-effective instances,
+
   or implementing scale-to-zero for dev workloads.
+
   Trigger with phrases like "coreweave cost", "coreweave pricing",
+
   "reduce coreweave spend", "coreweave budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Cost Tuning
 
 ## GPU Pricing Reference (approximate)

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-data-handling/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-data-handling/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-data-handling
-description: |
-  Handle training data and model artifacts on CoreWeave persistent storage.
+description: 'Handle training data and model artifacts on CoreWeave persistent storage.
+
   Use when managing large datasets, configuring storage classes,
+
   or implementing data pipelines for GPU workloads.
+
   Trigger with phrases like "coreweave data", "coreweave storage",
+
   "coreweave pvc", "coreweave dataset management".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Data Handling
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-debug-bundle/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-debug-bundle
-description: |
-  Collect CoreWeave cluster diagnostics for support tickets.
+description: 'Collect CoreWeave cluster diagnostics for support tickets.
+
   Use when preparing a support case, collecting GPU node status,
+
   or documenting pod failures.
+
   Trigger with phrases like "coreweave debug", "coreweave support",
+
   "coreweave diagnostics", "collect coreweave logs".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-deploy-integration
-description: |
-  Deploy inference services on CoreWeave with Helm charts and Kustomize.
+description: 'Deploy inference services on CoreWeave with Helm charts and Kustomize.
+
   Use when deploying multi-model inference, managing GPU deployments at scale,
+
   or templating CoreWeave manifests.
+
   Trigger with phrases like "deploy coreweave", "coreweave helm",
+
   "coreweave kustomize", "coreweave deployment patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(helm:*), Bash(kubectl:*), Bash(kustomize:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-enterprise-rbac/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: coreweave-enterprise-rbac
-description: |
-  Configure RBAC and namespace isolation for CoreWeave multi-team GPU access.
+description: 'Configure RBAC and namespace isolation for CoreWeave multi-team GPU
+  access.
+
   Use when managing team permissions, isolating GPU quotas,
+
   or implementing namespace-level access control.
+
   Trigger with phrases like "coreweave rbac", "coreweave permissions",
+
   "coreweave namespace isolation", "coreweave team access".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-hello-world/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-hello-world
-description: |
-  Deploy a GPU workload on CoreWeave with kubectl.
+description: 'Deploy a GPU workload on CoreWeave with kubectl.
+
   Use when running your first GPU job, testing inference,
+
   or verifying CoreWeave cluster access.
+
   Trigger with phrases like "coreweave hello world", "coreweave first deploy",
+
   "coreweave gpu test", "run on coreweave".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Hello World
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-incident-runbook
-description: |
-  Incident response runbook for CoreWeave GPU workload failures.
+description: 'Incident response runbook for CoreWeave GPU workload failures.
+
   Use when inference services are down, GPUs are unavailable,
+
   or responding to production incidents on CoreWeave.
+
   Trigger with phrases like "coreweave incident", "coreweave outage",
+
   "coreweave runbook", "coreweave service down".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Incident Runbook
 
 ## Triage Steps

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-install-auth/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: coreweave-install-auth
-description: |
-  Configure CoreWeave Kubernetes Service (CKS) access with kubeconfig and API tokens.
+description: 'Configure CoreWeave Kubernetes Service (CKS) access with kubeconfig
+  and API tokens.
+
   Use when setting up kubectl access to CoreWeave, configuring CKS clusters,
+
   or authenticating with CoreWeave cloud services.
+
   Trigger with phrases like "install coreweave", "setup coreweave",
+
   "coreweave kubeconfig", "coreweave auth", "connect to coreweave".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-local-dev-loop
-description: |
-  Set up local development workflow for CoreWeave GPU deployments.
+description: 'Set up local development workflow for CoreWeave GPU deployments.
+
   Use when building containers locally, testing YAML manifests,
+
   or iterating on model serving configurations before deploying.
+
   Trigger with phrases like "coreweave dev setup", "coreweave local testing",
+
   "develop for coreweave", "coreweave container build".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-migration-deep-dive/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-migration-deep-dive
-description: |
-  Migrate ML workloads from AWS/GCP/Azure to CoreWeave GPU cloud.
+description: 'Migrate ML workloads from AWS/GCP/Azure to CoreWeave GPU cloud.
+
   Use when moving inference services from hyperscaler GPU instances,
+
   migrating training pipelines, or evaluating CoreWeave vs cloud GPU costs.
+
   Trigger with phrases like "migrate to coreweave", "coreweave migration",
+
   "move from aws to coreweave", "coreweave vs aws gpu".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Migration Deep Dive
 
 ## Cost Comparison

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-multi-env-setup/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-multi-env-setup
-description: |
-  Configure CoreWeave across development, staging, and production environments.
+description: 'Configure CoreWeave across development, staging, and production environments.
+
   Use when setting up multi-environment GPU infrastructure, separating namespaces,
+
   or managing per-environment GPU quotas.
+
   Trigger with phrases like "coreweave environments", "coreweave staging",
+
   "coreweave multi-env", "coreweave namespace setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(kustomize:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-observability/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-observability
-description: |
-  Set up GPU monitoring and observability for CoreWeave workloads.
+description: 'Set up GPU monitoring and observability for CoreWeave workloads.
+
   Use when implementing GPU metrics dashboards, configuring alerts,
+
   or tracking inference latency and throughput.
+
   Trigger with phrases like "coreweave monitoring", "coreweave observability",
+
   "coreweave gpu metrics", "coreweave grafana".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Observability
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-performance-tuning
-description: |
-  Optimize CoreWeave GPU inference latency and throughput.
+description: 'Optimize CoreWeave GPU inference latency and throughput.
+
   Use when reducing inference latency, maximizing GPU utilization,
+
   or tuning batch sizes and concurrency.
+
   Trigger with phrases like "coreweave performance", "coreweave latency",
+
   "coreweave throughput", "optimize coreweave inference".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Performance Tuning
 
 ## GPU Selection by Workload

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-prod-checklist
-description: |
-  Production readiness checklist for CoreWeave GPU workloads.
+description: 'Production readiness checklist for CoreWeave GPU workloads.
+
   Use when launching inference services, preparing GPU training for production,
+
   or validating deployment configurations.
+
   Trigger with phrases like "coreweave production", "coreweave go-live",
+
   "coreweave checklist", "coreweave launch".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Production Checklist
 
 ## Inference Services

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-rate-limits/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-rate-limits/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-rate-limits
-description: |
-  Handle CoreWeave API and GPU quota limits.
+description: 'Handle CoreWeave API and GPU quota limits.
+
   Use when hitting quota limits, managing GPU resource allocation,
+
   or implementing request queuing for inference endpoints.
+
   Trigger with phrases like "coreweave quota", "coreweave limits",
+
   "coreweave gpu allocation", "coreweave throttle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-reference-architecture
-description: |
-  Reference architecture for CoreWeave GPU cloud deployments.
+description: 'Reference architecture for CoreWeave GPU cloud deployments.
+
   Use when designing ML infrastructure, planning multi-model serving,
+
   or establishing CoreWeave deployment standards.
+
   Trigger with phrases like "coreweave architecture", "coreweave design",
+
   "coreweave infrastructure", "coreweave best practices".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Reference Architecture
 
 ## Architecture Diagram

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-sdk-patterns/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: coreweave-sdk-patterns
-description: |
-  Production-ready patterns for CoreWeave GPU workload management with kubectl and Python.
+description: 'Production-ready patterns for CoreWeave GPU workload management with
+  kubectl and Python.
+
   Use when building inference clients, managing GPU deployments programmatically,
+
   or creating reusable CoreWeave deployment templates.
+
   Trigger with phrases like "coreweave patterns", "coreweave client",
+
   "coreweave Python", "coreweave deployment template".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-security-basics/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-security-basics/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: coreweave-security-basics
-description: |
-  Secure CoreWeave deployments with RBAC, network policies, and secrets management.
+description: 'Secure CoreWeave deployments with RBAC, network policies, and secrets
+  management.
+
   Use when hardening GPU workloads, managing model access,
+
   or configuring namespace isolation.
+
   Trigger with phrases like "coreweave security", "coreweave rbac",
+
   "secure coreweave", "coreweave secrets".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Security Basics
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-upgrade-migration
-description: |
-  Upgrade CoreWeave deployments and migrate between GPU types.
+description: 'Upgrade CoreWeave deployments and migrate between GPU types.
+
   Use when migrating from A100 to H100, upgrading CUDA versions,
+
   or updating inference server versions.
+
   Trigger with phrases like "upgrade coreweave", "coreweave gpu migration",
+
   "coreweave cuda upgrade", "migrate coreweave".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/coreweave-pack/skills/coreweave-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/coreweave-pack/skills/coreweave-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: coreweave-webhooks-events
-description: |
-  Monitor CoreWeave cluster events and GPU workload status.
+description: 'Monitor CoreWeave cluster events and GPU workload status.
+
   Use when tracking pod lifecycle events, monitoring GPU utilization,
+
   or alerting on inference service health changes.
+
   Trigger with phrases like "coreweave events", "coreweave monitoring",
+
   "coreweave pod alerts", "coreweave gpu monitoring".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, gpu-cloud, kubernetes, inference, coreweave]
-compatible-with: claude-code
+tags:
+- saas
+- gpu-cloud
+- kubernetes
+- inference
+- coreweave
+compatibility: Designed for Claude Code
 ---
-
 # CoreWeave Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/cursor-pack/skills/cursor-advanced-composer/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-advanced-composer/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-advanced-composer"
-description: |
-  Advanced Cursor Composer techniques: agent mode, parallel agents, complex refactoring, and multi-step
-  orchestration. Triggers on "advanced composer", "composer patterns", "multi-file generation",
+name: cursor-advanced-composer
+description: 'Advanced Cursor Composer techniques: agent mode, parallel agents, complex
+  refactoring, and multi-step
+
+  orchestration. Triggers on "advanced composer", "composer patterns", "multi-file
+  generation",
+
   "composer refactoring", "agent mode", "parallel agents".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-advanced]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-advanced
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Advanced Composer
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-ai-chat/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-ai-chat/SKILL.md
@@ -1,14 +1,21 @@
 ---
-name: "cursor-ai-chat"
-description: |
-  Master Cursor AI Chat with @-mentions, inline edit, and conversation patterns. Triggers on "cursor chat",
-  "cursor ai chat", "ask cursor", "cursor conversation", "chat with cursor", "Cmd+L", "inline edit".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+name: cursor-ai-chat
+description: 'Master Cursor AI Chat with @-mentions, inline edit, and conversation
+  patterns. Triggers on "cursor chat",
+
+  "cursor ai chat", "ask cursor", "cursor conversation", "chat with cursor", "Cmd+L",
+  "inline edit".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-ai]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-ai
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor AI Chat
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-api-key-management/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-api-key-management/SKILL.md
@@ -1,15 +1,24 @@
 ---
-name: "cursor-api-key-management"
-description: |
-  Configure BYOK API keys for OpenAI, Anthropic, Google, Azure, and custom models in Cursor.
-  Triggers on "cursor api key", "cursor openai key", "cursor anthropic key", "own api key cursor",
+name: cursor-api-key-management
+description: 'Configure BYOK API keys for OpenAI, Anthropic, Google, Azure, and custom
+  models in Cursor.
+
+  Triggers on "cursor api key", "cursor openai key", "cursor anthropic key", "own
+  api key cursor",
+
   "BYOK cursor", "cursor azure key".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, api, authentication]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor API Key Management
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-codebase-indexing/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-codebase-indexing/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-codebase-indexing"
-description: |
-  Set up and optimize Cursor codebase indexing for semantic code search and @Codebase queries.
-  Triggers on "cursor index", "codebase indexing", "index codebase", "cursor semantic search",
+name: cursor-codebase-indexing
+description: 'Set up and optimize Cursor codebase indexing for semantic code search
+  and @Codebase queries.
+
+  Triggers on "cursor index", "codebase indexing", "index codebase", "cursor semantic
+  search",
+
   "@codebase", "cursor embeddings".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-codebase]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-codebase
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Codebase Indexing
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-common-errors/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-common-errors/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-common-errors"
-description: |
-  Troubleshoot common Cursor IDE errors: authentication, completion, indexing, API, and performance
-  issues. Triggers on "cursor error", "cursor not working", "cursor issue", "cursor problem",
+name: cursor-common-errors
+description: 'Troubleshoot common Cursor IDE errors: authentication, completion, indexing,
+  API, and performance
+
+  issues. Triggers on "cursor error", "cursor not working", "cursor issue", "cursor
+  problem",
+
   "fix cursor", "cursor crash".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-common]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-common
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Common Errors
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-compliance-audit/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-compliance-audit/SKILL.md
@@ -1,15 +1,25 @@
 ---
-name: "cursor-compliance-audit"
-description: |
-  Compliance and security auditing for Cursor IDE usage: SOC 2, GDPR, HIPAA assessment, evidence
-  collection, and remediation. Triggers on "cursor compliance", "cursor audit", "cursor security review",
+name: cursor-compliance-audit
+description: 'Compliance and security auditing for Cursor IDE usage: SOC 2, GDPR,
+  HIPAA assessment, evidence
+
+  collection, and remediation. Triggers on "cursor compliance", "cursor audit", "cursor
+  security review",
+
   "cursor soc2", "cursor gdpr", "cursor data governance".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, security, compliance, audit]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- security
+- compliance
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Compliance Audit
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-composer-workflows/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-composer-workflows/SKILL.md
@@ -1,14 +1,21 @@
 ---
-name: "cursor-composer-workflows"
-description: |
-  Master Cursor Composer for multi-file AI editing, scaffolding, and refactoring. Triggers on "cursor composer",
-  "multi-file edit", "cursor generate files", "composer workflow", "cursor scaffold", "Cmd+I".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+name: cursor-composer-workflows
+description: 'Master Cursor Composer for multi-file AI editing, scaffolding, and refactoring.
+  Triggers on "cursor composer",
+
+  "multi-file edit", "cursor generate files", "composer workflow", "cursor scaffold",
+  "Cmd+I".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, workflow]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Composer Workflows
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-context-management/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-context-management/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-context-management"
-description: |
-  Optimize context window usage in Cursor with @-mentions, context pills, and conversation strategy.
-  Triggers on "cursor context", "context window", "context limit", "cursor memory", "context management",
+name: cursor-context-management
+description: 'Optimize context window usage in Cursor with @-mentions, context pills,
+  and conversation strategy.
+
+  Triggers on "cursor context", "context window", "context limit", "cursor memory",
+  "context management",
+
   "@-mentions", "context pills".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-context]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-context
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Context Management
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-custom-prompts/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-custom-prompts/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-custom-prompts"
-description: |
-  Create effective custom prompts for Cursor AI using project rules, prompt engineering patterns, and
-  reusable templates. Triggers on "cursor prompts", "prompt engineering cursor", "better cursor prompts",
+name: cursor-custom-prompts
+description: 'Create effective custom prompts for Cursor AI using project rules, prompt
+  engineering patterns, and
+
+  reusable templates. Triggers on "cursor prompts", "prompt engineering cursor", "better
+  cursor prompts",
+
   "cursor instructions", "cursor prompt templates".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-custom]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-custom
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Custom Prompts
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-debug-bundle/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-debug-bundle"
-description: |
-  Debug AI suggestion quality, context issues, and code generation problems in Cursor. Triggers on
-  "debug cursor ai", "cursor suggestions wrong", "bad cursor completion", "cursor ai debug",
+name: cursor-debug-bundle
+description: 'Debug AI suggestion quality, context issues, and code generation problems
+  in Cursor. Triggers on
+
+  "debug cursor ai", "cursor suggestions wrong", "bad cursor completion", "cursor
+  ai debug",
+
   "cursor hallucination".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, debugging]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Debug Bundle
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-extension-integration/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-extension-integration/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-extension-integration"
-description: |
-  Integrate VS Code extensions with Cursor IDE: compatibility, Open VSX registry, VSIX installation,
-  conflict resolution, and essential extensions. Triggers on "cursor extensions", "cursor vscode extensions",
+name: cursor-extension-integration
+description: 'Integrate VS Code extensions with Cursor IDE: compatibility, Open VSX
+  registry, VSIX installation,
+
+  conflict resolution, and essential extensions. Triggers on "cursor extensions",
+  "cursor vscode extensions",
+
   "cursor plugins", "cursor marketplace", "open vsx", "vsix install".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-extension]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-extension
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Extension Integration
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-git-integration/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-git-integration/SKILL.md
@@ -1,15 +1,24 @@
 ---
-name: "cursor-git-integration"
-description: |
-  Integrate Git workflows with Cursor IDE: AI commit messages, @Git context, diff review, and conflict
-  resolution. Triggers on "cursor git", "git in cursor", "cursor version control", "cursor commit",
+name: cursor-git-integration
+description: 'Integrate Git workflows with Cursor IDE: AI commit messages, @Git context,
+  diff review, and conflict
+
+  resolution. Triggers on "cursor git", "git in cursor", "cursor version control",
+  "cursor commit",
+
   "cursor branch", "@Git".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, git, workflow]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- git
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Git Integration
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-hello-world/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-hello-world/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-hello-world"
-description: |
-  Create your first project using Cursor AI features: Tab, Chat, Composer, and Inline Edit.
-  Triggers on "cursor hello world", "first cursor project", "cursor getting started", "try cursor ai",
+name: cursor-hello-world
+description: 'Create your first project using Cursor AI features: Tab, Chat, Composer,
+  and Inline Edit.
+
+  Triggers on "cursor hello world", "first cursor project", "cursor getting started",
+  "try cursor ai",
+
   "cursor basics", "cursor tutorial".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-hello]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-hello
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Hello World
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-indexing-issues/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-indexing-issues/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-indexing-issues"
-description: |
-  Troubleshoot Cursor codebase indexing: stuck indexing, empty search, @codebase failures, and
-  performance issues. Triggers on "cursor indexing", "cursor index", "@codebase not working",
+name: cursor-indexing-issues
+description: 'Troubleshoot Cursor codebase indexing: stuck indexing, empty search,
+  @codebase failures, and
+
+  performance issues. Triggers on "cursor indexing", "cursor index", "@codebase not
+  working",
+
   "cursor search broken", "indexing stuck".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-indexing]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-indexing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Indexing Issues
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-install-auth/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-install-auth/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-install-auth"
-description: |
-  Install Cursor IDE and configure authentication across macOS, Linux, and Windows. Triggers on
-  "install cursor", "setup cursor", "cursor authentication", "cursor login", "cursor license",
+name: cursor-install-auth
+description: 'Install Cursor IDE and configure authentication across macOS, Linux,
+  and Windows. Triggers on
+
+  "install cursor", "setup cursor", "cursor authentication", "cursor login", "cursor
+  license",
+
   "cursor download".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, authentication]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Install & Auth
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-keybindings/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-keybindings/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-keybindings"
-description: |
-  Master Cursor keyboard shortcuts and customize keybindings for AI features and editor commands.
-  Triggers on "cursor shortcuts", "cursor keybindings", "cursor keyboard", "cursor hotkeys",
+name: cursor-keybindings
+description: 'Master Cursor keyboard shortcuts and customize keybindings for AI features
+  and editor commands.
+
+  Triggers on "cursor shortcuts", "cursor keybindings", "cursor keyboard", "cursor
+  hotkeys",
+
   "cursor commands", "Cmd+K", "Cmd+L", "Cmd+I".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-keybindings]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-keybindings
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Keybindings
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-known-pitfalls/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-known-pitfalls"
-description: |
-  Avoid common Cursor IDE pitfalls: AI feature mistakes, security gotchas, configuration errors, and
-  team workflow issues. Triggers on "cursor pitfalls", "cursor mistakes", "cursor gotchas", "cursor issues",
+name: cursor-known-pitfalls
+description: 'Avoid common Cursor IDE pitfalls: AI feature mistakes, security gotchas,
+  configuration errors, and
+
+  team workflow issues. Triggers on "cursor pitfalls", "cursor mistakes", "cursor
+  gotchas", "cursor issues",
+
   "cursor problems", "cursor tips".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-known]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-known
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Known Pitfalls
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-local-dev-loop/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-local-dev-loop"
-description: |
-  Optimize daily development workflow with Cursor IDE using Chat, Composer, Tab, and Git integration.
-  Triggers on "cursor workflow", "cursor development loop", "cursor productivity", "cursor daily workflow",
+name: cursor-local-dev-loop
+description: 'Optimize daily development workflow with Cursor IDE using Chat, Composer,
+  Tab, and Git integration.
+
+  Triggers on "cursor workflow", "cursor development loop", "cursor productivity",
+  "cursor daily workflow",
+
   "cursor dev flow".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, workflow]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Local Dev Loop
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-model-selection/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-model-selection/SKILL.md
@@ -1,14 +1,21 @@
 ---
-name: "cursor-model-selection"
-description: |
-  Configure and select AI models in Cursor for Chat, Composer, and Agent mode. Triggers on "cursor model",
-  "cursor gpt", "cursor claude", "change cursor model", "cursor ai model", "cursor auto mode".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+name: cursor-model-selection
+description: 'Configure and select AI models in Cursor for Chat, Composer, and Agent
+  mode. Triggers on "cursor model",
+
+  "cursor gpt", "cursor claude", "change cursor model", "cursor ai model", "cursor
+  auto mode".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-model]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-model
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Model Selection
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-multi-repo/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-multi-repo/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-multi-repo"
-description: |
-  Work with multiple repositories in Cursor: multi-root workspaces, monorepo patterns, selective indexing,
-  and cross-project context. Triggers on "cursor multi repo", "cursor multiple projects", "cursor monorepo",
+name: cursor-multi-repo
+description: 'Work with multiple repositories in Cursor: multi-root workspaces, monorepo
+  patterns, selective indexing,
+
+  and cross-project context. Triggers on "cursor multi repo", "cursor multiple projects",
+  "cursor monorepo",
+
   "cursor workspace", "multi-root workspace".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-multi]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Multi-Repo
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-performance-tuning/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-performance-tuning"
-description: |
-  Optimize Cursor IDE performance: reduce memory usage, speed up indexing, tune AI features, and manage
-  extensions for large codebases. Triggers on "cursor performance", "cursor slow", "cursor optimization",
+name: cursor-performance-tuning
+description: 'Optimize Cursor IDE performance: reduce memory usage, speed up indexing,
+  tune AI features, and manage
+
+  extensions for large codebases. Triggers on "cursor performance", "cursor slow",
+  "cursor optimization",
+
   "cursor memory", "speed up cursor", "cursor lag".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, performance]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Performance Tuning
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-privacy-settings/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-privacy-settings/SKILL.md
@@ -1,15 +1,22 @@
 ---
-name: "cursor-privacy-settings"
-description: |
-  Configure Cursor privacy mode, data handling, telemetry, and sensitive file exclusion. Triggers on
+name: cursor-privacy-settings
+description: 'Configure Cursor privacy mode, data handling, telemetry, and sensitive
+  file exclusion. Triggers on
+
   "cursor privacy", "cursor data", "cursor security", "privacy mode", "cursor telemetry",
+
   "cursor data retention".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, security]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Privacy Settings
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-prod-checklist/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-prod-checklist"
-description: |
-  Production readiness checklist for Cursor IDE setup: security, rules, indexing, privacy, and team
-  standards. Triggers on "cursor production", "cursor ready", "cursor checklist", "optimize cursor setup",
+name: cursor-prod-checklist
+description: 'Production readiness checklist for Cursor IDE setup: security, rules,
+  indexing, privacy, and team
+
+  standards. Triggers on "cursor production", "cursor ready", "cursor checklist",
+  "optimize cursor setup",
+
   "cursor onboarding".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-prod]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-prod
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Production Checklist
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-reference-architecture/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-reference-architecture"
-description: |
-  Reference architecture for Cursor IDE projects: directory structure, rules organization, indexing
-  strategy, and team configuration patterns. Triggers on "cursor architecture", "cursor project structure",
+name: cursor-reference-architecture
+description: 'Reference architecture for Cursor IDE projects: directory structure,
+  rules organization, indexing
+
+  strategy, and team configuration patterns. Triggers on "cursor architecture", "cursor
+  project structure",
+
   "cursor best practices", "cursor file structure".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-reference]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Reference Architecture
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-rules-config/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-rules-config/SKILL.md
@@ -1,14 +1,21 @@
 ---
-name: "cursor-rules-config"
-description: |
-  Configure Cursor project rules using .cursor/rules/*.mdc files and legacy .cursorrules. Triggers on "cursorrules",
-  ".cursorrules", "cursor rules", "cursor config", "cursor project settings", ".mdc rules", "project rules".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+name: cursor-rules-config
+description: 'Configure Cursor project rules using .cursor/rules/*.mdc files and legacy
+  .cursorrules. Triggers on "cursorrules",
+
+  ".cursorrules", "cursor rules", "cursor config", "cursor project settings", ".mdc
+  rules", "project rules".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-rules]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-rules
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Rules Config
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-sso-integration/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-sso-integration/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-sso-integration"
-description: |
-  Configure SAML 2.0 and OIDC SSO for Cursor with Okta, Microsoft Entra ID, and Google Workspace.
-  Triggers on "cursor sso", "cursor saml", "cursor oauth", "enterprise cursor auth", "cursor okta",
+name: cursor-sso-integration
+description: 'Configure SAML 2.0 and OIDC SSO for Cursor with Okta, Microsoft Entra
+  ID, and Google Workspace.
+
+  Triggers on "cursor sso", "cursor saml", "cursor oauth", "enterprise cursor auth",
+  "cursor okta",
+
   "cursor entra", "cursor scim".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, authentication]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor SSO Integration
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-tab-completion/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-tab-completion/SKILL.md
@@ -1,14 +1,21 @@
 ---
-name: "cursor-tab-completion"
-description: |
-  Master Cursor Tab autocomplete, ghost text, and AI code suggestions. Triggers on "cursor completion",
-  "cursor tab", "cursor suggestions", "cursor autocomplete", "cursor ghost text", "cursor copilot".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+name: cursor-tab-completion
+description: 'Master Cursor Tab autocomplete, ghost text, and AI code suggestions.
+  Triggers on "cursor completion",
+
+  "cursor tab", "cursor suggestions", "cursor autocomplete", "cursor ghost text",
+  "cursor copilot".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-tab]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-tab
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Tab Completion
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-team-setup/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-team-setup/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-team-setup"
-description: |
-  Set up Cursor for teams: plan selection, member management, shared rules, admin dashboard, and
-  onboarding. Triggers on "cursor team", "cursor organization", "cursor business", "cursor enterprise setup",
+name: cursor-team-setup
+description: 'Set up Cursor for teams: plan selection, member management, shared rules,
+  admin dashboard, and
+
+  onboarding. Triggers on "cursor team", "cursor organization", "cursor business",
+  "cursor enterprise setup",
+
   "cursor admin".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, cursor-team]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- cursor-team
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Team Setup
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-upgrade-migration/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-upgrade-migration"
-description: |
-  Upgrade Cursor versions, migrate from VS Code, and transfer settings between machines. Triggers on
-  "upgrade cursor", "update cursor", "cursor migration", "cursor new version", "vs code to cursor",
+name: cursor-upgrade-migration
+description: 'Upgrade Cursor versions, migrate from VS Code, and transfer settings
+  between machines. Triggers on
+
+  "upgrade cursor", "update cursor", "cursor migration", "cursor new version", "vs
+  code to cursor",
+
   "cursor changelog".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, migration]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Upgrade & Migration
 

--- a/plugins/saas-packs/cursor-pack/skills/cursor-usage-analytics/SKILL.md
+++ b/plugins/saas-packs/cursor-pack/skills/cursor-usage-analytics/SKILL.md
@@ -1,15 +1,23 @@
 ---
-name: "cursor-usage-analytics"
-description: |
-  Track and analyze Cursor usage metrics via admin dashboard: requests, model usage, team productivity,
+name: cursor-usage-analytics
+description: 'Track and analyze Cursor usage metrics via admin dashboard: requests,
+  model usage, team productivity,
+
   and cost optimization. Triggers on "cursor analytics", "cursor usage", "cursor metrics",
+
   "cursor reporting", "cursor dashboard", "cursor ROI".
-allowed-tools: "Read, Write, Edit, Bash(cmd:*)"
+
+  '
+allowed-tools: Read, Write, Edit, Bash(cmd:*)
 version: 1.0.0
 license: MIT
-author: "Jeremy Longshore <jeremy@intentsolutions.io>"
-compatible-with: claude-code, codex, openclaw
-tags: [saas, cursor, analytics, dashboard]
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags:
+- saas
+- cursor
+- analytics
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Cursor Usage Analytics
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-advanced-troubleshooting
-description: |
-  Apply Customer.io advanced debugging and incident response.
+description: 'Apply Customer.io advanced debugging and incident response.
+
   Use when diagnosing complex delivery issues, investigating
+
   campaign failures, or running incident playbooks.
+
   Trigger: "debug customer.io", "customer.io investigation",
+
   "customer.io troubleshoot", "customer.io incident", "customer.io not delivering".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, debugging, incident-response]
+tags:
+- saas
+- customer-io
+- debugging
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Advanced Troubleshooting
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-ci-integration/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-ci-integration
-description: |
-  Configure Customer.io CI/CD integration with automated testing.
+description: 'Configure Customer.io CI/CD integration with automated testing.
+
   Use when setting up GitHub Actions, integration test suites,
+
   or pre-commit validation for Customer.io code.
+
   Trigger: "customer.io ci", "customer.io github actions",
+
   "customer.io pipeline", "customer.io automated testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(gh:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, ci-cd, testing, github-actions]
+tags:
+- saas
+- customer-io
+- ci-cd
+- testing
+- github-actions
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io CI Integration
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-common-errors/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-common-errors
-description: |
-  Diagnose and fix Customer.io common errors.
+description: 'Diagnose and fix Customer.io common errors.
+
   Use when troubleshooting API errors, delivery failures,
+
   campaign issues, or SDK exceptions.
+
   Trigger: "customer.io error", "customer.io not working",
+
   "debug customer.io", "customer.io 401", "customer.io 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, debugging, errors]
+tags:
+- saas
+- customer-io
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Common Errors
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-core-feature/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-core-feature/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: customerio-core-feature
-description: |
-  Implement Customer.io core features: transactional messages,
+description: 'Implement Customer.io core features: transactional messages,
+
   API-triggered broadcasts, segments, and person merge.
+
   Trigger: "customer.io segments", "customer.io transactional",
+
   "customer.io broadcast", "customer.io merge users", "customer.io send email".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, transactional, broadcasts, segments]
+tags:
+- saas
+- customer-io
+- transactional
+- broadcasts
+- segments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Core Features
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-cost-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-cost-tuning
-description: |
-  Optimize Customer.io costs and usage efficiency.
+description: 'Optimize Customer.io costs and usage efficiency.
+
   Use when reducing profile count, cleaning inactive users,
+
   deduplicating events, or right-sizing your plan.
+
   Trigger: "customer.io cost", "reduce customer.io spend",
+
   "customer.io billing", "customer.io pricing", "customer.io cleanup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, cost-optimization, billing]
+tags:
+- saas
+- customer-io
+- cost-optimization
+- billing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Cost Tuning
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-debug-bundle
-description: |
-  Collect Customer.io debug evidence for support tickets.
+description: 'Collect Customer.io debug evidence for support tickets.
+
   Use when creating support requests, investigating delivery
+
   failures, or documenting integration issues.
+
   Trigger: "customer.io debug", "customer.io support ticket",
+
   "collect customer.io logs", "customer.io diagnostics".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, debugging, support]
+tags:
+- saas
+- customer-io
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Debug Bundle
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-deploy-pipeline/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-deploy-pipeline/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: customerio-deploy-pipeline
-description: |
-  Deploy Customer.io integrations to production cloud platforms.
+description: 'Deploy Customer.io integrations to production cloud platforms.
+
   Use when deploying to Cloud Run, Vercel, AWS Lambda, or Kubernetes
+
   with proper secrets management and health checks.
+
   Trigger: "deploy customer.io", "customer.io cloud run",
+
   "customer.io kubernetes", "customer.io lambda", "customer.io vercel".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(gcloud:*), Bash(kubectl:*), Glob, Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(gcloud:*), Bash(kubectl:*), Glob,
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, deployment, cloud-run, kubernetes]
+tags:
+- saas
+- customer-io
+- deployment
+- cloud-run
+- kubernetes
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Deploy Pipeline
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-hello-world/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-hello-world
-description: |
-  Create a minimal working Customer.io example.
+description: 'Create a minimal working Customer.io example.
+
   Use when learning Customer.io basics, testing SDK setup,
+
   or creating your first identify + track integration.
+
   Trigger: "customer.io hello world", "first customer.io message",
+
   "test customer.io", "customer.io example", "customer.io quickstart".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, quickstart, testing]
+tags:
+- saas
+- customer-io
+- quickstart
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Hello World
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-install-auth/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-install-auth
-description: |
-  Install and configure Customer.io SDK/CLI authentication.
+description: 'Install and configure Customer.io SDK/CLI authentication.
+
   Use when setting up a new Customer.io integration, configuring API keys,
+
   or initializing Customer.io in your project.
+
   Trigger: "install customer.io", "setup customer.io", "customer.io auth",
+
   "configure customer.io API key", "customer.io credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, api, authentication, setup]
+tags:
+- saas
+- customer-io
+- api
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Install & Auth
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-known-pitfalls/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-known-pitfalls
-description: |
-  Identify and avoid Customer.io anti-patterns and gotchas.
+description: 'Identify and avoid Customer.io anti-patterns and gotchas.
+
   Use when reviewing integrations, onboarding developers,
+
   or auditing existing Customer.io code.
+
   Trigger: "customer.io mistakes", "customer.io anti-patterns",
+
   "customer.io gotchas", "customer.io pitfalls", "customer.io code review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, best-practices, anti-patterns]
+tags:
+- saas
+- customer-io
+- best-practices
+- anti-patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Known Pitfalls
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-load-scale/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: customerio-load-scale
-description: |
-  Implement Customer.io load testing and horizontal scaling.
+description: 'Implement Customer.io load testing and horizontal scaling.
+
   Use when preparing for high traffic, running load tests,
+
   or designing queue-based architectures for scale.
+
   Trigger: "customer.io load test", "customer.io scale",
+
   "customer.io high volume", "customer.io k6", "customer.io performance test".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(kubectl:*), Glob, Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(kubectl:*), Glob,
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, load-testing, scaling, performance]
+tags:
+- saas
+- customer-io
+- load-testing
+- scaling
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Load & Scale
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-local-dev-loop
-description: |
-  Configure Customer.io local development workflow.
+description: 'Configure Customer.io local development workflow.
+
   Use when setting up local testing, dev/staging isolation,
+
   or mocking Customer.io for unit tests.
+
   Trigger: "customer.io local dev", "test customer.io locally",
+
   "customer.io dev environment", "customer.io sandbox", "mock customer.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, testing, development, workflow]
+tags:
+- saas
+- customer-io
+- testing
+- development
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Local Dev Loop
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-multi-env-setup
-description: |
-  Configure Customer.io multi-environment setup with workspace isolation.
+description: 'Configure Customer.io multi-environment setup with workspace isolation.
+
   Use when setting up dev/staging/prod workspaces, environment-aware
+
   clients, or Kubernetes config overlays.
+
   Trigger: "customer.io environments", "customer.io staging",
+
   "customer.io dev prod", "customer.io workspace isolation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(kubectl:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, multi-environment, kubernetes]
+tags:
+- saas
+- customer-io
+- multi-environment
+- kubernetes
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Multi-Environment Setup
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-observability/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-observability
-description: |
-  Set up Customer.io monitoring and observability.
+description: 'Set up Customer.io monitoring and observability.
+
   Use when implementing metrics, structured logging, alerting,
+
   or Grafana dashboards for Customer.io integrations.
+
   Trigger: "customer.io monitoring", "customer.io metrics",
+
   "customer.io dashboard", "customer.io alerts", "customer.io observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, monitoring, observability, prometheus]
+tags:
+- saas
+- customer-io
+- monitoring
+- observability
+- prometheus
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Observability
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-performance-tuning
-description: |
-  Optimize Customer.io API performance for high throughput.
+description: 'Optimize Customer.io API performance for high throughput.
+
   Use when improving response times, implementing connection
+
   pooling, batching, caching, or regional routing.
+
   Trigger: "customer.io performance", "optimize customer.io",
+
   "customer.io latency", "customer.io connection pooling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, performance, optimization]
+tags:
+- saas
+- customer-io
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Performance Tuning
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-primary-workflow/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-primary-workflow/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-primary-workflow
-description: |
-  Implement Customer.io primary messaging workflow.
+description: 'Implement Customer.io primary messaging workflow.
+
   Use when setting up campaign triggers, welcome sequences,
+
   onboarding flows, or event-driven email automation.
+
   Trigger: "customer.io campaign", "customer.io workflow",
+
   "customer.io email automation", "customer.io messaging", "customer.io onboarding".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, workflow, campaigns, automation]
+tags:
+- saas
+- customer-io
+- workflow
+- campaigns
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Primary Workflow
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-prod-checklist
-description: |
-  Execute Customer.io production deployment checklist.
+description: 'Execute Customer.io production deployment checklist.
+
   Use when preparing for production launch, auditing integration
+
   quality, or performing pre-launch validation.
+
   Trigger: "customer.io production", "customer.io checklist",
+
   "deploy customer.io", "customer.io go-live", "customer.io launch".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, deployment, production, audit]
+tags:
+- saas
+- customer-io
+- deployment
+- production
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Production Checklist
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-rate-limits/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-rate-limits
-description: |
-  Implement Customer.io rate limiting and backoff.
+description: 'Implement Customer.io rate limiting and backoff.
+
   Use when handling high-volume API calls, implementing
+
   retry logic, or hitting 429 errors.
+
   Trigger: "customer.io rate limit", "customer.io throttle",
+
   "customer.io 429", "customer.io backoff", "customer.io too many requests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, api, rate-limiting]
+tags:
+- saas
+- customer-io
+- api
+- rate-limiting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Rate Limits
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-reference-architecture
-description: |
-  Implement Customer.io enterprise reference architecture.
+description: 'Implement Customer.io enterprise reference architecture.
+
   Use when designing integration layers, event-driven architectures,
+
   or enterprise-grade Customer.io setups.
+
   Trigger: "customer.io architecture", "customer.io design",
+
   "customer.io enterprise", "customer.io integration pattern".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, architecture, enterprise]
+tags:
+- saas
+- customer-io
+- architecture
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Reference Architecture
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-reliability-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-reliability-patterns
-description: |
-  Implement Customer.io reliability and fault-tolerance patterns.
+description: 'Implement Customer.io reliability and fault-tolerance patterns.
+
   Use when building circuit breakers, fallback queues, idempotency,
+
   or graceful degradation for Customer.io integrations.
+
   Trigger: "customer.io reliability", "customer.io resilience",
+
   "customer.io circuit breaker", "customer.io fault tolerance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, reliability, circuit-breaker, resilience]
+tags:
+- saas
+- customer-io
+- reliability
+- circuit-breaker
+- resilience
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Reliability Patterns
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-sdk-patterns
-description: |
-  Apply production-ready Customer.io SDK patterns.
+description: 'Apply production-ready Customer.io SDK patterns.
+
   Use when implementing typed clients, retry logic, event batching,
+
   or singleton management for customerio-node.
+
   Trigger: "customer.io best practices", "customer.io patterns",
+
   "production customer.io", "customer.io architecture", "customer.io singleton".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, sdk, patterns, typescript]
+tags:
+- saas
+- customer-io
+- sdk
+- patterns
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io SDK Patterns
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-security-basics/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-security-basics
-description: |
-  Apply Customer.io security best practices.
+description: 'Apply Customer.io security best practices.
+
   Use when implementing secure credential storage, PII handling,
+
   webhook signature verification, or GDPR/CCPA compliance.
+
   Trigger: "customer.io security", "customer.io pii",
+
   "secure customer.io", "customer.io gdpr", "customer.io webhook verify".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, security, gdpr, compliance]
+tags:
+- saas
+- customer-io
+- security
+- gdpr
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Security Basics
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: customerio-upgrade-migration
-description: |
-  Plan and execute Customer.io SDK upgrades and migrations.
+description: 'Plan and execute Customer.io SDK upgrades and migrations.
+
   Use when upgrading customerio-node versions, migrating from
+
   legacy APIs, or updating to new SDK patterns.
+
   Trigger: "upgrade customer.io", "customer.io migration",
+
   "update customer.io sdk", "customer.io breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, migration, upgrade]
+tags:
+- saas
+- customer-io
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Upgrade & Migration
 

--- a/plugins/saas-packs/customerio-pack/skills/customerio-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/customerio-pack/skills/customerio-webhooks-events/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: customerio-webhooks-events
-description: |
-  Implement Customer.io webhook and reporting event handling.
+description: 'Implement Customer.io webhook and reporting event handling.
+
   Use when processing email delivery events, click/open tracking,
+
   bounce handling, or streaming to a data warehouse.
+
   Trigger: "customer.io webhook", "customer.io events",
+
   "customer.io delivery status", "customer.io bounces", "customer.io open tracking".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, customer-io, webhooks, events, delivery]
+tags:
+- saas
+- customer-io
+- webhooks
+- events
+- delivery
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Customer.io Webhooks & Events
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-ci-integration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-ci-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: databricks-ci-integration
-description: |
-  Configure Databricks CI/CD integration with GitHub Actions and Asset Bundles.
+description: 'Configure Databricks CI/CD integration with GitHub Actions and Asset
+  Bundles.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Databricks deployments into your build process.
+
   Trigger with phrases like "databricks CI", "databricks GitHub Actions",
+
   "databricks automated tests", "CI databricks", "databricks pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, deployment, testing, ci-cd]
+tags:
+- saas
+- databricks
+- deployment
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks CI Integration
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-common-errors/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-common-errors
-description: |
-  Diagnose and fix Databricks common errors and exceptions.
+description: 'Diagnose and fix Databricks common errors and exceptions.
+
   Use when encountering Databricks errors, debugging failed jobs,
+
   or troubleshooting cluster and notebook issues.
+
   Trigger with phrases like "databricks error", "fix databricks",
+
   "databricks not working", "debug databricks", "spark error".
+
+  '
 allowed-tools: Read, Grep, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, debugging]
+tags:
+- saas
+- databricks
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Common Errors
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: databricks-core-workflow-a
-description: |
-  Execute Databricks primary workflow: Delta Lake ETL pipelines.
+description: 'Execute Databricks primary workflow: Delta Lake ETL pipelines.
+
   Use when building data ingestion pipelines, implementing medallion architecture,
+
   or creating Delta Lake transformations.
+
   Trigger with phrases like "databricks ETL", "delta lake pipeline",
+
   "medallion architecture", "databricks data pipeline", "bronze silver gold".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, workflow, data-pipeline, etl]
+tags:
+- saas
+- databricks
+- workflow
+- data-pipeline
+- etl
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Core Workflow A: Delta Lake ETL
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-b/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: databricks-core-workflow-b
-description: |
-  Execute Databricks secondary workflow: MLflow model training and deployment.
+description: 'Execute Databricks secondary workflow: MLflow model training and deployment.
+
   Use when building ML pipelines, training models, or deploying to production.
+
   Trigger with phrases like "databricks ML", "mlflow training",
+
   "databricks model", "feature store", "model registry".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, deployment, ml, workflow]
+tags:
+- saas
+- databricks
+- deployment
+- ml
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Core Workflow B: MLflow Training & Serving
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: databricks-cost-tuning
-description: |
-  Optimize Databricks costs with cluster policies, spot instances, and monitoring.
+description: 'Optimize Databricks costs with cluster policies, spot instances, and
+  monitoring.
+
   Use when reducing cloud spend, implementing cost controls,
+
   or analyzing Databricks usage costs.
+
   Trigger with phrases like "databricks cost", "reduce databricks spend",
+
   "databricks billing", "databricks cost optimization", "cluster cost".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, monitoring, cost-optimization]
+tags:
+- saas
+- databricks
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Cost Tuning
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-data-handling/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-data-handling/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-data-handling
-description: |
-  Implement Delta Lake data management patterns including GDPR, PII handling, and data lifecycle.
+description: 'Implement Delta Lake data management patterns including GDPR, PII handling,
+  and data lifecycle.
+
   Use when implementing data retention, handling GDPR requests,
+
   or managing data lifecycle in Delta Lake.
+
   Trigger with phrases like "databricks GDPR", "databricks PII",
+
   "databricks data retention", "databricks data lifecycle", "delete user data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, databricks-data]
+tags:
+- saas
+- databricks
+- databricks-data
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Data Handling
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-debug-bundle
-description: |
-  Collect Databricks debug evidence for support tickets and troubleshooting.
+description: 'Collect Databricks debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Databricks problems.
+
   Trigger with phrases like "databricks debug", "databricks support bundle",
+
   "collect databricks logs", "databricks diagnostic".
+
+  '
 allowed-tools: Read, Bash(databricks:*), Bash(tar:*), Bash(python:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, debugging]
+tags:
+- saas
+- databricks
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Debug Bundle
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-deploy-integration
-description: |
-  Deploy Databricks jobs and pipelines with Declarative Automation Bundles.
+description: 'Deploy Databricks jobs and pipelines with Declarative Automation Bundles.
+
   Use when deploying jobs to different environments, managing deployments,
+
   or setting up deployment automation.
+
   Trigger with phrases like "databricks deploy", "asset bundles",
+
   "databricks deployment", "deploy to production", "bundle deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, deployment]
+tags:
+- saas
+- databricks
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Deploy Integration
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-enterprise-rbac
-description: |
-  Configure Databricks enterprise SSO, Unity Catalog RBAC, and organization management.
+description: 'Configure Databricks enterprise SSO, Unity Catalog RBAC, and organization
+  management.
+
   Use when implementing SSO integration, configuring role-based permissions,
+
   or setting up organization-level controls with Unity Catalog.
+
   Trigger with phrases like "databricks SSO", "databricks RBAC",
+
   "databricks enterprise", "unity catalog permissions", "databricks SCIM".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, rbac]
+tags:
+- saas
+- databricks
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Enterprise RBAC
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-hello-world/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-hello-world/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-hello-world
-description: |
-  Create a minimal working Databricks example with cluster and notebook.
+description: 'Create a minimal working Databricks example with cluster and notebook.
+
   Use when starting a new Databricks project, testing your setup,
+
   or learning basic Databricks patterns.
+
   Trigger with phrases like "databricks hello world", "databricks example",
+
   "databricks quick start", "first databricks notebook", "create cluster".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Bash(python:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, testing]
+tags:
+- saas
+- databricks
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Hello World
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-incident-runbook
-description: |
-  Execute Databricks incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Databricks incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Databricks-related outages, investigating job failures,
+
   or running post-incident reviews for pipeline failures.
+
   Trigger with phrases like "databricks incident", "databricks outage",
+
   "databricks down", "databricks on-call", "databricks emergency", "job failed".
+
+  '
 allowed-tools: Read, Grep, Bash(databricks:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, incident-response]
+tags:
+- saas
+- databricks
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Incident Runbook
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-install-auth/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-install-auth/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-install-auth
-description: |
-  Install and configure Databricks CLI and SDK authentication.
+description: 'Install and configure Databricks CLI and SDK authentication.
+
   Use when setting up a new Databricks integration, configuring tokens,
+
   or initializing Databricks in your project.
+
   Trigger with phrases like "install databricks", "setup databricks",
+
   "databricks auth", "configure databricks token", "databricks CLI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(databricks:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, authentication]
+tags:
+- saas
+- databricks
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Install & Auth
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: databricks-local-dev-loop
-description: |
-  Configure Databricks local development with Databricks Connect, Asset Bundles, and IDE.
+description: 'Configure Databricks local development with Databricks Connect, Asset
+  Bundles, and IDE.
+
   Use when setting up a local dev environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Databricks.
+
   Trigger with phrases like "databricks dev setup", "databricks local",
+
   "databricks IDE", "develop with databricks", "databricks connect".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, testing, workflow]
+tags:
+- saas
+- databricks
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Local Dev Loop
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-migration-deep-dive
-description: |
-  Execute comprehensive platform migrations to Databricks from legacy systems.
+description: 'Execute comprehensive platform migrations to Databricks from legacy
+  systems.
+
   Use when migrating from on-premises Hadoop, other cloud platforms,
+
   or legacy data warehouses to Databricks.
+
   Trigger with phrases like "migrate to databricks", "hadoop migration",
+
   "snowflake to databricks", "legacy migration", "data warehouse migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, migration]
+tags:
+- saas
+- databricks
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Migration Deep Dive
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-multi-env-setup
-description: |
-  Configure Databricks across development, staging, and production environments.
+description: 'Configure Databricks across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment secrets,
+
   or implementing environment-specific Databricks configurations.
+
   Trigger with phrases like "databricks environments", "databricks staging",
+
   "databricks dev prod", "databricks environment setup", "databricks config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Bash(terraform:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, deployment]
+tags:
+- saas
+- databricks
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Multi-Environment Setup
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-observability/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-observability/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: databricks-observability
-description: |
-  Set up comprehensive observability for Databricks with metrics, traces, and alerts.
+description: 'Set up comprehensive observability for Databricks with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for Databricks jobs, setting up dashboards,
+
   or configuring alerting for pipeline health.
+
   Trigger with phrases like "databricks monitoring", "databricks metrics",
-  "databricks observability", "monitor databricks", "databricks alerts", "databricks logging".
+
+  "databricks observability", "monitor databricks", "databricks alerts", "databricks
+  logging".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, monitoring, observability, dashboard]
+tags:
+- saas
+- databricks
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Observability
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-performance-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-performance-tuning
-description: |
-  Optimize Databricks cluster and query performance.
+description: 'Optimize Databricks cluster and query performance.
+
   Use when jobs are running slowly, optimizing Spark configurations,
+
   or improving Delta Lake query performance.
+
   Trigger with phrases like "databricks performance", "spark tuning",
+
   "databricks slow", "optimize databricks", "cluster performance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, performance]
+tags:
+- saas
+- databricks
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Performance Tuning
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-prod-checklist
-description: |
-  Execute Databricks production deployment checklist and rollback procedures.
+description: 'Execute Databricks production deployment checklist and rollback procedures.
+
   Use when deploying Databricks jobs to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "databricks production", "deploy databricks",
+
   "databricks go-live", "databricks launch checklist".
+
+  '
 allowed-tools: Read, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, deployment]
+tags:
+- saas
+- databricks
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Production Checklist
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-rate-limits/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-rate-limits
-description: |
-  Implement Databricks API rate limiting, backoff, and idempotency patterns.
+description: 'Implement Databricks API rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Databricks.
+
   Trigger with phrases like "databricks rate limit", "databricks throttling",
+
   "databricks 429", "databricks retry", "databricks backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, api]
+tags:
+- saas
+- databricks
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Rate Limits
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-reference-architecture
-description: |
-  Implement Databricks reference architecture with best-practice project layout.
+description: 'Implement Databricks reference architecture with best-practice project
+  layout.
+
   Use when designing new Databricks projects, reviewing architecture,
+
   or establishing standards for Databricks applications.
+
   Trigger with phrases like "databricks architecture", "databricks best practices",
+
   "databricks project structure", "how to organize databricks", "databricks layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, databricks-reference]
+tags:
+- saas
+- databricks
+- databricks-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Reference Architecture
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: databricks-sdk-patterns
-description: |
-  Apply production-ready Databricks SDK patterns for Python and REST API.
+description: 'Apply production-ready Databricks SDK patterns for Python and REST API.
+
   Use when implementing Databricks integrations, refactoring SDK usage,
+
   or establishing team coding standards for Databricks.
+
   Trigger with phrases like "databricks SDK patterns", "databricks best practices",
+
   "databricks code patterns", "idiomatic databricks".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, api, python]
+tags:
+- saas
+- databricks
+- api
+- python
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks SDK Patterns
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-security-basics/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: databricks-security-basics
-description: |
-  Apply Databricks security best practices for secrets and access control.
+description: 'Apply Databricks security best practices for secrets and access control.
+
   Use when securing API tokens, implementing least privilege access,
+
   or auditing Databricks security configuration.
+
   Trigger with phrases like "databricks security", "databricks secrets",
+
   "secure databricks", "databricks token security", "databricks scopes".
+
+  '
 allowed-tools: Read, Write, Grep, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, api, security, audit]
+tags:
+- saas
+- databricks
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Security Basics
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-upgrade-migration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-upgrade-migration
-description: |
-  Upgrade Databricks runtime versions and migrate between features.
+description: 'Upgrade Databricks runtime versions and migrate between features.
+
   Use when upgrading DBR versions, migrating to Unity Catalog,
+
   or updating deprecated APIs and features.
+
   Trigger with phrases like "databricks upgrade", "DBR upgrade",
+
   "databricks migration", "unity catalog migration", "hive to unity".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, migration]
+tags:
+- saas
+- databricks
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Upgrade & Migration
 

--- a/plugins/saas-packs/databricks-pack/skills/databricks-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: databricks-webhooks-events
-description: |
-  Configure Databricks job notifications, webhooks, and event handling.
+description: 'Configure Databricks job notifications, webhooks, and event handling.
+
   Use when setting up Slack/Teams notifications, configuring alerts,
+
   or integrating Databricks events with external systems.
+
   Trigger with phrases like "databricks webhook", "databricks notifications",
+
   "databricks alerts", "job failure notification", "databricks slack".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(databricks:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, databricks, webhooks]
+tags:
+- saas
+- databricks
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Databricks Webhooks & Events
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-ci-integration/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-ci-integration
-description: |
-  Configure Deepgram CI/CD integration for automated testing and deployment.
+description: 'Configure Deepgram CI/CD integration for automated testing and deployment.
+
   Use when setting up continuous integration pipelines, automated testing,
+
   or deployment workflows for Deepgram integrations.
+
   Trigger: "deepgram CI", "deepgram CD", "deepgram pipeline",
+
   "deepgram github actions", "deepgram automated testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, deployment, testing, ci-cd]
+tags:
+- saas
+- deepgram
+- deployment
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram CI Integration
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-common-errors/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-common-errors
-description: |
-  Diagnose and fix common Deepgram errors and issues.
+description: 'Diagnose and fix common Deepgram errors and issues.
+
   Use when troubleshooting Deepgram API errors, debugging transcription failures,
+
   or resolving integration issues.
+
   Trigger: "deepgram error", "deepgram not working", "fix deepgram",
+
   "deepgram troubleshoot", "transcription failed", "deepgram 401".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, debugging, transcription]
+tags:
+- saas
+- deepgram
+- api
+- debugging
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Common Errors
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-core-workflow-a/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-core-workflow-a
-description: |
-  Implement production pre-recorded speech-to-text with Deepgram.
+description: 'Implement production pre-recorded speech-to-text with Deepgram.
+
   Use when building audio transcription, batch processing,
+
   or implementing diarization and intelligence features.
+
   Trigger: "deepgram transcription", "speech to text", "transcribe audio",
+
   "batch transcription", "deepgram nova", "diarize audio".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, voice-ai, transcription, workflow, stt]
+tags:
+- saas
+- deepgram
+- voice-ai
+- transcription
+- workflow
+- stt
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Core Workflow A: Pre-recorded Transcription
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-core-workflow-b
-description: |
-  Implement real-time streaming transcription with Deepgram WebSocket.
+description: 'Implement real-time streaming transcription with Deepgram WebSocket.
+
   Use when building live transcription, voice interfaces,
+
   real-time captioning, or voice AI applications.
+
   Trigger: "deepgram streaming", "real-time transcription", "live transcription",
+
   "websocket transcription", "voice streaming", "deepgram live".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, voice-ai, transcription, streaming, websocket]
+tags:
+- saas
+- deepgram
+- voice-ai
+- transcription
+- streaming
+- websocket
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Core Workflow B: Live Streaming Transcription
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-cost-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-cost-tuning
-description: |
-  Optimize Deepgram costs and usage for budget-conscious deployments.
+description: 'Optimize Deepgram costs and usage for budget-conscious deployments.
+
   Use when reducing transcription costs, implementing usage controls,
+
   or optimizing pricing tier utilization.
+
   Trigger: "deepgram cost", "reduce deepgram spending", "deepgram pricing",
+
   "deepgram budget", "optimize deepgram usage", "deepgram billing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(ffmpeg:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, cost-optimization, billing]
+tags:
+- saas
+- deepgram
+- cost-optimization
+- billing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Cost Tuning
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-data-handling/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-data-handling
-description: |
-  Implement audio data handling best practices for Deepgram integrations.
+description: 'Implement audio data handling best practices for Deepgram integrations.
+
   Use when managing audio file storage, implementing data retention,
+
   or ensuring GDPR/HIPAA compliance for transcription data.
+
   Trigger: "deepgram data", "audio storage", "transcription data",
+
   "deepgram GDPR", "deepgram HIPAA", "deepgram privacy", "PII redaction".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, data, compliance, privacy]
+tags:
+- saas
+- deepgram
+- data
+- compliance
+- privacy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Data Handling
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-debug-bundle
-description: |
-  Collect Deepgram debug evidence for support and troubleshooting.
+description: 'Collect Deepgram debug evidence for support and troubleshooting.
+
   Use when preparing support tickets, investigating issues,
+
   or collecting diagnostic information for Deepgram problems.
+
   Trigger: "deepgram debug", "deepgram support ticket", "collect deepgram logs",
+
   "deepgram diagnostic", "deepgram debug bundle".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(ffprobe:*), Bash(npm:*), Bash(tar:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, debugging, support]
+tags:
+- saas
+- deepgram
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Debug Bundle
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-deploy-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-deploy-integration
-description: |
-  Deploy Deepgram integrations to production environments.
+description: 'Deploy Deepgram integrations to production environments.
+
   Use when deploying to cloud platforms, configuring containers,
+
   or setting up Deepgram in Docker/Kubernetes/serverless.
+
   Trigger: "deploy deepgram", "deepgram docker", "deepgram kubernetes",
+
   "deepgram production deploy", "deepgram cloud run", "deepgram lambda".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, deployment, docker, kubernetes, serverless]
+tags:
+- saas
+- deepgram
+- deployment
+- docker
+- kubernetes
+- serverless
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Deploy Integration
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-enterprise-rbac/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-enterprise-rbac
-description: |
-  Configure enterprise role-based access control for Deepgram integrations.
+description: 'Configure enterprise role-based access control for Deepgram integrations.
+
   Use when implementing team permissions, managing API key scopes,
+
   or setting up organization-level access controls.
+
   Trigger: "deepgram RBAC", "deepgram permissions", "deepgram access control",
+
   "deepgram team roles", "deepgram enterprise", "deepgram key scopes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, rbac, enterprise]
+tags:
+- saas
+- deepgram
+- api
+- rbac
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Enterprise RBAC
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-hello-world/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-hello-world/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-hello-world
-description: |
-  Create a minimal working Deepgram transcription example.
+description: 'Create a minimal working Deepgram transcription example.
+
   Use when starting a new Deepgram integration, testing your setup,
+
   or learning basic Deepgram API patterns.
+
   Trigger: "deepgram hello world", "deepgram example", "deepgram quick start",
+
   "simple transcription", "transcribe audio".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, testing, transcription, quickstart]
+tags:
+- saas
+- deepgram
+- api
+- testing
+- transcription
+- quickstart
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Hello World
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-incident-runbook
-description: |
-  Execute Deepgram incident response procedures for production issues.
+description: 'Execute Deepgram incident response procedures for production issues.
+
   Use when handling Deepgram outages, debugging production failures,
+
   or responding to service degradation.
+
   Trigger: "deepgram incident", "deepgram outage", "deepgram production issue",
+
   "deepgram down", "deepgram emergency", "deepgram 500 errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, debugging, incident-response]
+tags:
+- saas
+- deepgram
+- debugging
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Incident Runbook
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-install-auth/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-install-auth
-description: |
-  Install and configure Deepgram SDK authentication.
+description: 'Install and configure Deepgram SDK authentication.
+
   Use when setting up a new Deepgram integration, configuring API keys,
+
   or initializing Deepgram in your project.
+
   Trigger: "install deepgram", "setup deepgram", "deepgram auth",
+
   "configure deepgram API key", "deepgram credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, authentication, setup]
+tags:
+- saas
+- deepgram
+- api
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Install & Auth
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-local-dev-loop
-description: |
-  Configure Deepgram local development workflow with testing and mocks.
+description: 'Configure Deepgram local development workflow with testing and mocks.
+
   Use when setting up development environment, configuring test fixtures,
+
   or establishing rapid iteration patterns for Deepgram integration.
+
   Trigger: "deepgram local dev", "deepgram development setup",
+
   "deepgram test environment", "deepgram dev workflow", "deepgram mock".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, testing, workflow, development]
+tags:
+- saas
+- deepgram
+- testing
+- workflow
+- development
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Local Dev Loop
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-migration-deep-dive
-description: |
-  Deep dive into migrating to Deepgram from other transcription providers.
+description: 'Deep dive into migrating to Deepgram from other transcription providers.
+
   Use when migrating from AWS Transcribe, Google Cloud STT, Azure Speech,
+
   OpenAI Whisper, AssemblyAI, or Rev.ai to Deepgram.
+
   Trigger: "deepgram migration", "switch to deepgram", "migrate transcription",
+
   "deepgram from AWS", "deepgram from Google", "replace whisper with deepgram".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, migration, transcription]
+tags:
+- saas
+- deepgram
+- migration
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Migration Deep Dive
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-multi-env-setup
-description: |
-  Configure Deepgram multi-environment setup for dev, staging, and production.
+description: 'Configure Deepgram multi-environment setup for dev, staging, and production.
+
   Use when setting up environment-specific configurations, managing multiple
+
   Deepgram projects, or implementing environment isolation.
+
   Trigger: "deepgram environments", "deepgram staging", "deepgram dev prod",
+
   "multi-environment deepgram", "deepgram config management".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, environments, configuration]
+tags:
+- saas
+- deepgram
+- environments
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Multi-Environment Setup
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-observability/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-observability
-description: |
-  Set up comprehensive observability for Deepgram integrations.
+description: 'Set up comprehensive observability for Deepgram integrations.
+
   Use when implementing monitoring, setting up dashboards,
+
   or configuring alerting for Deepgram integration health.
+
   Trigger: "deepgram monitoring", "deepgram metrics", "deepgram observability",
+
   "monitor deepgram", "deepgram alerts", "deepgram dashboard".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, monitoring, observability, prometheus]
+tags:
+- saas
+- deepgram
+- monitoring
+- observability
+- prometheus
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Observability
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-performance-tuning
-description: |
-  Optimize Deepgram API performance for faster transcription and lower latency.
+description: 'Optimize Deepgram API performance for faster transcription and lower
+  latency.
+
   Use when improving transcription speed, reducing latency,
+
   or optimizing audio processing pipelines.
+
   Trigger: "deepgram performance", "speed up deepgram", "optimize transcription",
+
   "deepgram latency", "deepgram faster", "deepgram throughput".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(ffmpeg:*), Bash(ffprobe:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, performance, optimization]
+tags:
+- saas
+- deepgram
+- api
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Performance Tuning
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-prod-checklist
-description: |
-  Execute Deepgram production deployment checklist.
+description: 'Execute Deepgram production deployment checklist.
+
   Use when preparing for production launch, auditing production readiness,
+
   or verifying deployment configurations.
+
   Trigger: "deepgram production", "deploy deepgram", "deepgram prod checklist",
+
   "deepgram go-live", "production ready deepgram".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, deployment, production]
+tags:
+- saas
+- deepgram
+- deployment
+- production
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Production Checklist
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-rate-limits/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: deepgram-rate-limits
-description: |
-  Implement Deepgram rate limiting and backoff strategies.
+description: 'Implement Deepgram rate limiting and backoff strategies.
+
   Use when handling API quotas, implementing request throttling,
+
   or dealing with 429 rate limit errors.
+
   Trigger: "deepgram rate limit", "deepgram throttling", "429 error deepgram",
+
   "deepgram quota", "deepgram backoff", "deepgram concurrency".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, rate-limiting]
+tags:
+- saas
+- deepgram
+- api
+- rate-limiting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Rate Limits
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-reference-architecture
-description: |
-  Implement Deepgram reference architecture for scalable transcription systems.
+description: 'Implement Deepgram reference architecture for scalable transcription
+  systems.
+
   Use when designing transcription pipelines, building production architectures,
+
   or planning Deepgram integration at scale.
+
   Trigger: "deepgram architecture", "transcription pipeline", "deepgram system design",
+
   "deepgram at scale", "enterprise deepgram", "deepgram queue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, architecture, scaling]
+tags:
+- saas
+- deepgram
+- architecture
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Reference Architecture
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-sdk-patterns
-description: |
-  Apply production-ready Deepgram SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Deepgram SDK patterns for TypeScript and Python.
+
   Use when implementing Deepgram integrations, refactoring SDK usage,
+
   or establishing team coding standards for Deepgram.
+
   Trigger: "deepgram SDK patterns", "deepgram best practices",
+
   "deepgram code patterns", "idiomatic deepgram", "deepgram typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, python, typescript, patterns]
+tags:
+- saas
+- deepgram
+- python
+- typescript
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram SDK Patterns
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-security-basics/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: deepgram-security-basics
-description: |
-  Apply Deepgram security best practices for API key management and data protection.
+description: 'Apply Deepgram security best practices for API key management and data
+  protection.
+
   Use when securing Deepgram integrations, implementing key rotation,
+
   or auditing security configurations.
+
   Trigger: "deepgram security", "deepgram API key security", "secure deepgram",
+
   "deepgram key rotation", "deepgram data protection", "deepgram PII redaction".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, security, compliance]
+tags:
+- saas
+- deepgram
+- api
+- security
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Security Basics
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-upgrade-migration
-description: |
-  Plan and execute Deepgram SDK upgrades and model migrations.
+description: 'Plan and execute Deepgram SDK upgrades and model migrations.
+
   Use when upgrading SDK versions (v3 to v4 to v5), migrating models
+
   (Nova-2 to Nova-3), or planning API version transitions.
+
   Trigger: "upgrade deepgram", "deepgram migration", "update deepgram SDK",
+
   "deepgram version upgrade", "nova-3 migration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, api, migration, upgrade]
+tags:
+- saas
+- deepgram
+- api
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Upgrade Migration
 

--- a/plugins/saas-packs/deepgram-pack/skills/deepgram-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/deepgram-pack/skills/deepgram-webhooks-events/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: deepgram-webhooks-events
-description: |
-  Implement Deepgram callback and webhook handling for async transcription.
+description: 'Implement Deepgram callback and webhook handling for async transcription.
+
   Use when implementing callback URLs, processing async transcription results,
+
   or handling Deepgram event notifications.
+
   Trigger: "deepgram callback", "deepgram webhook", "async transcription",
+
   "deepgram events", "deepgram notifications", "deepgram async".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, deepgram, webhooks, transcription, async]
+tags:
+- saas
+- deepgram
+- webhooks
+- transcription
+- async
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Deepgram Webhooks & Callbacks
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-ci-integration/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: documenso-ci-integration
-description: |
-  Configure CI/CD pipelines for Documenso integrations.
+description: 'Configure CI/CD pipelines for Documenso integrations.
+
   Use when setting up automated testing, deployment pipelines,
+
   or continuous integration for Documenso projects.
+
   Trigger with phrases like "documenso CI", "documenso GitHub Actions",
+
   "documenso pipeline", "documenso automated testing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, deployment, testing, ci-cd]
+tags:
+- saas
+- documenso
+- deployment
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso CI Integration
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-common-errors/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-common-errors
-description: |
-  Diagnose and resolve common Documenso API errors and issues.
+description: 'Diagnose and resolve common Documenso API errors and issues.
+
   Use when encountering Documenso errors, debugging integration issues,
+
   or troubleshooting failed operations.
+
   Trigger with phrases like "documenso error", "documenso 401",
+
   "documenso failed", "fix documenso", "documenso not working".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, debugging]
+tags:
+- saas
+- documenso
+- api
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Common Errors
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-core-workflow-a
-description: |
-  Implement Documenso document creation and recipient management workflows.
+description: 'Implement Documenso document creation and recipient management workflows.
+
   Use when creating documents, managing recipients, adding signature fields,
+
   or building signing workflows with Documenso.
+
   Trigger with phrases like "documenso document", "create document",
+
   "add recipient", "documenso signer", "signature field".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, workflow]
+tags:
+- saas
+- documenso
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Core Workflow A: Document Creation & Recipients
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-core-workflow-b
-description: |
-  Implement Documenso template-based workflows and direct signing links.
+description: 'Implement Documenso template-based workflows and direct signing links.
+
   Use when creating reusable templates, generating documents from templates,
+
   or implementing direct signing experiences.
+
   Trigger with phrases like "documenso template", "signing link",
+
   "direct template", "reusable document", "template workflow".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, workflow]
+tags:
+- saas
+- documenso
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Core Workflow B: Templates & Direct Signing
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-cost-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-cost-tuning
-description: |
-  Optimize Documenso usage costs and manage subscription efficiency.
+description: 'Optimize Documenso usage costs and manage subscription efficiency.
+
   Use when analyzing costs, optimizing document usage,
+
   or managing Documenso subscription tiers.
+
   Trigger with phrases like "documenso costs", "documenso pricing",
+
   "optimize documenso spending", "documenso usage".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, cost-optimization]
+tags:
+- saas
+- documenso
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Cost Tuning
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-data-handling/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-data-handling
-description: |
-  Handle document data, signatures, and PII in Documenso integrations.
+description: 'Handle document data, signatures, and PII in Documenso integrations.
+
   Use when managing document lifecycle, handling signed PDFs,
+
   or implementing data retention policies.
+
   Trigger with phrases like "documenso data", "signed document",
+
   "document retention", "documenso PII", "download signed pdf".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, documenso-data]
+tags:
+- saas
+- documenso
+- documenso-data
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Data Handling
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-debug-bundle
-description: |
-  Comprehensive debugging toolkit for Documenso integrations.
+description: 'Comprehensive debugging toolkit for Documenso integrations.
+
   Use when troubleshooting complex issues, gathering diagnostic information,
+
   or creating support tickets for Documenso problems.
+
   Trigger with phrases like "debug documenso", "documenso diagnostics",
+
   "troubleshoot documenso", "documenso support ticket".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, debugging]
+tags:
+- saas
+- documenso
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Debug Bundle
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-deploy-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: documenso-deploy-integration
-description: |
-  Deploy Documenso integrations across different platforms and environments.
+description: 'Deploy Documenso integrations across different platforms and environments.
+
   Use when deploying to cloud platforms, containerizing applications,
+
   or setting up infrastructure for Documenso integrations.
+
   Trigger with phrases like "deploy documenso", "documenso docker",
+
   "documenso kubernetes", "documenso cloud deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, deployment, docker, kubernetes]
+tags:
+- saas
+- documenso
+- deployment
+- docker
+- kubernetes
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Deploy Integration
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-enterprise-rbac
-description: |
-  Configure Documenso enterprise role-based access control and team management.
+description: 'Configure Documenso enterprise role-based access control and team management.
+
   Use when implementing team permissions, configuring organizational roles,
+
   or setting up enterprise access controls.
+
   Trigger with phrases like "documenso RBAC", "documenso teams",
+
   "documenso permissions", "documenso enterprise", "documenso roles".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, rbac]
+tags:
+- saas
+- documenso
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Enterprise RBAC
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-hello-world/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-hello-world/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-hello-world
-description: |
-  Create a minimal working Documenso example.
+description: 'Create a minimal working Documenso example.
+
   Use when starting a new Documenso integration, testing your setup,
+
   or learning basic document signing patterns.
+
   Trigger with phrases like "documenso hello world", "documenso example",
+
   "documenso quick start", "simple documenso code", "first document".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, testing]
+tags:
+- saas
+- documenso
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Hello World
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-incident-runbook
-description: |
-  Manage incident response for Documenso integration issues.
+description: 'Manage incident response for Documenso integration issues.
+
   Use when diagnosing production incidents, handling outages,
+
   or responding to Documenso service disruptions.
+
   Trigger with phrases like "documenso incident", "documenso outage",
+
   "documenso down", "documenso troubleshooting".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, incident-response]
+tags:
+- saas
+- documenso
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Incident Runbook
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-install-auth/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-install-auth
-description: |
-  Install and configure Documenso SDK/API authentication.
+description: 'Install and configure Documenso SDK/API authentication.
+
   Use when setting up a new Documenso integration, configuring API keys,
+
   or initializing Documenso in your project.
+
   Trigger with phrases like "install documenso", "setup documenso",
+
   "documenso auth", "configure documenso API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, authentication]
+tags:
+- saas
+- documenso
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Install & Auth
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-local-dev-loop
-description: |
-  Set up local development environment and testing workflow for Documenso.
+description: 'Set up local development environment and testing workflow for Documenso.
+
   Use when configuring dev environment, setting up test workflows,
+
   or establishing rapid iteration patterns with Documenso.
+
   Trigger with phrases like "documenso local dev", "documenso development",
+
   "test documenso locally", "documenso dev environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, testing, workflow]
+tags:
+- saas
+- documenso
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Local Dev Loop
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-migration-deep-dive
-description: |
-  Execute comprehensive Documenso migration strategies for platform switches.
+description: 'Execute comprehensive Documenso migration strategies for platform switches.
+
   Use when migrating from other signing platforms, re-platforming to Documenso,
+
   or performing major infrastructure changes.
+
   Trigger with phrases like "migrate to documenso", "documenso migration",
+
   "switch to documenso", "documenso replatform", "replace docusign".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, migration]
+tags:
+- saas
+- documenso
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Migration Deep Dive
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-multi-env-setup
-description: |
-  Configure Documenso across multiple environments (dev, staging, production).
+description: 'Configure Documenso across multiple environments (dev, staging, production).
+
   Use when setting up environment-specific configurations, managing API keys,
+
   or implementing environment promotion workflows.
+
   Trigger with phrases like "documenso environments", "documenso staging",
+
   "documenso dev setup", "multi-environment documenso".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, workflow]
+tags:
+- saas
+- documenso
+- api
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Multi-Environment Setup
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-observability/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: documenso-observability
-description: |
-  Implement monitoring, logging, and tracing for Documenso integrations.
+description: 'Implement monitoring, logging, and tracing for Documenso integrations.
+
   Use when setting up observability, implementing metrics collection,
+
   or debugging production issues.
+
   Trigger with phrases like "documenso monitoring", "documenso metrics",
+
   "documenso logging", "documenso tracing", "documenso observability".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, monitoring, observability, debugging]
+tags:
+- saas
+- documenso
+- monitoring
+- observability
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Observability
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: documenso-performance-tuning
-description: |
-  Optimize Documenso integration performance with caching, batching, and efficient patterns.
+description: 'Optimize Documenso integration performance with caching, batching, and
+  efficient patterns.
+
   Use when improving response times, reducing API calls,
+
   or optimizing bulk document operations.
+
   Trigger with phrases like "documenso performance", "optimize documenso",
+
   "documenso caching", "documenso batch operations".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, performance]
+tags:
+- saas
+- documenso
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Performance Tuning
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-prod-checklist
-description: |
-  Execute Documenso production deployment checklist and rollback procedures.
+description: 'Execute Documenso production deployment checklist and rollback procedures.
+
   Use when deploying Documenso integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "documenso production", "deploy documenso",
+
   "documenso go-live", "documenso launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, deployment]
+tags:
+- saas
+- documenso
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Production Checklist
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-rate-limits/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-rate-limits
-description: |
-  Implement Documenso rate limiting, backoff, and request throttling patterns.
+description: 'Implement Documenso rate limiting, backoff, and request throttling patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Documenso.
+
   Trigger with phrases like "documenso rate limit", "documenso throttling",
+
   "documenso 429", "documenso retry", "documenso backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api]
+tags:
+- saas
+- documenso
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Rate Limits
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-reference-architecture
-description: |
-  Implement Documenso reference architecture with best-practice project layout.
+description: 'Implement Documenso reference architecture with best-practice project
+  layout.
+
   Use when designing new Documenso integrations, reviewing project structure,
+
   or establishing architecture standards for document signing applications.
+
   Trigger with phrases like "documenso architecture", "documenso best practices",
+
   "documenso project structure", "how to organize documenso".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, documenso-reference]
+tags:
+- saas
+- documenso
+- documenso-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Reference Architecture
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-sdk-patterns
-description: |
-  Apply production-ready Documenso SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Documenso SDK patterns for TypeScript and Python.
+
   Use when implementing Documenso integrations, refactoring SDK usage,
+
   or establishing team coding standards for Documenso.
+
   Trigger with phrases like "documenso SDK patterns", "documenso best practices",
+
   "documenso code patterns", "idiomatic documenso".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, python, typescript]
+tags:
+- saas
+- documenso
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso SDK Patterns
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-security-basics/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: documenso-security-basics
-description: |
-  Implement security best practices for Documenso document signing integrations.
+description: 'Implement security best practices for Documenso document signing integrations.
+
   Use when securing API keys, configuring webhooks securely,
+
   or implementing document security measures.
+
   Trigger with phrases like "documenso security", "secure documenso",
+
   "documenso API key security", "documenso webhook security".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, security, webhooks]
+tags:
+- saas
+- documenso
+- api
+- security
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Security Basics
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: documenso-upgrade-migration
-description: |
-  Manage Documenso API version upgrades and SDK migrations.
+description: 'Manage Documenso API version upgrades and SDK migrations.
+
   Use when upgrading from v1 to v2 API, updating SDK versions,
+
   or migrating between Documenso versions.
+
   Trigger with phrases like "documenso upgrade", "documenso v2 migration",
+
   "update documenso SDK", "documenso API version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, api, migration]
+tags:
+- saas
+- documenso
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Upgrade & Migration
 

--- a/plugins/saas-packs/documenso-pack/skills/documenso-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/documenso-pack/skills/documenso-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: documenso-webhooks-events
-description: |
-  Implement Documenso webhook configuration and event handling.
+description: 'Implement Documenso webhook configuration and event handling.
+
   Use when setting up webhook endpoints, handling document events,
+
   or implementing real-time notifications for document signing.
+
   Trigger with phrases like "documenso webhook", "documenso events",
+
   "document completed webhook", "signing notification".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(ngrok:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, documenso, webhooks]
+tags:
+- saas
+- documenso
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Documenso Webhooks & Events
 

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-ci-integration/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-ci-integration/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: elevenlabs-ci-integration
-description: |
-  Configure CI/CD pipelines for ElevenLabs with mocked unit tests and gated integration tests.
+description: 'Configure CI/CD pipelines for ElevenLabs with mocked unit tests and
+  gated integration tests.
+
   Use when setting up GitHub Actions for TTS projects, configuring CI test strategies,
+
   or automating ElevenLabs integration validation.
+
   Trigger: "elevenlabs CI", "elevenlabs GitHub Actions",
+
   "elevenlabs automated tests", "CI elevenlabs", "elevenlabs pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, ci, github-actions]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- ci
+- github-actions
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs CI Integration
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-common-errors/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-common-errors/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-common-errors
-description: |
-  Diagnose and fix ElevenLabs API errors by HTTP status code.
+description: 'Diagnose and fix ElevenLabs API errors by HTTP status code.
+
   Use when encountering ElevenLabs errors, debugging failed TTS/STS requests,
+
   or troubleshooting voice cloning and streaming issues.
+
   Trigger: "elevenlabs error", "fix elevenlabs", "elevenlabs not working",
+
   "debug elevenlabs", "elevenlabs 401", "elevenlabs 429", "elevenlabs 400".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, debugging, errors]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- debugging
+- errors
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Common Errors
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-core-workflow-a
-description: |
-  Implement ElevenLabs text-to-speech and voice cloning workflows.
+description: 'Implement ElevenLabs text-to-speech and voice cloning workflows.
+
   Use when building TTS features, cloning voices from audio samples,
+
   or implementing the primary ElevenLabs money-path: voice generation.
+
   Trigger: "elevenlabs TTS", "text to speech", "voice cloning elevenlabs",
+
   "clone a voice", "generate speech", "elevenlabs voice".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, tts, voice-cloning]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- tts
+- voice-cloning
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Core Workflow A — TTS & Voice Cloning
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-core-workflow-b/SKILL.md
@@ -1,19 +1,31 @@
 ---
 name: elevenlabs-core-workflow-b
-description: |
-  Implement ElevenLabs speech-to-speech, sound effects, audio isolation, and speech-to-text.
+description: 'Implement ElevenLabs speech-to-speech, sound effects, audio isolation,
+  and speech-to-text.
+
   Use when converting voice to another voice, generating sound effects from text,
+
   removing background noise, or transcribing audio.
+
   Trigger: "elevenlabs speech to speech", "voice changer", "sound effects",
+
   "audio isolation", "remove background noise", "elevenlabs transcribe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, speech-to-speech, sound-effects, audio-isolation]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- speech-to-speech
+- sound-effects
+- audio-isolation
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Core Workflow B — Speech-to-Speech, Sound Effects & Audio Isolation
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-cost-tuning/SKILL.md
@@ -1,21 +1,34 @@
 ---
 name: elevenlabs-cost-tuning
-description: |
-  Optimize ElevenLabs costs through model selection, character-efficient patterns,
+description: 'Optimize ElevenLabs costs through model selection, character-efficient
+  patterns,
+
   caching, and usage monitoring with budget alerts.
+
   Use when analyzing ElevenLabs billing, reducing character usage,
+
   or implementing quota monitoring for TTS workloads.
+
   Trigger: "elevenlabs cost", "elevenlabs billing", "reduce elevenlabs costs",
+
   "elevenlabs pricing", "elevenlabs expensive", "elevenlabs budget",
+
   "elevenlabs characters", "elevenlabs quota".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, cost, billing]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- cost
+- billing
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-debug-bundle/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-debug-bundle
-description: |
-  Collect ElevenLabs debug evidence for support tickets and troubleshooting.
+description: 'Collect ElevenLabs debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for ElevenLabs problems.
+
   Trigger: "elevenlabs debug", "elevenlabs support bundle",
+
   "collect elevenlabs logs", "elevenlabs diagnostic", "elevenlabs support ticket".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, debugging, support]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- debugging
+- support
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-deploy-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-deploy-integration
-description: |
-  Deploy ElevenLabs TTS applications to Vercel, Fly.io, and Cloud Run.
+description: 'Deploy ElevenLabs TTS applications to Vercel, Fly.io, and Cloud Run.
+
   Use when deploying ElevenLabs-powered apps to production,
+
   configuring platform-specific secrets, or setting up serverless TTS.
+
   Trigger: "deploy elevenlabs", "elevenlabs Vercel", "elevenlabs Cloud Run",
+
   "elevenlabs Fly.io", "elevenlabs serverless", "host TTS API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, deployment, serverless]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- deployment
+- serverless
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-hello-world/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-hello-world
-description: |
-  Generate your first ElevenLabs text-to-speech audio file.
+description: 'Generate your first ElevenLabs text-to-speech audio file.
+
   Use when starting a new ElevenLabs integration, testing your setup,
+
   or learning basic TTS API patterns.
+
   Trigger: "elevenlabs hello world", "elevenlabs example",
+
   "elevenlabs quick start", "first elevenlabs TTS", "text to speech demo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, tts, audio]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- tts
+- audio
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Hello World
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-install-auth/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-install-auth
-description: |
-  Install and configure ElevenLabs SDK authentication for Node.js or Python.
+description: 'Install and configure ElevenLabs SDK authentication for Node.js or Python.
+
   Use when setting up a new ElevenLabs project, configuring API keys,
+
   or initializing the elevenlabs npm/pip package.
+
   Trigger: "install elevenlabs", "setup elevenlabs", "elevenlabs auth",
+
   "configure elevenlabs API key", "elevenlabs credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, tts, audio]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- tts
+- audio
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-local-dev-loop/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: elevenlabs-local-dev-loop
-description: |
-  Configure local ElevenLabs development with mocking, hot reload, and audio testing.
+description: 'Configure local ElevenLabs development with mocking, hot reload, and
+  audio testing.
+
   Use when setting up a dev environment for TTS/voice projects, configuring test
+
   workflows, or building a fast iteration cycle with ElevenLabs audio.
+
   Trigger: "elevenlabs dev setup", "elevenlabs local development",
+
   "elevenlabs dev environment", "develop with elevenlabs", "test elevenlabs locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, tts, testing]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- tts
+- testing
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-performance-tuning/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: elevenlabs-performance-tuning
-description: |
-  Optimize ElevenLabs TTS latency with model selection, streaming, caching, and audio format tuning.
+description: 'Optimize ElevenLabs TTS latency with model selection, streaming, caching,
+  and audio format tuning.
+
   Use when experiencing slow TTS responses, implementing real-time voice features,
+
   or optimizing audio generation throughput.
+
   Trigger: "elevenlabs performance", "optimize elevenlabs", "elevenlabs latency",
+
   "elevenlabs slow", "fast TTS", "reduce elevenlabs latency", "TTS streaming".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, performance, optimization]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- performance
+- optimization
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-prod-checklist/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: elevenlabs-prod-checklist
-description: |
-  Execute ElevenLabs production deployment checklist with health checks and rollback.
+description: 'Execute ElevenLabs production deployment checklist with health checks
+  and rollback.
+
   Use when deploying TTS/voice integrations to production, preparing for launch,
+
   or implementing go-live procedures for ElevenLabs-powered apps.
+
   Trigger: "elevenlabs production", "deploy elevenlabs",
+
   "elevenlabs go-live", "elevenlabs launch checklist", "production TTS".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, production, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- production
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-rate-limits/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-rate-limits/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: elevenlabs-rate-limits
-description: |
-  Implement ElevenLabs rate limiting, concurrency queuing, and backoff patterns.
+description: 'Implement ElevenLabs rate limiting, concurrency queuing, and backoff
+  patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or managing concurrent TTS request throughput.
+
   Trigger: "elevenlabs rate limit", "elevenlabs throttling",
+
   "elevenlabs 429", "elevenlabs retry", "elevenlabs backoff",
+
   "elevenlabs concurrent requests".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, rate-limits, reliability]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- rate-limits
+- reliability
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-reference-architecture/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: elevenlabs-reference-architecture
-description: |
-  Implement ElevenLabs reference architecture for production TTS/voice applications.
+description: 'Implement ElevenLabs reference architecture for production TTS/voice
+  applications.
+
   Use when designing new ElevenLabs integrations, reviewing project structure,
+
   or building a scalable audio generation service.
+
   Trigger: "elevenlabs architecture", "elevenlabs project structure",
+
   "how to organize elevenlabs", "TTS service architecture",
+
   "elevenlabs design patterns", "voice API architecture".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, architecture, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- architecture
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-sdk-patterns/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: elevenlabs-sdk-patterns
-description: |
-  Apply production-ready ElevenLabs SDK patterns for TypeScript and Python.
+description: 'Apply production-ready ElevenLabs SDK patterns for TypeScript and Python.
+
   Use when implementing ElevenLabs integrations, refactoring SDK usage,
+
   or establishing team coding standards for audio AI applications.
+
   Trigger: "elevenlabs SDK patterns", "elevenlabs best practices",
+
   "elevenlabs code patterns", "idiomatic elevenlabs", "elevenlabs typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, sdk, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- sdk
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-security-basics/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-security-basics/SKILL.md
@@ -1,21 +1,34 @@
 ---
 name: elevenlabs-security-basics
-description: |
-  Apply ElevenLabs security best practices for API keys, webhook HMAC validation,
+description: 'Apply ElevenLabs security best practices for API keys, webhook HMAC
+  validation,
+
   and voice data protection.
+
   Use when securing API keys, validating webhook signatures,
+
   or auditing ElevenLabs security configuration.
+
   Trigger: "elevenlabs security", "elevenlabs secrets",
+
   "secure elevenlabs", "elevenlabs API key security",
+
   "elevenlabs webhook signature", "elevenlabs HMAC".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, security, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- security
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Security Basics
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-upgrade-migration/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: elevenlabs-upgrade-migration
-description: |
-  Upgrade ElevenLabs SDK versions and migrate between API model generations.
+description: 'Upgrade ElevenLabs SDK versions and migrate between API model generations.
+
   Use when upgrading the elevenlabs-js or elevenlabs Python SDK,
+
   migrating from v1 to v2 models, or handling deprecations.
+
   Trigger: "upgrade elevenlabs", "elevenlabs migration",
+
   "elevenlabs breaking changes", "update elevenlabs SDK",
+
   "migrate elevenlabs model", "eleven_v3 migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, migration, upgrade]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- migration
+- upgrade
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/elevenlabs-pack/skills/elevenlabs-webhooks-events/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: elevenlabs-webhooks-events
-description: |
-  Implement ElevenLabs webhook HMAC signature verification and event handling.
+description: 'Implement ElevenLabs webhook HMAC signature verification and event handling.
+
   Use when setting up webhook endpoints for transcription completion,
+
   call recording, or agent conversation events from ElevenLabs.
+
   Trigger: "elevenlabs webhook", "elevenlabs events",
+
   "elevenlabs webhook signature", "handle elevenlabs notifications",
+
   "elevenlabs post-call webhook", "elevenlabs transcription webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, ai, elevenlabs, webhooks, events]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- ai
+- elevenlabs
+- webhooks
+- events
+compatibility: Designed for Claude Code
 ---
-
 # ElevenLabs Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/evernote-pack/skills/evernote-ci-integration/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: evernote-ci-integration
-description: |
-  Configure CI/CD pipelines for Evernote integrations.
+description: 'Configure CI/CD pipelines for Evernote integrations.
+
   Use when setting up automated testing, continuous integration,
+
   or deployment pipelines for Evernote projects.
+
   Trigger with phrases like "evernote ci", "evernote github actions",
+
   "evernote pipeline", "automate evernote tests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, deployment, testing, ci-cd]
+tags:
+- saas
+- evernote
+- deployment
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote CI Integration
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-common-errors/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-common-errors
-description: |
-  Diagnose and fix common Evernote API errors.
+description: 'Diagnose and fix common Evernote API errors.
+
   Use when encountering Evernote API exceptions, debugging failures,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "evernote error", "evernote exception",
+
   "fix evernote issue", "debug evernote", "evernote troubleshooting".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, debugging]
+tags:
+- saas
+- evernote
+- api
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Common Errors
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-core-workflow-a
-description: |
-  Execute Evernote primary workflow: Note Creation and Management.
+description: 'Execute Evernote primary workflow: Note Creation and Management.
+
   Use when creating notes, organizing content, managing notebooks,
+
   or implementing note-taking features.
+
   Trigger with phrases like "create evernote note", "evernote note workflow",
+
   "manage evernote notes", "evernote content".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, workflow]
+tags:
+- saas
+- evernote
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Core Workflow A: Note Creation & Management
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-core-workflow-b
-description: |
-  Execute Evernote secondary workflow: Search and Retrieval.
+description: 'Execute Evernote secondary workflow: Search and Retrieval.
+
   Use when implementing search features, finding notes,
+
   filtering content, or building search interfaces.
+
   Trigger with phrases like "search evernote", "find evernote notes",
+
   "evernote search", "query evernote".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, workflow]
+tags:
+- saas
+- evernote
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Core Workflow B: Search & Retrieval
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-cost-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-cost-tuning
-description: |
-  Optimize Evernote integration costs and resource usage.
+description: 'Optimize Evernote integration costs and resource usage.
+
   Use when managing API quotas, reducing storage usage,
+
   or optimizing upload limits.
+
   Trigger with phrases like "evernote cost", "evernote quota",
+
   "evernote limits", "evernote upload".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, cost-optimization]
+tags:
+- saas
+- evernote
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Cost Tuning
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-data-handling/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-data-handling
-description: |
-  Best practices for handling Evernote data.
+description: 'Best practices for handling Evernote data.
+
   Use when implementing data storage, processing notes,
+
   handling attachments, or ensuring data integrity.
+
   Trigger with phrases like "evernote data", "handle evernote notes",
+
   "evernote storage", "process evernote content".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, evernote-data]
+tags:
+- saas
+- evernote
+- evernote-data
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Data Handling
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-debug-bundle
-description: |
-  Debug Evernote API issues with diagnostic tools and techniques.
+description: 'Debug Evernote API issues with diagnostic tools and techniques.
+
   Use when troubleshooting API calls, inspecting requests/responses,
+
   or diagnosing integration problems.
+
   Trigger with phrases like "debug evernote", "evernote diagnostic",
+
   "troubleshoot evernote", "evernote logs", "inspect evernote".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, debugging]
+tags:
+- saas
+- evernote
+- api
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Debug Bundle
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-deploy-integration
-description: |
-  Deploy Evernote integrations to production environments.
+description: 'Deploy Evernote integrations to production environments.
+
   Use when deploying to cloud platforms, configuring production,
+
   or setting up deployment pipelines.
+
   Trigger with phrases like "deploy evernote", "evernote production deploy",
+
   "release evernote", "evernote cloud deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, deployment]
+tags:
+- saas
+- evernote
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Deploy Integration
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-enterprise-rbac
-description: |
-  Implement enterprise RBAC for Evernote integrations.
+description: 'Implement enterprise RBAC for Evernote integrations.
+
   Use when building multi-tenant systems, implementing
+
   role-based access, or handling business accounts.
+
   Trigger with phrases like "evernote enterprise", "evernote rbac",
+
   "evernote business", "evernote permissions".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, rbac]
+tags:
+- saas
+- evernote
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Enterprise RBAC
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-hello-world/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-hello-world
-description: |
-  Create a minimal working Evernote example.
+description: 'Create a minimal working Evernote example.
+
   Use when starting a new Evernote integration, testing your setup,
+
   or learning basic Evernote API patterns.
+
   Trigger with phrases like "evernote hello world", "evernote example",
+
   "evernote quick start", "simple evernote code", "create first note".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, testing]
+tags:
+- saas
+- evernote
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Hello World
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-incident-runbook
-description: |
-  Manage incident response for Evernote integration issues.
+description: 'Manage incident response for Evernote integration issues.
+
   Use when troubleshooting production incidents, handling outages,
+
   or responding to Evernote service issues.
+
   Trigger with phrases like "evernote incident", "evernote outage",
+
   "evernote emergency", "troubleshoot evernote production".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, incident-response]
+tags:
+- saas
+- evernote
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Incident Runbook
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-install-auth/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-install-auth
-description: |
-  Install and configure Evernote SDK and OAuth authentication.
+description: 'Install and configure Evernote SDK and OAuth authentication.
+
   Use when setting up a new Evernote integration, configuring API keys,
+
   or initializing Evernote in your project.
+
   Trigger with phrases like "install evernote", "setup evernote",
+
   "evernote auth", "configure evernote API", "evernote oauth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, authentication]
+tags:
+- saas
+- evernote
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Install & Auth
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-local-dev-loop
-description: |
-  Set up efficient local development workflow for Evernote integrations.
+description: 'Set up efficient local development workflow for Evernote integrations.
+
   Use when configuring dev environment, setting up sandbox testing,
+
   or optimizing development iteration speed.
+
   Trigger with phrases like "evernote dev setup", "evernote local development",
+
   "evernote sandbox", "test evernote locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, testing, workflow]
+tags:
+- saas
+- evernote
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Local Dev Loop
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-migration-deep-dive
-description: |
-  Deep dive into Evernote data migration strategies.
+description: 'Deep dive into Evernote data migration strategies.
+
   Use when migrating to/from Evernote, bulk data transfers,
+
   or complex migration scenarios.
+
   Trigger with phrases like "migrate to evernote", "migrate from evernote",
+
   "evernote data transfer", "bulk evernote migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, migration]
+tags:
+- saas
+- evernote
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Migration Deep Dive
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-multi-env-setup
-description: |
-  Configure multi-environment setup for Evernote integrations.
+description: 'Configure multi-environment setup for Evernote integrations.
+
   Use when setting up dev, staging, and production environments,
+
   or managing environment-specific configurations.
+
   Trigger with phrases like "evernote environments", "evernote staging",
+
   "evernote dev setup", "multiple environments evernote".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, evernote-multi]
+tags:
+- saas
+- evernote
+- evernote-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Multi-Environment Setup
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-observability/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: evernote-observability
-description: |
-  Implement observability for Evernote integrations.
+description: 'Implement observability for Evernote integrations.
+
   Use when setting up monitoring, logging, tracing,
+
   or alerting for Evernote applications.
+
   Trigger with phrases like "evernote monitoring", "evernote logging",
+
   "evernote metrics", "evernote observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, monitoring, observability, logging]
+tags:
+- saas
+- evernote
+- monitoring
+- observability
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Observability
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: evernote-performance-tuning
-description: |
-  Optimize Evernote integration performance.
+description: 'Optimize Evernote integration performance.
+
   Use when improving response times, reducing API calls,
+
   or scaling Evernote integrations.
+
   Trigger with phrases like "evernote performance", "optimize evernote",
+
   "evernote speed", "evernote caching".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, performance, scaling]
+tags:
+- saas
+- evernote
+- api
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Performance Tuning
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: evernote-prod-checklist
-description: |
-  Production readiness checklist for Evernote integrations.
+description: 'Production readiness checklist for Evernote integrations.
+
   Use when preparing to deploy Evernote integration to production,
+
   or auditing production readiness.
+
   Trigger with phrases like "evernote production", "deploy evernote",
+
   "evernote go live", "production checklist evernote".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, deployment, golang, audit]
+tags:
+- saas
+- evernote
+- deployment
+- golang
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Production Checklist
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-rate-limits/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-rate-limits
-description: |
-  Handle Evernote API rate limits effectively.
+description: 'Handle Evernote API rate limits effectively.
+
   Use when implementing rate limit handling, optimizing API usage,
+
   or troubleshooting rate limit errors.
+
   Trigger with phrases like "evernote rate limit", "evernote throttling",
+
   "api quota evernote", "rate limit exceeded".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api]
+tags:
+- saas
+- evernote
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Rate Limits
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-reference-architecture
-description: |
-  Reference architecture for Evernote integrations.
+description: 'Reference architecture for Evernote integrations.
+
   Use when designing system architecture, planning integrations,
+
   or building scalable Evernote applications.
+
   Trigger with phrases like "evernote architecture", "design evernote system",
+
   "evernote integration pattern", "evernote scale".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, scaling]
+tags:
+- saas
+- evernote
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Reference Architecture
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-sdk-patterns
-description: |
-  Advanced Evernote SDK patterns and best practices.
+description: 'Advanced Evernote SDK patterns and best practices.
+
   Use when implementing complex note operations, batch processing,
+
   search queries, or optimizing SDK usage.
+
   Trigger with phrases like "evernote sdk patterns", "evernote best practices",
+
   "evernote advanced", "evernote batch operations".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, evernote-sdk]
+tags:
+- saas
+- evernote
+- evernote-sdk
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote SDK Patterns
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-security-basics/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-security-basics/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-security-basics
-description: |
-  Implement security best practices for Evernote integrations.
+description: 'Implement security best practices for Evernote integrations.
+
   Use when securing API credentials, implementing OAuth securely,
+
   or hardening Evernote integrations.
+
   Trigger with phrases like "evernote security", "secure evernote",
+
   "evernote credentials", "evernote oauth security".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, security]
+tags:
+- saas
+- evernote
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Security Basics
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: evernote-upgrade-migration
-description: |
-  Upgrade Evernote SDK versions and migrate between API versions.
+description: 'Upgrade Evernote SDK versions and migrate between API versions.
+
   Use when upgrading SDK, handling breaking changes,
+
   or migrating to newer API patterns.
+
   Trigger with phrases like "upgrade evernote sdk", "evernote migration",
+
   "update evernote", "evernote breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, api, migration]
+tags:
+- saas
+- evernote
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Upgrade & Migration
 

--- a/plugins/saas-packs/evernote-pack/skills/evernote-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/evernote-pack/skills/evernote-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: evernote-webhooks-events
-description: |
-  Implement Evernote webhook notifications and sync events.
+description: 'Implement Evernote webhook notifications and sync events.
+
   Use when handling note changes, implementing real-time sync,
+
   or processing Evernote notifications.
+
   Trigger with phrases like "evernote webhook", "evernote events",
+
   "evernote sync", "evernote notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, evernote, webhooks]
+tags:
+- saas
+- evernote
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Evernote Webhooks & Events
 

--- a/plugins/saas-packs/exa-pack/skills/exa-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-advanced-troubleshooting
-description: |
-  Apply advanced debugging techniques for hard-to-diagnose Exa issues.
+description: 'Apply advanced debugging techniques for hard-to-diagnose Exa issues.
+
   Use when standard troubleshooting fails, investigating latency spikes,
+
   or preparing evidence bundles for Exa support escalation.
+
   Trigger with phrases like "exa hard bug", "exa mystery error",
+
   "exa deep debug", "difficult exa issue", "exa latency spike".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*), Bash(tcpdump:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, debugging, advanced]
+tags:
+- saas
+- exa
+- debugging
+- advanced
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Advanced Troubleshooting
 

--- a/plugins/saas-packs/exa-pack/skills/exa-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-architecture-variants/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: exa-architecture-variants
-description: |
-  Choose and implement Exa architecture patterns at different scales: direct search, cached search, and RAG pipeline.
+description: 'Choose and implement Exa architecture patterns at different scales:
+  direct search, cached search, and RAG pipeline.
+
   Use when designing Exa integrations, choosing between simple search and full RAG,
+
   or planning architecture for different traffic volumes.
+
   Trigger with phrases like "exa architecture", "exa blueprint",
+
   "how to structure exa", "exa RAG design", "exa at scale".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, architecture, rag, scaling]
+tags:
+- saas
+- exa
+- architecture
+- rag
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Architecture Variants
 

--- a/plugins/saas-packs/exa-pack/skills/exa-ci-integration/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-ci-integration
-description: |
-  Configure Exa CI/CD integration with GitHub Actions and automated testing.
+description: 'Configure Exa CI/CD integration with GitHub Actions and automated testing.
+
   Use when setting up automated testing for Exa integrations,
+
   configuring CI pipelines, or adding Exa health checks to builds.
+
   Trigger with phrases like "exa CI", "exa GitHub Actions",
+
   "exa automated tests", "CI exa", "exa pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, testing, ci-cd]
+tags:
+- saas
+- exa
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa CI Integration
 

--- a/plugins/saas-packs/exa-pack/skills/exa-common-errors/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-common-errors
-description: |
-  Diagnose and fix Exa API errors by HTTP code and error tag.
+description: 'Diagnose and fix Exa API errors by HTTP code and error tag.
+
   Use when encountering Exa errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "exa error", "fix exa",
+
   "exa not working", "debug exa", "exa 429", "exa 401".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, debugging, errors]
+tags:
+- saas
+- exa
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Common Errors
 

--- a/plugins/saas-packs/exa-pack/skills/exa-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-core-workflow-a
-description: |
-  Execute Exa neural search with contents, date filters, and domain scoping.
+description: 'Execute Exa neural search with contents, date filters, and domain scoping.
+
   Use when building search features, implementing RAG context retrieval,
+
   or querying the web with semantic understanding.
+
   Trigger with phrases like "exa search", "exa neural search",
+
   "search with exa", "exa searchAndContents", "exa query".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, workflow, neural-search, search]
+tags:
+- saas
+- exa
+- workflow
+- neural-search
+- search
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Core Workflow A — Neural Search
 

--- a/plugins/saas-packs/exa-pack/skills/exa-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-core-workflow-b
-description: |
-  Execute Exa findSimilar, getContents, answer, and streaming answer workflows.
+description: 'Execute Exa findSimilar, getContents, answer, and streaming answer workflows.
+
   Use when finding pages similar to a URL, retrieving content for known URLs,
+
   or getting AI-generated answers with citations.
+
   Trigger with phrases like "exa find similar", "exa get contents",
+
   "exa answer", "exa similarity search", "findSimilarAndContents".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, workflow, similarity-search, answer]
+tags:
+- saas
+- exa
+- workflow
+- similarity-search
+- answer
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Core Workflow B — Similarity, Contents & Answer
 

--- a/plugins/saas-packs/exa-pack/skills/exa-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-cost-tuning
-description: |
-  Optimize Exa costs through search type selection, caching, and usage monitoring.
+description: 'Optimize Exa costs through search type selection, caching, and usage
+  monitoring.
+
   Use when analyzing Exa billing, reducing API costs,
+
   or implementing budget controls and usage alerts.
+
   Trigger with phrases like "exa cost", "exa billing",
+
   "reduce exa costs", "exa pricing", "exa expensive", "exa budget".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, cost-optimization]
+tags:
+- saas
+- exa
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Cost Tuning
 

--- a/plugins/saas-packs/exa-pack/skills/exa-data-handling/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-data-handling/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: exa-data-handling
-description: |
-  Implement Exa search result processing, content extraction, caching, and RAG context management.
+description: 'Implement Exa search result processing, content extraction, caching,
+  and RAG context management.
+
   Use when handling search results, implementing caching, building citation pipelines,
+
   or managing content payloads for LLM context windows.
+
   Trigger with phrases like "exa data", "exa results processing",
+
   "exa cache", "exa RAG context", "exa content extraction".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, data, rag, caching]
+tags:
+- saas
+- exa
+- data
+- rag
+- caching
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Data Handling
 

--- a/plugins/saas-packs/exa-pack/skills/exa-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: exa-debug-bundle
-description: |
-  Collect Exa debug evidence for support tickets and troubleshooting.
+description: 'Collect Exa debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Exa problems.
+
   Trigger with phrases like "exa debug", "exa support bundle",
+
   "collect exa logs", "exa diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, debugging]
+tags:
+- saas
+- exa
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Debug Bundle
 

--- a/plugins/saas-packs/exa-pack/skills/exa-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-deploy-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-deploy-integration
-description: |
-  Deploy Exa integrations to Vercel, Docker, and Cloud Run platforms.
+description: 'Deploy Exa integrations to Vercel, Docker, and Cloud Run platforms.
+
   Use when deploying Exa-powered applications to production,
+
   configuring platform-specific secrets, or building search API endpoints.
+
   Trigger with phrases like "deploy exa", "exa Vercel",
+
   "exa production deploy", "exa Cloud Run", "exa Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, deployment, vercel, docker]
+tags:
+- saas
+- exa
+- deployment
+- vercel
+- docker
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Deploy Integration
 

--- a/plugins/saas-packs/exa-pack/skills/exa-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-enterprise-rbac
-description: |
-  Manage Exa API key scoping, team access controls, and domain restrictions.
+description: 'Manage Exa API key scoping, team access controls, and domain restrictions.
+
   Use when implementing multi-key access control, configuring per-team search limits,
+
   or setting up organization-level Exa governance.
+
   Trigger with phrases like "exa access control", "exa RBAC",
+
   "exa enterprise", "exa team keys", "exa permissions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, rbac, enterprise]
+tags:
+- saas
+- exa
+- rbac
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Enterprise RBAC
 

--- a/plugins/saas-packs/exa-pack/skills/exa-hello-world/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-hello-world
-description: |
-  Create a minimal working Exa search example with real results.
+description: 'Create a minimal working Exa search example with real results.
+
   Use when starting a new Exa integration, testing your setup,
+
   or learning basic search, searchAndContents, and findSimilar patterns.
+
   Trigger with phrases like "exa hello world", "exa example",
+
   "exa quick start", "simple exa search", "first exa query".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, quickstart, neural-search]
+tags:
+- saas
+- exa
+- api
+- quickstart
+- neural-search
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Hello World
 

--- a/plugins/saas-packs/exa-pack/skills/exa-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-incident-runbook
-description: |
-  Execute Exa incident response with triage, mitigation, and postmortem procedures.
+description: 'Execute Exa incident response with triage, mitigation, and postmortem
+  procedures.
+
   Use when responding to Exa-related outages, investigating errors,
+
   or running post-incident reviews for Exa integration failures.
+
   Trigger with phrases like "exa incident", "exa outage",
+
   "exa down", "exa on-call", "exa emergency", "exa broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, incident-response]
+tags:
+- saas
+- exa
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Incident Runbook
 

--- a/plugins/saas-packs/exa-pack/skills/exa-install-auth/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-install-auth
-description: |
-  Install the exa-js SDK and configure API key authentication.
+description: 'Install the exa-js SDK and configure API key authentication.
+
   Use when setting up a new Exa integration, configuring API keys,
+
   or initializing Exa in a Node.js/Python project.
+
   Trigger with phrases like "install exa", "setup exa",
+
   "exa auth", "configure exa API key", "exa-js".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, authentication, setup]
+tags:
+- saas
+- exa
+- api
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Install & Auth
 

--- a/plugins/saas-packs/exa-pack/skills/exa-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-known-pitfalls/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-known-pitfalls
-description: |
-  Identify and avoid Exa anti-patterns and common integration mistakes.
+description: 'Identify and avoid Exa anti-patterns and common integration mistakes.
+
   Use when reviewing Exa code, onboarding new developers,
+
   or auditing existing Exa integrations for correctness.
+
   Trigger with phrases like "exa mistakes", "exa anti-patterns",
+
   "exa pitfalls", "exa what not to do", "exa code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, audit, best-practices]
+tags:
+- saas
+- exa
+- audit
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Known Pitfalls
 

--- a/plugins/saas-packs/exa-pack/skills/exa-load-scale/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-load-scale/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-load-scale
-description: |
-  Implement Exa load testing, capacity planning, and scaling strategies.
+description: 'Implement Exa load testing, capacity planning, and scaling strategies.
+
   Use when running performance tests, planning capacity for Exa integrations,
+
   or designing high-throughput search architectures.
+
   Trigger with phrases like "exa load test", "exa scale",
+
   "exa capacity", "exa k6", "exa benchmark", "exa throughput".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, testing, performance, scaling]
+tags:
+- saas
+- exa
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Load & Scale
 

--- a/plugins/saas-packs/exa-pack/skills/exa-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-local-dev-loop
-description: |
-  Configure Exa local development with hot reload, testing, and mock responses.
+description: 'Configure Exa local development with hot reload, testing, and mock responses.
+
   Use when setting up a development environment, writing tests against Exa,
+
   or establishing a fast iteration cycle.
+
   Trigger with phrases like "exa dev setup", "exa local development",
+
   "exa test setup", "develop with exa", "mock exa".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, testing, development]
+tags:
+- saas
+- exa
+- testing
+- development
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Local Dev Loop
 

--- a/plugins/saas-packs/exa-pack/skills/exa-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-migration-deep-dive
-description: |
-  Migrate from other search APIs (Google, Bing, Tavily, Serper) to Exa neural search.
+description: 'Migrate from other search APIs (Google, Bing, Tavily, Serper) to Exa
+  neural search.
+
   Use when switching to Exa from another search provider, migrating search pipelines,
+
   or evaluating Exa as a replacement for traditional search APIs.
-  Trigger with phrases like "migrate to exa", "switch to exa", "replace google search with exa",
+
+  Trigger with phrases like "migrate to exa", "switch to exa", "replace google search
+  with exa",
+
   "exa vs tavily", "exa migration", "move to exa".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, migration]
+tags:
+- saas
+- exa
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Migration Deep Dive
 

--- a/plugins/saas-packs/exa-pack/skills/exa-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-multi-env-setup
-description: |
-  Configure Exa across development, staging, and production environments.
+description: 'Configure Exa across development, staging, and production environments.
+
   Use when setting up multi-environment search pipelines, managing API key isolation,
+
   or configuring per-environment search limits and caching.
+
   Trigger with phrases like "exa environments", "exa staging", "exa dev prod",
+
   "exa environment setup", "exa multi-env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, deployment, api, environments]
+tags:
+- saas
+- exa
+- deployment
+- api
+- environments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Multi-Environment Setup
 

--- a/plugins/saas-packs/exa-pack/skills/exa-observability/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-observability/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-observability
-description: |
-  Set up monitoring, metrics, and alerting for Exa search integrations.
+description: 'Set up monitoring, metrics, and alerting for Exa search integrations.
+
   Use when implementing monitoring for Exa operations, building dashboards,
+
   or configuring alerting for search quality and latency.
+
   Trigger with phrases like "exa monitoring", "exa metrics",
+
   "exa observability", "monitor exa", "exa alerts", "exa dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, monitoring, observability]
+tags:
+- saas
+- exa
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Observability
 

--- a/plugins/saas-packs/exa-pack/skills/exa-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: exa-performance-tuning
-description: |
-  Optimize Exa API performance with search type selection, caching, and parallelization.
+description: 'Optimize Exa API performance with search type selection, caching, and
+  parallelization.
+
   Use when experiencing slow responses, implementing caching strategies,
+
   or optimizing request throughput for Exa integrations.
+
   Trigger with phrases like "exa performance", "optimize exa",
+
   "exa latency", "exa caching", "exa slow", "exa fast".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, performance, optimization]
+tags:
+- saas
+- exa
+- api
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Performance Tuning
 

--- a/plugins/saas-packs/exa-pack/skills/exa-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-policy-guardrails/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-policy-guardrails
-description: |
-  Implement content policy enforcement, domain filtering, and usage guardrails for Exa.
+description: 'Implement content policy enforcement, domain filtering, and usage guardrails
+  for Exa.
+
   Use when setting up content safety rules, restricting search domains,
+
   or enforcing query and budget policies for Exa integrations.
+
   Trigger with phrases like "exa policy", "exa content filter",
+
   "exa guardrails", "exa domain allowlist", "exa content moderation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, policy, content-moderation]
+tags:
+- saas
+- exa
+- policy
+- content-moderation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Policy Guardrails
 

--- a/plugins/saas-packs/exa-pack/skills/exa-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-prod-checklist
-description: |
-  Execute Exa production deployment checklist with pre-flight, deploy, and rollback.
+description: 'Execute Exa production deployment checklist with pre-flight, deploy,
+  and rollback.
+
   Use when deploying Exa integrations to production, preparing for launch,
+
   or verifying production readiness.
+
   Trigger with phrases like "exa production", "deploy exa to prod",
+
   "exa go-live", "exa launch checklist", "exa production ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, deployment, production]
+tags:
+- saas
+- exa
+- deployment
+- production
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Production Checklist
 

--- a/plugins/saas-packs/exa-pack/skills/exa-rate-limits/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: exa-rate-limits
-description: |
-  Implement Exa rate limiting, exponential backoff, and request queuing.
+description: 'Implement Exa rate limiting, exponential backoff, and request queuing.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Exa.
+
   Trigger with phrases like "exa rate limit", "exa throttling",
+
   "exa 429", "exa retry", "exa backoff", "exa QPS".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, rate-limiting]
+tags:
+- saas
+- exa
+- api
+- rate-limiting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Rate Limits
 

--- a/plugins/saas-packs/exa-pack/skills/exa-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-reference-architecture
-description: |
-  Implement Exa reference architecture for search pipelines, RAG, and content discovery.
+description: 'Implement Exa reference architecture for search pipelines, RAG, and
+  content discovery.
+
   Use when designing new Exa integrations, reviewing project structure,
+
   or establishing architecture standards for neural search applications.
+
   Trigger with phrases like "exa architecture", "exa project structure",
+
   "exa RAG pipeline", "exa reference design", "exa search pipeline".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, architecture, rag]
+tags:
+- saas
+- exa
+- architecture
+- rag
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Reference Architecture
 

--- a/plugins/saas-packs/exa-pack/skills/exa-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-reliability-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-reliability-patterns
-description: |
-  Implement Exa reliability patterns: query fallback chains, circuit breakers, and graceful degradation.
+description: 'Implement Exa reliability patterns: query fallback chains, circuit breakers,
+  and graceful degradation.
+
   Use when building fault-tolerant Exa integrations, implementing fallback strategies,
+
   or adding resilience to production search services.
+
   Trigger with phrases like "exa reliability", "exa circuit breaker",
+
   "exa fallback", "exa resilience", "exa graceful degradation".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, reliability, resilience]
+tags:
+- saas
+- exa
+- reliability
+- resilience
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Reliability Patterns
 

--- a/plugins/saas-packs/exa-pack/skills/exa-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-sdk-patterns
-description: |
-  Apply production-ready exa-js SDK patterns with type safety, singletons, and wrappers.
+description: 'Apply production-ready exa-js SDK patterns with type safety, singletons,
+  and wrappers.
+
   Use when implementing Exa integrations, refactoring SDK usage,
+
   or establishing team coding standards for Exa.
+
   Trigger with phrases like "exa SDK patterns", "exa best practices",
+
   "exa code patterns", "idiomatic exa", "exa wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, typescript, patterns]
+tags:
+- saas
+- exa
+- typescript
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa SDK Patterns
 

--- a/plugins/saas-packs/exa-pack/skills/exa-security-basics/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-security-basics
-description: |
-  Secure Exa API keys, implement content moderation, and manage domain restrictions.
+description: 'Secure Exa API keys, implement content moderation, and manage domain
+  restrictions.
+
   Use when securing API keys, auditing Exa security configuration,
+
   or implementing content safety filtering.
+
   Trigger with phrases like "exa security", "exa secrets",
+
   "secure exa", "exa API key security", "exa content moderation".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, security]
+tags:
+- saas
+- exa
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Security Basics
 

--- a/plugins/saas-packs/exa-pack/skills/exa-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: exa-upgrade-migration
-description: |
-  Upgrade exa-js SDK versions and handle breaking changes safely.
+description: 'Upgrade exa-js SDK versions and handle breaking changes safely.
+
   Use when upgrading the Exa SDK, detecting deprecations,
+
   or migrating between exa-js versions.
+
   Trigger with phrases like "upgrade exa", "exa update",
+
   "exa breaking changes", "update exa-js", "exa new version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, api, migration, upgrade]
+tags:
+- saas
+- exa
+- api
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Upgrade & Migration
 

--- a/plugins/saas-packs/exa-pack/skills/exa-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/exa-pack/skills/exa-webhooks-events/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: exa-webhooks-events
-description: |
-  Build event-driven integrations with Exa using scheduled monitors and content alerts.
+description: 'Build event-driven integrations with Exa using scheduled monitors and
+  content alerts.
+
   Use when building content monitoring, competitive intelligence pipelines,
+
   or scheduled search automation with Exa.
+
   Trigger with phrases like "exa monitor", "exa content alerts",
+
   "exa scheduled search", "exa event-driven", "exa notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, exa, webhooks, monitoring, automation]
+tags:
+- saas
+- exa
+- webhooks
+- monitoring
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Exa Webhooks & Events
 

--- a/plugins/saas-packs/fathom-pack/skills/fathom-ci-integration/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-ci-integration
-description: |
-  Test Fathom integrations in CI/CD pipelines.
+description: 'Test Fathom integrations in CI/CD pipelines.
+
   Trigger with phrases like "fathom CI", "fathom github actions", "test fathom pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom CI Integration
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-common-errors/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-common-errors/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: fathom-common-errors
-description: |
-  Diagnose and fix Fathom API errors including auth failures and missing data.
+description: 'Diagnose and fix Fathom API errors including auth failures and missing
+  data.
+
   Use when API calls fail, transcripts are empty, or webhooks are not firing.
+
   Trigger with phrases like "fathom error", "fathom not working",
+
   "fathom api failure", "fix fathom".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/fathom-pack/skills/fathom-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-core-workflow-a
-description: |
-  Build a meeting analytics pipeline with Fathom transcripts and summaries.
+description: 'Build a meeting analytics pipeline with Fathom transcripts and summaries.
+
   Use when extracting insights from meetings, building CRM sync,
+
   or creating automated meeting follow-up workflows.
+
   Trigger with phrases like "fathom analytics", "fathom meeting pipeline",
+
   "fathom transcript analysis", "fathom action items sync".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Core Workflow: Meeting Analytics
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-core-workflow-b
-description: |
-  Sync Fathom meeting data to CRM and build automated follow-up workflows.
+description: 'Sync Fathom meeting data to CRM and build automated follow-up workflows.
+
   Use when integrating Fathom with Salesforce, HubSpot, or custom CRMs,
+
   or creating automated post-meeting email summaries.
+
   Trigger with phrases like "fathom crm sync", "fathom salesforce",
+
   "fathom follow-up", "fathom post-meeting workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Core Workflow: CRM Sync & Follow-Up
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-cost-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-cost-tuning
-description: |
-  Optimize Fathom API usage and plan selection.
+description: 'Optimize Fathom API usage and plan selection.
+
   Trigger with phrases like "fathom cost", "fathom pricing", "fathom plan".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-debug-bundle
-description: |
-  Collect Fathom API diagnostics for support cases.
+description: 'Collect Fathom API diagnostics for support cases.
+
   Trigger with phrases like "fathom debug", "fathom diagnostics".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-deploy-integration/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: fathom-deploy-integration
-description: |
-  Deploy Fathom webhook handlers and meeting sync services.
-  Trigger with phrases like "deploy fathom", "fathom webhook server", "fathom cloud function".
+description: 'Deploy Fathom webhook handlers and meeting sync services.
+
+  Trigger with phrases like "deploy fathom", "fathom webhook server", "fathom cloud
+  function".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-hello-world/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-hello-world
-description: |
-  Retrieve meeting transcripts and summaries from the Fathom API.
+description: 'Retrieve meeting transcripts and summaries from the Fathom API.
+
   Use when fetching meeting data, testing API access,
+
   or learning Fathom API response structure.
+
   Trigger with phrases like "fathom hello world", "fathom first api call",
+
   "get fathom transcript", "fathom meeting data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Hello World
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-install-auth/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-install-auth
-description: |
-  Configure Fathom AI meeting assistant API access with API key authentication.
+description: 'Configure Fathom AI meeting assistant API access with API key authentication.
+
   Use when setting up Fathom API integration, generating API keys,
+
   or configuring webhook access for meeting data.
+
   Trigger with phrases like "install fathom", "setup fathom api",
+
   "fathom auth", "fathom api key", "configure fathom".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: fathom-local-dev-loop
-description: |
-  Set up local development for Fathom API integrations with mock meeting data.
+description: 'Set up local development for Fathom API integrations with mock meeting
+  data.
+
   Use when building meeting analytics tools, testing webhook handlers,
+
   or iterating on transcript processing pipelines.
+
   Trigger with phrases like "fathom dev setup", "fathom local testing",
+
   "develop with fathom", "fathom mock data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Local Dev Loop
 
 ## Project Structure

--- a/plugins/saas-packs/fathom-pack/skills/fathom-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-performance-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-performance-tuning
-description: |
-  Optimize Fathom API performance with caching and batch processing.
+description: 'Optimize Fathom API performance with caching and batch processing.
+
   Trigger with phrases like "fathom performance", "fathom caching", "optimize fathom".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-prod-checklist
-description: |
-  Production readiness checklist for Fathom API integrations.
+description: 'Production readiness checklist for Fathom API integrations.
+
   Trigger with phrases like "fathom production", "fathom go-live", "fathom checklist".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-rate-limits/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-rate-limits/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-rate-limits
-description: |
-  Handle Fathom API rate limits (60 requests/minute per user).
+description: 'Handle Fathom API rate limits (60 requests/minute per user).
+
   Trigger with phrases like "fathom rate limit", "fathom 429", "fathom throttle".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-reference-architecture/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: fathom-reference-architecture
-description: |
-  Reference architecture for Fathom meeting intelligence integrations.
-  Trigger with phrases like "fathom architecture", "fathom design", "fathom integration pattern".
+description: 'Reference architecture for Fathom meeting intelligence integrations.
+
+  Trigger with phrases like "fathom architecture", "fathom design", "fathom integration
+  pattern".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Reference Architecture
 
 ## Architecture

--- a/plugins/saas-packs/fathom-pack/skills/fathom-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-sdk-patterns
-description: |
-  Production-ready Fathom API client patterns in Python and TypeScript.
+description: 'Production-ready Fathom API client patterns in Python and TypeScript.
+
   Use when building reusable Fathom clients, implementing meeting data pipelines,
+
   or wrapping the Fathom REST API.
+
   Trigger with phrases like "fathom API patterns", "fathom client wrapper",
+
   "fathom Python client", "fathom TypeScript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom SDK Patterns
 
 ## Python Client

--- a/plugins/saas-packs/fathom-pack/skills/fathom-security-basics/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-security-basics
-description: |
-  Secure Fathom API keys and handle meeting data privacy.
+description: 'Secure Fathom API keys and handle meeting data privacy.
+
   Trigger with phrases like "fathom security", "fathom api key safety", "fathom privacy".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Security Basics
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: fathom-upgrade-migration
-description: |
-  Handle Fathom API changes and version migrations.
+description: 'Handle Fathom API changes and version migrations.
+
   Trigger with phrases like "upgrade fathom", "fathom api changes", "fathom migration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/fathom-pack/skills/fathom-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/fathom-pack/skills/fathom-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: fathom-webhooks-events
-description: |
-  Configure Fathom webhooks for real-time meeting notifications.
+description: 'Configure Fathom webhooks for real-time meeting notifications.
+
   Use when setting up automated meeting processing, receiving real-time
+
   transcripts, or triggering workflows when meetings complete.
+
   Trigger with phrases like "fathom webhook", "fathom notifications",
+
   "fathom real-time", "fathom event handler".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, meeting-intelligence, ai-notes, fathom]
-compatible-with: claude-code
+tags:
+- saas
+- meeting-intelligence
+- ai-notes
+- fathom
+compatibility: Designed for Claude Code
 ---
-
 # Fathom Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-advanced-troubleshooting
-description: |
-  Deep debugging for Figma API issues: network analysis, response inspection, and support escalation.
+description: 'Deep debugging for Figma API issues: network analysis, response inspection,
+  and support escalation.
+
   Use when standard troubleshooting fails, diagnosing intermittent failures,
+
   or preparing detailed evidence for Figma support.
+
   Trigger with phrases like "figma hard bug", "figma mystery error",
+
   "figma deep debug", "figma intermittent failure", "figma support ticket".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-architecture-variants/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-architecture-variants
-description: |
-  Choose between Figma integration architectures: CLI script, webhook service, or plugin.
+description: 'Choose between Figma integration architectures: CLI script, webhook
+  service, or plugin.
+
   Use when deciding how to integrate with Figma, comparing REST API vs Plugin API,
+
   or planning a Figma-connected application.
+
   Trigger with phrases like "figma architecture", "figma blueprint",
+
   "how to integrate figma", "figma plugin vs api", "figma project type".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-ci-integration/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-ci-integration/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-ci-integration
-description: |
-  Automate Figma design token sync and asset export in CI/CD pipelines.
+description: 'Automate Figma design token sync and asset export in CI/CD pipelines.
+
   Use when setting up GitHub Actions for Figma, automating icon exports,
+
   or validating design token changes in pull requests.
+
   Trigger with phrases like "figma CI", "figma GitHub Actions",
+
   "automate figma export", "figma CI pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma CI Integration
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-common-errors/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-common-errors/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-common-errors
-description: |
-  Diagnose and fix common Figma REST API and Plugin API errors.
+description: 'Diagnose and fix common Figma REST API and Plugin API errors.
+
   Use when encountering HTTP errors, plugin sandbox crashes,
+
   or unexpected API responses from Figma.
+
   Trigger with phrases like "figma error", "fix figma",
+
   "figma not working", "figma 403", "figma 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Common Errors
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-core-workflow-a/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-core-workflow-a
-description: |
-  Extract design tokens, colors, typography, and spacing from Figma files via REST API.
+description: 'Extract design tokens, colors, typography, and spacing from Figma files
+  via REST API.
+
   Use when building a design-to-code pipeline, syncing design tokens,
+
   or extracting styles from a Figma design system file.
+
   Trigger with phrases like "figma design tokens", "extract figma styles",
+
   "figma to CSS", "sync figma colors", "figma typography".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Core Workflow A -- Design Token Extraction
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-core-workflow-b/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-core-workflow-b
-description: |
-  Export images, icons, and assets from Figma files via the REST API.
+description: 'Export images, icons, and assets from Figma files via the REST API.
+
   Use when building an asset pipeline, exporting icons as SVG/PNG,
+
   or rendering frames to images for documentation or previews.
+
   Trigger with phrases like "figma export", "figma images",
+
   "export figma icons", "figma assets", "figma render".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Core Workflow B -- Asset Export
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-cost-tuning/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-cost-tuning
-description: |
-  Optimize Figma API usage to minimize costs and stay within plan limits.
+description: 'Optimize Figma API usage to minimize costs and stay within plan limits.
+
   Use when analyzing request volumes, reducing unnecessary API calls,
+
   or choosing the right Figma plan for your integration needs.
+
   Trigger with phrases like "figma cost", "figma pricing",
+
   "reduce figma API calls", "figma plan limits", "figma budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-data-handling/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-data-handling/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-data-handling
-description: |
-  Handle Figma API data correctly: comments, versions, user data, and privacy compliance.
+description: 'Handle Figma API data correctly: comments, versions, user data, and
+  privacy compliance.
+
   Use when working with Figma comments API, version history,
+
   or ensuring GDPR compliance for Figma user data.
+
   Trigger with phrases like "figma data", "figma comments",
+
   "figma versions", "figma GDPR", "figma user data".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Data Handling
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-debug-bundle/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-debug-bundle
-description: |
-  Collect Figma API diagnostic evidence for support tickets and troubleshooting.
+description: 'Collect Figma API diagnostic evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Figma API problems.
+
   Trigger with phrases like "figma debug", "figma support bundle",
+
   "collect figma logs", "figma diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-deploy-integration/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-deploy-integration
-description: |
-  Deploy Figma-powered applications to Vercel, Cloud Run, and Fly.io.
+description: 'Deploy Figma-powered applications to Vercel, Cloud Run, and Fly.io.
+
   Use when deploying webhook receivers, design token APIs,
+
   or Figma-connected web apps to production platforms.
+
   Trigger with phrases like "deploy figma", "figma Vercel",
+
   "figma production deploy", "figma Cloud Run".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-enterprise-rbac/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-enterprise-rbac
-description: |
-  Configure Figma Enterprise features: OAuth 2.0, team management, and access control.
+description: 'Configure Figma Enterprise features: OAuth 2.0, team management, and
+  access control.
+
   Use when implementing OAuth flows, managing team/project access via API,
+
   or building Enterprise-level Figma integrations.
+
   Trigger with phrases like "figma enterprise", "figma OAuth",
+
   "figma team management", "figma access control", "figma SCIM".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-hello-world/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-hello-world
-description: |
-  Make your first Figma REST API call to fetch a file and inspect its node tree.
+description: 'Make your first Figma REST API call to fetch a file and inspect its
+  node tree.
+
   Use when starting a new Figma integration, testing API connectivity,
+
   or learning the Figma document structure.
+
   Trigger with phrases like "figma hello world", "figma first call",
+
   "figma quick start", "fetch figma file".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Hello World
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-incident-runbook/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-incident-runbook
-description: |
-  Respond to Figma API outages, auth failures, and rate limit incidents.
+description: 'Respond to Figma API outages, auth failures, and rate limit incidents.
+
   Use when Figma integration is down, experiencing errors,
+
   or running post-incident reviews for Figma-related failures.
+
   Trigger with phrases like "figma incident", "figma outage",
+
   "figma down", "figma broken", "figma emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-install-auth/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-install-auth
-description: |
-  Set up Figma REST API authentication with personal access tokens or OAuth 2.0.
+description: 'Set up Figma REST API authentication with personal access tokens or
+  OAuth 2.0.
+
   Use when connecting to the Figma API, generating tokens, configuring scopes,
+
   or setting up OAuth flows for Figma integrations.
+
   Trigger with phrases like "install figma", "setup figma API",
+
   "figma auth", "figma personal access token", "figma OAuth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-known-pitfalls/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-known-pitfalls
-description: |
-  Avoid the most common Figma API integration mistakes and anti-patterns.
+description: 'Avoid the most common Figma API integration mistakes and anti-patterns.
+
   Use when reviewing Figma code, onboarding new developers,
+
   or auditing an existing Figma integration.
+
   Trigger with phrases like "figma mistakes", "figma anti-patterns",
+
   "figma pitfalls", "figma code review", "figma what not to do".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-load-scale/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-load-scale/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-load-scale
-description: |
-  Load test Figma API integrations and plan for scale.
+description: 'Load test Figma API integrations and plan for scale.
+
   Use when benchmarking API throughput, testing rate limit behavior,
+
   or planning capacity for high-volume Figma integrations.
+
   Trigger with phrases like "figma load test", "figma scale",
+
   "figma benchmark", "figma capacity", "figma throughput".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-local-dev-loop/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-local-dev-loop
-description: |
-  Set up a local development workflow for Figma plugin and REST API projects.
+description: 'Set up a local development workflow for Figma plugin and REST API projects.
+
   Use when building Figma plugins, creating design-to-code pipelines,
+
   or developing against the Figma API with hot reload.
+
   Trigger with phrases like "figma dev setup", "figma plugin development",
+
   "figma local development", "develop figma plugin".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-migration-deep-dive/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-migration-deep-dive
-description: |
-  Migrate design systems between Figma files, or from other tools to Figma via API.
+description: 'Migrate design systems between Figma files, or from other tools to Figma
+  via API.
+
   Use when migrating design tokens between files, syncing variables across libraries,
+
   or building automated migration pipelines for Figma.
+
   Trigger with phrases like "migrate figma", "figma migration",
+
   "move figma library", "figma file migration", "sync figma files".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-multi-env-setup/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-multi-env-setup
-description: |
-  Configure Figma API access across dev, staging, and production environments.
+description: 'Configure Figma API access across dev, staging, and production environments.
+
   Use when setting up per-environment tokens, managing multiple Figma files,
+
   or isolating development from production Figma resources.
+
   Trigger with phrases like "figma environments", "figma staging",
+
   "figma dev prod", "figma environment config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-observability/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-observability/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-observability
-description: |
-  Set up monitoring, metrics, and alerting for Figma API integrations.
+description: 'Set up monitoring, metrics, and alerting for Figma API integrations.
+
   Use when implementing observability for Figma operations, tracking API health,
+
   or configuring alerts for rate limits and errors.
+
   Trigger with phrases like "figma monitoring", "figma metrics",
+
   "figma observability", "figma alerts", "figma dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Observability
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-performance-tuning/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-performance-tuning
-description: |
-  Optimize Figma REST API performance with caching, partial fetches, and connection reuse.
+description: 'Optimize Figma REST API performance with caching, partial fetches, and
+  connection reuse.
+
   Use when experiencing slow API responses, reducing bandwidth for large files,
+
   or optimizing request throughput for Figma integrations.
+
   Trigger with phrases like "figma performance", "figma slow",
+
   "figma caching", "figma optimize", "figma large file".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-policy-guardrails/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-policy-guardrails
-description: |
-  Enforce security policies and coding standards for Figma API integrations.
+description: 'Enforce security policies and coding standards for Figma API integrations.
+
   Use when setting up linting rules for Figma tokens, preventing accidental
+
   credential leaks, or enforcing API usage best practices.
+
   Trigger with phrases like "figma policy", "figma lint",
+
   "figma guardrails", "figma security rules", "figma best practices check".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-prod-checklist/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-prod-checklist
-description: |
-  Production readiness checklist for Figma REST API integrations.
+description: 'Production readiness checklist for Figma REST API integrations.
+
   Use when deploying Figma integrations to production, preparing for launch,
+
   or auditing an existing integration for production fitness.
+
   Trigger with phrases like "figma production", "deploy figma",
+
   "figma go-live", "figma launch checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-rate-limits/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-rate-limits
-description: |
-  Handle Figma REST API rate limits with exponential backoff and request queuing.
+description: 'Handle Figma REST API rate limits with exponential backoff and request
+  queuing.
+
   Use when encountering 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Figma.
+
   Trigger with phrases like "figma rate limit", "figma throttling",
+
   "figma 429", "figma retry", "figma backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-reference-architecture/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-reference-architecture
-description: |
-  Reference architecture for production Figma API integrations.
+description: 'Reference architecture for production Figma API integrations.
+
   Use when designing a new Figma integration, planning project structure,
+
   or establishing patterns for design-to-code pipelines.
+
   Trigger with phrases like "figma architecture", "figma project structure",
+
   "figma integration design", "figma best practices layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-reliability-patterns/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-reliability-patterns
-description: |
-  Build resilient Figma integrations with circuit breakers, fallbacks, and graceful degradation.
+description: 'Build resilient Figma integrations with circuit breakers, fallbacks,
+  and graceful degradation.
+
   Use when implementing fault tolerance, handling Figma outages gracefully,
+
   or building production-grade reliability into Figma API consumers.
+
   Trigger with phrases like "figma reliability", "figma circuit breaker",
+
   "figma fallback", "figma resilience", "figma graceful degradation".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-sdk-patterns/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-sdk-patterns
-description: |
-  Production-ready patterns for the Figma REST API and Plugin API.
+description: 'Production-ready patterns for the Figma REST API and Plugin API.
+
   Use when building reusable Figma client wrappers, extracting design tokens,
+
   traversing node trees, or creating typed API helpers.
+
   Trigger with phrases like "figma patterns", "figma best practices",
+
   "figma client wrapper", "figma typed API".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-security-basics/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-security-basics/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-security-basics
-description: |
-  Secure Figma API tokens, configure scopes, and validate webhook signatures.
+description: 'Secure Figma API tokens, configure scopes, and validate webhook signatures.
+
   Use when securing API keys, implementing least-privilege scopes,
+
   or auditing Figma security configuration.
+
   Trigger with phrases like "figma security", "figma secrets",
+
   "secure figma token", "figma scopes", "figma webhook verify".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Security Basics
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-upgrade-migration/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: figma-upgrade-migration
-description: |
-  Handle Figma REST API scope changes, deprecations, and migration tasks.
+description: 'Handle Figma REST API scope changes, deprecations, and migration tasks.
+
   Use when migrating from deprecated scopes, updating webhook versions,
+
   or adapting to Figma API changelog changes.
+
   Trigger with phrases like "upgrade figma", "figma deprecation",
+
   "figma scope migration", "figma API changes", "figma v2 webhooks".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/figma-pack/skills/figma-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/figma-pack/skills/figma-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: figma-webhooks-events
-description: |
-  Implement Figma Webhooks V2 for real-time file, comment, and library events.
+description: 'Implement Figma Webhooks V2 for real-time file, comment, and library
+  events.
+
   Use when setting up webhook endpoints, handling FILE_UPDATE events,
+
   or building event-driven Figma automation.
+
   Trigger with phrases like "figma webhook", "figma events",
+
   "figma FILE_UPDATE", "figma notifications", "figma real-time".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, figma]
-compatible-with: claude-code
+tags:
+- saas
+- figma
+compatibility: Designed for Claude Code
 ---
-
 # Figma Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-ci-integration/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-ci-integration
-description: |
-  Automate Finta data export and reporting in CI pipelines.
+description: 'Automate Finta data export and reporting in CI pipelines.
+
   Trigger with phrases like "finta CI", "finta automated reporting".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta CI Integration
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-common-errors/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-common-errors/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: finta-common-errors
-description: |
-  Diagnose and fix common Finta CRM issues with email sync, deal rooms, and pipeline.
+description: 'Diagnose and fix common Finta CRM issues with email sync, deal rooms,
+  and pipeline.
+
   Trigger with phrases like "finta error", "finta not working", "fix finta".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Common Errors
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: finta-core-workflow-a
-description: |
-  Manage a fundraise pipeline end-to-end with Finta.
+description: 'Manage a fundraise pipeline end-to-end with Finta.
+
   Use when running a fundraise, tracking investor conversations,
+
   managing deal rooms, or collecting commitments.
+
   Trigger with phrases like "finta fundraise", "finta pipeline management",
+
   "finta investor tracking", "run fundraise with finta".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Core Workflow: Fundraise Pipeline
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: finta-core-workflow-b
-description: |
-  Manage ongoing investor relations and updates with Finta.
+description: 'Manage ongoing investor relations and updates with Finta.
+
   Use when sending investor updates, tracking cap table changes,
+
   or maintaining LP relationships post-close.
+
   Trigger with phrases like "finta investor updates", "finta LP management",
+
   "finta post-close", "finta investor relations".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Core Workflow: Investor Relations
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-cost-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-cost-tuning
-description: |
-  Optimize Finta plan selection and feature usage.
+description: 'Optimize Finta plan selection and feature usage.
+
   Trigger with phrases like "finta cost", "finta pricing", "finta plan selection".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-debug-bundle
-description: |
-  Collect Finta diagnostic information for support.
+description: 'Collect Finta diagnostic information for support.
+
   Trigger with phrases like "finta debug", "finta support".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-deploy-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-deploy-integration
-description: |
-  Deploy Finta integrations and reporting dashboards.
+description: 'Deploy Finta integrations and reporting dashboards.
+
   Trigger with phrases like "deploy finta", "finta dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-hello-world/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: finta-hello-world
-description: |
-  Set up your first fundraise pipeline in Finta with investors and deal stages.
+description: 'Set up your first fundraise pipeline in Finta with investors and deal
+  stages.
+
   Use when starting a new fundraise, importing investor lists,
-  or learning Finta's pipeline management features.
+
+  or learning Finta''s pipeline management features.
+
   Trigger with phrases like "finta hello world", "finta first pipeline",
+
   "start fundraise in finta", "finta quick start".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Hello World
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-install-auth/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: finta-install-auth
-description: |
-  Set up Finta fundraising CRM account and configure integrations.
+description: 'Set up Finta fundraising CRM account and configure integrations.
+
   Use when onboarding to Finta, connecting email/calendar,
+
   or configuring investor pipeline automation.
+
   Trigger with phrases like "install finta", "setup finta",
+
   "finta onboarding", "configure finta crm".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: finta-local-dev-loop
-description: |
-  Set up Finta workflow automation and data export for local analysis.
+description: 'Set up Finta workflow automation and data export for local analysis.
+
   Use when building fundraising reports, exporting pipeline data,
+
   or automating investor outreach workflows.
+
   Trigger with phrases like "finta workflow", "finta automation",
+
   "finta data export", "finta reporting".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-performance-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-performance-tuning
-description: |
-  Optimize Finta fundraise workflow efficiency.
+description: 'Optimize Finta fundraise workflow efficiency.
+
   Trigger with phrases like "finta performance", "finta efficiency", "optimize finta".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-prod-checklist
-description: |
-  Fundraise launch checklist using Finta CRM.
+description: 'Fundraise launch checklist using Finta CRM.
+
   Trigger with phrases like "finta checklist", "finta launch", "finta go-live".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-rate-limits/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-rate-limits/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-rate-limits
-description: |
-  Understand Finta usage limits and plan tiers.
+description: 'Understand Finta usage limits and plan tiers.
+
   Trigger with phrases like "finta limits", "finta plan limits".
+
+  '
 allowed-tools: Read
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-reference-architecture/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-reference-architecture
-description: |
-  Reference architecture for fundraising operations with Finta CRM.
+description: 'Reference architecture for fundraising operations with Finta CRM.
+
   Trigger with phrases like "finta architecture", "finta fundraising stack".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-sdk-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: finta-sdk-patterns
-description: |
-  Integration patterns for Finta fundraising CRM with email and calendar APIs.
+description: 'Integration patterns for Finta fundraising CRM with email and calendar
+  APIs.
+
   Use when building automated investor outreach, syncing data from Finta exports,
+
   or creating custom fundraising dashboards.
+
   Trigger with phrases like "finta integration", "finta patterns",
+
   "finta automation", "finta data pipeline".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-security-basics/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-security-basics
-description: |
-  Secure Finta fundraising data and investor information.
+description: 'Secure Finta fundraising data and investor information.
+
   Trigger with phrases like "finta security", "finta data privacy".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Security Basics
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: finta-upgrade-migration
-description: |
-  Handle Finta platform updates and data migration.
+description: 'Handle Finta platform updates and data migration.
+
   Trigger with phrases like "finta upgrade", "finta migration".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/finta-pack/skills/finta-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/finta-pack/skills/finta-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: finta-webhooks-events
-description: |
-  Automate Finta pipeline events with Zapier and email triggers.
+description: 'Automate Finta pipeline events with Zapier and email triggers.
+
   Use when setting up notifications for investor responses,
+
   automating follow-up reminders, or syncing events to other tools.
+
   Trigger with phrases like "finta automation", "finta notifications",
+
   "finta pipeline events", "finta zapier".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, fundraising-crm, investor-management, finta]
-compatible-with: claude-code
+tags:
+- saas
+- fundraising-crm
+- investor-management
+- finta
+compatibility: Designed for Claude Code
 ---
-
 # Finta Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-advanced-troubleshooting
-description: |
-  Debug hard-to-diagnose Firecrawl issues with systematic isolation and evidence collection.
-  Use when standard troubleshooting fails, investigating why scrapes return empty content,
-  crawl jobs hang, or webhooks don't fire.
+description: 'Debug hard-to-diagnose Firecrawl issues with systematic isolation and
+  evidence collection.
+
+  Use when standard troubleshooting fails, investigating why scrapes return empty
+  content,
+
+  crawl jobs hang, or webhooks don''t fire.
+
   Trigger with phrases like "firecrawl hard bug", "firecrawl mystery error",
+
   "firecrawl impossible to debug", "firecrawl deep debug", "firecrawl not scraping".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, debugging, scaling]
+tags:
+- saas
+- firecrawl
+- debugging
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Advanced Troubleshooting
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-architecture-variants/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-architecture-variants
-description: |
-  Choose and implement Firecrawl architecture patterns for different scales and use cases.
+description: 'Choose and implement Firecrawl architecture patterns for different scales
+  and use cases.
+
   Use when designing new Firecrawl integrations, choosing between on-demand/scheduled/pipeline
+
   architectures, or planning scraping infrastructure.
+
   Trigger with phrases like "firecrawl architecture", "firecrawl blueprint",
+
   "how to structure firecrawl", "firecrawl at scale", "firecrawl pipeline design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, migration, scaling, microservices]
+tags:
+- saas
+- firecrawl
+- migration
+- scaling
+- microservices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Architecture Variants
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-ci-integration/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-ci-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-ci-integration
-description: |
-  Configure Firecrawl CI/CD integration with GitHub Actions and automated scraping tests.
-  Use when setting up automated testing of Firecrawl integrations, configuring CI pipelines,
+description: 'Configure Firecrawl CI/CD integration with GitHub Actions and automated
+  scraping tests.
+
+  Use when setting up automated testing of Firecrawl integrations, configuring CI
+  pipelines,
+
   or validating scraping behavior in pull requests.
+
   Trigger with phrases like "firecrawl CI", "firecrawl GitHub Actions",
+
   "firecrawl automated tests", "CI firecrawl", "test firecrawl in CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, testing, ci-cd]
+tags:
+- saas
+- firecrawl
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl CI Integration
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-common-errors/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-common-errors
-description: |
-  Diagnose and fix Firecrawl common errors and API response codes.
+description: 'Diagnose and fix Firecrawl common errors and API response codes.
+
   Use when encountering Firecrawl errors, debugging failed scrapes,
+
   or troubleshooting crawl job issues.
+
   Trigger with phrases like "firecrawl error", "fix firecrawl",
+
   "firecrawl not working", "debug firecrawl", "firecrawl 429", "firecrawl 402".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, debugging]
+tags:
+- saas
+- firecrawl
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Common Errors
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-core-workflow-a
-description: |
-  Execute Firecrawl primary workflow: scrape and crawl websites into LLM-ready markdown.
+description: 'Execute Firecrawl primary workflow: scrape and crawl websites into LLM-ready
+  markdown.
+
   Use when scraping single pages, crawling entire sites, or building content
-  ingestion pipelines with Firecrawl's scrapeUrl and crawlUrl methods.
+
+  ingestion pipelines with Firecrawl''s scrapeUrl and crawlUrl methods.
+
   Trigger with phrases like "firecrawl scrape", "firecrawl crawl site",
+
   "scrape page to markdown", "crawl documentation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, workflow]
+tags:
+- saas
+- firecrawl
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Core Workflow A — Scrape & Crawl
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-core-workflow-b/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-core-workflow-b
-description: |
-  Execute Firecrawl secondary workflow: LLM extraction, batch scraping, and site mapping.
+description: 'Execute Firecrawl secondary workflow: LLM extraction, batch scraping,
+  and site mapping.
+
   Use when extracting structured data from pages, batch scraping known URLs,
+
   or discovering site structure with the map endpoint.
+
   Trigger with phrases like "firecrawl extract", "firecrawl batch scrape",
+
   "firecrawl map site", "firecrawl structured data", "firecrawl JSON extract".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, workflow]
+tags:
+- saas
+- firecrawl
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Core Workflow B — Extract, Batch & Map
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-cost-tuning
-description: |
-  Optimize Firecrawl costs through crawl limits, format selection, caching, and credit monitoring.
+description: 'Optimize Firecrawl costs through crawl limits, format selection, caching,
+  and credit monitoring.
+
   Use when analyzing Firecrawl billing, reducing API costs,
+
   or implementing credit budget alerts.
+
   Trigger with phrases like "firecrawl cost", "firecrawl billing",
+
   "reduce firecrawl costs", "firecrawl pricing", "firecrawl credits", "firecrawl budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, monitoring, cost-optimization]
+tags:
+- saas
+- firecrawl
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Cost Tuning
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-data-handling/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: firecrawl-data-handling
-description: |
-  Process, validate, and store Firecrawl scraped content with deduplication and chunking.
-  Use when handling scraped markdown, implementing content pipelines, building RAG knowledge
+description: 'Process, validate, and store Firecrawl scraped content with deduplication
+  and chunking.
+
+  Use when handling scraped markdown, implementing content pipelines, building RAG
+  knowledge
+
   bases, or processing crawl results for downstream consumption.
+
   Trigger with phrases like "firecrawl data", "firecrawl content processing",
+
   "firecrawl markdown cleaning", "firecrawl storage", "firecrawl RAG pipeline".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, compliance]
+tags:
+- saas
+- firecrawl
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Data Handling
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-debug-bundle
-description: |
-  Collect Firecrawl debug evidence for support tickets and troubleshooting.
+description: 'Collect Firecrawl debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Firecrawl problems.
+
   Trigger with phrases like "firecrawl debug", "firecrawl support bundle",
+
   "collect firecrawl logs", "firecrawl diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, debugging]
+tags:
+- saas
+- firecrawl
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Debug Bundle
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-deploy-integration
-description: |
-  Deploy Firecrawl integrations to Vercel, Cloud Run, and Docker platforms.
+description: 'Deploy Firecrawl integrations to Vercel, Cloud Run, and Docker platforms.
+
   Use when deploying Firecrawl-powered applications to production,
+
   configuring platform-specific secrets, or setting up self-hosted Firecrawl.
+
   Trigger with phrases like "deploy firecrawl", "firecrawl Vercel",
+
   "firecrawl production deploy", "firecrawl Cloud Run", "firecrawl Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(docker:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, deployment]
+tags:
+- saas
+- firecrawl
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Deploy Integration
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-enterprise-rbac
-description: |
-  Configure Firecrawl team access control with per-key credit limits and domain restrictions.
+description: 'Configure Firecrawl team access control with per-key credit limits and
+  domain restrictions.
+
   Use when managing multiple API keys per team, implementing credit budgets per consumer,
+
   or controlling which domains each team can scrape.
+
   Trigger with phrases like "firecrawl RBAC", "firecrawl teams",
+
   "firecrawl enterprise", "firecrawl access control", "firecrawl permissions".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, rbac]
+tags:
+- saas
+- firecrawl
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Enterprise RBAC
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-hello-world/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-hello-world
-description: |
-  Create a minimal working Firecrawl example that scrapes a page to markdown.
+description: 'Create a minimal working Firecrawl example that scrapes a page to markdown.
+
   Use when starting a new Firecrawl integration, testing your setup,
+
   or learning the scrape/crawl/map/extract API surface.
+
   Trigger with phrases like "firecrawl hello world", "firecrawl example",
+
   "firecrawl quick start", "simple firecrawl code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, testing]
+tags:
+- saas
+- firecrawl
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Hello World
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-incident-runbook
-description: |
-  Execute Firecrawl incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Firecrawl incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Firecrawl-related outages, investigating scrape/crawl failures,
+
   or running post-incident reviews for Firecrawl integration issues.
+
   Trigger with phrases like "firecrawl incident", "firecrawl outage",
+
   "firecrawl down", "firecrawl on-call", "firecrawl emergency", "firecrawl broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, incident-response]
+tags:
+- saas
+- firecrawl
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Incident Runbook
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-install-auth/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-install-auth
-description: |
-  Install and configure Firecrawl SDK authentication for web scraping.
+description: 'Install and configure Firecrawl SDK authentication for web scraping.
+
   Use when setting up a new Firecrawl integration, configuring API keys,
+
   or initializing Firecrawl in your project.
+
   Trigger with phrases like "install firecrawl", "setup firecrawl",
+
   "firecrawl auth", "configure firecrawl API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, authentication]
+tags:
+- saas
+- firecrawl
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Install & Auth
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-known-pitfalls/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-known-pitfalls
-description: |
-  Identify and avoid Firecrawl anti-patterns and common integration mistakes.
+description: 'Identify and avoid Firecrawl anti-patterns and common integration mistakes.
+
   Use when reviewing Firecrawl code, onboarding new developers,
+
   or auditing existing integrations for best practices violations.
+
   Trigger with phrases like "firecrawl mistakes", "firecrawl anti-patterns",
+
   "firecrawl pitfalls", "firecrawl what not to do", "firecrawl code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, audit]
+tags:
+- saas
+- firecrawl
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Known Pitfalls
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-load-scale/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-load-scale
-description: |
-  Load test and scale Firecrawl scraping pipelines with concurrency control and batching.
+description: 'Load test and scale Firecrawl scraping pipelines with concurrency control
+  and batching.
+
   Use when testing scraping throughput, planning capacity for large crawl jobs,
+
   or optimizing concurrent scrape performance.
+
   Trigger with phrases like "firecrawl load test", "firecrawl scale",
+
   "firecrawl throughput", "firecrawl capacity", "firecrawl concurrent".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, testing, performance, scaling]
+tags:
+- saas
+- firecrawl
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Load & Scale
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-local-dev-loop/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-local-dev-loop
-description: |
-  Configure Firecrawl local development with self-hosted Docker, mocking, and testing.
-  Use when setting up a development environment, running Firecrawl locally to save credits,
+description: 'Configure Firecrawl local development with self-hosted Docker, mocking,
+  and testing.
+
+  Use when setting up a development environment, running Firecrawl locally to save
+  credits,
+
   or configuring test workflows with vitest.
+
   Trigger with phrases like "firecrawl dev setup", "firecrawl local development",
+
   "firecrawl docker", "firecrawl self-hosted dev", "firecrawl test setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, testing, workflow]
+tags:
+- saas
+- firecrawl
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Local Dev Loop
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-migration-deep-dive
-description: |
-  Migrate to Firecrawl from Puppeteer, Playwright, Cheerio, or other scraping tools.
+description: 'Migrate to Firecrawl from Puppeteer, Playwright, Cheerio, or other scraping
+  tools.
+
   Use when replacing custom scraping code with Firecrawl, migrating between
+
   scraping APIs, or re-platforming content ingestion pipelines.
+
   Trigger with phrases like "migrate to firecrawl", "replace puppeteer with firecrawl",
+
   "switch to firecrawl", "firecrawl vs puppeteer", "firecrawl migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, migration]
+tags:
+- saas
+- firecrawl
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Migration Deep Dive
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: firecrawl-multi-env-setup
-description: |
-  Configure Firecrawl across development, staging, and production environments.
-  Use when setting up multi-environment scraping pipelines, managing credit budgets per env,
+description: 'Configure Firecrawl across development, staging, and production environments.
+
+  Use when setting up multi-environment scraping pipelines, managing credit budgets
+  per env,
+
   or configuring self-hosted Firecrawl for development.
+
   Trigger with phrases like "firecrawl environments", "firecrawl staging",
+
   "firecrawl dev prod", "firecrawl environment setup", "firecrawl config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, deployment, api]
+tags:
+- saas
+- firecrawl
+- deployment
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Multi-Environment Setup
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-observability/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-observability
-description: |
-  Monitor Firecrawl scraping pipelines with metrics, credit tracking, and quality alerts.
+description: 'Monitor Firecrawl scraping pipelines with metrics, credit tracking,
+  and quality alerts.
+
   Use when implementing monitoring for Firecrawl operations, setting up dashboards,
+
   or configuring alerting for scrape failures and credit consumption.
+
   Trigger with phrases like "firecrawl monitoring", "firecrawl metrics",
+
   "firecrawl observability", "monitor firecrawl", "firecrawl alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, monitoring, observability, dashboard]
+tags:
+- saas
+- firecrawl
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Observability
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: firecrawl-performance-tuning
-description: |
-  Optimize Firecrawl scraping performance with caching, batch scraping, and format selection.
+description: 'Optimize Firecrawl scraping performance with caching, batch scraping,
+  and format selection.
+
   Use when experiencing slow scrapes, optimizing credit usage per page,
+
   or building high-throughput scraping pipelines.
+
   Trigger with phrases like "firecrawl performance", "optimize firecrawl",
+
   "firecrawl latency", "firecrawl caching", "firecrawl slow", "firecrawl batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, performance]
+tags:
+- saas
+- firecrawl
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Performance Tuning
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-policy-guardrails/SKILL.md
@@ -1,18 +1,28 @@
 ---
 name: firecrawl-policy-guardrails
-description: |
-  Implement Firecrawl scraping policy enforcement: domain blocklists, credit budgets,
+description: 'Implement Firecrawl scraping policy enforcement: domain blocklists,
+  credit budgets,
+
   content filtering, and robots.txt compliance guardrails.
+
   Use when setting up scraping policies, enforcing crawl limits, or preventing
+
   accidental scraping of prohibited domains.
+
   Trigger with phrases like "firecrawl policy", "firecrawl guardrails",
+
   "firecrawl domain blocklist", "firecrawl scraping rules", "firecrawl compliance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, firecrawl-policy]
+tags:
+- saas
+- firecrawl
+- firecrawl-policy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Policy Guardrails
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-prod-checklist
-description: |
-  Execute Firecrawl production deployment checklist and rollback procedures.
+description: 'Execute Firecrawl production deployment checklist and rollback procedures.
+
   Use when deploying Firecrawl integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "firecrawl production", "deploy firecrawl",
+
   "firecrawl go-live", "firecrawl launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, deployment]
+tags:
+- saas
+- firecrawl
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Production Checklist
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-rate-limits/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: firecrawl-rate-limits
-description: |
-  Implement Firecrawl rate limiting, backoff, and request queuing patterns.
+description: 'Implement Firecrawl rate limiting, backoff, and request queuing patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Firecrawl.
+
   Trigger with phrases like "firecrawl rate limit", "firecrawl throttling",
+
   "firecrawl 429", "firecrawl retry", "firecrawl backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api]
+tags:
+- saas
+- firecrawl
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Rate Limits
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-reference-architecture
-description: |
-  Implement Firecrawl reference architecture with scrape/crawl/map/extract pipelines.
+description: 'Implement Firecrawl reference architecture with scrape/crawl/map/extract
+  pipelines.
+
   Use when designing new Firecrawl integrations, reviewing project structure,
+
   or building content ingestion pipelines for AI/RAG applications.
+
   Trigger with phrases like "firecrawl architecture", "firecrawl project structure",
+
   "firecrawl pipeline", "firecrawl RAG", "firecrawl knowledge base".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, firecrawl-reference]
+tags:
+- saas
+- firecrawl
+- firecrawl-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Reference Architecture
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-reliability-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: firecrawl-reliability-patterns
-description: |
-  Implement Firecrawl reliability patterns: circuit breakers, crawl fallbacks, and content validation.
-  Use when building fault-tolerant scraping pipelines, implementing crawl-to-scrape fallback,
+description: 'Implement Firecrawl reliability patterns: circuit breakers, crawl fallbacks,
+  and content validation.
+
+  Use when building fault-tolerant scraping pipelines, implementing crawl-to-scrape
+  fallback,
+
   or adding content quality gates to Firecrawl integrations.
+
   Trigger with phrases like "firecrawl reliability", "firecrawl circuit breaker",
+
   "firecrawl fallback", "firecrawl resilience", "firecrawl fault tolerant".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, firecrawl-reliability]
+tags:
+- saas
+- firecrawl
+- firecrawl-reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Reliability Patterns
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-sdk-patterns
-description: |
-  Apply production-ready Firecrawl SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Firecrawl SDK patterns for TypeScript and Python.
+
   Use when implementing Firecrawl integrations, building reusable scraping services,
+
   or establishing team coding standards for Firecrawl.
+
   Trigger with phrases like "firecrawl SDK patterns", "firecrawl best practices",
+
   "firecrawl code patterns", "idiomatic firecrawl", "firecrawl wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, python, typescript]
+tags:
+- saas
+- firecrawl
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl SDK Patterns
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-security-basics/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: firecrawl-security-basics
-description: |
-  Apply Firecrawl security best practices for API key management and webhook verification.
+description: 'Apply Firecrawl security best practices for API key management and webhook
+  verification.
+
   Use when securing API keys, implementing webhook signature validation,
+
   or auditing Firecrawl security configuration.
+
   Trigger with phrases like "firecrawl security", "firecrawl secrets",
+
   "secure firecrawl", "firecrawl API key security", "firecrawl webhook signature".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, security, audit]
+tags:
+- saas
+- firecrawl
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Security Basics
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: firecrawl-upgrade-migration
-description: |
-  Upgrade Firecrawl SDK versions and migrate between API versions (v0 to v1/v2).
+description: 'Upgrade Firecrawl SDK versions and migrate between API versions (v0
+  to v1/v2).
+
   Use when upgrading the SDK, handling breaking changes between versions,
+
   or migrating from the old API to the current v2 API.
+
   Trigger with phrases like "upgrade firecrawl", "firecrawl migration",
+
   "firecrawl v2", "update firecrawl SDK", "firecrawl breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, api, migration]
+tags:
+- saas
+- firecrawl
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Upgrade & Migration
 

--- a/plugins/saas-packs/firecrawl-pack/skills/firecrawl-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/firecrawl-pack/skills/firecrawl-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: firecrawl-webhooks-events
-description: |
-  Implement Firecrawl webhook event handling for async crawl and batch scrape jobs.
+description: 'Implement Firecrawl webhook event handling for async crawl and batch
+  scrape jobs.
+
   Use when setting up webhook endpoints, handling crawl.page/crawl.completed events,
+
   or processing async job results in real-time.
+
   Trigger with phrases like "firecrawl webhook", "firecrawl events",
+
   "firecrawl webhook signature", "handle firecrawl events", "firecrawl notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, firecrawl, webhooks]
+tags:
+- saas
+- firecrawl
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Firecrawl Webhooks & Events
 


### PR DESCRIPTION
## Summary

Chunk 2 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated \`compatible-with\` CSV-platform-list field to the spec-aligned \`compatibility\` free-text field per agentskills.io/specification.

**Pure schema migration. No content changes.** Same tool used in PRs #620 and #622.

### Assigned packs (chunk 2 of 6)

| Pack | Files |
|---|---|
| clerk-pack | 24 |
| clickhouse-pack | 24 |
| clickup-pack | 24 |
| coderabbit-pack | 24 |
| cohere-pack | 24 |
| coreweave-pack | 24 |
| cursor-pack | 30 |
| customerio-pack | 24 |
| databricks-pack | 24 |
| deepgram-pack | 24 |
| documenso-pack | 24 |
| elevenlabs-pack | 18 |
| evernote-pack | 24 |
| exa-pack | 30 |
| fathom-pack | 18 |
| figma-pack | 30 |
| finta-pack | 18 |
| firecrawl-pack | 30 |
| **TOTAL** | **438** |

### Side effect

\`yaml.safe_dump\` round-trips the entire frontmatter — so \`description: |\` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] \`grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/\` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Refs #613

jeremy made me do it
-claude