### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 1/6, 422 skills)

### DIFF
--- a/plugins/saas-packs/abridge-pack/skills/abridge-ci-integration/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-ci-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: abridge-ci-integration
-description: |
-  Configure CI/CD pipeline for Abridge clinical AI integrations with GitHub Actions.
+description: 'Configure CI/CD pipeline for Abridge clinical AI integrations with GitHub
+  Actions.
+
   Use when setting up automated testing, FHIR validation, HIPAA compliance checks,
+
   or deployment pipelines for healthcare AI applications.
+
   Trigger: "abridge CI", "abridge GitHub Actions", "abridge pipeline",
+
   "abridge automated testing", "abridge CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, ci-cd]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- ci-cd
+compatibility: Designed for Claude Code
 ---
-
 # Abridge CI Integration
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-common-errors/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-common-errors
-description: |
-  Diagnose and fix common Abridge clinical AI integration errors.
+description: 'Diagnose and fix common Abridge clinical AI integration errors.
+
   Use when encountering EHR connectivity failures, note generation errors,
+
   audio streaming issues, or FHIR validation problems with Abridge.
+
   Trigger: "abridge error", "abridge not working", "abridge debug",
+
   "fix abridge issue", "abridge troubleshoot".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, troubleshooting]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- troubleshooting
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Common Errors
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-core-workflow-a/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-core-workflow-a
-description: |
-  Implement Abridge ambient clinical documentation capture-to-note pipeline.
+description: 'Implement Abridge ambient clinical documentation capture-to-note pipeline.
+
   Use when building the primary encounter workflow: audio capture, real-time
+
   transcription, AI note generation, and EHR note insertion.
+
   Trigger: "abridge clinical workflow", "abridge encounter pipeline",
+
   "ambient documentation workflow", "abridge note generation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, clinical-documentation]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- clinical-documentation
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Core Workflow A — Encounter-to-Note Pipeline
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-core-workflow-b/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: abridge-core-workflow-b
-description: |
-  Implement Abridge patient-facing documentation and after-visit summary generation.
+description: 'Implement Abridge patient-facing documentation and after-visit summary
+  generation.
+
   Use when building patient portal integration, generating plain-language summaries,
+
   multi-language translations, or after-visit instructions from clinical encounters.
+
   Trigger: "abridge patient summary", "after-visit summary", "patient portal abridge",
+
   "abridge patient-facing", "abridge multilingual".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, patient-engagement]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- patient-engagement
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Core Workflow B — Patient-Facing Documentation
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-cost-tuning/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: abridge-cost-tuning
-description: |
-  Optimize Abridge clinical AI costs through tier selection, session management,
+description: 'Optimize Abridge clinical AI costs through tier selection, session management,
+
   and usage monitoring for healthcare organizations.
+
   Use when analyzing Abridge billing, optimizing encounter volume,
+
   or right-sizing your Abridge contract for provider count.
+
   Trigger: "abridge cost", "abridge pricing", "abridge billing",
+
   "abridge budget", "abridge ROI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, cost-optimization]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- cost-optimization
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-debug-bundle/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-debug-bundle
-description: |
-  Collect Abridge debug evidence for support tickets and troubleshooting.
+description: 'Collect Abridge debug evidence for support tickets and troubleshooting.
+
   Use when filing Abridge support tickets, collecting diagnostic data,
+
   or preparing evidence for escalation to Abridge engineering.
+
   Trigger: "abridge debug bundle", "abridge support ticket",
+
   "abridge diagnostics", "collect abridge evidence".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, debugging]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-deploy-integration
-description: |
-  Deploy Abridge clinical AI integration to HIPAA-compliant cloud infrastructure.
+description: 'Deploy Abridge clinical AI integration to HIPAA-compliant cloud infrastructure.
+
   Use when deploying to GCP Cloud Run, AWS ECS, or Azure Container Apps
+
   with healthcare-grade secrets management and compliance controls.
+
   Trigger: "deploy abridge", "abridge production deploy", "abridge Cloud Run",
+
   "abridge AWS deploy", "abridge HIPAA infrastructure".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(docker:*), Bash(aws:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-hello-world/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-hello-world/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: abridge-hello-world
-description: |
-  Create a minimal Abridge ambient AI clinical documentation example.
+description: 'Create a minimal Abridge ambient AI clinical documentation example.
+
   Use when testing Abridge integration, verifying EHR connectivity,
+
   or learning how Abridge captures and structures clinical conversations.
-  Trigger: "abridge hello world", "abridge example", "abridge quick start", "test abridge".
+
+  Trigger: "abridge hello world", "abridge example", "abridge quick start", "test
+  abridge".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, clinical-documentation]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- clinical-documentation
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Hello World
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-install-auth/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-install-auth/SKILL.md
@@ -1,18 +1,28 @@
 ---
 name: abridge-install-auth
-description: |
-  Set up Abridge clinical AI platform authentication and EHR integration credentials.
+description: 'Set up Abridge clinical AI platform authentication and EHR integration
+  credentials.
+
   Use when onboarding a healthcare org to Abridge, configuring Epic/Athena integration,
+
   or setting up developer sandbox access for ambient AI documentation.
-  Trigger: "install abridge", "setup abridge", "abridge auth", "configure abridge credentials".
+
+  Trigger: "install abridge", "setup abridge", "abridge auth", "configure abridge
+  credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, clinical-documentation]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- clinical-documentation
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-local-dev-loop/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: abridge-local-dev-loop
-description: |
-  Configure Abridge local development with FHIR server, synthetic data, and hot reload.
+description: 'Configure Abridge local development with FHIR server, synthetic data,
+  and hot reload.
+
   Use when setting up a development environment for clinical AI integration,
+
   testing encounter workflows locally, or iterating on EHR integration code.
+
   Trigger: "abridge local dev", "abridge dev setup", "abridge test locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, development]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- development
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-performance-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: abridge-performance-tuning
-description: |
-  Optimize Abridge clinical AI integration performance for high-volume deployments.
+description: 'Optimize Abridge clinical AI integration performance for high-volume
+  deployments.
+
   Use when reducing note generation latency, optimizing audio streaming throughput,
+
   improving FHIR push performance, or scaling for multi-site health systems.
+
   Trigger: "abridge performance", "abridge latency", "abridge optimization",
+
   "abridge slow", "abridge scale".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, performance]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-prod-checklist
-description: |
-  Execute Abridge production readiness checklist for clinical AI deployment.
+description: 'Execute Abridge production readiness checklist for clinical AI deployment.
+
   Use when launching Abridge in a healthcare org, preparing for go-live,
+
   or validating HIPAA compliance before production deployment.
+
   Trigger: "abridge production checklist", "abridge go-live",
+
   "abridge launch readiness", "abridge prod deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, production]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- production
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-rate-limits/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-rate-limits/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-rate-limits
-description: |
-  Implement Abridge rate limiting, backoff, and session throttling patterns.
+description: 'Implement Abridge rate limiting, backoff, and session throttling patterns.
+
   Use when handling 429 errors, managing concurrent encounter sessions,
+
   or optimizing API throughput for high-volume clinical deployments.
+
   Trigger: "abridge rate limit", "abridge 429", "abridge throttling",
+
   "abridge concurrent sessions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, rate-limiting]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- rate-limiting
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-reference-architecture
-description: |
-  Implement Abridge reference architecture for clinical AI integration.
+description: 'Implement Abridge reference architecture for clinical AI integration.
+
   Use when designing a new Abridge deployment, reviewing project structure,
+
   or planning multi-site health system rollouts with EHR integration.
+
   Trigger: "abridge architecture", "abridge project structure",
+
   "abridge system design", "abridge multi-site".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-sdk-patterns/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: abridge-sdk-patterns
-description: |
-  Apply production-ready patterns for Abridge clinical AI integration.
+description: 'Apply production-ready patterns for Abridge clinical AI integration.
+
   Use when building reusable Abridge client wrappers, implementing HIPAA-compliant
+
   error handling, or establishing team coding standards for healthcare AI.
+
   Trigger: "abridge SDK patterns", "abridge best practices", "abridge code patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # Abridge SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-security-basics/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-security-basics/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: abridge-security-basics
-description: |
-  Apply HIPAA-compliant security practices for Abridge clinical AI integrations.
+description: 'Apply HIPAA-compliant security practices for Abridge clinical AI integrations.
+
   Use when securing PHI in transit/at rest, configuring access controls,
+
   implementing audit logging, or preparing for HIPAA security audits.
+
   Trigger: "abridge security", "abridge HIPAA", "abridge PHI protection",
+
   "abridge access control", "abridge audit logging".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(openssl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, security, hipaa]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- security
+- hipaa
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Security Basics
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-upgrade-migration
-description: |
-  Plan and execute Abridge integration upgrades and EHR migration procedures.
+description: 'Plan and execute Abridge integration upgrades and EHR migration procedures.
+
   Use when upgrading Abridge API versions, migrating between EHR systems,
+
   or handling breaking changes in clinical documentation workflows.
+
   Trigger: "abridge upgrade", "abridge migration", "abridge version update",
+
   "migrate abridge EHR", "abridge breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, migration]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- migration
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/abridge-pack/skills/abridge-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/abridge-pack/skills/abridge-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: abridge-webhooks-events
-description: |
-  Implement Abridge webhook handling for clinical documentation events.
+description: 'Implement Abridge webhook handling for clinical documentation events.
+
   Use when receiving note completion notifications, encounter status changes,
+
   provider enrollment events, or quality alert callbacks from Abridge.
+
   Trigger: "abridge webhook", "abridge events", "abridge notifications",
+
   "abridge note completed event", "abridge encounter event".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, healthcare, ai, abridge, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- healthcare
+- ai
+- abridge
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # Abridge Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-advanced-troubleshooting
-description: |
-  Apply advanced debugging techniques for Adobe API issues: IMS token
+description: 'Apply advanced debugging techniques for Adobe API issues: IMS token
+
   introspection, Firefly job failure analysis, PDF Services error
+
   codes, and network-layer diagnostics for Adobe endpoints.
+
   Trigger with phrases like "adobe hard bug", "adobe mystery error",
+
   "adobe impossible to debug", "difficult adobe issue", "adobe deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*), Bash(tcpdump:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-architecture-variants/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-architecture-variants
-description: |
-  Choose and implement Adobe architecture blueprints: standalone SDK integration,
+description: 'Choose and implement Adobe architecture blueprints: standalone SDK integration,
+
   Adobe App Builder serverless, and dedicated microservice with event-driven
+
   Firefly/PDF pipelines. Decision matrix based on team size and throughput.
+
   Trigger with phrases like "adobe architecture", "adobe blueprint",
+
   "adobe app builder vs standalone", "adobe microservice".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-ci-integration/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-ci-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-ci-integration
-description: |
-  Configure CI/CD pipelines for Adobe integrations with GitHub Actions,
+description: 'Configure CI/CD pipelines for Adobe integrations with GitHub Actions,
+
   including OAuth credential injection, PDF Services testing, Firefly API
+
   smoke tests, and secret scanning for Adobe credential patterns.
+
   Trigger with phrases like "adobe CI", "adobe GitHub Actions",
+
   "adobe automated tests", "CI adobe", "adobe pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe CI Integration
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-common-errors/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-common-errors/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: adobe-common-errors
-description: |
-  Diagnose and fix common Adobe API errors across Firefly Services, PDF Services,
+description: 'Diagnose and fix common Adobe API errors across Firefly Services, PDF
+  Services,
+
   Photoshop API, and Adobe I/O Events.
+
   Use when encountering Adobe errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "adobe error", "fix adobe",
+
   "adobe not working", "debug adobe", "adobe 403", "adobe 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Common Errors
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-core-workflow-a/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: adobe-core-workflow-a
-description: |
-  Execute Adobe Firefly Services workflow: AI image generation, generative fill,
+description: 'Execute Adobe Firefly Services workflow: AI image generation, generative
+  fill,
+
   and expand image using the Firefly v3 API.
+
   Use when generating images from prompts, filling or expanding images with AI,
+
   or building creative automation pipelines.
+
   Trigger with phrases like "adobe firefly", "generate image adobe",
+
   "firefly text to image", "adobe AI image", "generative fill".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Core Workflow A — Firefly Services
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-core-workflow-b/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: adobe-core-workflow-b
-description: |
-  Execute Adobe PDF Services workflow: create PDFs from HTML/DOCX, extract text/tables,
+description: 'Execute Adobe PDF Services workflow: create PDFs from HTML/DOCX, extract
+  text/tables,
+
   document generation from templates, and PDF-to-Markdown conversion.
+
   Use when building document automation, extracting content from PDFs,
+
   or generating dynamic reports.
+
   Trigger with phrases like "adobe pdf", "pdf services", "extract pdf",
+
   "create pdf", "document generation", "pdf to markdown".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Core Workflow B — PDF Services
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-cost-tuning/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-cost-tuning
-description: |
-  Optimize Adobe API costs across Firefly Services (generative credits),
+description: 'Optimize Adobe API costs across Firefly Services (generative credits),
+
   PDF Services (document transactions), and Photoshop/Lightroom APIs.
+
   Use when analyzing Adobe billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "adobe cost", "adobe billing", "adobe credits",
+
   "reduce adobe costs", "adobe pricing", "adobe budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-data-handling/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-data-handling/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-data-handling
-description: |
-  Implement data handling for Adobe APIs including PII redaction in logs,
+description: 'Implement data handling for Adobe APIs including PII redaction in logs,
+
   Firefly content policy compliance, PDF document data classification,
+
   and GDPR/CCPA data subject access requests via Adobe Privacy Service.
+
   Trigger with phrases like "adobe data", "adobe PII",
+
   "adobe GDPR", "adobe data retention", "adobe privacy", "adobe content policy".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Data Handling
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-debug-bundle
-description: |
-  Collect Adobe debug evidence for support tickets and troubleshooting.
+description: 'Collect Adobe debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Adobe API problems.
+
   Trigger with phrases like "adobe debug", "adobe support bundle",
+
   "collect adobe logs", "adobe diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: adobe-deploy-integration
-description: |
-  Deploy Adobe-powered applications to Vercel, Cloud Run, and Adobe App Builder
+description: 'Deploy Adobe-powered applications to Vercel, Cloud Run, and Adobe App
+  Builder
+
   with proper credential injection and health monitoring.
+
   Use when deploying Adobe API integrations to production platforms.
+
   Trigger with phrases like "deploy adobe", "adobe Vercel",
+
   "adobe Cloud Run", "adobe App Builder deploy", "adobe production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(aio:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-enterprise-rbac/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-enterprise-rbac
-description: |
-  Configure Adobe enterprise identity with Admin Console SCIM provisioning,
+description: 'Configure Adobe enterprise identity with Admin Console SCIM provisioning,
+
   User Management API, product profile-based RBAC, and Federated ID
+
   with Azure AD or Google Workspace.
+
   Trigger with phrases like "adobe SSO", "adobe RBAC",
+
   "adobe enterprise", "adobe roles", "adobe SCIM", "adobe user management".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-hello-world/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-hello-world/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-hello-world
-description: |
-  Create minimal working examples for Adobe APIs: Firefly image generation,
+description: 'Create minimal working examples for Adobe APIs: Firefly image generation,
+
   PDF extraction, and Photoshop background removal.
+
   Use when starting a new Adobe integration, testing your setup,
+
   or learning basic Adobe API patterns.
+
   Trigger with phrases like "adobe hello world", "adobe example",
+
   "adobe quick start", "simple adobe code", "first adobe API call".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Hello World
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-incident-runbook/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-incident-runbook
-description: |
-  Execute Adobe incident response procedures with triage, mitigation,
+description: 'Execute Adobe incident response procedures with triage, mitigation,
+
   and postmortem for Firefly Services, PDF Services, and I/O Events outages.
+
   Use when responding to Adobe-related incidents, investigating API failures,
+
   or running post-incident reviews.
+
   Trigger with phrases like "adobe incident", "adobe outage",
+
   "adobe down", "adobe on-call", "adobe emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-install-auth/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: adobe-install-auth
-description: |
-  Install and configure Adobe Developer Console OAuth Server-to-Server credentials.
+description: 'Install and configure Adobe Developer Console OAuth Server-to-Server
+  credentials.
+
   Use when setting up a new Adobe integration, configuring API credentials,
+
   or initializing Adobe SDKs (Firefly Services, PDF Services, I/O Runtime).
+
   Trigger with phrases like "install adobe", "setup adobe",
+
   "adobe auth", "configure adobe credentials", "adobe developer console".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-known-pitfalls/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: adobe-known-pitfalls
-description: |
-  Identify and avoid Adobe-specific anti-patterns: using deprecated JWT auth,
+description: 'Identify and avoid Adobe-specific anti-patterns: using deprecated JWT
+  auth,
+
   not caching IMS tokens, ignoring Firefly content policy, missing async job
+
   polling, and leaking p8_ secrets. Real code examples with fixes.
+
   Trigger with phrases like "adobe mistakes", "adobe anti-patterns",
+
   "adobe pitfalls", "adobe what not to do", "adobe code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-load-scale/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-load-scale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: adobe-load-scale
-description: |
-  Implement load testing, auto-scaling, and capacity planning for Adobe API
+description: 'Implement load testing, auto-scaling, and capacity planning for Adobe
+  API
+
   integrations with k6 scripts targeting Firefly, PDF Services, and
+
   Photoshop APIs, plus Kubernetes HPA configuration.
+
   Trigger with phrases like "adobe load test", "adobe scale",
+
   "adobe performance test", "adobe capacity", "adobe benchmark".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-local-dev-loop/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-local-dev-loop
-description: |
-  Configure Adobe local development with App Builder CLI, Runtime actions,
+description: 'Configure Adobe local development with App Builder CLI, Runtime actions,
+
   hot reload, and mock testing for Firefly/PDF/Photoshop APIs.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Adobe APIs.
+
   Trigger with phrases like "adobe dev setup", "adobe local development",
+
   "adobe dev environment", "develop with adobe", "aio app".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-migration-deep-dive/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-migration-deep-dive
-description: |
-  Execute major Adobe re-architecture: migrating from legacy Adobe APIs
+description: 'Execute major Adobe re-architecture: migrating from legacy Adobe APIs
+
   to Firefly Services, consolidating Creative Cloud integrations, and
+
   strangler-fig migration from competitor document/image APIs to Adobe.
+
   Trigger with phrases like "migrate adobe", "adobe migration",
+
   "switch to adobe", "adobe replatform", "replace with adobe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-multi-env-setup/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-multi-env-setup
-description: |
-  Configure Adobe OAuth credentials and API access across development,
+description: 'Configure Adobe OAuth credentials and API access across development,
+
   staging, and production environments with separate Developer Console
+
   projects, secret managers, and environment-specific scoping.
+
   Trigger with phrases like "adobe environments", "adobe staging",
+
   "adobe dev prod", "adobe environment setup", "adobe config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-observability/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-observability/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-observability
-description: |
-  Set up comprehensive observability for Adobe API integrations with
+description: 'Set up comprehensive observability for Adobe API integrations with
+
   Prometheus metrics, OpenTelemetry traces, structured logging, and
+
   alert rules covering Firefly, PDF Services, and Photoshop APIs.
+
   Trigger with phrases like "adobe monitoring", "adobe metrics",
+
   "adobe observability", "monitor adobe", "adobe alerts", "adobe tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Observability
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-performance-tuning/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-performance-tuning
-description: |
-  Optimize Adobe API performance with token caching, async job batching,
+description: 'Optimize Adobe API performance with token caching, async job batching,
+
   connection pooling, and response caching for Firefly, PDF Services,
+
   and Photoshop API workflows.
+
   Trigger with phrases like "adobe performance", "optimize adobe",
+
   "adobe latency", "adobe caching", "adobe slow", "adobe batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-policy-guardrails/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-policy-guardrails
-description: |
-  Implement Adobe-specific lint rules, CI policy checks, and runtime guardrails
+description: 'Implement Adobe-specific lint rules, CI policy checks, and runtime guardrails
+
   covering credential scanning (p8_ patterns), Firefly content policy pre-screening,
+
   PDF Services quota enforcement, and OAuth scope validation.
+
   Trigger with phrases like "adobe policy", "adobe lint",
+
   "adobe guardrails", "adobe eslint", "adobe content policy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-prod-checklist/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-prod-checklist
-description: |
-  Execute Adobe production deployment checklist covering credential management,
+description: 'Execute Adobe production deployment checklist covering credential management,
+
   API health checks, rate limit configuration, and rollback procedures
+
   for Firefly Services, PDF Services, and I/O Events integrations.
+
   Trigger with phrases like "adobe production", "deploy adobe",
+
   "adobe go-live", "adobe launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-rate-limits/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-rate-limits/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-rate-limits
-description: |
-  Implement Adobe API rate limiting, backoff, and quota management across
+description: 'Implement Adobe API rate limiting, backoff, and quota management across
+
   Firefly, PDF Services, Photoshop, and I/O Events APIs.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Adobe.
+
   Trigger with phrases like "adobe rate limit", "adobe throttling",
+
   "adobe 429", "adobe retry", "adobe backoff", "adobe quota".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-reference-architecture/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-reference-architecture
-description: |
-  Implement Adobe reference architecture for production integrations covering
+description: 'Implement Adobe reference architecture for production integrations covering
+
   Firefly Services, PDF Services, I/O Events, and App Builder with layered
+
   project layout, error boundaries, and health monitoring.
+
   Trigger with phrases like "adobe architecture", "adobe project structure",
+
   "how to organize adobe", "adobe layout", "adobe best practices".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-reliability-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: adobe-reliability-patterns
-description: |
-  Implement reliability patterns for Adobe APIs: circuit breakers for IMS/Firefly,
+description: 'Implement reliability patterns for Adobe APIs: circuit breakers for
+  IMS/Firefly,
+
   idempotency for PDF Services operations, graceful degradation when Adobe is down,
+
   and dead letter queues for failed async jobs.
+
   Trigger with phrases like "adobe reliability", "adobe circuit breaker",
+
   "adobe fallback", "adobe resilience", "adobe graceful degradation".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-sdk-patterns/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: adobe-sdk-patterns
-description: |
-  Apply production-ready patterns for Adobe Firefly Services SDK, PDF Services SDK,
+description: 'Apply production-ready patterns for Adobe Firefly Services SDK, PDF
+  Services SDK,
+
   and raw REST API usage in TypeScript and Python.
+
   Use when implementing Adobe integrations, refactoring SDK usage,
+
   or establishing team coding standards for Adobe APIs.
+
   Trigger with phrases like "adobe SDK patterns", "adobe best practices",
+
   "adobe code patterns", "idiomatic adobe", "adobe typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-security-basics/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-security-basics/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: adobe-security-basics
-description: |
-  Apply Adobe security best practices for OAuth credentials, secret rotation,
+description: 'Apply Adobe security best practices for OAuth credentials, secret rotation,
+
   I/O Events webhook signature verification, and least-privilege scoping.
+
   Use when securing API credentials, implementing webhook validation,
+
   or auditing Adobe security configuration.
+
   Trigger with phrases like "adobe security", "adobe secrets",
+
   "secure adobe", "adobe credential rotation", "adobe webhook signature".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Security Basics
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-upgrade-migration/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: adobe-upgrade-migration
-description: |
-  Analyze, plan, and execute Adobe SDK upgrades — including the critical
-  JWT-to-OAuth migration, PDF Services SDK v3-to-v4, and Photoshop API
-  endpoint changes (cutout v1 to remove-background v2).
-  Trigger with phrases like "upgrade adobe", "adobe migration",
-  "adobe breaking changes", "update adobe SDK", "jwt to oauth".
+description: "Analyze, plan, and execute Adobe SDK upgrades \u2014 including the critical\n\
+  JWT-to-OAuth migration, PDF Services SDK v3-to-v4, and Photoshop API\nendpoint changes\
+  \ (cutout v1 to remove-background v2).\nTrigger with phrases like \"upgrade adobe\"\
+  , \"adobe migration\",\n\"adobe breaking changes\", \"update adobe SDK\", \"jwt\
+  \ to oauth\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/adobe-pack/skills/adobe-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/adobe-pack/skills/adobe-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: adobe-webhooks-events
-description: |
-  Implement Adobe I/O Events webhook registration, RSA-SHA256 signature
+description: 'Implement Adobe I/O Events webhook registration, RSA-SHA256 signature
+
   verification, challenge handshake, and event-driven architectures
+
   with Creative Cloud, Experience Platform, and Firefly Services events.
+
   Trigger with phrases like "adobe webhook", "adobe events",
+
   "adobe I/O events", "adobe event registration", "adobe notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, adobe]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- adobe
+compatibility: Designed for Claude Code
 ---
-
 # Adobe Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-ci-integration/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-ci-integration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: alchemy-ci-integration
-description: |
-  Configure CI/CD pipeline for Alchemy-powered Web3 applications.
+description: 'Configure CI/CD pipeline for Alchemy-powered Web3 applications.
+
   Use when setting up automated testing with Hardhat forks,
+
   smart contract verification, or testnet deployment pipelines.
+
   Trigger: "alchemy CI", "alchemy GitHub Actions", "web3 CI/CD pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, ci-cd]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- ci-cd
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy CI Integration
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-common-errors/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-common-errors
-description: |
-  Diagnose and fix common Alchemy SDK and Web3 API errors.
+description: 'Diagnose and fix common Alchemy SDK and Web3 API errors.
+
   Use when encountering rate limits, RPC failures, invalid parameters,
+
   or blockchain query errors with the Alchemy SDK.
+
   Trigger: "alchemy error", "alchemy not working", "alchemy 429",
