### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 3/6, 408 skills)

### DIFF
--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-ci-integration/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: fireflies-ci-integration
-description: |
-  Configure CI/CD pipelines for Fireflies.ai integrations with GraphQL testing.
+description: 'Configure CI/CD pipelines for Fireflies.ai integrations with GraphQL
+  testing.
+
   Use when setting up automated testing, configuring GitHub Actions,
+
   or validating Fireflies.ai queries in your build process.
+
   Trigger with phrases like "fireflies CI", "fireflies GitHub Actions",
+
   "fireflies automated tests", "CI fireflies", "test fireflies pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, testing, ci-cd]
+tags:
+- saas
+- fireflies
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai CI Integration
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-common-errors/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: fireflies-common-errors
-description: |
-  Diagnose and fix Fireflies.ai GraphQL API errors by error code.
+description: 'Diagnose and fix Fireflies.ai GraphQL API errors by error code.
+
   Use when encountering Fireflies.ai errors, debugging failed requests,
+
   or troubleshooting authentication and rate limit issues.
+
   Trigger with phrases like "fireflies error", "fix fireflies",
+
   "fireflies not working", "debug fireflies", "fireflies 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, debugging]
+tags:
+- saas
+- fireflies
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Common Errors
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: fireflies-core-workflow-a
-description: |
-  Retrieve and process Fireflies.ai meeting transcripts with speaker diarization and summaries.
+description: 'Retrieve and process Fireflies.ai meeting transcripts with speaker diarization
+  and summaries.
+
   Use when fetching transcripts, extracting action items,
+
   or building meeting intelligence pipelines.
+
   Trigger with phrases like "fireflies transcript", "get meeting notes",
+
   "fireflies meeting data", "fetch fireflies recording".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, workflow, transcripts]
+tags:
+- saas
+- fireflies
+- workflow
+- transcripts
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Core Workflow A -- Transcript Retrieval & Processing
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: fireflies-core-workflow-b
-description: |
-  Search across Fireflies.ai transcripts, use AskFred AI, and build meeting analytics.
+description: 'Search across Fireflies.ai transcripts, use AskFred AI, and build meeting
+  analytics.
+
   Use when searching meeting history, querying Fred AI assistant,
+
   or aggregating meeting data for reports.
+
   Trigger with phrases like "fireflies search", "ask fred", "fireflies analytics",
+
   "search meetings", "fireflies AskFred".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, workflow, search, analytics]
+tags:
+- saas
+- fireflies
+- workflow
+- search
+- analytics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Core Workflow B -- Search, AskFred & Analytics
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: fireflies-cost-tuning
-description: |
-  Optimize Fireflies.ai subscription costs through seat auditing, selective recording, and plan sizing.
+description: 'Optimize Fireflies.ai subscription costs through seat auditing, selective
+  recording, and plan sizing.
+
   Use when analyzing Fireflies.ai billing, reducing per-seat costs,
+
   or implementing usage monitoring and right-sizing.
+
   Trigger with phrases like "fireflies cost", "fireflies billing",
-  "reduce fireflies costs", "fireflies pricing", "fireflies expensive", "fireflies budget".
+
+  "reduce fireflies costs", "fireflies pricing", "fireflies expensive", "fireflies
+  budget".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, cost-optimization]
+tags:
+- saas
+- fireflies
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Cost Tuning
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-data-handling/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-data-handling/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-data-handling
-description: |
-  Handle Fireflies.ai transcript data: export formats, PII redaction, retention policies, and compliance.
+description: 'Handle Fireflies.ai transcript data: export formats, PII redaction,
+  retention policies, and compliance.
+
   Use when exporting transcripts, implementing data redaction,
+
   configuring retention, or ensuring GDPR/CCPA compliance.
+
   Trigger with phrases like "fireflies data", "fireflies PII",
+
   "fireflies GDPR", "fireflies data retention", "fireflies privacy", "fireflies export".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, compliance]
+tags:
+- saas
+- fireflies
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Data Handling
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: fireflies-debug-bundle
-description: |
-  Collect Fireflies.ai debug evidence for support tickets and troubleshooting.
+description: 'Collect Fireflies.ai debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Fireflies.ai problems.
+
   Trigger with phrases like "fireflies debug", "fireflies support bundle",
+
   "collect fireflies logs", "fireflies diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, debugging]
+tags:
+- saas
+- fireflies
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Debug Bundle
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-deploy-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-deploy-integration
-description: |
-  Deploy Fireflies.ai webhook receivers and GraphQL clients to Vercel, Docker, and Cloud Run.
+description: 'Deploy Fireflies.ai webhook receivers and GraphQL clients to Vercel,
+  Docker, and Cloud Run.
+
   Use when deploying Fireflies.ai-powered applications to production,
+
   configuring platform-specific secrets, or hosting webhook endpoints.
+
   Trigger with phrases like "deploy fireflies", "fireflies Vercel",
+
   "fireflies production deploy", "fireflies Cloud Run", "fireflies Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(docker:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, deployment]
+tags:
+- saas
+- fireflies
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Deploy Integration
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-enterprise-rbac
-description: |
-  Configure Fireflies.ai workspace roles, channels, privacy controls, and meeting sharing.
+description: 'Configure Fireflies.ai workspace roles, channels, privacy controls,
+  and meeting sharing.
+
   Use when managing team access, setting up channels,
+
   or configuring transcript visibility and sharing rules.
+
   Trigger with phrases like "fireflies roles", "fireflies permissions",
+
   "fireflies channels", "fireflies privacy", "fireflies sharing", "fireflies RBAC".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, rbac]
+tags:
+- saas
+- fireflies
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Enterprise RBAC
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-hello-world/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-hello-world
-description: |
-  Create a minimal working Fireflies.ai example that queries transcripts.
+description: 'Create a minimal working Fireflies.ai example that queries transcripts.
+
   Use when starting a new Fireflies.ai integration, testing your setup,
+
   or learning the GraphQL API patterns for meeting data.
+
   Trigger with phrases like "fireflies hello world", "fireflies example",
+
   "fireflies quick start", "simple fireflies code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, testing]
+tags:
+- saas
+- fireflies
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Hello World
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-incident-runbook
-description: |
-  Execute Fireflies.ai incident response with triage, remediation, and postmortem.
+description: 'Execute Fireflies.ai incident response with triage, remediation, and
+  postmortem.
+
   Use when responding to Fireflies.ai API outages, auth failures,
+
   or webhook delivery problems.
+
   Trigger with phrases like "fireflies incident", "fireflies outage",
+
   "fireflies down", "fireflies on-call", "fireflies emergency", "fireflies broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, incident-response]
+tags:
+- saas
+- fireflies
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Incident Runbook
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-install-auth/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-install-auth
-description: |
-  Configure Fireflies.ai GraphQL API authentication and verify connectivity.
+description: 'Configure Fireflies.ai GraphQL API authentication and verify connectivity.
+
   Use when setting up a new Fireflies.ai integration, configuring API keys,
+
   or initializing the GraphQL client for transcript access.
+
   Trigger with phrases like "install fireflies", "setup fireflies",
+
   "fireflies auth", "configure fireflies API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, authentication]
+tags:
+- saas
+- fireflies
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Install & Auth
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-local-dev-loop
-description: |
-  Configure local development workflow for Fireflies.ai GraphQL integrations.
+description: 'Configure local development workflow for Fireflies.ai GraphQL integrations.
+
   Use when setting up a development environment, mocking transcript data,
+
   or establishing a fast iteration cycle with the Fireflies API.
+
   Trigger with phrases like "fireflies dev setup", "fireflies local development",
+
   "fireflies dev environment", "develop with fireflies", "mock fireflies".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, testing, workflow]
+tags:
+- saas
+- fireflies
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Local Dev Loop
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-migration-deep-dive
-description: |
-  Migrate to Fireflies.ai from other meeting transcription platforms or legacy recording systems.
+description: 'Migrate to Fireflies.ai from other meeting transcription platforms or
+  legacy recording systems.
+
   Use when switching from Otter.ai, Rev, or custom transcription to Fireflies,
+
   or importing historical meeting data into the Fireflies ecosystem.
+
   Trigger with phrases like "migrate to fireflies", "switch from otter",
+
   "fireflies migration", "import meetings to fireflies", "fireflies replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, migration]
+tags:
+- saas
+- fireflies
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Migration Deep Dive
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-multi-env-setup
-description: |
-  Configure Fireflies.ai across dev, staging, and production with isolated API keys.
+description: 'Configure Fireflies.ai across dev, staging, and production with isolated
+  API keys.
+
   Use when setting up multi-environment deployments, managing per-env secrets,
+
   or implementing environment-specific Fireflies configurations.
+
   Trigger with phrases like "fireflies environments", "fireflies staging",
+
   "fireflies dev prod", "fireflies environment setup", "fireflies config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, deployment]
+tags:
+- saas
+- fireflies
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Multi-Environment Setup
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-observability/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-observability/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-observability
-description: |
-  Monitor Fireflies.ai integration health with metrics, alerts, and dashboards.
+description: 'Monitor Fireflies.ai integration health with metrics, alerts, and dashboards.
+
   Use when implementing monitoring, setting up alerting,
+
   or tracking transcript processing reliability.
+
   Trigger with phrases like "fireflies monitoring", "fireflies metrics",
+
   "fireflies observability", "monitor fireflies", "fireflies alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, monitoring, observability]
+tags:
+- saas
+- fireflies
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Observability
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: fireflies-performance-tuning
-description: |
-  Optimize Fireflies.ai GraphQL query performance with field selection, caching, and batching.
+description: 'Optimize Fireflies.ai GraphQL query performance with field selection,
+  caching, and batching.
+
   Use when experiencing slow API responses, implementing caching,
+
   or optimizing transcript processing throughput.
+
   Trigger with phrases like "fireflies performance", "optimize fireflies",
+
   "fireflies latency", "fireflies caching", "fireflies slow", "fireflies batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, performance]
+tags:
+- saas
+- fireflies
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Performance Tuning
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-prod-checklist
-description: |
-  Execute Fireflies.ai production deployment checklist with health checks and rollback.
+description: 'Execute Fireflies.ai production deployment checklist with health checks
+  and rollback.
+
   Use when deploying Fireflies.ai integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "fireflies production", "deploy fireflies",
+
   "fireflies go-live", "fireflies launch checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, deployment]
+tags:
+- saas
+- fireflies
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Production Checklist
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-rate-limits/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: fireflies-rate-limits
-description: |
-  Implement Fireflies.ai rate limiting, backoff, and request queuing.
+description: 'Implement Fireflies.ai rate limiting, backoff, and request queuing.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Fireflies.ai.
+
   Trigger with phrases like "fireflies rate limit", "fireflies throttling",
+
   "fireflies 429", "fireflies retry", "fireflies backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api]
+tags:
+- saas
+- fireflies
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Rate Limits
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-reference-architecture
-description: |
-  Design meeting intelligence architecture with Fireflies.ai GraphQL API, webhooks, and CRM sync.
+description: 'Design meeting intelligence architecture with Fireflies.ai GraphQL API,
+  webhooks, and CRM sync.
+
   Use when designing new integrations, planning transcript pipelines,
+
   or establishing architecture for meeting analytics platforms.
+
   Trigger with phrases like "fireflies architecture", "fireflies design",
+
   "fireflies project structure", "meeting intelligence pipeline".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, architecture]
+tags:
+- saas
+- fireflies
+- architecture
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Reference Architecture
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: fireflies-sdk-patterns
-description: |
-  Apply production-ready Fireflies.ai GraphQL client patterns for TypeScript and Python.
+description: 'Apply production-ready Fireflies.ai GraphQL client patterns for TypeScript
+  and Python.
+
   Use when implementing Fireflies.ai integrations, building typed clients,
+
   or establishing team coding standards for the GraphQL API.
+
   Trigger with phrases like "fireflies SDK patterns", "fireflies best practices",
+
   "fireflies client", "fireflies GraphQL wrapper", "typed fireflies".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, python, typescript]
+tags:
+- saas
+- fireflies
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Client Patterns
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-security-basics/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: fireflies-security-basics
-description: |
-  Apply Fireflies.ai security best practices for API keys and webhook verification.
+description: 'Apply Fireflies.ai security best practices for API keys and webhook
+  verification.
+
   Use when securing API keys, verifying webhook signatures,
+
   or auditing Fireflies.ai security configuration.
+
   Trigger with phrases like "fireflies security", "fireflies secrets",
+
   "secure fireflies", "fireflies webhook signature", "fireflies HMAC".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, security]
+tags:
+- saas
+- fireflies
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Security Basics
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-upgrade-migration
-description: |
-  Handle Fireflies.ai API deprecations and migrate to current query patterns.
+description: 'Handle Fireflies.ai API deprecations and migrate to current query patterns.
+
   Use when updating deprecated fields, migrating query patterns,
+
   or responding to Fireflies API changelog updates.
+
   Trigger with phrases like "upgrade fireflies", "fireflies deprecated",
+
   "fireflies migration", "fireflies breaking changes", "fireflies changelog".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, api, migration]
+tags:
+- saas
+- fireflies
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Upgrade & Migration
 

--- a/plugins/saas-packs/fireflies-pack/skills/fireflies-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/fireflies-pack/skills/fireflies-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: fireflies-webhooks-events
-description: |
-  Implement Fireflies.ai webhook receiver with HMAC signature verification and event processing.
+description: 'Implement Fireflies.ai webhook receiver with HMAC signature verification
+  and event processing.
+
   Use when setting up webhook endpoints, handling transcript-ready notifications,
+
   or building real-time meeting intelligence pipelines.
+
   Trigger with phrases like "fireflies webhook", "fireflies events",
+
   "fireflies webhook signature", "handle fireflies events", "fireflies notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, fireflies, webhooks]
+tags:
+- saas
+- fireflies
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Fireflies.ai Webhooks & Events
 

--- a/plugins/saas-packs/flexport-pack/skills/flexport-ci-integration/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-ci-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-ci-integration
-description: |
-  Configure CI/CD pipelines for Flexport logistics integrations with GitHub Actions,
+description: 'Configure CI/CD pipelines for Flexport logistics integrations with GitHub
+  Actions,
+
   automated API contract testing, and deployment workflows.
+
   Trigger: "flexport CI", "flexport GitHub Actions", "flexport CI/CD pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport CI Integration
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-common-errors/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-common-errors/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-common-errors
-description: |
-  Diagnose and fix common Flexport API errors including HTTP status codes,
+description: 'Diagnose and fix common Flexport API errors including HTTP status codes,
+
   webhook failures, and data validation issues.
-  Trigger: "flexport error", "fix flexport", "flexport not working", "debug flexport API".
+
+  Trigger: "flexport error", "fix flexport", "flexport not working", "debug flexport
+  API".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Common Errors
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flexport-core-workflow-a
-description: |
-  Execute Flexport primary workflow: shipment booking and purchase order management.
+description: 'Execute Flexport primary workflow: shipment booking and purchase order
+  management.
+
   Use when creating bookings, managing purchase orders, tracking freight,
+
   or building the core shipment lifecycle integration.
+
   Trigger: "flexport booking", "flexport purchase order", "create flexport shipment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Core Workflow A: Bookings & Purchase Orders
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-core-workflow-b/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flexport-core-workflow-b
-description: |
-  Execute Flexport secondary workflow: commercial invoices, products catalog, and freight invoices.
+description: 'Execute Flexport secondary workflow: commercial invoices, products catalog,
+  and freight invoices.
+
   Use when managing commercial invoices for customs, maintaining product catalogs,
+
   or handling freight billing through the Flexport API.
+
   Trigger: "flexport invoice", "flexport products", "flexport customs documents".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Core Workflow B: Invoices & Products
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-cost-tuning
-description: |
-  Optimize Flexport API usage costs through efficient pagination, caching,
+description: 'Optimize Flexport API usage costs through efficient pagination, caching,
+
   webhook-driven updates, and monitoring API call volume.
-  Trigger: "flexport costs", "flexport API usage", "reduce flexport calls", "flexport billing".
+
+  Trigger: "flexport costs", "flexport API usage", "reduce flexport calls", "flexport
+  billing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-data-handling/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-data-handling/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: flexport-data-handling
-description: |
-  Implement data handling for Flexport supply chain data including PII redaction,
+description: 'Implement data handling for Flexport supply chain data including PII
+  redaction,
+
   shipment data retention, GDPR compliance, and secure document management.
-  Trigger: "flexport data handling", "flexport PII", "flexport GDPR", "flexport data retention".
+
+  Trigger: "flexport data handling", "flexport PII", "flexport GDPR", "flexport data
+  retention".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Data Handling
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-debug-bundle/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flexport-debug-bundle
-description: |
-  Collect Flexport API debug evidence for support tickets and troubleshooting.
+description: 'Collect Flexport API debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent API issues, preparing support tickets,
+
   or collecting diagnostic information for Flexport logistics problems.
+
   Trigger: "flexport debug", "flexport support bundle", "flexport diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flexport-deploy-integration
-description: |
-  Deploy Flexport logistics integrations to Vercel, Fly.io, and Cloud Run.
+description: 'Deploy Flexport logistics integrations to Vercel, Fly.io, and Cloud
+  Run.
+
   Use when deploying shipment tracking dashboards, webhook receivers,
+
   or supply chain automation services to production infrastructure.
+
   Trigger: "deploy flexport", "flexport hosting", "flexport Cloud Run".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(fly:*), Bash(gcloud:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-enterprise-rbac/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: flexport-enterprise-rbac
-description: |
-  Configure role-based access control for Flexport integrations with scoped API keys,
+description: 'Configure role-based access control for Flexport integrations with scoped
+  API keys,
+
   multi-tenant patterns, and organization-level permission management.
-  Trigger: "flexport RBAC", "flexport permissions", "flexport multi-tenant", "flexport access control".
+
+  Trigger: "flexport RBAC", "flexport permissions", "flexport multi-tenant", "flexport
+  access control".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-hello-world/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-hello-world/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: flexport-hello-world
-description: |
-  Create a minimal working Flexport example — list shipments and track containers.
-  Use when starting a new Flexport integration, testing your setup,
-  or learning the Flexport REST API v2 patterns.
-  Trigger: "flexport hello world", "flexport example", "flexport quick start".
+description: "Create a minimal working Flexport example \u2014 list shipments and\
+  \ track containers.\nUse when starting a new Flexport integration, testing your\
+  \ setup,\nor learning the Flexport REST API v2 patterns.\nTrigger: \"flexport hello\
+  \ world\", \"flexport example\", \"flexport quick start\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Hello World
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-incident-runbook/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flexport-incident-runbook
-description: |
-  Execute Flexport incident response for API outages, webhook failures,
+description: 'Execute Flexport incident response for API outages, webhook failures,
+
   and supply chain data sync issues with triage and mitigation steps.
+
   Trigger: "flexport incident", "flexport outage", "flexport down", "flexport emergency".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-install-auth/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flexport-install-auth
-description: |
-  Install and configure Flexport API authentication with API keys or OAuth credentials.
+description: 'Install and configure Flexport API authentication with API keys or OAuth
+  credentials.
+
   Use when setting up a new Flexport logistics integration, configuring bearer tokens,
+
   or initializing the Flexport REST API client for shipment and supply chain operations.
+
   Trigger: "install flexport", "setup flexport", "flexport auth", "flexport API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-local-dev-loop/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flexport-local-dev-loop
-description: |
-  Configure Flexport local development with mock API responses and testing.
+description: 'Configure Flexport local development with mock API responses and testing.
+
   Use when setting up a development environment, creating mock shipment data,
+
   or establishing a fast iteration cycle for Flexport logistics integration.
+
   Trigger: "flexport dev setup", "flexport local development", "flexport mock API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-migration-deep-dive/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-migration-deep-dive
-description: |
-  Execute major migration strategies for Flexport including migrating from
+description: 'Execute major migration strategies for Flexport including migrating
+  from
+
   legacy freight forwarders, ERP system integration, and strangler fig patterns.
+
   Trigger: "flexport migration", "migrate to flexport", "flexport ERP integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-multi-env-setup/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flexport-multi-env-setup
-description: |
-  Configure Flexport API across dev, staging, and production environments
+description: 'Configure Flexport API across dev, staging, and production environments
+
   with isolated API keys, separate webhook endpoints, and environment guards.
+
   Trigger: "flexport environments", "flexport staging", "flexport multi-env".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-observability/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-observability/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-observability
-description: |
-  Set up observability for Flexport logistics integrations with metrics,
+description: 'Set up observability for Flexport logistics integrations with metrics,
+
   structured logging, distributed tracing, and alerting dashboards.
-  Trigger: "flexport monitoring", "flexport observability", "flexport metrics", "flexport alerts".
+
+  Trigger: "flexport monitoring", "flexport observability", "flexport metrics", "flexport
+  alerts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Observability
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-performance-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-performance-tuning
-description: |
-  Optimize Flexport API performance with pagination tuning, response caching,
+description: 'Optimize Flexport API performance with pagination tuning, response caching,
+
   parallel requests, and connection pooling for logistics data.
-  Trigger: "flexport performance", "flexport slow API", "flexport caching", "optimize flexport".
+
+  Trigger: "flexport performance", "flexport slow API", "flexport caching", "optimize
+  flexport".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-prod-checklist/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flexport-prod-checklist
-description: |
-  Execute Flexport production deployment checklist for logistics integrations.
+description: 'Execute Flexport production deployment checklist for logistics integrations.
+
   Use when deploying shipment tracking, booking automation, or supply chain
+
   integrations to production with proper monitoring and rollback.
+
   Trigger: "flexport production", "deploy flexport", "flexport go-live checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-rate-limits/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-rate-limits/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: flexport-rate-limits
-description: |
-  Handle Flexport API rate limits with exponential backoff, queue-based throttling,
+description: 'Handle Flexport API rate limits with exponential backoff, queue-based
+  throttling,
+
   and response header monitoring for logistics API calls.
-  Trigger: "flexport rate limit", "flexport 429", "flexport throttling", "flexport backoff".
+
+  Trigger: "flexport rate limit", "flexport 429", "flexport throttling", "flexport
+  backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-reference-architecture/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flexport-reference-architecture
-description: |
-  Implement Flexport reference architecture for supply chain integrations
+description: 'Implement Flexport reference architecture for supply chain integrations
+
   with best-practice project layout, service boundaries, and data flow.
-  Trigger: "flexport architecture", "flexport project structure", "flexport system design".
+
+  Trigger: "flexport architecture", "flexport project structure", "flexport system
+  design".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-sdk-patterns/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flexport-sdk-patterns
-description: |
-  Apply production-ready Flexport API patterns for TypeScript and Python.
+description: 'Apply production-ready Flexport API patterns for TypeScript and Python.
+
   Use when building typed HTTP clients, implementing pagination,
+
   or establishing team coding standards for Flexport logistics integration.
+
   Trigger: "flexport SDK patterns", "flexport best practices", "flexport client wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-security-basics/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-security-basics/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: flexport-security-basics
-description: |
-  Apply Flexport API security best practices including webhook signature verification,
+description: 'Apply Flexport API security best practices including webhook signature
+  verification,
+
   API key rotation, and least-privilege access patterns.
-  Trigger: "flexport security", "flexport webhook signature", "secure flexport API key".
+
+  Trigger: "flexport security", "flexport webhook signature", "secure flexport API
+  key".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Security Basics
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-upgrade-migration/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flexport-upgrade-migration
-description: |
-  Migrate between Flexport API versions (v1 to v2, Logistics API versions).
+description: 'Migrate between Flexport API versions (v1 to v2, Logistics API versions).
+
   Use when upgrading API version headers, handling deprecated endpoints,
+
   or migrating from legacy Flexport API patterns.
+
   Trigger: "upgrade flexport", "flexport API version", "flexport migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/flexport-pack/skills/flexport-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/flexport-pack/skills/flexport-webhooks-events/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flexport-webhooks-events
-description: |
-  Implement Flexport webhook event handling for shipment milestones, booking updates,
+description: 'Implement Flexport webhook event handling for shipment milestones, booking
+  updates,
+
   purchase order events, and invoice notifications.
+
   Trigger: "flexport webhooks", "flexport events", "flexport milestones",
+
   "flexport shipment tracking webhook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, logistics, flexport]
-compatible-with: claude-code
+tags:
+- saas
+- logistics
+- flexport
+compatibility: Designed for Claude Code
 ---
-
 # Flexport Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-ci-integration/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-ci-integration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-ci-integration
-description: |
-  Configure CI/CD pipelines for Fly.io with GitHub Actions, Docker builds,
+description: 'Configure CI/CD pipelines for Fly.io with GitHub Actions, Docker builds,
+
   deploy tokens, and automated deployment workflows.
+
   Trigger: "fly.io CI", "fly.io GitHub Actions", "fly deploy CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io CI Integration
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-common-errors/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-common-errors/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: flyio-common-errors
-description: |
-  Diagnose and fix common Fly.io errors including deployment failures, health check
+description: 'Diagnose and fix common Fly.io errors including deployment failures,
+  health check
+
   failures, machine issues, and networking problems.
-  Trigger: "fly.io error", "fly deploy failed", "fly.io not working", "fly health check".
+
+  Trigger: "fly.io error", "fly deploy failed", "fly.io not working", "fly health
+  check".
+
+  '
 allowed-tools: Read, Bash(fly:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Common Errors
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flyio-core-workflow-a
-description: |
-  Execute Fly.io primary workflow: deploy, scale, and manage apps with flyctl and fly.toml.
+description: 'Execute Fly.io primary workflow: deploy, scale, and manage apps with
+  flyctl and fly.toml.
+
   Use when deploying applications, configuring regions, setting secrets,
+
   or managing the app lifecycle on Fly.io.
+
   Trigger: "fly deploy", "fly.io app management", "fly scale", "fly.io regions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Core Workflow A: Deploy & Scale
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-core-workflow-b/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flyio-core-workflow-b
-description: |
-  Execute Fly.io secondary workflow: Postgres clusters, persistent volumes, and private networking.
+description: 'Execute Fly.io secondary workflow: Postgres clusters, persistent volumes,
+  and private networking.
+
   Use when adding databases, persistent storage, or internal service communication.
+
   Trigger: "fly postgres", "fly volumes", "fly.io database", "fly.io persistent storage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(psql:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Core Workflow B: Postgres, Volumes & Networking
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-cost-tuning/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-cost-tuning
-description: |
-  Optimize Fly.io costs with auto-stop/suspend, right-sizing VMs,
+description: 'Optimize Fly.io costs with auto-stop/suspend, right-sizing VMs,
+
   volume management, and monitoring spend across apps and regions.
+
   Trigger: "fly.io costs", "fly.io pricing", "fly.io billing", "reduce fly.io spend".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-debug-bundle/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flyio-debug-bundle
-description: |
-  Collect Fly.io debug evidence for support tickets including machine status,
+description: 'Collect Fly.io debug evidence for support tickets including machine
+  status,
+
   logs, health checks, volume state, and networking diagnostics.
+
   Trigger: "fly.io debug", "fly.io support", "fly.io diagnostic", "fly doctor".
+
+  '
 allowed-tools: Read, Bash(fly:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-deploy-integration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-deploy-integration
-description: |
-  Advanced Fly.io deployment strategies including blue-green deployments,
+description: 'Advanced Fly.io deployment strategies including blue-green deployments,
+
   canary releases, multi-region rollouts, and Machines API orchestration.
+
   Trigger: "fly.io blue-green", "fly.io canary deploy", "fly.io rolling update".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-hello-world/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-hello-world/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: flyio-hello-world
-description: |
-  Deploy your first app to Fly.io with flyctl launch and the Machines API.
+description: 'Deploy your first app to Fly.io with flyctl launch and the Machines
+  API.
+
   Use when starting a new Fly.io project, deploying a container globally,
+
   or testing edge compute deployment.
+
   Trigger: "fly.io hello world", "fly launch", "deploy to fly.io", "first fly app".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(curl:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Hello World
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-install-auth/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-install-auth/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flyio-install-auth
-description: |
-  Install flyctl CLI and configure Fly.io authentication with API tokens.
+description: 'Install flyctl CLI and configure Fly.io authentication with API tokens.
+
   Use when setting up a new Fly.io project, configuring deploy tokens,
+
   or initializing the Machines API for edge compute deployments.
+
   Trigger: "install fly.io", "setup flyctl", "fly.io auth", "fly.io API token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-local-dev-loop/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: flyio-local-dev-loop
-description: |
-  Configure Fly.io local development with Docker, proxy, and SSH console.
+description: 'Configure Fly.io local development with Docker, proxy, and SSH console.
+
   Use when setting up local dev against Fly services, testing Dockerfiles,
+
   or establishing a fast iteration cycle.
+
   Trigger: "fly.io dev setup", "fly.io local development", "fly proxy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-performance-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flyio-performance-tuning
-description: |
-  Optimize Fly.io application performance with auto-stop/start tuning,
+description: 'Optimize Fly.io application performance with auto-stop/start tuning,
+
   VM sizing, multi-region latency optimization, and connection pooling.
-  Trigger: "fly.io performance", "fly.io cold start", "fly.io latency", "fly.io VM sizing".
+
+  Trigger: "fly.io performance", "fly.io cold start", "fly.io latency", "fly.io VM
+  sizing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-prod-checklist/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-prod-checklist
-description: |
-  Execute Fly.io production deployment checklist with health checks,
+description: 'Execute Fly.io production deployment checklist with health checks,
+
   auto-scaling, monitoring, and rollback procedures.
+
   Trigger: "fly.io production", "fly.io go-live", "fly.io prod checklist".
+
+  '
 allowed-tools: Read, Bash(fly:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-rate-limits/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-rate-limits/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-rate-limits
-description: |
-  Handle Fly.io Machines API rate limits with backoff, concurrency control,
+description: 'Handle Fly.io Machines API rate limits with backoff, concurrency control,
+
   and request batching for machine management operations.
+
   Trigger: "fly.io rate limit", "fly.io 429", "fly.io throttling", "machines API limit".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-reference-architecture/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-reference-architecture
-description: |
-  Implement Fly.io reference architecture with multi-region apps, Postgres,
+description: 'Implement Fly.io reference architecture with multi-region apps, Postgres,
+
   Redis, background workers, and private networking.
+
   Trigger: "fly.io architecture", "fly.io system design", "fly.io multi-region".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-sdk-patterns/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flyio-sdk-patterns
-description: |
-  Apply production-ready Fly.io Machines API patterns for TypeScript with typed
+description: 'Apply production-ready Fly.io Machines API patterns for TypeScript with
+  typed
+
   clients, machine lifecycle management, and multi-region orchestration.
+
   Trigger: "fly.io Machines API", "fly.io SDK patterns", "fly.io API client".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-security-basics/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-security-basics/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: flyio-security-basics
-description: |
-  Apply Fly.io security best practices for secrets management, private networking,
+description: 'Apply Fly.io security best practices for secrets management, private
+  networking,
+
   TLS certificates, and deploy token scoping.
+
   Trigger: "fly.io security", "fly secrets", "fly.io TLS", "fly.io private network".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Security Basics
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-upgrade-migration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-upgrade-migration
-description: |
-  Migrate between Fly.io platform versions including Apps v1 to v2 (Machines),
+description: 'Migrate between Fly.io platform versions including Apps v1 to v2 (Machines),
+
   flyctl upgrades, and Postgres major version upgrades.
+
   Trigger: "fly.io upgrade", "fly.io migration", "fly apps v2", "fly postgres upgrade".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/flyio-pack/skills/flyio-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/flyio-pack/skills/flyio-webhooks-events/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: flyio-webhooks-events
-description: |
-  Implement Fly.io machine events, health check monitoring, and log-based
+description: 'Implement Fly.io machine events, health check monitoring, and log-based
+
   event processing for deployment automation and alerting.
+
   Trigger: "fly.io events", "fly.io machine status", "fly.io health monitoring".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(fly:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, edge-compute, flyio]
-compatible-with: claude-code
+tags:
+- saas
+- edge-compute
+- flyio
+compatibility: Designed for Claude Code
 ---
-
 # Fly.io Events & Monitoring
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-ci-integration/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-ci-integration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-ci-integration
-description: |
-  Automate financial reporting workflows that complement Fondo with CI/CD
+description: 'Automate financial reporting workflows that complement Fondo with CI/CD
+
   pipelines for expense tracking, budget alerts, and financial data validation.
+
   Trigger: "fondo CI", "fondo automation", "fondo financial alerts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo CI Integration
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-common-errors/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-common-errors/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-common-errors
-description: |
-  Diagnose and fix common Fondo issues including integration sync failures,
+description: 'Diagnose and fix common Fondo issues including integration sync failures,
+
   categorization errors, and R&D credit qualification problems.
+
   Trigger: "fondo error", "fondo sync issue", "fondo not syncing", "fondo problem".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Common Errors
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: fondo-core-workflow-a
-description: |
-  Execute Fondo primary workflow: monthly bookkeeping close and financial reporting.
+description: 'Execute Fondo primary workflow: monthly bookkeeping close and financial
+  reporting.
+
   Use when managing month-end close, reviewing financial statements,
+
   or preparing for board meetings and fundraising.
+
   Trigger: "fondo bookkeeping", "fondo month close", "fondo financial reports".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Core Workflow A: Monthly Bookkeeping
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-core-workflow-b/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: fondo-core-workflow-b
-description: |
-  Execute Fondo R&D tax credit workflow: qualify activities, calculate credits,
+description: 'Execute Fondo R&D tax credit workflow: qualify activities, calculate
+  credits,
+
   file Form 6765, and claim payroll tax offset for startups.
-  Trigger: "fondo R&D credit", "fondo tax credit", "fondo Form 6765", "startup tax credit".
+
+  Trigger: "fondo R&D credit", "fondo tax credit", "fondo Form 6765", "startup tax
+  credit".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Core Workflow B: R&D Tax Credits
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-cost-tuning
-description: |
-  Optimize Fondo costs by maximizing R&D tax credits, choosing the right plan,
+description: 'Optimize Fondo costs by maximizing R&D tax credits, choosing the right
+  plan,
+
   and reducing unnecessary bookkeeping complexity.
+
   Trigger: "fondo costs", "fondo pricing", "maximize R&D credit", "fondo ROI".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-debug-bundle/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-debug-bundle
-description: |
-  Collect diagnostic information for Fondo support including integration status,
+description: 'Collect diagnostic information for Fondo support including integration
+  status,
+
   transaction discrepancies, and financial data reconciliation issues.
+
   Trigger: "fondo debug", "fondo support", "fondo diagnostic", "fondo reconciliation".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-deploy-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-deploy-integration
-description: |
-  Deploy financial dashboards and reporting tools that consume Fondo data
+description: 'Deploy financial dashboards and reporting tools that consume Fondo data
+
   to Vercel, Fly.io, or internal infrastructure.
-  Trigger: "fondo dashboard deploy", "fondo financial dashboard", "deploy finance app".
+
+  Trigger: "fondo dashboard deploy", "fondo financial dashboard", "deploy finance
+  app".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-hello-world/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-hello-world/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-hello-world
-description: |
-  Verify Fondo setup by checking financial data sync, reviewing categorized
+description: 'Verify Fondo setup by checking financial data sync, reviewing categorized
+
   transactions, and confirming R&D tax credit eligibility.
+
   Trigger: "fondo first sync", "fondo verify", "fondo hello world", "fondo test".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Hello World
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-install-auth/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-install-auth
-description: |
-  Set up Fondo account and configure integrations with Gusto, QuickBooks,
+description: 'Set up Fondo account and configure integrations with Gusto, QuickBooks,
+
   and bank accounts for automated startup bookkeeping and R&D tax credits.
+
   Trigger: "setup fondo", "fondo account", "fondo integrations", "connect fondo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-local-dev-loop/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-local-dev-loop
-description: |
-  Configure local development workflows that integrate with Fondo for
+description: 'Configure local development workflows that integrate with Fondo for
+
   financial data, using Fondo exports with QuickBooks or accounting tools.
+
   Trigger: "fondo dev setup", "fondo export", "fondo QuickBooks", "fondo local data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-performance-tuning/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-performance-tuning
-description: |
-  Optimize Fondo workflows including faster month-end close, efficient
+description: 'Optimize Fondo workflows including faster month-end close, efficient
+
   data exports, and streamlined CPA communication.
+
   Trigger: "fondo performance", "fondo faster close", "optimize fondo workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-prod-checklist/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-prod-checklist
-description: |
-  Execute Fondo production readiness checklist for year-end tax filing,
+description: 'Execute Fondo production readiness checklist for year-end tax filing,
+
   R&D credit claims, and board-ready financial reporting.
+
   Trigger: "fondo production", "fondo tax filing ready", "fondo year-end checklist".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-rate-limits/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-rate-limits/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-rate-limits
-description: |
-  Manage rate limits for Fondo-connected services including Gusto API,
+description: 'Manage rate limits for Fondo-connected services including Gusto API,
+
   QuickBooks API, Plaid, and Stripe when building parallel integrations.
+
   Trigger: "fondo rate limit", "gusto API limits", "QuickBooks throttling".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-reference-architecture/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-reference-architecture
-description: |
-  Reference architecture for startup financial operations using Fondo as the
+description: 'Reference architecture for startup financial operations using Fondo
+  as the
+
   bookkeeping backbone with complementary tools for banking, payroll, and reporting.
+
   Trigger: "fondo architecture", "startup finance stack", "fondo integration architecture".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-sdk-patterns/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: fondo-sdk-patterns
-description: |
-  Build internal tools that consume Fondo financial data exports with
+description: 'Build internal tools that consume Fondo financial data exports with
+
   typed parsers, QuickBooks integration, and financial modeling patterns.
+
   Trigger: "fondo data patterns", "fondo integration", "fondo QuickBooks sync".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-security-basics/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-security-basics/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-security-basics
-description: |
-  Apply security best practices for Fondo including OAuth token management,
+description: 'Apply security best practices for Fondo including OAuth token management,
+
   financial data protection, SOC 2 compliance, and access control.
-  Trigger: "fondo security", "fondo data protection", "fondo SOC 2", "fondo access control".
+
+  Trigger: "fondo security", "fondo data protection", "fondo SOC 2", "fondo access
+  control".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Security Basics
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-upgrade-migration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-upgrade-migration
-description: |
-  Migrate to Fondo from other bookkeeping services, switch between Fondo plans,
+description: 'Migrate to Fondo from other bookkeeping services, switch between Fondo
+  plans,
+
   or transition accountants while maintaining financial continuity.
+
   Trigger: "migrate to fondo", "switch to fondo", "fondo migration", "change accountant".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/fondo-pack/skills/fondo-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/fondo-pack/skills/fondo-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: fondo-webhooks-events
-description: |
-  Implement event-driven financial workflows using webhooks from Fondo-connected
+description: 'Implement event-driven financial workflows using webhooks from Fondo-connected
+
   services: Stripe payment events, Gusto payroll events, and Plaid transactions.
-  Trigger: "fondo webhooks", "fondo events", "stripe payroll webhooks", "financial events".
+
+  Trigger: "fondo webhooks", "fondo events", "stripe payroll webhooks", "financial
+  events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, accounting, fondo]
-compatible-with: claude-code
+tags:
+- saas
+- accounting
+- fondo
+compatibility: Designed for Claude Code
 ---
-
 # Fondo Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-ci-integration/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-ci-integration/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-ci-integration
-description: |
-  Configure Framer CI/CD integration with GitHub Actions and testing.
+description: 'Configure Framer CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Framer tests into your build process.
+
   Trigger with phrases like "framer CI", "framer GitHub Actions",
+
   "framer automated tests", "CI framer".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer CI Integration
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-common-errors/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-common-errors/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-common-errors
-description: |
-  Diagnose and fix Framer common errors and exceptions.
+description: 'Diagnose and fix Framer common errors and exceptions.
+
   Use when encountering Framer errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "framer error", "fix framer",
+
   "framer not working", "debug framer".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Common Errors
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: framer-core-workflow-a
-description: |
-  Execute Framer primary workflow: Core Workflow A.
+description: 'Execute Framer primary workflow: Core Workflow A.
+
   Use when implementing primary use case,
+
   building main features, or core integration tasks.
+
   Trigger with phrases like "framer main workflow",
+
   "primary task with framer".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer, cms, plugin]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+- cms
+- plugin
+compatibility: Designed for Claude Code
 ---
-
 # Framer CMS Plugin — Managed Collections
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: framer-core-workflow-b
-description: |
-  Execute Framer secondary workflow: Core Workflow B.
+description: 'Execute Framer secondary workflow: Core Workflow B.
+
   Use when implementing secondary use case,
+
   or complementing primary workflow.
+
   Trigger with phrases like "framer secondary workflow",
+
   "secondary task with framer".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer, components, overrides]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+- components
+- overrides
+compatibility: Designed for Claude Code
 ---
-
 # Framer Code Components & Overrides
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-cost-tuning/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-cost-tuning
-description: |
-  Optimize Framer costs through tier selection, sampling, and usage monitoring.
+description: 'Optimize Framer costs through tier selection, sampling, and usage monitoring.
+
   Use when analyzing Framer billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "framer cost", "framer billing",
+
   "reduce framer costs", "framer pricing", "framer expensive", "framer budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-debug-bundle/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-debug-bundle
-description: |
-  Collect Framer debug evidence for support tickets and troubleshooting.
+description: 'Collect Framer debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Framer problems.
+
   Trigger with phrases like "framer debug", "framer support bundle",
+
   "collect framer logs", "framer diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-deploy-integration/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-deploy-integration
-description: |
-  Deploy Framer integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Framer integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Framer-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy framer", "framer Vercel",
+
   "framer production deploy", "framer Cloud Run", "framer Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-hello-world/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-hello-world/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-hello-world
-description: |
-  Create a minimal working Framer example.
+description: 'Create a minimal working Framer example.
+
   Use when starting a new Framer integration, testing your setup,
+
   or learning basic Framer API patterns.
+
   Trigger with phrases like "framer hello world", "framer example",
+
   "framer quick start", "simple framer code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Hello World
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-install-auth/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-install-auth/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-install-auth
-description: |
-  Install and configure Framer SDK/CLI authentication.
+description: 'Install and configure Framer SDK/CLI authentication.
+
   Use when setting up a new Framer integration, configuring API keys,
+
   or initializing Framer in your project.
+
   Trigger with phrases like "install framer", "setup framer",
+
   "framer auth", "configure framer API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-local-dev-loop/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-local-dev-loop
-description: |
-  Configure Framer local development with hot reload and testing.
+description: 'Configure Framer local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Framer.
+
   Trigger with phrases like "framer dev setup", "framer local development",
+
   "framer dev environment", "develop with framer".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-performance-tuning/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: framer-performance-tuning
-description: |
-  Optimize Framer API performance with caching, batching, and connection pooling.
+description: 'Optimize Framer API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Framer integrations.
+
   Trigger with phrases like "framer performance", "optimize framer",
+
   "framer latency", "framer caching", "framer slow", "framer batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-prod-checklist/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-prod-checklist
-description: |
-  Execute Framer production deployment checklist and rollback procedures.
+description: 'Execute Framer production deployment checklist and rollback procedures.
+
   Use when deploying Framer integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "framer production", "deploy framer",
+
   "framer go-live", "framer launch checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-rate-limits/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-rate-limits/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-rate-limits
-description: |
-  Implement Framer rate limiting, backoff, and idempotency patterns.
+description: 'Implement Framer rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Framer.
+
   Trigger with phrases like "framer rate limit", "framer throttling",
+
   "framer 429", "framer retry", "framer backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-reference-architecture/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-reference-architecture
-description: |
-  Implement Framer reference architecture with best-practice project layout.
+description: 'Implement Framer reference architecture with best-practice project layout.
+
   Use when designing new Framer integrations, reviewing project structure,
+
   or establishing architecture standards for Framer applications.
+
   Trigger with phrases like "framer architecture", "framer best practices",
+
   "framer project structure", "how to organize framer", "framer layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-sdk-patterns/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-sdk-patterns
-description: |
-  Apply production-ready Framer SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Framer SDK patterns for TypeScript and Python.
+
   Use when implementing Framer integrations, refactoring SDK usage,
+
   or establishing team coding standards for Framer.
+
   Trigger with phrases like "framer SDK patterns", "framer best practices",
+
   "framer code patterns", "idiomatic framer".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-security-basics/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-security-basics/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-security-basics
-description: |
-  Apply Framer security best practices for secrets and access control.
+description: 'Apply Framer security best practices for secrets and access control.
+
   Use when securing API keys, implementing least privilege access,
+
   or auditing Framer security configuration.
+
   Trigger with phrases like "framer security", "framer secrets",
+
   "secure framer", "framer API key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Security Basics
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-upgrade-migration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: framer-upgrade-migration
-description: |
-  Analyze, plan, and execute Framer SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Framer SDK upgrades with breaking change
+  detection.
+
   Use when upgrading Framer SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade framer", "framer migration",
+
   "framer breaking changes", "update framer SDK", "analyze framer version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/framer-pack/skills/framer-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/framer-pack/skills/framer-webhooks-events/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: framer-webhooks-events
-description: |
-  Implement Framer webhook signature validation and event handling.
+description: 'Implement Framer webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling Framer event notifications securely.
+
   Trigger with phrases like "framer webhook", "framer events",
+
   "framer webhook signature", "handle framer events", "framer notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, framer]
-compatible-with: claude-code
+tags:
+- saas
+- framer
+compatibility: Designed for Claude Code
 ---
-
 # Framer Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/gamma-pack/skills/gamma-ci-integration/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-ci-integration
-description: |
-  Configure Gamma CI/CD integration with GitHub Actions and testing.
+description: 'Configure Gamma CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Gamma tests into your build process.
+
   Trigger with phrases like "gamma CI", "gamma GitHub Actions",
+
   "gamma automated tests", "CI gamma", "gamma pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, testing, ci-cd]
+tags:
+- saas
+- gamma
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma CI Integration
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-common-errors/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-common-errors
-description: |
-  Debug and resolve common Gamma API errors.
+description: 'Debug and resolve common Gamma API errors.
+
   Use when encountering authentication failures, rate limits,
+
   generation errors, or unexpected API responses.
+
   Trigger with phrases like "gamma error", "gamma not working",
+
   "gamma API error", "gamma debug", "gamma troubleshoot".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, debugging, authentication]
+tags:
+- saas
+- gamma
+- api
+- debugging
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Common Errors
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-core-workflow-a
-description: |
-  Generate presentations, documents, and webpages via Gamma API.
+description: 'Generate presentations, documents, and webpages via Gamma API.
+
   Use when creating content from text prompts, configuring themes,
+
   image styles, text modes, and output formats.
+
   Trigger: "gamma generate", "gamma presentation from text",
+
   "gamma AI slides", "gamma create deck", "gamma content generation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, workflow, generation]
+tags:
+- saas
+- gamma
+- workflow
+- generation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Core Workflow A: Content Generation
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: gamma-core-workflow-b
-description: |
-  Generate from templates, retrieve exports, and manage sharing via Gamma API.
+description: 'Generate from templates, retrieve exports, and manage sharing via Gamma
+  API.
+
   Use when creating content from template gammas, downloading PDF/PPTX/PNG exports,
+
   or configuring sharing and folder organization.
+
   Trigger: "gamma template", "gamma export", "gamma download PDF",
+
   "gamma PPTX", "gamma sharing", "gamma from template".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, workflow, export, templates]