+
   "alchemy debug", "fix alchemy issue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, troubleshooting]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- troubleshooting
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Common Errors
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: alchemy-core-workflow-a
-description: |
-  Build a complete wallet portfolio tracker using Alchemy Enhanced APIs.
+description: 'Build a complete wallet portfolio tracker using Alchemy Enhanced APIs.
+
   Use when implementing token balance dashboards, NFT galleries,
+
   transaction history views, or wallet analytics applications.
+
   Trigger: "alchemy wallet tracker", "alchemy portfolio", "alchemy token dashboard",
+
   "alchemy transaction history", "build dApp with alchemy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, defi, portfolio]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- defi
+- portfolio
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Core Workflow A — Wallet Portfolio Tracker
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-core-workflow-b/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: alchemy-core-workflow-b
-description: |
-  Build NFT collection explorer and smart contract interaction with Alchemy.
+description: 'Build NFT collection explorer and smart contract interaction with Alchemy.
+
   Use when fetching NFT metadata, building galleries, reading contract state,
+
   or implementing NFT marketplace features.
+
   Trigger: "alchemy NFT", "alchemy smart contract", "alchemy collection",
+
   "alchemy NFT metadata", "alchemy contract read".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, nft, smart-contracts]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- nft
+- smart-contracts
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Core Workflow B — NFT & Smart Contract Interaction
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-cost-tuning
-description: |
-  Optimize Alchemy API costs through CU budgeting, caching, and plan selection.
+description: 'Optimize Alchemy API costs through CU budgeting, caching, and plan selection.
+
   Use when analyzing Alchemy billing, reducing Compute Unit consumption,
+
   or choosing the right plan for your dApp traffic.
+
   Trigger: "alchemy cost", "alchemy pricing", "alchemy CU budget",
+
   "alchemy billing optimization", "alchemy free tier limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, cost-optimization]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- cost-optimization
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-debug-bundle/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: alchemy-debug-bundle
-description: |
-  Collect Alchemy SDK debug evidence for troubleshooting and support tickets.
+description: 'Collect Alchemy SDK debug evidence for troubleshooting and support tickets.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or debugging blockchain query failures.
+
   Trigger: "alchemy debug bundle", "alchemy support ticket", "alchemy diagnostics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, debugging]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-deploy-integration
-description: |
-  Deploy Alchemy-powered Web3 applications to Vercel, Cloud Run, and AWS.
+description: 'Deploy Alchemy-powered Web3 applications to Vercel, Cloud Run, and AWS.
+
   Use when deploying dApps with server-side Alchemy SDK access,
+
   configuring API key secrets, or setting up RPC proxy endpoints.
+
   Trigger: "deploy alchemy", "alchemy Vercel", "alchemy Cloud Run",
+
   "alchemy production deploy", "dApp deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-hello-world/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: alchemy-hello-world
-description: |
-  Create a minimal Alchemy Web3 example: get ETH balance, fetch NFTs, read token balances.
+description: 'Create a minimal Alchemy Web3 example: get ETH balance, fetch NFTs,
+  read token balances.
+
   Use when starting blockchain development, testing Alchemy setup,
+
   or learning basic blockchain query patterns.
+
   Trigger: "alchemy hello world", "alchemy example", "alchemy quick start",
+
   "get ETH balance", "fetch NFTs alchemy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, nft]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- nft
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Hello World
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-install-auth/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-install-auth/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: alchemy-install-auth
-description: |
-  Install the Alchemy SDK and configure API key authentication for Web3 development.
+description: 'Install the Alchemy SDK and configure API key authentication for Web3
+  development.
+
   Use when setting up blockchain API access, creating an Alchemy app,
+
   or configuring multi-chain RPC endpoints.
+
   Trigger: "install alchemy", "setup alchemy", "alchemy auth", "alchemy API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-local-dev-loop/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: alchemy-local-dev-loop
-description: |
-  Set up local Web3 development workflow with Alchemy, Hardhat, and testnets.
+description: 'Set up local Web3 development workflow with Alchemy, Hardhat, and testnets.
+
   Use when configuring local blockchain dev, testing with Sepolia faucets,
+
   or setting up hot-reload for smart contract development.
+
   Trigger: "alchemy local dev", "alchemy hardhat", "alchemy testnet setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, development]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- development
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-performance-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: alchemy-performance-tuning
-description: |
-  Optimize Alchemy SDK performance with caching, batching, and multi-chain parallelism.
+description: 'Optimize Alchemy SDK performance with caching, batching, and multi-chain
+  parallelism.
+
   Use when reducing latency for blockchain queries, optimizing CU consumption,
+
   or scaling dApps for high request volumes.
+
   Trigger: "alchemy performance", "alchemy slow", "alchemy optimization",
+
   "alchemy caching", "alchemy batch requests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, performance]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Performance Tuning
 
 ## Performance Targets

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-prod-checklist
-description: |
-  Execute production readiness checklist for Alchemy-powered dApps.
+description: 'Execute production readiness checklist for Alchemy-powered dApps.
+
   Use when deploying Web3 applications, preparing for mainnet launch,
+
   or validating blockchain integration before go-live.
+
   Trigger: "alchemy production", "alchemy go-live", "alchemy mainnet checklist",
+
   "dApp production readiness".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, production]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- production
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Production Checklist
 
 ## Pre-Launch Checklist

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-rate-limits/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-rate-limits/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-rate-limits
-description: |
-  Implement Alchemy Compute Unit (CU) rate limiting and request throttling.
+description: 'Implement Alchemy Compute Unit (CU) rate limiting and request throttling.
+
   Use when handling 429 errors, optimizing CU usage, or managing
+
   concurrent blockchain queries within plan limits.
+
   Trigger: "alchemy rate limit", "alchemy 429", "alchemy compute units",
+
   "alchemy throttling", "alchemy CU budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, rate-limiting]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- rate-limiting
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-reference-architecture
-description: |
-  Implement reference architecture for Alchemy-powered Web3 applications.
+description: 'Implement reference architecture for Alchemy-powered Web3 applications.
+
   Use when designing dApp infrastructure, planning multi-chain deployments,
+
   or structuring a production blockchain application.
+
   Trigger: "alchemy architecture", "dApp architecture", "alchemy project structure",
+
   "web3 system design", "alchemy multi-chain design".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Reference Architecture
 
 ## System Architecture

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-sdk-patterns/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: alchemy-sdk-patterns
-description: |
-  Apply production-ready Alchemy SDK patterns for Web3 applications.
+description: 'Apply production-ready Alchemy SDK patterns for Web3 applications.
+
   Use when building reusable blockchain clients, implementing caching,
+
   multi-chain abstractions, or type-safe contract interactions.
+
   Trigger: "alchemy SDK patterns", "alchemy best practices", "alchemy code patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-security-basics/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-security-basics/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-security-basics
-description: |
-  Apply Web3 security best practices for Alchemy-powered applications.
+description: 'Apply Web3 security best practices for Alchemy-powered applications.
+
   Use when securing API keys, validating blockchain inputs, preventing
+
   private key exposure, or hardening dApp infrastructure.
+
   Trigger: "alchemy security", "web3 security", "protect private key",
+
   "alchemy API key security", "dApp security".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, security]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- security
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Security Basics
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-upgrade-migration
-description: |
-  Migrate from alchemy-sdk v2 to v3 and handle breaking changes.
+description: 'Migrate from alchemy-sdk v2 to v3 and handle breaking changes.
+
   Use when upgrading Alchemy SDK versions, migrating from deprecated
+
   alchemy-web3, or adapting to new API patterns.
+
   Trigger: "alchemy upgrade", "alchemy migration", "alchemy-sdk v3",
+
   "migrate alchemy-web3", "alchemy breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, migration]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- migration
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/alchemy-pack/skills/alchemy-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/alchemy-pack/skills/alchemy-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: alchemy-webhooks-events
-description: |
-  Implement Alchemy Notify webhooks for real-time blockchain event notifications.
+description: 'Implement Alchemy Notify webhooks for real-time blockchain event notifications.
+
   Use when tracking wallet activity, monitoring mined transactions,
+
   watching smart contract events, or building real-time dApp features.
+
   Trigger: "alchemy webhook", "alchemy notify", "alchemy events",
+
   "alchemy address activity", "alchemy real-time notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, blockchain, web3, alchemy, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- blockchain
+- web3
+- alchemy
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # Alchemy Webhooks & Events (Notify API)
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-ci-integration/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-ci-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-ci-integration
-description: |
-  Configure Algolia CI/CD: GitHub Actions for index validation, automated reindexing
+description: 'Configure Algolia CI/CD: GitHub Actions for index validation, automated
+  reindexing
+
   on deploy, and integration testing against real Algolia indices.
+
   Trigger: "algolia CI", "algolia GitHub Actions", "algolia automated tests",
+
   "CI algolia", "algolia deploy pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia CI Integration
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-common-errors/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-common-errors/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-common-errors
-description: |
-  Diagnose and fix the top Algolia API errors: 400, 403, 404, 429, ApiError,
+description: 'Diagnose and fix the top Algolia API errors: 400, 403, 404, 429, ApiError,
+
   RetryError, and indexing failures.
+
   Trigger: "algolia error", "fix algolia", "algolia not working",
+
   "debug algolia", "algolia 429", "algolia 403".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Common Errors
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-core-workflow-a/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-core-workflow-a
-description: |
-  Implement Algolia search with filters, facets, highlighting, and pagination.
+description: 'Implement Algolia search with filters, facets, highlighting, and pagination.
+
   The primary money-path workflow: search records, apply filters, display results.
+
   Trigger: "algolia search", "search with algolia", "algolia filters",
+
   "algolia facets", "algolia search implementation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Core Workflow A — Search & Filtering
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-core-workflow-b/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-core-workflow-b
-description: |
-  Implement Algolia indexing pipeline: data sync, partial updates, synonyms, and rules.
+description: 'Implement Algolia indexing pipeline: data sync, partial updates, synonyms,
+  and rules.
+
   The secondary money-path workflow: keep your index in sync with source data.
+
   Trigger: "algolia indexing", "sync data to algolia", "algolia synonyms",
+
   "algolia rules", "algolia partial update", "algolia reindex".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Core Workflow B — Indexing & Data Sync
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-cost-tuning/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-cost-tuning
-description: |
-  Optimize Algolia costs: understand search request vs record pricing,
+description: 'Optimize Algolia costs: understand search request vs record pricing,
+
   reduce operations with batching and caching, monitor usage via Analytics API.
+
   Trigger: "algolia cost", "algolia billing", "reduce algolia costs",
+
   "algolia pricing", "algolia expensive", "algolia budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-data-handling/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-data-handling/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: algolia-data-handling
-description: |
-  Implement Algolia data handling: record transforms, PII filtering before indexing,
-  data retention, GDPR/CCPA compliance with Algolia's deleteByQuery and Insights deletion.
+description: 'Implement Algolia data handling: record transforms, PII filtering before
+  indexing,
+
+  data retention, GDPR/CCPA compliance with Algolia''s deleteByQuery and Insights
+  deletion.
+
   Trigger: "algolia data", "algolia PII", "algolia GDPR", "algolia data retention",
+
   "algolia privacy", "algolia CCPA", "algolia data sync".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Data Handling
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-debug-bundle/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-debug-bundle
-description: |
-  Collect Algolia debug evidence: index stats, API key ACLs, query logs,
+description: 'Collect Algolia debug evidence: index stats, API key ACLs, query logs,
+
   and network diagnostics for support tickets.
+
   Trigger: "algolia debug", "algolia support bundle", "collect algolia logs",
+
   "algolia diagnostic", "algolia troubleshoot".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(npm:*), Bash(tar:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-deploy-integration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-deploy-integration
-description: |
-  Deploy Algolia-powered apps to Vercel, Fly.io, and Cloud Run with proper
+description: 'Deploy Algolia-powered apps to Vercel, Fly.io, and Cloud Run with proper
+
   API key management and InstantSearch frontend integration.
+
   Trigger: "deploy algolia", "algolia Vercel", "algolia production deploy",
+
   "algolia Cloud Run", "algolia Fly.io", "algolia InstantSearch".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-enterprise-rbac/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-enterprise-rbac
-description: |
-  Configure Algolia enterprise access control: team-scoped API keys, Secured API Keys
+description: 'Configure Algolia enterprise access control: team-scoped API keys, Secured
+  API Keys
+
   for multi-tenant RBAC, dashboard team management, and audit logging.
+
   Trigger: "algolia RBAC", "algolia enterprise", "algolia roles", "algolia permissions",
+
   "algolia team access", "algolia multi-tenant", "algolia SSO".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-hello-world/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-hello-world/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: algolia-hello-world
-description: |
-  Create a minimal working Algolia example — index records and search them.
-  Use when starting a new Algolia integration, testing your setup,
-  or learning the saveObjects/searchSingleIndex pattern.
-  Trigger: "algolia hello world", "algolia example", "algolia quick start", "first algolia search".
+description: "Create a minimal working Algolia example \u2014 index records and search\
+  \ them.\nUse when starting a new Algolia integration, testing your setup,\nor learning\
+  \ the saveObjects/searchSingleIndex pattern.\nTrigger: \"algolia hello world\",\
+  \ \"algolia example\", \"algolia quick start\", \"first algolia search\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Hello World
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-incident-runbook/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-incident-runbook
-description: |
-  Execute Algolia incident response: triage search failures, distinguish
+description: 'Execute Algolia incident response: triage search failures, distinguish
+
   Algolia-side vs your-side issues, apply fallbacks, and run postmortems.
+
   Trigger: "algolia incident", "algolia outage", "algolia down",
+
   "algolia on-call", "algolia emergency", "algolia broken", "search is down".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-install-auth/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-install-auth/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: algolia-install-auth
-description: |
-  Install and configure the Algolia JavaScript v5 client with proper API key management.
-  Use when setting up a new Algolia integration, configuring Application ID and API keys,
+description: 'Install and configure the Algolia JavaScript v5 client with proper API
+  key management.
+
+  Use when setting up a new Algolia integration, configuring Application ID and API
+  keys,
+
   or initializing the algoliasearch client in a Node.js/TypeScript project.
-  Trigger: "install algolia", "setup algolia", "algolia auth", "configure algolia keys".
+
+  Trigger: "install algolia", "setup algolia", "algolia auth", "configure algolia
+  keys".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-local-dev-loop/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: algolia-local-dev-loop
-description: |
-  Configure Algolia local development with separate dev index, mocking, and testing.
+description: 'Configure Algolia local development with separate dev index, mocking,
+  and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Algolia.
-  Trigger: "algolia dev setup", "algolia local development", "algolia dev environment", "test algolia locally".
+
+  Trigger: "algolia dev setup", "algolia local development", "algolia dev environment",
+  "test algolia locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-migration-deep-dive/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: algolia-migration-deep-dive
-description: |
-  Migrate to Algolia from Elasticsearch, Typesense, or Meilisearch.
+description: 'Migrate to Algolia from Elasticsearch, Typesense, or Meilisearch.
+
   Covers data migration, query translation, replaceAllObjects zero-downtime swap,
+
   and strangler fig traffic shifting.
+
   Trigger: "migrate to algolia", "switch to algolia", "algolia migration",
+
   "elasticsearch to algolia", "replace search engine", "algolia replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-multi-env-setup/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-multi-env-setup
-description: |
-  Configure Algolia across dev/staging/production: index prefixing, per-environment
+description: 'Configure Algolia across dev/staging/production: index prefixing, per-environment
+
   API keys, settings-as-code, and environment isolation guards.
+
   Trigger: "algolia environments", "algolia staging", "algolia dev prod",
+
   "algolia environment setup", "algolia config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-observability/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-observability/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-observability
-description: |
-  Set up observability for Algolia: Prometheus metrics for search latency/errors,
+description: 'Set up observability for Algolia: Prometheus metrics for search latency/errors,
+
   OpenTelemetry tracing, structured logging, and Grafana dashboards.
+
   Trigger: "algolia monitoring", "algolia metrics", "algolia observability",
+
   "monitor algolia", "algolia alerts", "algolia tracing", "algolia dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Observability
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-performance-tuning/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: algolia-performance-tuning
-description: |
-  Optimize Algolia search performance: record size, searchable attributes,
+description: 'Optimize Algolia search performance: record size, searchable attributes,
+
   replica strategy, response caching, and query-time parameter tuning.
+
   Trigger: "algolia performance", "optimize algolia", "algolia latency",
+
   "algolia slow", "algolia caching", "algolia response time".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-prod-checklist/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-prod-checklist
-description: |
-  Execute Algolia production readiness checklist: index settings, key security,
+description: 'Execute Algolia production readiness checklist: index settings, key
+  security,
+
   replica configuration, monitoring, and rollback procedures.
+
   Trigger: "algolia production", "deploy algolia", "algolia go-live",
+
   "algolia launch checklist", "algolia production ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-rate-limits/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-rate-limits
-description: |
-  Handle Algolia rate limits and throttling: per-key limits, indexing queue limits,
+description: 'Handle Algolia rate limits and throttling: per-key limits, indexing
+  queue limits,
+
   429 responses, and backoff strategies.
+
   Trigger: "algolia rate limit", "algolia throttling", "algolia 429",
+
   "algolia retry", "algolia backoff", "algolia too many requests".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-reference-architecture/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-reference-architecture
-description: |
-  Implement Algolia reference architecture: index design, multi-index strategy,
+description: 'Implement Algolia reference architecture: index design, multi-index
+  strategy,
+
   data pipeline, search service layer, and frontend/backend separation.
+
   Trigger: "algolia architecture", "algolia best practices", "algolia project structure",
+
   "how to organize algolia", "algolia index design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-sdk-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: algolia-sdk-patterns
-description: |
-  Apply production-ready algoliasearch v5 patterns: singleton client, typed search,
+description: 'Apply production-ready algoliasearch v5 patterns: singleton client,
+  typed search,
+
   error handling, and batch operations.
+
   Use when implementing Algolia integrations, refactoring SDK usage,
+
   or establishing team coding standards.
-  Trigger: "algolia SDK patterns", "algolia best practices", "algolia code patterns", "idiomatic algolia".
+
+  Trigger: "algolia SDK patterns", "algolia best practices", "algolia code patterns",
+  "idiomatic algolia".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-security-basics/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-security-basics/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-security-basics
-description: |
-  Apply Algolia security best practices: API key scoping, secured API keys,
+description: 'Apply Algolia security best practices: API key scoping, secured API
+  keys,
+
   frontend vs backend key separation, and key rotation.
+
   Trigger: "algolia security", "algolia API key security", "secure algolia",
+
   "algolia secrets", "algolia key rotation", "algolia secured key".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Security Basics
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-upgrade-migration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: algolia-upgrade-migration
-description: |
-  Upgrade algoliasearch from v4 to v5 with breaking change detection and codemod.
-  Use when upgrading SDK versions, detecting deprecations, or migrating initIndex patterns.
+description: 'Upgrade algoliasearch from v4 to v5 with breaking change detection and
+  codemod.
+
+  Use when upgrading SDK versions, detecting deprecations, or migrating initIndex
+  patterns.
+
   Trigger: "upgrade algolia", "algolia migration v5", "algolia breaking changes",
+
   "update algolia SDK", "algolia v4 to v5".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Upgrade & Migration (v4 to v5)
 
 ## Overview

--- a/plugins/saas-packs/algolia-pack/skills/algolia-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/algolia-pack/skills/algolia-webhooks-events/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: algolia-webhooks-events
-description: |
-  Implement Algolia Insights API for click/conversion tracking, search analytics,
+description: 'Implement Algolia Insights API for click/conversion tracking, search
+  analytics,
+
   and real-time event-driven index updates via database change listeners.
+
   Trigger: "algolia events", "algolia analytics", "algolia insights",
+
   "algolia click tracking", "algolia conversion", "algolia event tracking".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, algolia]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- algolia
+compatibility: Designed for Claude Code
 ---
-
 # Algolia Events & Insights
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-ci-integration/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-ci-integration/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: anima-ci-integration
-description: |
-  Configure CI/CD pipeline for automated Figma-to-code generation with Anima.
+description: 'Configure CI/CD pipeline for automated Figma-to-code generation with
+  Anima.
+
   Use when automating design-to-code in GitHub Actions, setting up PR-based
+
   component generation, or integrating Anima into design handoff workflows.
+
   Trigger: "anima CI", "anima GitHub Actions", "anima automated generation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, ci-cd]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- ci-cd
+compatibility: Designed for Claude Code
 ---
-
 # Anima CI Integration
 
 ## Instructions

--- a/plugins/saas-packs/anima-pack/skills/anima-common-errors/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-common-errors/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-common-errors
-description: |
-  Diagnose and fix common Anima SDK design-to-code errors.
+description: 'Diagnose and fix common Anima SDK design-to-code errors.
+
   Use when encountering Figma token errors, code generation failures,
+
   node not found issues, or output quality problems.
+
   Trigger: "anima error", "anima not working", "anima debug", "figma to code error".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, troubleshooting]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- troubleshooting
+compatibility: Designed for Claude Code
 ---
-
 # Anima Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/anima-pack/skills/anima-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: anima-core-workflow-a
-description: |
-  Build automated Figma-to-React pipeline with the Anima SDK.
+description: 'Build automated Figma-to-React pipeline with the Anima SDK.
+
   Use when automating design handoff, building CI/CD design-to-code workflows,
+
   or creating a design system code generator from Figma components.
+
   Trigger: "anima design pipeline", "figma to react pipeline",
+
   "automated design handoff", "anima component generator".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, react, automation]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- react
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Anima Core Workflow A — Figma-to-React Pipeline
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: anima-core-workflow-b
-description: |
-  Clone websites to React/HTML code and customize Anima output with AI.
+description: 'Clone websites to React/HTML code and customize Anima output with AI.
+
   Use when converting live websites to code, customizing generated components,
+
   or building design-system-aware code from URL screenshots.
+
   Trigger: "anima website to code", "anima URL clone", "anima AI customization",
+
   "website to react", "clone website to code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, website-cloning]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- website-cloning
+compatibility: Designed for Claude Code
 ---
-
 # Anima Core Workflow B — Website-to-Code & AI Customization
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-cost-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: anima-cost-tuning
-description: |
-  Optimize Anima API costs through caching, incremental generation, and tier selection.
+description: 'Optimize Anima API costs through caching, incremental generation, and
+  tier selection.
+
   Use when managing Anima API usage, reducing unnecessary code generations,
+
   or right-sizing your Anima plan for team size.
+
   Trigger: "anima cost", "anima pricing", "anima budget", "anima API usage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, cost-optimization]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- cost-optimization
+compatibility: Designed for Claude Code
 ---
-
 # Anima Cost Tuning
 
 ## Pricing Context

--- a/plugins/saas-packs/anima-pack/skills/anima-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-debug-bundle/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-debug-bundle
-description: |
-  Collect Anima SDK debug evidence for support tickets and troubleshooting.
+description: 'Collect Anima SDK debug evidence for support tickets and troubleshooting.
+
   Use when filing Anima support requests, debugging code generation issues,
+
   or collecting diagnostic data for the Anima team.
+
   Trigger: "anima debug bundle", "anima support ticket", "anima diagnostics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, debugging]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # Anima Debug Bundle
 
 ## Instructions

--- a/plugins/saas-packs/anima-pack/skills/anima-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-deploy-integration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-deploy-integration
-description: |
-  Deploy Anima design-to-code service as a backend API endpoint.
+description: 'Deploy Anima design-to-code service as a backend API endpoint.
+
   Use when building a design-to-code microservice, deploying Anima SDK
+
   as a serverless function, or creating an internal design tool API.
+
   Trigger: "deploy anima", "anima service deploy", "anima serverless".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # Anima Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-hello-world/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: anima-hello-world
-description: |
-  Generate React/Vue/HTML code from a Figma design using the Anima SDK.
-  Use when testing design-to-code conversion, learning Anima's code output format,
+description: 'Generate React/Vue/HTML code from a Figma design using the Anima SDK.
+
+  Use when testing design-to-code conversion, learning Anima''s code output format,
+
   or building your first automated design-to-code pipeline.
+
   Trigger: "anima hello world", "anima example", "figma to react",
+
   "figma to code", "anima generate code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, react, code-generation]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- react
+- code-generation
+compatibility: Designed for Claude Code
 ---
-
 # Anima Hello World
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-install-auth/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-install-auth/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: anima-install-auth
-description: |
-  Install the Anima SDK and configure authentication for Figma-to-code generation.
+description: 'Install the Anima SDK and configure authentication for Figma-to-code
+  generation.
+
   Use when setting up design-to-code automation, configuring Figma token access,
+
   or initializing the @animaapp/anima-sdk for server-side code generation.
+
   Trigger: "install anima", "setup anima", "anima auth", "anima figma token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, code-generation]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- code-generation
+compatibility: Designed for Claude Code
 ---
-
 # Anima Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-local-dev-loop/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-local-dev-loop
-description: |
-  Set up iterative design-to-code development loop with Anima SDK.
+description: 'Set up iterative design-to-code development loop with Anima SDK.
+
   Use when rapidly iterating on Figma-to-code output, comparing framework outputs,
+
   or building a local preview server for generated components.
+
   Trigger: "anima local dev", "anima dev loop", "anima preview", "anima iteration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, development]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- development
+compatibility: Designed for Claude Code
 ---
-
 # Anima Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-performance-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: anima-performance-tuning
-description: |
-  Optimize Anima code generation performance with caching, parallelism, and output tuning.
+description: 'Optimize Anima code generation performance with caching, parallelism,
+  and output tuning.
+
   Use when reducing generation latency, optimizing batch component generation,
+
   or improving generated code quality for production use.