+tags:
+- saas
+- gamma
+- workflow
+- export
+- templates
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Core Workflow B: Templates & Export
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-cost-tuning
-description: |
-  Optimize Gamma usage costs and manage API spending.
+description: 'Optimize Gamma usage costs and manage API spending.
+
   Use when reducing API costs, implementing usage quotas,
+
   or planning for scale with budget constraints.
+
   Trigger with phrases like "gamma cost", "gamma billing",
+
   "gamma budget", "gamma expensive", "gamma pricing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, scaling, cost-optimization]
+tags:
+- saas
+- gamma
+- api
+- scaling
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Cost Tuning
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-data-handling/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-data-handling/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-data-handling
-description: |
-  Handle data privacy, retention, and compliance for Gamma integrations.
+description: 'Handle data privacy, retention, and compliance for Gamma integrations.
+
   Use when implementing GDPR compliance, data retention policies,
+
   or managing user data within Gamma workflows.
+
   Trigger with phrases like "gamma data", "gamma privacy",
+
   "gamma GDPR", "gamma data retention", "gamma compliance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, workflow, compliance]
+tags:
+- saas
+- gamma
+- workflow
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Data Handling
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-debug-bundle/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-debug-bundle
-description: |
-  Comprehensive debugging toolkit for Gamma integration issues.
+description: 'Comprehensive debugging toolkit for Gamma integration issues.
+
   Use when you need detailed diagnostics, request tracing,
+
   or systematic debugging of Gamma API problems.
+
   Trigger with phrases like "gamma debug bundle", "gamma diagnostics",
+
   "gamma trace", "gamma inspect", "gamma detailed logs".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, debugging, tracing]
+tags:
+- saas
+- gamma
+- api
+- debugging
+- tracing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Debug Bundle
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-deploy-integration
-description: |
-  Deploy Gamma-integrated applications to production environments.
+description: 'Deploy Gamma-integrated applications to production environments.
+
   Use when deploying to Vercel, AWS, GCP, or other cloud platforms
+
   with proper secret management and configuration.
+
   Trigger with phrases like "gamma deploy", "gamma production",
+
   "gamma vercel", "gamma AWS", "gamma cloud deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(aws:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, deployment]
+tags:
+- saas
+- gamma
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Deploy Integration
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-enterprise-rbac
-description: |
-  Implement enterprise role-based access control for Gamma integrations.
+description: 'Implement enterprise role-based access control for Gamma integrations.
+
   Use when configuring team permissions, multi-tenant access,
+
   or enterprise authorization patterns.
+
   Trigger with phrases like "gamma RBAC", "gamma permissions",
+
   "gamma access control", "gamma enterprise", "gamma roles".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, authentication, rbac]
+tags:
+- saas
+- gamma
+- authentication
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Enterprise RBAC
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-hello-world/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-hello-world
-description: |
-  Generate your first Gamma presentation via the API.
+description: 'Generate your first Gamma presentation via the API.
+
   Use when learning the generate-poll-retrieve workflow,
+
   testing API connectivity, or creating a minimal example.
+
   Trigger: "gamma hello world", "gamma quick start",
+
   "first gamma presentation", "gamma example", "gamma test".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, getting-started]
+tags:
+- saas
+- gamma
+- api
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Hello World
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-incident-runbook
-description: |
-  Manage incident response for Gamma integration issues.
+description: 'Manage incident response for Gamma integration issues.
+
   Use when experiencing production incidents, outages,
+
   or need systematic troubleshooting procedures.
+
   Trigger with phrases like "gamma incident", "gamma outage",
+
   "gamma down", "gamma emergency", "gamma runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, incident-response]
+tags:
+- saas
+- gamma
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Incident Runbook
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-install-auth/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-install-auth
-description: |
-  Set up Gamma API v1.0 authentication and first request.
+description: 'Set up Gamma API v1.0 authentication and first request.
+
   Use when configuring API keys, setting up X-API-KEY header,
+
   or initializing Gamma REST API access in a project.
+
   Trigger: "install gamma", "setup gamma API", "gamma auth",
+
   "gamma API key", "configure gamma".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, authentication]
+tags:
+- saas
+- gamma
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Install & Auth
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-local-dev-loop
-description: |
-  Set up local development workflow for Gamma API integration.
+description: 'Set up local development workflow for Gamma API integration.
+
   Use when building automation scripts, testing API calls locally,
+
   or configuring a dev environment with mock responses.
+
   Trigger: "gamma local dev", "gamma development setup",
+
   "gamma test locally", "gamma mock API", "gamma dev workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, development, testing]
+tags:
+- saas
+- gamma
+- development
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Local Dev Loop
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-migration-deep-dive
-description: |
-  Deep dive into migrating to Gamma from other presentation platforms.
+description: 'Deep dive into migrating to Gamma from other presentation platforms.
+
   Use when migrating from PowerPoint, Google Slides, Canva,
+
   or other presentation tools to Gamma.
+
   Trigger with phrases like "gamma migration", "migrate to gamma",
+
   "gamma import", "gamma from powerpoint", "gamma from google slides".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, migration]
+tags:
+- saas
+- gamma
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Migration Deep Dive
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-multi-env-setup
-description: |
-  Configure Gamma across development, staging, and production environments.
+description: 'Configure Gamma across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment secrets,
+
   or implementing environment-specific Gamma configurations.
+
   Trigger with phrases like "gamma environments", "gamma staging",
+
   "gamma dev prod", "gamma environment setup", "gamma config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, deployment]
+tags:
+- saas
+- gamma
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Multi-Environment Setup
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-observability/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-observability
-description: |
-  Implement comprehensive observability for Gamma integrations.
+description: 'Implement comprehensive observability for Gamma integrations.
+
   Use when setting up monitoring, logging, tracing,
+
   or building dashboards for Gamma API usage.
+
   Trigger with phrases like "gamma monitoring", "gamma logging",
+
   "gamma metrics", "gamma observability", "gamma dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, monitoring, observability]
+tags:
+- saas
+- gamma
+- api
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Observability
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-performance-tuning
-description: |
-  Optimize Gamma API performance and reduce latency.
+description: 'Optimize Gamma API performance and reduce latency.
+
   Use when experiencing slow response times, optimizing throughput,
+
   or improving user experience with Gamma integrations.
+
   Trigger with phrases like "gamma performance", "gamma slow",
+
   "gamma latency", "gamma optimization", "gamma speed".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, performance]
+tags:
+- saas
+- gamma
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Performance Tuning
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-prod-checklist
-description: |
-  Production readiness checklist for Gamma integration.
+description: 'Production readiness checklist for Gamma integration.
+
   Use when preparing to deploy Gamma integration to production,
+
   or auditing existing production setup.
+
   Trigger with phrases like "gamma production", "gamma prod ready",
+
   "gamma go live", "gamma deployment checklist", "gamma launch".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, deployment, golang, audit]
+tags:
+- saas
+- gamma
+- deployment
+- golang
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Production Checklist
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-rate-limits/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-rate-limits
-description: |
-  Understand and manage Gamma API rate limits effectively.
+description: 'Understand and manage Gamma API rate limits effectively.
+
   Use when hitting rate limits, optimizing API usage,
+
   or implementing request queuing systems.
+
   Trigger with phrases like "gamma rate limit", "gamma quota",
+
   "gamma 429", "gamma throttle", "gamma request limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api]
+tags:
+- saas
+- gamma
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Rate Limits
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-reference-architecture
-description: |
-  Reference architecture for enterprise Gamma integrations.
+description: 'Reference architecture for enterprise Gamma integrations.
+
   Use when designing systems, planning integrations,
+
   or implementing best-practice Gamma architectures.
+
   Trigger with phrases like "gamma architecture", "gamma design",
+
   "gamma system design", "gamma integration pattern", "gamma enterprise".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, gamma-reference]
+tags:
+- saas
+- gamma
+- gamma-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Reference Architecture
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-sdk-patterns
-description: |
-  Reusable patterns for the Gamma REST API (no SDK exists).
+description: 'Reusable patterns for the Gamma REST API (no SDK exists).
+
   Use when building typed wrappers, generation helpers,
+
   template factories, or error handling for Gamma.
+
   Trigger: "gamma patterns", "gamma client wrapper",
+
   "gamma best practices", "gamma API helper", "gamma code structure".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, patterns, api]
+tags:
+- saas
+- gamma
+- patterns
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma API Patterns
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-security-basics/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: gamma-security-basics
-description: |
-  Implement security best practices for Gamma integration.
+description: 'Implement security best practices for Gamma integration.
+
   Use when securing API keys, implementing access controls,
+
   or auditing Gamma security configuration.
+
   Trigger with phrases like "gamma security", "gamma API key security",
+
   "gamma secure", "gamma credentials", "gamma access control".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, security, audit]
+tags:
+- saas
+- gamma
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Security Basics
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: gamma-upgrade-migration
-description: |
-  Upgrade Gamma SDK versions and migrate between API versions.
+description: 'Upgrade Gamma SDK versions and migrate between API versions.
+
   Use when upgrading SDK packages, handling deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "gamma upgrade", "gamma migration",
+
   "gamma new version", "gamma deprecated", "gamma SDK update".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, api, migration]
+tags:
+- saas
+- gamma
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Upgrade & Migration
 

--- a/plugins/saas-packs/gamma-pack/skills/gamma-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/gamma-pack/skills/gamma-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: gamma-webhooks-events
-description: |
-  Handle Gamma webhooks and events for real-time updates.
+description: 'Handle Gamma webhooks and events for real-time updates.
+
   Use when implementing webhook receivers, processing events,
+
   or building real-time Gamma integrations.
+
   Trigger with phrases like "gamma webhooks", "gamma events",
+
   "gamma notifications", "gamma real-time", "gamma callbacks".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, gamma, webhooks]
+tags:
+- saas
+- gamma
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Gamma Webhooks & Events
 

--- a/plugins/saas-packs/glean-pack/skills/glean-ci-integration/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-ci-integration
-description: |
-  CI/CD for Glean connectors with automated indexing tests and search quality validation.
+description: 'CI/CD for Glean connectors with automated indexing tests and search
+  quality validation.
+
   Trigger: "glean CI", "glean GitHub Actions", "glean connector CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean CI Integration
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-common-errors/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-common-errors/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-common-errors
-description: |
-  Diagnose and fix common Glean API errors including indexing failures, search issues, and permission problems.
+description: 'Diagnose and fix common Glean API errors including indexing failures,
+  search issues, and permission problems.
+
   Trigger: "glean error", "glean not indexing", "glean search empty", "debug glean".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Common Errors
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-core-workflow-a/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: glean-core-workflow-a
-description: |
-  Execute Glean primary workflow: search, chat, and AI-powered answers across enterprise data.
+description: 'Execute Glean primary workflow: search, chat, and AI-powered answers
+  across enterprise data.
+
   Use when building search integrations, implementing Glean chat, or creating AI assistants.
+
   Trigger: "glean search API", "glean chat", "glean AI answers", "enterprise search".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Core Workflow A: Search & Chat
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-core-workflow-b/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: glean-core-workflow-b
-description: |
-  Execute Glean secondary workflow: bulk document indexing, custom datasource connectors,
+description: 'Execute Glean secondary workflow: bulk document indexing, custom datasource
+  connectors,
+
   and content lifecycle management via the Indexing API.
-  Trigger: "glean bulk index", "glean custom connector", "glean datasource", "glean indexing".
+
+  Trigger: "glean bulk index", "glean custom connector", "glean datasource", "glean
+  indexing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Core Workflow B: Indexing & Connectors
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: glean-cost-tuning
-description: |
-  Optimize Glean costs by managing indexed content volume, datasource efficiency,
+description: 'Optimize Glean costs by managing indexed content volume, datasource
+  efficiency,
+
   and connector resource usage.
+
   Trigger: "glean costs", "glean optimization", "reduce glean indexing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-data-handling/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-data-handling/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-data-handling
-description: |
-  PII filtering: strip emails, phone numbers, SSNs from document body before indexing.
+description: 'PII filtering: strip emails, phone numbers, SSNs from document body
+  before indexing.
+
   Trigger: "glean data handling", "data-handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Data Handling
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-debug-bundle
-description: |
-  Collect Glean diagnostic information for support including datasource config, indexing status, and search quality metrics.
+description: 'Collect Glean diagnostic information for support including datasource
+  config, indexing status, and search quality metrics.
+
   Trigger: "glean debug", "glean support", "glean diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-deploy-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-deploy-integration
-description: |
-  Deploy Glean custom connectors as scheduled jobs on Cloud Run, Lambda, or Fly.io.
+description: 'Deploy Glean custom connectors as scheduled jobs on Cloud Run, Lambda,
+  or Fly.io.
+
   Trigger: "deploy glean connector", "glean connector hosting", "schedule glean indexing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(gcloud:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-enterprise-rbac/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-enterprise-rbac
-description: |
-  Map AD/Okta groups to Glean document permissions using allowedGroups.
+description: 'Map AD/Okta groups to Glean document permissions using allowedGroups.
+
   Trigger: "glean enterprise rbac", "enterprise-rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-hello-world/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-hello-world/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: glean-hello-world
-description: |
-  Index documents into Glean and search them back using the Indexing and Client APIs.
+description: 'Index documents into Glean and search them back using the Indexing and
+  Client APIs.
+
   Use when starting a new Glean custom connector, testing search quality,
+
   or learning the index/search pattern.
+
   Trigger: "glean hello world", "glean example", "glean index document", "glean search".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Hello World
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-incident-runbook/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-incident-runbook
-description: |
-  Triage: Is search returning results? Check Glean status page.
+description: 'Triage: Is search returning results? Check Glean status page.
+
   Trigger: "glean incident runbook", "incident-runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-install-auth/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: glean-install-auth
-description: |
-  Install and configure Glean API authentication with indexing and client tokens.
+description: 'Install and configure Glean API authentication with indexing and client
+  tokens.
+
   Use when setting up custom datasource indexing, configuring search API access,
+
   or initializing the Glean developer SDK for enterprise search.
+
   Trigger: "install glean", "setup glean", "glean auth", "glean API token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-local-dev-loop/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-local-dev-loop
-description: |
-  Configure Glean local development with mock search responses, test datasources, and connector development workflow.
+description: 'Configure Glean local development with mock search responses, test datasources,
+  and connector development workflow.
+
   Trigger: "glean dev setup", "glean local development", "glean connector development".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-migration-deep-dive/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: glean-migration-deep-dive
-description: |
-  Migrate from Elasticsearch/Algolia: 1) Export all documents from source, 2) Transform to Glean document schema (id, title, url, body, permissions), 3) Create datasource with adddatasource, 4) Bulk index with bulkindexdocuments, 5) Validate search quality with test queries, 6) Switch search UI to use Glean Client API.
+description: 'Migrate from Elasticsearch/Algolia: 1) Export all documents from source,
+  2) Transform to Glean document schema (id, title, url, body, permissions), 3) Create
+  datasource with adddatasource, 4) Bulk index with bulkindexdocuments, 5) Validate
+  search quality with test queries, 6) Switch search UI to use Glean Client API.
+
   Trigger: "glean migration deep dive", "migration-deep-dive".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-multi-env-setup/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-multi-env-setup
-description: |
-  Use separate datasource names per environment (wiki_staging vs wiki_prod).
+description: 'Use separate datasource names per environment (wiki_staging vs wiki_prod).
+
   Trigger: "glean multi env setup", "multi-env-setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-observability/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-observability/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: glean-observability
-description: |
-  Track: documents indexed per run (total + new + updated + deleted), indexing errors and retries, search API latency, zero-result query rate, stale content age distribution.
+description: 'Track: documents indexed per run (total + new + updated + deleted),
+  indexing errors and retries, search API latency, zero-result query rate, stale content
+  age distribution.
+
   Trigger: "glean observability", "observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Observability
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-performance-tuning/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: glean-performance-tuning
-description: |
-  Optimize Glean search relevance and indexing throughput with batch sizing,
+description: 'Optimize Glean search relevance and indexing throughput with batch sizing,
+
   datasource configuration, and content quality improvements.
+
   Trigger: "glean performance", "glean search quality", "glean indexing speed".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-prod-checklist
-description: |
-  Pre-launch: All datasources indexed and searchable.
+description: 'Pre-launch: All datasources indexed and searchable.
+
   Trigger: "glean prod checklist", "prod-checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-rate-limits/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-rate-limits
-description: |
-  Glean Indexing API: ~100 requests/min per token.
+description: 'Glean Indexing API: ~100 requests/min per token.
+
   Trigger: "glean rate limits", "rate-limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-reference-architecture/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: glean-reference-architecture
-description: |
-  Enterprise architecture: Source Systems to Connectors (Cloud Run/Lambda, event-driven or scheduled) to Glean Indexing API to Glean Search Index to Client API (Search + Chat) to Your Apps (Slack bot, portal, internal tools).
+description: 'Enterprise architecture: Source Systems to Connectors (Cloud Run/Lambda,
+  event-driven or scheduled) to Glean Indexing API to Glean Search Index to Client
+  API (Search + Chat) to Your Apps (Slack bot, portal, internal tools).
+
   Trigger: "glean reference architecture", "reference-architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-sdk-patterns/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-sdk-patterns
-description: |
-  Apply production-ready Glean API patterns with typed clients, batch indexing, pagination, and error handling.
+description: 'Apply production-ready Glean API patterns with typed clients, batch
+  indexing, pagination, and error handling.
+
   Trigger: "glean SDK patterns", "glean best practices", "glean API client".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-security-basics/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: glean-security-basics
-description: |
-  Token security: Indexing tokens have write access -- never expose in frontend.
+description: 'Token security: Indexing tokens have write access -- never expose in
+  frontend.
+
   Trigger: "glean security basics", "security-basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Security Basics
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: glean-upgrade-migration
-description: |
-  Check Glean developer changelog for API changes.
+description: 'Check Glean developer changelog for API changes.
+
   Trigger: "glean upgrade migration", "upgrade-migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/glean-pack/skills/glean-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/glean-pack/skills/glean-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: glean-webhooks-events
-description: |
-  Implement event-driven Glean indexing triggered by source system webhooks from
+description: 'Implement event-driven Glean indexing triggered by source system webhooks
+  from
+
   GitHub, Confluence, Notion, and other content platforms.
+
   Trigger: "glean webhooks", "glean event indexing", "incremental glean index".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, enterprise-search, glean]
-compatible-with: claude-code
+tags:
+- saas
+- enterprise-search
+- glean
+compatibility: Designed for Claude Code
 ---
-
 # Glean Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-ci-integration/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-ci-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-ci-integration
-description: |
-  Configure Grammarly CI/CD integration with GitHub Actions and testing.
+description: 'Configure Grammarly CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Grammarly tests into your build process.
+
   Trigger with phrases like "grammarly CI", "grammarly GitHub Actions",
+
   "grammarly automated tests", "CI grammarly".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly CI Integration
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-common-errors/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-common-errors
-description: |
-  Diagnose and fix Grammarly common errors and exceptions.
+description: 'Diagnose and fix Grammarly common errors and exceptions.
+
   Use when encountering Grammarly errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "grammarly error", "fix grammarly",
+
   "grammarly not working", "debug grammarly".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: grammarly-core-workflow-a
-description: |
-  Execute Grammarly primary workflow: Core Workflow A.
+description: 'Execute Grammarly primary workflow: Core Workflow A.
+
   Use when implementing primary use case,
+
   building main features, or core integration tasks.
+
   Trigger with phrases like "grammarly main workflow",
+
   "primary task with grammarly".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing, scoring]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+- scoring
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Writing Score Integration
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: grammarly-core-workflow-b
-description: |
-  Execute Grammarly secondary workflow: Core Workflow B.
+description: 'Execute Grammarly secondary workflow: Core Workflow B.
+
   Use when implementing secondary use case,
+
   or complementing primary workflow.
+
   Trigger with phrases like "grammarly secondary workflow",
+
   "secondary task with grammarly".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing, ai-detection]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+- ai-detection
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly AI & Plagiarism Detection
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: grammarly-cost-tuning
-description: |
-  Optimize Grammarly costs through tier selection, sampling, and usage monitoring.
+description: 'Optimize Grammarly costs through tier selection, sampling, and usage
+  monitoring.
+
   Use when analyzing Grammarly billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "grammarly cost", "grammarly billing",
-  "reduce grammarly costs", "grammarly pricing", "grammarly expensive", "grammarly budget".
+
+  "reduce grammarly costs", "grammarly pricing", "grammarly expensive", "grammarly
+  budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-data-handling/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-data-handling/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-data-handling
-description: |
-  Implement Grammarly data handling patterns for document processing.
+description: 'Implement Grammarly data handling patterns for document processing.
+
   Use when handling large documents, managing text chunking,
+
   or implementing data pipelines for Grammarly API.
+
   Trigger with phrases like "grammarly data", "grammarly documents",
+
   "grammarly text processing", "grammarly pipeline".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Data Handling
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-debug-bundle
-description: |
-  Collect Grammarly debug evidence for support tickets and troubleshooting.
+description: 'Collect Grammarly debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Grammarly problems.
+
   Trigger with phrases like "grammarly debug", "grammarly support bundle",
+
   "collect grammarly logs", "grammarly diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-deploy-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-deploy-integration
-description: |
-  Deploy Grammarly integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Grammarly integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Grammarly-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy grammarly", "grammarly Vercel",
+
   "grammarly production deploy", "grammarly Cloud Run", "grammarly Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-enterprise-rbac/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: grammarly-enterprise-rbac
-description: |
-  Configure Grammarly enterprise role-based access control.
+description: 'Configure Grammarly enterprise role-based access control.
+
   Use when managing team access, configuring organization settings,
+
   or implementing Grammarly enterprise governance.
+
   Trigger with phrases like "grammarly enterprise", "grammarly teams",
+
   "grammarly rbac", "grammarly organization", "grammarly admin".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing, enterprise]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+- enterprise
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-hello-world/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-hello-world
-description: |
-  Create a minimal working Grammarly example.
+description: 'Create a minimal working Grammarly example.
+
   Use when starting a new Grammarly integration, testing your setup,
+
   or learning basic Grammarly API patterns.
+
   Trigger with phrases like "grammarly hello world", "grammarly example",
+
   "grammarly quick start", "simple grammarly code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Hello World
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-incident-runbook/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-incident-runbook
-description: |
-  Follow Grammarly incident response runbook for API outages.
+description: 'Follow Grammarly incident response runbook for API outages.
+
   Use when Grammarly API is down, experiencing errors,
+
   or when investigating service degradation.
+
   Trigger with phrases like "grammarly down", "grammarly outage",
+
   "grammarly incident", "grammarly not responding".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-install-auth/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-install-auth
-description: |
-  Install and configure Grammarly SDK/CLI authentication.
+description: 'Install and configure Grammarly SDK/CLI authentication.
+
   Use when setting up a new Grammarly integration, configuring API keys,
+
   or initializing Grammarly in your project.
+
   Trigger with phrases like "install grammarly", "setup grammarly",
+
   "grammarly auth", "configure grammarly API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-local-dev-loop/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-local-dev-loop
-description: |
-  Configure Grammarly local development with hot reload and testing.
+description: 'Configure Grammarly local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Grammarly.
+
   Trigger with phrases like "grammarly dev setup", "grammarly local development",
+
   "grammarly dev environment", "develop with grammarly".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-migration-deep-dive/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: grammarly-migration-deep-dive
-description: |
-  Deep dive into Grammarly API migration patterns.
+description: 'Deep dive into Grammarly API migration patterns.
+
   Use when migrating between API versions or from deprecated endpoints.
+
   Trigger with phrases like "grammarly migration deep dive",
+
   "grammarly api migration", "grammarly version change".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-multi-env-setup/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: grammarly-multi-env-setup
-description: |
-  Configure Grammarly across multiple environments.
+description: 'Configure Grammarly across multiple environments.
+
   Use when setting up dev/staging/prod environments with Grammarly API.
+
   Trigger with phrases like "grammarly multi-env", "grammarly environments",
+
   "grammarly staging", "grammarly dev prod setup".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-observability/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-observability/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-observability
-description: |
-  Implement Grammarly observability with metrics and logging.
+description: 'Implement Grammarly observability with metrics and logging.
+
   Use when setting up monitoring, tracking API performance,
+
   or implementing alerting for Grammarly integrations.
+
   Trigger with phrases like "grammarly monitoring", "grammarly metrics",
+
   "grammarly observability", "grammarly logging", "grammarly alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Observability
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-performance-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: grammarly-performance-tuning
-description: |
-  Optimize Grammarly API performance with caching, batching, and connection pooling.
+description: 'Optimize Grammarly API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Grammarly integrations.
+
   Trigger with phrases like "grammarly performance", "optimize grammarly",
+
   "grammarly latency", "grammarly caching", "grammarly slow", "grammarly batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Performance Tuning
 
 ## Latency Benchmarks

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: grammarly-prod-checklist
-description: |
-  Production readiness checklist for Grammarly API integrations. Use when preparing
+description: 'Production readiness checklist for Grammarly API integrations. Use when
+  preparing
+
   a Grammarly integration for production deployment.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-rate-limits/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-rate-limits
-description: |
-  Implement Grammarly rate limiting, backoff, and idempotency patterns.
+description: 'Implement Grammarly rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Grammarly.
+
   Trigger with phrases like "grammarly rate limit", "grammarly throttling",
+
   "grammarly 429", "grammarly retry", "grammarly backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: grammarly-reference-architecture
-description: |
-  Implement Grammarly reference architecture with best-practice project layout.
+description: 'Implement Grammarly reference architecture with best-practice project
+  layout.
+
   Use when designing new Grammarly integrations, reviewing project structure,
+
   or establishing architecture standards for Grammarly applications.
+
   Trigger with phrases like "grammarly architecture", "grammarly best practices",
+
   "grammarly project structure", "how to organize grammarly", "grammarly layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Reference Architecture
 
 ## Architecture

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-sdk-patterns/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-sdk-patterns
-description: |
-  Apply production-ready Grammarly SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Grammarly SDK patterns for TypeScript and Python.
+
   Use when implementing Grammarly integrations, refactoring SDK usage,
+
   or establishing team coding standards for Grammarly.
+
   Trigger with phrases like "grammarly SDK patterns", "grammarly best practices",
+
   "grammarly code patterns", "idiomatic grammarly".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-security-basics/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: grammarly-security-basics
-description: |
-  Security fundamentals for Grammarly API credential management. Use when setting up
+description: 'Security fundamentals for Grammarly API credential management. Use when
+  setting up
+
   secure authentication and token handling for Grammarly integrations.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Security Basics
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: grammarly-upgrade-migration
-description: |
-  Upgrade and migration guidance for Grammarly API version changes. Use when migrating
+description: 'Upgrade and migration guidance for Grammarly API version changes. Use
+  when migrating
+
   between Grammarly API versions or updating endpoint references.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/grammarly-pack/skills/grammarly-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/grammarly-pack/skills/grammarly-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: grammarly-webhooks-events
-description: |
-  Implement Grammarly webhook signature validation and event handling.
+description: 'Implement Grammarly webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling Grammarly event notifications securely.
+
   Trigger with phrases like "grammarly webhook", "grammarly events",
+
   "grammarly webhook signature", "handle grammarly events", "grammarly notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, grammarly, writing]
-compatible-with: claude-code
+tags:
+- saas
+- grammarly
+- writing
+compatibility: Designed for Claude Code
 ---
-
 # Grammarly Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/granola-pack/skills/granola-ci-integration/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-ci-integration/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: granola-ci-integration
-description: |
-  Build automated pipelines from Granola meeting notes to GitHub Issues, Linear tasks,
+description: 'Build automated pipelines from Granola meeting notes to GitHub Issues,
+  Linear tasks,
+
   Slack notifications, and documentation updates using Zapier and GitHub Actions.
+
   Trigger: "granola CI", "granola automation pipeline", "granola to github",
+
   "granola to linear", "meeting notes automation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, ci-cd, automation]
+tags:
+- saas
+- granola
+- ci-cd
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola CI Integration
 

--- a/plugins/saas-packs/granola-pack/skills/granola-common-errors/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-common-errors/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: granola-common-errors
-description: |
-  Troubleshoot common Granola errors — audio capture failures, transcription issues,
-  calendar sync problems, and integration errors. Platform-specific fixes for macOS and Windows.
-  Trigger: "granola error", "granola not working", "granola not recording",
-  "fix granola", "granola troubleshoot".
-allowed-tools: Read, Write, Edit, Bash(pgrep:*), Bash(ps:*), Bash(system_profiler:*), Bash(defaults:*)
+description: "Troubleshoot common Granola errors \u2014 audio capture failures, transcription\
+  \ issues,\ncalendar sync problems, and integration errors. Platform-specific fixes\
+  \ for macOS and Windows.\nTrigger: \"granola error\", \"granola not working\", \"\
+  granola not recording\",\n\"fix granola\", \"granola troubleshoot\".\n"
+allowed-tools: Read, Write, Edit, Bash(pgrep:*), Bash(ps:*), Bash(system_profiler:*),
+  Bash(defaults:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, troubleshooting]
+tags:
+- saas
+- granola
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Common Errors
 

--- a/plugins/saas-packs/granola-pack/skills/granola-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-core-workflow-a/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: granola-core-workflow-a
-description: |
-  Meeting preparation and template setup in Granola — templates, recipes, and pre-meeting workflows.
-  Use when configuring note templates for 1:1s, standups, discovery calls, or sprint planning,
-  creating custom recipes, or preparing agenda notes before important meetings.
-  Trigger: "granola template", "granola meeting prep", "granola recipe", "granola agenda".
+description: "Meeting preparation and template setup in Granola \u2014 templates,\
+  \ recipes, and pre-meeting workflows.\nUse when configuring note templates for 1:1s,\
+  \ standups, discovery calls, or sprint planning,\ncreating custom recipes, or preparing\
+  \ agenda notes before important meetings.\nTrigger: \"granola template\", \"granola\
+  \ meeting prep\", \"granola recipe\", \"granola agenda\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, workflow, templates]
+tags:
+- saas
+- granola
+- workflow
+- templates
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Core Workflow A: Meeting Preparation & Templates
 

--- a/plugins/saas-packs/granola-pack/skills/granola-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-core-workflow-b/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-core-workflow-b
-description: |
-  Post-meeting note processing, sharing, and follow-up workflows in Granola.
+description: 'Post-meeting note processing, sharing, and follow-up workflows in Granola.
+
   Use when enhancing notes after meetings, sharing to Slack/Notion/CRM,
+
   drafting follow-up emails, or processing action items.
+
   Trigger: "granola post-meeting", "share granola notes", "granola follow-up",
+
   "granola enhance", "granola share".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, workflow, sharing]
+tags:
+- saas
+- granola
+- workflow
+- sharing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Core Workflow B: Post-Meeting Processing & Sharing
 

--- a/plugins/saas-packs/granola-pack/skills/granola-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-cost-tuning/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: granola-cost-tuning
-description: |
-  Optimize Granola costs — plan selection, ROI calculation, seat management,
-  and billing strategies for individuals and teams.
-  Trigger: "granola cost", "granola pricing", "granola plan selection",
-  "save money granola", "granola ROI", "granola subscription".
+description: "Optimize Granola costs \u2014 plan selection, ROI calculation, seat\
+  \ management,\nand billing strategies for individuals and teams.\nTrigger: \"granola\
+  \ cost\", \"granola pricing\", \"granola plan selection\",\n\"save money granola\"\
+  , \"granola ROI\", \"granola subscription\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, cost-optimization]
+tags:
+- saas
+- granola
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Cost Tuning
 

--- a/plugins/saas-packs/granola-pack/skills/granola-data-handling/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-data-handling/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: granola-data-handling
-description: |
-  Manage Granola data export, retention policies, GDPR/CCPA compliance,
+description: 'Manage Granola data export, retention policies, GDPR/CCPA compliance,
+
   and archival workflows. Handle Subject Access Requests and Right to Erasure.
+
   Trigger: "granola export", "granola data", "granola GDPR",
+
   "granola retention", "granola delete data", "granola compliance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, compliance, data, gdpr]
+tags:
+- saas
+- granola
+- compliance
+- data
+- gdpr
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Data Handling
 

--- a/plugins/saas-packs/granola-pack/skills/granola-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-debug-bundle/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: granola-debug-bundle
-description: |
-  Create diagnostic bundles for Granola support requests.
+description: 'Create diagnostic bundles for Granola support requests.
+
   Use when preparing support tickets, collecting system/audio/network info,
+
   or diagnosing complex issues that require Granola support team assistance.
+
   Trigger: "granola debug", "granola diagnostics", "granola support bundle",
+
   "granola logs", "granola system info".
-allowed-tools: Read, Write, Edit, Bash(system_profiler:*), Bash(sw_vers:*), Bash(defaults:*), Bash(curl:*), Bash(pgrep:*), Bash(ls:*), Bash(zip:*), Bash(mkdir:*), Bash(uname:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(system_profiler:*), Bash(sw_vers:*), Bash(defaults:*),
+  Bash(curl:*), Bash(pgrep:*), Bash(ls:*), Bash(zip:*), Bash(mkdir:*), Bash(uname:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, debugging, support]
+tags:
+- saas
+- granola
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Debug Bundle
 

--- a/plugins/saas-packs/granola-pack/skills/granola-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: granola-deploy-integration
-description: |
-  Deploy Granola native integrations — Slack, Notion, HubSpot, Attio, Affinity, and Zapier.
-  Step-by-step setup for each platform with configuration, testing, and automation chains.
-  Trigger: "granola slack", "granola notion", "granola hubspot",
-  "granola attio", "connect granola", "granola integration".
+description: "Deploy Granola native integrations \u2014 Slack, Notion, HubSpot, Attio,\
+  \ Affinity, and Zapier.\nStep-by-step setup for each platform with configuration,\
+  \ testing, and automation chains.\nTrigger: \"granola slack\", \"granola notion\"\
+  , \"granola hubspot\",\n\"granola attio\", \"connect granola\", \"granola integration\"\
+  .\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, integrations, deployment]
+tags:
+- saas
+- granola
+- integrations
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Deploy Integration
 

--- a/plugins/saas-packs/granola-pack/skills/granola-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: granola-enterprise-rbac
-description: |
-  Configure enterprise role-based access control for Granola workspaces.
-  Use when defining user roles, setting sharing permissions, configuring SSO group mappings,
+description: 'Configure enterprise role-based access control for Granola workspaces.
+
+  Use when defining user roles, setting sharing permissions, configuring SSO group
+  mappings,
+
   or implementing least-privilege access for meeting data.
+
   Trigger: "granola roles", "granola permissions", "granola access control",
+
   "granola RBAC", "granola admin roles".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, rbac, enterprise, security]
+tags:
+- saas
+- granola
+- rbac
+- enterprise
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Enterprise RBAC
 

--- a/plugins/saas-packs/granola-pack/skills/granola-hello-world/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-hello-world/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: granola-hello-world
-description: |
-  Capture your first meeting with Granola and review AI-enhanced notes.
+description: 'Capture your first meeting with Granola and review AI-enhanced notes.
+
   Use when testing Granola setup, learning the notepad + transcript flow,
+
   or understanding how Enhance Notes and Granola Chat work.
-  Trigger: "granola hello world", "first granola meeting", "try granola", "granola test".
+
+  Trigger: "granola hello world", "first granola meeting", "try granola", "granola
+  test".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pgrep:*), Bash(open:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, getting-started]
+tags:
+- saas
+- granola
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Hello World
 

--- a/plugins/saas-packs/granola-pack/skills/granola-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-incident-runbook
-description: |
-  Incident response procedures for Granola meeting capture failures and outages.
-  Use when meetings aren't recording, transcription fails mid-meeting,
+description: 'Incident response procedures for Granola meeting capture failures and
+  outages.
+
+  Use when meetings aren''t recording, transcription fails mid-meeting,
+
   integrations stop syncing, or the Granola service is down.
+
   Trigger: "granola incident", "granola outage", "granola down",
+
   "granola not recording", "granola emergency".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(pgrep:*), Bash(pkill:*), Bash(open:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, incident-response]
+tags:
+- saas
+- granola
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Incident Runbook
 

--- a/plugins/saas-packs/granola-pack/skills/granola-install-auth/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-install-auth/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: granola-install-auth
-description: |
-  Install and configure Granola AI meeting notes with calendar and audio permissions.
+description: 'Install and configure Granola AI meeting notes with calendar and audio
+  permissions.
+
   Use when setting up Granola for the first time, connecting Google/Outlook calendars,
+
   granting macOS Screen Recording permission, or configuring Windows audio capture.
+
   Trigger: "install granola", "setup granola", "granola calendar", "granola permissions".
-allowed-tools: Read, Write, Edit, Bash(brew:*), Bash(open:*), Bash(pgrep:*), Bash(defaults:*), Bash(ls:*)
+
+  '
+allowed-tools: Read, Write, Edit, Bash(brew:*), Bash(open:*), Bash(pgrep:*), Bash(defaults:*),
+  Bash(ls:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, granola-install]
+tags:
+- saas
+- granola
+- granola-install
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Install & Auth
 

--- a/plugins/saas-packs/granola-pack/skills/granola-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-local-dev-loop
-description: |
-  Access Granola meeting data programmatically for developer workflows.
+description: 'Access Granola meeting data programmatically for developer workflows.
+
   Use when reading notes from the local cache, building MCP integrations,
+
   extracting action items into code, or syncing meeting outcomes to dev tools.
+
   Trigger: "granola dev workflow", "granola MCP", "granola local cache",
+
   "granola developer", "granola programmatic".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, workflow, developer]
+tags:
+- saas
+- granola
+- workflow
+- developer
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Local Dev Loop
 

--- a/plugins/saas-packs/granola-pack/skills/granola-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-migration-deep-dive
-description: |
-  Migrate to Granola from Otter.ai, Fireflies, Fathom, tl;dv, or manual note-taking.
+description: 'Migrate to Granola from Otter.ai, Fireflies, Fathom, tl;dv, or manual
+  note-taking.
+
   Covers data export from source tools, parallel-run strategy, team transition,
+
   and historical data preservation.
+
   Trigger: "migrate to granola", "switch to granola", "granola from otter",
+
   "granola from fireflies", "replace meeting tool with granola".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, migration]
+tags:
+- saas
+- granola
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Migration Deep Dive
 

--- a/plugins/saas-packs/granola-pack/skills/granola-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-multi-env-setup/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: granola-multi-env-setup
-description: |
-  Configure Granola across multiple workspaces and teams with SSO/SCIM provisioning.
+description: 'Configure Granola across multiple workspaces and teams with SSO/SCIM
+  provisioning.
+
   Use when setting up department-level workspaces, configuring user provisioning,
+
   or managing enterprise-scale Granola deployments.
+
   Trigger: "granola workspaces", "granola multi-team", "granola SSO",
+
   "granola SCIM", "granola organization setup".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, deployment, scaling, enterprise]
+tags:
+- saas
+- granola
+- deployment
+- scaling
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Multi-Environment Setup
 

--- a/plugins/saas-packs/granola-pack/skills/granola-observability/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: granola-observability
-description: |
-  Monitor Granola adoption, meeting analytics, and build custom dashboards.
+description: 'Monitor Granola adoption, meeting analytics, and build custom dashboards.
+
   Use when tracking team meeting patterns, measuring adoption,
+
   building analytics pipelines, or creating executive reports.
+
   Trigger: "granola analytics", "granola metrics", "granola monitoring",
+
   "granola adoption", "meeting insights".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, monitoring, analytics, observability]
+tags:
+- saas
+- granola
+- monitoring
+- analytics
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Observability
 

--- a/plugins/saas-packs/granola-pack/skills/granola-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: granola-performance-tuning
-description: |
-  Optimize Granola transcription accuracy, note quality, and processing speed.
+description: 'Optimize Granola transcription accuracy, note quality, and processing
+  speed.
+
   Use when improving transcription quality, reducing processing time,
+
   optimizing templates for better AI output, or tuning audio setup.
+
   Trigger: "granola performance", "granola accuracy", "granola quality",
+
   "improve granola", "granola transcription better".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, performance, transcription]
+tags:
+- saas
+- granola
+- performance
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Performance Tuning
 

--- a/plugins/saas-packs/granola-pack/skills/granola-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-prod-checklist
-description: |
-  Production readiness checklist for Granola team and enterprise deployment.
+description: 'Production readiness checklist for Granola team and enterprise deployment.
+
   Use when rolling out Granola to a team, planning enterprise deployment,
+
   or verifying all configuration is production-ready.
+
   Trigger: "granola production", "granola rollout", "granola deployment",
+
   "granola checklist", "granola go-live".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, deployment, enterprise]
+tags:
+- saas
+- granola
+- deployment
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Production Checklist
 

--- a/plugins/saas-packs/granola-pack/skills/granola-rate-limits/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-rate-limits
-description: |
-  Understand Granola plan limits, usage quotas, and API rate limiting.
+description: 'Understand Granola plan limits, usage quotas, and API rate limiting.
+
   Use when hitting meeting limits, choosing between plans,
+
   or managing Enterprise API rate limits.
+
   Trigger: "granola limits", "granola quota", "granola plan",
+
   "granola usage", "granola restrictions".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, monitoring, plans]
+tags:
+- saas
+- granola
+- monitoring
+- plans
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Rate Limits & Plan Quotas
 

--- a/plugins/saas-packs/granola-pack/skills/granola-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-reference-architecture
-description: |
-  Enterprise reference architecture for meeting management with Granola.
+description: 'Enterprise reference architecture for meeting management with Granola.
+
   Use when designing org-wide meeting workflows, planning integration topology,
+
   or architecting meeting-to-action pipelines across departments.
+
   Trigger: "granola architecture", "granola enterprise design",
+
   "granola system design", "meeting system architecture".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, architecture, enterprise]
+tags:
+- saas
+- granola
+- architecture
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Reference Architecture
 

--- a/plugins/saas-packs/granola-pack/skills/granola-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-sdk-patterns/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: granola-sdk-patterns
-description: |
-  Zapier automation patterns and Enterprise API integration for Granola.
+description: 'Zapier automation patterns and Enterprise API integration for Granola.
+
   Use when building automated workflows, connecting Granola to 8,000+ apps via Zapier,
+
   or querying the Enterprise API for notes and transcripts.
+
   Trigger: "granola zapier", "granola automation", "granola API", "granola SDK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, automation, api]
+tags:
+- saas
+- granola
+- automation
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola SDK Patterns
 

--- a/plugins/saas-packs/granola-pack/skills/granola-security-basics/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: granola-security-basics
-description: |
-  Security and privacy configuration for Granola meeting data.
+description: 'Security and privacy configuration for Granola meeting data.
+
   Use when reviewing data handling practices, configuring encryption,
+
   ensuring SOC 2/GDPR compliance, or securing meeting recordings.
+
   Trigger: "granola security", "granola privacy", "granola encryption",
+
   "granola SOC 2", "granola GDPR", "secure granola".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, security, compliance, privacy]
+tags:
+- saas
+- granola
+- security
+- compliance
+- privacy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Security Basics
 

--- a/plugins/saas-packs/granola-pack/skills/granola-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-upgrade-migration
-description: |
-  Upgrade Granola app versions and migrate between subscription plans.
+description: 'Upgrade Granola app versions and migrate between subscription plans.
+
   Use when upgrading the desktop app, changing from free to paid plans,
+
   downgrading with data preservation, or resolving update issues.
+
   Trigger: "upgrade granola", "granola update", "change granola plan",
+
   "granola new version", "granola downgrade".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(brew:*), Bash(defaults:*), Bash(rm:*), Bash(open:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, migration, upgrade]
+tags:
+- saas
+- granola
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Upgrade & Migration
 

--- a/plugins/saas-packs/granola-pack/skills/granola-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/granola-pack/skills/granola-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: granola-webhooks-events
-description: |
-  Build event-driven automations with Granola's Zapier webhook triggers.
+description: 'Build event-driven automations with Granola''s Zapier webhook triggers.
+
   Use when creating real-time notification systems, processing meeting events,
+
   or building custom integrations that react to Granola note creation.
+
   Trigger: "granola webhooks", "granola events", "granola triggers",
+
   "granola real-time", "granola event-driven".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, granola, webhooks, automation]
+tags:
+- saas
+- granola
+- webhooks
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Granola Webhooks & Events
 

--- a/plugins/saas-packs/groq-pack/skills/groq-ci-integration/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: groq-ci-integration
-description: |
-  Configure Groq CI/CD integration with GitHub Actions, testing, and model validation.
+description: 'Configure Groq CI/CD integration with GitHub Actions, testing, and model
+  validation.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Groq tests into your build process.
+
   Trigger with phrases like "groq CI", "groq GitHub Actions",
+
   "groq automated tests", "CI groq".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, testing, ci-cd]
+tags:
+- saas
+- groq
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq CI Integration
 

--- a/plugins/saas-packs/groq-pack/skills/groq-common-errors/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: groq-common-errors
-description: |
-  Diagnose and fix Groq API errors with real error codes and solutions.
+description: 'Diagnose and fix Groq API errors with real error codes and solutions.
+
   Use when encountering Groq errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "groq error", "fix groq",
+
   "groq not working", "debug groq", "groq 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, debugging]
+tags:
+- saas
+- groq
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Common Errors
 