+
   Trigger: "anima performance", "anima slow", "anima optimization", "anima caching".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, performance]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # Anima Performance Tuning
 
 ## Performance Targets

--- a/plugins/saas-packs/anima-pack/skills/anima-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-prod-checklist/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-prod-checklist
-description: |
-  Production readiness checklist for Anima design-to-code pipelines.
+description: 'Production readiness checklist for Anima design-to-code pipelines.
+
   Use when deploying automated design-to-code services, preparing CI/CD
+
   Figma-to-code automation, or validating output quality before production.
+
   Trigger: "anima production", "anima go-live", "anima prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, production]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- production
+compatibility: Designed for Claude Code
 ---
-
 # Anima Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-rate-limits/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-rate-limits/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-rate-limits
-description: |
-  Implement rate limiting for Anima API code generation requests.
+description: 'Implement rate limiting for Anima API code generation requests.
+
   Use when batching component generation, handling rate limit errors,
+
   or optimizing API throughput for large design systems.
+
   Trigger: "anima rate limit", "anima throttling", "anima batch generation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, rate-limiting]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- rate-limiting
+compatibility: Designed for Claude Code
 ---
-
 # Anima Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: anima-reference-architecture
-description: |
-  Implement reference architecture for Anima design-to-code automation.
+description: 'Implement reference architecture for Anima design-to-code automation.
+
   Use when designing a design system automation pipeline, structuring
+
   a Figma-to-React project, or planning team-scale design handoff.
+
   Trigger: "anima architecture", "design-to-code architecture",
+
   "anima project structure", "figma automation architecture".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # Anima Reference Architecture
 
 ## System Architecture

--- a/plugins/saas-packs/anima-pack/skills/anima-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-sdk-patterns/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-sdk-patterns
-description: |
-  Apply production-ready patterns for the Anima SDK design-to-code pipeline.
+description: 'Apply production-ready patterns for the Anima SDK design-to-code pipeline.
+
   Use when building reusable Anima client wrappers, implementing output caching,
+
   or establishing team standards for design-to-code automation.
+
   Trigger: "anima SDK patterns", "anima best practices", "anima code patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # Anima SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/anima-pack/skills/anima-security-basics/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-security-basics/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-security-basics
-description: |
-  Secure Anima and Figma tokens for design-to-code pipelines.
+description: 'Secure Anima and Figma tokens for design-to-code pipelines.
+
   Use when protecting API credentials, restricting Figma access scope,
+
   or hardening CI/CD design automation pipelines.
+
   Trigger: "anima security", "anima token safety", "figma token security".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, security]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- security
+compatibility: Designed for Claude Code
 ---
-
 # Anima Security Basics
 
 ## Security Checklist

--- a/plugins/saas-packs/anima-pack/skills/anima-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-upgrade-migration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: anima-upgrade-migration
-description: |
-  Upgrade @animaapp/anima-sdk versions and handle API changes.
+description: 'Upgrade @animaapp/anima-sdk versions and handle API changes.
+
   Use when upgrading SDK versions, migrating from the Figma plugin workflow
+
   to SDK-based automation, or adapting to new Anima API features.
+
   Trigger: "anima upgrade", "anima migration", "anima SDK update".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, migration]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- migration
+compatibility: Designed for Claude Code
 ---
-
 # Anima Upgrade & Migration
 
 ## Migration Paths

--- a/plugins/saas-packs/anima-pack/skills/anima-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/anima-pack/skills/anima-webhooks-events/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: anima-webhooks-events
-description: |
-  Use Figma webhooks to trigger automatic Anima code generation on design changes.
+description: 'Use Figma webhooks to trigger automatic Anima code generation on design
+  changes.
+
   Use when building event-driven design-to-code pipelines, auto-generating
+
   components when Figma files change, or integrating design updates into CI.
+
   Trigger: "anima webhook", "figma webhook", "anima auto-generate on change".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, figma, anima, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- figma
+- anima
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # Anima Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-advanced-troubleshooting/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-advanced-troubleshooting
-description: |
-  Debug complex Claude API issues including context window overflow,
+description: 'Debug complex Claude API issues including context window overflow,
+
   tool use failures, streaming corruption, and response quality problems.
+
   Trigger with phrases like "anthropic advanced debug", "claude complex issue",
+
   "claude tool use failing", "claude context overflow".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Advanced Troubleshooting
 
 ## Issue: Context Window Overflow

--- a/plugins/saas-packs/anthropic-pack/skills/anth-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-architecture-variants/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: anth-architecture-variants
-description: |
-  Choose and implement Claude API architecture patterns for different scales:
+description: 'Choose and implement Claude API architecture patterns for different
+  scales:
+
   serverless, microservice, event-driven, and edge deployment.
+
   Trigger with phrases like "anthropic architecture", "claude serverless",
+
   "claude microservice design", "edge claude deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-ci-integration/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-ci-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-ci-integration
-description: |
-  Configure CI/CD pipelines for Anthropic Claude API integrations.
+description: 'Configure CI/CD pipelines for Anthropic Claude API integrations.
+
   Use when setting up automated testing, prompt regression tests,
+
   or CI validation for Claude-powered features.
+
   Trigger with phrases like "anthropic ci", "claude ci/cd",
+
   "test claude in pipeline", "anthropic github actions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic CI Integration
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-common-errors/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-common-errors
-description: |
-  Diagnose and fix Anthropic Claude API errors by HTTP status code.
+description: 'Diagnose and fix Anthropic Claude API errors by HTTP status code.
+
   Use when encountering API errors, debugging failed requests,
+
   or troubleshooting authentication, rate limiting, or input validation issues.
+
   Trigger with phrases like "anthropic error", "claude api error",
+
   "fix anthropic 429", "claude not working", "debug claude api".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Common Errors
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: anth-core-workflow-a
-description: |
-  Build Claude tool use (function calling) workflows with the Messages API.
+description: 'Build Claude tool use (function calling) workflows with the Messages
+  API.
+
   Use when implementing tool use, function calling, agent loops,
+
   or building AI assistants that interact with external systems.
+
   Trigger with phrases like "claude tool use", "anthropic function calling",
+
   "claude tools", "agent loop anthropic", "tool_use blocks".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Core Workflow A — Tool Use (Function Calling)
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-core-workflow-b/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-core-workflow-b
-description: |
-  Build Claude streaming and Message Batches API workflows.
+description: 'Build Claude streaming and Message Batches API workflows.
+
   Use when implementing real-time streaming responses, SSE event handling,
+
   or processing bulk requests with the 50% cheaper Batches API.
+
   Trigger with phrases like "claude streaming", "anthropic batch",
+
   "message batches api", "SSE events anthropic", "stream claude response".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Core Workflow B — Streaming & Batches
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-cost-tuning/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: anth-cost-tuning
-description: |
-  Optimize Anthropic Claude API costs with model routing, prompt caching,
+description: 'Optimize Anthropic Claude API costs with model routing, prompt caching,
+
   batching, and spend monitoring.
+
   Use when analyzing Claude API billing, reducing costs,
+
   or implementing cost controls and budget alerts.
+
   Trigger with phrases like "anthropic cost", "claude billing",
+
   "reduce claude spend", "anthropic budget", "claude pricing optimize".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-data-handling/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-data-handling/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: anth-data-handling
-description: |
-  Implement data privacy, PII handling, and compliance patterns for Claude API.
+description: 'Implement data privacy, PII handling, and compliance patterns for Claude
+  API.
+
   Use when handling sensitive data, implementing PII redaction,
+
   or configuring data retention for GDPR/CCPA compliance with Claude.
+
   Trigger with phrases like "anthropic data privacy", "claude PII",
+
   "anthropic gdpr", "claude data handling", "redact data claude".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Data Handling
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-debug-bundle
-description: |
-  Collect Anthropic Claude API debug evidence for support and troubleshooting.
+description: 'Collect Anthropic Claude API debug evidence for support and troubleshooting.
+
   Use when encountering persistent API issues, preparing support tickets,
+
   or collecting diagnostic information including request IDs and rate limit headers.
+
   Trigger with phrases like "anthropic debug", "claude debug bundle",
+
   "collect anthropic logs", "anthropic diagnostic", "claude support ticket".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-deploy-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-deploy-integration
-description: |
-  Deploy Claude API integrations to production cloud environments.
+description: 'Deploy Claude API integrations to production cloud environments.
+
   Use when deploying Claude-powered services to Docker, Cloud Run, ECS,
+
   or Kubernetes with proper secret management and health checks.
+
   Trigger with phrases like "deploy anthropic", "claude production deploy",
+
   "ship claude integration", "anthropic cloud deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-enterprise-rbac/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-enterprise-rbac
-description: |
-  Configure Anthropic enterprise organization management, Workspaces,
+description: 'Configure Anthropic enterprise organization management, Workspaces,
+
   and role-based access control for teams.
+
   Trigger with phrases like "anthropic enterprise", "claude rbac",
+
   "anthropic workspaces", "claude team access", "anthropic organization".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-hello-world/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-hello-world
-description: |
-  Create a minimal working Anthropic Claude Messages API example.
+description: 'Create a minimal working Anthropic Claude Messages API example.
+
   Use when starting a new Claude integration, testing your setup,
+
   or learning basic Messages API patterns for text, vision, and streaming.
+
   Trigger with phrases like "anthropic hello world", "claude api example",
+
   "anthropic quick start", "simple claude code", "first messages api call".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Hello World
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-incident-runbook/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-incident-runbook
-description: |
-  Execute incident response procedures for Claude API outages and degradation.
+description: 'Execute incident response procedures for Claude API outages and degradation.
+
   Use when Claude API is returning errors, experiencing high latency,
+
   or showing degraded performance in production.
+
   Trigger with phrases like "anthropic incident", "claude api down",
+
   "anthropic outage", "claude degraded", "anthropic runbook".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Incident Runbook
 
 ## Severity Classification

--- a/plugins/saas-packs/anthropic-pack/skills/anth-install-auth/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: anth-install-auth
-description: |
-  Install and configure Anthropic Claude SDK authentication for Python and TypeScript.
+description: 'Install and configure Anthropic Claude SDK authentication for Python
+  and TypeScript.
+
   Use when setting up a new Claude API integration, configuring API keys,
+
   or initializing the Anthropic SDK in your project.
+
   Trigger with phrases like "install anthropic", "setup claude api",
+
   "anthropic auth", "configure anthropic API key", "claude sdk setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-known-pitfalls/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-known-pitfalls
-description: |
-  Identify and avoid common Claude API anti-patterns and integration mistakes.
+description: 'Identify and avoid common Claude API anti-patterns and integration mistakes.
+
   Use when reviewing code, onboarding developers, or debugging subtle issues
+
   with Anthropic integrations.
+
   Trigger with phrases like "anthropic pitfalls", "claude anti-patterns",
+
   "claude mistakes", "anthropic common issues", "claude gotchas".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Known Pitfalls
 
 ## Pitfall 1: Wrong Import / Class Name

--- a/plugins/saas-packs/anthropic-pack/skills/anth-load-scale/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-load-scale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: anth-load-scale
-description: |
-  Implement load testing, auto-scaling, and capacity planning for Claude API.
+description: 'Implement load testing, auto-scaling, and capacity planning for Claude
+  API.
+
   Use when running performance benchmarks, planning for traffic spikes,
+
   or configuring horizontal scaling for Claude-powered services.
+
   Trigger with phrases like "anthropic load test", "claude scaling",
+
   "anthropic capacity planning", "scale claude api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-local-dev-loop/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-local-dev-loop
-description: |
-  Configure a local development workflow for Anthropic Claude API projects.
+description: 'Configure a local development workflow for Anthropic Claude API projects.
+
   Use when setting up dev environment, configuring hot reload,
+
   or establishing a fast iteration cycle with the Messages API.
+
   Trigger with phrases like "anthropic local dev", "claude dev setup",
+
   "anthropic development workflow", "test claude locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-migration-deep-dive/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-migration-deep-dive
-description: |
-  Migrate to Claude API from OpenAI, Gemini, or other LLM providers.
+description: 'Migrate to Claude API from OpenAI, Gemini, or other LLM providers.
+
   Use when switching from GPT-4 to Claude, migrating from Text Completions,
+
   or building a multi-provider abstraction layer.
+
   Trigger with phrases like "migrate to claude", "openai to anthropic",
+
   "switch from gpt to claude", "multi-provider llm".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-multi-env-setup/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-multi-env-setup
-description: |
-  Configure Claude API across dev, staging, and production environments
+description: 'Configure Claude API across dev, staging, and production environments
+
   with isolated keys, model routing, and spend controls per environment.
+
   Trigger with phrases like "anthropic environments", "claude multi-env",
+
   "anthropic staging setup", "claude dev vs prod config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-observability/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-observability/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-observability
-description: |
-  Set up observability for Claude API integrations with metrics, logging,
+description: 'Set up observability for Claude API integrations with metrics, logging,
+
   and alerting for latency, cost, errors, and token usage.
+
   Trigger with phrases like "anthropic monitoring", "claude observability",
+
   "anthropic metrics", "track claude usage", "claude dashboard".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Observability
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-performance-tuning/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: anth-performance-tuning
-description: |
-  Optimize Claude API performance with prompt caching, model selection,
+description: 'Optimize Claude API performance with prompt caching, model selection,
+
   streaming, and latency reduction techniques.
+
   Use when experiencing slow responses, optimizing token usage,
+
   or reducing time-to-first-token in production.
+
   Trigger with phrases like "anthropic performance", "claude speed",
+
   "optimize claude latency", "anthropic caching", "faster claude responses".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-policy-guardrails/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-policy-guardrails
-description: |
-  Implement content policy guardrails, input/output validation,
+description: 'Implement content policy guardrails, input/output validation,
+
   and usage governance for Claude API integrations.
+
   Trigger with phrases like "anthropic guardrails", "claude content policy",
+
   "claude input validation", "anthropic safety rules".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Policy Guardrails
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-prod-checklist/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-prod-checklist
-description: |
-  Execute production deployment checklist for Claude API integrations.
+description: 'Execute production deployment checklist for Claude API integrations.
+
   Use when deploying Claude-powered features to production,
+
   preparing for launch, or implementing go-live validation.
+
   Trigger with phrases like "anthropic production", "deploy claude",
+
   "claude go-live", "anthropic launch checklist", "production ready claude".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-rate-limits/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-rate-limits
-description: |
-  Implement Anthropic Claude API rate limiting, backoff, and quota management.
+description: 'Implement Anthropic Claude API rate limiting, backoff, and quota management.
+
   Use when handling 429 errors, optimizing request throughput,
+
   or managing RPM/TPM limits across usage tiers.
+
   Trigger with phrases like "anthropic rate limit", "claude 429",
+
   "anthropic throttling", "claude retry", "anthropic backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-reference-architecture/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-reference-architecture
-description: |
-  Implement Claude API reference architectures for common use cases.
+description: 'Implement Claude API reference architectures for common use cases.
+
   Use when designing a Claude-powered application, choosing between
+
   direct API vs queue-based, or planning a multi-model architecture.
+
   Trigger with phrases like "anthropic architecture", "claude system design",
+
   "anthropic reference architecture", "design claude integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-reliability-patterns/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: anth-reliability-patterns
-description: |
-  Implement reliability patterns for Claude API: circuit breakers,
+description: 'Implement reliability patterns for Claude API: circuit breakers,
+
   graceful degradation, idempotency, and fallback strategies.
+
   Trigger with phrases like "anthropic reliability", "claude circuit breaker",
+
   "claude fallback", "anthropic fault tolerance".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-sdk-patterns/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-sdk-patterns
-description: |
-  Apply production-ready Anthropic SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Anthropic SDK patterns for TypeScript and Python.
+
   Use when implementing Claude integrations, building reusable wrappers,
+
   or establishing team coding standards for the Messages API.
+
   Trigger with phrases like "anthropic SDK patterns", "claude best practices",
+
   "anthropic code patterns", "production claude code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-security-basics/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-security-basics/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: anth-security-basics
-description: |
-  Apply Anthropic Claude API security best practices for key management,
+description: 'Apply Anthropic Claude API security best practices for key management,
+
   input validation, and prompt injection defense.
+
   Use when securing API keys, validating user inputs before sending to Claude,
+
   or implementing content safety guardrails.
+
   Trigger with phrases like "anthropic security", "claude api key security",
+
   "secure anthropic", "prompt injection defense".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Security Basics
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-upgrade-migration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-upgrade-migration
-description: |
-  Upgrade Anthropic SDK versions and migrate between Claude API versions.
+description: 'Upgrade Anthropic SDK versions and migrate between Claude API versions.
+
   Use when upgrading the Python/TypeScript SDK, migrating from Text Completions
+
   to Messages API, or adopting new API features like tool use or batches.
+
   Trigger with phrases like "upgrade anthropic sdk", "anthropic migration",
+
   "update claude sdk", "migrate to messages api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/anthropic-pack/skills/anth-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/anthropic-pack/skills/anth-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: anth-webhooks-events
-description: |
-  Implement event-driven patterns with Claude API: streaming SSE events,
+description: 'Implement event-driven patterns with Claude API: streaming SSE events,
+
   Message Batches callbacks, and async processing architectures.
+
   Use when building real-time Claude integrations or processing batch results.
+
   Trigger with phrases like "anthropic events", "claude streaming events",
+
   "anthropic async processing", "claude batch callbacks".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, anthropic]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- anthropic
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Events & Async Processing
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-ci-integration/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-ci-integration
-description: |
-  Configure CI/CD pipelines for Apify Actor builds and deployments.
+description: 'Configure CI/CD pipelines for Apify Actor builds and deployments.
+
   Use when automating Actor deployment via GitHub Actions,
+
   running integration tests against Apify, or building CI/CD for scrapers.
+
   Trigger: "apify CI", "apify GitHub Actions", "apify automated deploy",
+
   "CI apify", "apify pipeline", "auto deploy actor".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify CI Integration
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-common-errors/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-common-errors
-description: |
-  Diagnose and fix common Apify Actor and API errors.
+description: 'Diagnose and fix common Apify Actor and API errors.
+
   Use when encountering run failures, API errors, proxy issues,
+
   or Actor crashes on the Apify platform.
+
   Trigger: "apify error", "fix apify", "actor failed",
+
   "apify not working", "debug apify", "apify 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(apify:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Common Errors
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-core-workflow-a
-description: |
-  Build a complete web scraping Actor with Crawlee and deploy to Apify.
+description: 'Build a complete web scraping Actor with Crawlee and deploy to Apify.
+
   Use when implementing end-to-end scraping: input schema, crawler,
+
   data extraction, dataset output, and platform deployment.
+
   Trigger: "apify scrape website", "build apify actor",
+
   "crawlee scraper", "apify main workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(apify:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Core Workflow A — Build & Deploy a Scraper
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-core-workflow-b
-description: |
-  Manage Apify datasets, key-value stores, and request queues programmatically.
+description: 'Manage Apify datasets, key-value stores, and request queues programmatically.
+
   Use when reading/writing datasets, exporting data, managing Actor storage,
+
   or orchestrating multi-Actor pipelines.
+
   Trigger: "apify dataset", "apify key-value store", "apify storage",
+
   "export apify data", "apify pipeline", "apify request queue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Core Workflow B — Storage & Pipelines
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apify-cost-tuning
-description: |
-  Optimize Apify platform costs through memory tuning, compute unit management, and proxy budgeting.
+description: 'Optimize Apify platform costs through memory tuning, compute unit management,
+  and proxy budgeting.
+
   Use when analyzing Apify billing, reducing Actor run costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger: "apify cost", "apify billing", "reduce apify costs",
+
   "apify pricing", "apify expensive", "apify budget", "compute units".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-debug-bundle/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apify-debug-bundle
-description: |
-  Collect Apify debug evidence for support tickets and troubleshooting.
+description: 'Collect Apify debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information about failed Actor runs.
+
   Trigger: "apify debug", "apify support bundle", "collect apify logs",
+
   "apify diagnostic", "apify run failed why".
-allowed-tools: Read, Bash(curl:*), Bash(npm:*), Bash(node:*), Bash(tar:*), Bash(apify:*), Grep
+
+  '
+allowed-tools: Read, Bash(curl:*), Bash(npm:*), Bash(node:*), Bash(tar:*), Bash(apify:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-deploy-integration
-description: |
-  Deploy Apify Actors and integrate scraping into external applications.
+description: 'Deploy Apify Actors and integrate scraping into external applications.
+
   Use when deploying Actors to the platform, integrating Actor results
+
   into web apps, or connecting Apify with external services.
+
   Trigger: "deploy apify actor", "apify Vercel integration",
+
   "apify production deploy", "integrate apify results", "apify API endpoint".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(apify:*), Bash(npm:*), Bash(vercel:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-hello-world/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-hello-world
-description: |
-  Run your first Apify Actor and retrieve results via apify-client.
+description: 'Run your first Apify Actor and retrieve results via apify-client.
+
   Use when starting a new Apify integration, testing connectivity,
+
   or learning the Actor call/dataset retrieval pattern.
+
   Trigger: "apify hello world", "apify example", "run an apify actor",
+
   "apify quick start", "first apify scrape".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Hello World
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-install-auth/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: apify-install-auth
-description: |
-  Install and configure Apify SDK, CLI, and API client authentication.
+description: 'Install and configure Apify SDK, CLI, and API client authentication.
+
   Use when setting up a new Apify project, configuring API tokens,
+
   or initializing apify-client / Apify SDK in your codebase.
+
   Trigger: "install apify", "setup apify", "apify auth", "configure apify token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(apify:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-local-dev-loop
-description: |
-  Set up local Apify Actor development with Apify CLI and Crawlee.
+description: 'Set up local Apify Actor development with Apify CLI and Crawlee.
+
   Use when creating Actors locally, testing with apify run,
+
   or establishing a fast develop-test-deploy cycle.
+
   Trigger: "apify dev setup", "apify local development",
+
   "develop actor locally", "apify run local".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(apify:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-performance-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: apify-performance-tuning
-description: |
-  Optimize Apify Actor performance: crawl speed, memory usage, concurrency, and proxy rotation.
-  Use when Actors are slow, consuming too much memory, or being blocked by target sites.
+description: 'Optimize Apify Actor performance: crawl speed, memory usage, concurrency,
+  and proxy rotation.
+
+  Use when Actors are slow, consuming too much memory, or being blocked by target
+  sites.
+
   Trigger: "apify performance", "optimize apify actor", "apify slow",
+
   "crawlee concurrency", "apify memory tuning", "scraper performance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-prod-checklist
-description: |
-  Production readiness checklist for Apify Actor deployments.
+description: 'Production readiness checklist for Apify Actor deployments.
+
   Use when deploying Actors to production, preparing for launch,
+
   or validating Actor configuration before going live.
+
   Trigger: "apify production", "deploy actor to prod",
+
   "apify go-live", "apify launch checklist", "actor production ready".
+
+  '
 allowed-tools: Read, Bash(apify:*), Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-rate-limits/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-rate-limits
-description: |
-  Handle Apify API rate limits with proper backoff and request queuing.
+description: 'Handle Apify API rate limits with proper backoff and request queuing.
+
   Use when hitting 429 errors, optimizing API request throughput,
+
   or implementing rate-aware client wrappers.
+
   Trigger: "apify rate limit", "apify throttling", "apify 429",
+
   "apify retry", "apify backoff", "too many requests apify".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-reference-architecture
-description: |
-  Production-grade architecture patterns for Apify-powered applications.
+description: 'Production-grade architecture patterns for Apify-powered applications.
+
   Use when designing scraping infrastructure, building multi-Actor pipelines,
+
   or integrating Apify into a larger system architecture.
+
   Trigger: "apify architecture", "apify best practices",
+
   "apify project structure", "scraping architecture", "apify system design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-sdk-patterns
-description: |
-  Production-ready patterns for Apify SDK and apify-client in TypeScript.
+description: 'Production-ready patterns for Apify SDK and apify-client in TypeScript.
+
   Use when building Actors with Crawlee, managing datasets/KV stores,
+
   or implementing robust client wrappers with retry and validation.
+
   Trigger: "apify SDK patterns", "apify best practices",
+
   "apify client wrapper", "crawlee patterns", "idiomatic apify".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-security-basics/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-security-basics
-description: |
-  Secure Apify API tokens, configure proxy access, and protect Actor data.
+description: 'Secure Apify API tokens, configure proxy access, and protect Actor data.
+
   Use when hardening API key management, setting up environment-specific tokens,
+
   or auditing Apify security configuration.
+
   Trigger: "apify security", "apify secrets", "secure apify token",
+
   "apify API key security", "rotate apify token".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Security Basics
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: apify-upgrade-migration
-description: |
-  Upgrade Apify SDK, apify-client, and Crawlee versions safely.
+description: 'Upgrade Apify SDK, apify-client, and Crawlee versions safely.
+
   Use when migrating between SDK versions, handling breaking changes,
+
   or updating from Apify SDK v2 to v3 (Crawlee split).
+
   Trigger: "upgrade apify", "apify migration", "apify breaking changes",
+
   "update apify SDK", "crawlee upgrade", "apify v2 to v3".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/apify-pack/skills/apify-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/apify-pack/skills/apify-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apify-webhooks-events
-description: |
-  Implement Apify webhooks for Actor run notifications and event-driven pipelines.
+description: 'Implement Apify webhooks for Actor run notifications and event-driven
+  pipelines.
+
   Use when setting up run completion alerts, building event-driven scraping pipelines,
+
   or configuring ad-hoc webhooks for individual runs.
+
   Trigger: "apify webhook", "apify events", "actor run notification",
+
   "apify run succeeded webhook", "apify ad-hoc webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, automation, apify]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- automation
+- apify
+compatibility: Designed for Claude Code
 ---
-
 # Apify Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/apollo-pack/skills/apollo-ci-integration/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: apollo-ci-integration
-description: |
-  Configure Apollo.io CI/CD integration.
+description: 'Configure Apollo.io CI/CD integration.
+
   Use when setting up automated testing, continuous integration,
+
   or deployment pipelines for Apollo integrations.
+
   Trigger with phrases like "apollo ci", "apollo github actions",
+
   "apollo pipeline", "apollo ci/cd", "apollo automated tests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, deployment, testing, ci-cd]
+tags:
+- saas
+- apollo
+- deployment
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo CI Integration
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-common-errors/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-common-errors
-description: |
-  Diagnose and fix common Apollo.io API errors.
+description: 'Diagnose and fix common Apollo.io API errors.
+
   Use when encountering Apollo API errors, debugging integration issues,
+
   or troubleshooting failed requests.
+
   Trigger with phrases like "apollo error", "apollo api error",
+
   "debug apollo", "apollo 401", "apollo 429", "apollo troubleshoot".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, debugging]
+tags:
+- saas
+- apollo
+- api
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Common Errors
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-core-workflow-a
-description: |
-  Implement Apollo.io lead search and enrichment workflow.
+description: 'Implement Apollo.io lead search and enrichment workflow.
+
   Use when building lead generation features, searching for contacts,
+
   or enriching prospect data from Apollo.
+
   Trigger with phrases like "apollo lead search", "search apollo contacts",
+
   "find leads in apollo", "apollo people search", "enrich contacts apollo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, workflow]
+tags:
+- saas
+- apollo
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Core Workflow A: Lead Search & Enrichment
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-core-workflow-b
-description: |
-  Implement Apollo.io email sequences and outreach workflow.
+description: 'Implement Apollo.io email sequences and outreach workflow.
+
   Use when building automated email campaigns, creating sequences,
+
   or managing outreach through Apollo.
+
   Trigger with phrases like "apollo email sequence", "apollo outreach",
+
   "apollo campaign", "apollo sequences", "apollo automated emails".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, workflow]
+tags:
+- saas
+- apollo
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Core Workflow B: Email Sequences & Outreach
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-cost-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-cost-tuning
-description: |
-  Optimize Apollo.io costs and credit usage.
+description: 'Optimize Apollo.io costs and credit usage.
+
   Use when managing Apollo credits, reducing API costs,
+
   or optimizing subscription usage.
+
   Trigger with phrases like "apollo cost", "apollo credits",
+
   "apollo billing", "reduce apollo costs", "apollo usage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, cost-optimization]
+tags:
+- saas
+- apollo
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Cost Tuning
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-data-handling/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-data-handling
-description: |
-  Apollo.io data management and compliance.
+description: 'Apollo.io data management and compliance.
+
   Use when handling contact data, implementing GDPR compliance,
+
   or managing data exports and retention.
+
   Trigger with phrases like "apollo data", "apollo gdpr", "apollo compliance",
+
   "apollo data export", "apollo data retention", "apollo pii".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, compliance]