--- a/plugins/saas-packs/groq-pack/skills/groq-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-core-workflow-a
-description: |
-  Execute Groq primary workflow: chat completions with tool use and JSON mode.
+description: 'Execute Groq primary workflow: chat completions with tool use and JSON
+  mode.
+
   Use when implementing chat interfaces, function calling, structured output,
-  or building AI features with Groq's fast inference.
+
+  or building AI features with Groq''s fast inference.
+
   Trigger with phrases like "groq chat completion", "groq tool use",
+
   "groq function calling", "groq JSON mode".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, workflow]
+tags:
+- saas
+- groq
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Core Workflow A: Chat, Tools & Structured Output
 

--- a/plugins/saas-packs/groq-pack/skills/groq-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-core-workflow-b/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: groq-core-workflow-b
-description: |
-  Execute Groq secondary workflows: audio transcription (Whisper), vision,
+description: 'Execute Groq secondary workflows: audio transcription (Whisper), vision,
+
   text-to-speech, and batch model evaluation.
+
   Trigger with phrases like "groq whisper", "groq transcription",
+
   "groq audio", "groq vision", "groq TTS", "groq speech".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, workflow, audio, vision]
+tags:
+- saas
+- groq
+- workflow
+- audio
+- vision
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Core Workflow B: Audio, Vision & Speech
 

--- a/plugins/saas-packs/groq-pack/skills/groq-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: groq-cost-tuning
-description: |
-  Optimize Groq costs through model routing, token management, and usage monitoring.
+description: 'Optimize Groq costs through model routing, token management, and usage
+  monitoring.
+
   Use when analyzing Groq billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "groq cost", "groq billing",
+
   "reduce groq costs", "groq pricing", "groq expensive", "groq budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, monitoring, cost-optimization]
+tags:
+- saas
+- groq
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Cost Tuning
 

--- a/plugins/saas-packs/groq-pack/skills/groq-data-handling/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-data-handling/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: groq-data-handling
-description: |
-  Implement prompt sanitization, PII redaction, response filtering, and
+description: 'Implement prompt sanitization, PII redaction, response filtering, and
+
   usage tracking for Groq API integrations.
+
   Trigger with phrases like "groq data", "groq PII",
+
   "groq GDPR", "groq data retention", "groq privacy", "groq compliance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, compliance]
+tags:
+- saas
+- groq
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Data Handling
 

--- a/plugins/saas-packs/groq-pack/skills/groq-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: groq-debug-bundle
-description: |
-  Collect Groq debug evidence for support tickets and troubleshooting.
+description: 'Collect Groq debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Groq problems.
+
   Trigger with phrases like "groq debug", "groq support bundle",
+
   "collect groq logs", "groq diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, debugging]
+tags:
+- saas
+- groq
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Debug Bundle
 

--- a/plugins/saas-packs/groq-pack/skills/groq-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: groq-deploy-integration
-description: |
-  Deploy Groq integrations to Vercel, Cloud Run, and containerized platforms.
+description: 'Deploy Groq integrations to Vercel, Cloud Run, and containerized platforms.
+
   Use when deploying Groq-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy groq", "groq Vercel",
+
   "groq production deploy", "groq Cloud Run", "groq Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, deployment]
+tags:
+- saas
+- groq
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Deploy Integration
 

--- a/plugins/saas-packs/groq-pack/skills/groq-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-enterprise-rbac/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: groq-enterprise-rbac
-description: |
-  Configure Groq organization management, API key scoping, spending controls, and team access patterns.
+description: 'Configure Groq organization management, API key scoping, spending controls,
+  and team access patterns.
+
   Trigger with phrases like "groq organization", "groq RBAC",
+
   "groq enterprise", "groq team access", "groq spending limits", "groq multi-team".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, rbac]
+tags:
+- saas
+- groq
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Enterprise Access Management
 

--- a/plugins/saas-packs/groq-pack/skills/groq-hello-world/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-hello-world
-description: |
-  Create a minimal working Groq chat completion example.
+description: 'Create a minimal working Groq chat completion example.
+
   Use when starting a new Groq integration, testing your setup,
+
   or learning basic Groq API patterns.
+
   Trigger with phrases like "groq hello world", "groq example",
+
   "groq quick start", "simple groq code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, testing]
+tags:
+- saas
+- groq
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Hello World
 

--- a/plugins/saas-packs/groq-pack/skills/groq-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: groq-incident-runbook
-description: |
-  Execute Groq incident response: triage, mitigation, fallback, and postmortem.
+description: 'Execute Groq incident response: triage, mitigation, fallback, and postmortem.
+
   Use when responding to Groq-related outages, investigating errors,
+
   or running post-incident reviews for Groq integration failures.
+
   Trigger with phrases like "groq incident", "groq outage",
+
   "groq down", "groq on-call", "groq emergency", "groq broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, incident-response]
+tags:
+- saas
+- groq
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Incident Runbook
 

--- a/plugins/saas-packs/groq-pack/skills/groq-install-auth/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-install-auth
-description: |
-  Install and configure Groq SDK authentication for TypeScript or Python.
+description: 'Install and configure Groq SDK authentication for TypeScript or Python.
+
   Use when setting up a new Groq integration, configuring API keys,
+
   or initializing the groq-sdk in your project.
+
   Trigger with phrases like "install groq", "setup groq",
+
   "groq auth", "configure groq API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, authentication]
+tags:
+- saas
+- groq
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Install & Auth
 

--- a/plugins/saas-packs/groq-pack/skills/groq-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-local-dev-loop
-description: |
-  Configure Groq local development with hot reload, mocking, and testing.
+description: 'Configure Groq local development with hot reload, mocking, and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Groq.
+
   Trigger with phrases like "groq dev setup", "groq local development",
+
   "groq dev environment", "develop with groq".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, testing, workflow]
+tags:
+- saas
+- groq
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Local Dev Loop
 

--- a/plugins/saas-packs/groq-pack/skills/groq-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-migration-deep-dive/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: groq-migration-deep-dive
-description: |
-  Migrate from OpenAI/Anthropic/other LLM providers to Groq, or migrate
+description: 'Migrate from OpenAI/Anthropic/other LLM providers to Groq, or migrate
+
   between Groq model generations with zero-downtime traffic shifting.
+
   Trigger with phrases like "migrate to groq", "switch to groq",
+
   "groq migration", "openai to groq", "groq replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, migration]
+tags:
+- saas
+- groq
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Migration Deep Dive
 

--- a/plugins/saas-packs/groq-pack/skills/groq-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-multi-env-setup/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: groq-multi-env-setup
-description: |
-  Configure Groq across dev, staging, and production with environment-specific
+description: 'Configure Groq across dev, staging, and production with environment-specific
+
   model selection, rate limits, and API keys.
+
   Trigger with phrases like "groq environments", "groq staging", "groq dev prod",
+
   "groq environment setup", "groq multi-env", "groq config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, deployment, api, llm]
+tags:
+- saas
+- groq
+- deployment
+- api
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Multi-Environment Setup
 

--- a/plugins/saas-packs/groq-pack/skills/groq-observability/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-observability/SKILL.md
@@ -1,16 +1,26 @@
 ---
 name: groq-observability
-description: |
-  Set up observability for Groq integrations: latency histograms, token throughput,
+description: 'Set up observability for Groq integrations: latency histograms, token
+  throughput,
+
   rate limit gauges, cost tracking, and Prometheus alerts.
+
   Trigger with phrases like "groq monitoring", "groq metrics",
+
   "groq observability", "monitor groq", "groq alerts", "groq dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, monitoring, observability, dashboard]
+tags:
+- saas
+- groq
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Observability
 

--- a/plugins/saas-packs/groq-pack/skills/groq-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: groq-performance-tuning
-description: |
-  Optimize Groq API performance with model selection, caching, streaming, and parallel requests.
+description: 'Optimize Groq API performance with model selection, caching, streaming,
+  and parallel requests.
+
   Use when experiencing slow responses, implementing caching strategies,
+
   or optimizing request throughput for Groq integrations.
+
   Trigger with phrases like "groq performance", "optimize groq",
+
   "groq latency", "groq caching", "groq slow", "groq speed".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, performance]
+tags:
+- saas
+- groq
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Performance Tuning
 

--- a/plugins/saas-packs/groq-pack/skills/groq-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: groq-prod-checklist
-description: |
-  Execute Groq production deployment checklist and go-live procedures.
+description: 'Execute Groq production deployment checklist and go-live procedures.
+
   Use when deploying Groq integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "groq production", "deploy groq",
+
   "groq go-live", "groq launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, deployment]
+tags:
+- saas
+- groq
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Production Checklist
 

--- a/plugins/saas-packs/groq-pack/skills/groq-rate-limits/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-rate-limits
-description: |
-  Implement Groq rate limit handling with backoff, queuing, and header parsing.
+description: 'Implement Groq rate limit handling with backoff, queuing, and header
+  parsing.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Groq.
+
   Trigger with phrases like "groq rate limit", "groq throttling",
+
   "groq 429", "groq retry", "groq backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api]
+tags:
+- saas
+- groq
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Rate Limits
 

--- a/plugins/saas-packs/groq-pack/skills/groq-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-reference-architecture
-description: |
-  Implement Groq reference architecture with model routing, streaming pipelines, and fallbacks.
+description: 'Implement Groq reference architecture with model routing, streaming
+  pipelines, and fallbacks.
+
   Use when designing new Groq integrations, reviewing project structure,
+
   or establishing architecture standards for Groq applications.
+
   Trigger with phrases like "groq architecture", "groq best practices",
+
   "groq project structure", "how to organize groq", "groq design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, groq-reference]
+tags:
+- saas
+- groq
+- groq-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Reference Architecture
 

--- a/plugins/saas-packs/groq-pack/skills/groq-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-sdk-patterns
-description: |
-  Apply production-ready Groq SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Groq SDK patterns for TypeScript and Python.
+
   Use when implementing Groq integrations, refactoring SDK usage,
+
   or establishing team coding standards for Groq.
+
   Trigger with phrases like "groq SDK patterns", "groq best practices",
+
   "groq code patterns", "idiomatic groq".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, python, typescript]
+tags:
+- saas
+- groq
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq SDK Patterns
 

--- a/plugins/saas-packs/groq-pack/skills/groq-security-basics/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: groq-security-basics
-description: |
-  Apply Groq security best practices for API key management and data protection.
+description: 'Apply Groq security best practices for API key management and data protection.
+
   Use when securing API keys, implementing least privilege access,
+
   or auditing Groq security configuration.
+
   Trigger with phrases like "groq security", "groq secrets",
+
   "secure groq", "groq API key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, security, audit]
+tags:
+- saas
+- groq
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Security Basics
 

--- a/plugins/saas-packs/groq-pack/skills/groq-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-upgrade-migration
-description: |
-  Upgrade groq-sdk versions and handle Groq model deprecations.
+description: 'Upgrade groq-sdk versions and handle Groq model deprecations.
+
   Use when upgrading SDK versions, detecting deprecated models,
+
   or migrating to new Groq model IDs.
+
   Trigger with phrases like "upgrade groq", "groq migration",
+
   "groq breaking changes", "update groq SDK", "groq deprecated model".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, api, migration]
+tags:
+- saas
+- groq
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Upgrade & Migration
 

--- a/plugins/saas-packs/groq-pack/skills/groq-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/groq-pack/skills/groq-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: groq-webhooks-events
-description: |
-  Build event-driven architectures with Groq streaming, batch processing, and async patterns.
+description: 'Build event-driven architectures with Groq streaming, batch processing,
+  and async patterns.
+
   Use when setting up real-time SSE endpoints, batch processing pipelines,
+
   or event-driven LLM processing with Groq.
+
   Trigger with phrases like "groq streaming", "groq events",
+
   "groq SSE", "groq batch", "groq async", "groq event-driven".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, groq, webhooks]
+tags:
+- saas
+- groq
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Groq Events & Async Patterns
 

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-ci-integration/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-ci-integration
-description: |
-  Configure CI/CD pipelines for Guidewire with Gosu compilation, GUnit tests, and configuration deployment.
+description: 'Configure CI/CD pipelines for Guidewire with Gosu compilation, GUnit
+  tests, and configuration deployment.
+
   Trigger: "guidewire ci integration", "ci-integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-common-errors/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-common-errors/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-common-errors
-description: |
-  Diagnose and fix common Guidewire Cloud API errors including Gosu exceptions, validation failures, and integration issues.
+description: 'Diagnose and fix common Guidewire Cloud API errors including Gosu exceptions,
+  validation failures, and integration issues.
+
   Trigger: "guidewire common errors", "common-errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Common Errors
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-core-workflow-a/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: guidewire-core-workflow-a
-description: |
-  Execute Guidewire primary workflow: Policy lifecycle in PolicyCenter.
+description: 'Execute Guidewire primary workflow: Policy lifecycle in PolicyCenter.
+
   Use when implementing quoting, binding, issuing, endorsing, or renewing policies.
+
   Trigger: "policycenter workflow", "create policy", "bind submission", "issue policy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Core Workflow A: Policy Lifecycle
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-core-workflow-b/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: guidewire-core-workflow-b
-description: |
-  Execute Guidewire claims workflow in ClaimCenter: FNOL, investigation, reserves, and settlement.
-  Trigger: "claimcenter workflow", "create claim", "FNOL", "claim settlement", "process claim".
+description: 'Execute Guidewire claims workflow in ClaimCenter: FNOL, investigation,
+  reserves, and settlement.
+
+  Trigger: "claimcenter workflow", "create claim", "FNOL", "claim settlement", "process
+  claim".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Core Workflow B: Claims Processing
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-cost-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-cost-tuning
-description: |
-  Optimize Guidewire Cloud costs: license management, API usage, compute right-sizing.
+description: 'Optimize Guidewire Cloud costs: license management, API usage, compute
+  right-sizing.
+
   Trigger: "guidewire cost tuning", "cost-tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-data-handling/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-data-handling/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-data-handling
-description: |
-  Data handling for Guidewire: entity management, data migration, batch operations, and governance.
+description: 'Data handling for Guidewire: entity management, data migration, batch
+  operations, and governance.
+
   Trigger: "guidewire data handling", "data-handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Data Handling
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-debug-bundle/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-debug-bundle
-description: |
-  Collect Guidewire diagnostic info including Cloud API responses, Gosu stack traces, and server logs.
+description: 'Collect Guidewire diagnostic info including Cloud API responses, Gosu
+  stack traces, and server logs.
+
   Trigger: "guidewire debug bundle", "debug-bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-deploy-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-deploy-integration
-description: |
-  Deploy Guidewire integrations to Cloud Platform with configuration packages and release management.
+description: 'Deploy Guidewire integrations to Cloud Platform with configuration packages
+  and release management.
+
   Trigger: "guidewire deploy integration", "deploy-integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-enterprise-rbac/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-enterprise-rbac
-description: |
-  Implement Guidewire RBAC: API roles, user permissions, and security policies.
+description: 'Implement Guidewire RBAC: API roles, user permissions, and security
+  policies.
+
   Trigger: "guidewire enterprise rbac", "enterprise-rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-hello-world/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-hello-world/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: guidewire-hello-world
-description: |
-  Execute first API calls to Guidewire PolicyCenter, ClaimCenter, and BillingCenter.
+description: 'Execute first API calls to Guidewire PolicyCenter, ClaimCenter, and
+  BillingCenter.
+
   Use when testing connectivity, exploring Cloud API structure, or learning REST patterns.
+
   Trigger: "guidewire hello world", "first guidewire call", "test policycenter api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Hello World
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-incident-runbook/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: guidewire-incident-runbook
-description: |
-  Respond to Guidewire production incidents: triage, mitigation, and recovery.
+description: 'Respond to Guidewire production incidents: triage, mitigation, and recovery.
+
   Trigger: "guidewire incident runbook", "incident-runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-install-auth/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-install-auth/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: guidewire-install-auth
-description: |
-  Install Guidewire Studio, configure Cloud API OAuth2 authentication,
+description: 'Install Guidewire Studio, configure Cloud API OAuth2 authentication,
+
   and register applications with Guidewire Hub.
-  Trigger: "install guidewire", "guidewire auth", "guidewire OAuth2", "guidewire Cloud API setup".
+
+  Trigger: "install guidewire", "guidewire auth", "guidewire OAuth2", "guidewire Cloud
+  API setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(java:*), Bash(gradle:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-local-dev-loop/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-local-dev-loop
-description: |
-  Configure Guidewire Studio local development with Gosu debugging, hot reload, and test data.
+description: 'Configure Guidewire Studio local development with Gosu debugging, hot
+  reload, and test data.
+
   Trigger: "guidewire local dev loop", "local-dev-loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-migration-deep-dive/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: guidewire-migration-deep-dive
-description: |
-  Migrate to Guidewire Cloud from self-managed or legacy insurance systems.
+description: 'Migrate to Guidewire Cloud from self-managed or legacy insurance systems.
+
   Trigger: "guidewire migration deep dive", "migration-deep-dive".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-multi-env-setup/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-multi-env-setup
-description: |
-  Configure Guidewire multi-environment: dev, staging, and production with configuration promotion.
+description: 'Configure Guidewire multi-environment: dev, staging, and production
+  with configuration promotion.
+
   Trigger: "guidewire multi env setup", "multi-env-setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Multi Env Setup
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-observability/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-observability/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-observability
-description: |
-  Monitor Guidewire InsuranceSuite: logging, metrics, tracing, and alerting via GCC.
+description: 'Monitor Guidewire InsuranceSuite: logging, metrics, tracing, and alerting
+  via GCC.
+
   Trigger: "guidewire observability", "observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Observability
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-performance-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-performance-tuning
-description: |
-  Optimize Guidewire performance: Gosu query optimization, batch processing, caching, and JVM tuning.
+description: 'Optimize Guidewire performance: Gosu query optimization, batch processing,
+  caching, and JVM tuning.
+
   Trigger: "guidewire performance tuning", "performance-tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-prod-checklist/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-prod-checklist
-description: |
-  Production deployment readiness for Guidewire Cloud including configuration promotion and testing.
+description: 'Production deployment readiness for Guidewire Cloud including configuration
+  promotion and testing.
+
   Trigger: "guidewire prod checklist", "prod-checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-rate-limits/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-rate-limits/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-rate-limits
-description: |
-  Manage Guidewire Cloud API rate limits, quotas, and throttling for high-volume integrations.
+description: 'Manage Guidewire Cloud API rate limits, quotas, and throttling for high-volume
+  integrations.
+
   Trigger: "guidewire rate limits", "rate-limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-reference-architecture/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-reference-architecture
-description: |
-  Enterprise reference architecture for Guidewire InsuranceSuite Cloud deployments.
+description: 'Enterprise reference architecture for Guidewire InsuranceSuite Cloud
+  deployments.
+
   Trigger: "guidewire reference architecture", "reference-architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-sdk-patterns/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-sdk-patterns
-description: |
-  Master Guidewire SDK patterns: REST API Client, Jutro Digital SDK, and Gosu best practices.
+description: 'Master Guidewire SDK patterns: REST API Client, Jutro Digital SDK, and
+  Gosu best practices.
+
   Trigger: "guidewire sdk patterns", "sdk-patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-security-basics/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-security-basics/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-security-basics
-description: |
-  Implement Guidewire security: OAuth2 JWT, API roles, Gosu secure coding, and data protection.
+description: 'Implement Guidewire security: OAuth2 JWT, API roles, Gosu secure coding,
+  and data protection.
+
   Trigger: "guidewire security basics", "security-basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Security Basics
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-upgrade-migration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-upgrade-migration
-description: |
-  Upgrade Guidewire InsuranceSuite versions and migrate between Cloud environments.
+description: 'Upgrade Guidewire InsuranceSuite versions and migrate between Cloud
+  environments.
+
   Trigger: "guidewire upgrade migration", "upgrade-migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/guidewire-pack/skills/guidewire-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/guidewire-pack/skills/guidewire-webhooks-events/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: guidewire-webhooks-events
-description: |
-  Implement Guidewire App Events and webhook integrations for event-driven architecture.
+description: 'Implement Guidewire App Events and webhook integrations for event-driven
+  architecture.
+
   Trigger: "guidewire webhooks events", "webhooks-events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(gradle:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, insurance, guidewire]
-compatible-with: claude-code
+tags:
+- saas
+- insurance
+- guidewire
+compatibility: Designed for Claude Code
 ---
-
 # Guidewire Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-ci-integration/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-ci-integration
-description: |
-  Configure Hex CI/CD integration with GitHub Actions and testing.
+description: 'Configure Hex CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Hex tests into your build process.
+
   Trigger with phrases like "hex CI", "hex GitHub Actions",
+
   "hex automated tests", "CI hex".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex CI Integration
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-common-errors/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-common-errors
-description: |
-  Diagnose and fix Hex common errors and exceptions.
+description: 'Diagnose and fix Hex common errors and exceptions.
+
   Use when encountering Hex errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "hex error", "fix hex",
+
   "hex not working", "debug hex".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/hex-pack/skills/hex-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-core-workflow-a
-description: |
-  Execute Hex primary workflow: Core Workflow A.
+description: 'Execute Hex primary workflow: Core Workflow A.
+
   Use when implementing primary use case,
+
   building main features, or core integration tasks.
+
   Trigger with phrases like "hex main workflow",
+
   "primary task with hex".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, orchestration]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- orchestration
+compatibility: Designed for Claude Code
 ---
-
 # Hex Project Orchestration
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-core-workflow-b
-description: |
-  Execute Hex secondary workflow: Core Workflow B.
+description: 'Execute Hex secondary workflow: Core Workflow B.
+
   Use when implementing secondary use case,
+
   or complementing primary workflow.
+
   Trigger with phrases like "hex secondary workflow",
+
   "secondary task with hex".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, scheduling]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- scheduling
+compatibility: Designed for Claude Code
 ---
-
 # Hex Scheduled Runs & Admin API
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-cost-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-cost-tuning
-description: |
-  Optimize Hex costs through tier selection, sampling, and usage monitoring.
+description: 'Optimize Hex costs through tier selection, sampling, and usage monitoring.
+
   Use when analyzing Hex billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "hex cost", "hex billing",
+
   "reduce hex costs", "hex pricing", "hex expensive", "hex budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-debug-bundle
-description: |
-  Collect Hex debug evidence for support tickets and troubleshooting.
+description: 'Collect Hex debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Hex problems.
+
   Trigger with phrases like "hex debug", "hex support bundle",
+
   "collect hex logs", "hex diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-deploy-integration
-description: |
-  Deploy Hex integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Hex integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Hex-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy hex", "hex Vercel",
+
   "hex production deploy", "hex Cloud Run", "hex Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-hello-world/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-hello-world
-description: |
-  Create a minimal working Hex example.
+description: 'Create a minimal working Hex example.
+
   Use when starting a new Hex integration, testing your setup,
+
   or learning basic Hex API patterns.
+
   Trigger with phrases like "hex hello world", "hex example",
+
   "hex quick start", "simple hex code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Hello World
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-install-auth/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-install-auth
-description: |
-  Install and configure Hex SDK/CLI authentication.
+description: 'Install and configure Hex SDK/CLI authentication.
+
   Use when setting up a new Hex integration, configuring API keys,
+
   or initializing Hex in your project.
+
   Trigger with phrases like "install hex", "setup hex",
+
   "hex auth", "configure hex API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-local-dev-loop
-description: |
-  Configure Hex local development with hot reload and testing.
+description: 'Configure Hex local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Hex.
+
   Trigger with phrases like "hex dev setup", "hex local development",
+
   "hex dev environment", "develop with hex".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hex-performance-tuning
-description: |
-  Optimize Hex API performance with caching, batching, and connection pooling.
+description: 'Optimize Hex API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Hex integrations.
+
   Trigger with phrases like "hex performance", "optimize hex",
+
   "hex latency", "hex caching", "hex slow", "hex batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Performance Tuning
 
 ## Latency Benchmarks

--- a/plugins/saas-packs/hex-pack/skills/hex-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-prod-checklist
-description: |
-  Execute Hex production deployment checklist and rollback procedures.
+description: 'Execute Hex production deployment checklist and rollback procedures.
+
   Use when deploying Hex integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "hex production", "deploy hex",
+
   "hex go-live", "hex launch checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-rate-limits/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-rate-limits
-description: |
-  Implement Hex rate limiting, backoff, and idempotency patterns.
+description: 'Implement Hex rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Hex.
+
   Trigger with phrases like "hex rate limit", "hex throttling",
+
   "hex 429", "hex retry", "hex backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-reference-architecture
-description: |
-  Implement Hex reference architecture with best-practice project layout.
+description: 'Implement Hex reference architecture with best-practice project layout.
+
   Use when designing new Hex integrations, reviewing project structure,
+
   or establishing architecture standards for Hex applications.
+
   Trigger with phrases like "hex architecture", "hex best practices",
+
   "hex project structure", "how to organize hex", "hex layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Reference Architecture
 
 ## Architecture

--- a/plugins/saas-packs/hex-pack/skills/hex-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-sdk-patterns
-description: |
-  Apply production-ready Hex SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Hex SDK patterns for TypeScript and Python.
+
   Use when implementing Hex integrations, refactoring SDK usage,
+
   or establishing team coding standards for Hex.
+
   Trigger with phrases like "hex SDK patterns", "hex best practices",
+
   "hex code patterns", "idiomatic hex".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-security-basics/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-security-basics
-description: |
-  Apply Hex security best practices for secrets and access control.
+description: 'Apply Hex security best practices for secrets and access control.
+
   Use when securing API keys, implementing least privilege access,
+
   or auditing Hex security configuration.
+
   Trigger with phrases like "hex security", "hex secrets",
+
   "secure hex", "hex API key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Security Basics
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-upgrade-migration
-description: |
-  Analyze, plan, and execute Hex SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Hex SDK upgrades with breaking change detection.
+
   Use when upgrading Hex SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade hex", "hex migration",
+
   "hex breaking changes", "update hex SDK", "analyze hex version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/hex-pack/skills/hex-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/hex-pack/skills/hex-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hex-webhooks-events
-description: |
-  Implement Hex webhook signature validation and event handling.
+description: 'Implement Hex webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling Hex event notifications securely.
+
   Trigger with phrases like "hex webhook", "hex events",
+
   "hex webhook signature", "handle hex events", "hex notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hex, data, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hex
+- data
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hex Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-ci-integration/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-ci-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-ci-integration
-description: |
-  Configure Hootsuite CI/CD integration with GitHub Actions and testing.
+description: 'Configure Hootsuite CI/CD integration with GitHub Actions and testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Hootsuite tests into your build process.
+
   Trigger with phrases like "hootsuite CI", "hootsuite GitHub Actions",
+
   "hootsuite automated tests", "CI hootsuite".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite CI Integration
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-common-errors/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-common-errors
-description: |
-  Diagnose and fix Hootsuite common errors and exceptions.
+description: 'Diagnose and fix Hootsuite common errors and exceptions.
+
   Use when encountering Hootsuite errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "hootsuite error", "fix hootsuite",
+
   "hootsuite not working", "debug hootsuite".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hootsuite-core-workflow-a
-description: |
-  Execute Hootsuite primary workflow: Core Workflow A.
+description: 'Execute Hootsuite primary workflow: Core Workflow A.
+
   Use when implementing primary use case,
+
   building main features, or core integration tasks.
+
   Trigger with phrases like "hootsuite main workflow",
+
   "primary task with hootsuite".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media, publishing]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+- publishing
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Publishing — Schedule Posts with Media
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hootsuite-core-workflow-b
-description: |
-  Execute Hootsuite secondary workflow: Core Workflow B.
+description: 'Execute Hootsuite secondary workflow: Core Workflow B.
+
   Use when implementing secondary use case,
+
   or complementing primary workflow.
+
   Trigger with phrases like "hootsuite secondary workflow",
+
   "secondary task with hootsuite".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media, analytics]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+- analytics
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Analytics & URL Shortening
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hootsuite-cost-tuning
-description: |
-  Optimize Hootsuite costs through tier selection, sampling, and usage monitoring.
+description: 'Optimize Hootsuite costs through tier selection, sampling, and usage
+  monitoring.
+
   Use when analyzing Hootsuite billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "hootsuite cost", "hootsuite billing",
-  "reduce hootsuite costs", "hootsuite pricing", "hootsuite expensive", "hootsuite budget".
+
+  "reduce hootsuite costs", "hootsuite pricing", "hootsuite expensive", "hootsuite
+  budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Cost Tuning
 
 ## Hootsuite Plans

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-debug-bundle
-description: |
-  Collect Hootsuite debug evidence for support tickets and troubleshooting.
+description: 'Collect Hootsuite debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Hootsuite problems.
+
   Trigger with phrases like "hootsuite debug", "hootsuite support bundle",
+
   "collect hootsuite logs", "hootsuite diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-deploy-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-deploy-integration
-description: |
-  Deploy Hootsuite integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Hootsuite integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Hootsuite-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy hootsuite", "hootsuite Vercel",
+
   "hootsuite production deploy", "hootsuite Cloud Run", "hootsuite Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-hello-world/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-hello-world
-description: |
-  Create a minimal working Hootsuite example.
+description: 'Create a minimal working Hootsuite example.
+
   Use when starting a new Hootsuite integration, testing your setup,
+
   or learning basic Hootsuite API patterns.
+
   Trigger with phrases like "hootsuite hello world", "hootsuite example",
+
   "hootsuite quick start", "simple hootsuite code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Hello World
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-install-auth/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-install-auth/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-install-auth
-description: |
-  Install and configure Hootsuite SDK/CLI authentication.
+description: 'Install and configure Hootsuite SDK/CLI authentication.
+
   Use when setting up a new Hootsuite integration, configuring API keys,
+
   or initializing Hootsuite in your project.
+
   Trigger with phrases like "install hootsuite", "setup hootsuite",
+
   "hootsuite auth", "configure hootsuite API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-local-dev-loop/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-local-dev-loop
-description: |
-  Configure Hootsuite local development with hot reload and testing.
+description: 'Configure Hootsuite local development with hot reload and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Hootsuite.
+
   Trigger with phrases like "hootsuite dev setup", "hootsuite local development",
+
   "hootsuite dev environment", "develop with hootsuite".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-performance-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hootsuite-performance-tuning
-description: |
-  Optimize Hootsuite API performance with caching, batching, and connection pooling.
+description: 'Optimize Hootsuite API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Hootsuite integrations.
+
   Trigger with phrases like "hootsuite performance", "optimize hootsuite",
+
   "hootsuite latency", "hootsuite caching", "hootsuite slow", "hootsuite batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Performance Tuning
 
 ## Instructions

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-prod-checklist/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-prod-checklist
-description: |
-  Execute Hootsuite production deployment checklist and rollback procedures.
+description: 'Execute Hootsuite production deployment checklist and rollback procedures.
+
   Use when deploying Hootsuite integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "hootsuite production", "deploy hootsuite",
+
   "hootsuite go-live", "hootsuite launch checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-rate-limits/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-rate-limits
-description: |
-  Implement Hootsuite rate limiting, backoff, and idempotency patterns.
+description: 'Implement Hootsuite rate limiting, backoff, and idempotency patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Hootsuite.
+
   Trigger with phrases like "hootsuite rate limit", "hootsuite throttling",
+
   "hootsuite 429", "hootsuite retry", "hootsuite backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hootsuite-reference-architecture
-description: |
-  Implement Hootsuite reference architecture with best-practice project layout.
+description: 'Implement Hootsuite reference architecture with best-practice project
+  layout.
+
   Use when designing new Hootsuite integrations, reviewing project structure,
+
   or establishing architecture standards for Hootsuite applications.
+
   Trigger with phrases like "hootsuite architecture", "hootsuite best practices",
+
   "hootsuite project structure", "how to organize hootsuite", "hootsuite layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Reference Architecture
 
 ## Architecture

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-sdk-patterns/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-sdk-patterns
-description: |
-  Apply production-ready Hootsuite SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Hootsuite SDK patterns for TypeScript and Python.
+
   Use when implementing Hootsuite integrations, refactoring SDK usage,
+
   or establishing team coding standards for Hootsuite.
+
   Trigger with phrases like "hootsuite SDK patterns", "hootsuite best practices",
+
   "hootsuite code patterns", "idiomatic hootsuite".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-security-basics/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-security-basics/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-security-basics
-description: |
-  Apply Hootsuite security best practices for secrets and access control.
+description: 'Apply Hootsuite security best practices for secrets and access control.
+
   Use when securing API keys, implementing least privilege access,
+
   or auditing Hootsuite security configuration.
+
   Trigger with phrases like "hootsuite security", "hootsuite secrets",
+
   "secure hootsuite", "hootsuite API key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Security Basics
 
 ## Credential Inventory

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hootsuite-upgrade-migration
-description: |
-  Analyze, plan, and execute Hootsuite SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Hootsuite SDK upgrades with breaking change
+  detection.
+
   Use when upgrading Hootsuite SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade hootsuite", "hootsuite migration",
+
   "hootsuite breaking changes", "update hootsuite SDK", "analyze hootsuite version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/hootsuite-pack/skills/hootsuite-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/hootsuite-pack/skills/hootsuite-webhooks-events/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: hootsuite-webhooks-events
-description: |
-  Implement Hootsuite webhook signature validation and event handling.
+description: 'Implement Hootsuite webhook signature validation and event handling.
+
   Use when setting up webhook endpoints, implementing signature verification,
+
   or handling Hootsuite event notifications securely.
+
   Trigger with phrases like "hootsuite webhook", "hootsuite events",
+
   "hootsuite webhook signature", "handle hootsuite events", "hootsuite notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hootsuite, social-media]
-compatible-with: claude-code
+tags:
+- saas
+- hootsuite
+- social-media
+compatibility: Designed for Claude Code
 ---
-
 # Hootsuite Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-advanced-troubleshooting
-description: |
-  Debug complex HubSpot API issues with systematic isolation and evidence collection.
+description: 'Debug complex HubSpot API issues with systematic isolation and evidence
+  collection.
+
   Use when standard troubleshooting fails, investigating intermittent CRM errors,
+
   or preparing evidence bundles for HubSpot support escalation.
+
   Trigger with phrases like "hubspot hard bug", "hubspot mystery error",
+
   "hubspot intermittent failure", "hubspot deep debug", "hubspot support ticket".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*), Bash(tcpdump:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-architecture-variants/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-architecture-variants
-description: |
-  Choose and implement HubSpot integration architecture for different scales.
+description: 'Choose and implement HubSpot integration architecture for different
+  scales.
+
   Use when designing new HubSpot integrations, choosing between embedded/service/gateway
+
   patterns, or planning architecture for HubSpot CRM applications.
+
   Trigger with phrases like "hubspot architecture", "hubspot design pattern",
+
   "how to structure hubspot", "hubspot integration pattern", "hubspot microservice".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-ci-integration/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-ci-integration
-description: |
-  Configure CI/CD pipelines for HubSpot integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for HubSpot integrations with GitHub Actions.
+
   Use when setting up automated testing, configuring CI with HubSpot secrets,
+
   or integrating HubSpot API tests into your build process.
+
   Trigger with phrases like "hubspot CI", "hubspot GitHub Actions",
+
   "hubspot automated tests", "CI hubspot", "hubspot pipeline test".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot CI Integration
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-common-errors/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-common-errors
-description: |
-  Diagnose and fix common HubSpot API errors with real error responses.
+description: 'Diagnose and fix common HubSpot API errors with real error responses.
+
   Use when encountering HubSpot errors, debugging failed API requests,
+
   or troubleshooting integration issues with specific HTTP status codes.
+
   Trigger with phrases like "hubspot error", "fix hubspot", "hubspot 401",
+
   "hubspot 429", "hubspot not working", "debug hubspot API".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Common Errors
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-core-workflow-a
-description: |
-  Build a complete HubSpot CRM contact-to-deal pipeline workflow.
+description: 'Build a complete HubSpot CRM contact-to-deal pipeline workflow.
+
   Use when implementing lead capture, contact management, deal creation,
+
   or end-to-end sales pipeline automation with HubSpot.
+
   Trigger with phrases like "hubspot sales pipeline", "hubspot lead workflow",
+
   "hubspot contact to deal", "hubspot CRM automation", "hubspot pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Core Workflow A: Contact-to-Deal Pipeline
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-core-workflow-b
-description: |
-  Build HubSpot marketing automation with emails, forms, lists, and tickets.
+description: 'Build HubSpot marketing automation with emails, forms, lists, and tickets.
+
   Use when implementing marketing email campaigns, form submissions,
+
   contact list management, or support ticket workflows.
+
   Trigger with phrases like "hubspot marketing", "hubspot email campaign",
+
   "hubspot forms", "hubspot lists", "hubspot tickets", "hubspot automation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Core Workflow B: Marketing & Tickets
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-cost-tuning
-description: |
-  Optimize HubSpot costs through API call reduction, plan selection, and usage monitoring.
+description: 'Optimize HubSpot costs through API call reduction, plan selection, and
+  usage monitoring.
+
   Use when analyzing HubSpot API usage, reducing unnecessary calls,
+
   or implementing usage tracking and budget alerts.
+
   Trigger with phrases like "hubspot cost", "hubspot API usage",
+
   "reduce hubspot calls", "hubspot pricing", "hubspot budget", "hubspot quota".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-data-handling/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-data-handling/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-data-handling
-description: |
-  Implement HubSpot GDPR compliance, data export, and contact privacy operations.
+description: 'Implement HubSpot GDPR compliance, data export, and contact privacy
+  operations.
+
   Use when handling GDPR/CCPA data subject requests, implementing data export,
+
   contact deletion, or privacy-compliant HubSpot integrations.
+
   Trigger with phrases like "hubspot GDPR", "hubspot data export",
+
   "hubspot delete contact", "hubspot privacy", "hubspot CCPA", "hubspot PII".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Data Handling
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-debug-bundle
-description: |
-  Collect HubSpot debug evidence for support tickets and troubleshooting.
+description: 'Collect HubSpot debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for HubSpot API problems.
+
   Trigger with phrases like "hubspot debug", "hubspot support bundle",
+
   "collect hubspot logs", "hubspot diagnostic", "hubspot correlation id".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-deploy-integration
-description: |
-  Deploy HubSpot integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy HubSpot integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying HubSpot-powered applications, configuring platform secrets,
+
   or setting up deployment pipelines with HubSpot access tokens.
+
   Trigger with phrases like "deploy hubspot", "hubspot Vercel",
+
   "hubspot Cloud Run", "hubspot Fly.io", "hubspot production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-enterprise-rbac/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: hubspot-enterprise-rbac
-description: |
-  Configure HubSpot enterprise access control with OAuth scopes and team permissions.
+description: 'Configure HubSpot enterprise access control with OAuth scopes and team
+  permissions.
+
   Use when implementing role-based access, configuring per-team HubSpot scopes,
+
   or setting up multi-user access patterns for HubSpot integrations.
+
   Trigger with phrases like "hubspot RBAC", "hubspot roles",
-  "hubspot enterprise", "hubspot permissions", "hubspot team access", "hubspot OAuth scopes".
+
+  "hubspot enterprise", "hubspot permissions", "hubspot team access", "hubspot OAuth
+  scopes".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-hello-world/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-hello-world
-description: |
-  Create a working HubSpot CRM example with contacts, companies, and deals.
+description: 'Create a working HubSpot CRM example with contacts, companies, and deals.
+
   Use when starting a new HubSpot integration, testing your setup,
+
   or learning basic CRM API patterns with real endpoints.
+
   Trigger with phrases like "hubspot hello world", "hubspot example",
+
   "hubspot quick start", "first hubspot API call", "hubspot contact create".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Hello World
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-incident-runbook/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-incident-runbook
-description: |
-  Execute HubSpot incident response with triage, mitigation, and postmortem.
+description: 'Execute HubSpot incident response with triage, mitigation, and postmortem.
+
   Use when responding to HubSpot API outages, investigating CRM errors,
+
   or running post-incident reviews for HubSpot integration failures.
+
   Trigger with phrases like "hubspot incident", "hubspot outage",
+
   "hubspot down", "hubspot on-call", "hubspot emergency", "hubspot broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-install-auth/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-install-auth
-description: |
-  Install and configure HubSpot API client with authentication.
+description: 'Install and configure HubSpot API client with authentication.
+
   Use when setting up a new HubSpot integration, configuring private app tokens,
+
   OAuth 2.0 flows, or initializing the @hubspot/api-client SDK.
+
   Trigger with phrases like "install hubspot", "setup hubspot auth",
+
   "hubspot access token", "configure hubspot API", "hubspot private app".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-known-pitfalls/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-known-pitfalls
-description: |
-  Identify and avoid HubSpot API anti-patterns and common integration mistakes.
+description: 'Identify and avoid HubSpot API anti-patterns and common integration
+  mistakes.
+
   Use when reviewing HubSpot code, onboarding developers to HubSpot integrations,
+
   or auditing existing CRM integrations for best practice violations.
+
   Trigger with phrases like "hubspot mistakes", "hubspot anti-patterns",
+
   "hubspot pitfalls", "hubspot code review", "hubspot gotchas".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-load-scale/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-load-scale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-load-scale
-description: |
-  Load test HubSpot integrations and plan capacity around API rate limits.
+description: 'Load test HubSpot integrations and plan capacity around API rate limits.
+
   Use when running performance tests, planning for traffic growth,
+
   or sizing your HubSpot integration for production load.
+
   Trigger with phrases like "hubspot load test", "hubspot scale",
+
   "hubspot capacity", "hubspot benchmark", "hubspot traffic planning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-local-dev-loop
-description: |
-  Configure HubSpot local development with testing and sandbox accounts.
+description: 'Configure HubSpot local development with testing and sandbox accounts.
+
   Use when setting up a development environment, mocking HubSpot APIs,
+
   or establishing a fast iteration cycle for HubSpot integrations.
+
   Trigger with phrases like "hubspot dev setup", "hubspot local development",
+
   "hubspot test sandbox", "develop with hubspot", "mock hubspot".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-migration-deep-dive
-description: |
-  Execute CRM data migration to HubSpot with batch imports and validation.
+description: 'Execute CRM data migration to HubSpot with batch imports and validation.
+
   Use when migrating from Salesforce/Pipedrive/spreadsheets to HubSpot,
+
   performing bulk data imports, or re-platforming to HubSpot CRM.
+
   Trigger with phrases like "migrate to hubspot", "hubspot data import",
+
   "salesforce to hubspot", "hubspot migration", "bulk import hubspot".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-multi-env-setup/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-multi-env-setup
-description: |
-  Configure HubSpot across development, staging, and production environments.
+description: 'Configure HubSpot across development, staging, and production environments.
+
   Use when setting up per-environment HubSpot portals, configuring separate
+
   access tokens, or implementing environment isolation for HubSpot integrations.
+
   Trigger with phrases like "hubspot environments", "hubspot staging",
+
   "hubspot dev prod", "hubspot test account", "hubspot config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-observability/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-observability
-description: |
-  Set up observability for HubSpot integrations with metrics, traces, and alerts.
+description: 'Set up observability for HubSpot integrations with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for HubSpot API operations, setting up dashboards,
+
   or configuring alerting for CRM integration health.
+
   Trigger with phrases like "hubspot monitoring", "hubspot metrics",
+
   "hubspot observability", "monitor hubspot", "hubspot alerts", "hubspot dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Observability
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-performance-tuning
-description: |
-  Optimize HubSpot API performance with caching, batching, and search optimization.
+description: 'Optimize HubSpot API performance with caching, batching, and search
+  optimization.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for HubSpot CRM operations.
+
   Trigger with phrases like "hubspot performance", "optimize hubspot",
+
   "hubspot slow", "hubspot caching", "hubspot batch", "hubspot latency".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-policy-guardrails/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-policy-guardrails
-description: |
-  Implement HubSpot lint rules, secret scanning, and CI policy checks.
+description: 'Implement HubSpot lint rules, secret scanning, and CI policy checks.
+
   Use when setting up code quality rules for HubSpot integrations,
+
   preventing token leaks, or configuring CI guardrails.
+
   Trigger with phrases like "hubspot policy", "hubspot lint",
+
   "hubspot guardrails", "hubspot security check", "hubspot eslint rules".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-prod-checklist
-description: |
-  Execute HubSpot production deployment checklist and go-live procedures.
+description: 'Execute HubSpot production deployment checklist and go-live procedures.
+
   Use when deploying HubSpot integrations to production, preparing for launch,
+
   or implementing health checks for HubSpot connectivity.
+
   Trigger with phrases like "hubspot production", "deploy hubspot",
+
   "hubspot go-live", "hubspot launch checklist", "hubspot health check".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-rate-limits/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-rate-limits
-description: |
-  Implement HubSpot rate limiting, backoff, and request queuing patterns.
+description: 'Implement HubSpot rate limiting, backoff, and request queuing patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API throughput against HubSpot rate limits.
+
   Trigger with phrases like "hubspot rate limit", "hubspot throttling",
+
   "hubspot 429", "hubspot retry", "hubspot backoff", "hubspot quota".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-reference-architecture
-description: |
-  Implement a production-ready HubSpot integration architecture with layered design.
+description: 'Implement a production-ready HubSpot integration architecture with layered
+  design.
+
   Use when designing new HubSpot integrations, reviewing project structure,
+
   or establishing architecture standards for HubSpot CRM applications.
+
   Trigger with phrases like "hubspot architecture", "hubspot project structure",
+
   "hubspot integration design", "hubspot best practices layout", "hubspot layers".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-reliability-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-reliability-patterns
-description: |
-  Implement HubSpot reliability patterns: circuit breakers, retries, and graceful degradation.
+description: 'Implement HubSpot reliability patterns: circuit breakers, retries, and
+  graceful degradation.
+
   Use when building fault-tolerant HubSpot integrations, implementing retry strategies,
+
   or adding resilience to production CRM services.
+
   Trigger with phrases like "hubspot reliability", "hubspot circuit breaker",
+
   "hubspot resilience", "hubspot fallback", "hubspot fault tolerant".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-sdk-patterns
-description: |
-  Apply production-ready @hubspot/api-client SDK patterns for TypeScript.
+description: 'Apply production-ready @hubspot/api-client SDK patterns for TypeScript.
+
   Use when implementing HubSpot integrations, building typed wrappers,
+
   or establishing team standards for HubSpot CRM operations.
+
   Trigger with phrases like "hubspot SDK patterns", "hubspot best practices",
+
   "hubspot typed client", "hubspot api-client wrapper", "idiomatic hubspot".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-security-basics/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-security-basics/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: hubspot-security-basics
-description: |
-  Apply HubSpot security best practices for tokens, scopes, and webhook verification.
+description: 'Apply HubSpot security best practices for tokens, scopes, and webhook
+  verification.
+
   Use when securing private app tokens, implementing least privilege scopes,
+
   or validating HubSpot webhook signatures.
+
   Trigger with phrases like "hubspot security", "hubspot token rotation",
+
   "secure hubspot", "hubspot scopes", "hubspot webhook verify".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Security Basics
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-upgrade-migration
-description: |
-  Upgrade @hubspot/api-client SDK versions and migrate between API versions.
+description: 'Upgrade @hubspot/api-client SDK versions and migrate between API versions.
+
   Use when upgrading the HubSpot Node.js SDK, migrating from v1/v2 to v3 APIs,
+
   or handling breaking changes in the HubSpot API client.
+
   Trigger with phrases like "upgrade hubspot", "hubspot SDK update",
+
   "hubspot breaking changes", "migrate hubspot API version", "hubspot v3 migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/hubspot-pack/skills/hubspot-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/hubspot-pack/skills/hubspot-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: hubspot-webhooks-events
-description: |
-  Implement HubSpot webhook subscriptions and CRM event handling.
+description: 'Implement HubSpot webhook subscriptions and CRM event handling.
+
   Use when setting up webhook endpoints for CRM events, implementing
+
   signature verification, or handling contact/deal/company change notifications.
+
   Trigger with phrases like "hubspot webhook", "hubspot events",
+
   "hubspot subscription", "handle hubspot notifications", "hubspot CRM events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, marketing, hubspot]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- marketing
+- hubspot
+compatibility: Designed for Claude Code
 ---
-
 # HubSpot Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-ci-integration/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-ci-integration
-description: |
-  Configure CI/CD pipelines for Ideogram integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Ideogram integrations with GitHub Actions.
+
   Use when setting up automated testing, visual regression tests,
+
   or integrating Ideogram validation into your build process.
+
   Trigger with phrases like "ideogram CI", "ideogram GitHub Actions",
+
   "ideogram automated tests", "CI ideogram", "ideogram pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, testing, ci-cd]
+tags:
+- saas
+- ideogram
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram CI Integration
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-common-errors/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-common-errors
-description: |
-  Diagnose and fix Ideogram API errors and exceptions.
+description: 'Diagnose and fix Ideogram API errors and exceptions.
+
   Use when encountering Ideogram errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "ideogram error", "fix ideogram",
+
   "ideogram not working", "debug ideogram", "ideogram 422", "ideogram 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, debugging, errors]
+tags:
+- saas
+- ideogram
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Common Errors
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-core-workflow-a/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: ideogram-core-workflow-a
-description: |
-  Execute Ideogram primary workflow: text-to-image generation with text rendering.
+description: 'Execute Ideogram primary workflow: text-to-image generation with text
+  rendering.
+
   Use when generating images from text prompts, creating designs with embedded text,
+
   or building the main image generation pipeline.
+
   Trigger with phrases like "ideogram generate image", "ideogram text to image",
+
   "create image with ideogram", "ideogram primary workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, workflow, image-generation, text-rendering]
+tags:
+- saas
+- ideogram
+- workflow
+- image-generation
+- text-rendering
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Core Workflow A -- Text-to-Image Generation
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-core-workflow-b/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: ideogram-core-workflow-b
-description: |
-  Execute Ideogram secondary workflows: edit (Magic Fill), remix, upscale, describe, and reframe.
+description: 'Execute Ideogram secondary workflows: edit (Magic Fill), remix, upscale,
+  describe, and reframe.
+
   Use when modifying existing images, applying style transfer, upscaling,
+
   or building image-to-image pipelines.
+
   Trigger with phrases like "ideogram edit image", "ideogram remix",
+
   "ideogram upscale", "ideogram inpaint", "ideogram magic fill", "ideogram reframe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, workflow, editing, remix, upscale]
+tags:
+- saas
+- ideogram
+- workflow
+- editing
+- remix
+- upscale
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Core Workflow B -- Edit, Remix, Upscale, Describe, Reframe
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-cost-tuning
-description: |
-  Optimize Ideogram costs through model selection, caching, and usage monitoring.
+description: 'Optimize Ideogram costs through model selection, caching, and usage
+  monitoring.
+
   Use when analyzing Ideogram billing, reducing API costs,
+
   or implementing budget alerts and usage tracking.
+
   Trigger with phrases like "ideogram cost", "ideogram billing",
+
   "reduce ideogram costs", "ideogram pricing", "ideogram budget", "ideogram credits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, cost-optimization]
+tags:
+- saas
+- ideogram
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Cost Tuning
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-data-handling/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-data-handling
-description: |
-  Manage Ideogram generated image assets, metadata tracking, and lifecycle management.
+description: 'Manage Ideogram generated image assets, metadata tracking, and lifecycle
+  management.
+
   Use when implementing image persistence, tracking generation history,
+
   or building asset management for Ideogram outputs.
+
   Trigger with phrases like "ideogram data", "ideogram images",
+
   "ideogram asset management", "ideogram metadata", "ideogram image storage".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, data, asset-management]