+tags:
+- saas
+- apollo
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Data Handling
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-debug-bundle
-description: |
-  Collect Apollo.io debug evidence for support.
+description: 'Collect Apollo.io debug evidence for support.
+
   Use when preparing support tickets, documenting issues,
+
   or gathering diagnostic information for Apollo problems.
+
   Trigger with phrases like "apollo debug", "apollo support bundle",
+
   "collect apollo diagnostics", "apollo troubleshooting info".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, debugging]
+tags:
+- saas
+- apollo
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Debug Bundle
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-deploy-integration
-description: |
-  Deploy Apollo.io integrations to production.
+description: 'Deploy Apollo.io integrations to production.
+
   Use when deploying Apollo integrations, configuring production environments,
+
   or setting up deployment pipelines.
+
   Trigger with phrases like "deploy apollo", "apollo production deploy",
+
   "apollo deployment pipeline", "apollo to production".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, deployment]
+tags:
+- saas
+- apollo
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Deploy Integration
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-enterprise-rbac
-description: |
-  Enterprise role-based access control for Apollo.io.
+description: 'Enterprise role-based access control for Apollo.io.
+
   Use when implementing team permissions, restricting data access,
+
   or setting up enterprise security controls.
+
   Trigger with phrases like "apollo rbac", "apollo permissions",
+
   "apollo roles", "apollo team access", "apollo enterprise security".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, security, rbac]
+tags:
+- saas
+- apollo
+- security
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Enterprise RBAC
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-hello-world/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-hello-world
-description: |
-  Create a minimal working Apollo.io example.
+description: 'Create a minimal working Apollo.io example.
+
   Use when starting a new Apollo integration, testing your setup,
+
   or learning basic Apollo API patterns.
+
   Trigger with phrases like "apollo hello world", "apollo example",
+
   "apollo quick start", "simple apollo code", "test apollo api".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, testing]
+tags:
+- saas
+- apollo
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Hello World
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-incident-runbook
-description: |
-  Apollo.io incident response procedures.
+description: 'Apollo.io incident response procedures.
+
   Use when handling Apollo outages, debugging production issues,
+
   or responding to integration failures.
+
   Trigger with phrases like "apollo incident", "apollo outage",
+
   "apollo down", "apollo production issue", "apollo emergency".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, debugging, incident-response]
+tags:
+- saas
+- apollo
+- debugging
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Incident Runbook
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-install-auth/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-install-auth
-description: |
-  Install and configure Apollo.io API authentication.
+description: 'Install and configure Apollo.io API authentication.
+
   Use when setting up a new Apollo integration, configuring API keys,
+
   or initializing Apollo client in your project.
+
   Trigger with phrases like "install apollo", "setup apollo api",
+
   "apollo authentication", "configure apollo api key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, authentication]
+tags:
+- saas
+- apollo
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Install & Auth
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: apollo-local-dev-loop
-description: |
-  Configure Apollo.io local development workflow.
+description: 'Configure Apollo.io local development workflow.
+
   Use when setting up development environment, testing API calls locally,
+
   or establishing team development practices.
+
   Trigger with phrases like "apollo local dev", "apollo development setup",
+
   "apollo dev environment", "apollo testing locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, testing, workflow]
+tags:
+- saas
+- apollo
+- api
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Local Dev Loop
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-migration-deep-dive
-description: |
-  Comprehensive Apollo.io migration strategies.
+description: 'Comprehensive Apollo.io migration strategies.
+
   Use when migrating from other CRMs to Apollo, consolidating data sources,
+
   or executing large-scale data migrations.
+
   Trigger with phrases like "apollo migration", "migrate to apollo",
+
   "apollo data import", "crm to apollo", "apollo migration strategy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, migration, scaling]
+tags:
+- saas
+- apollo
+- migration
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Migration Deep Dive
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-multi-env-setup
-description: |
-  Configure Apollo.io multi-environment setup.
+description: 'Configure Apollo.io multi-environment setup.
+
   Use when setting up development, staging, and production environments,
+
   or managing multiple Apollo configurations.
+
   Trigger with phrases like "apollo environments", "apollo staging",
+
   "apollo dev prod", "apollo multi-tenant", "apollo env config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, apollo-multi]
+tags:
+- saas
+- apollo
+- apollo-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Multi-Environment Setup
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-observability/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: apollo-observability
-description: |
-  Set up Apollo.io monitoring and observability.
+description: 'Set up Apollo.io monitoring and observability.
+
   Use when implementing logging, metrics, tracing, and alerting
+
   for Apollo integrations.
+
   Trigger with phrases like "apollo monitoring", "apollo metrics",
+
   "apollo observability", "apollo logging", "apollo alerts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, monitoring, observability, logging]
+tags:
+- saas
+- apollo
+- monitoring
+- observability
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Observability
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-performance-tuning
-description: |
-  Optimize Apollo.io API performance.
+description: 'Optimize Apollo.io API performance.
+
   Use when improving API response times, reducing latency,
+
   or optimizing bulk operations.
+
   Trigger with phrases like "apollo performance", "optimize apollo",
+
   "apollo slow", "apollo latency", "speed up apollo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, performance]
+tags:
+- saas
+- apollo
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Performance Tuning
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-prod-checklist
-description: |
-  Execute Apollo.io production deployment checklist.
+description: 'Execute Apollo.io production deployment checklist.
+
   Use when preparing to deploy Apollo integrations to production,
+
   doing pre-launch verification, or auditing production readiness.
+
   Trigger with phrases like "apollo production checklist", "deploy apollo",
+
   "apollo go-live", "apollo production ready", "apollo launch checklist".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, deployment, audit]
+tags:
+- saas
+- apollo
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Production Checklist
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-rate-limits/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-rate-limits
-description: |
-  Implement Apollo.io rate limiting and backoff.
+description: 'Implement Apollo.io rate limiting and backoff.
+
   Use when handling rate limits, implementing retry logic,
+
   or optimizing API request throughput.
+
   Trigger with phrases like "apollo rate limit", "apollo 429",
+
   "apollo throttling", "apollo backoff", "apollo request limits".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api]
+tags:
+- saas
+- apollo
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Rate Limits
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-reference-architecture
-description: |
-  Implement Apollo.io reference architecture.
+description: 'Implement Apollo.io reference architecture.
+
   Use when designing Apollo integrations, establishing patterns,
+
   or building production-grade sales intelligence systems.
+
   Trigger with phrases like "apollo architecture", "apollo system design",
+
   "apollo integration patterns", "apollo best practices architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, apollo-reference]
+tags:
+- saas
+- apollo
+- apollo-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Reference Architecture
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-sdk-patterns
-description: |
-  Apply production-ready Apollo.io SDK patterns.
+description: 'Apply production-ready Apollo.io SDK patterns.
+
   Use when implementing Apollo integrations, refactoring API usage,
+
   or establishing team coding standards.
+
   Trigger with phrases like "apollo sdk patterns", "apollo best practices",
+
   "apollo code patterns", "idiomatic apollo", "apollo client wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api]
+tags:
+- saas
+- apollo
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo SDK Patterns
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-security-basics/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-security-basics/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-security-basics
-description: |
-  Apply Apollo.io API security best practices.
+description: 'Apply Apollo.io API security best practices.
+
   Use when securing Apollo integrations, managing API keys,
+
   or implementing secure data handling.
+
   Trigger with phrases like "apollo security", "secure apollo api",
+
   "apollo api key security", "apollo data protection".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, security]
+tags:
+- saas
+- apollo
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Security Basics
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: apollo-upgrade-migration
-description: |
-  Manage Apollo.io API upgrades and endpoint migrations.
+description: 'Manage Apollo.io API upgrades and endpoint migrations.
+
   Use when upgrading Apollo API versions, migrating to new endpoints,
+
   or updating deprecated API usage.
+
   Trigger with phrases like "apollo upgrade", "apollo migration",
+
   "update apollo api", "apollo breaking changes", "apollo deprecation".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, api, migration]
+tags:
+- saas
+- apollo
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Upgrade Migration
 

--- a/plugins/saas-packs/apollo-pack/skills/apollo-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/apollo-pack/skills/apollo-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: apollo-webhooks-events
-description: |
-  Implement Apollo.io webhook and event-driven integrations.
+description: 'Implement Apollo.io webhook and event-driven integrations.
+
   Use when receiving Apollo notifications, syncing data on changes,
+
   or building event-driven pipelines from Apollo activity.
+
   Trigger with phrases like "apollo webhooks", "apollo events",
+
   "apollo notifications", "apollo webhook handler", "apollo triggers".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, apollo, webhooks]
+tags:
+- saas
+- apollo
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Apollo Webhooks & Events
 

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-ci-integration/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-ci-integration
-description: |
-  Configure CI/CD pipeline for AppFolio property management integrations.
+description: 'Configure CI/CD pipeline for AppFolio property management integrations.
+
   Trigger: "appfolio CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio CI Integration
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-common-errors/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-common-errors/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-common-errors
-description: |
-  Diagnose and fix common AppFolio API integration errors.
+description: 'Diagnose and fix common AppFolio API integration errors.
+
   Trigger: "appfolio error".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Common Errors
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-core-workflow-a/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-core-workflow-a
-description: |
-  Build property management dashboard with AppFolio API data.
+description: 'Build property management dashboard with AppFolio API data.
+
   Trigger: "appfolio property dashboard".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio — Property & Tenant Management
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-core-workflow-b/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-core-workflow-b
-description: |
-  Automate tenant management and lease operations with AppFolio.
+description: 'Automate tenant management and lease operations with AppFolio.
+
   Trigger: "appfolio tenant management".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio — Work Orders & Maintenance
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-cost-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-cost-tuning
-description: |
-  Optimize AppFolio API costs through efficient usage patterns.
+description: 'Optimize AppFolio API costs through efficient usage patterns.
+
   Trigger: "appfolio cost".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-debug-bundle
-description: |
-  Collect AppFolio API debug evidence for support tickets.
+description: 'Collect AppFolio API debug evidence for support tickets.
+
   Trigger: "appfolio debug".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-deploy-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-deploy-integration
-description: |
-  Deploy AppFolio integration service to cloud infrastructure.
+description: 'Deploy AppFolio integration service to cloud infrastructure.
+
   Trigger: "deploy appfolio".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-hello-world/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-hello-world/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-hello-world
-description: |
-  Query AppFolio properties, units, and tenants via REST API.
+description: 'Query AppFolio properties, units, and tenants via REST API.
+
   Trigger: "appfolio hello world".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Hello World
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-install-auth/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: appfolio-install-auth
-description: |
-  Configure AppFolio Stack API authentication with OAuth 2.0.
+description: 'Configure AppFolio Stack API authentication with OAuth 2.0.
+
   Use when setting up property management API access, registering as an
+
   AppFolio Stack partner, or configuring client credentials for API calls.
+
   Trigger: "install appfolio", "setup appfolio", "appfolio auth", "appfolio API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-local-dev-loop/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-local-dev-loop
-description: |
-  Set up local development for AppFolio property management API integration.
+description: 'Set up local development for AppFolio property management API integration.
+
   Trigger: "appfolio local dev".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-performance-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-performance-tuning
-description: |
-  Optimize AppFolio API performance with caching and batch operations.
+description: 'Optimize AppFolio API performance with caching and batch operations.
+
   Trigger: "appfolio performance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-prod-checklist
-description: |
-  Production readiness checklist for AppFolio integrations.
+description: 'Production readiness checklist for AppFolio integrations.
+
   Trigger: "appfolio production checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-rate-limits/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-rate-limits/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-rate-limits
-description: |
-  Handle AppFolio API rate limits with throttling and backoff.
+description: 'Handle AppFolio API rate limits with throttling and backoff.
+
   Trigger: "appfolio rate limit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-reference-architecture/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-reference-architecture
-description: |
-  Reference architecture for AppFolio property management integration.
+description: 'Reference architecture for AppFolio property management integration.
+
   Trigger: "appfolio architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-sdk-patterns/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-sdk-patterns
-description: |
-  Apply production-ready patterns for AppFolio REST API integration.
+description: 'Apply production-ready patterns for AppFolio REST API integration.
+
   Trigger: "appfolio patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-security-basics/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-security-basics
-description: |
-  Secure AppFolio API credentials and tenant data.
+description: 'Secure AppFolio API credentials and tenant data.
+
   Trigger: "appfolio security".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Security Basics
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-upgrade-migration
-description: |
-  Migrate between AppFolio API versions and handle endpoint changes.
+description: 'Migrate between AppFolio API versions and handle endpoint changes.
+
   Trigger: "appfolio upgrade".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/appfolio-pack/skills/appfolio-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/appfolio-pack/skills/appfolio-webhooks-events/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: appfolio-webhooks-events
-description: |
-  Handle AppFolio webhook events for property management notifications.
+description: 'Handle AppFolio webhook events for property management notifications.
+
   Trigger: "appfolio webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, property-management, appfolio, real-estate]
-compatible-with: claude-code
+tags:
+- saas
+- property-management
+- appfolio
+- real-estate
+compatibility: Designed for Claude Code
 ---
-
 # AppFolio Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-ci-integration/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-ci-integration
-description: |
-  Run Apple Notes automation in CI on macOS runners.
+description: 'Run Apple Notes automation in CI on macOS runners.
+
   Trigger: "apple notes CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes CI Integration
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-common-errors/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-common-errors/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-common-errors
-description: |
-  Diagnose and fix common Apple Notes automation errors.
+description: 'Diagnose and fix common Apple Notes automation errors.
+
   Trigger: "apple notes error".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Common Errors
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-core-workflow-a/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apple-notes-core-workflow-a
-description: |
-  Build automated note management workflows with Apple Notes JXA scripts.
+description: 'Build automated note management workflows with Apple Notes JXA scripts.
+
   Use when batch-creating notes, syncing content from external sources,
+
   organizing notes into folder hierarchies, or building note templates.
+
   Trigger: "apple notes workflow", "batch notes", "note templates",
+
   "organize apple notes", "sync notes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation, workflow]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+- workflow
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Core Workflow A — Note Management Automation
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apple-notes-core-workflow-b
-description: |
-  Export and convert Apple Notes to Markdown, JSON, HTML, and SQLite.
+description: 'Export and convert Apple Notes to Markdown, JSON, HTML, and SQLite.
+
   Use when backing up notes, exporting to other apps, converting HTML to Markdown,
+
   or building searchable note archives from Apple Notes.
+
   Trigger: "export apple notes", "apple notes to markdown", "backup apple notes",
+
   "apple notes to JSON", "convert apple notes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation, export]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+- export
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Core Workflow B — Export & Conversion
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-cost-tuning/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: apple-notes-cost-tuning
-description: |
-  Apple Notes cost optimization — it is free, focus on iCloud storage management.
-  Trigger: "apple notes cost".
+description: "Apple Notes cost optimization \u2014 it is free, focus on iCloud storage\
+  \ management.\nTrigger: \"apple notes cost\".\n"
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-data-handling/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-data-handling/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-data-handling
-description: |
-  Handle Apple Notes data formats: HTML body, attachments, and rich content.
+description: 'Handle Apple Notes data formats: HTML body, attachments, and rich content.
+
   Trigger: "apple notes data handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Data Handling
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-debug-bundle
-description: |
-  Collect Apple Notes automation debug evidence for troubleshooting.
+description: 'Collect Apple Notes automation debug evidence for troubleshooting.
+
   Trigger: "apple notes debug".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-deploy-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-deploy-integration
-description: |
-  Deploy Apple Notes automation as a local macOS service.
+description: 'Deploy Apple Notes automation as a local macOS service.
+
   Trigger: "apple notes deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-enterprise-rbac/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-enterprise-rbac
-description: |
-  Implement access control for multi-user Apple Notes automation.
+description: 'Implement access control for multi-user Apple Notes automation.
+
   Trigger: "apple notes access control".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-hello-world/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: apple-notes-hello-world
-description: |
-  Create, read, and list Apple Notes using JXA and AppleScript.
+description: 'Create, read, and list Apple Notes using JXA and AppleScript.
+
   Use when learning Notes automation, creating your first automated note,
+
   or testing read/write access to Apple Notes from scripts.
+
   Trigger: "apple notes hello world", "create apple note", "read apple notes",
+
   "apple notes example", "osascript notes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation, jxa]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+- jxa
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Hello World
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-incident-runbook/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-incident-runbook
-description: |
-  Incident response runbook for Apple Notes automation failures.
+description: 'Incident response runbook for Apple Notes automation failures.
+
   Trigger: "apple notes incident".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-install-auth/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-install-auth/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: apple-notes-install-auth
-description: |
-  Set up macOS automation access for Apple Notes via AppleScript, JXA, and Shortcuts.
+description: 'Set up macOS automation access for Apple Notes via AppleScript, JXA,
+  and Shortcuts.
+
   Use when configuring accessibility permissions, setting up osascript access,
+
   or initializing Apple Notes automation on macOS.
+
   Trigger: "setup apple notes", "apple notes automation", "apple notes permissions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Bash(defaults:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation, applescript]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+- applescript
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-local-dev-loop/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: apple-notes-local-dev-loop
-description: |
-  Set up local development workflow for Apple Notes automation with JXA hot reload.
+description: 'Set up local development workflow for Apple Notes automation with JXA
+  hot reload.
+
   Trigger: "apple notes dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-migration-deep-dive/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-migration-deep-dive
-description: |
-  Migrate notes between Apple Notes, Obsidian, Notion, and other platforms.
+description: 'Migrate notes between Apple Notes, Obsidian, Notion, and other platforms.
+
   Trigger: "apple notes migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-multi-env-setup/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-multi-env-setup
-description: |
-  Configure Apple Notes automation for multiple accounts and environments.
+description: 'Configure Apple Notes automation for multiple accounts and environments.
+
   Trigger: "apple notes multi account".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-observability/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-observability/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-observability
-description: |
-  Monitor Apple Notes automation health and performance metrics.
+description: 'Monitor Apple Notes automation health and performance metrics.
+
   Trigger: "apple notes monitoring".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Observability
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-performance-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-performance-tuning
-description: |
-  Optimize Apple Notes automation performance for large note collections.
+description: 'Optimize Apple Notes automation performance for large note collections.
+
   Trigger: "apple notes performance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-prod-checklist
-description: |
-  Production checklist for Apple Notes automation deployments.
+description: 'Production checklist for Apple Notes automation deployments.
+
   Trigger: "apple notes production checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-rate-limits/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-rate-limits/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-rate-limits
-description: |
-  Handle Apple Notes automation rate limits and iCloud sync throttling.
+description: 'Handle Apple Notes automation rate limits and iCloud sync throttling.
+
   Trigger: "apple notes rate limit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-reference-architecture/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-reference-architecture
-description: |
-  Reference architecture for Apple Notes automation systems.
+description: 'Reference architecture for Apple Notes automation systems.
+
   Trigger: "apple notes architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-sdk-patterns/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-sdk-patterns
-description: |
-  Apply production-ready patterns for Apple Notes JXA/AppleScript automation.
+description: 'Apply production-ready patterns for Apple Notes JXA/AppleScript automation.
+
   Trigger: "apple notes patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-security-basics/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-security-basics
-description: |
-  Apply security best practices for Apple Notes automation scripts.
+description: 'Apply security best practices for Apple Notes automation scripts.
+
   Trigger: "apple notes security".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Security Basics
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-upgrade-migration
-description: |
-  Migrate Apple Notes automation scripts between macOS versions.
+description: 'Migrate Apple Notes automation scripts between macOS versions.
+
   Trigger: "apple notes upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/apple-notes-pack/skills/apple-notes-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/apple-notes-pack/skills/apple-notes-webhooks-events/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: apple-notes-webhooks-events
-description: |
-  Monitor Apple Notes changes using file system events and Shortcuts triggers.
+description: 'Monitor Apple Notes changes using file system events and Shortcuts triggers.
+
   Trigger: "apple notes events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(osascript:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, macos, apple-notes, automation]
-compatible-with: claude-code
+tags:
+- saas
+- macos
+- apple-notes
+- automation
+compatibility: Designed for Claude Code
 ---
-
 # Apple Notes Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-ci-integration/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-ci-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-ci-integration
-description: |
-  Configure AssemblyAI CI/CD integration with GitHub Actions and testing.
+description: 'Configure AssemblyAI CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating AssemblyAI transcription tests into your build process.
+
   Trigger with phrases like "assemblyai CI", "assemblyai GitHub Actions",
+
   "assemblyai automated tests", "CI assemblyai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, ci]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- ci
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI CI Integration
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-common-errors/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-common-errors
-description: |
-  Diagnose and fix AssemblyAI common errors and exceptions.
+description: 'Diagnose and fix AssemblyAI common errors and exceptions.
+
   Use when encountering AssemblyAI errors, debugging failed transcriptions,
+
   or troubleshooting streaming and LeMUR issues.
+
   Trigger with phrases like "assemblyai error", "fix assemblyai",
+
   "assemblyai not working", "debug assemblyai", "transcription failed".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Common Errors
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-core-workflow-a
-description: |
-  Execute AssemblyAI primary workflow: async transcription with audio intelligence.
+description: 'Execute AssemblyAI primary workflow: async transcription with audio
+  intelligence.
+
   Use when transcribing audio/video files, enabling speaker diarization,
+
   sentiment analysis, entity detection, PII redaction, or content moderation.
+
   Trigger with phrases like "assemblyai transcribe", "assemblyai transcription",
+
   "transcribe audio", "speaker diarization assemblyai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Core Workflow A — Async Transcription
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-core-workflow-b/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-core-workflow-b
-description: |
-  Execute AssemblyAI streaming transcription and LeMUR workflows.
+description: 'Execute AssemblyAI streaming transcription and LeMUR workflows.
+
   Use when implementing real-time speech-to-text, live captions,
+
   voice agents, or LLM-powered audio analysis with LeMUR.
+
   Trigger with phrases like "assemblyai streaming", "assemblyai real-time",
+
   "assemblyai live transcription", "assemblyai LeMUR", "assemblyai summarize audio".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, streaming, lemur]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- streaming
+- lemur
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Core Workflow B — Streaming & LeMUR
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-cost-tuning/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: assemblyai-cost-tuning
-description: |
-  Optimize AssemblyAI costs through model selection, feature budgeting, and usage monitoring.
+description: 'Optimize AssemblyAI costs through model selection, feature budgeting,
+  and usage monitoring.
+
   Use when analyzing AssemblyAI billing, reducing transcription costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "assemblyai cost", "assemblyai billing",
+
   "reduce assemblyai costs", "assemblyai pricing", "assemblyai budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, cost]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- cost
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-debug-bundle/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-debug-bundle
-description: |
-  Collect AssemblyAI debug evidence for support tickets and troubleshooting.
+description: 'Collect AssemblyAI debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for AssemblyAI problems.
+
   Trigger with phrases like "assemblyai debug", "assemblyai support bundle",