+tags:
+- saas
+- ideogram
+- data
+- asset-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Data Handling
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-debug-bundle
-description: |
-  Collect Ideogram debug evidence for support tickets and troubleshooting.
+description: 'Collect Ideogram debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Ideogram problems.
+
   Trigger with phrases like "ideogram debug", "ideogram support bundle",
+
   "collect ideogram logs", "ideogram diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, debugging, support]
+tags:
+- saas
+- ideogram
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Debug Bundle
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: ideogram-deploy-integration
-description: |
-  Deploy Ideogram integrations to Vercel, Cloud Run, and Docker platforms.
+description: 'Deploy Ideogram integrations to Vercel, Cloud Run, and Docker platforms.
+
   Use when deploying Ideogram-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy ideogram", "ideogram Vercel",
+
   "ideogram production deploy", "ideogram Cloud Run", "ideogram Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, deployment]
+tags:
+- saas
+- ideogram
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Deploy Integration
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-enterprise-rbac
-description: |
-  Implement team-based access control and credit management for Ideogram.
+description: 'Implement team-based access control and credit management for Ideogram.
+
   Use when managing multiple teams with separate budgets, enforcing content policies,
+
   or implementing API key isolation for enterprise Ideogram usage.
+
   Trigger with phrases like "ideogram RBAC", "ideogram enterprise",
+
   "ideogram teams", "ideogram permissions", "ideogram multi-tenant".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, rbac, enterprise]
+tags:
+- saas
+- ideogram
+- rbac
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Enterprise RBAC
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-hello-world/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-hello-world
-description: |
-  Create a minimal working Ideogram image generation example.
+description: 'Create a minimal working Ideogram image generation example.
+
   Use when starting a new Ideogram integration, testing your setup,
+
   or learning basic Ideogram API patterns.
+
   Trigger with phrases like "ideogram hello world", "ideogram example",
+
   "ideogram quick start", "simple ideogram code", "first ideogram image".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, getting-started, image-generation]
+tags:
+- saas
+- ideogram
+- api
+- getting-started
+- image-generation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Hello World
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: ideogram-incident-runbook
-description: |
-  Execute Ideogram incident response with triage, mitigation, and postmortem.
+description: 'Execute Ideogram incident response with triage, mitigation, and postmortem.
+
   Use when responding to Ideogram-related outages, investigating errors,
+
   or running post-incident reviews for Ideogram integration failures.
+
   Trigger with phrases like "ideogram incident", "ideogram outage",
+
   "ideogram down", "ideogram on-call", "ideogram emergency", "ideogram broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, incident-response]
+tags:
+- saas
+- ideogram
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Incident Runbook
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-install-auth/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-install-auth
-description: |
-  Install and configure Ideogram API authentication.
+description: 'Install and configure Ideogram API authentication.
+
   Use when setting up a new Ideogram integration, configuring API keys,
+
   or initializing Ideogram in your project.
+
   Trigger with phrases like "install ideogram", "setup ideogram",
+
   "ideogram auth", "configure ideogram API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, authentication, image-generation]
+tags:
+- saas
+- ideogram
+- api
+- authentication
+- image-generation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Install & Auth
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-local-dev-loop
-description: |
-  Configure Ideogram local development with mock responses and testing.
+description: 'Configure Ideogram local development with mock responses and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Ideogram.
+
   Trigger with phrases like "ideogram dev setup", "ideogram local development",
+
   "ideogram dev environment", "develop with ideogram", "ideogram testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, testing, workflow, development]
+tags:
+- saas
+- ideogram
+- testing
+- workflow
+- development
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Local Dev Loop
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-migration-deep-dive
-description: |
-  Migrate from other image generation APIs to Ideogram, or re-architect existing Ideogram integrations.
+description: 'Migrate from other image generation APIs to Ideogram, or re-architect
+  existing Ideogram integrations.
+
   Use when switching from DALL-E/Midjourney/Stable Diffusion to Ideogram,
+
   or performing major integration overhauls.
+
   Trigger with phrases like "migrate to ideogram", "switch to ideogram",
+
   "replace dall-e with ideogram", "ideogram replatform", "ideogram migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, migration]
+tags:
+- saas
+- ideogram
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Migration Deep Dive
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-multi-env-setup
-description: |
-  Configure Ideogram across development, staging, and production environments.
+description: 'Configure Ideogram across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment keys,
+
   or implementing environment-specific Ideogram configurations.
+
   Trigger with phrases like "ideogram environments", "ideogram staging",
+
   "ideogram dev prod", "ideogram environment setup", "ideogram multi-env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, deployment, environments]
+tags:
+- saas
+- ideogram
+- deployment
+- environments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Multi-Environment Setup
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-observability/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-observability/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-observability
-description: |
-  Set up monitoring, metrics, and alerts for Ideogram integrations.
+description: 'Set up monitoring, metrics, and alerts for Ideogram integrations.
+
   Use when implementing observability for Ideogram operations, tracking costs,
+
   or configuring alerting for generation health.
+
   Trigger with phrases like "ideogram monitoring", "ideogram metrics",
+
   "ideogram observability", "monitor ideogram", "ideogram alerts", "ideogram dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, monitoring, observability]
+tags:
+- saas
+- ideogram
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Observability
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-performance-tuning
-description: |
-  Optimize Ideogram API performance with caching, model selection, and parallel generation.
+description: 'Optimize Ideogram API performance with caching, model selection, and
+  parallel generation.
+
   Use when experiencing slow generation, implementing caching strategies,
+
   or optimizing throughput for Ideogram integrations.
+
   Trigger with phrases like "ideogram performance", "optimize ideogram",
+
   "ideogram latency", "ideogram caching", "ideogram slow", "ideogram speed".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, performance]
+tags:
+- saas
+- ideogram
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Performance Tuning
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-prod-checklist
-description: |
-  Execute Ideogram production deployment checklist and rollback procedures.
+description: 'Execute Ideogram production deployment checklist and rollback procedures.
+
   Use when deploying Ideogram integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "ideogram production", "deploy ideogram",
+
   "ideogram go-live", "ideogram launch checklist", "ideogram production ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(kubectl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, deployment, production]
+tags:
+- saas
+- ideogram
+- deployment
+- production
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Production Checklist
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-rate-limits/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: ideogram-rate-limits
-description: |
-  Implement Ideogram rate limiting, backoff, and request queuing patterns.
+description: 'Implement Ideogram rate limiting, backoff, and request queuing patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Ideogram.
+
   Trigger with phrases like "ideogram rate limit", "ideogram throttling",
+
   "ideogram 429", "ideogram retry", "ideogram backoff", "ideogram queue".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, rate-limiting]
+tags:
+- saas
+- ideogram
+- api
+- rate-limiting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Rate Limits
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-reference-architecture
-description: |
-  Implement Ideogram reference architecture with prompt templates, asset pipelines, and CDN delivery.
+description: 'Implement Ideogram reference architecture with prompt templates, asset
+  pipelines, and CDN delivery.
+
   Use when designing new Ideogram integrations, building brand asset systems,
+
   or establishing architecture for image generation at scale.
+
   Trigger with phrases like "ideogram architecture", "ideogram project structure",
+
   "ideogram brand assets", "ideogram pipeline design", "ideogram at scale".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, architecture, reference]
+tags:
+- saas
+- ideogram
+- architecture
+- reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Reference Architecture
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-sdk-patterns
-description: |
-  Apply production-ready Ideogram API patterns for TypeScript and Python.
+description: 'Apply production-ready Ideogram API patterns for TypeScript and Python.
+
   Use when implementing Ideogram integrations, refactoring API usage,
+
   or establishing team coding standards for Ideogram.
+
   Trigger with phrases like "ideogram SDK patterns", "ideogram best practices",
+
   "ideogram code patterns", "idiomatic ideogram", "ideogram wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, python, typescript, patterns]
+tags:
+- saas
+- ideogram
+- python
+- typescript
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram SDK Patterns
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-security-basics/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-security-basics
-description: |
-  Apply Ideogram security best practices for API key management and access control.
+description: 'Apply Ideogram security best practices for API key management and access
+  control.
+
   Use when securing API keys, implementing key rotation,
+
   or auditing Ideogram security configuration.
+
   Trigger with phrases like "ideogram security", "ideogram secrets",
+
   "secure ideogram", "ideogram API key security", "ideogram key rotation".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, security]
+tags:
+- saas
+- ideogram
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Security Basics
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-upgrade-migration
-description: |
-  Migrate between Ideogram API versions (V_1 to V_2 to V3) with breaking change detection.
+description: 'Migrate between Ideogram API versions (V_1 to V_2 to V3) with breaking
+  change detection.
+
   Use when upgrading from legacy to V3 endpoints, updating model versions,
+
   or handling deprecated API parameters.
+
   Trigger with phrases like "upgrade ideogram", "ideogram migration",
+
   "ideogram v2 to v3", "ideogram breaking changes", "migrate ideogram API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, api, migration]
+tags:
+- saas
+- ideogram
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Upgrade & Migration
 

--- a/plugins/saas-packs/ideogram-pack/skills/ideogram-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/ideogram-pack/skills/ideogram-webhooks-events/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: ideogram-webhooks-events
-description: |
-  Build event-driven workflows around Ideogram's synchronous API.
+description: 'Build event-driven workflows around Ideogram''s synchronous API.
+
   Use when implementing async generation queues, batch processing,
+
   callback patterns, or image processing pipelines.
+
   Trigger with phrases like "ideogram webhook", "ideogram events",
+
   "ideogram async", "ideogram queue", "ideogram batch pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, ideogram, webhooks, async, queue]
+tags:
+- saas
+- ideogram
+- webhooks
+- async
+- queue
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Ideogram Events & Async Patterns
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-ci-integration/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-ci-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-ci-integration
-description: |
-  Configure CI/CD pipelines for Instantly.ai integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Instantly.ai integrations with GitHub
+  Actions.
+
   Use when setting up automated testing, deployment pipelines,
+
   or continuous validation of Instantly API integrations.
+
   Trigger with phrases like "instantly ci", "instantly github actions",
+
   "instantly pipeline", "instantly automated testing", "instantly ci/cd".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, ci-cd, github-actions, testing]
+tags:
+- saas
+- instantly
+- ci-cd
+- github-actions
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly CI Integration
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-common-errors/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-common-errors
-description: |
-  Diagnose and fix Instantly.ai API v2 common errors and exceptions.
+description: 'Diagnose and fix Instantly.ai API v2 common errors and exceptions.
+
   Use when encountering Instantly errors, debugging failed requests,
+
   or troubleshooting campaign/account/lead issues.
+
   Trigger with phrases like "instantly error", "instantly 401", "instantly 429",
+
   "instantly api failed", "instantly debug", "instantly troubleshoot".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, debugging, errors]
+tags:
+- saas
+- instantly
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Common Errors
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-core-workflow-a
-description: |
-  Build and launch an Instantly.ai cold email campaign end-to-end.
+description: 'Build and launch an Instantly.ai cold email campaign end-to-end.
+
   Use when creating campaigns, adding leads, configuring sequences,
+
   and launching outreach via the Instantly API v2.
+
   Trigger with phrases like "instantly campaign", "launch instantly campaign",
+
   "create instantly outreach", "instantly cold email", "instantly send campaign".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, workflow, campaigns, cold-email]
+tags:
+- saas
+- instantly
+- workflow
+- campaigns
+- cold-email
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Core Workflow A: Campaign Launch Pipeline
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-core-workflow-b
-description: |
-  Manage Instantly.ai email account warmup, analytics, and deliverability.
+description: 'Manage Instantly.ai email account warmup, analytics, and deliverability.
+
   Use when enabling warmup, monitoring sender reputation, pulling analytics,
+
   or troubleshooting deliverability issues.
+
   Trigger with phrases like "instantly warmup", "instantly analytics",
+
   "email warmup instantly", "instantly deliverability", "instantly account health".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, workflow, warmup, analytics, deliverability]
+tags:
+- saas
+- instantly
+- workflow
+- warmup
+- analytics
+- deliverability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Core Workflow B: Warmup & Analytics Pipeline
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-cost-tuning
-description: |
-  Optimize Instantly.ai costs through plan selection, account management, and usage monitoring.
+description: 'Optimize Instantly.ai costs through plan selection, account management,
+  and usage monitoring.
+
   Use when analyzing Instantly billing, reducing per-campaign costs,
+
   or choosing between Instantly pricing tiers.
+
   Trigger with phrases like "instantly cost", "instantly pricing",
+
   "instantly billing", "reduce instantly cost", "instantly plan comparison".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, cost-optimization, pricing]
+tags:
+- saas
+- instantly
+- cost-optimization
+- pricing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Cost Tuning
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-data-handling/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-data-handling/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: instantly-data-handling
-description: |
-  Implement Instantly.ai lead data management, GDPR/CAN-SPAM compliance, and list operations.
+description: 'Implement Instantly.ai lead data management, GDPR/CAN-SPAM compliance,
+  and list operations.
+
   Use when handling lead imports, managing block lists, implementing unsubscribe flows,
+
   or ensuring compliance with email regulations.
+
   Trigger with phrases like "instantly leads", "instantly data", "instantly GDPR",
+
   "instantly block list", "instantly lead management", "instantly unsubscribe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, data-handling, gdpr, compliance, leads]
+tags:
+- saas
+- instantly
+- data-handling
+- gdpr
+- compliance
+- leads
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Data Handling
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-debug-bundle
-description: |
-  Collect Instantly.ai debug evidence for support tickets and troubleshooting.
+description: 'Collect Instantly.ai debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or auditing campaign/account state.
+
   Trigger with phrases like "instantly debug", "instantly support ticket",
+
   "instantly diagnostic", "instantly audit", "collect instantly evidence".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, debugging, support]
+tags:
+- saas
+- instantly
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Debug Bundle
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-deploy-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-deploy-integration
-description: |
-  Deploy Instantly.ai webhook receivers and API integrations to cloud platforms.
+description: 'Deploy Instantly.ai webhook receivers and API integrations to cloud
+  platforms.
+
   Use when deploying to Vercel, Cloud Run, or Fly.io,
+
   or setting up production webhook endpoints.
+
   Trigger with phrases like "deploy instantly", "instantly cloud run",
+
   "instantly vercel", "instantly webhook deployment", "instantly production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, deployment, vercel, cloud-run]
+tags:
+- saas
+- instantly
+- deployment
+- vercel
+- cloud-run
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Deploy Integration
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-enterprise-rbac
-description: |
-  Configure Instantly.ai workspace access control, team management, and API key governance.
+description: 'Configure Instantly.ai workspace access control, team management, and
+  API key governance.
+
   Use when managing workspace members, setting up team permissions,
+
   or implementing API key governance for multi-user Instantly workspaces.
+
   Trigger with phrases like "instantly team", "instantly permissions",
+
   "instantly workspace members", "instantly access control", "instantly rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, enterprise, access-control, team-management]
+tags:
+- saas
+- instantly
+- enterprise
+- access-control
+- team-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Enterprise RBAC
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-hello-world/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-hello-world
-description: |
-  Create a minimal working Instantly.ai example with real API calls.
+description: 'Create a minimal working Instantly.ai example with real API calls.
+
   Use when starting a new Instantly integration, testing your setup,
+
   or learning basic Instantly API v2 patterns.
+
   Trigger with phrases like "instantly hello world", "instantly example",
+
   "instantly quick start", "simple instantly code", "test instantly api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, api, getting-started]
+tags:
+- saas
+- instantly
+- api
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Hello World
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-incident-runbook/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-incident-runbook
-description: |
-  Execute Instantly.ai incident response procedures with triage, mitigation, and recovery.
+description: 'Execute Instantly.ai incident response procedures with triage, mitigation,
+  and recovery.
+
   Use when responding to campaign failures, account health crises,
+
   deliverability drops, or Instantly API outages.
+
   Trigger with phrases like "instantly incident", "instantly outage",
+
   "instantly campaign failed", "instantly emergency", "instantly runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, incident-response, runbook]
+tags:
+- saas
+- instantly
+- incident-response
+- runbook
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Incident Runbook
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-install-auth/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-install-auth
-description: |
-  Set up Instantly.ai API v2 authentication and project configuration.
+description: 'Set up Instantly.ai API v2 authentication and project configuration.
+
   Use when creating a new Instantly integration, generating API keys,
+
   or configuring environment variables for the Instantly outreach platform.
+
   Trigger with phrases like "install instantly", "setup instantly",
+
   "instantly auth", "configure instantly API key", "instantly credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, api, authentication, email-outreach]
+tags:
+- saas
+- instantly
+- api
+- authentication
+- email-outreach
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Install & Auth
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-local-dev-loop
-description: |
-  Configure Instantly.ai local development with mock server and test workflows.
+description: 'Configure Instantly.ai local development with mock server and test workflows.
+
   Use when setting up a dev environment, testing API calls without sending emails,
+
   or building integration tests against Instantly endpoints.
+
   Trigger with phrases like "instantly dev setup", "test instantly locally",
+
   "instantly mock server", "instantly development environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, development, testing]
+tags:
+- saas
+- instantly
+- development
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Local Dev Loop
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-migration-deep-dive
-description: |
-  Execute complex Instantly.ai migration strategies for platform changes.
+description: 'Execute complex Instantly.ai migration strategies for platform changes.
+
   Use when migrating between cold email platforms, consolidating workspaces,
+
   or re-architecting outreach infrastructure around Instantly.
+
   Trigger with phrases like "migrate to instantly", "instantly migration",
+
   "switch to instantly", "instantly platform migration", "outreach migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, migration, architecture]
+tags:
+- saas
+- instantly
+- migration
+- architecture
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Migration Deep Dive
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-multi-env-setup
-description: |
-  Configure Instantly.ai across development, staging, and production environments.
+description: 'Configure Instantly.ai across development, staging, and production environments.
+
   Use when setting up multi-workspace deployments, isolating test from production,
+
   or managing per-environment API keys and webhook endpoints.
+
   Trigger with phrases like "instantly environments", "instantly staging",
+
   "instantly dev prod", "instantly multi-env", "instantly workspace isolation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, multi-environment, configuration]
+tags:
+- saas
+- instantly
+- multi-environment
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Multi-Environment Setup
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-observability/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-observability
-description: |
-  Set up monitoring, alerting, and dashboards for Instantly.ai integrations.
+description: 'Set up monitoring, alerting, and dashboards for Instantly.ai integrations.
+
   Use when implementing campaign health monitoring, account health alerts,
+
   or building analytics dashboards from Instantly data.
+
   Trigger with phrases like "instantly monitoring", "instantly dashboard",
+
   "instantly alerts", "instantly observability", "monitor instantly campaigns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, observability, monitoring, alerting]
+tags:
+- saas
+- instantly
+- observability
+- monitoring
+- alerting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Observability
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-performance-tuning
-description: |
-  Optimize Instantly.ai API performance with caching, batching, and connection pooling.
+description: 'Optimize Instantly.ai API performance with caching, batching, and connection
+  pooling.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing high-volume lead operations.
+
   Trigger with phrases like "instantly performance", "instantly slow",
+
   "instantly caching", "instantly batch", "optimize instantly api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, performance, caching, optimization]
+tags:
+- saas
+- instantly
+- performance
+- caching
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Performance Tuning
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-prod-checklist
-description: |
-  Execute Instantly.ai production launch checklist and pre-flight validation.
+description: 'Execute Instantly.ai production launch checklist and pre-flight validation.
+
   Use when deploying Instantly integrations to production, launching first campaign,
+
   or auditing production readiness.
+
   Trigger with phrases like "instantly production", "instantly launch checklist",
+
   "instantly go-live", "instantly pre-flight", "instantly prod ready".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, production, deployment]
+tags:
+- saas
+- instantly
+- production
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Production Checklist
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-rate-limits/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-rate-limits/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-rate-limits
-description: |
-  Implement Instantly.ai rate limiting, backoff, and request throttling patterns.
+description: 'Implement Instantly.ai rate limiting, backoff, and request throttling
+  patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or building high-throughput Instantly integrations.
+
   Trigger with phrases like "instantly rate limit", "instantly 429",
+
   "instantly throttle", "instantly backoff", "instantly retry".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, rate-limits, reliability]
+tags:
+- saas
+- instantly
+- rate-limits
+- reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Rate Limits
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-reference-architecture/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-reference-architecture
-description: |
-  Implement Instantly.ai reference architecture with best-practice project layout.
+description: 'Implement Instantly.ai reference architecture with best-practice project
+  layout.
+
   Use when designing new Instantly integrations, planning multi-campaign systems,
+
   or building an outreach automation platform.
+
   Trigger with phrases like "instantly architecture", "instantly project structure",
-  "instantly reference design", "instantly system design", "instantly integration layout".
+
+  "instantly reference design", "instantly system design", "instantly integration
+  layout".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, architecture, design]
+tags:
+- saas
+- instantly
+- architecture
+- design
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Reference Architecture
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-sdk-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-sdk-patterns
-description: |
-  Apply production-ready Instantly.ai API client patterns for TypeScript and Python.
+description: 'Apply production-ready Instantly.ai API client patterns for TypeScript
+  and Python.
+
   Use when building reusable API wrappers, implementing retry logic,
+
   or establishing coding standards for Instantly integrations.
+
   Trigger with phrases like "instantly SDK patterns", "instantly best practices",
+
   "instantly client wrapper", "instantly code patterns", "idiomatic instantly".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, patterns, typescript, python]
+tags:
+- saas
+- instantly
+- patterns
+- typescript
+- python
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly SDK Patterns
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-security-basics/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: instantly-security-basics
-description: |
-  Apply Instantly.ai security best practices for API keys, scopes, and access control.
+description: 'Apply Instantly.ai security best practices for API keys, scopes, and
+  access control.
+
   Use when securing API keys, implementing least-privilege access,
+
   or auditing Instantly workspace permissions.
+
   Trigger with phrases like "instantly security", "instantly api key safety",
+
   "instantly least privilege", "secure instantly", "instantly access control".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, security, access-control]
+tags:
+- saas
+- instantly
+- security
+- access-control
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Security Basics
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: instantly-upgrade-migration
-description: |
-  Migrate Instantly.ai integrations from API v1 to v2.
+description: 'Migrate Instantly.ai integrations from API v1 to v2.
+
   Use when upgrading from deprecated v1 endpoints, updating authentication,
+
   or migrating endpoint paths and request formats.
+
   Trigger with phrases like "instantly v1 to v2", "instantly api migration",
+
   "instantly upgrade", "instantly deprecated", "migrate instantly api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, migration, upgrade]
+tags:
+- saas
+- instantly
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Upgrade Migration: API v1 to v2
 

--- a/plugins/saas-packs/instantly-pack/skills/instantly-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/instantly-pack/skills/instantly-webhooks-events/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: instantly-webhooks-events
-description: |
-  Implement Instantly.ai webhook event handling with real API v2 event types.
+description: 'Implement Instantly.ai webhook event handling with real API v2 event
+  types.
+
   Use when setting up webhook endpoints, processing email events,
+
   or building CRM sync pipelines from Instantly notifications.
+
   Trigger with phrases like "instantly webhook", "instantly events",
+
   "instantly webhook handler", "handle instantly events", "instantly notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, instantly, webhooks, events, crm-sync]
+tags:
+- saas
+- instantly
+- webhooks
+- events
+- crm-sync
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Instantly Webhooks & Events
 

--- a/plugins/saas-packs/intercom-pack/skills/intercom-ci-integration/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-ci-integration
-description: |
-  Configure CI/CD pipelines for Intercom integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Intercom integrations with GitHub Actions.
+
   Use when setting up automated testing, configuring CI with Intercom secrets,
+
   or integrating Intercom API tests into your build process.
+
   Trigger with phrases like "intercom CI", "intercom GitHub Actions",
+
   "intercom automated tests", "CI intercom", "intercom pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom CI Integration
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-common-errors/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-common-errors
-description: |
-  Diagnose and fix Intercom API errors by HTTP status code and error type.
+description: 'Diagnose and fix Intercom API errors by HTTP status code and error type.
+
   Use when encountering Intercom errors, debugging failed API requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "intercom error", "fix intercom",
+
   "intercom not working", "debug intercom", "intercom 401", "intercom 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Common Errors
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-core-workflow-a/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: intercom-core-workflow-a
-description: |
-  Manage Intercom contacts: create, search, update, merge leads into users.
+description: 'Manage Intercom contacts: create, search, update, merge leads into users.
+
   Use when building contact management features, syncing user data,
+
   or implementing contact search and segmentation.
+
   Trigger with phrases like "intercom contacts", "intercom users",
+
   "intercom leads", "create intercom contact", "search intercom contacts",
+
   "merge intercom lead".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Contacts & Contact Management
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-core-workflow-b/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: intercom-core-workflow-b
-description: |
-  Manage Intercom conversations: create, reply, close, snooze, assign, and tag.
+description: 'Manage Intercom conversations: create, reply, close, snooze, assign,
+  and tag.
+
   Use when building conversation management features, automating replies,
+
   or implementing support workflow automation.
+
   Trigger with phrases like "intercom conversations", "intercom reply",
+
   "intercom assign conversation", "intercom close conversation",
+
   "intercom snooze", "manage intercom conversations".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Conversations & Messaging
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-cost-tuning
-description: |
-  Optimize Intercom API costs through caching, request reduction, and usage monitoring.
+description: 'Optimize Intercom API costs through caching, request reduction, and
+  usage monitoring.
+
   Use when analyzing Intercom API usage, reducing unnecessary requests,
+
   or implementing usage tracking and budget awareness.
+
   Trigger with phrases like "intercom cost", "intercom billing",
+
   "reduce intercom requests", "intercom pricing", "intercom usage", "intercom budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-data-handling/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-data-handling/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: intercom-data-handling
-description: |
-  Implement Intercom data handling for GDPR, contact export, data retention, and PII.
+description: 'Implement Intercom data handling for GDPR, contact export, data retention,
+  and PII.
+
   Use when handling sensitive data, implementing data export/deletion requests,
+
   or ensuring compliance with privacy regulations for Intercom integrations.
+
   Trigger with phrases like "intercom data", "intercom PII",
+
   "intercom GDPR", "intercom data retention", "intercom privacy", "intercom CCPA",
+
   "intercom data export", "intercom delete contact".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Data Handling
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-debug-bundle
-description: |
-  Collect Intercom debug evidence for support tickets and troubleshooting.
+description: 'Collect Intercom debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Intercom API problems.
+
   Trigger with phrases like "intercom debug", "intercom support bundle",
+
   "collect intercom logs", "intercom diagnostic", "intercom troubleshoot".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-deploy-integration
-description: |
-  Deploy Intercom integrations to Vercel, Fly.io, and Cloud Run with proper secrets.
+description: 'Deploy Intercom integrations to Vercel, Fly.io, and Cloud Run with proper
+  secrets.
+
   Use when deploying Intercom-powered applications to production,
+
   configuring platform-specific secrets, or setting up webhook endpoints.
+
   Trigger with phrases like "deploy intercom", "intercom Vercel",
+
   "intercom production deploy", "intercom Cloud Run", "intercom Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-enterprise-rbac/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: intercom-enterprise-rbac
-description: |
-  Configure Intercom enterprise OAuth, admin roles, and app-level access control.
+description: 'Configure Intercom enterprise OAuth, admin roles, and app-level access
+  control.
+
   Use when implementing OAuth integration, managing admin permissions,
+
   or setting up organization-level controls for Intercom.
+
   Trigger with phrases like "intercom OAuth", "intercom RBAC",
-  "intercom enterprise", "intercom roles", "intercom permissions", "intercom admin access".
+
+  "intercom enterprise", "intercom roles", "intercom permissions", "intercom admin
+  access".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-hello-world/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-hello-world
-description: |
-  Create a minimal working Intercom example with contacts, conversations, and messages.
+description: 'Create a minimal working Intercom example with contacts, conversations,
+  and messages.
+
   Use when starting a new Intercom integration, testing your setup,
+
   or learning the core Intercom API data model.
+
   Trigger with phrases like "intercom hello world", "intercom example",
+
   "intercom quick start", "simple intercom code", "first intercom API call".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Hello World
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-incident-runbook
-description: |
-  Execute Intercom incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Intercom incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Intercom API outages, investigating integration errors,
+
   or running post-incident reviews for Intercom failures.
+
   Trigger with phrases like "intercom incident", "intercom outage",
+
   "intercom down", "intercom on-call", "intercom emergency", "intercom broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-install-auth/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-install-auth/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-install-auth
-description: |
-  Install and configure Intercom API authentication with access tokens or OAuth.
+description: 'Install and configure Intercom API authentication with access tokens
+  or OAuth.
+
   Use when setting up a new Intercom integration, configuring API credentials,
+
   or initializing the intercom-client SDK in your project.
+
   Trigger with phrases like "install intercom", "setup intercom",
+
   "intercom auth", "configure intercom API key", "intercom access token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-local-dev-loop
-description: |
-  Configure Intercom local development with testing, mocking, and hot reload.
+description: 'Configure Intercom local development with testing, mocking, and hot
+  reload.
+
   Use when setting up a development environment, writing tests against the
+
   Intercom API, or establishing a fast iteration cycle.
+
   Trigger with phrases like "intercom dev setup", "intercom local development",
+
   "intercom dev environment", "develop with intercom", "test intercom locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-migration-deep-dive/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: intercom-migration-deep-dive
-description: |
-  Execute major Intercom data migrations and re-platforming with the contacts,
+description: 'Execute major Intercom data migrations and re-platforming with the contacts,
+
   conversations, and articles APIs. Use when migrating from Zendesk/Freshdesk to
+
   Intercom, bulk-importing contacts, or re-platforming to Intercom.
+
   Trigger with phrases like "migrate to intercom", "intercom migration",
+
   "import contacts to intercom", "switch to intercom", "zendesk to intercom",
+
   "intercom data import".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-multi-env-setup/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-multi-env-setup
-description: |
-  Configure Intercom across development, staging, and production workspaces.
+description: 'Configure Intercom across development, staging, and production workspaces.
+
   Use when setting up multi-environment deployments, configuring per-environment
+
   access tokens, or implementing workspace isolation.
+
   Trigger with phrases like "intercom environments", "intercom staging",
+
   "intercom dev prod", "intercom environment setup", "intercom workspace isolation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-observability/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-observability
-description: |
-  Set up observability for Intercom integrations with metrics, traces, and alerts.
+description: 'Set up observability for Intercom integrations with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for Intercom API operations, setting up dashboards,
+
   or configuring alerting for integration health.
+
   Trigger with phrases like "intercom monitoring", "intercom metrics",
+
   "intercom observability", "monitor intercom", "intercom alerts", "intercom tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Observability
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-performance-tuning
-description: |
-  Optimize Intercom API performance with caching, search optimization, and pagination.
+description: 'Optimize Intercom API performance with caching, search optimization,
+  and pagination.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Intercom integrations.
+
   Trigger with phrases like "intercom performance", "optimize intercom",
+
   "intercom latency", "intercom caching", "intercom slow", "intercom pagination".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-prod-checklist
-description: |
-  Execute Intercom production readiness checklist and rollback procedures.
+description: 'Execute Intercom production readiness checklist and rollback procedures.
+
   Use when deploying Intercom integrations to production, preparing for launch,
+
   or implementing go-live validation.
+
   Trigger with phrases like "intercom production", "deploy intercom",
+
   "intercom go-live", "intercom launch checklist", "intercom production readiness".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-rate-limits/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-rate-limits
-description: |
-  Handle Intercom API rate limits with backoff, queuing, and header monitoring.
+description: 'Handle Intercom API rate limits with backoff, queuing, and header monitoring.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Intercom.
+
   Trigger with phrases like "intercom rate limit", "intercom throttling",
+
   "intercom 429", "intercom retry", "intercom backoff", "intercom request limit".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-reference-architecture/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-reference-architecture
-description: |
-  Implement Intercom reference architecture with layered project structure.
+description: 'Implement Intercom reference architecture with layered project structure.
+
   Use when designing new Intercom integrations, reviewing project structure,
+
   or establishing architecture standards for Intercom applications.
+
   Trigger with phrases like "intercom architecture", "intercom project structure",
+
   "how to organize intercom", "intercom layout", "intercom design patterns".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-sdk-patterns
-description: |
-  Apply production-ready intercom-client SDK patterns for TypeScript.
+description: 'Apply production-ready intercom-client SDK patterns for TypeScript.
+
   Use when implementing Intercom integrations, refactoring SDK usage,
+
   or establishing team coding standards for Intercom API calls.
+
   Trigger with phrases like "intercom SDK patterns", "intercom best practices",
+
   "intercom code patterns", "idiomatic intercom", "intercom typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-security-basics/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-security-basics/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: intercom-security-basics
-description: |
-  Apply Intercom security best practices for tokens, webhook verification, and scopes.
+description: 'Apply Intercom security best practices for tokens, webhook verification,
+  and scopes.
+
   Use when securing access tokens, implementing webhook signature validation,
+
   or configuring least-privilege OAuth scopes.
+
   Trigger with phrases like "intercom security", "intercom secrets",
+
   "secure intercom", "intercom webhook signature", "intercom token rotation".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Security Basics
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: intercom-upgrade-migration
-description: |
-  Upgrade intercom-client SDK versions and handle API version changes.
+description: 'Upgrade intercom-client SDK versions and handle API version changes.
+
   Use when upgrading the SDK, migrating between API versions,
+
   or detecting breaking changes in Intercom releases.
+
   Trigger with phrases like "upgrade intercom", "intercom migration",
+
   "intercom breaking changes", "update intercom SDK", "intercom API version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/intercom-pack/skills/intercom-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/intercom-pack/skills/intercom-webhooks-events/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: intercom-webhooks-events
-description: |
-  Implement Intercom webhook handling and data event tracking.
+description: 'Implement Intercom webhook handling and data event tracking.
+
   Use when setting up webhook endpoints, processing Intercom notifications,
+
   or submitting custom data events for contact activity tracking.
+
   Trigger with phrases like "intercom webhook", "intercom events",
+
   "intercom webhook signature", "handle intercom events", "intercom data events",
+
   "track intercom events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, support, messaging, intercom]
-compatible-with: claude-code
+tags:
+- saas
+- support
+- messaging
+- intercom
+compatibility: Designed for Claude Code
 ---
-
 # Intercom Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-ci-integration/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-ci-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-ci-integration
-description: |
-  Configure Juicebox CI/CD.
+description: 'Configure Juicebox CI/CD.
+
   Trigger: "juicebox ci", "juicebox pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox CI Integration
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-common-errors/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-common-errors/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-common-errors
-description: |
-  Diagnose and fix Juicebox API errors.
+description: 'Diagnose and fix Juicebox API errors.
+
   Trigger: "juicebox error", "fix juicebox", "debug juicebox".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Common Errors
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-core-workflow-a/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-core-workflow-a
-description: |
-  Execute Juicebox people search with power filters and ATS export.
+description: 'Execute Juicebox people search with power filters and ATS export.
+
   Trigger: "find candidates", "people search", "juicebox search".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox People Search Workflow
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-core-workflow-b/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-core-workflow-b
-description: |
-  Execute Juicebox enrichment and outreach workflow.
+description: 'Execute Juicebox enrichment and outreach workflow.
+
   Trigger: "juicebox enrich", "candidate enrichment", "talent pool".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox — Advanced Analysis
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-cost-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-cost-tuning
-description: |
-  Optimize Juicebox costs.
+description: 'Optimize Juicebox costs.
+
   Trigger: "juicebox cost", "juicebox billing", "juicebox budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Cost Tuning
 
 ## Cost Factors

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-data-handling/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-data-handling/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-data-handling
-description: |
-  Juicebox data privacy and GDPR.
+description: 'Juicebox data privacy and GDPR.
+
   Trigger: "juicebox data privacy", "juicebox gdpr".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Data Handling
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-debug-bundle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-debug-bundle
-description: |
-  Collect Juicebox debug evidence.
+description: 'Collect Juicebox debug evidence.
+
   Trigger: "juicebox debug", "juicebox support ticket".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-deploy-integration
-description: |
-  Deploy Juicebox integrations.
+description: 'Deploy Juicebox integrations.
+
   Trigger: "deploy juicebox", "juicebox production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-enterprise-rbac/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-enterprise-rbac
-description: |
-  Configure Juicebox team access.
+description: 'Configure Juicebox team access.
+
   Trigger: "juicebox rbac", "juicebox team roles".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-hello-world/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-hello-world/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-hello-world
-description: |
-  Create a minimal Juicebox people search example.
+description: 'Create a minimal Juicebox people search example.
+
   Trigger: "juicebox hello world", "first people search", "test juicebox".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Hello World
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-incident-runbook/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-incident-runbook
-description: |
-  Juicebox incident response.
+description: 'Juicebox incident response.
+
   Trigger: "juicebox incident", "juicebox outage".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-install-auth/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: juicebox-install-auth
-description: |
-  Install and configure Juicebox PeopleGPT API authentication.
+description: 'Install and configure Juicebox PeopleGPT API authentication.
+
   Use when setting up people search or initializing Juicebox.
+
   Trigger: "install juicebox", "setup juicebox", "juicebox auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-local-dev-loop/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-local-dev-loop
-description: |
-  Configure Juicebox local dev workflow.
+description: 'Configure Juicebox local dev workflow.
+
   Trigger: "juicebox local dev", "juicebox dev setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-migration-deep-dive/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-migration-deep-dive
-description: |
-  Migrate to Juicebox from other tools.
+description: 'Migrate to Juicebox from other tools.
+
   Trigger: "switch to juicebox", "migrate to juicebox".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Migration Deep Dive
 
 ## Comparison

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-multi-env-setup/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-multi-env-setup
-description: |
-  Configure Juicebox multi-environment.
+description: 'Configure Juicebox multi-environment.
+
   Trigger: "juicebox environments", "juicebox staging".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-observability/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-observability/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-observability
-description: |
-  Set up Juicebox monitoring.
+description: 'Set up Juicebox monitoring.
+
   Trigger: "juicebox monitoring", "juicebox metrics".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Observability
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-performance-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-performance-tuning
-description: |
-  Optimize Juicebox performance.
+description: 'Optimize Juicebox performance.
+
   Trigger: "juicebox performance", "optimize juicebox".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-prod-checklist
-description: |
-  Execute Juicebox production checklist.
+description: 'Execute Juicebox production checklist.
+
   Trigger: "juicebox production", "deploy juicebox".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-rate-limits/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-rate-limits
-description: |
-  Implement Juicebox rate limiting.
+description: 'Implement Juicebox rate limiting.
+
   Trigger: "juicebox rate limit", "juicebox 429", "juicebox throttle".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-reference-architecture/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-reference-architecture
-description: |
-  Implement Juicebox reference architecture.
+description: 'Implement Juicebox reference architecture.
+
   Trigger: "juicebox architecture", "recruiting platform design".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-sdk-patterns/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-sdk-patterns
-description: |
-  Apply production Juicebox SDK patterns.
+description: 'Apply production Juicebox SDK patterns.
+
   Trigger: "juicebox patterns", "juicebox best practices".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-security-basics/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-security-basics/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-security-basics
-description: |
-  Apply Juicebox security best practices.
+description: 'Apply Juicebox security best practices.
+
   Trigger: "juicebox security", "juicebox api key security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Security Basics
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-upgrade-migration
-description: |
-  Plan Juicebox SDK upgrades.
+description: 'Plan Juicebox SDK upgrades.
+
   Trigger: "upgrade juicebox", "juicebox migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/juicebox-pack/skills/juicebox-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/juicebox-pack/skills/juicebox-webhooks-events/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: juicebox-webhooks-events
-description: |
-  Handle Juicebox webhooks and events.
+description: 'Handle Juicebox webhooks and events.
+
   Trigger: "juicebox webhooks", "juicebox events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, recruiting, juicebox]
-compatible-with: claude-code
+tags:
+- saas
+- recruiting
+- juicebox
+compatibility: Designed for Claude Code
 ---
-
 # Juicebox Webhooks & Events
 
 ## Overview


### PR DESCRIPTION
## Summary

Chunk 3 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated `compatible-with` CSV-platform-list field to the spec-aligned `compatibility` free-text field per agentskills.io/specification.

**Pure schema migration. No content changes.** Same tool used in PRs #620 and #622.

### Assigned packs (chunk 3 of 6)

| Pack | Files |
|---|---|
| fireflies-pack | 24 |
| flexport-pack | 24 |
| flyio-pack | 18 |
| fondo-pack | 18 |
| framer-pack | 18 |
| gamma-pack | 24 |
| glean-pack | 24 |
| grammarly-pack | 24 |
| granola-pack | 24 |
| groq-pack | 24 |
| guidewire-pack | 24 |
| hex-pack | 18 |
| hootsuite-pack | 18 |
| hubspot-pack | 30 |
| ideogram-pack | 24 |
| instantly-pack | 24 |
| intercom-pack | 24 |
| juicebox-pack | 24 |
| **TOTAL** | **408** |

### Side effect

`yaml.safe_dump` round-trips the entire frontmatter — so `description: |` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] `grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Refs #613

jeremy made me do it
-claude