+
   "collect assemblyai logs", "assemblyai diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-deploy-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-deploy-integration
-description: |
-  Deploy AssemblyAI integrations to Vercel, Cloud Run, and Fly.io platforms.
+description: 'Deploy AssemblyAI integrations to Vercel, Cloud Run, and Fly.io platforms.
+
   Use when deploying AssemblyAI-powered transcription services to production,
+
   configuring platform-specific secrets, or setting up webhook endpoints.
+
   Trigger with phrases like "deploy assemblyai", "assemblyai Vercel",
+
   "assemblyai production deploy", "assemblyai Cloud Run", "assemblyai Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, deploy]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- deploy
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-hello-world/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-hello-world
-description: |
-  Create a minimal working AssemblyAI transcription example.
+description: 'Create a minimal working AssemblyAI transcription example.
+
   Use when starting a new AssemblyAI integration, testing your setup,
+
   or learning basic transcription patterns.
+
   Trigger with phrases like "assemblyai hello world", "assemblyai example",
+
   "assemblyai quick start", "simple assemblyai transcription".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Hello World
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-install-auth/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-install-auth/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-install-auth
-description: |
-  Install and configure AssemblyAI SDK authentication.
+description: 'Install and configure AssemblyAI SDK authentication.
+
   Use when setting up a new AssemblyAI integration, configuring API keys,
+
   or initializing the assemblyai npm package in your project.
+
   Trigger with phrases like "install assemblyai", "setup assemblyai",
+
   "assemblyai auth", "configure assemblyai API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-local-dev-loop
-description: |
-  Configure AssemblyAI local development with hot reload and testing.
+description: 'Configure AssemblyAI local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with AssemblyAI.
+
   Trigger with phrases like "assemblyai dev setup", "assemblyai local development",
+
   "assemblyai dev environment", "develop with assemblyai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-performance-tuning/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: assemblyai-performance-tuning
-description: |
-  Optimize AssemblyAI API performance with caching, parallel processing, and model selection.
+description: 'Optimize AssemblyAI API performance with caching, parallel processing,
+  and model selection.
+
   Use when experiencing slow transcriptions, implementing caching strategies,
+
   or optimizing throughput for batch transcription workloads.
+
   Trigger with phrases like "assemblyai performance", "optimize assemblyai",
+
   "assemblyai latency", "assemblyai caching", "assemblyai slow", "assemblyai batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, performance]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-prod-checklist/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-prod-checklist
-description: |
-  Execute AssemblyAI production deployment checklist and rollback procedures.
+description: 'Execute AssemblyAI production deployment checklist and rollback procedures.
+
   Use when deploying AssemblyAI integrations to production, preparing for launch,
+
   or implementing go-live procedures for transcription services.
+
   Trigger with phrases like "assemblyai production", "deploy assemblyai",
+
   "assemblyai go-live", "assemblyai launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, production]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- production
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-rate-limits/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-rate-limits/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-rate-limits
-description: |
-  Implement AssemblyAI rate limiting, backoff, and queue-based throttling.
+description: 'Implement AssemblyAI rate limiting, backoff, and queue-based throttling.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or managing concurrent transcription throughput.
+
   Trigger with phrases like "assemblyai rate limit", "assemblyai throttling",
+
   "assemblyai 429", "assemblyai retry", "assemblyai backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-reference-architecture/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: assemblyai-reference-architecture
-description: |
-  Implement AssemblyAI reference architecture with best-practice project layout.
+description: 'Implement AssemblyAI reference architecture with best-practice project
+  layout.
+
   Use when designing new AssemblyAI transcription services, reviewing project structure,
+
   or building production-grade speech-to-text applications.
+
   Trigger with phrases like "assemblyai architecture", "assemblyai best practices",
+
   "assemblyai project structure", "how to organize assemblyai", "assemblyai design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-sdk-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: assemblyai-sdk-patterns
-description: |
-  Apply production-ready AssemblyAI SDK patterns for TypeScript and Python.
+description: 'Apply production-ready AssemblyAI SDK patterns for TypeScript and Python.
+
   Use when implementing AssemblyAI integrations, refactoring SDK usage,
+
   or establishing team coding standards for transcription workflows.
+
   Trigger with phrases like "assemblyai SDK patterns", "assemblyai best practices",
+
   "assemblyai code patterns", "idiomatic assemblyai".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-security-basics/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-security-basics/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: assemblyai-security-basics
-description: |
-  Apply AssemblyAI security best practices for API keys, PII, and access control.
+description: 'Apply AssemblyAI security best practices for API keys, PII, and access
+  control.
+
   Use when securing API keys, implementing PII redaction,
+
   or configuring temporary tokens for browser-side streaming.
+
   Trigger with phrases like "assemblyai security", "assemblyai secrets",
+
   "secure assemblyai", "assemblyai API key security", "assemblyai PII".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, security]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- security
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Security Basics
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-upgrade-migration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-upgrade-migration
-description: |
-  Analyze, plan, and execute AssemblyAI SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute AssemblyAI SDK upgrades with breaking change
+  detection.
+
   Use when upgrading the assemblyai npm package, migrating from the old SDK,
+
   or switching between speech models (Best, Nano, Universal).
+
   Trigger with phrases like "upgrade assemblyai", "assemblyai migration",
+
   "assemblyai breaking changes", "update assemblyai SDK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/assemblyai-pack/skills/assemblyai-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/assemblyai-pack/skills/assemblyai-webhooks-events/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: assemblyai-webhooks-events
-description: |
-  Implement AssemblyAI webhook handling for transcription completion events.
+description: 'Implement AssemblyAI webhook handling for transcription completion events.
+
   Use when setting up webhook endpoints, handling transcription callbacks,
+
   or processing async transcription results via webhooks.
+
   Trigger with phrases like "assemblyai webhook", "assemblyai events",
+
   "assemblyai transcription callback", "handle assemblyai webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, speech-to-text, assemblyai, transcription, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- speech-to-text
+- assemblyai
+- transcription
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # AssemblyAI Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-ci-integration/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-ci-integration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-ci-integration
-description: |
-  Configure CI/CD pipelines for Attio integrations with GitHub Actions,
+description: 'Configure CI/CD pipelines for Attio integrations with GitHub Actions,
+
   mock-based unit tests, and live API integration tests.
+
   Trigger: "attio CI", "attio GitHub Actions", "attio automated tests",
+
   "CI attio", "attio pipeline", "test attio in CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio CI Integration
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-common-errors/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-common-errors/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-common-errors
-description: |
-  Diagnose and fix the top Attio REST API errors by HTTP status code.
+description: 'Diagnose and fix the top Attio REST API errors by HTTP status code.
+
   Real error response formats, actual error codes, and proven fixes.
+
   Trigger: "attio error", "fix attio", "attio not working",
+
   "attio 429", "attio 403", "attio 422", "debug attio".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Common Errors
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-core-workflow-a/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-core-workflow-a
-description: |
-  Full CRUD on Attio records -- create, read, update, delete, and search
+description: 'Full CRUD on Attio records -- create, read, update, delete, and search
+
   across people, companies, deals, and custom objects.
+
   Trigger: "attio records", "attio CRUD", "create attio record",
+
   "update attio person", "search attio companies", "attio objects".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Records CRUD (Core Workflow A)
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-core-workflow-b/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: attio-core-workflow-b
-description: |
-  Manage Attio lists, entries, notes, and tasks via the REST API.
+description: 'Manage Attio lists, entries, notes, and tasks via the REST API.
+
   Use when working with sales pipelines, kanban boards, CRM notes,
+
   or task assignments in Attio.
+
   Trigger: "attio lists", "attio entries", "attio pipeline",
+
   "attio notes", "attio tasks", "add to attio list".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Lists, Notes & Tasks (Core Workflow B)
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-cost-tuning/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-cost-tuning
-description: |
-  Optimize Attio API usage costs -- reduce request volume, select the
+description: 'Optimize Attio API usage costs -- reduce request volume, select the
+
   right plan, monitor usage, and implement budget alerts.
+
   Trigger: "attio cost", "attio billing", "reduce attio costs",
+
   "attio pricing", "attio expensive", "attio budget", "attio usage".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-debug-bundle/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-debug-bundle
-description: |
-  Collect Attio integration diagnostic evidence -- API health, scopes,
+description: 'Collect Attio integration diagnostic evidence -- API health, scopes,
+
   object schema, and rate limit status -- for debugging or support tickets.
+
   Trigger: "attio debug", "attio support bundle", "attio diagnostic",
+
   "collect attio logs", "attio not working debug".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(jq:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-deploy-integration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-deploy-integration
-description: |
-  Deploy Attio integrations to Vercel, Fly.io, Railway, and Cloud Run
+description: 'Deploy Attio integrations to Vercel, Fly.io, Railway, and Cloud Run
+
   with proper secrets, health checks, and webhook endpoint configuration.
+
   Trigger: "deploy attio", "attio Vercel", "attio production deploy",
+
   "attio Cloud Run", "attio Fly.io", "attio Railway".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*), Bash(railway:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-hello-world/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: attio-hello-world
-description: |
-  Make your first Attio API calls -- list objects, create a person,
+description: 'Make your first Attio API calls -- list objects, create a person,
+
   query companies, and read attributes.
+
   Use when starting a new Attio integration or learning the API.
+
   Trigger: "attio hello world", "attio example", "first attio call",
+
   "attio quick start", "try attio API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Hello World
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-install-auth/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: attio-install-auth
-description: |
-  Set up Attio REST API authentication with access tokens or OAuth 2.0.
+description: 'Set up Attio REST API authentication with access tokens or OAuth 2.0.
+
   Use when configuring API keys, setting token scopes, initializing
+
   the Attio client, or connecting an app via OAuth.
+
   Trigger: "install attio", "setup attio", "attio auth", "attio API key",
+
   "attio OAuth", "attio access token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-local-dev-loop/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-local-dev-loop
-description: |
-  Set up a fast local development loop for Attio integrations with
+description: 'Set up a fast local development loop for Attio integrations with
+
   hot reload, mock server, and integration tests.
+
   Trigger: "attio dev setup", "attio local development",
+
   "attio dev environment", "develop with attio", "attio project setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-performance-tuning/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-performance-tuning
-description: |
-  Optimize Attio API performance -- caching, batch queries, pagination
+description: 'Optimize Attio API performance -- caching, batch queries, pagination
+
   strategies, connection pooling, and latency reduction.
+
   Trigger: "attio performance", "optimize attio", "attio slow",
+
   "attio latency", "attio caching", "attio batch requests".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-prod-checklist/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-prod-checklist
-description: |
-  Production readiness checklist for Attio API integrations -- auth,
+description: 'Production readiness checklist for Attio API integrations -- auth,
+
   error handling, rate limits, health checks, monitoring, and rollback.
+
   Trigger: "attio production", "deploy attio", "attio go-live",
+
   "attio launch checklist", "attio production ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-rate-limits/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-rate-limits/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-rate-limits
-description: |
-  Handle Attio API rate limits with exponential backoff, queue-based
+description: 'Handle Attio API rate limits with exponential backoff, queue-based
+
   throttling, and Retry-After header parsing.
+
   Trigger: "attio rate limit", "attio 429", "attio throttling",
+
   "attio retry", "attio backoff", "attio too many requests".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-reference-architecture/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-reference-architecture
-description: |
-  Production reference architecture for Attio CRM integrations -- layered
+description: 'Production reference architecture for Attio CRM integrations -- layered
+
   project structure, sync patterns, webhook processing, and multi-environment setup.
+
   Trigger: "attio architecture", "attio best practices", "attio project structure",
+
   "how to organize attio", "attio integration design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-sdk-patterns/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-sdk-patterns
-description: |
-  Production-ready patterns for the Attio REST API: typed client,
+description: 'Production-ready patterns for the Attio REST API: typed client,
+
   retry with backoff, pagination iterators, and multi-tenant factory.
+
   Trigger: "attio SDK patterns", "attio best practices",
+
   "attio client wrapper", "idiomatic attio", "attio TypeScript patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-security-basics/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-security-basics/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-security-basics
-description: |
-  Secure Attio API integrations -- token scoping, secret management,
+description: 'Secure Attio API integrations -- token scoping, secret management,
+
   scope auditing, webhook signature verification, and rotation procedures.
+
   Trigger: "attio security", "attio secrets", "secure attio",
+
   "attio API key security", "attio scopes", "attio token rotation".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Security Basics
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-upgrade-migration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-upgrade-migration
-description: |
-  Migrate between Attio API versions, handle breaking changes in the
+description: 'Migrate between Attio API versions, handle breaking changes in the
+
   v1-to-v2 transition, and plan for future deprecations.
+
   Trigger: "upgrade attio", "attio migration", "attio v1 to v2",
+
   "attio breaking changes", "attio API version", "attio deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/attio-pack/skills/attio-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/attio-pack/skills/attio-webhooks-events/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: attio-webhooks-events
-description: |
-  Implement Attio v2 webhooks -- subscribe to record/list/note/task events,
+description: 'Implement Attio v2 webhooks -- subscribe to record/list/note/task events,
+
   verify signatures, filter by object or attribute, and handle idempotently.
+
   Trigger: "attio webhook", "attio events", "attio webhook signature",
+
   "handle attio events", "attio notifications", "attio real-time".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, attio]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- attio
+compatibility: Designed for Claude Code
 ---
-
 # Attio Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-ci-integration/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-ci-integration/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: bamboohr-ci-integration
-description: |
-  Configure CI/CD pipelines for BambooHR integrations with GitHub Actions,
+description: 'Configure CI/CD pipelines for BambooHR integrations with GitHub Actions,
+
   automated testing, and secret management.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating BambooHR API tests into your build process.
+
   Trigger with phrases like "bamboohr CI", "bamboohr GitHub Actions",
+
   "bamboohr automated tests", "CI bamboohr", "bamboohr pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, ci-cd]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- ci-cd
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR CI Integration
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-common-errors/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-common-errors
-description: |
-  Diagnose and fix BambooHR API errors and exceptions.
+description: 'Diagnose and fix BambooHR API errors and exceptions.
+
   Use when encountering BambooHR errors, debugging failed requests,
+
   or troubleshooting HTTP 400/401/403/404/429/500/503 responses.
+
   Trigger with phrases like "bamboohr error", "fix bamboohr",
+
   "bamboohr not working", "debug bamboohr", "bamboohr 401", "bamboohr 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, debugging]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Common Errors
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: bamboohr-core-workflow-a
-description: |
-  Execute BambooHR primary workflows: employee CRUD, directory sync, and custom reports.
+description: 'Execute BambooHR primary workflows: employee CRUD, directory sync, and
+  custom reports.
+
   Use when managing employees, syncing employee data to external systems,
+
   or building HR data pipelines with BambooHR.
+
   Trigger with phrases like "bamboohr employees", "bamboohr employee management",
+
   "sync bamboohr directory", "bamboohr custom report", "add employee bamboohr".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, employees, reports]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- employees
+- reports
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Core Workflow A — Employee Management & Reports
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-core-workflow-b/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: bamboohr-core-workflow-b
-description: |
-  Execute BambooHR secondary workflows: time off requests, PTO balances,
+description: 'Execute BambooHR secondary workflows: time off requests, PTO balances,
+
   benefits administration, and employee files/photos.
+
   Use when managing time off, checking PTO balances, handling benefits data,
+
   or working with employee documents in BambooHR.
+
   Trigger with phrases like "bamboohr time off", "bamboohr PTO", "bamboohr benefits",
+
   "bamboohr vacation", "bamboohr files", "bamboohr leave request".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, timeoff, benefits]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- timeoff
+- benefits
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Core Workflow B — Time Off, Benefits & Files
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-cost-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-cost-tuning
-description: |
-  Optimize BambooHR integration costs through request reduction, caching,
+description: 'Optimize BambooHR integration costs through request reduction, caching,
+
   and usage monitoring. Use when analyzing API usage patterns, reducing
+
   unnecessary calls, or implementing request budgets.
+
   Trigger with phrases like "bamboohr cost", "bamboohr usage",
+
   "reduce bamboohr calls", "bamboohr optimization", "bamboohr budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, optimization]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- optimization
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-debug-bundle
-description: |
-  Collect BambooHR debug evidence for support tickets and troubleshooting.
+description: 'Collect BambooHR debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for BambooHR API problems.
+
   Trigger with phrases like "bamboohr debug", "bamboohr support bundle",
+
   "collect bamboohr logs", "bamboohr diagnostic", "bamboohr troubleshoot".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, debugging]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-deploy-integration
-description: |
-  Deploy BambooHR integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy BambooHR integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying BambooHR-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy bamboohr", "bamboohr Vercel",
+
   "bamboohr production deploy", "bamboohr Cloud Run", "bamboohr Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-hello-world/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-hello-world/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: bamboohr-hello-world
-description: |
-  Create a minimal working BambooHR example — fetch employee directory and single employee.
-  Use when starting a new BambooHR integration, testing your setup,
-  or learning basic BambooHR REST API patterns.
-  Trigger with phrases like "bamboohr hello world", "bamboohr example",
-  "bamboohr quick start", "simple bamboohr code", "first bamboohr call".
+description: "Create a minimal working BambooHR example \u2014 fetch employee directory\
+  \ and single employee.\nUse when starting a new BambooHR integration, testing your\
+  \ setup,\nor learning basic BambooHR REST API patterns.\nTrigger with phrases like\
+  \ \"bamboohr hello world\", \"bamboohr example\",\n\"bamboohr quick start\", \"\
+  simple bamboohr code\", \"first bamboohr call\".\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, quickstart]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- quickstart
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Hello World
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-install-auth/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-install-auth
-description: |
-  Install and configure BambooHR API authentication with HTTP Basic Auth.
+description: 'Install and configure BambooHR API authentication with HTTP Basic Auth.
+
   Use when setting up a new BambooHR integration, configuring API keys,
+
   or initializing BambooHR REST API access in your project.
+
   Trigger with phrases like "install bamboohr", "setup bamboohr",
+
   "bamboohr auth", "configure bamboohr API key", "bamboohr credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, authentication]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- authentication
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-local-dev-loop
-description: |
-  Configure BambooHR local development with hot reload, mocking, and testing.
+description: 'Configure BambooHR local development with hot reload, mocking, and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with BambooHR API.
+
   Trigger with phrases like "bamboohr dev setup", "bamboohr local development",
+
   "bamboohr dev environment", "develop with bamboohr", "bamboohr mock".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, development]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- development
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: bamboohr-performance-tuning
-description: |
-  Optimize BambooHR API performance with caching, batch reports, incremental sync,
+description: 'Optimize BambooHR API performance with caching, batch reports, incremental
+  sync,
+
   and connection pooling. Use when experiencing slow API responses,
+
   implementing caching, or optimizing sync throughput.
+
   Trigger with phrases like "bamboohr performance", "optimize bamboohr",
+
   "bamboohr latency", "bamboohr caching", "bamboohr slow", "bamboohr batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, performance]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-prod-checklist
-description: |
-  Execute BambooHR production deployment checklist and rollback procedures.
+description: 'Execute BambooHR production deployment checklist and rollback procedures.
+
   Use when deploying BambooHR integrations to production, preparing for launch,
+
   or implementing go-live procedures with BambooHR API.
+
   Trigger with phrases like "bamboohr production", "deploy bamboohr",
+
   "bamboohr go-live", "bamboohr launch checklist", "bamboohr prod ready".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, production]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- production
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-rate-limits/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-rate-limits
-description: |
-  Implement BambooHR rate limiting, backoff, and request optimization.
+description: 'Implement BambooHR rate limiting, backoff, and request optimization.
+
   Use when handling 429/503 rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for BambooHR.
+
   Trigger with phrases like "bamboohr rate limit", "bamboohr throttling",
+
   "bamboohr 429", "bamboohr 503", "bamboohr retry", "bamboohr backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, rate-limiting]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- rate-limiting
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-reference-architecture
-description: |
-  Implement BambooHR reference architecture for production HR data pipelines.
+description: 'Implement BambooHR reference architecture for production HR data pipelines.
+
   Use when designing new BambooHR integrations, building employee sync systems,
+
   or establishing architecture standards for BambooHR-powered applications.
+
   Trigger with phrases like "bamboohr architecture", "bamboohr design",
+
   "bamboohr project structure", "bamboohr system design", "bamboohr pipeline".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-sdk-patterns
-description: |
-  Apply production-ready BambooHR API patterns for TypeScript and Python.
+description: 'Apply production-ready BambooHR API patterns for TypeScript and Python.
+
   Use when implementing BambooHR integrations, building reusable clients,
+
   or establishing team coding standards for BambooHR REST API.
+
   Trigger with phrases like "bamboohr SDK patterns", "bamboohr best practices",
+
   "bamboohr code patterns", "idiomatic bamboohr", "bamboohr client wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, patterns]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- patterns
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-security-basics/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-security-basics/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: bamboohr-security-basics
-description: |
-  Apply BambooHR security best practices for API keys, webhook verification,
+description: 'Apply BambooHR security best practices for API keys, webhook verification,
+
   and PII data handling compliance.
+
   Use when securing API keys, implementing webhook signature validation,
+
   or handling sensitive employee data from BambooHR.
+
   Trigger with phrases like "bamboohr security", "bamboohr secrets",
+
   "secure bamboohr", "bamboohr PII", "bamboohr data protection".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, security]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- security
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Security Basics
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: bamboohr-upgrade-migration
-description: |
-  Plan and execute BambooHR API migration with breaking change detection.
+description: 'Plan and execute BambooHR API migration with breaking change detection.
+
   Use when BambooHR announces API changes, adapting to deprecated endpoints,
+
   or migrating from legacy API patterns to current best practices.
+
   Trigger with phrases like "upgrade bamboohr", "bamboohr migration",
+
   "bamboohr breaking changes", "bamboohr API update", "bamboohr deprecated".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, migration]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- migration
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/bamboohr-pack/skills/bamboohr-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/bamboohr-pack/skills/bamboohr-webhooks-events/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: bamboohr-webhooks-events
-description: |
-  Implement BambooHR webhook endpoints with HMAC signature validation
+description: 'Implement BambooHR webhook endpoints with HMAC signature validation
+
   and employee change event handling. Covers global and permissioned webhooks.
+
   Use when setting up real-time employee notifications, implementing sync triggers,
+
   or handling BambooHR webhook payloads.
+
   Trigger with phrases like "bamboohr webhook", "bamboohr events",
+
   "bamboohr real-time sync", "bamboohr notifications", "bamboohr employee changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, bamboohr, webhooks]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- bamboohr
+- webhooks
+compatibility: Designed for Claude Code
 ---
-
 # BambooHR Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-ci-integration/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-ci-integration
-description: |
-  Configure Bright Data CI/CD integration with GitHub Actions and testing.
+description: 'Configure Bright Data CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Bright Data tests into your build process.
+
   Trigger with phrases like "brightdata CI", "brightdata GitHub Actions",
+
   "brightdata automated tests", "CI brightdata".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data CI Integration
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-common-errors/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-common-errors
-description: |
-  Diagnose and fix Bright Data common errors and exceptions.
+description: 'Diagnose and fix Bright Data common errors and exceptions.
+
   Use when encountering Bright Data errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "brightdata error", "fix brightdata",
+
   "brightdata not working", "debug brightdata".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Common Errors
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-core-workflow-a/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: brightdata-core-workflow-a
-description: |
-  Scrape structured data with Bright Data Scraping Browser using Playwright/Puppeteer.
+description: 'Scrape structured data with Bright Data Scraping Browser using Playwright/Puppeteer.
+
   Use when scraping JavaScript-rendered pages, SPAs, or sites requiring browser interaction.
+
   Trigger with phrases like "brightdata scraping browser", "brightdata playwright",
+
   "brightdata puppeteer", "scrape SPA with brightdata", "browser scraping".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata, playwright, puppeteer]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+- playwright
+- puppeteer
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Scraping Browser
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-core-workflow-b
-description: |
-  Execute Bright Data secondary workflow: Core Workflow B.
+description: 'Execute Bright Data secondary workflow: Core Workflow B.
+
   Use when implementing secondary use case,
+
   or complementing primary workflow.
+
   Trigger with phrases like "brightdata secondary workflow",
+
   "secondary task with brightdata".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data SERP API & Web Scraper API
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-cost-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: brightdata-cost-tuning
-description: |
-  Optimize Bright Data costs through tier selection, sampling, and usage monitoring.
+description: 'Optimize Bright Data costs through tier selection, sampling, and usage
+  monitoring.
+
   Use when analyzing Bright Data billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "brightdata cost", "brightdata billing",
-  "reduce brightdata costs", "brightdata pricing", "brightdata expensive", "brightdata budget".
+
+  "reduce brightdata costs", "brightdata pricing", "brightdata expensive", "brightdata
+  budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-debug-bundle
-description: |
-  Collect Bright Data debug evidence for support tickets and troubleshooting.
+description: 'Collect Bright Data debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Bright Data problems.
+
   Trigger with phrases like "brightdata debug", "brightdata support bundle",
+
   "collect brightdata logs", "brightdata diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-deploy-integration
-description: |
-  Deploy Bright Data integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Bright Data integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Bright Data-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy brightdata", "brightdata Vercel",
+
   "brightdata production deploy", "brightdata Cloud Run", "brightdata Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-hello-world/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-hello-world
-description: |
-  Create a minimal working Bright Data example.
+description: 'Create a minimal working Bright Data example.
+
   Use when starting a new Bright Data integration, testing your setup,
+
   or learning basic Bright Data API patterns.
+
   Trigger with phrases like "brightdata hello world", "brightdata example",
+
   "brightdata quick start", "simple brightdata code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Hello World
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-install-auth/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-install-auth
-description: |
-  Install and configure Bright Data SDK/CLI authentication.
+description: 'Install and configure Bright Data SDK/CLI authentication.
+
   Use when setting up a new Bright Data integration, configuring API keys,
+
   or initializing Bright Data in your project.
+
   Trigger with phrases like "install brightdata", "setup brightdata",
+
   "brightdata auth", "configure brightdata API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-local-dev-loop
-description: |
-  Configure Bright Data local development with hot reload and testing.
+description: 'Configure Bright Data local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Bright Data.
+
   Trigger with phrases like "brightdata dev setup", "brightdata local development",
+
   "brightdata dev environment", "develop with brightdata".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: brightdata-performance-tuning
-description: |
-  Optimize Bright Data API performance with caching, batching, and connection pooling.
+description: 'Optimize Bright Data API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Bright Data integrations.
+
   Trigger with phrases like "brightdata performance", "optimize brightdata",
+
   "brightdata latency", "brightdata caching", "brightdata slow", "brightdata batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-prod-checklist
-description: |
-  Execute Bright Data production deployment checklist and rollback procedures.
+description: 'Execute Bright Data production deployment checklist and rollback procedures.
+
   Use when deploying Bright Data integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "brightdata production", "deploy brightdata",
+
   "brightdata go-live", "brightdata launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-rate-limits/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-rate-limits
-description: |
-  Implement Bright Data rate limiting, backoff, and idempotency patterns.
+description: 'Implement Bright Data rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Bright Data.
+
   Trigger with phrases like "brightdata rate limit", "brightdata throttling",
+
   "brightdata 429", "brightdata retry", "brightdata backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: brightdata-reference-architecture
-description: |
-  Implement Bright Data reference architecture with best-practice project layout.
+description: 'Implement Bright Data reference architecture with best-practice project
+  layout.
+
   Use when designing new Bright Data integrations, reviewing project structure,
+
   or establishing architecture standards for Bright Data applications.
+
   Trigger with phrases like "brightdata architecture", "brightdata best practices",
+
   "brightdata project structure", "how to organize brightdata", "brightdata layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-sdk-patterns
-description: |
-  Apply production-ready Bright Data SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Bright Data SDK patterns for TypeScript and Python.
+
   Use when implementing Bright Data integrations, refactoring SDK usage,
+
   or establishing team coding standards for Bright Data.
+
   Trigger with phrases like "brightdata SDK patterns", "brightdata best practices",
+
   "brightdata code patterns", "idiomatic brightdata".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-security-basics/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-security-basics
-description: |
-  Apply Bright Data security best practices for secrets and access control.
+description: 'Apply Bright Data security best practices for secrets and access control.
+
   Use when securing API keys, implementing least privilege access,
+
   or auditing Bright Data security configuration.
+
   Trigger with phrases like "brightdata security", "brightdata secrets",
+
   "secure brightdata", "brightdata API key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Security Basics
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: brightdata-upgrade-migration
-description: |
-  Analyze, plan, and execute Bright Data SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Bright Data SDK upgrades with breaking change
+  detection.
+
   Use when upgrading Bright Data SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade brightdata", "brightdata migration",
+
   "brightdata breaking changes", "update brightdata SDK", "analyze brightdata version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/brightdata-pack/skills/brightdata-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/brightdata-pack/skills/brightdata-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brightdata-webhooks-events
-description: |
-  Implement Bright Data webhook signature validation and event handling.
+description: 'Implement Bright Data webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling Bright Data event notifications securely.
+
   Trigger with phrases like "brightdata webhook", "brightdata events",
+
   "brightdata webhook signature", "handle brightdata events", "brightdata notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, scraping, data, brightdata]
-compatible-with: claude-code
+tags:
+- saas
+- scraping
+- data
+- brightdata
+compatibility: Designed for Claude Code
 ---
-
 # Bright Data Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-advanced-troubleshooting
-description: |
-  Apply Canva Connect API advanced debugging for hard-to-diagnose issues.
+description: 'Apply Canva Connect API advanced debugging for hard-to-diagnose issues.
+
   Use when standard troubleshooting fails, investigating intermittent failures,
+
   or preparing evidence bundles for Canva developer support.
+
   Trigger with phrases like "canva hard bug", "canva mystery error",
+
   "canva impossible to debug", "difficult canva issue", "canva deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*), Bash(tcpdump:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-architecture-variants/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-architecture-variants
-description: |
-  Choose and implement Canva Connect API architecture blueprints for different scales.
+description: 'Choose and implement Canva Connect API architecture blueprints for different
+  scales.
+
   Use when designing new Canva integrations, choosing between monolith/service/microservice
+
   architectures, or planning migration paths.
+
   Trigger with phrases like "canva architecture", "canva blueprint",
+
   "how to structure canva", "canva project layout", "canva microservice".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-ci-integration/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-ci-integration
-description: |
-  Configure CI/CD pipelines for Canva Connect API integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Canva Connect API integrations with GitHub
+  Actions.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Canva API tests into your build process.
+
   Trigger with phrases like "canva CI", "canva GitHub Actions",
+
   "canva automated tests", "CI canva", "canva pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva CI Integration
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-common-errors/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-common-errors
-description: |
-  Diagnose and fix Canva Connect API errors and HTTP status codes.
+description: 'Diagnose and fix Canva Connect API errors and HTTP status codes.
+
   Use when encountering Canva errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "canva error", "fix canva",
+
   "canva not working", "debug canva", "canva 401", "canva 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Common Errors
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-core-workflow-a
-description: |
-  Execute the Canva design creation and export pipeline via the Connect API.
+description: 'Execute the Canva design creation and export pipeline via the Connect
+  API.
+
   Use when building design creation workflows, exporting designs programmatically,
-  or integrating Canva's design tools into your application.
+
+  or integrating Canva''s design tools into your application.
+
   Trigger with phrases like "canva create design", "canva export",
+
   "canva design pipeline", "canva generate content".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Core Workflow A — Design Creation & Export
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-core-workflow-b
-description: |
-  Execute Canva asset management, brand template autofill, and folder organization.
+description: 'Execute Canva asset management, brand template autofill, and folder
+  organization.
+
   Use when uploading assets, autofilling brand templates with dynamic data,
+
   or organizing designs into folders via the Connect API.
+
   Trigger with phrases like "canva assets", "canva brand template",
+
   "canva autofill", "canva folders", "canva upload image".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Core Workflow B — Assets, Autofill & Folders
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-cost-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-cost-tuning
-description: |
-  Optimize Canva Connect API usage costs through efficient API patterns and monitoring.
+description: 'Optimize Canva Connect API usage costs through efficient API patterns
+  and monitoring.
+
   Use when analyzing Canva API usage, reducing unnecessary calls,
+
   or implementing usage monitoring and budget tracking.
+
   Trigger with phrases like "canva cost", "canva usage",
+
   "reduce canva calls", "canva API efficiency", "canva budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-data-handling/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-data-handling/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-data-handling
-description: |
-  Implement Canva Connect API data handling, PII protection, and GDPR/CCPA compliance.
+description: 'Implement Canva Connect API data handling, PII protection, and GDPR/CCPA
+  compliance.
+
   Use when handling user design data, implementing data retention policies,
+
   or ensuring privacy compliance for Canva integrations.
+
   Trigger with phrases like "canva data", "canva PII",
+
   "canva GDPR", "canva data retention", "canva privacy", "canva CCPA".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Data Handling
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-debug-bundle
-description: |
-  Collect Canva Connect API debug evidence for troubleshooting and support.
+description: 'Collect Canva Connect API debug evidence for troubleshooting and support.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Canva API problems.
+
   Trigger with phrases like "canva debug", "canva support bundle",
+
   "collect canva logs", "canva diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-deploy-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-deploy-integration
-description: |
-  Deploy Canva Connect API integrations to Vercel, Fly.io, and Cloud Run.
+description: 'Deploy Canva Connect API integrations to Vercel, Fly.io, and Cloud Run.
+
   Use when deploying Canva-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy canva", "canva Vercel",
+
   "canva production deploy", "canva Cloud Run", "canva Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-enterprise-rbac/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-enterprise-rbac
-description: |
-  Configure Canva Enterprise organization access control and scope management.
+description: 'Configure Canva Enterprise organization access control and scope management.
+
   Use when implementing per-user scope control, managing Canva Enterprise features,
+
   or setting up organization-level Canva integration governance.
+
   Trigger with phrases like "canva enterprise", "canva RBAC",
+
   "canva roles", "canva permissions", "canva organization", "canva team".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-hello-world/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-hello-world
-description: |
-  Create a minimal working Canva Connect API example.
+description: 'Create a minimal working Canva Connect API example.
+
   Use when starting a new Canva integration, testing your setup,
+
   or learning basic Canva REST API patterns.
+
   Trigger with phrases like "canva hello world", "canva example",
+
   "canva quick start", "simple canva code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Hello World
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-incident-runbook/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-incident-runbook
-description: |
-  Execute Canva Connect API incident response with triage, mitigation, and postmortem.
+description: 'Execute Canva Connect API incident response with triage, mitigation,
+  and postmortem.
+
   Use when responding to Canva-related outages, investigating API errors,
+
   or running post-incident reviews for Canva integration failures.
+
   Trigger with phrases like "canva incident", "canva outage",
+
   "canva down", "canva on-call", "canva emergency", "canva broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-install-auth/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-install-auth
-description: |
-  Set up Canva Connect API OAuth 2.0 PKCE authentication and project scaffolding.
+description: 'Set up Canva Connect API OAuth 2.0 PKCE authentication and project scaffolding.
+
   Use when creating a new Canva integration, setting up OAuth credentials,
+
   or initializing a Canva Connect API project.
+
   Trigger with phrases like "install canva", "setup canva",
+
   "canva auth", "configure canva API", "canva OAuth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Connect API — Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-known-pitfalls/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-known-pitfalls
-description: |
-  Identify and avoid Canva Connect API anti-patterns and common integration mistakes.
+description: 'Identify and avoid Canva Connect API anti-patterns and common integration
+  mistakes.
+
   Use when reviewing Canva code, onboarding developers,
+
   or auditing existing Canva integrations for best practices violations.
+
   Trigger with phrases like "canva mistakes", "canva anti-patterns",
+
   "canva pitfalls", "canva what not to do", "canva code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-load-scale/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-load-scale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-load-scale
-description: |
-  Implement Canva Connect API load testing, auto-scaling, and capacity planning.
+description: 'Implement Canva Connect API load testing, auto-scaling, and capacity
+  planning.
+
   Use when running performance tests, planning capacity around Canva rate limits,
+
   or scaling Canva integrations for production workloads.
+
   Trigger with phrases like "canva load test", "canva scale",
+
   "canva performance test", "canva capacity", "canva k6", "canva benchmark".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-local-dev-loop
-description: |
-  Configure Canva Connect API local development with hot reload and mock server.
+description: 'Configure Canva Connect API local development with hot reload and mock
+  server.
+
   Use when setting up a development environment, testing OAuth flows locally,
+
   or establishing a fast iteration cycle for Canva integrations.
+
   Trigger with phrases like "canva dev setup", "canva local development",
+
   "canva dev environment", "develop with canva", "canva mock".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-migration-deep-dive
-description: |
-  Execute major Canva Connect API integration migrations with strangler fig pattern.
+description: 'Execute major Canva Connect API integration migrations with strangler
+  fig pattern.
+
   Use when migrating to Canva from another design platform, re-platforming
+
   existing integrations, or performing major architectural changes.
+
   Trigger with phrases like "migrate to canva", "canva migration",
+
   "switch to canva", "canva replatform", "replace design tool with canva".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-multi-env-setup/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: canva-multi-env-setup
-description: |
-  Configure Canva Connect API across development, staging, and production environments.
-  Use when setting up multi-environment deployments, managing OAuth credentials per environment,
+description: 'Configure Canva Connect API across development, staging, and production
+  environments.
+
+  Use when setting up multi-environment deployments, managing OAuth credentials per
+  environment,
+
   or implementing environment-specific Canva configurations.
+
   Trigger with phrases like "canva environments", "canva staging",
+
   "canva dev prod", "canva environment setup", "canva config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-observability/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-observability/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-observability
-description: |
-  Set up observability for Canva Connect API integrations with metrics, traces, and alerts.
+description: 'Set up observability for Canva Connect API integrations with metrics,
+  traces, and alerts.
+
   Use when implementing monitoring for Canva API operations, setting up dashboards,
+
   or configuring alerting for Canva integration health.
+
   Trigger with phrases like "canva monitoring", "canva metrics",
+
   "canva observability", "monitor canva", "canva alerts", "canva tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Observability
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-performance-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-performance-tuning
-description: |
-  Optimize Canva Connect API performance with caching, pagination, and connection pooling.
+description: 'Optimize Canva Connect API performance with caching, pagination, and
+  connection pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Canva integrations.
+
   Trigger with phrases like "canva performance", "optimize canva",
+
   "canva latency", "canva caching", "canva slow", "canva pagination".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-policy-guardrails/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-policy-guardrails
-description: |
-  Implement Canva Connect API lint rules, policy enforcement, and automated guardrails.
+description: 'Implement Canva Connect API lint rules, policy enforcement, and automated
+  guardrails.
+
   Use when setting up code quality rules for Canva integrations, implementing
+
   pre-commit hooks, or configuring CI policy checks.
+
   Trigger with phrases like "canva policy", "canva lint",
+
   "canva guardrails", "canva best practices check", "canva eslint".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-prod-checklist
-description: |
-  Execute Canva Connect API production deployment checklist and go-live procedures.
+description: 'Execute Canva Connect API production deployment checklist and go-live
+  procedures.
+
   Use when deploying Canva integrations to production, preparing for launch,
+
   or validating production readiness.
+
   Trigger with phrases like "canva production", "deploy canva",
+
   "canva go-live", "canva launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-rate-limits/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-rate-limits
-description: |
-  Handle Canva Connect API rate limits with backoff, queuing, and monitoring.
+description: 'Handle Canva Connect API rate limits with backoff, queuing, and monitoring.
+
   Use when hitting 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Canva integrations.
+
   Trigger with phrases like "canva rate limit", "canva throttling",
+
   "canva 429", "canva retry", "canva backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-reference-architecture
-description: |
-  Implement Canva Connect API reference architecture with best-practice project layout.
+description: 'Implement Canva Connect API reference architecture with best-practice
+  project layout.
+
   Use when designing new Canva integrations, reviewing project structure,
+
   or establishing architecture standards for Canva applications.
+
   Trigger with phrases like "canva architecture", "canva project structure",
+
   "how to organize canva", "canva layout", "canva reference".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-reliability-patterns/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: canva-reliability-patterns
-description: |
-  Implement reliability patterns for Canva Connect API — circuit breakers, idempotency, graceful degradation.
-  Use when building fault-tolerant Canva integrations, implementing retry strategies,
-  or adding resilience to production Canva services.
-  Trigger with phrases like "canva reliability", "canva circuit breaker",
-  "canva resilience", "canva fallback", "canva fault tolerance".
+description: "Implement reliability patterns for Canva Connect API \u2014 circuit\
+  \ breakers, idempotency, graceful degradation.\nUse when building fault-tolerant\
+  \ Canva integrations, implementing retry strategies,\nor adding resilience to production\
+  \ Canva services.\nTrigger with phrases like \"canva reliability\", \"canva circuit\
+  \ breaker\",\n\"canva resilience\", \"canva fallback\", \"canva fault tolerance\"\
+  .\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-sdk-patterns
-description: |
-  Apply production-ready Canva Connect API client patterns for TypeScript and Python.
+description: 'Apply production-ready Canva Connect API client patterns for TypeScript
+  and Python.
+
   Use when building a reusable API client, implementing token refresh,
+
   or establishing team coding standards for Canva integrations.
+
   Trigger with phrases like "canva client patterns", "canva best practices",
+
   "canva code patterns", "canva API wrapper", "canva TypeScript client".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-security-basics/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-security-basics
-description: |
-  Apply Canva Connect API security best practices for OAuth tokens and access control.
+description: 'Apply Canva Connect API security best practices for OAuth tokens and
+  access control.
+
   Use when securing OAuth credentials, implementing least-privilege scopes,
+
   or auditing Canva integration security.
+
   Trigger with phrases like "canva security", "canva secrets",
+
   "secure canva", "canva token security", "canva OAuth security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Security Basics
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: canva-upgrade-migration
-description: |
-  Plan and execute Canva Connect API version upgrades and breaking change detection.
+description: 'Plan and execute Canva Connect API version upgrades and breaking change
+  detection.
+
   Use when Canva releases API changes, migrating brand template IDs,
+
   or adapting to endpoint deprecations.
+
   Trigger with phrases like "upgrade canva", "canva API changes",
+
   "canva breaking changes", "canva deprecation", "canva changelog".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/canva-pack/skills/canva-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/canva-pack/skills/canva-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: canva-webhooks-events
-description: |
-  Implement Canva Connect API webhook handling with JWK signature verification.
+description: 'Implement Canva Connect API webhook handling with JWK signature verification.
+
   Use when setting up webhook endpoints, handling Canva event notifications,
+
   or implementing real-time design collaboration features.
+
   Trigger with phrases like "canva webhook", "canva events",
+
   "canva notifications", "handle canva events", "canva JWK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, canva]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- canva
+compatibility: Designed for Claude Code
 ---
-
 # Canva Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-ci-integration/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-ci-integration
-description: |
-  Integrate CAST AI policy validation and cost checks into CI/CD pipelines.
+description: 'Integrate CAST AI policy validation and cost checks into CI/CD pipelines.
+
   Use when adding CAST AI savings verification to GitHub Actions,
+
   validating Terraform plans, or gating deployments on cost thresholds.
+
   Trigger with phrases like "cast ai CI", "cast ai github actions",
+
   "cast ai terraform CI", "cast ai pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI CI Integration
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-common-errors/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-common-errors
-description: |
-  Diagnose and fix CAST AI agent, API, and autoscaler errors.
+description: 'Diagnose and fix CAST AI agent, API, and autoscaler errors.
+
   Use when the CAST AI agent is offline, nodes are not scaling,
+
   or API calls return errors.
+
   Trigger with phrases like "cast ai error", "cast ai not working",
+
   "cast ai agent offline", "cast ai debug", "fix cast ai".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Common Errors
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-core-workflow-a
-description: |
-  Configure CAST AI autoscaler policies and node templates for cost optimization.
+description: 'Configure CAST AI autoscaler policies and node templates for cost optimization.
+
   Use when enabling Phase 2 automation, setting spot instance policies,
+
   or configuring node downscaler and evictor settings.
+
   Trigger with phrases like "cast ai autoscaler", "cast ai policies",
+
   "cast ai spot instances", "cast ai node optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Core Workflow: Autoscaler & Policies
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-core-workflow-b
-description: |
-  Configure CAST AI Workload Autoscaler for pod-level right-sizing and VPA.
+description: 'Configure CAST AI Workload Autoscaler for pod-level right-sizing and
+  VPA.
+
   Use when enabling workload autoscaling, configuring resource recommendations,
+
   or tuning pod CPU and memory requests with CAST AI.
+
   Trigger with phrases like "cast ai workload autoscaler", "cast ai pod sizing",
+
   "cast ai resource recommendations", "cast ai VPA".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Core Workflow: Workload Autoscaler
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-cost-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-cost-tuning
-description: |
-  Maximize Kubernetes cost savings with CAST AI spot strategies and right-sizing.
+description: 'Maximize Kubernetes cost savings with CAST AI spot strategies and right-sizing.
+
   Use when analyzing cloud spend, optimizing spot-to-on-demand ratios,
+
   or configuring CAST AI for maximum savings.
+
   Trigger with phrases like "cast ai cost", "cast ai savings",
+
   "cast ai spot strategy", "reduce kubernetes cost", "cast ai budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-debug-bundle
-description: |
-  Collect CAST AI diagnostic bundle for support tickets and troubleshooting.
+description: 'Collect CAST AI diagnostic bundle for support tickets and troubleshooting.
+
   Use when preparing a support case, collecting agent logs,
+
   or building a diagnostic snapshot of cluster state.
+
   Trigger with phrases like "cast ai debug", "cast ai support bundle",
+
   "collect cast ai diagnostics", "cast ai logs".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Bash(tar:*), Bash(helm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-deploy-integration
-description: |
-  Deploy CAST AI across multi-cloud Kubernetes clusters with Terraform modules.
+description: 'Deploy CAST AI across multi-cloud Kubernetes clusters with Terraform
+  modules.
+
   Use when onboarding EKS, GKE, or AKS clusters to CAST AI using
+
   infrastructure-as-code patterns.
+
   Trigger with phrases like "deploy cast ai", "cast ai eks",
+
   "cast ai gke", "cast ai aks", "cast ai terraform module".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(terraform:*), Bash(helm:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-hello-world/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-hello-world
-description: |
-  Query CAST AI cluster savings report and node inventory.
+description: 'Query CAST AI cluster savings report and node inventory.
+
   Use when verifying CAST AI connectivity, viewing cluster cost savings,
+
   or listing managed nodes after onboarding.
+
   Trigger with phrases like "cast ai hello world", "cast ai savings",
+
   "cast ai cluster status", "test cast ai connection".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Hello World
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-install-auth/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: castai-install-auth
-description: |
-  Install and configure CAST AI agent on a Kubernetes cluster with API key authentication.
+description: 'Install and configure CAST AI agent on a Kubernetes cluster with API
+  key authentication.
+
   Use when onboarding a cluster to CAST AI, setting up Helm charts,
+
   or configuring Terraform provider authentication.
+
   Trigger with phrases like "install cast ai", "connect cluster to cast ai",
+
   "cast ai setup", "cast ai api key", "cast ai helm install".
-allowed-tools: Read, Write, Edit, Bash(helm:*), Bash(kubectl:*), Bash(terraform:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(helm:*), Bash(kubectl:*), Bash(terraform:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-local-dev-loop
-description: |
-  Set up a local Kubernetes development loop with CAST AI cost monitoring.
+description: 'Set up a local Kubernetes development loop with CAST AI cost monitoring.
+
   Use when building cost-aware deployments, testing autoscaler policies,
+
   or iterating on Terraform CAST AI configurations locally.
+
   Trigger with phrases like "cast ai dev setup", "cast ai local testing",
+
   "develop with cast ai", "cast ai terraform dev".
-allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(helm:*), Bash(terraform:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(helm:*), Bash(terraform:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-performance-tuning
-description: |
-  Optimize CAST AI autoscaler performance, node provisioning speed, and API efficiency.
+description: 'Optimize CAST AI autoscaler performance, node provisioning speed, and
+  API efficiency.
+
   Use when nodes take too long to provision, autoscaler is not reacting fast enough,
+
   or optimizing API call patterns for multi-cluster dashboards.
+
   Trigger with phrases like "cast ai performance", "cast ai slow",
+
   "cast ai node provisioning", "cast ai autoscaler speed".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-prod-checklist
-description: |
-  Production readiness checklist for CAST AI cluster onboarding.
+description: 'Production readiness checklist for CAST AI cluster onboarding.
+
   Use when going live with CAST AI autoscaling, validating Phase 2 setup,
+
   or preparing for production cost optimization.
+
   Trigger with phrases like "cast ai production", "cast ai go-live",
+
   "cast ai checklist", "cast ai launch".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Bash(helm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-rate-limits/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-rate-limits
-description: |
-  Handle CAST AI API rate limits with backoff and request queuing.
+description: 'Handle CAST AI API rate limits with backoff and request queuing.
+
   Use when hitting 429 errors, optimizing API call patterns,
+
   or implementing rate-aware batch operations.
+
   Trigger with phrases like "cast ai rate limit", "cast ai 429",
+
   "cast ai throttle", "cast ai API limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-reference-architecture
-description: |
-  CAST AI reference architecture for multi-cluster Kubernetes cost optimization.
+description: 'CAST AI reference architecture for multi-cluster Kubernetes cost optimization.
+
   Use when designing CAST AI deployment across environments, planning
+
   Terraform module structure, or establishing team standards.
+
   Trigger with phrases like "cast ai architecture", "cast ai best practices",
+
   "cast ai multi-cluster", "cast ai terraform structure".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-sdk-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-sdk-patterns
-description: |
-  Production-ready CAST AI REST API wrapper patterns in TypeScript and Python.
+description: 'Production-ready CAST AI REST API wrapper patterns in TypeScript and
+  Python.
+
   Use when building reusable CAST AI clients, implementing retry logic,
+
   or wrapping the CAST AI API for team use.
+
   Trigger with phrases like "cast ai API patterns", "cast ai client wrapper",
+
   "cast ai TypeScript", "cast ai Python client".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-security-basics/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-security-basics
-description: |
-  Secure CAST AI API keys, RBAC configuration, and Kvisor security agent.
+description: 'Secure CAST AI API keys, RBAC configuration, and Kvisor security agent.
+
   Use when hardening CAST AI cluster access, configuring security scanning,
+
   or implementing API key rotation procedures.
+
   Trigger with phrases like "cast ai security", "cast ai api key rotation",
+
   "cast ai rbac", "cast ai kvisor", "secure cast ai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(kubectl:*), Bash(helm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Security Basics
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: castai-upgrade-migration
-description: |
-  Upgrade CAST AI Helm charts, Terraform provider, and agent components.
+description: 'Upgrade CAST AI Helm charts, Terraform provider, and agent components.
+
   Use when upgrading CAST AI versions, checking for breaking changes,
+
   or migrating between CAST AI agent releases.
+
   Trigger with phrases like "upgrade cast ai", "update cast ai agent",
+
   "cast ai helm upgrade", "cast ai terraform upgrade".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(helm:*), Bash(terraform:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/castai-pack/skills/castai-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/castai-pack/skills/castai-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: castai-webhooks-events
-description: |
-  Configure CAST AI webhook notifications for cluster events and audit logs.
+description: 'Configure CAST AI webhook notifications for cluster events and audit
+  logs.
+
   Use when setting up alerts for node scaling, cost threshold events,
+
   or integrating CAST AI events with Slack, PagerDuty, or custom endpoints.
+
   Trigger with phrases like "cast ai webhooks", "cast ai notifications",
+
   "cast ai slack alerts", "cast ai events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, kubernetes, cost-optimization, castai]
-compatible-with: claude-code
+tags:
+- saas
+- kubernetes
+- cost-optimization
+- castai
+compatibility: Designed for Claude Code
 ---
-
 # CAST AI Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-ci-integration
-description: |
-  Integrate Clari export pipeline testing and validation into CI/CD.
+description: 'Integrate Clari export pipeline testing and validation into CI/CD.
+
   Use when adding automated tests for Clari integrations,
+
   validating export schemas in CI, or testing pipeline reliability.
+
   Trigger with phrases like "clari CI", "clari github actions",
+
   "clari automated tests", "test clari pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari CI Integration
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-common-errors/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clari-common-errors
-description: |
-  Diagnose and fix Clari API errors including auth failures, export issues, and data mismatches.
+description: 'Diagnose and fix Clari API errors including auth failures, export issues,
+  and data mismatches.
+
   Use when Clari API calls fail, exports return empty data,
+
   or forecast numbers do not match the UI.
+
   Trigger with phrases like "clari error", "clari not working",
+
   "clari api failure", "fix clari", "debug clari".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Common Errors
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-core-workflow-a
-description: |
-  Build a Clari forecast export pipeline to your data warehouse.
+description: 'Build a Clari forecast export pipeline to your data warehouse.
+
   Use when exporting forecast calls, quota data, and CRM totals
+
   from Clari to Snowflake, BigQuery, or a local database.
+
   Trigger with phrases like "clari forecast export", "clari data pipeline",
+
   "clari to snowflake", "clari to bigquery", "export clari data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Core Workflow: Forecast Export Pipeline
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-core-workflow-b/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: clari-core-workflow-b
-description: |
-  Build Clari revenue analytics: pipeline coverage, forecast accuracy,
+description: 'Build Clari revenue analytics: pipeline coverage, forecast accuracy,
+
   and rep performance dashboards from exported data.
+
   Use when analyzing forecast accuracy, building attainment reports,
+
   or creating executive revenue dashboards.
+
   Trigger with phrases like "clari analytics", "clari dashboard",
+
   "clari forecast accuracy", "clari pipeline coverage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Core Workflow: Revenue Analytics
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-cost-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-cost-tuning
-description: |
-  Optimize Clari API usage and integration costs.
+description: 'Optimize Clari API usage and integration costs.
+
   Use when reducing API call volume, optimizing export frequency,
+
   or evaluating Clari license utilization.
+
   Trigger with phrases like "clari cost", "clari api usage",
+
   "reduce clari calls", "clari optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-debug-bundle
-description: |
-  Collect Clari API diagnostic info for support cases.
+description: 'Collect Clari API diagnostic info for support cases.
+
   Use when preparing a support ticket, collecting API response samples,
+
   or documenting integration issues.
+
   Trigger with phrases like "clari debug", "clari support bundle",
+
   "collect clari diagnostics", "clari troubleshoot".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clari-deploy-integration
-description: |
-  Deploy Clari export pipelines to production with Airflow, Cloud Functions, or Lambda.
+description: 'Deploy Clari export pipelines to production with Airflow, Cloud Functions,
+  or Lambda.
+
   Use when scheduling automated exports, deploying to cloud platforms,
+
   or setting up serverless Clari sync.
+
   Trigger with phrases like "deploy clari", "clari airflow",
+
   "clari lambda", "clari cloud function", "clari scheduled export".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(aws:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-hello-world/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-hello-world
-description: |
-  Export your first Clari forecast and pipeline snapshot.
+description: 'Export your first Clari forecast and pipeline snapshot.
+
   Use when testing Clari API connectivity, pulling forecast data,
+
   or learning the export API structure.
+
   Trigger with phrases like "clari hello world", "clari first export",
+
   "clari test api", "clari forecast export".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Hello World
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-install-auth/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-install-auth
-description: |
-  Configure Clari API authentication with API key and set up export access.
+description: 'Configure Clari API authentication with API key and set up export access.
+
   Use when connecting to the Clari API, generating API tokens,
+
   or configuring forecast data exports.
+
   Trigger with phrases like "install clari", "setup clari api",
+
   "clari auth", "clari api key", "configure clari".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-local-dev-loop
-description: |
-  Set up local development for Clari API integrations with mock data.
+description: 'Set up local development for Clari API integrations with mock data.
+
   Use when building forecast dashboards, testing export pipelines,
+
   or iterating on Clari data transformations locally.
+
   Trigger with phrases like "clari dev setup", "clari local testing",
+
   "develop with clari", "clari mock data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clari-performance-tuning
-description: |
-  Optimize Clari API performance with caching, batch exports, and data pipeline efficiency.
+description: 'Optimize Clari API performance with caching, batch exports, and data
+  pipeline efficiency.
+
   Use when exports take too long, optimizing data warehouse load times,
+
   or reducing API calls in multi-forecast environments.
+
   Trigger with phrases like "clari performance", "clari slow export",
+
   "optimize clari pipeline", "clari caching".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-prod-checklist
-description: |
-  Production readiness checklist for Clari API integrations.
+description: 'Production readiness checklist for Clari API integrations.
+
   Use when launching a Clari data pipeline, validating export automation,
+
   or preparing for production forecast sync.
+
   Trigger with phrases like "clari production", "clari go-live",
+
   "clari checklist", "clari launch".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-rate-limits/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-rate-limits
-description: |
-  Handle Clari API rate limits with backoff and export job scheduling.
+description: 'Handle Clari API rate limits with backoff and export job scheduling.
+
   Use when hitting 429 errors, optimizing export frequency,
+
   or scheduling bulk forecast exports.
+
   Trigger with phrases like "clari rate limit", "clari 429",
+
   "clari throttle", "clari api limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-reference-architecture
-description: |
-  Reference architecture for Clari revenue intelligence integrations.
+description: 'Reference architecture for Clari revenue intelligence integrations.
+
   Use when designing a forecast data platform, planning Clari integration
+
   architecture, or establishing team patterns for revenue analytics.
+
   Trigger with phrases like "clari architecture", "clari data platform",
+
   "clari integration design", "clari best practices".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-sdk-patterns
-description: |
-  Production-ready Clari API client patterns in Python and TypeScript.
+description: 'Production-ready Clari API client patterns in Python and TypeScript.
+
   Use when building reusable Clari clients, implementing export pipelines,
+
   or wrapping the Clari v4 API for team use.
+
   Trigger with phrases like "clari API patterns", "clari client wrapper",
+
   "clari Python client", "clari TypeScript client".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-security-basics/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-security-basics
-description: |
-  Secure Clari API tokens and implement data handling best practices.
+description: 'Secure Clari API tokens and implement data handling best practices.
+
   Use when managing API tokens, restricting data access,
+
   or implementing PII handling for exported forecast data.
+
   Trigger with phrases like "clari security", "clari api key rotation",
+
   "secure clari", "clari pii handling".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Security Basics
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-upgrade-migration
-description: |
-  Handle Clari API version changes and export schema migrations.
+description: 'Handle Clari API version changes and export schema migrations.
+
   Use when Clari updates their API, export format changes,
+
   or migrating from v3 to v4 API.
+
   Trigger with phrases like "upgrade clari", "clari api migration",
+
   "clari schema change", "clari v4 migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/clari-pack/skills/clari-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clari-pack/skills/clari-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clari-webhooks-events
-description: |
-  Monitor Clari forecast changes using export job polling and change detection.
+description: 'Monitor Clari forecast changes using export job polling and change detection.
+
   Use when tracking forecast submission changes, building alerts
+
   for significant forecast movements, or syncing Clari data in near-real-time.
+
   Trigger with phrases like "clari webhooks", "clari notifications",
+
   "clari forecast alerts", "clari change detection".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, revenue-intelligence, forecasting, clari]
-compatible-with: claude-code
+tags:
+- saas
+- revenue-intelligence
+- forecasting
+- clari
+compatibility: Designed for Claude Code
 ---
-
 # Clari Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-advanced-troubleshooting
-description: |
-  Debug complex Claude issues — inconsistent outputs, tool use failures,
-  Use when working with advanced-troubleshooting patterns.
-  streaming problems, and edge cases.
-  Trigger with "claude inconsistent", "anthropic advanced debug",
-  "claude tool use broken", "anthropic streaming issues".
+description: "Debug complex Claude issues \u2014 inconsistent outputs, tool use failures,\n\
+  Use when working with advanced-troubleshooting patterns.\nstreaming problems, and\
+  \ edge cases.\nTrigger with \"claude inconsistent\", \"anthropic advanced debug\"\
+  ,\n\"claude tool use broken\", \"anthropic streaming issues\".\n"
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, debugging, advanced]
+tags:
+- saas
+- anthropic
+- claude
+- debugging
+- advanced
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-architecture-variants/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: clade-architecture-variants
-description: |
-  Build different types of Claude-powered applications — chatbots, RAG systems,
-  Use when working with architecture-variants patterns.
-  agents, content pipelines, and code generation tools.
-  Trigger with "claude architecture", "anthropic rag", "build with claude",
-  "claude agent pattern", "anthropic app design".
+description: "Build different types of Claude-powered applications \u2014 chatbots,\
+  \ RAG systems,\nUse when working with architecture-variants patterns.\nagents, content\
+  \ pipelines, and code generation tools.\nTrigger with \"claude architecture\", \"\
+  anthropic rag\", \"build with claude\",\n\"claude agent pattern\", \"anthropic app\
+  \ design\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, architecture, rag, agents]
+tags:
+- saas
+- anthropic
+- claude
+- architecture
+- rag
+- agents
+compatibility: Designed for Claude Code
 ---
-
 # Claude Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-ci-integration/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-ci-integration/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-ci-integration
-description: |
-  Test and validate Claude integrations in CI/CD pipelines —
-  Use when working with ci-integration patterns.
-  GitHub Actions, mocking strategies, and cost control.
-  Trigger with "anthropic ci", "test claude in ci", "anthropic github actions",
-  "claude automated testing".
+description: "Test and validate Claude integrations in CI/CD pipelines \u2014\nUse\
+  \ when working with ci-integration patterns.\nGitHub Actions, mocking strategies,\
+  \ and cost control.\nTrigger with \"anthropic ci\", \"test claude in ci\", \"anthropic\
+  \ github actions\",\n\"claude automated testing\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, ci, testing]
+tags:
+- saas
+- anthropic
+- claude
+- ci
+- testing
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic CI Integration
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-common-errors/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-common-errors/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-common-errors
-description: |
-  Diagnose and fix Anthropic API errors — authentication, rate limits,
-  Use when working with common-errors patterns.
-  overloaded, context length, and content policy issues.
-  Trigger with "anthropic error", "claude 429", "claude overloaded",
-  "anthropic not working", "debug claude api".
+description: "Diagnose and fix Anthropic API errors \u2014 authentication, rate limits,\n\
+  Use when working with common-errors patterns.\noverloaded, context length, and content\
+  \ policy issues.\nTrigger with \"anthropic error\", \"claude 429\", \"claude overloaded\"\
+  ,\n\"anthropic not working\", \"debug claude api\".\n"
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, errors, debugging]
+tags:
+- saas
+- anthropic
+- claude
+- errors
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Common Errors
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-core-workflow-a/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clade-core-workflow-a
-description: |
-  Redirect to claude-model-inference for Messages API streaming,
+description: 'Redirect to claude-model-inference for Messages API streaming,
+
   vision, and structured output patterns.
+
   Use when looking for the primary Anthropic workflow.
+
   Trigger with "anthropic workflow", "claude main workflow".
+
+  '
 allowed-tools: Read
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude]
+tags:
+- saas
+- anthropic
+- claude
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Core Workflow A → Model Inference
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-core-workflow-b/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: clade-core-workflow-b
-description: |
-  Redirect to claude-embeddings-search for tool use (function calling)
+description: 'Redirect to claude-embeddings-search for tool use (function calling)
+
   and agentic loop patterns with Claude.
+
   Use when looking for the secondary Anthropic workflow.
+
   Trigger with "anthropic tools", "claude function calling".
+
+  '
 allowed-tools: Read
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude]
+tags:
+- saas
+- anthropic
+- claude
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Core Workflow B → Tool Use
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-cost-tuning/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-cost-tuning
-description: |
-  Optimize Anthropic API costs — model selection, prompt caching, batches,
-  Use when working with cost-tuning patterns.
-  token reduction, and usage monitoring.
-  Trigger with "anthropic pricing", "claude cost", "reduce anthropic spend",
-  "anthropic billing", "claude cheaper".
+description: "Optimize Anthropic API costs \u2014 model selection, prompt caching,\
+  \ batches,\nUse when working with cost-tuning patterns.\ntoken reduction, and usage\
+  \ monitoring.\nTrigger with \"anthropic pricing\", \"claude cost\", \"reduce anthropic\
+  \ spend\",\n\"anthropic billing\", \"claude cheaper\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, cost, pricing]
+tags:
+- saas
+- anthropic
+- claude
+- cost
+- pricing
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-data-handling/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-data-handling/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: clade-data-handling
-description: |
-  Handle sensitive data with Claude — PII redaction, conversation management,
-  Use when working with data-handling patterns.
-  context window optimization, and data retention policies.
-  Trigger with "anthropic data privacy", "claude pii", "anthropic context window",
-  "manage claude conversations", "anthropic data retention".
+description: "Handle sensitive data with Claude \u2014 PII redaction, conversation\
+  \ management,\nUse when working with data-handling patterns.\ncontext window optimization,\
+  \ and data retention policies.\nTrigger with \"anthropic data privacy\", \"claude\
+  \ pii\", \"anthropic context window\",\n\"manage claude conversations\", \"anthropic\
+  \ data retention\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, data, privacy, context]
+tags:
+- saas
+- anthropic
+- claude
+- data
+- privacy
+- context
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Data Handling
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-debug-bundle/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: clade-debug-bundle
-description: |
-  Collect debug evidence for Anthropic API issues — request IDs, headers,
-  Use when working with debug-bundle patterns.
-  error payloads, and reproduction steps for support tickets.
-  Trigger with "anthropic debug", "claude support ticket", "anthropic request id",
-  "debug claude api call".
+description: "Collect debug evidence for Anthropic API issues \u2014 request IDs,\
+  \ headers,\nUse when working with debug-bundle patterns.\nerror payloads, and reproduction\
+  \ steps for support tickets.\nTrigger with \"anthropic debug\", \"claude support\
+  \ ticket\", \"anthropic request id\",\n\"debug claude api call\".\n"
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, debugging]
+tags:
+- saas
+- anthropic
+- claude
+- debugging
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clade-deploy-integration
-description: |
-  Deploy Claude-powered applications to Vercel, Fly.io, and Cloud Run
+description: 'Deploy Claude-powered applications to Vercel, Fly.io, and Cloud Run
+
   Use when working with deploy-integration patterns.
+
   with proper secrets management and streaming support.
+
   Trigger with "deploy anthropic", "claude production deploy",
+
   "anthropic vercel", "deploy claude app".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, deploy, production]
+tags:
+- saas
+- anthropic
+- claude
+- deploy
+- production
+compatibility: Designed for Claude Code
 ---
-
 # Deploy Anthropic Integration
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-embeddings-search/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-embeddings-search/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: clade-embeddings-search
-description: |
-  Implement tool use (function calling) with Claude to let it execute actions,
+description: 'Implement tool use (function calling) with Claude to let it execute
+  actions,
+
   Use when working with embeddings-search patterns.
+
   query databases, call APIs, and interact with external systems.
+
   Trigger with "anthropic tool use", "claude function calling", "claude tools",
+
   "anthropic structured output with tools".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, tool-use, function-calling]
+tags:
+- saas
+- anthropic
+- claude
+- tool-use
+- function-calling
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Tool Use (Function Calling)
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-enterprise-rbac/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clade-enterprise-rbac
-description: |
-  Manage Anthropic workspaces, API keys, team access, and spending limits
+description: 'Manage Anthropic workspaces, API keys, team access, and spending limits
+
   Use when working with enterprise-rbac patterns.
+
   for enterprise Claude deployments.
+
   Trigger with "anthropic workspace", "anthropic team management",
+
   "claude enterprise", "anthropic api key management".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, enterprise, rbac]
+tags:
+- saas
+- anthropic
+- claude
+- enterprise
+- rbac
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Enterprise & Access Management
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-hello-world/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clade-hello-world
-description: |
-  Send your first message to Claude using the Anthropic SDK.
+description: 'Send your first message to Claude using the Anthropic SDK.
+
   Use when starting a new Claude integration, testing your setup,
+
   or learning the Messages API basics.
+
   Trigger with phrases like "anthropic hello world", "claude api example",
+
   "first claude call", "anthropic quick start".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, messages-api]
+tags:
+- saas
+- anthropic
+- claude
+- messages-api
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Hello World
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-incident-runbook/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-incident-runbook
-description: |
-  Respond to Anthropic API incidents — outages, degraded performance,
-  Use when working with incident-runbook patterns.
-  error spikes, and rate limit issues in production.
-  Trigger with "anthropic down", "claude outage", "anthropic incident",
-  "claude not responding", "anthropic 529".
+description: "Respond to Anthropic API incidents \u2014 outages, degraded performance,\n\
+  Use when working with incident-runbook patterns.\nerror spikes, and rate limit issues\
+  \ in production.\nTrigger with \"anthropic down\", \"claude outage\", \"anthropic\
+  \ incident\",\n\"claude not responding\", \"anthropic 529\".\n"
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, incident, runbook]
+tags:
+- saas
+- anthropic
+- claude
+- incident
+- runbook
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-install-auth/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: clade-install-auth
-description: |
-  Install and configure the Anthropic SDK for Claude API access.
+description: 'Install and configure the Anthropic SDK for Claude API access.
+
   Use when setting up Claude integration, configuring API keys,
+
   or initializing the Anthropic client in your project.
+
   Trigger with phrases like "install anthropic", "setup claude api",
+
   "anthropic auth", "configure anthropic API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, ai]
+tags:
+- saas
+- anthropic
+- claude
+- ai
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-known-pitfalls/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: clade-known-pitfalls
-description: |
-  Common mistakes when building with the Anthropic API and how to avoid them.
+description: 'Common mistakes when building with the Anthropic API and how to avoid
+  them.
+
   Use when working with known-pitfalls patterns.
+
   Trigger with "anthropic mistakes", "claude pitfalls", "anthropic gotchas",
+
   "common claude errors", "anthropic anti-patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, pitfalls, best-practices]
+tags:
+- saas
+- anthropic
+- claude
+- pitfalls
+- best-practices
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-load-scale/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-load-scale/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-load-scale
-description: |
-  Scale Claude usage for high-throughput applications — batches, queues,
-  Use when working with load-scale patterns.
-  concurrency control, and tier upgrades.
-  Trigger with "anthropic scale", "claude high volume", "anthropic throughput",
-  "scale claude api", "anthropic concurrent requests".
+description: "Scale Claude usage for high-throughput applications \u2014 batches,\
+  \ queues,\nUse when working with load-scale patterns.\nconcurrency control, and\
+  \ tier upgrades.\nTrigger with \"anthropic scale\", \"claude high volume\", \"anthropic\
+  \ throughput\",\n\"scale claude api\", \"anthropic concurrent requests\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, scale, throughput]
+tags:
+- saas
+- anthropic
+- claude
+- scale
+- throughput
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-local-dev-loop/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-local-dev-loop
-description: |
-  Set up a fast local development loop for building with the Anthropic API —
-  Use when working with local-dev-loop patterns.
-  hot reload, cost-saving tips, and test patterns.
-  Trigger with "anthropic dev setup", "claude local development",
-  "anthropic test locally", "claude dev workflow".
+description: "Set up a fast local development loop for building with the Anthropic\
+  \ API \u2014\nUse when working with local-dev-loop patterns.\nhot reload, cost-saving\
+  \ tips, and test patterns.\nTrigger with \"anthropic dev setup\", \"claude local\
+  \ development\",\n\"anthropic test locally\", \"claude dev workflow\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, development, testing]
+tags:
+- saas
+- anthropic
+- claude
+- development
+- testing
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-migration-deep-dive/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-migration-deep-dive
-description: |
-  Migrate from OpenAI/GPT to Anthropic/Claude — API differences,
-  Use when working with migration-deep-dive patterns.
-  prompt adaptation, SDK swap, and feature mapping.
-  Trigger with "migrate to claude", "openai to anthropic",
-  "switch from gpt to claude", "replace openai with anthropic".
+description: "Migrate from OpenAI/GPT to Anthropic/Claude \u2014 API differences,\n\
+  Use when working with migration-deep-dive patterns.\nprompt adaptation, SDK swap,\
+  \ and feature mapping.\nTrigger with \"migrate to claude\", \"openai to anthropic\"\
+  ,\n\"switch from gpt to claude\", \"replace openai with anthropic\".\n"
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, migration, openai]
+tags:
+- saas
+- anthropic
+- claude
+- migration
+- openai
+compatibility: Designed for Claude Code
 ---
-
 # Migrate from OpenAI to Anthropic
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-model-inference/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-model-inference/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clade-model-inference
-description: |
-  Stream Claude responses, use system prompts, handle multi-turn conversations,
+description: 'Stream Claude responses, use system prompts, handle multi-turn conversations,
+
   Use when working with model-inference patterns.
+
   and process structured output with the Messages API.
+
   Trigger with "anthropic streaming", "claude messages api", "claude inference",
+
   "stream claude response".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, streaming, messages-api]
+tags:
+- saas
+- anthropic
+- claude
+- streaming
+- messages-api
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Messages API — Streaming & Advanced Patterns
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-multi-env-setup/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: clade-multi-env-setup
-description: |
-  Configure Claude across dev, staging, and production with different
+description: 'Configure Claude across dev, staging, and production with different
+
   Use when working with multi-env-setup patterns.
+
   models, keys, and rate limits per environment.
+
   Trigger with "anthropic environments", "claude staging",
+
   "anthropic dev vs prod", "claude multi-environment".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, environments, config]
+tags:
+- saas
+- anthropic
+- claude
+- environments
+- config
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-observability/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-observability/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-observability
-description: |
-  Monitor Claude API calls — log tokens, latency, costs, errors, and
-  Use when working with observability patterns.
-  set up alerts for production Claude integrations.
-  Trigger with "anthropic monitoring", "claude observability",
-  "track claude usage", "anthropic logging".
+description: "Monitor Claude API calls \u2014 log tokens, latency, costs, errors,\
+  \ and\nUse when working with observability patterns.\nset up alerts for production\
+  \ Claude integrations.\nTrigger with \"anthropic monitoring\", \"claude observability\"\
+  ,\n\"track claude usage\", \"anthropic logging\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, monitoring, observability]
+tags:
+- saas
+- anthropic
+- claude
+- monitoring
+- observability
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Observability
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-performance-tuning/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-performance-tuning
-description: |
-  Optimize Anthropic API latency — streaming, prompt caching, model selection,
-  Use when working with performance-tuning patterns.
-  connection reuse, and parallel requests.
-  Trigger with "anthropic slow", "claude latency", "speed up anthropic",
-  "anthropic performance", "claude response time".
+description: "Optimize Anthropic API latency \u2014 streaming, prompt caching, model\
+  \ selection,\nUse when working with performance-tuning patterns.\nconnection reuse,\
+  \ and parallel requests.\nTrigger with \"anthropic slow\", \"claude latency\", \"\
+  speed up anthropic\",\n\"anthropic performance\", \"claude response time\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, performance, latency]
+tags:
+- saas
+- anthropic
+- claude
+- performance
+- latency
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-policy-guardrails/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: clade-policy-guardrails
-description: |
-  Implement content safety guardrails for Claude — input filtering,
-  Use when working with policy-guardrails patterns.
-  output validation, usage policies, and prompt injection defense.
-  Trigger with "anthropic content policy", "claude safety", "claude guardrails",
-  "anthropic prompt injection", "claude content filtering".
+description: "Implement content safety guardrails for Claude \u2014 input filtering,\n\
+  Use when working with policy-guardrails patterns.\noutput validation, usage policies,\
+  \ and prompt injection defense.\nTrigger with \"anthropic content policy\", \"claude\
+  \ safety\", \"claude guardrails\",\n\"anthropic prompt injection\", \"claude content\
+  \ filtering\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, safety, guardrails]
+tags:
+- saas
+- anthropic
+- claude
+- safety
+- guardrails
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-prod-checklist/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-prod-checklist
-description: |
-  Production readiness checklist for Claude-powered applications —
-  Use when working with prod-checklist patterns.
-  error handling, monitoring, fallbacks, cost controls, and security.
-  Trigger with "anthropic production", "claude production ready",
-  "anthropic launch checklist", "go live with claude".
+description: "Production readiness checklist for Claude-powered applications \u2014\
+  \nUse when working with prod-checklist patterns.\nerror handling, monitoring, fallbacks,\
+  \ cost controls, and security.\nTrigger with \"anthropic production\", \"claude\
+  \ production ready\",\n\"anthropic launch checklist\", \"go live with claude\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, production, checklist]
+tags:
+- saas
+- anthropic
+- claude
+- production
+- checklist
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-rate-limits/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-rate-limits/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: clade-rate-limits
-description: |
-  Handle Anthropic rate limits — understand tiers, implement backoff,
-  Use when working with rate-limits patterns.
-  optimize throughput, and monitor usage.
-  Trigger with "anthropic rate limit", "claude 429", "anthropic throttling",
-  "anthropic usage limits", "claude tokens per minute".
+description: "Handle Anthropic rate limits \u2014 understand tiers, implement backoff,\n\
+  Use when working with rate-limits patterns.\noptimize throughput, and monitor usage.\n\
+  Trigger with \"anthropic rate limit\", \"claude 429\", \"anthropic throttling\"\
+  ,\n\"anthropic usage limits\", \"claude tokens per minute\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, rate-limits]
+tags:
+- saas
+- anthropic
+- claude
+- rate-limits
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-reference-architecture/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: clade-reference-architecture
-description: |
-  Build Claude Code plugins — skills, agents, MCP servers, hooks, and slash commands.
-  Use when working with reference-architecture patterns.
-  The complete guide to extending Claude Code with the Anthropic plugin system.
-  Trigger with "claude code plugin", "build a skill", "create mcp server",
-  "anthropic plugin architecture", "claude code hooks".
+description: "Build Claude Code plugins \u2014 skills, agents, MCP servers, hooks,\
+  \ and slash commands.\nUse when working with reference-architecture patterns.\n\
+  The complete guide to extending Claude Code with the Anthropic plugin system.\n\
+  Trigger with \"claude code plugin\", \"build a skill\", \"create mcp server\",\n\
+  \"anthropic plugin architecture\", \"claude code hooks\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude-code, plugins, skills, mcp]
+tags:
+- saas
+- anthropic
+- claude-code
+- plugins
+- skills
+- mcp
+compatibility: Designed for Claude Code
 ---
-
 # Claude Code Plugin Architecture
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-reliability-patterns/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: clade-reliability-patterns
-description: |
-  Build fault-tolerant Claude integrations — retries, circuit breakers,
-  Use when working with reliability-patterns patterns.
-  fallbacks, timeouts, and graceful degradation.
-  Trigger with "anthropic reliability", "claude fault tolerance",
-  "anthropic circuit breaker", "claude fallback".
+description: "Build fault-tolerant Claude integrations \u2014 retries, circuit breakers,\n\
+  Use when working with reliability-patterns patterns.\nfallbacks, timeouts, and graceful\
+  \ degradation.\nTrigger with \"anthropic reliability\", \"claude fault tolerance\"\
+  ,\n\"anthropic circuit breaker\", \"claude fallback\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, reliability, resilience]
+tags:
+- saas
+- anthropic
+- claude
+- reliability
+- resilience
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-sdk-patterns/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: clade-sdk-patterns
-description: |
-  Production-ready Anthropic SDK patterns — client config, retries, timeouts,
-  Use when working with sdk-patterns patterns.
-  error handling, TypeScript types, and async patterns.
-  Trigger with "anthropic sdk", "claude client setup", "anthropic typescript",
-  "anthropic python patterns".
+description: "Production-ready Anthropic SDK patterns \u2014 client config, retries,\
+  \ timeouts,\nUse when working with sdk-patterns patterns.\nerror handling, TypeScript\
+  \ types, and async patterns.\nTrigger with \"anthropic sdk\", \"claude client setup\"\
+  , \"anthropic typescript\",\n\"anthropic python patterns\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, sdk, typescript, python]
+tags:
+- saas
+- anthropic
+- claude
+- sdk
+- typescript
+- python
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-security-basics/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-security-basics/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: clade-security-basics
-description: |
-  Secure your Anthropic integration — API key management, input validation,
-  Use when working with security-basics patterns.
-  prompt injection defense, and data privacy.
-  Trigger with "anthropic security", "claude api key security",
-  "anthropic prompt injection", "secure claude integration".
+description: "Secure your Anthropic integration \u2014 API key management, input validation,\n\
+  Use when working with security-basics patterns.\nprompt injection defense, and data\
+  \ privacy.\nTrigger with \"anthropic security\", \"claude api key security\",\n\"\
+  anthropic prompt injection\", \"secure claude integration\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, security]
+tags:
+- saas
+- anthropic
+- claude
+- security
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Security Basics
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-upgrade-migration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: clade-upgrade-migration
-description: |
-  Upgrade Anthropic SDK versions and migrate between Claude model generations.
+description: 'Upgrade Anthropic SDK versions and migrate between Claude model generations.
+
   Use when working with upgrade-migration patterns.
+
   Trigger with "upgrade anthropic sdk", "migrate claude model",
+
   "anthropic breaking changes", "new claude model".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, migration, upgrade]
+tags:
+- saas
+- anthropic
+- claude
+- migration
+- upgrade
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/claude-pack/skills/clade-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/claude-pack/skills/clade-webhooks-events/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: clade-webhooks-events
-description: |
-  Use Anthropic Message Batches for async bulk processing and event handling.
+description: 'Use Anthropic Message Batches for async bulk processing and event handling.
+
   Use when working with webhooks-events patterns.
+
   Trigger with "anthropic batches", "claude batch api", "anthropic async",
+
   "bulk claude processing", "anthropic webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, anthropic, claude, batches, async]
+tags:
+- saas
+- anthropic
+- claude
+- batches
+- async
+compatibility: Designed for Claude Code
 ---
-
 # Anthropic Message Batches & Async Processing
 
 ## Overview

--- a/plugins/saas-packs/clay-pack/skills/clay-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-advanced-troubleshooting
-description: |
-  Deep-debug complex Clay enrichment failures, provider degradation, and data flow issues.
+description: 'Deep-debug complex Clay enrichment failures, provider degradation, and
+  data flow issues.
+
   Use when standard troubleshooting fails, investigating intermittent enrichment failures,
+
   or preparing detailed evidence for Clay support escalation.
+
   Trigger with phrases like "clay hard bug", "clay mystery error",
+
   "clay impossible to debug", "difficult clay issue", "clay deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, debugging, scaling]
+tags:
+- saas
+- clay
+- debugging
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Advanced Troubleshooting
 

--- a/plugins/saas-packs/clay-pack/skills/clay-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-architecture-variants/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-architecture-variants
-description: |
-  Choose and implement Clay integration architecture for different scales and use cases.
+description: 'Choose and implement Clay integration architecture for different scales
+  and use cases.
+
   Use when designing new Clay integrations, comparing direct vs queue-based vs event-driven,
+
   or planning architecture for Clay-powered data operations.
+
   Trigger with phrases like "clay architecture", "clay blueprint",
+
   "how to structure clay", "clay integration design", "clay event-driven".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, migration, scaling]
+tags:
+- saas
+- clay
+- migration
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Architecture Variants
 

--- a/plugins/saas-packs/clay-pack/skills/clay-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-ci-integration
-description: |
-  Configure CI/CD pipelines for Clay integrations with automated testing and validation.
+description: 'Configure CI/CD pipelines for Clay integrations with automated testing
+  and validation.
+
   Use when setting up automated tests for Clay webhook handlers, validating
+
   enrichment data quality in CI, or integrating Clay checks into your build process.
+
   Trigger with phrases like "clay CI", "clay GitHub Actions",
+
   "clay automated tests", "CI clay", "test clay integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, testing, ci-cd]
+tags:
+- saas
+- clay
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay CI Integration
 

--- a/plugins/saas-packs/clay-pack/skills/clay-common-errors/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clay-common-errors
-description: |
-  Diagnose and fix the most common Clay errors and integration issues.
+description: 'Diagnose and fix the most common Clay errors and integration issues.
+
   Use when encountering Clay errors, debugging failed enrichments,
+
   or troubleshooting webhook delivery problems.
+
   Trigger with phrases like "clay error", "fix clay", "clay not working",
+
   "debug clay", "clay enrichment failed", "clay webhook error".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, debugging]
+tags:
+- saas
+- clay
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Common Errors
 

--- a/plugins/saas-packs/clay-pack/skills/clay-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-core-workflow-a
-description: |
-  Build a complete lead enrichment pipeline using Clay tables, webhooks, and waterfall enrichment.
+description: 'Build a complete lead enrichment pipeline using Clay tables, webhooks,
+  and waterfall enrichment.
+
   Use when building lead generation features, enriching prospect lists,
+
   or creating automated data enrichment workflows.
+
   Trigger with phrases like "clay lead enrichment", "clay main workflow",
+
   "enrich contacts in clay", "clay prospect list", "clay enrichment pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, workflow]
+tags:
+- saas
+- clay
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Core Workflow A: Lead Enrichment Pipeline
 

--- a/plugins/saas-packs/clay-pack/skills/clay-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: clay-core-workflow-b
-description: |
-  Use Claygent AI research and AI-powered personalization to generate outreach copy from enriched data.
+description: 'Use Claygent AI research and AI-powered personalization to generate
+  outreach copy from enriched data.
+
   Use when writing personalized email openers, running Claygent research prompts,
+
   or configuring AI columns for campaign personalization at scale.
+
   Trigger with phrases like "clay AI personalization", "claygent research",
+
   "clay outreach copy", "clay secondary workflow", "clay AI column".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, workflow, ai, claygent]
+tags:
+- saas
+- clay
+- workflow
+- ai
+- claygent
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Core Workflow B: Claygent AI Research & Personalization
 

--- a/plugins/saas-packs/clay-pack/skills/clay-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: clay-cost-tuning
-description: |
-  Optimize Clay credit spending with provider key management, waterfall tuning, and budget controls.
+description: 'Optimize Clay credit spending with provider key management, waterfall
+  tuning, and budget controls.
+
   Use when analyzing Clay costs, reducing credit consumption,
+
   or implementing spending alerts and caps.
+
   Trigger with phrases like "clay cost", "clay billing", "reduce clay costs",
+
   "clay pricing", "clay expensive", "clay budget", "clay credits".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, monitoring, cost-optimization]
+tags:
+- saas
+- clay
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Cost Tuning
 

--- a/plugins/saas-packs/clay-pack/skills/clay-data-handling/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clay-data-handling
-description: |
-  Implement GDPR/CCPA-compliant data handling for Clay enrichment pipelines.
+description: 'Implement GDPR/CCPA-compliant data handling for Clay enrichment pipelines.
+
   Use when handling PII from enrichments, implementing data retention policies,
+
   or ensuring regulatory compliance for Clay-enriched lead data.
+
   Trigger with phrases like "clay data", "clay PII", "clay GDPR",
+
   "clay data retention", "clay privacy", "clay CCPA", "clay compliance".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, compliance]
+tags:
+- saas
+- clay
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Data Handling
 

--- a/plugins/saas-packs/clay-pack/skills/clay-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clay-debug-bundle
-description: |
-  Collect Clay debug evidence for support tickets and troubleshooting.
+description: 'Collect Clay debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Clay integration problems.
+
   Trigger with phrases like "clay debug", "clay support bundle",
+
   "collect clay logs", "clay diagnostic", "clay support ticket".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, debugging]
+tags:
+- saas
+- clay
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Debug Bundle
 

--- a/plugins/saas-packs/clay-pack/skills/clay-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-deploy-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-deploy-integration
-description: |
-  Deploy Clay-powered applications to Vercel, Cloud Run, or Docker with proper secrets management.
+description: 'Deploy Clay-powered applications to Vercel, Cloud Run, or Docker with
+  proper secrets management.
+
   Use when deploying Clay webhook receivers, enrichment pipelines,
+
   or CRM sync services to production infrastructure.
+
   Trigger with phrases like "deploy clay", "clay Vercel", "clay production deploy",
+
   "clay Cloud Run", "clay Docker", "host clay integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, deployment]
+tags:
+- saas
+- clay
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Deploy Integration
 

--- a/plugins/saas-packs/clay-pack/skills/clay-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-enterprise-rbac
-description: |
-  Configure Clay workspace roles, team access control, and credit budget allocation.
+description: 'Configure Clay workspace roles, team access control, and credit budget
+  allocation.
+
   Use when managing team access to Clay tables, setting per-user credit budgets,
+
   or configuring workspace-level permissions for Clay.
+
   Trigger with phrases like "clay SSO", "clay RBAC", "clay enterprise",
+
   "clay roles", "clay permissions", "clay team access", "clay workspace".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, rbac]
+tags:
+- saas
+- clay
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Enterprise RBAC
 

--- a/plugins/saas-packs/clay-pack/skills/clay-hello-world/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-hello-world
-description: |
-  Send your first record to Clay and get enriched data back.
+description: 'Send your first record to Clay and get enriched data back.
+
   Use when starting a new Clay integration, testing webhook setup,
+
   or verifying that enrichment columns are working.
+
   Trigger with phrases like "clay hello world", "clay example",
+
   "clay quick start", "first clay enrichment", "test clay webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, testing]
+tags:
+- saas
+- clay
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Hello World
 

--- a/plugins/saas-packs/clay-pack/skills/clay-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-incident-runbook
-description: |
-  Execute Clay incident response procedures for enrichment failures, credit exhaustion, and data flow outages.
+description: 'Execute Clay incident response procedures for enrichment failures, credit
+  exhaustion, and data flow outages.
+
   Use when Clay enrichments stop working, webhook delivery fails,
+
   or CRM sync breaks in production.
+
   Trigger with phrases like "clay incident", "clay outage", "clay down",
+
   "clay emergency", "clay broken", "clay enrichment stopped".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, incident-response]
+tags:
+- saas
+- clay
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Incident Runbook
 

--- a/plugins/saas-packs/clay-pack/skills/clay-install-auth/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-install-auth
-description: |
-  Set up Clay account access, API keys, webhook URLs, and provider connections.
+description: 'Set up Clay account access, API keys, webhook URLs, and provider connections.
+
   Use when onboarding to Clay, connecting data providers, configuring API keys,
+
   or setting up webhook endpoints for programmatic data flow.
+
   Trigger with phrases like "install clay", "setup clay", "clay auth",
+
   "configure clay API key", "connect clay providers".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, authentication]
+tags:
+- saas
+- clay
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Install & Auth
 

--- a/plugins/saas-packs/clay-pack/skills/clay-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-known-pitfalls/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-known-pitfalls
-description: |
-  Identify and avoid the top Clay anti-patterns, gotchas, and integration mistakes.
+description: 'Identify and avoid the top Clay anti-patterns, gotchas, and integration
+  mistakes.
+
   Use when reviewing Clay integrations for issues, onboarding new team members,
+
   or auditing existing Clay table configurations.
+
   Trigger with phrases like "clay mistakes", "clay anti-patterns",
+
   "clay pitfalls", "clay what not to do", "clay gotchas", "clay code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, audit]
+tags:
+- saas
+- clay
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Known Pitfalls
 

--- a/plugins/saas-packs/clay-pack/skills/clay-load-scale/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: clay-load-scale
-description: |
-  Scale Clay enrichment pipelines for high-volume processing (10K-100K+ leads/month).
+description: 'Scale Clay enrichment pipelines for high-volume processing (10K-100K+
+  leads/month).
+
   Use when planning capacity for large enrichment runs, optimizing batch processing,
+
   or designing high-volume Clay architectures.
+
   Trigger with phrases like "clay scale", "clay high volume", "clay large batch",
+
   "clay capacity planning", "clay 100k leads", "clay bulk enrichment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, testing, performance, scaling]
+tags:
+- saas
+- clay
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Load & Scale
 

--- a/plugins/saas-packs/clay-pack/skills/clay-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-local-dev-loop
-description: |
-  Set up a local development loop for building and testing Clay integrations.
+description: 'Set up a local development loop for building and testing Clay integrations.
+
   Use when iterating on Clay webhook handlers, testing enrichment pipelines,
+
   or building scripts that push data into Clay tables.
+
   Trigger with phrases like "clay local dev", "clay development setup",
+
   "clay testing locally", "clay dev workflow", "iterate clay integration".
-allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(python3:*)
+
+  '
+allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Bash(npx:*), Bash(node:*),
+  Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, development, testing]
+tags:
+- saas
+- clay
+- development
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Local Dev Loop
 

--- a/plugins/saas-packs/clay-pack/skills/clay-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-migration-deep-dive
-description: |
-  Migrate to Clay from other enrichment tools or consolidate multiple data sources into Clay.
-  Use when migrating from ZoomInfo, Apollo, Clearbit, or custom enrichment scripts to Clay,
+description: 'Migrate to Clay from other enrichment tools or consolidate multiple
+  data sources into Clay.
+
+  Use when migrating from ZoomInfo, Apollo, Clearbit, or custom enrichment scripts
+  to Clay,
+
   or consolidating fragmented enrichment workflows.
+
   Trigger with phrases like "migrate to clay", "clay migration", "switch to clay",
+
   "replace zoominfo with clay", "consolidate enrichment tools".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, migration]
+tags:
+- saas
+- clay
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Migration Deep Dive
 

--- a/plugins/saas-packs/clay-pack/skills/clay-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-multi-env-setup
-description: |
-  Configure Clay integrations across development, staging, and production environments.
+description: 'Configure Clay integrations across development, staging, and production
+  environments.
+
   Use when setting up per-environment Clay tables, managing webhook URLs per environment,
+
   or implementing environment-specific enrichment configurations.
+
   Trigger with phrases like "clay environments", "clay staging", "clay dev prod",
+
   "clay environment setup", "clay config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, deployment]
+tags:
+- saas
+- clay
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Multi-Environment Setup
 

--- a/plugins/saas-packs/clay-pack/skills/clay-observability/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-observability/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: clay-observability
-description: |
-  Monitor Clay enrichment pipeline health, credit consumption, and data quality metrics.
-  Use when setting up dashboards for Clay operations, configuring alerts for credit burn,
+description: 'Monitor Clay enrichment pipeline health, credit consumption, and data
+  quality metrics.
+
+  Use when setting up dashboards for Clay operations, configuring alerts for credit
+  burn,
+
   or tracking enrichment success rates.
+
   Trigger with phrases like "clay monitoring", "clay metrics", "clay observability",
+
   "monitor clay", "clay alerts", "clay dashboard", "clay credit tracking".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, monitoring, observability, dashboard]
+tags:
+- saas
+- clay
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Observability
 

--- a/plugins/saas-packs/clay-pack/skills/clay-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-performance-tuning
-description: |
-  Optimize Clay table enrichment throughput, reduce processing time, and improve hit rates.
+description: 'Optimize Clay table enrichment throughput, reduce processing time, and
+  improve hit rates.
+
   Use when experiencing slow enrichment, poor email find rates,
+
   or needing to process large tables efficiently.
+
   Trigger with phrases like "clay performance", "optimize clay", "clay slow",
+
   "clay throughput", "clay fast enrichment", "clay batch optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, performance]
+tags:
+- saas
+- clay
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Performance Tuning
 

--- a/plugins/saas-packs/clay-pack/skills/clay-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-policy-guardrails/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-policy-guardrails
-description: |
-  Implement credit spending limits, data privacy enforcement, and input validation guardrails for Clay pipelines.
+description: 'Implement credit spending limits, data privacy enforcement, and input
+  validation guardrails for Clay pipelines.
+
   Use when enforcing spending caps, blocking PII enrichment,
+
   or adding pre-enrichment validation rules.
+
   Trigger with phrases like "clay policy", "clay guardrails", "clay spending limit",
+
   "clay data privacy rules", "clay validation", "clay controls".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, clay-policy]
+tags:
+- saas
+- clay
+- clay-policy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Policy Guardrails
 

--- a/plugins/saas-packs/clay-pack/skills/clay-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clay-prod-checklist
-description: |
-  Execute production readiness checklist for Clay integrations.
+description: 'Execute production readiness checklist for Clay integrations.
+
   Use when launching Clay-powered enrichment pipelines, preparing for go-live,
+
   or auditing production Clay configurations.
+
   Trigger with phrases like "clay production", "clay go-live", "clay launch checklist",
+
   "clay production readiness", "deploy clay pipeline".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, deployment]
+tags:
+- saas
+- clay
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Production Checklist
 

--- a/plugins/saas-packs/clay-pack/skills/clay-rate-limits/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: clay-rate-limits
-description: |
-  Handle Clay rate limits, webhook throttling, and credit pacing strategies.
+description: 'Handle Clay rate limits, webhook throttling, and credit pacing strategies.
+
   Use when hitting 429 errors, managing webhook submission rates,
-  or optimizing throughput within Clay's plan limits.
+
+  or optimizing throughput within Clay''s plan limits.
+
   Trigger with phrases like "clay rate limit", "clay throttling",
+
   "clay 429", "clay slow", "clay records per hour".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api]
+tags:
+- saas
+- clay
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Rate Limits
 

--- a/plugins/saas-packs/clay-pack/skills/clay-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-reference-architecture
-description: |
-  Design production Clay enrichment pipelines with table schemas, waterfall patterns, and CRM sync.
+description: 'Design production Clay enrichment pipelines with table schemas, waterfall
+  patterns, and CRM sync.
+
   Use when architecting new Clay integrations, reviewing data flow design,
+
   or establishing enrichment pipeline standards.
+
   Trigger with phrases like "clay architecture", "clay best practices",
+
   "clay pipeline design", "clay reference", "clay data flow".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, clay-reference]
+tags:
+- saas
+- clay
+- clay-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Reference Architecture
 

--- a/plugins/saas-packs/clay-pack/skills/clay-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-reliability-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-reliability-patterns
-description: |
-  Build fault-tolerant Clay integrations with circuit breakers, dead letter queues, and graceful degradation.
+description: 'Build fault-tolerant Clay integrations with circuit breakers, dead letter
+  queues, and graceful degradation.
+
   Use when building production Clay pipelines that need resilience,
+
   implementing retry strategies, or adding fault tolerance to enrichment workflows.
+
   Trigger with phrases like "clay reliability", "clay circuit breaker", "clay resilience",
+
   "clay fallback", "clay fault tolerance", "clay dead letter queue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, clay-reliability]
+tags:
+- saas
+- clay
+- clay-reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Reliability Patterns
 

--- a/plugins/saas-packs/clay-pack/skills/clay-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: clay-sdk-patterns
-description: |
-  Apply production-ready patterns for integrating with Clay via webhooks and HTTP API.
+description: 'Apply production-ready patterns for integrating with Clay via webhooks
+  and HTTP API.
+
   Use when building Clay integrations, implementing webhook handlers,
+
   or establishing team coding standards for Clay data pipelines.
+
   Trigger with phrases like "clay SDK patterns", "clay best practices",
+
   "clay code patterns", "clay integration patterns", "clay webhook patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, python, typescript]
+tags:
+- saas
+- clay
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Integration Patterns
 

--- a/plugins/saas-packs/clay-pack/skills/clay-security-basics/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: clay-security-basics
-description: |
-  Apply Clay security best practices for API keys, webhook secrets, and data access control.
+description: 'Apply Clay security best practices for API keys, webhook secrets, and
+  data access control.
+
   Use when securing Clay integrations, rotating API keys, auditing access,
+
   or implementing webhook authentication.
+
   Trigger with phrases like "clay security", "clay secrets", "secure clay",
+
   "clay API key security", "clay webhook security".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, security, audit]
+tags:
+- saas
+- clay
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Security Basics
 

--- a/plugins/saas-packs/clay-pack/skills/clay-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-upgrade-migration
-description: |
-  Navigate Clay plan changes, pricing migrations, and feature upgrades.
+description: 'Navigate Clay plan changes, pricing migrations, and feature upgrades.
+
   Use when upgrading Clay plans, migrating to the 2026 pricing model,
+
   or adapting integrations to new Clay features.
+
   Trigger with phrases like "upgrade clay", "clay migration", "clay pricing change",
+
   "clay plan upgrade", "clay new pricing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, api, migration]
+tags:
+- saas
+- clay
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Upgrade & Migration
 

--- a/plugins/saas-packs/clay-pack/skills/clay-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clay-pack/skills/clay-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: clay-webhooks-events
-description: |
-  Implement Clay webhook receivers and HTTP API column callbacks for real-time data flow.
+description: 'Implement Clay webhook receivers and HTTP API column callbacks for real-time
+  data flow.
+
   Use when setting up webhook endpoints, handling enrichment callbacks from Clay,
+
   or building event-driven integrations with Clay tables.
+
   Trigger with phrases like "clay webhook", "clay events", "clay callback",
+
   "handle clay data", "clay notifications", "clay HTTP API column".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, clay, webhooks]
+tags:
+- saas
+- clay
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Clay Webhooks & Events
 


### PR DESCRIPTION
## Summary

Chunk 1 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated `compatible-with` CSV-platform-list field to the spec-aligned `compatibility` free-text field per agentskills.io/specification.

**Pure schema migration. No content changes.** Same tool used in PRs #620 and #622.

### Assigned packs (chunk 1 of 6)

| Pack | Files |
|---|---|
| abridge-pack | 18 |
| adobe-pack | 30 |
| alchemy-pack | 18 |
| algolia-pack | 24 |
| anima-pack | 18 |
| anthropic-pack | 30 |
| apify-pack | 18 |
| apollo-pack | 24 |
| appfolio-pack | 18 |
| apple-notes-pack | 24 |
| assemblyai-pack | 18 |
| attio-pack | 18 |
| bamboohr-pack | 18 |
| brightdata-pack | 18 |
| canva-pack | 30 |
| castai-pack | 18 |
| clari-pack | 18 |
| claude-pack | 32 |
| clay-pack | 30 |
| **TOTAL** | **422** |

### Side effect

`yaml.safe_dump` round-trips the entire frontmatter — so `description: |` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] `grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Refs #613

jeremy made me do it
-claude