### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 4/6, 433 skills)

### DIFF
--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-ci-integration/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-ci-integration
-description: |
-  Configure CI/CD pipelines for Klaviyo integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Klaviyo integrations with GitHub Actions.
+
   Use when setting up automated testing, configuring CI secrets,
+
   or integrating Klaviyo SDK tests into your build pipeline.
+
   Trigger with phrases like "klaviyo CI", "klaviyo GitHub Actions",
+
   "klaviyo automated tests", "CI klaviyo", "klaviyo pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo CI Integration
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-common-errors/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-common-errors
-description: |
-  Diagnose and fix common Klaviyo API errors and exceptions.
+description: 'Diagnose and fix common Klaviyo API errors and exceptions.
+
   Use when encountering Klaviyo 4xx/5xx errors, debugging failed requests,
+
   or troubleshooting SDK integration issues.
+
   Trigger with phrases like "klaviyo error", "fix klaviyo",
+
   "klaviyo not working", "debug klaviyo", "klaviyo 400", "klaviyo 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Common Errors
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-core-workflow-a
-description: |
-  Execute Klaviyo primary workflow: profiles, lists, and subscriptions.
+description: 'Execute Klaviyo primary workflow: profiles, lists, and subscriptions.
+
   Use when creating/updating profiles, managing lists, subscribing contacts,
+
   or syncing customer data to Klaviyo for email/SMS marketing.
+
   Trigger with phrases like "klaviyo profiles", "klaviyo lists",
+
   "klaviyo subscribe", "add contacts to klaviyo", "klaviyo customer data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Core Workflow A -- Profiles, Lists & Subscriptions
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-core-workflow-b
-description: |
-  Execute Klaviyo secondary workflow: event tracking, segments, and campaigns.
+description: 'Execute Klaviyo secondary workflow: event tracking, segments, and campaigns.
+
   Use when tracking customer events, creating segments, building campaigns,
+
   or triggering flows via the Klaviyo API.
+
   Trigger with phrases like "klaviyo events", "klaviyo segments",
+
   "klaviyo campaigns", "track klaviyo event", "klaviyo flow trigger".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Core Workflow B -- Events, Segments & Campaigns
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-cost-tuning
-description: |
-  Optimize Klaviyo costs through plan selection, contact management, and usage monitoring.
+description: 'Optimize Klaviyo costs through plan selection, contact management, and
+  usage monitoring.
+
   Use when analyzing Klaviyo billing, reducing active profile costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "klaviyo cost", "klaviyo billing",
+
   "reduce klaviyo costs", "klaviyo pricing", "klaviyo expensive", "klaviyo budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-data-handling/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-data-handling/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: klaviyo-data-handling
-description: |
-  Implement Klaviyo data privacy, GDPR/CCPA compliance, and PII handling patterns.
+description: 'Implement Klaviyo data privacy, GDPR/CCPA compliance, and PII handling
+  patterns.
+
   Use when handling profile data, implementing right-to-deletion, configuring
+
   data retention, or ensuring compliance with privacy regulations.
+
   Trigger with phrases like "klaviyo data", "klaviyo PII",
+
   "klaviyo GDPR", "klaviyo data retention", "klaviyo privacy", "klaviyo CCPA",
+
   "klaviyo delete profile", "klaviyo data privacy".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Data Handling
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-debug-bundle
-description: |
-  Collect Klaviyo debug evidence for support tickets and troubleshooting.
+description: 'Collect Klaviyo debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Klaviyo API problems.
+
   Trigger with phrases like "klaviyo debug", "klaviyo support bundle",
+
   "collect klaviyo logs", "klaviyo diagnostic", "klaviyo troubleshoot".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-deploy-integration
-description: |
-  Deploy Klaviyo integrations to Vercel, Fly.io, and Cloud Run platforms.
+description: 'Deploy Klaviyo integrations to Vercel, Fly.io, and Cloud Run platforms.
+
   Use when deploying Klaviyo-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy klaviyo", "klaviyo Vercel",
+
   "klaviyo production deploy", "klaviyo Cloud Run", "klaviyo Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-enterprise-rbac/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-enterprise-rbac
-description: |
-  Configure Klaviyo enterprise access control with API key scopes and OAuth.
+description: 'Configure Klaviyo enterprise access control with API key scopes and
+  OAuth.
+
   Use when implementing per-key scoping, configuring OAuth app authorization,
+
   or setting up organization-level access controls for Klaviyo.
+
   Trigger with phrases like "klaviyo scopes", "klaviyo RBAC",
+
   "klaviyo enterprise", "klaviyo permissions", "klaviyo OAuth", "klaviyo access control".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-hello-world/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-hello-world
-description: |
-  Create a minimal working Klaviyo example with real API calls.
+description: 'Create a minimal working Klaviyo example with real API calls.
+
   Use when starting a new Klaviyo integration, testing your setup,
+
   or learning basic profile creation and event tracking patterns.
+
   Trigger with phrases like "klaviyo hello world", "klaviyo example",
+
   "klaviyo quick start", "simple klaviyo code", "first klaviyo call".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Hello World
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-incident-runbook
-description: |
-  Execute Klaviyo incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Klaviyo incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Klaviyo-related outages, investigating API errors,
+
   or running post-incident reviews for Klaviyo integration failures.
+
   Trigger with phrases like "klaviyo incident", "klaviyo outage",
+
   "klaviyo down", "klaviyo on-call", "klaviyo emergency", "klaviyo broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(kubectl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-install-auth/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-install-auth
-description: |
-  Install and configure Klaviyo Node.js SDK with API key authentication.
+description: 'Install and configure Klaviyo Node.js SDK with API key authentication.
+
   Use when setting up a new Klaviyo integration, configuring API keys,
+
   or initializing the klaviyo-api package in your project.
+
   Trigger with phrases like "install klaviyo", "setup klaviyo",
+
   "klaviyo auth", "configure klaviyo API key", "klaviyo SDK setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-local-dev-loop
-description: |
-  Configure Klaviyo local development with hot reload, mocking, and testing.
+description: 'Configure Klaviyo local development with hot reload, mocking, and testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with the Klaviyo API.
+
   Trigger with phrases like "klaviyo dev setup", "klaviyo local development",
+
   "klaviyo dev environment", "develop with klaviyo", "klaviyo testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-migration-deep-dive/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-migration-deep-dive
-description: |
-  Execute major Klaviyo migration strategies: from legacy v1/v2 APIs, from competitors,
+description: 'Execute major Klaviyo migration strategies: from legacy v1/v2 APIs,
+  from competitors,
+
   or full re-platforming to Klaviyo with the strangler fig pattern.
+
   Trigger with phrases like "migrate to klaviyo", "klaviyo migration",
+
   "switch to klaviyo", "klaviyo replatform", "mailchimp to klaviyo",
+
   "legacy to klaviyo", "v1 to v2 klaviyo".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-multi-env-setup/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-multi-env-setup
-description: |
-  Configure Klaviyo across development, staging, and production environments.
-  Use when setting up multi-environment deployments, configuring per-environment API keys,
+description: 'Configure Klaviyo across development, staging, and production environments.
+
+  Use when setting up multi-environment deployments, configuring per-environment API
+  keys,
+
   or implementing environment-specific Klaviyo configurations.
+
   Trigger with phrases like "klaviyo environments", "klaviyo staging",
+
   "klaviyo dev prod", "klaviyo environment setup", "klaviyo config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-observability/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-observability
-description: |
-  Set up observability for Klaviyo integrations with metrics, traces, and alerts.
+description: 'Set up observability for Klaviyo integrations with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for Klaviyo API operations, setting up dashboards,
+
   or configuring alerting for Klaviyo integration health.
+
   Trigger with phrases like "klaviyo monitoring", "klaviyo metrics",
+
   "klaviyo observability", "monitor klaviyo", "klaviyo alerts", "klaviyo tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Observability
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-performance-tuning
-description: |
-  Optimize Klaviyo API performance with caching, batching, and pagination tuning.
+description: 'Optimize Klaviyo API performance with caching, batching, and pagination
+  tuning.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Klaviyo integrations.
+
   Trigger with phrases like "klaviyo performance", "optimize klaviyo",
+
   "klaviyo latency", "klaviyo caching", "klaviyo slow", "klaviyo batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-prod-checklist
-description: |
-  Execute Klaviyo production deployment checklist and validation procedures.
+description: 'Execute Klaviyo production deployment checklist and validation procedures.
+
   Use when deploying Klaviyo integrations to production, preparing for launch,
+
   or implementing go-live procedures for email/SMS marketing.
+
   Trigger with phrases like "klaviyo production", "deploy klaviyo",
+
   "klaviyo go-live", "klaviyo launch checklist", "klaviyo prod ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-rate-limits/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-rate-limits
-description: |
-  Implement Klaviyo rate limiting, backoff, and request queuing patterns.
+description: 'Implement Klaviyo rate limiting, backoff, and request queuing patterns.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Klaviyo.
+
   Trigger with phrases like "klaviyo rate limit", "klaviyo throttling",
+
   "klaviyo 429", "klaviyo retry", "klaviyo backoff", "klaviyo Retry-After".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-reference-architecture
-description: |
-  Implement Klaviyo reference architecture with best-practice project layout.
+description: 'Implement Klaviyo reference architecture with best-practice project
+  layout.
+
   Use when designing new Klaviyo integrations, reviewing project structure,
+
   or establishing architecture standards for email/SMS marketing applications.
+
   Trigger with phrases like "klaviyo architecture", "klaviyo project structure",
+
   "klaviyo design", "how to organize klaviyo", "klaviyo layout".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-sdk-patterns
-description: |
-  Apply production-ready Klaviyo SDK patterns for the klaviyo-api package.
+description: 'Apply production-ready Klaviyo SDK patterns for the klaviyo-api package.
+
   Use when implementing Klaviyo integrations, refactoring SDK usage,
+
   or establishing team coding standards for Klaviyo API calls.
+
   Trigger with phrases like "klaviyo SDK patterns", "klaviyo best practices",
+
   "klaviyo code patterns", "idiomatic klaviyo", "klaviyo wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-security-basics/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-security-basics/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-security-basics
-description: |
-  Apply Klaviyo security best practices for API key management and access control.
+description: 'Apply Klaviyo security best practices for API key management and access
+  control.
+
   Use when securing API keys, configuring OAuth scopes, implementing webhook
+
   signature verification, or auditing Klaviyo security configuration.
+
   Trigger with phrases like "klaviyo security", "klaviyo secrets",
+
   "secure klaviyo", "klaviyo API key security", "klaviyo OAuth".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Security Basics
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: klaviyo-upgrade-migration
-description: |
-  Upgrade Klaviyo SDK versions and migrate between API revisions.
+description: 'Upgrade Klaviyo SDK versions and migrate between API revisions.
+
   Use when upgrading the klaviyo-api package, migrating from v1/v2 legacy APIs
+
   to the current REST API, or handling breaking changes between revisions.
+
   Trigger with phrases like "upgrade klaviyo", "klaviyo migration",
+
   "klaviyo breaking changes", "update klaviyo SDK", "klaviyo API revision".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/klaviyo-pack/skills/klaviyo-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/klaviyo-pack/skills/klaviyo-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: klaviyo-webhooks-events
-description: |
-  Implement Klaviyo webhooks with HMAC-SHA256 signature verification and event handling.
+description: 'Implement Klaviyo webhooks with HMAC-SHA256 signature verification and
+  event handling.
+
   Use when setting up webhook endpoints, handling Klaviyo event notifications,
+
   or creating event-driven integrations with Klaviyo.
+
   Trigger with phrases like "klaviyo webhook", "klaviyo events",
+
   "klaviyo webhook signature", "handle klaviyo events", "klaviyo notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, klaviyo, email-marketing, cdp]
-compatible-with: claude-code
+tags:
+- saas
+- klaviyo
+- email-marketing
+- cdp
+compatibility: Designed for Claude Code
 ---
-
 # Klaviyo Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/klingai-pack/skills/klingai-async-workflows/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-async-workflows/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-async-workflows
-description: |
-  Build async video generation workflows with Kling AI using queues, state machines, and
-  event-driven patterns. Trigger with phrases like 'klingai async', 'kling ai workflow',
-  'klingai pipeline', 'async video generation'.
+description: 'Build async video generation workflows with Kling AI using queues, state
+  machines, and
+
+  event-driven patterns. Trigger with phrases like ''klingai async'', ''kling ai workflow'',
+
+  ''klingai pipeline'', ''async video generation''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, async, workflows]
+tags:
+- saas
+- kling-ai
+- async
+- workflows
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Async Workflows
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-audit-logging/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-audit-logging/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: klingai-audit-logging
-description: |
-  Implement audit logging for Kling AI operations for compliance and security. Use when tracking
-  API usage or preparing for audits. Trigger with phrases like 'klingai audit', 'kling ai audit log',
-  'klingai compliance log', 'video generation audit trail'.
+description: 'Implement audit logging for Kling AI operations for compliance and security.
+  Use when tracking
+
+  API usage or preparing for audits. Trigger with phrases like ''klingai audit'',
+  ''kling ai audit log'',
+
+  ''klingai compliance log'', ''video generation audit trail''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, audit, compliance, logging]
+tags:
+- saas
+- kling-ai
+- audit
+- compliance
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Audit Logging
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-batch-processing/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-batch-processing/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-batch-processing
-description: |
-  Process multiple video generation requests efficiently with Kling AI. Use when generating
-  batches of videos or building content pipelines. Trigger with phrases like 'klingai batch',
-  'kling ai bulk', 'multiple videos klingai', 'klingai parallel generation'.
+description: 'Process multiple video generation requests efficiently with Kling AI.
+  Use when generating
+
+  batches of videos or building content pipelines. Trigger with phrases like ''klingai
+  batch'',
+
+  ''kling ai bulk'', ''multiple videos klingai'', ''klingai parallel generation''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, batch, pipelines]
+tags:
+- saas
+- kling-ai
+- batch
+- pipelines
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Batch Processing
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-camera-control/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-camera-control/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-camera-control
-description: |
-  Control camera movements in Kling AI video generation. Use when creating cinematic shots,
-  pans, tilts, zooms, or dolly moves. Trigger with phrases like 'klingai camera',
-  'kling ai camera motion', 'klingai cinematic', 'klingai pan zoom'.
+description: 'Control camera movements in Kling AI video generation. Use when creating
+  cinematic shots,
+
+  pans, tilts, zooms, or dolly moves. Trigger with phrases like ''klingai camera'',
+
+  ''kling ai camera motion'', ''klingai cinematic'', ''klingai pan zoom''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, camera-control, cinematic]
+tags:
+- saas
+- kling-ai
+- camera-control
+- cinematic
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Camera Control
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-ci-integration/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-ci-integration/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-ci-integration
-description: |
-  Integrate Kling AI video generation into CI/CD pipelines. Use when automating video content
-  in GitHub Actions or GitLab CI. Trigger with phrases like 'klingai ci', 'kling ai github actions',
-  'klingai automation', 'automated video generation'.
+description: 'Integrate Kling AI video generation into CI/CD pipelines. Use when automating
+  video content
+
+  in GitHub Actions or GitLab CI. Trigger with phrases like ''klingai ci'', ''kling
+  ai github actions'',
+
+  ''klingai automation'', ''automated video generation''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, ci-cd, automation]
+tags:
+- saas
+- kling-ai
+- ci-cd
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI CI Integration
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-common-errors/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-common-errors/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-common-errors
-description: |
-  Diagnose and fix common Kling AI API errors. Use when troubleshooting failed video generation
-  or API issues. Trigger with phrases like 'kling ai error', 'klingai not working', 'fix klingai',
-  'klingai failed'.
+description: 'Diagnose and fix common Kling AI API errors. Use when troubleshooting
+  failed video generation
+
+  or API issues. Trigger with phrases like ''kling ai error'', ''klingai not working'',
+  ''fix klingai'',
+
+  ''klingai failed''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, debugging, errors]
+tags:
+- saas
+- kling-ai
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Common Errors
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-compliance-review/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-compliance-review/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-compliance-review
-description: |
-  Security and compliance review framework for Kling AI integrations. Use when preparing for
-  audits or reviewing security posture. Trigger with phrases like 'klingai compliance',
-  'kling ai security review', 'klingai audit prep', 'video generation compliance'.
+description: 'Security and compliance review framework for Kling AI integrations.
+  Use when preparing for
+
+  audits or reviewing security posture. Trigger with phrases like ''klingai compliance'',
+
+  ''kling ai security review'', ''klingai audit prep'', ''video generation compliance''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, compliance, security]
+tags:
+- saas
+- kling-ai
+- compliance
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Compliance Review
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-content-policy/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-content-policy/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-content-policy
-description: |
-  Implement content policy compliance for Kling AI prompts and outputs. Use when filtering
-  user prompts or handling moderation. Trigger with phrases like 'klingai content policy',
-  'kling ai moderation', 'safe video generation', 'klingai content filter'.
+description: 'Implement content policy compliance for Kling AI prompts and outputs.
+  Use when filtering
+
+  user prompts or handling moderation. Trigger with phrases like ''klingai content
+  policy'',
+
+  ''kling ai moderation'', ''safe video generation'', ''klingai content filter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, content-policy, moderation]
+tags:
+- saas
+- kling-ai
+- content-policy
+- moderation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Content Policy
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-cost-controls/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-cost-controls/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-cost-controls
-description: |
-  Implement budget limits, usage alerts, and spending controls for Kling AI. Use when managing
-  costs or preventing overruns. Trigger with phrases like 'klingai cost', 'kling ai budget',
-  'klingai spending limit', 'video generation costs'.
+description: 'Implement budget limits, usage alerts, and spending controls for Kling
+  AI. Use when managing
+
+  costs or preventing overruns. Trigger with phrases like ''klingai cost'', ''kling
+  ai budget'',
+
+  ''klingai spending limit'', ''video generation costs''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, cost-controls, budget]
+tags:
+- saas
+- kling-ai
+- cost-controls
+- budget
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Cost Controls
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-debug-bundle/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-debug-bundle
-description: |
-  Set up logging and debugging for Kling AI API integrations. Use when troubleshooting video
-  generation or building observability. Trigger with phrases like 'klingai debug', 'kling ai logging',
-  'klingai troubleshoot', 'debug kling video generation'.
+description: 'Set up logging and debugging for Kling AI API integrations. Use when
+  troubleshooting video
+
+  generation or building observability. Trigger with phrases like ''klingai debug'',
+  ''kling ai logging'',
+
+  ''klingai troubleshoot'', ''debug kling video generation''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, debugging, observability]
+tags:
+- saas
+- kling-ai
+- debugging
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Debug Bundle
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-hello-world/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-hello-world/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-hello-world
-description: |
-  Create your first Kling AI video generation with a minimal working example. Use when learning
-  Kling AI or testing your setup. Trigger with phrases like 'kling ai hello world', 'first kling video',
-  'klingai quickstart', 'test klingai'.
+description: 'Create your first Kling AI video generation with a minimal working example.
+  Use when learning
+
+  Kling AI or testing your setup. Trigger with phrases like ''kling ai hello world'',
+  ''first kling video'',
+
+  ''klingai quickstart'', ''test klingai''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, quickstart]
+tags:
+- saas
+- kling-ai
+- quickstart
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Hello World
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-image-to-video/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-image-to-video/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-image-to-video
-description: |
-  Animate static images into video using Kling AI. Use when converting images to video,
-  adding motion to stills, or building I2V pipelines. Trigger with phrases like 'klingai image to video',
-  'kling ai animate image', 'klingai img2vid', 'animate picture klingai'.
+description: 'Animate static images into video using Kling AI. Use when converting
+  images to video,
+
+  adding motion to stills, or building I2V pipelines. Trigger with phrases like ''klingai
+  image to video'',
+
+  ''kling ai animate image'', ''klingai img2vid'', ''animate picture klingai''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, image-to-video, video-generation]
+tags:
+- saas
+- kling-ai
+- image-to-video
+- video-generation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Image-to-Video
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-install-auth/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-install-auth/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-install-auth
-description: |
-  Set up Kling AI API authentication with JWT tokens. Use when starting a new Kling AI
-  integration or troubleshooting auth issues. Trigger with phrases like 'kling ai setup',
-  'klingai api key', 'kling ai authentication', 'configure klingai'.
+description: 'Set up Kling AI API authentication with JWT tokens. Use when starting
+  a new Kling AI
+
+  integration or troubleshooting auth issues. Trigger with phrases like ''kling ai
+  setup'',
+
+  ''klingai api key'', ''kling ai authentication'', ''configure klingai''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, api, authentication]
+tags:
+- saas
+- kling-ai
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Install & Auth
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-job-monitoring/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-job-monitoring/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-job-monitoring
-description: |
-  Track and monitor Kling AI video generation task status. Use when building dashboards,
-  tracking batch jobs, or debugging stuck tasks. Trigger with phrases like 'klingai job status',
-  'kling ai monitor', 'track klingai task', 'klingai progress'.
+description: 'Track and monitor Kling AI video generation task status. Use when building
+  dashboards,
+
+  tracking batch jobs, or debugging stuck tasks. Trigger with phrases like ''klingai
+  job status'',
+
+  ''kling ai monitor'', ''track klingai task'', ''klingai progress''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, monitoring, jobs]
+tags:
+- saas
+- kling-ai
+- monitoring
+- jobs
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Job Monitoring
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-known-pitfalls/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-known-pitfalls
-description: |
-  Avoid common mistakes when using Kling AI API. Use when troubleshooting or learning best
-  practices. Trigger with phrases like 'klingai pitfalls', 'kling ai mistakes', 'klingai gotchas',
-  'klingai best practices'.
+description: 'Avoid common mistakes when using Kling AI API. Use when troubleshooting
+  or learning best
+
+  practices. Trigger with phrases like ''klingai pitfalls'', ''kling ai mistakes'',
+  ''klingai gotchas'',
+
+  ''klingai best practices''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, troubleshooting, best-practices]
+tags:
+- saas
+- kling-ai
+- troubleshooting
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Known Pitfalls
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-model-catalog/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-model-catalog/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-model-catalog
-description: |
-  Explore Kling AI models, versions, and capabilities for video and image generation. Use when
-  selecting models or comparing features. Trigger with phrases like 'kling ai models',
-  'klingai capabilities', 'kling video models', 'klingai features'.
+description: 'Explore Kling AI models, versions, and capabilities for video and image
+  generation. Use when
+
+  selecting models or comparing features. Trigger with phrases like ''kling ai models'',
+
+  ''klingai capabilities'', ''kling video models'', ''klingai features''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, models, reference]
+tags:
+- saas
+- kling-ai
+- models
+- reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Model Catalog
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-performance-tuning/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-performance-tuning
-description: |
-  Optimize Kling AI for speed, quality, and cost efficiency. Use when improving generation times
-  or finding optimal settings. Trigger with phrases like 'klingai performance', 'kling ai optimize',
-  'faster klingai', 'klingai quality settings'.
+description: 'Optimize Kling AI for speed, quality, and cost efficiency. Use when
+  improving generation times
+
+  or finding optimal settings. Trigger with phrases like ''klingai performance'',
+  ''kling ai optimize'',
+
+  ''faster klingai'', ''klingai quality settings''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, performance, optimization]
+tags:
+- saas
+- kling-ai
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Performance Tuning
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-pricing-basics/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-pricing-basics/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-pricing-basics
-description: |
-  Understand Kling AI pricing, credits, and cost optimization strategies. Use when budgeting
-  or estimating costs. Trigger with phrases like 'kling ai pricing', 'klingai credits',
-  'kling ai cost', 'klingai budget'.
+description: 'Understand Kling AI pricing, credits, and cost optimization strategies.
+  Use when budgeting
+
+  or estimating costs. Trigger with phrases like ''kling ai pricing'', ''klingai credits'',
+
+  ''kling ai cost'', ''klingai budget''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, pricing, cost-optimization]
+tags:
+- saas
+- kling-ai
+- pricing
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Pricing Basics
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-prod-checklist/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-prod-checklist
-description: |
-  Production readiness checklist for Kling AI integrations. Use before going live or during
-  deployment review. Trigger with phrases like 'klingai production ready', 'kling ai go live',
-  'klingai checklist', 'deploy klingai'.
+description: 'Production readiness checklist for Kling AI integrations. Use before
+  going live or during
+
+  deployment review. Trigger with phrases like ''klingai production ready'', ''kling
+  ai go live'',
+
+  ''klingai checklist'', ''deploy klingai''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, production, deployment]
+tags:
+- saas
+- kling-ai
+- production
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Production Checklist
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-rate-limits/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-rate-limits/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-rate-limits
-description: |
-  Handle Kling AI API rate limits with backoff and queuing strategies. Use when hitting 429 errors
-  or planning high-volume workflows. Trigger with phrases like 'klingai rate limit', 'kling ai 429',
-  'klingai throttle', 'kling api limits'.
+description: 'Handle Kling AI API rate limits with backoff and queuing strategies.
+  Use when hitting 429 errors
+
+  or planning high-volume workflows. Trigger with phrases like ''klingai rate limit'',
+  ''kling ai 429'',
+
+  ''klingai throttle'', ''kling api limits''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, rate-limits, reliability]
+tags:
+- saas
+- kling-ai
+- rate-limits
+- reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Rate Limits
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-reference-architecture/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-reference-architecture
-description: |
-  Production reference architecture for Kling AI video generation platforms. Use when designing
-  scalable systems. Trigger with phrases like 'klingai architecture', 'kling ai system design',
-  'video platform architecture', 'klingai production setup'.
+description: 'Production reference architecture for Kling AI video generation platforms.
+  Use when designing
+
+  scalable systems. Trigger with phrases like ''klingai architecture'', ''kling ai
+  system design'',
+
+  ''video platform architecture'', ''klingai production setup''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, architecture, scaling]
+tags:
+- saas
+- kling-ai
+- architecture
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Reference Architecture
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-sdk-patterns/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-sdk-patterns
-description: |
-  Production SDK patterns for Kling AI: client wrapper, retry logic, async polling, and error
-  handling. Use when building robust integrations. Trigger with phrases like 'klingai sdk',
-  'kling ai client', 'klingai patterns', 'kling ai wrapper'.
+description: 'Production SDK patterns for Kling AI: client wrapper, retry logic, async
+  polling, and error
+
+  handling. Use when building robust integrations. Trigger with phrases like ''klingai
+  sdk'',
+
+  ''kling ai client'', ''klingai patterns'', ''kling ai wrapper''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, sdk, patterns]
+tags:
+- saas
+- kling-ai
+- sdk
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI SDK Patterns
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-storage-integration/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-storage-integration/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: klingai-storage-integration
-description: |
-  Download and store Kling AI generated videos in cloud storage (S3, GCS, Azure). Use when
-  persisting videos or building CDN pipelines. Trigger with phrases like 'klingai storage',
-  'save klingai video', 'kling ai s3 upload', 'klingai cloud storage'.
+description: 'Download and store Kling AI generated videos in cloud storage (S3, GCS,
+  Azure). Use when
+
+  persisting videos or building CDN pipelines. Trigger with phrases like ''klingai
+  storage'',
+
+  ''save klingai video'', ''kling ai s3 upload'', ''klingai cloud storage''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, storage, s3, gcs]
+tags:
+- saas
+- kling-ai
+- storage
+- s3
+- gcs
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Storage Integration
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-style-transfer/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-style-transfer/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-style-transfer
-description: |
-  Apply artistic styles and visual effects to Kling AI video generation. Use when creating
-  stylized content or using effects API. Trigger with phrases like 'klingai style', 'kling ai effects',
-  'klingai artistic video', 'stylize klingai video'.
+description: 'Apply artistic styles and visual effects to Kling AI video generation.
+  Use when creating
+
+  stylized content or using effects API. Trigger with phrases like ''klingai style'',
+  ''kling ai effects'',
+
+  ''klingai artistic video'', ''stylize klingai video''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, style-transfer, effects]
+tags:
+- saas
+- kling-ai
+- style-transfer
+- effects
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Style Transfer & Effects
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-team-setup/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-team-setup/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-team-setup
-description: |
-  Configure Kling AI for teams with per-project API keys, usage quotas, and role-based access.
-  Trigger with phrases like 'klingai team', 'kling ai organization', 'klingai multi-user',
-  'shared klingai access'.
+description: 'Configure Kling AI for teams with per-project API keys, usage quotas,
+  and role-based access.
+
+  Trigger with phrases like ''klingai team'', ''kling ai organization'', ''klingai
+  multi-user'',
+
+  ''shared klingai access''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, teams, access-control]
+tags:
+- saas
+- kling-ai
+- teams
+- access-control
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Team Setup
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-text-to-video/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-text-to-video/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-text-to-video
-description: |
-  Generate videos from text prompts with Kling AI. Use when creating videos from descriptions,
-  learning prompt techniques, or building T2V pipelines. Trigger with phrases like 'kling ai text to video',
-  'klingai prompt', 'generate video from text', 'text2video kling'.
+description: 'Generate videos from text prompts with Kling AI. Use when creating videos
+  from descriptions,
+
+  learning prompt techniques, or building T2V pipelines. Trigger with phrases like
+  ''kling ai text to video'',
+
+  ''klingai prompt'', ''generate video from text'', ''text2video kling''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, text-to-video, video-generation]
+tags:
+- saas
+- kling-ai
+- text-to-video
+- video-generation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Text-to-Video
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-upgrade-migration/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-upgrade-migration
-description: |
-  Migrate between Kling AI model versions safely. Use when upgrading from v1.x to v2.x or
-  adopting new features. Trigger with phrases like 'klingai upgrade', 'kling ai migrate',
-  'klingai version update', 'upgrade kling model'.
+description: 'Migrate between Kling AI model versions safely. Use when upgrading from
+  v1.x to v2.x or
+
+  adopting new features. Trigger with phrases like ''klingai upgrade'', ''kling ai
+  migrate'',
+
+  ''klingai version update'', ''upgrade kling model''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, migration, upgrade]
+tags:
+- saas
+- kling-ai
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Upgrade & Migration
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-usage-analytics/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-usage-analytics/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: klingai-usage-analytics
-description: |
-  Build usage analytics and reporting for Kling AI video generation. Use when tracking patterns,
-  analyzing costs, or building dashboards. Trigger with phrases like 'klingai analytics',
-  'kling ai usage report', 'klingai metrics', 'video generation stats'.
+description: 'Build usage analytics and reporting for Kling AI video generation. Use
+  when tracking patterns,
+
+  analyzing costs, or building dashboards. Trigger with phrases like ''klingai analytics'',
+
+  ''kling ai usage report'', ''klingai metrics'', ''video generation stats''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, analytics, reporting]
+tags:
+- saas
+- kling-ai
+- analytics
+- reporting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Usage Analytics
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-video-extension/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-video-extension/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-video-extension
-description: |
-  Extend video duration using Kling AI continuation. Use when creating longer videos from
-  shorter clips or building sequences. Trigger with phrases like 'klingai extend video',
-  'kling ai video continuation', 'klingai longer video', 'extend klingai clip'.
+description: 'Extend video duration using Kling AI continuation. Use when creating
+  longer videos from
+
+  shorter clips or building sequences. Trigger with phrases like ''klingai extend
+  video'',
+
+  ''kling ai video continuation'', ''klingai longer video'', ''extend klingai clip''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, video-extension, continuation]
+tags:
+- saas
+- kling-ai
+- video-extension
+- continuation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Video Extension
 

--- a/plugins/saas-packs/klingai-pack/skills/klingai-webhook-config/SKILL.md
+++ b/plugins/saas-packs/klingai-pack/skills/klingai-webhook-config/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: klingai-webhook-config
-description: |
-  Configure webhook callbacks for Kling AI task completion. Use when building event-driven
-  pipelines or replacing polling. Trigger with phrases like 'klingai webhook', 'kling ai callback',
-  'klingai notifications', 'video completion webhook'.
+description: 'Configure webhook callbacks for Kling AI task completion. Use when building
+  event-driven
+
+  pipelines or replacing polling. Trigger with phrases like ''klingai webhook'', ''kling
+  ai callback'',
+
+  ''klingai notifications'', ''video completion webhook''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, kling-ai, webhooks, callbacks]
+tags:
+- saas
+- kling-ai
+- webhooks
+- callbacks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Kling AI Webhook Configuration
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-ci-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-ci-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: langchain-ci-integration
-description: |
-  Configure CI/CD for LangChain with GitHub Actions, mocked unit tests,
+description: 'Configure CI/CD for LangChain with GitHub Actions, mocked unit tests,
+
   gated integration tests, and RAG pipeline validation.
+
   Trigger: "langchain CI", "langchain GitHub Actions",
+
   "langchain automated tests", "CI langchain", "langchain pipeline testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, testing, ci-cd]
+tags:
+- saas
+- langchain
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain CI Integration
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-common-errors/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langchain-common-errors
-description: |
-  Diagnose and fix common LangChain errors and exceptions.
+description: 'Diagnose and fix common LangChain errors and exceptions.
+
   Use when encountering LangChain import errors, auth failures,
+
   output parsing issues, agent loops, or version conflicts.
+
   Trigger: "langchain error", "langchain exception", "debug langchain",
+
   "langchain not working", "langchain troubleshoot".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, debugging]
+tags:
+- saas
+- langchain
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Common Errors
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-core-workflow-a
-description: |
-  Build LangChain LCEL chains with prompts, parsers, and composition.
+description: 'Build LangChain LCEL chains with prompts, parsers, and composition.
+
   Use when creating prompt templates, building RunnableSequence pipelines,
+
   parallel/branching chains, or multi-step processing workflows.
+
   Trigger: "langchain chains", "langchain prompts", "LCEL workflow",
+
   "langchain pipeline", "prompt template", "RunnableSequence".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, llm, workflow]
+tags:
+- saas
+- langchain
+- llm
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Core Workflow A: Chains & Prompts
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langchain-core-workflow-b
-description: |
-  Build LangChain agents with tool calling for autonomous task execution.
+description: 'Build LangChain agents with tool calling for autonomous task execution.
+
   Use when creating AI agents, implementing tool/function calling,
+
   binding tools to models, or building autonomous multi-step workflows.
+
   Trigger: "langchain agents", "langchain tools", "tool calling",
+
   "create agent", "function calling", "createToolCallingAgent".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, workflow]
+tags:
+- saas
+- langchain
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Core Workflow B: Agents & Tools
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-cost-tuning/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: langchain-cost-tuning
-description: |
-  Optimize LangChain API costs with token tracking, model tiering,
+description: 'Optimize LangChain API costs with token tracking, model tiering,
+
   caching, prompt compression, and budget enforcement.
+
   Trigger: "langchain cost", "langchain tokens", "reduce langchain cost",
+
   "langchain billing", "langchain budget", "token optimization".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, api, llm, cost-optimization]
+tags:
+- saas
+- langchain
+- api
+- llm
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Cost Tuning
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-data-handling/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-data-handling/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: langchain-data-handling
-description: |
-  Implement LangChain RAG pipelines with document loaders, text splitters,
+description: 'Implement LangChain RAG pipelines with document loaders, text splitters,
+
   embeddings, and vector stores (Chroma, Pinecone, FAISS).
+
   Trigger: "langchain RAG", "langchain documents", "langchain vector store",
+
   "langchain embeddings", "document loaders", "text splitters", "retrieval".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, llm, rag, vector-store]
+tags:
+- saas
+- langchain
+- llm
+- rag
+- vector-store
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Data Handling: RAG & Document Processing
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langchain-debug-bundle
-description: |
-  Collect LangChain debug evidence for troubleshooting and bug reports.
+description: 'Collect LangChain debug evidence for troubleshooting and bug reports.
+
   Use when preparing GitHub issues, collecting LangSmith traces,
+
   or gathering diagnostic info for complex LangChain failures.
+
   Trigger: "langchain debug bundle", "langchain diagnostics",
+
   "langchain support info", "collect langchain logs", "langchain trace".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npm:*), Bash(python:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, debugging]
+tags:
+- saas
+- langchain
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Debug Bundle
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-deploy-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: langchain-deploy-integration
-description: |
-  Deploy LangChain applications to production with LangServe,
+description: 'Deploy LangChain applications to production with LangServe,
+
   Docker, and cloud platforms (Cloud Run, AWS Lambda).
+
   Trigger: "deploy langchain", "langchain production deploy",
+
   "langchain docker", "langchain cloud run", "LangServe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, deployment, docker]
+tags:
+- saas
+- langchain
+- deployment
+- docker
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Deploy Integration
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-enterprise-rbac/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: langchain-enterprise-rbac
-description: |
-  Implement role-based access control for LangChain applications
+description: 'Implement role-based access control for LangChain applications
+
   with multi-tenant isolation, model access control, and usage quotas.
+
   Trigger: "langchain RBAC", "langchain permissions",
+
   "langchain access control", "langchain multi-tenant", "enterprise LLM auth".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, security, llm, authentication]
+tags:
+- saas
+- langchain
+- security
+- llm
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Enterprise RBAC
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-hello-world/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-hello-world/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langchain-hello-world
-description: |
-  Create a minimal working LangChain example with LCEL chains.
+description: 'Create a minimal working LangChain example with LCEL chains.
+
   Use when starting a new LangChain integration, testing your setup,
+
   or learning LCEL pipe syntax with prompts and output parsers.
+
   Trigger: "langchain hello world", "langchain example",
+
   "langchain quick start", "simple langchain code", "first langchain app".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, testing]
+tags:
+- saas
+- langchain
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Hello World
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-incident-runbook/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: langchain-incident-runbook
-description: |
-  Incident response procedures for LangChain production issues:
+description: 'Incident response procedures for LangChain production issues:
+
   provider outages, high error rates, latency spikes, and cost overruns.
+
   Trigger: "langchain incident", "langchain outage", "langchain production issue",
+
   "langchain emergency", "langchain down", "LLM provider outage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, llm, incident-response]
+tags:
+- saas
+- langchain
+- llm
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Incident Runbook
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-install-auth/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-install-auth
-description: |
-  Install and configure LangChain SDK with provider authentication.
+description: 'Install and configure LangChain SDK with provider authentication.
+
   Use when setting up a new LangChain project, configuring API keys
+
   for OpenAI/Anthropic/Google, or initializing @langchain/core in Node.js or Python.
+
   Trigger: "install langchain", "setup langchain", "langchain auth",
+
   "configure langchain API key", "langchain credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, api, authentication]
+tags:
+- saas
+- langchain
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Install & Auth
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-local-dev-loop
-description: |
-  Configure LangChain local development workflow with testing and mocks.
+description: 'Configure LangChain local development workflow with testing and mocks.
+
   Use when setting up dev environment, creating test fixtures with mocked LLMs,
+
   or establishing a rapid iteration workflow for LangChain apps.
+
   Trigger: "langchain dev setup", "langchain local development",
+
   "langchain testing", "langchain mock", "test langchain chains".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pytest:*), Bash(python:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, testing, workflow]
+tags:
+- saas
+- langchain
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Local Dev Loop
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langchain-migration-deep-dive
-description: |
-  Migrate to LangChain from raw OpenAI SDK, LlamaIndex, or custom LLM code.
+description: 'Migrate to LangChain from raw OpenAI SDK, LlamaIndex, or custom LLM
+  code.
+
   Covers codebase assessment, side-by-side validation, RAG migration,
+
   agent migration, and feature-flagged gradual rollout.
+
   Trigger: "migrate to langchain", "langchain refactor", "legacy LLM migration",
+
   "replace openai SDK with langchain", "llamaindex to langchain".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, llm, migration]
+tags:
+- saas
+- langchain
+- llm
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Migration Deep Dive
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-multi-env-setup/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: langchain-multi-env-setup
-description: |
-  Configure LangChain across dev/staging/production environments
+description: 'Configure LangChain across dev/staging/production environments
+
   with isolated API keys, environment-specific settings, and secrets.
+
   Trigger: "langchain environments", "langchain staging",
+
   "langchain dev prod", "environment configuration", "langchain env setup".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, workflow]
+tags:
+- saas
+- langchain
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Multi-Environment Setup
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-observability/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-observability/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: langchain-observability
-description: |
-  Set up comprehensive observability for LangChain applications
+description: 'Set up comprehensive observability for LangChain applications
+
   with LangSmith tracing, OpenTelemetry, Prometheus metrics, and alerts.
+
   Trigger: "langchain monitoring", "langchain metrics", "langchain observability",
+
   "langchain tracing", "LangSmith", "langchain alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, monitoring, observability, dashboard]
+tags:
+- saas
+- langchain
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Observability
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-performance-tuning/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: langchain-performance-tuning
-description: |
-  Optimize LangChain application performance: latency, throughput,
+description: 'Optimize LangChain application performance: latency, throughput,
+
   streaming, caching, batch processing, and connection pooling.
+
   Trigger: "langchain performance", "langchain optimization",
+
   "langchain latency", "langchain slow", "speed up langchain".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, performance]
+tags:
+- saas
+- langchain
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Performance Tuning
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-prod-checklist
-description: |
-  Production readiness checklist for LangChain applications.
+description: 'Production readiness checklist for LangChain applications.
+
   Use when preparing for launch, validating deployment readiness,
+
   or auditing existing production LangChain systems.
+
   Trigger: "langchain production", "langchain prod ready",
+
   "deploy langchain", "langchain launch checklist", "go-live langchain".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, deployment, audit]
+tags:
+- saas
+- langchain
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Production Checklist
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-rate-limits/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-rate-limits
-description: |
-  Implement LangChain rate limiting, retry strategies, and backoff.
+description: 'Implement LangChain rate limiting, retry strategies, and backoff.
+
   Use when handling API rate limits, controlling request throughput,
+
   or implementing concurrency-safe batch processing.
+
   Trigger: "langchain rate limit", "langchain throttling",
+
   "langchain backoff", "langchain retry", "API quota", "429 error".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, api, llm]
+tags:
+- saas
+- langchain
+- api
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Rate Limits
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langchain-reference-architecture
-description: |
-  Implement LangChain reference architecture for production systems:
+description: 'Implement LangChain reference architecture for production systems:
+
   layered design, provider abstraction, chain registry, RAG pipelines,
+
   and multi-agent orchestration.
+
   Trigger: "langchain architecture", "langchain design patterns",
+
   "langchain scalable", "langchain enterprise", "LLM architecture".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, llm, scaling]
+tags:
+- saas
+- langchain
+- llm
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Reference Architecture
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langchain-sdk-patterns
-description: |
-  Apply production-ready LangChain SDK patterns for structured output,
+description: 'Apply production-ready LangChain SDK patterns for structured output,
+
   fallbacks, batch processing, streaming, and caching.
+
   Trigger: "langchain SDK patterns", "langchain best practices",
+
   "idiomatic langchain", "langchain architecture", "withStructuredOutput",
+
   "withFallbacks", "abatch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, langchain-sdk]
+tags:
+- saas
+- langchain
+- langchain-sdk
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain SDK Patterns
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-security-basics/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langchain-security-basics
-description: |
-  Apply LangChain security best practices for production LLM apps.
+description: 'Apply LangChain security best practices for production LLM apps.
+
   Use when securing API keys, preventing prompt injection,
+
   sandboxing tool execution, or validating LLM outputs.
+
   Trigger: "langchain security", "prompt injection", "langchain secrets",
+
   "secure langchain", "LLM security", "safe tool execution".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, api, security, llm]
+tags:
+- saas
+- langchain
+- api
+- security
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Security Basics
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-upgrade-migration/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: langchain-upgrade-migration
-description: |
-  Upgrade LangChain SDK versions safely with import path migration,
+description: 'Upgrade LangChain SDK versions safely with import path migration,
+
   LCEL conversion from legacy chains, and agent API updates.
+
   Trigger: "upgrade langchain", "langchain migration", "langchain breaking changes",
+
   "update langchain version", "langchain 0.3", "langchain deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, migration]
+tags:
+- saas
+- langchain
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Upgrade Migration
 

--- a/plugins/saas-packs/langchain-pack/skills/langchain-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/langchain-pack/skills/langchain-webhooks-events/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: langchain-webhooks-events
-description: |
-  Implement LangChain callback handlers, streaming, webhooks,
+description: 'Implement LangChain callback handlers, streaming, webhooks,
+
   Server-Sent Events (SSE), and WebSocket integration.
+
   Trigger: "langchain callbacks", "langchain webhooks",
+
   "langchain events", "langchain streaming", "langchain SSE", "WebSocket LLM".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langchain, webhooks]
+tags:
+- saas
+- langchain
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # LangChain Webhooks & Events
 

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-ci-integration/SKILL.md
@@ -1,22 +1,28 @@
 ---
 name: langchain-ci-integration
-description: |
-  Wire LangChain 1.0 / LangGraph 1.0 tests into a GitHub Actions pipeline —
-  unit tests with FakeListChatModel, VCR-gated integration tests, warning-filter
-  policy, and eval-regression merge gates. Complements langchain-local-dev-loop
-  (F23) which covers the inner loop; THIS covers the CI wire-up. Use when setting
-  up GHA for a new LLM service, after a VCR cassette leak incident, or hardening
-  an existing pipeline.
-  Trigger with "langchain ci", "langchain github actions", "langchain test pipeline",
-  "vcr ci", "langchain eval gate", "pytest -W error langchain".
+description: "Wire LangChain 1.0 / LangGraph 1.0 tests into a GitHub Actions pipeline\
+  \ \u2014\nunit tests with FakeListChatModel, VCR-gated integration tests, warning-filter\n\
+  policy, and eval-regression merge gates. Complements langchain-local-dev-loop\n\
+  (F23) which covers the inner loop; THIS covers the CI wire-up. Use when setting\n\
+  up GHA for a new LLM service, after a VCR cassette leak incident, or hardening\n\
+  an existing pipeline.\nTrigger with \"langchain ci\", \"langchain github actions\"\
+  , \"langchain test pipeline\",\n\"vcr ci\", \"langchain eval gate\", \"pytest -W\
+  \ error langchain\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pytest:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, ci, github-actions, testing]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- ci
+- github-actions
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain CI Integration (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-common-errors/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: langchain-common-errors
-description: |
-  Paste-match catalog of 14 real LangChain 1.0 / LangGraph 1.0 exceptions with named
-  causes and named fixes, plus a triage decision tree. Use when you have a traceback
-  and want the specific fix, not speculative documentation. Covers ImportError (0.2/0.3 → 1.0
-  migration), AttributeError on AIMessage.content, KeyError in LCEL and prompts,
-  GraphRecursionError, silent thread_id memory loss, JSON-serialization crashes,
-  and graphs that halt without reaching END. Trigger with "langchain error",
-  "langgraph traceback", "OutputParserException", "GraphRecursionError",
-  "ImportError langchain", "AttributeError AIMessage content".
+description: "Paste-match catalog of 14 real LangChain 1.0 / LangGraph 1.0 exceptions\
+  \ with named\ncauses and named fixes, plus a triage decision tree. Use when you\
+  \ have a traceback\nand want the specific fix, not speculative documentation. Covers\
+  \ ImportError (0.2/0.3 \u2192 1.0\nmigration), AttributeError on AIMessage.content,\
+  \ KeyError in LCEL and prompts,\nGraphRecursionError, silent thread_id memory loss,\
+  \ JSON-serialization crashes,\nand graphs that halt without reaching END. Trigger\
+  \ with \"langchain error\",\n\"langgraph traceback\", \"OutputParserException\"\
+  , \"GraphRecursionError\",\n\"ImportError langchain\", \"AttributeError AIMessage\
+  \ content\".\n"
 allowed-tools: Read, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, errors, troubleshooting, debugging]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- errors
+- troubleshooting
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Common Errors (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-content-blocks/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-content-blocks/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: langchain-content-blocks
-description: |
-  Works correctly with LangChain 1.0's typed content blocks on AIMessage.content
-  — text, tool_use, image, thinking, document — across Claude, GPT-4o, and
-  Gemini, including multi-modal composition and tool-call iteration. Use when
-  composing multi-modal messages, iterating tool_use blocks, handling Claude's
-  thinking content, or unifying image inputs across providers. Trigger with
-  "langchain content blocks", "AIMessage.content", "tool_use block", "claude
-  image input", "langchain multimodal", "thinking block replay",
-  "claude citations".
+description: "Works correctly with LangChain 1.0's typed content blocks on AIMessage.content\n\
+  \u2014 text, tool_use, image, thinking, document \u2014 across Claude, GPT-4o, and\n\
+  Gemini, including multi-modal composition and tool-call iteration. Use when\ncomposing\
+  \ multi-modal messages, iterating tool_use blocks, handling Claude's\nthinking content,\
+  \ or unifying image inputs across providers. Trigger with\n\"langchain content blocks\"\
+  , \"AIMessage.content\", \"tool_use block\", \"claude\nimage input\", \"langchain\
+  \ multimodal\", \"thinking block replay\",\n\"claude citations\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, content-blocks, multimodal, tool-use]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- content-blocks
+- multimodal
+- tool-use
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Content Blocks (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-core-workflow/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: langchain-core-workflow
-description: |
-  Compose LangChain 1.0 chains with RunnableParallel, RunnableBranch,
-  RunnablePassthrough.assign, and RunnableLambda — correct input/output shapes,
-  debug probes, and typed composition that catches dict-shape bugs before
-  invocation. Use when wiring multi-step chains, parallel retrievals,
-  conditional routing, or threading state through a chain for RAG,
-  classification, or extraction pipelines.
-  Trigger with "runnable parallel", "runnable branch", "langchain rag
-  composition", "passthrough assign", "langchain lcel", "runnable lambda",
-  "debug probe".
+description: "Compose LangChain 1.0 chains with RunnableParallel, RunnableBranch,\n\
+  RunnablePassthrough.assign, and RunnableLambda \u2014 correct input/output shapes,\n\
+  debug probes, and typed composition that catches dict-shape bugs before\ninvocation.\
+  \ Use when wiring multi-step chains, parallel retrievals,\nconditional routing,\
+  \ or threading state through a chain for RAG,\nclassification, or extraction pipelines.\n\
+  Trigger with \"runnable parallel\", \"runnable branch\", \"langchain rag\ncomposition\"\
+  , \"passthrough assign\", \"langchain lcel\", \"runnable lambda\",\n\"debug probe\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, lcel, runnables, rag]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- lcel
+- runnables
+- rag
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Core Workflow (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-cost-tuning/SKILL.md
@@ -1,21 +1,35 @@
 ---
 name: langchain-cost-tuning
-description: |
-  Control LangChain 1.0 AI spend with accurate streaming token accounting,
+description: 'Control LangChain 1.0 AI spend with accurate streaming token accounting,
+
   model tiering, provider-specific cache hit tuning, per-tenant budgets,
+
   and retry dedup. Use when AI spend grows faster than traffic, a cost
+
   regression lands, or you need per-tenant budget enforcement.
+
   Trigger with "langchain cost", "langchain token accounting",
+
   "langchain per-tenant budget", "langchain model tiering",
+
   "prompt cache savings".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(redis-cli:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, cost, tokens, budget]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- cost
+- tokens
+- budget
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Cost Tuning (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-data-handling/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-data-handling/SKILL.md
@@ -1,21 +1,27 @@
 ---
 name: langchain-data-handling
-description: |
-  Load and chunk documents for LangChain 1.0 RAG pipelines correctly —
-  language-aware splitters, table-safe PDF loaders, Cloudflare-compatible web
-  loaders, chunk-boundary strategies that survive real-world structure. Use when
-  building a RAG pipeline, diagnosing why retrieval misquotes a table, or
-  debugging a crawler returning blank content. Trigger with "langchain document
-  loader", "text splitter", "chunking strategy", "pdf loader",
-  "markdown splitter", "webbaseloader".
+description: "Load and chunk documents for LangChain 1.0 RAG pipelines correctly \u2014\
+  \nlanguage-aware splitters, table-safe PDF loaders, Cloudflare-compatible web\n\
+  loaders, chunk-boundary strategies that survive real-world structure. Use when\n\
+  building a RAG pipeline, diagnosing why retrieval misquotes a table, or\ndebugging\
+  \ a crawler returning blank content. Trigger with \"langchain document\nloader\"\
+  , \"text splitter\", \"chunking strategy\", \"pdf loader\",\n\"markdown splitter\"\
+  , \"webbaseloader\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, document-loaders, text-splitters, rag]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- document-loaders
+- text-splitters
+- rag
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Data Handling — Loaders and Splitters (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/SKILL.md
@@ -1,23 +1,29 @@
 ---
 name: langchain-debug-bundle
-description: |
-  Produce a reproducible, sanitized diagnostic bundle for a LangChain / LangGraph
-  incident — environment snapshot, version manifest, filtered astream_events(v2)
-  transcript, propagating callback stack, LangSmith trace URL — so a debug
-  colleague can reproduce the failure without a live terminal. Use when triaging
-  a production incident, filing a Discord or GitHub bug report, asking for help
-  on the LangChain forum, or archiving a post-mortem artifact.
-  Trigger with "langchain debug bundle", "langgraph debug dump",
-  "langchain diagnostic export", "langsmith trace export", "astream_events dump",
-  "langchain incident bundle".
+description: "Produce a reproducible, sanitized diagnostic bundle for a LangChain\
+  \ / LangGraph\nincident \u2014 environment snapshot, version manifest, filtered\
+  \ astream_events(v2)\ntranscript, propagating callback stack, LangSmith trace URL\
+  \ \u2014 so a debug\ncolleague can reproduce the failure without a live terminal.\
+  \ Use when triaging\na production incident, filing a Discord or GitHub bug report,\
+  \ asking for help\non the LangChain forum, or archiving a post-mortem artifact.\n\
+  Trigger with \"langchain debug bundle\", \"langgraph debug dump\",\n\"langchain\
+  \ diagnostic export\", \"langsmith trace export\", \"astream_events dump\",\n\"\
+  langchain incident bundle\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, debugging, observability, incident-response]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- debugging
+- observability
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Debug Bundle (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deep-agents/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deep-agents/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: langchain-deep-agents
-description: |
-  Build a LangGraph 1.0 Deep Agent — planner + subagents + virtual filesystem +
-  reflection loop — without the state-growth and prompt-inheritance traps. Use
-  when building a long-horizon agent that must plan, delegate subtasks, work
-  against a scratchpad filesystem, and reflect on progress.
-  Trigger with "langchain deep agent", "planner subagent", "virtual filesystem
-  agent", "reflection loop", "langgraph deep agent".
+description: "Build a LangGraph 1.0 Deep Agent \u2014 planner + subagents + virtual\
+  \ filesystem +\nreflection loop \u2014 without the state-growth and prompt-inheritance\
+  \ traps. Use\nwhen building a long-horizon agent that must plan, delegate subtasks,\
+  \ work\nagainst a scratchpad filesystem, and reflect on progress.\nTrigger with\
+  \ \"langchain deep agent\", \"planner subagent\", \"virtual filesystem\nagent\"\
+  , \"reflection loop\", \"langgraph deep agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, agents, deep-agents, research]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- agents
+- deep-agents
+- research
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Deep Agents (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-deploy-integration/SKILL.md
@@ -1,21 +1,27 @@
 ---
 name: langchain-deploy-integration
-description: |
-  Deploy a LangChain 1.0 / LangGraph 1.0 app to Cloud Run, Vercel, or LangServe
-  correctly — timeouts sized for chain length, cold-start mitigation, SSE
-  anti-buffering headers, Secret Manager over `.env`. Use when prepping first
-  prod deploy, debugging a stream that hangs behind a proxy, or diagnosing p99
-  latency spikes.
-  Trigger with "langchain deploy", "langchain cloud run", "langchain vercel python",
-  "langchain langserve", "langchain docker".
+description: "Deploy a LangChain 1.0 / LangGraph 1.0 app to Cloud Run, Vercel, or\
+  \ LangServe\ncorrectly \u2014 timeouts sized for chain length, cold-start mitigation,\
+  \ SSE\nanti-buffering headers, Secret Manager over `.env`. Use when prepping first\n\
+  prod deploy, debugging a stream that hangs behind a proxy, or diagnosing p99\nlatency\
+  \ spikes.\nTrigger with \"langchain deploy\", \"langchain cloud run\", \"langchain\
+  \ vercel python\",\n\"langchain langserve\", \"langchain docker\".\n"
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(gcloud:*), Bash(vercel:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, deployment, cloud-run, vercel, langserve]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- deployment
+- cloud-run
+- vercel
+- langserve
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Deploy Integration (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-embeddings-search/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-embeddings-search/SKILL.md
@@ -1,20 +1,33 @@
 ---
 name: langchain-embeddings-search
-description: |
-  Build and query vector stores with LangChain 1.0 without getting burned by
+description: 'Build and query vector stores with LangChain 1.0 without getting burned
+  by
+
   flipped score semantics, embedding-dim mismatches, reranker quirks, and
+
   chunk-splitter bugs. Use when building a RAG pipeline, choosing between FAISS /
+
   Pinecone / Chroma / PGVector, filtering by similarity score, or adding a reranker.
+
   Trigger with "langchain embeddings", "vector store similarity search",
+
   "langchain RAG retrieval", "FAISS score", "Pinecone score", "reranker score".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, python, langchain-1.0, embeddings, rag, vector-store]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- python
+- langchain-1.0
+- embeddings
+- rag
+- vector-store
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Embeddings and Vector Search (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-enterprise-rbac/SKILL.md
@@ -1,20 +1,27 @@
 ---
 name: langchain-enterprise-rbac
-description: |
-  Enforce tenant isolation and role-based access across LangChain 1.0 chains and
-  LangGraph 1.0 agents — per-request retriever construction, tenant-scoped rate
-  limits, role-scoped tool allowlists, and structured audit logs. Use when
-  building multi-tenant saas, passing soc2 review, or debugging cross-tenant
-  leak. Trigger with "langchain multi-tenant", "langchain tenant isolation",
-  "langchain rbac", "langchain row-level security", "langchain audit log".
+description: "Enforce tenant isolation and role-based access across LangChain 1.0\
+  \ chains and\nLangGraph 1.0 agents \u2014 per-request retriever construction, tenant-scoped\
+  \ rate\nlimits, role-scoped tool allowlists, and structured audit logs. Use when\n\
+  building multi-tenant saas, passing soc2 review, or debugging cross-tenant\nleak.\
+  \ Trigger with \"langchain multi-tenant\", \"langchain tenant isolation\",\n\"langchain\
+  \ rbac\", \"langchain row-level security\", \"langchain audit log\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, multi-tenant, rbac, enterprise, security]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- multi-tenant
+- rbac
+- enterprise
+- security
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Enterprise RBAC (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-eval-harness/SKILL.md
@@ -1,21 +1,29 @@
 ---
 name: langchain-eval-harness
-description: |
-  Build reproducible evaluation pipelines for LangChain 1.0 chains and LangGraph 1.0
-  agents — golden datasets, LangSmith evaluate(), ragas RAG metrics, deepeval
-  LLM-as-judge, agent trajectory analysis, and CI gating on quality regressions.
-  Use when setting up quality measurement for a new chain, diagnosing regression
-  after a model switch, or building an evaluation gate for a pull request.
-  Trigger with "langchain eval", "langsmith evaluate", "ragas", "llm-as-judge",
-  "agent trajectory eval", "eval regression gate".
+description: "Build reproducible evaluation pipelines for LangChain 1.0 chains and\
+  \ LangGraph 1.0\nagents \u2014 golden datasets, LangSmith evaluate(), ragas RAG\
+  \ metrics, deepeval\nLLM-as-judge, agent trajectory analysis, and CI gating on quality\
+  \ regressions.\nUse when setting up quality measurement for a new chain, diagnosing\
+  \ regression\nafter a model switch, or building an evaluation gate for a pull request.\n\
+  Trigger with \"langchain eval\", \"langsmith evaluate\", \"ragas\", \"llm-as-judge\"\
+  ,\n\"agent trajectory eval\", \"eval regression gate\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*), Bash(pytest:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, evaluation, langsmith, ragas, deepeval, research]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- evaluation
+- langsmith
+- ragas
+- deepeval
+- research
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Eval Harness (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-incident-runbook/SKILL.md
@@ -1,20 +1,27 @@
 ---
 name: langchain-incident-runbook
-description: |
-  Triage LangChain 1.0 / LangGraph 1.0 production incidents — LLM-specific SLOs,
-  provider outage runbook, latency spike decision tree, cost-overrun response,
-  agent loop containment. Use during an on-call page, in a post-mortem, or writing
-  the team's first LLM runbook.
-  Trigger with "langchain incident", "llm on-call", "langchain slo",
-  "langchain outage", "langchain cost spike", "langchain agent loop".
+description: "Triage LangChain 1.0 / LangGraph 1.0 production incidents \u2014 LLM-specific\
+  \ SLOs,\nprovider outage runbook, latency spike decision tree, cost-overrun response,\n\
+  agent loop containment. Use during an on-call page, in a post-mortem, or writing\n\
+  the team's first LLM runbook.\nTrigger with \"langchain incident\", \"llm on-call\"\
+  , \"langchain slo\",\n\"langchain outage\", \"langchain cost spike\", \"langchain\
+  \ agent loop\".\n"
 allowed-tools: Read
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, sre, incident-response, slo, on-call]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- sre
+- incident-response
+- slo
+- on-call
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-agents/SKILL.md
@@ -1,20 +1,25 @@
 ---
 name: langchain-langgraph-agents
-description: |
-  Build a correct LangGraph 1.0 ReAct agent with `create_react_agent` — typed tools,
-  error propagation, recursion caps, and stop conditions that actually stop. Use when
-  writing your first tool-calling agent, migrating from `AgentExecutor` / `initialize_agent`,
-  or diagnosing an agent that loops on vague prompts.
-  Trigger with "langgraph agent", "create_react_agent", "langgraph tool calling",
-  "AgentExecutor migration", "agent loop cost".
+description: "Build a correct LangGraph 1.0 ReAct agent with `create_react_agent`\
+  \ \u2014 typed tools,\nerror propagation, recursion caps, and stop conditions that\
+  \ actually stop. Use when\nwriting your first tool-calling agent, migrating from\
+  \ `AgentExecutor` / `initialize_agent`,\nor diagnosing an agent that loops on vague\
+  \ prompts.\nTrigger with \"langgraph agent\", \"create_react_agent\", \"langgraph\
+  \ tool calling\",\n\"AgentExecutor migration\", \"agent loop cost\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, agents, tool-calling]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- agents
+- tool-calling
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain LangGraph Agents (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-basics/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: langchain-langgraph-basics
-description: |
-  Build a correct LangGraph 1.0 StateGraph — typed TypedDict state with reducers,
-  nodes, edges, compile, and recursion budgets — without hitting the silent-termination
-  and state-replacement traps. Use when writing your first LangGraph StateGraph,
-  diagnosing why a graph halted without reaching END, or picking recursion_limit.
-  Trigger with "langgraph statgraph", "langgraph basics", "GraphRecursionError",
-  "langgraph conditional edges".
+description: "Build a correct LangGraph 1.0 StateGraph \u2014 typed TypedDict state\
+  \ with reducers,\nnodes, edges, compile, and recursion budgets \u2014 without hitting\
+  \ the silent-termination\nand state-replacement traps. Use when writing your first\
+  \ LangGraph StateGraph,\ndiagnosing why a graph halted without reaching END, or\
+  \ picking recursion_limit.\nTrigger with \"langgraph statgraph\", \"langgraph basics\"\
+  , \"GraphRecursionError\",\n\"langgraph conditional edges\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, statgraph]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- statgraph
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain LangGraph Basics (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-checkpointing/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: langchain-langgraph-checkpointing
-description: |
-  Persist LangGraph agent state correctly with MemorySaver and PostgresSaver —
-  thread_id discipline, JSON-serializable state rules, time-travel, schema
-  migration. Use when adding chat memory, migrating from ConversationBufferMemory,
-  or time-traveling an agent state to debug an incident.
-  Trigger with "langgraph checkpointer", "MemorySaver", "PostgresSaver",
-  "thread_id", "langgraph time travel", "langgraph state persistence".
+description: "Persist LangGraph agent state correctly with MemorySaver and PostgresSaver\
+  \ \u2014\nthread_id discipline, JSON-serializable state rules, time-travel, schema\n\
+  migration. Use when adding chat memory, migrating from ConversationBufferMemory,\n\
+  or time-traveling an agent state to debug an incident.\nTrigger with \"langgraph\
+  \ checkpointer\", \"MemorySaver\", \"PostgresSaver\",\n\"thread_id\", \"langgraph\
+  \ time travel\", \"langgraph state persistence\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(psql:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, checkpointing, persistence, memory]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- checkpointing
+- persistence
+- memory
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangGraph Checkpointing (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-human-in-loop/SKILL.md
@@ -1,21 +1,27 @@
 ---
 name: langchain-langgraph-human-in-loop
-description: |
-  Build LangGraph 1.0 human-in-the-loop approval flows with `interrupt_before` /
-  `interrupt_after` and `Command(resume=...)` — JSON-serializable state, clean
-  resume semantics, and UI wiring for approval decisions. Use when adding an
-  approval gate before an expensive tool call, wiring a Slack/web UI for agent
-  approvals, or debugging a graph that crashes on interrupt.
-  Trigger with "langgraph human in loop", "langgraph interrupt_before",
-  "langgraph approval flow", "Command resume", "langgraph HITL".
+description: "Build LangGraph 1.0 human-in-the-loop approval flows with `interrupt_before`\
+  \ /\n`interrupt_after` and `Command(resume=...)` \u2014 JSON-serializable state,\
+  \ clean\nresume semantics, and UI wiring for approval decisions. Use when adding\
+  \ an\napproval gate before an expensive tool call, wiring a Slack/web UI for agent\n\
+  approvals, or debugging a graph that crashes on interrupt.\nTrigger with \"langgraph\
+  \ human in loop\", \"langgraph interrupt_before\",\n\"langgraph approval flow\"\
+  , \"Command resume\", \"langgraph HITL\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, human-in-loop, approval, interrupts]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- human-in-loop
+- approval
+- interrupts
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain LangGraph Human-in-the-Loop (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-streaming/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-streaming/SKILL.md
@@ -1,22 +1,38 @@
 ---
 name: langchain-langgraph-streaming
-description: |
-  Pick the correct LangGraph 1.0 stream_mode ("messages" vs "updates" vs "values"),
+description: 'Pick the correct LangGraph 1.0 stream_mode ("messages" vs "updates"
+  vs "values"),
+
   wire it into SSE or WebSocket without proxy-buffering gotchas, and filter
+
   astream_events(v2) server-side before forwarding to the browser. Use when
+
   building a live-token chat UI, a per-node progress bar, a debug/time-travel
+
   view, or diagnosing a LangGraph stream that hangs over a production proxy.
+
   Trigger with "langgraph streaming", "stream_mode messages", "stream_mode updates",
+
   "stream_mode values", "langgraph SSE", "langgraph astream_events", "SSE hangs
+
   behind nginx", "cloud run streaming".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, streaming, sse, websocket]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- streaming
+- sse
+- websocket
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangGraph Streaming (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-langgraph-subgraphs/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: langchain-langgraph-subgraphs
-description: |
-  Compose LangGraph 1.0 subgraphs correctly — shared state key propagation,
-  Send / Command(graph=...) dispatch, callback scoping, per-subgraph recursion
-  budgets, and testing each subgraph in isolation. Use when building a planner +
-  executor, a nested agent team, or a reusable subgraph library. Trigger with
-  "langgraph subgraph", "langgraph composition", "langgraph send",
-  "nested agents", "langgraph state propagation", "Command(graph=...)",
-  "langgraph subgraph callbacks".
+description: "Compose LangGraph 1.0 subgraphs correctly \u2014 shared state key propagation,\n\
+  Send / Command(graph=...) dispatch, callback scoping, per-subgraph recursion\nbudgets,\
+  \ and testing each subgraph in isolation. Use when building a planner +\nexecutor,\
+  \ a nested agent team, or a reusable subgraph library. Trigger with\n\"langgraph\
+  \ subgraph\", \"langgraph composition\", \"langgraph send\",\n\"nested agents\"\
+  , \"langgraph state propagation\", \"Command(graph=...)\",\n\"langgraph subgraph\
+  \ callbacks\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, subgraphs, composition]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- subgraphs
+- composition
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangGraph Subgraphs and Composition (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-local-dev-loop/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: langchain-local-dev-loop
-description: |
-  Build a fast, deterministic local test loop for LangChain 1.0 / LangGraph 1.0
-  — FakeListChatModel fixtures, pytest config, VCR cassettes with key redaction,
-  warning-filter policy. Use when adding tests to a new chain, fixing a flaky
-  test, or making integration tests reproducible.
-  Trigger with "langchain pytest", "FakeListChatModel", "VCR langchain",
-  "langchain test fixtures", "langchain integration test".
+description: "Build a fast, deterministic local test loop for LangChain 1.0 / LangGraph\
+  \ 1.0\n\u2014 FakeListChatModel fixtures, pytest config, VCR cassettes with key\
+  \ redaction,\nwarning-filter policy. Use when adding tests to a new chain, fixing\
+  \ a flaky\ntest, or making integration tests reproducible.\nTrigger with \"langchain\
+  \ pytest\", \"FakeListChatModel\", \"VCR langchain\",\n\"langchain test fixtures\"\
+  , \"langchain integration test\".\n"
 allowed-tools: Read, Write, Edit, Bash(pytest:*), Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, testing, pytest, vcr]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- testing
+- pytest
+- vcr
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Local Dev Loop (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-middleware-patterns/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-middleware-patterns/SKILL.md
@@ -1,21 +1,27 @@
 ---
 name: langchain-middleware-patterns
-description: |
-  Build composable middleware for LangChain 1.0 chains and LangGraph 1.0 agents —
-  PII redaction, caching, retry, token budgets, guardrails — with ORDERING rules
-  that avoid cache-key leakage and double-counting. Use when adding cross-cutting
-  behavior, hardening against prompt injection, enforcing per-tenant budgets, or
-  debugging cache-poisoning incidents.
-  Trigger with "langchain middleware", "langgraph middleware", "PII redaction
-  middleware", "cache middleware order", "langchain guardrails".
+description: "Build composable middleware for LangChain 1.0 chains and LangGraph 1.0\
+  \ agents \u2014\nPII redaction, caching, retry, token budgets, guardrails \u2014\
+  \ with ORDERING rules\nthat avoid cache-key leakage and double-counting. Use when\
+  \ adding cross-cutting\nbehavior, hardening against prompt injection, enforcing\
+  \ per-tenant budgets, or\ndebugging cache-poisoning incidents.\nTrigger with \"\
+  langchain middleware\", \"langgraph middleware\", \"PII redaction\nmiddleware\"\
+  , \"cache middleware order\", \"langchain guardrails\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, middleware, security, caching]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- middleware
+- security
+- caching
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Middleware Patterns (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-model-inference/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-model-inference/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: langchain-model-inference
-description: |
-  Invoke Claude, GPT-4o, and Gemini through LangChain 1.0 without tripping on
+description: 'Invoke Claude, GPT-4o, and Gemini through LangChain 1.0 without tripping
+  on
+
   the content-block, token-accounting, and structured-output quirks that silently
+
   break production code. Use when initializing chat models, routing across providers,
+
   iterating AIMessage content, or choosing a structured-output method.
+
   Trigger with "langchain model inference", "ChatAnthropic", "ChatOpenAI",
+
   "with_structured_output", "AIMessage content blocks", "langchain routing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, model-inference]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- model-inference
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Model Inference (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-multi-env-setup/SKILL.md
@@ -1,21 +1,28 @@
 ---
 name: langchain-multi-env-setup
-description: |
-  Build reliable dev / staging / prod isolation for LangChain 1.0 services —
-  Pydantic `Settings` + `SecretStr`, cloud Secret Manager in prod, per-env
-  prompt and model version pinning, env-specific checkpointer and observability.
-  Use when graduating from `.env`-in-dev to real prod infra, or debugging a
-  config that loaded the wrong values in the wrong env.
-  Trigger with "langchain multi-env", "langchain pydantic settings",
-  "langchain secret manager", "langchain env config", "langchain prod setup".
+description: "Build reliable dev / staging / prod isolation for LangChain 1.0 services\
+  \ \u2014\nPydantic `Settings` + `SecretStr`, cloud Secret Manager in prod, per-env\n\
+  prompt and model version pinning, env-specific checkpointer and observability.\n\
+  Use when graduating from `.env`-in-dev to real prod infra, or debugging a\nconfig\
+  \ that loaded the wrong values in the wrong env.\nTrigger with \"langchain multi-env\"\
+  , \"langchain pydantic settings\",\n\"langchain secret manager\", \"langchain env\
+  \ config\", \"langchain prod setup\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(gcloud:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, config, pydantic, multi-env, secrets]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- config
+- pydantic
+- multi-env
+- secrets
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Multi-Env Setup (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-observability/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-observability/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: langchain-observability
-description: |
-  Wire LangSmith tracing and custom metric callbacks into a LangChain 1.0 chain
-  or LangGraph 1.0 agent correctly — env-var spelling, subgraph propagation,
-  per-tenant dimensions, cost and latency counters. Use when setting up
-  observability on a new service, debugging blank traces in LangSmith, or adding
-  per-tenant cost breakdowns. Trigger with "langchain observability",
-  "langsmith tracing", "langchain callbacks", "langchain metrics".
+description: "Wire LangSmith tracing and custom metric callbacks into a LangChain\
+  \ 1.0 chain\nor LangGraph 1.0 agent correctly \u2014 env-var spelling, subgraph\
+  \ propagation,\nper-tenant dimensions, cost and latency counters. Use when setting\
+  \ up\nobservability on a new service, debugging blank traces in LangSmith, or adding\n\
+  per-tenant cost breakdowns. Trigger with \"langchain observability\",\n\"langsmith\
+  \ tracing\", \"langchain callbacks\", \"langchain metrics\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, observability, langsmith, callbacks]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- observability
+- langsmith
+- callbacks
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Observability (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-otel-observability/SKILL.md
@@ -1,22 +1,39 @@
 ---
 name: langchain-otel-observability
-description: |
-  Wire LangChain 1.0 / LangGraph 1.0 traces into an OpenTelemetry-native backend
+description: 'Wire LangChain 1.0 / LangGraph 1.0 traces into an OpenTelemetry-native
+  backend
+
   (Jaeger, Honeycomb, Grafana Tempo, Datadog) with LLM-specific SLOs, safe
+
   prompt-content policy, and subgraph-aware span propagation. Use when LangSmith
+
   is not the right fit (existing OTEL stack, compliance, multi-cloud) or
+
   alongside LangSmith for deep-system traces.
+
   Trigger with "langchain OTEL", "langchain opentelemetry", "langchain jaeger",
+
   "langchain honeycomb", "langchain SLO", "LLM span", "langchain tempo",
+
   "langchain datadog tracing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, observability, opentelemetry, jaeger, honeycomb]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- observability
+- opentelemetry
+- jaeger
+- honeycomb
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain OTEL Observability (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-performance-tuning/SKILL.md
@@ -1,21 +1,27 @@
 ---
 name: langchain-performance-tuning
-description: |
-  Tune LangChain 1.0 / LangGraph 1.0 Python chains and agents for throughput,
-  latency, and cost — streaming modes, explicit batch concurrency, semantic
-  plus exact caches, persistent message history, and async-safe retriever
-  patterns. Use when p95 latency exceeds target, batching "does not work",
-  cost grows linearly with traffic, or a process restart wipes chat history.
-  Trigger with "langchain performance", "langchain slow batch",
-  "langchain throughput", "langchain p95 latency", "semantic cache hit rate".
+description: "Tune LangChain 1.0 / LangGraph 1.0 Python chains and agents for throughput,\n\
+  latency, and cost \u2014 streaming modes, explicit batch concurrency, semantic\n\
+  plus exact caches, persistent message history, and async-safe retriever\npatterns.\
+  \ Use when p95 latency exceeds target, batching \"does not work\",\ncost grows linearly\
+  \ with traffic, or a process restart wipes chat history.\nTrigger with \"langchain\
+  \ performance\", \"langchain slow batch\",\n\"langchain throughput\", \"langchain\
+  \ p95 latency\", \"semantic cache hit rate\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(redis-cli:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex
-tags: [saas, langchain, langgraph, python, langchain-1.0, performance, caching, async]
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- performance
+- caching
+- async
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-prompt-engineering/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-prompt-engineering/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: langchain-prompt-engineering
-description: |
-  Manage LangChain 1.0 prompts like code — LangSmith prompt hub versioning,
-  XML-tag conventions for Claude, few-shot example selection, discriminated-union
-  extraction schemas, and A/B test wiring. Use when taking ad-hoc prompts into
-  version control, migrating prompts from f-strings to ChatPromptTemplate,
-  optimizing prompts for Claude vs GPT-4o vs Gemini, or A/B testing a prompt
-  change. Trigger with "langchain prompt hub", "langsmith prompts",
-  "prompt versioning", "claude xml prompt", "few-shot example selector",
-  "prompt engineering".
+description: "Manage LangChain 1.0 prompts like code \u2014 LangSmith prompt hub versioning,\n\
+  XML-tag conventions for Claude, few-shot example selection, discriminated-union\n\
+  extraction schemas, and A/B test wiring. Use when taking ad-hoc prompts into\nversion\
+  \ control, migrating prompts from f-strings to ChatPromptTemplate,\noptimizing prompts\
+  \ for Claude vs GPT-4o vs Gemini, or A/B testing a prompt\nchange. Trigger with\
+  \ \"langchain prompt hub\", \"langsmith prompts\",\n\"prompt versioning\", \"claude\
+  \ xml prompt\", \"few-shot example selector\",\n\"prompt engineering\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, prompts, langsmith, prompt-engineering]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- prompts
+- langsmith
+- prompt-engineering
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Prompt Engineering (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-rate-limits/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: langchain-rate-limits
-description: |
-  Rate-limit LangChain 1.0 calls correctly across multi-worker deployments —
-  Redis-backed limiters, asyncio.Semaphore, narrow exception whitelists, and
-  provider-specific throttle handling. Use when hitting 429s in production,
-  scaling workers horizontally, or tuning throughput against Anthropic, OpenAI,
-  or Gemini tier limits.
-  Trigger with "langchain rate limit", "langchain 429", "langchain semaphore",
-  "langchain token bucket", "anthropic rpm", "openai rpm throttling",
-  "InMemoryRateLimiter", "redis rate limiter".
+description: "Rate-limit LangChain 1.0 calls correctly across multi-worker deployments\
+  \ \u2014\nRedis-backed limiters, asyncio.Semaphore, narrow exception whitelists,\
+  \ and\nprovider-specific throttle handling. Use when hitting 429s in production,\n\
+  scaling workers horizontally, or tuning throughput against Anthropic, OpenAI,\n\
+  or Gemini tier limits.\nTrigger with \"langchain rate limit\", \"langchain 429\"\
+  , \"langchain semaphore\",\n\"langchain token bucket\", \"anthropic rpm\", \"openai\
+  \ rpm throttling\",\n\"InMemoryRateLimiter\", \"redis rate limiter\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(redis-cli:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, rate-limits, throttling, concurrency]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- rate-limits
+- throttling
+- concurrency
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Rate Limits (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-reference-architecture/SKILL.md
@@ -1,22 +1,28 @@
 ---
 name: langchain-reference-architecture
-description: |
-  A reference layered architecture for production LangChain 1.0 / LangGraph 1.0
-  services — LLM factory with version-safe defaults, chain/graph registry,
-  retriever and tool DI, Pydantic-validated config, per-request tenant scoping,
-  middleware ordering, checkpointer selection per environment. Use when starting
-  a new service, refactoring a tangled chain, or onboarding a team to existing code.
-  Trigger with "langchain architecture", "langchain llm factory",
-  "langchain chain registry", "langchain dependency injection",
-  "langchain project structure".
+description: "A reference layered architecture for production LangChain 1.0 / LangGraph\
+  \ 1.0\nservices \u2014 LLM factory with version-safe defaults, chain/graph registry,\n\
+  retriever and tool DI, Pydantic-validated config, per-request tenant scoping,\n\
+  middleware ordering, checkpointer selection per environment. Use when starting\n\
+  a new service, refactoring a tangled chain, or onboarding a team to existing code.\n\
+  Trigger with \"langchain architecture\", \"langchain llm factory\",\n\"langchain\
+  \ chain registry\", \"langchain dependency injection\",\n\"langchain project structure\"\
+  .\n"
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, architecture, reference-architecture, patterns]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- architecture
+- reference-architecture
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Reference Architecture (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-sdk-patterns/SKILL.md
@@ -1,21 +1,35 @@
 ---
 name: langchain-sdk-patterns
-description: |
-  Compose LangChain 1.0 Python runnables with the production defaults the docs
+description: 'Compose LangChain 1.0 Python runnables with the production defaults
+  the docs
+
   do not warn about: parallel batching, narrow fallbacks, and brace-safe prompts.
+
   Use when building an LCEL chain with RunnableSequence / RunnableParallel,
+
   adding resilience via `.with_fallbacks()`, tuning throughput with `.batch()`
+
   or `.abatch()`, or wrapping user input in a prompt template.
+
   Trigger with "langchain runnable", "with_fallbacks", "langchain batch",
+
   "runnable sequence", "lcel", "runnableparallel", "chain composition".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, lcel, runnables]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- lcel
+- runnables
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain SDK Patterns (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-security-basics/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-security-basics/SKILL.md
@@ -1,28 +1,34 @@
 ---
 name: langchain-security-basics
-description: |
-  Harden a LangChain 1.0 chain or LangGraph agent against prompt injection, tool
-  abuse, PII leakage in traces, and secrets exfiltration — wrap user content in
-  XML tags, enforce the tool allowlist via provider-native tool calling, redact
-  PII in middleware upstream of cache and tracing, validate outputs with Pydantic,
-  and lock down secrets behind a secret manager. Use when prepping for a security
-  review, responding to an incident, building a multi-tenant SaaS, or writing a
-  threat model.
-  Trigger with "langchain security", "prompt injection defense",
-  "langchain tool allowlist", "langchain PII redaction",
-  "langchain secrets management".
+description: "Harden a LangChain 1.0 chain or LangGraph agent against prompt injection,\
+  \ tool\nabuse, PII leakage in traces, and secrets exfiltration \u2014 wrap user\
+  \ content in\nXML tags, enforce the tool allowlist via provider-native tool calling,\
+  \ redact\nPII in middleware upstream of cache and tracing, validate outputs with\
+  \ Pydantic,\nand lock down secrets behind a secret manager. Use when prepping for\
+  \ a security\nreview, responding to an incident, building a multi-tenant SaaS, or\
+  \ writing a\nthreat model.\nTrigger with \"langchain security\", \"prompt injection\
+  \ defense\",\n\"langchain tool allowlist\", \"langchain PII redaction\",\n\"langchain\
+  \ secrets management\".\n"
 allowed-tools: Read, Write, Edit, Grep, Bash(grep:*)
 model: inherit
-argument-hint: "<chain-or-agent-path>"
+argument-hint: <chain-or-agent-path>
 user-invocable: true
 disable-model-invocation: false
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, security, prompt-injection, pii, owasp-llm]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- security
+- prompt-injection
+- pii
+- owasp-llm
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Security Basics (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-upgrade-migration/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: langchain-upgrade-migration
-description: |
-  Migrate a LangChain 0.3.x Python codebase to LangChain 1.0 / LangGraph 1.0 without
-  breaking production — named breaking changes, codemod patterns, and a phased rollout.
-  Use when upgrading LangChain or LangGraph from 0.2 or 0.3 to 1.0, when hitting
-  ImportError after an upgrade, or when preparing a migration PR.
-  Trigger with "langchain 1.0 migration", "langchain upgrade", "LLMChain removed",
-  "initialize_agent removed", "ConversationBufferMemory removed", "astream_log deprecated",
-  "langchain-anthropic 1.0".
+description: "Migrate a LangChain 0.3.x Python codebase to LangChain 1.0 / LangGraph\
+  \ 1.0 without\nbreaking production \u2014 named breaking changes, codemod patterns,\
+  \ and a phased rollout.\nUse when upgrading LangChain or LangGraph from 0.2 or 0.3\
+  \ to 1.0, when hitting\nImportError after an upgrade, or when preparing a migration\
+  \ PR.\nTrigger with \"langchain 1.0 migration\", \"langchain upgrade\", \"LLMChain\
+  \ removed\",\n\"initialize_agent removed\", \"ConversationBufferMemory removed\"\
+  , \"astream_log deprecated\",\n\"langchain-anthropic 1.0\".\n"
 allowed-tools: Read, Write, Edit, Grep, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, migration, upgrade]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain 1.0 Upgrade Migration (Python)
 
 ## Overview

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-webhooks-events/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: langchain-webhooks-events
-description: |
-  Dispatch LangChain 1.0 chain/agent events to external systems — webhooks, Kafka,
-  Redis Streams, SNS — via async fire-and-forget callbacks, subgraph-aware wiring,
-  and HMAC-signed delivery with idempotency keys. Use when firing webhooks on tool
-  calls, pushing telemetry to Kafka / Redis Streams, or fanning progress to multiple
-  subscribers without blocking the chain.
-  Trigger with "langchain webhook", "langchain event dispatch", "langchain callback kafka",
-  "langchain pubsub", "langchain per-tool webhook", "BaseCallbackHandler webhook",
-  "on_tool_end webhook", "langchain analytics event".
+description: "Dispatch LangChain 1.0 chain/agent events to external systems \u2014\
+  \ webhooks, Kafka,\nRedis Streams, SNS \u2014 via async fire-and-forget callbacks,\
+  \ subgraph-aware wiring,\nand HMAC-signed delivery with idempotency keys. Use when\
+  \ firing webhooks on tool\ncalls, pushing telemetry to Kafka / Redis Streams, or\
+  \ fanning progress to multiple\nsubscribers without blocking the chain.\nTrigger\
+  \ with \"langchain webhook\", \"langchain event dispatch\", \"langchain callback\
+  \ kafka\",\n\"langchain pubsub\", \"langchain per-tool webhook\", \"BaseCallbackHandler\
+  \ webhook\",\n\"on_tool_end webhook\", \"langchain analytics event\".\n"
 allowed-tools: Read, Write, Edit, Bash(python:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, langchain, langgraph, python, langchain-1.0, webhooks, async, events, callbacks]
-compatible-with: claude-code, codex
+tags:
+- saas
+- langchain
+- langgraph
+- python
+- langchain-1.0
+- webhooks
+- async
+- events
+- callbacks
+compatibility: Designed for Claude Code, also compatible with Codex
 ---
-
 # LangChain Webhooks and Event Dispatch (Python)
 
 ## Overview

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-ci-integration/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-ci-integration
-description: |
-  Configure Langfuse CI/CD integration with GitHub Actions and automated testing.
+description: 'Configure Langfuse CI/CD integration with GitHub Actions and automated
+  testing.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Langfuse tests into your build process.
+
   Trigger with phrases like "langfuse CI", "langfuse GitHub Actions",
+
   "langfuse automated tests", "CI langfuse", "langfuse pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, testing, ci-cd]
+tags:
+- saas
+- langfuse
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse CI Integration
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-common-errors/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langfuse-common-errors
-description: |
-  Diagnose and fix common Langfuse errors and exceptions.
+description: 'Diagnose and fix common Langfuse errors and exceptions.
+
   Use when encountering Langfuse errors, debugging missing traces,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "langfuse error", "fix langfuse",
+
   "langfuse not working", "debug langfuse", "traces not appearing".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, debugging]
+tags:
+- saas
+- langfuse
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Common Errors
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-core-workflow-a
-description: |
-  Execute Langfuse primary workflow: Tracing LLM calls and spans.
+description: 'Execute Langfuse primary workflow: Tracing LLM calls and spans.
+
   Use when implementing LLM tracing, building traced AI features,
+
   or adding observability to existing LLM applications.
+
   Trigger with phrases like "langfuse tracing", "trace LLM calls",
+
   "add langfuse to openai", "langfuse spans", "track llm requests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, llm, workflow]
+tags:
+- saas
+- langfuse
+- observability
+- llm
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Core Workflow A: Tracing LLM Calls
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-core-workflow-b
-description: |
-  Execute Langfuse secondary workflow: Evaluation, scoring, and datasets.
+description: 'Execute Langfuse secondary workflow: Evaluation, scoring, and datasets.
+
   Use when implementing LLM evaluation, adding user feedback,
+
   or setting up automated quality scoring and experiment datasets.
+
   Trigger with phrases like "langfuse evaluation", "langfuse scoring",
+
   "rate llm outputs", "langfuse feedback", "langfuse datasets", "langfuse experiments".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, llm, workflow, evaluation]
+tags:
+- saas
+- langfuse
+- llm
+- workflow
+- evaluation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Core Workflow B: Evaluation, Scoring & Datasets
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-cost-tuning
-description: |
-  Monitor and optimize LLM costs using Langfuse analytics and dashboards.
+description: 'Monitor and optimize LLM costs using Langfuse analytics and dashboards.
+
   Use when tracking LLM spending, identifying cost anomalies,
+
   or implementing cost controls for AI applications.
+
   Trigger with phrases like "langfuse costs", "LLM spending",
+
   "track AI costs", "langfuse token usage", "optimize LLM budget".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, monitoring, llm, analytics]
+tags:
+- saas
+- langfuse
+- monitoring
+- llm
+- analytics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Cost Tuning
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-data-handling/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-data-handling
-description: |
-  Manage Langfuse data export, retention, and compliance requirements.
+description: 'Manage Langfuse data export, retention, and compliance requirements.
+
   Use when exporting trace data, configuring retention policies,
+
   or implementing data compliance for LLM observability.
+
   Trigger with phrases like "langfuse data export", "langfuse retention",
+
   "langfuse GDPR", "langfuse compliance", "export langfuse traces".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, llm, compliance]
+tags:
+- saas
+- langfuse
+- observability
+- llm
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Data Handling
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langfuse-debug-bundle
-description: |
-  Collect Langfuse debug evidence for support tickets and troubleshooting.
+description: 'Collect Langfuse debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Langfuse problems.
+
   Trigger with phrases like "langfuse debug", "langfuse support bundle",
+
   "collect langfuse logs", "langfuse diagnostic", "langfuse troubleshoot".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, debugging]
+tags:
+- saas
+- langfuse
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Debug Bundle
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-deploy-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-deploy-integration
-description: |
-  Deploy Langfuse with your application across different platforms.
+description: 'Deploy Langfuse with your application across different platforms.
+
   Use when deploying Langfuse to Vercel, AWS, GCP, or Docker,
+
   or integrating Langfuse into your deployment pipeline.
+
   Trigger with phrases like "deploy langfuse", "langfuse Vercel",
+
   "langfuse AWS", "langfuse Docker", "langfuse production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(docker:*), Bash(vercel:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, deployment, docker]
+tags:
+- saas
+- langfuse
+- deployment
+- docker
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Deploy Integration
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langfuse-enterprise-rbac
-description: |
-  Configure Langfuse enterprise organization management and access control.
+description: 'Configure Langfuse enterprise organization management and access control.
+
   Use when implementing team access controls, configuring organization settings,
+
   or setting up role-based permissions for Langfuse projects.
+
   Trigger with phrases like "langfuse RBAC", "langfuse teams",
+
   "langfuse organization", "langfuse access control", "langfuse permissions".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, rbac]
+tags:
+- saas
+- langfuse
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Enterprise RBAC
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-hello-world/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-hello-world
-description: |
-  Create a minimal working Langfuse trace example.
+description: 'Create a minimal working Langfuse trace example.
+
   Use when starting a new Langfuse integration, testing your setup,
+
   or learning basic Langfuse tracing patterns.
+
   Trigger with phrases like "langfuse hello world", "langfuse example",
+
   "langfuse quick start", "first langfuse trace", "simple langfuse code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, testing, tracing]
+tags:
+- saas
+- langfuse
+- testing
+- tracing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Hello World
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-incident-runbook/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-incident-runbook
-description: |
-  Troubleshoot and respond to Langfuse-related incidents and outages.
+description: 'Troubleshoot and respond to Langfuse-related incidents and outages.
+
   Use when experiencing Langfuse outages, debugging production issues,
+
   or responding to LLM observability incidents.
+
   Trigger with phrases like "langfuse incident", "langfuse outage",
+
   "langfuse down", "langfuse production issue", "langfuse troubleshoot".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, llm, debugging]
+tags:
+- saas
+- langfuse
+- observability
+- llm
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Incident Runbook
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-install-auth/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-install-auth
-description: |
-  Install and configure Langfuse SDK authentication for LLM observability.
+description: 'Install and configure Langfuse SDK authentication for LLM observability.
+
   Use when setting up a new Langfuse integration, configuring API keys,
+
   or initializing Langfuse tracing in your project.
+
   Trigger with phrases like "install langfuse", "setup langfuse",
+
   "langfuse auth", "configure langfuse API key", "langfuse tracing setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, api, observability, llm]
+tags:
+- saas
+- langfuse
+- api
+- observability
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Install & Auth
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-local-dev-loop
-description: |
-  Set up Langfuse local development workflow with hot reload and debugging.
+description: 'Set up Langfuse local development workflow with hot reload and debugging.
+
   Use when developing LLM applications locally, debugging traces,
+
   or setting up a fast iteration loop with Langfuse.
+
   Trigger with phrases like "langfuse local dev", "langfuse development",
+
   "debug langfuse traces", "langfuse hot reload", "langfuse dev workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Bash(pnpm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, llm, debugging, workflow]
+tags:
+- saas
+- langfuse
+- llm
+- debugging
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Local Dev Loop
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-migration-deep-dive
-description: |
-  Execute complex Langfuse migrations including data migration and platform changes.
+description: 'Execute complex Langfuse migrations including data migration and platform
+  changes.
+
   Use when migrating from other observability platforms, moving between Langfuse instances,
+
   or performing major infrastructure migrations.
+
   Trigger with phrases like "langfuse migration", "migrate to langfuse",
+
   "langfuse data migration", "langfuse platform migration", "switch to langfuse".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, migration]
+tags:
+- saas
+- langfuse
+- observability
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Migration Deep Dive
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: langfuse-multi-env-setup
-description: |
-  Configure Langfuse across development, staging, and production environments.
+description: 'Configure Langfuse across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment keys,
+
   or implementing environment-specific Langfuse configurations.
+
   Trigger with phrases like "langfuse environments", "langfuse staging",
+
   "langfuse dev prod", "langfuse environment setup", "langfuse config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, deployment]
+tags:
+- saas
+- langfuse
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Multi-Environment Setup
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-observability/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: langfuse-observability
-description: |
-  Set up comprehensive observability for Langfuse with metrics, dashboards, and alerts.
+description: 'Set up comprehensive observability for Langfuse with metrics, dashboards,
+  and alerts.
+
   Use when implementing monitoring for LLM operations, setting up dashboards,
+
   or configuring alerting for Langfuse integration health.
+
   Trigger with phrases like "langfuse monitoring", "langfuse metrics",
+
   "langfuse observability", "monitor langfuse", "langfuse alerts", "langfuse dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, monitoring, observability, llm]
+tags:
+- saas
+- langfuse
+- monitoring
+- observability
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Observability
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-performance-tuning
-description: |
-  Optimize Langfuse tracing performance for high-throughput applications.
+description: 'Optimize Langfuse tracing performance for high-throughput applications.
+
   Use when experiencing latency issues, optimizing trace overhead,
+
   or scaling Langfuse for production workloads.
+
   Trigger with phrases like "langfuse performance", "optimize langfuse",
+
   "langfuse latency", "langfuse overhead", "langfuse slow".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, performance, scaling, tracing]
+tags:
+- saas
+- langfuse
+- performance
+- scaling
+- tracing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Performance Tuning
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-prod-checklist
-description: |
-  Langfuse production readiness checklist and verification.
+description: 'Langfuse production readiness checklist and verification.
+
   Use when preparing to deploy Langfuse to production,
+
   validating production configuration, or auditing existing setup.
+
   Trigger with phrases like "langfuse production", "langfuse prod ready",
+
   "deploy langfuse", "langfuse checklist", "langfuse go live".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, deployment, audit]
+tags:
+- saas
+- langfuse
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Production Checklist
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-rate-limits/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-rate-limits/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-rate-limits
-description: |
-  Implement Langfuse rate limiting, batching, and backoff patterns.
+description: 'Implement Langfuse rate limiting, batching, and backoff patterns.
+
   Use when handling rate limit errors, optimizing trace ingestion,
+
   or managing high-volume LLM observability workloads.
+
   Trigger with phrases like "langfuse rate limit", "langfuse throttling",
+
   "langfuse 429", "langfuse batching", "langfuse high volume".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, llm]
+tags:
+- saas
+- langfuse
+- observability
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Rate Limits
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-reference-architecture
-description: |
-  Production-grade Langfuse architecture patterns and best practices.
+description: 'Production-grade Langfuse architecture patterns and best practices.
+
   Use when designing LLM observability infrastructure, planning Langfuse deployment,
+
   or implementing enterprise-grade tracing architecture.
+
   Trigger with phrases like "langfuse architecture", "langfuse design",
+
   "langfuse infrastructure", "langfuse enterprise", "langfuse at scale".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, deployment, observability, llm]
+tags:
+- saas
+- langfuse
+- deployment
+- observability
+- llm
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Reference Architecture
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-sdk-patterns
-description: |
-  Langfuse SDK best practices, patterns, and idiomatic usage.
+description: 'Langfuse SDK best practices, patterns, and idiomatic usage.
+
   Use when learning Langfuse SDK patterns, implementing proper tracing,
+
   or following best practices for LLM observability.
+
   Trigger with phrases like "langfuse patterns", "langfuse best practices",
+
   "langfuse SDK guide", "how to use langfuse", "langfuse idioms".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, observability, llm, tracing]
+tags:
+- saas
+- langfuse
+- observability
+- llm
+- tracing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse SDK Patterns
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-security-basics/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: langfuse-security-basics
-description: |
-  Implement Langfuse security best practices for API keys and data privacy.
+description: 'Implement Langfuse security best practices for API keys and data privacy.
+
   Use when securing Langfuse integration, protecting API keys,
+
   or implementing data privacy controls for LLM observability.
+
   Trigger with phrases like "langfuse security", "langfuse API key security",
+
   "langfuse data privacy", "secure langfuse", "langfuse PII".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, api, security, observability]
+tags:
+- saas
+- langfuse
+- api
+- security
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Security Basics
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-upgrade-migration
-description: |
-  Upgrade Langfuse SDK versions and migrate between API changes.
+description: 'Upgrade Langfuse SDK versions and migrate between API changes.
+
   Use when upgrading Langfuse SDK, handling breaking changes,
+
   or migrating between Langfuse versions.
+
   Trigger with phrases like "upgrade langfuse", "langfuse migration",
+
   "update langfuse SDK", "langfuse breaking changes", "langfuse version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, api, migration]
+tags:
+- saas
+- langfuse
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Upgrade & Migration
 

--- a/plugins/saas-packs/langfuse-pack/skills/langfuse-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/langfuse-pack/skills/langfuse-webhooks-events/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: langfuse-webhooks-events
-description: |
-  Configure Langfuse webhooks for prompt change notifications and event-driven workflows.
+description: 'Configure Langfuse webhooks for prompt change notifications and event-driven
+  workflows.
+
   Use when setting up prompt change notifications, triggering CI/CD on prompt updates,
+
   or integrating Langfuse events with Slack and external systems.
+
   Trigger with phrases like "langfuse webhooks", "langfuse events",
+
   "langfuse notifications", "langfuse prompt webhook", "langfuse alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, langfuse, webhooks]
+tags:
+- saas
+- langfuse
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Langfuse Webhooks & Events
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-ci-integration/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-ci-integration
-description: |
-  Configure CI/CD pipelines for testing Lindy AI agent integrations.
+description: 'Configure CI/CD pipelines for testing Lindy AI agent integrations.
+
   Use when setting up automated testing, configuring GitHub Actions
+
   for webhook receiver tests, or validating agent connectivity in CI.
+
   Trigger with phrases like "lindy CI", "lindy GitHub Actions",
+
   "lindy automated tests", "CI lindy pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, testing, ci-cd]
+tags:
+- saas
+- lindy
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy CI Integration
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-common-errors/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-common-errors
-description: |
-  Troubleshoot common Lindy AI agent errors and workflow failures.
+description: 'Troubleshoot common Lindy AI agent errors and workflow failures.
+
   Use when encountering errors, debugging agent failures,
+
   or resolving integration problems.
+
   Trigger with phrases like "lindy error", "lindy not working",
+
   "debug lindy", "lindy troubleshoot", "lindy agent failed".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, debugging]
+tags:
+- saas
+- lindy
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Common Errors
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-core-workflow-a
-description: |
-  Build and configure multi-step Lindy AI agent workflows.
+description: 'Build and configure multi-step Lindy AI agent workflows.
+
   Use when creating agents with triggers, actions, conditions,
+
   knowledge bases, or agent steps.
+
   Trigger with phrases like "create lindy agent", "build lindy agent",
+
   "lindy agent workflow", "configure lindy agent", "lindy workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, workflow]
+tags:
+- saas
+- lindy
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Core Workflow A: Agent Creation
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-core-workflow-b
-description: |
-  Configure Lindy triggers, scheduling, multi-agent delegation, and automation.
+description: 'Configure Lindy triggers, scheduling, multi-agent delegation, and automation.
+
   Use when setting up trigger-based workflows, scheduling agents,
+
   building multi-agent societies, or configuring agent delegation.
+
   Trigger with phrases like "lindy automation", "schedule lindy agent",
+
   "lindy workflow automation", "lindy delegation", "lindy multi-agent".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, workflow]
+tags:
+- saas
+- lindy
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Core Workflow B: Triggers & Multi-Agent Automation
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-cost-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: lindy-cost-tuning
-description: |
-  Optimize Lindy AI costs through credit management, model selection,
+description: 'Optimize Lindy AI costs through credit management, model selection,
+
   and agent consolidation.
+
   Use when reducing spend, analyzing credit usage patterns,
+
   or optimizing budget allocation across agents.
+
   Trigger with phrases like "lindy cost", "lindy billing",
+
   "reduce lindy spend", "lindy budget", "lindy credits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, cost-optimization]
+tags:
+- saas
+- lindy
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Cost Tuning
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-data-handling/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-data-handling
-description: |
-  Data handling best practices for Lindy AI agents.
+description: 'Data handling best practices for Lindy AI agents.
+
   Use when managing sensitive data in agent workflows,
+
   implementing data privacy controls, or ensuring compliance.
+
   Trigger with phrases like "lindy data", "lindy privacy",
+
   "lindy PII", "lindy data handling", "lindy GDPR", "lindy HIPAA".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, compliance]
+tags:
+- saas
+- lindy
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Data Handling
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-debug-bundle
-description: |
-  Comprehensive debugging toolkit for Lindy AI agents.
+description: 'Comprehensive debugging toolkit for Lindy AI agents.
+
   Use when investigating complex agent failures, collecting diagnostics,
+
   or preparing support tickets for Lindy support.
+
   Trigger with phrases like "lindy debug", "lindy diagnostics",
+
   "lindy support bundle", "investigate lindy issue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, debugging]
+tags:
+- saas
+- lindy
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Debug Bundle
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-deploy-integration
-description: |
-  Deploy applications that integrate with Lindy AI agents.
+description: 'Deploy applications that integrate with Lindy AI agents.
+
   Use when deploying webhook receivers, callback handlers,
+
   or applications connected to Lindy agents.
+
   Trigger with phrases like "deploy lindy", "lindy deployment",
+
   "lindy production deploy", "release lindy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(docker:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, deployment]
+tags:
+- saas
+- lindy
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Deploy Integration
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-enterprise-rbac
-description: |
-  Configure enterprise role-based access control for Lindy AI workspaces.
+description: 'Configure enterprise role-based access control for Lindy AI workspaces.
+
   Use when setting up team permissions, managing workspace access,
+
   or implementing enterprise security policies with SSO/SCIM.
+
   Trigger with phrases like "lindy permissions", "lindy RBAC",
+
   "lindy access control", "lindy enterprise security", "lindy SSO".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, security, rbac]
+tags:
+- saas
+- lindy
+- security
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Enterprise RBAC
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-hello-world/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-hello-world
-description: |
-  Create your first Lindy AI agent with a real trigger and action.
+description: 'Create your first Lindy AI agent with a real trigger and action.
+
   Use when starting with Lindy, testing your setup,
+
   or learning basic agent workflow patterns.
+
   Trigger with phrases like "lindy hello world", "lindy example",
+
   "lindy quick start", "simple lindy agent", "first lindy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, api, testing]
+tags:
+- saas
+- lindy
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Hello World
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-incident-runbook
-description: |
-  Incident response procedures for Lindy AI agent failures and outages.
+description: 'Incident response procedures for Lindy AI agent failures and outages.
+
   Use when responding to incidents, troubleshooting agent outages,
+
   or creating on-call procedures for Lindy-powered systems.
+
   Trigger with phrases like "lindy incident", "lindy outage",
+
   "lindy on-call", "lindy runbook", "lindy down".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, incident-response]
+tags:
+- saas
+- lindy
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Incident Runbook
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-install-auth/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-install-auth
-description: |
-  Set up Lindy AI account, API access, and webhook authentication.
+description: 'Set up Lindy AI account, API access, and webhook authentication.
+
   Use when onboarding to Lindy, configuring API keys for webhook triggers,
+
   or connecting Lindy agents to your application.
+
   Trigger with phrases like "install lindy", "setup lindy",
+
   "lindy auth", "configure lindy API key", "lindy webhook secret".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, api, authentication]
+tags:
+- saas
+- lindy
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Install & Auth
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-local-dev-loop
-description: |
-  Set up local development workflow for testing Lindy AI agent integrations.
+description: 'Set up local development workflow for testing Lindy AI agent integrations.
+
   Use when building webhook receivers, testing agent callbacks,
+
   or iterating on Lindy-connected applications locally.
+
   Trigger with phrases like "lindy local dev", "lindy development",
+
   "test lindy locally", "lindy webhook local".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, testing, workflow]
+tags:
+- saas
+- lindy
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Local Dev Loop
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-migration-deep-dive
-description: |
-  Advanced migration strategies for moving to Lindy AI from other platforms.
+description: 'Advanced migration strategies for moving to Lindy AI from other platforms.
+
   Use when migrating from Zapier, Make, n8n, custom automations,
+
   or consolidating fragmented agent systems.
+
   Trigger with phrases like "lindy migration", "migrate to lindy",
+
   "zapier to lindy", "switch to lindy", "consolidate automations".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, migration]
+tags:
+- saas
+- lindy
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Migration Deep Dive
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-multi-env-setup
-description: |
-  Configure Lindy AI across development, staging, and production environments.
+description: 'Configure Lindy AI across development, staging, and production environments.
+
   Use when setting up isolated workspaces, per-environment secrets,
+
   or environment-specific agent configurations.
+
   Trigger with phrases like "lindy environments", "lindy staging",
+
   "lindy dev prod", "lindy environment setup", "lindy workspace isolation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, deployment]
+tags:
+- saas
+- lindy
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Multi-Environment Setup
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-observability/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: lindy-observability
-description: |
-  Monitor Lindy AI agent health, task success rates, and credit consumption.
+description: 'Monitor Lindy AI agent health, task success rates, and credit consumption.
+
   Use when setting up monitoring, building dashboards, configuring alerts,
+
   or tracking agent performance over time.
+
   Trigger with phrases like "lindy monitoring", "lindy observability",
+
   "lindy metrics", "lindy logging", "lindy dashboard".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, monitoring, observability, dashboard]
+tags:
+- saas
+- lindy
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Observability
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-performance-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-performance-tuning
-description: |
-  Optimize Lindy AI agent execution speed, reliability, and cost efficiency.
+description: 'Optimize Lindy AI agent execution speed, reliability, and cost efficiency.
+
   Use when agents are slow, consuming too many credits,
+
   or producing inconsistent results.
+
   Trigger with phrases like "lindy performance", "lindy slow",
+
   "optimize lindy", "lindy latency", "lindy speed".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, performance]
+tags:
+- saas
+- lindy
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Performance Tuning
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-prod-checklist
-description: |
-  Production readiness checklist for Lindy AI agent deployments.
+description: 'Production readiness checklist for Lindy AI agent deployments.
+
   Use when preparing agents for production, auditing live agents,
+
   or validating go-live readiness.
+
   Trigger with phrases like "lindy production", "lindy prod ready",
+
   "lindy go live", "lindy deployment checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, deployment, audit]
+tags:
+- saas
+- lindy
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Production Checklist
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-rate-limits/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-rate-limits
-description: |
-  Manage Lindy AI credits, rate limits, and usage optimization.
+description: 'Manage Lindy AI credits, rate limits, and usage optimization.
+
   Use when hitting rate limits, optimizing credit consumption,
+
   or implementing usage controls.
+
   Trigger with phrases like "lindy rate limit", "lindy credits",
+
   "lindy quota", "lindy throttling", "lindy API limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, api]
+tags:
+- saas
+- lindy
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Rate Limits & Credits
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-reference-architecture
-description: |
-  Reference architectures for Lindy AI agent integrations.
+description: 'Reference architectures for Lindy AI agent integrations.
+
   Use when designing systems, planning multi-agent architectures,
+
   or implementing production integration patterns.
+
   Trigger with phrases like "lindy architecture", "lindy design",
+
   "lindy system design", "lindy patterns", "lindy multi-agent".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, lindy-reference]
+tags:
+- saas
+- lindy
+- lindy-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Reference Architecture
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-sdk-patterns
-description: |
-  Lindy AI integration patterns for webhook handling, HTTP actions, and Run Code.
+description: 'Lindy AI integration patterns for webhook handling, HTTP actions, and
+  Run Code.
+
   Use when building integrations, calling Lindy agents from code,
+
   or implementing the Run Code action with Python/JavaScript.
+
   Trigger with phrases like "lindy SDK patterns", "lindy best practices",
+
   "lindy API patterns", "lindy Run Code", "lindy HTTP Request".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, api]
+tags:
+- saas
+- lindy
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy SDK & Integration Patterns
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-security-basics/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-security-basics/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lindy-security-basics
-description: |
-  Implement security best practices for Lindy AI agents and integrations.
+description: 'Implement security best practices for Lindy AI agents and integrations.
+
   Use when securing API keys, configuring agent permissions,
+
   verifying webhooks, or auditing agent access.
+
   Trigger with phrases like "lindy security", "secure lindy",
+
   "lindy API key security", "lindy permissions", "lindy audit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, api, security]
+tags:
+- saas
+- lindy
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Security Basics
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-upgrade-migration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-upgrade-migration
-description: |
-  Manage Lindy agent configuration changes, platform updates, and migrations.
+description: 'Manage Lindy agent configuration changes, platform updates, and migrations.
+
   Use when reconfiguring agents, handling platform changes,
+
   or migrating agents between workspaces.
+
   Trigger with phrases like "upgrade lindy", "lindy migration",
+
   "lindy reconfigure", "update lindy agents", "lindy workspace migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, migration]
+tags:
+- saas
+- lindy
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Upgrade & Migration
 

--- a/plugins/saas-packs/lindy-pack/skills/lindy-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/lindy-pack/skills/lindy-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lindy-webhooks-events
-description: |
-  Configure Lindy AI webhook triggers, callback patterns, and event handling.
+description: 'Configure Lindy AI webhook triggers, callback patterns, and event handling.
+
   Use when setting up webhook triggers, implementing callback receivers,
+
   or building event-driven Lindy integrations.
+
   Trigger with phrases like "lindy webhook", "lindy events",
+
   "lindy callback", "lindy webhook trigger".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lindy, webhooks]
+tags:
+- saas
+- lindy
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lindy Webhooks & Events
 

--- a/plugins/saas-packs/linear-pack/skills/linear-ci-integration/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-ci-integration
-description: |
-  Integrate Linear with GitHub Actions CI/CD pipelines.
+description: 'Integrate Linear with GitHub Actions CI/CD pipelines.
+
   Use when setting up automated testing, PR-to-issue linking,
+
   or creating Linear issues from CI failures.
+
   Trigger: "linear CI", "linear GitHub Actions", "linear CI/CD",
+
   "linear automated tests", "linear PR integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, testing, ci-cd]
+tags:
+- saas
+- linear
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear CI Integration
 

--- a/plugins/saas-packs/linear-pack/skills/linear-common-errors/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: linear-common-errors
-description: |
-  Diagnose and fix common Linear API and SDK errors.
+description: 'Diagnose and fix common Linear API and SDK errors.
+
   Use when encountering Linear API errors, debugging integration issues,
+
   or troubleshooting authentication, rate limits, or query problems.
+
   Trigger: "linear error", "linear API error", "debug linear",
+
   "linear not working", "linear 429", "linear authentication error".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, debugging, authentication]
+tags:
+- saas
+- linear
+- api
+- debugging
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Common Errors
 

--- a/plugins/saas-packs/linear-pack/skills/linear-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-core-workflow-a
-description: |
-  Issue lifecycle management with Linear: create, update, transition,
+description: 'Issue lifecycle management with Linear: create, update, transition,
+
   relate, comment, and organize issues through the SDK and GraphQL API.
+
   Trigger: "linear issue workflow", "linear issue lifecycle",
+
   "create linear issues", "update linear issue", "linear state transition",
+
   "linear sub-issues", "linear comments".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, workflow]
+tags:
+- saas
+- linear
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Core Workflow A: Issue Lifecycle
 

--- a/plugins/saas-packs/linear-pack/skills/linear-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-core-workflow-b
-description: |
-  Project, cycle, and roadmap management workflows with Linear.
+description: 'Project, cycle, and roadmap management workflows with Linear.
+
   Use when implementing sprint planning, managing projects and milestones,
+
   or organizing work into cycles.
+
   Trigger: "linear project", "linear cycle", "linear sprint",
+
   "linear roadmap", "linear planning", "linear milestone".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, workflow]
+tags:
+- saas
+- linear
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Core Workflow B: Projects & Cycles
 

--- a/plugins/saas-packs/linear-pack/skills/linear-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-cost-tuning/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: linear-cost-tuning
-description: |
-  Optimize Linear API usage, reduce unnecessary calls, and maximize
+description: 'Optimize Linear API usage, reduce unnecessary calls, and maximize
+
   efficiency within rate limit budgets.
+
   Trigger: "linear cost", "reduce linear API calls", "linear efficiency",
+
   "linear API usage", "optimize linear costs", "linear budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, cost-optimization]
+tags:
+- saas
+- linear
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Cost Tuning
 

--- a/plugins/saas-packs/linear-pack/skills/linear-data-handling/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-data-handling
-description: |
-  Data synchronization, backup, and consistency patterns for Linear.
+description: 'Data synchronization, backup, and consistency patterns for Linear.
+
   Use when implementing data sync, creating backups, exporting data,
+
   or ensuring data consistency between Linear and local state.
+
   Trigger: "linear data sync", "backup linear", "linear export",
+
   "linear data consistency", "sync linear issues".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, backup]
+tags:
+- saas
+- linear
+- backup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Data Handling
 

--- a/plugins/saas-packs/linear-pack/skills/linear-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-debug-bundle/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: linear-debug-bundle
-description: |
-  Comprehensive debugging toolkit for Linear integrations.
+description: 'Comprehensive debugging toolkit for Linear integrations.
+
   Use when setting up logging, tracing API calls,
+
   or building debug utilities for Linear.
+
   Trigger: "debug linear integration", "linear logging",
+
   "trace linear API", "linear debugging tools".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, debugging, logging]
+tags:
+- saas
+- linear
+- api
+- debugging
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Debug Bundle
 

--- a/plugins/saas-packs/linear-pack/skills/linear-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-deploy-integration
-description: |
-  Deploy Linear-integrated applications and track deployments.
+description: 'Deploy Linear-integrated applications and track deployments.
+
   Use when deploying to production, linking deploys to issues,
+
   or setting up deployment tracking with Vercel/Railway/Cloud Run.
+
   Trigger: "deploy linear integration", "linear deployment",
+
   "linear vercel", "track linear deployments", "linear deploy tracking".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(gcloud:*), Bash(aws:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, deployment]
+tags:
+- saas
+- linear
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Deploy Integration
 

--- a/plugins/saas-packs/linear-pack/skills/linear-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-enterprise-rbac
-description: |
-  Implement enterprise role-based access control with Linear.
+description: 'Implement enterprise role-based access control with Linear.
+
   Use when setting up team permissions, OAuth scopes,
+
   SAML SSO, SCIM provisioning, or audit logging.
+
   Trigger: "linear RBAC", "linear permissions", "linear SSO",
+
   "linear enterprise access", "linear role management", "linear SCIM".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, rbac]
+tags:
+- saas
+- linear
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Enterprise RBAC
 

--- a/plugins/saas-packs/linear-pack/skills/linear-hello-world/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: linear-hello-world
-description: |
-  Create your first Linear issue and query using the SDK and GraphQL API.
+description: 'Create your first Linear issue and query using the SDK and GraphQL API.
+
   Use when making initial API calls, testing connection,
+
   or learning basic Linear CRUD operations.
+
   Trigger: "linear hello world", "first linear issue",
+
   "create linear issue", "linear API example", "test linear".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, graphql, testing]
+tags:
+- saas
+- linear
+- api
+- graphql
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Hello World
 

--- a/plugins/saas-packs/linear-pack/skills/linear-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-incident-runbook
-description: |
-  Production incident response procedures for Linear integrations.
+description: 'Production incident response procedures for Linear integrations.
+
   Use when handling production issues, diagnosing outages,
+
   or responding to Linear-related incidents.
+
   Trigger: "linear incident", "linear outage", "linear production issue",
+
   "debug linear production", "linear down", "linear 500".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, debugging, incident-response]
+tags:
+- saas
+- linear
+- debugging
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Incident Runbook
 

--- a/plugins/saas-packs/linear-pack/skills/linear-install-auth/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-install-auth
-description: |
-  Install and configure Linear SDK/CLI authentication.
+description: 'Install and configure Linear SDK/CLI authentication.
+
   Use when setting up a new Linear integration, configuring API keys,
+
   OAuth2 flows, or initializing LinearClient in your project.
+
   Trigger: "install linear", "setup linear", "linear auth",
+
   "configure linear API key", "linear SDK setup", "linear OAuth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(yarn:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, authentication]
+tags:
+- saas
+- linear
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Install & Auth
 

--- a/plugins/saas-packs/linear-pack/skills/linear-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-local-dev-loop
-description: |
-  Set up local Linear development environment and testing workflow.
+description: 'Set up local Linear development environment and testing workflow.
+
   Use when configuring local dev, testing integrations,
+
   or setting up a development workflow with Linear webhooks.
+
   Trigger: "linear local development", "linear dev setup",
+
   "test linear locally", "linear development environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, testing, workflow]
+tags:
+- saas
+- linear
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Local Dev Loop
 

--- a/plugins/saas-packs/linear-pack/skills/linear-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-migration-deep-dive
-description: |
-  Migrate from Jira, Asana, GitHub Issues, or other tools to Linear.
+description: 'Migrate from Jira, Asana, GitHub Issues, or other tools to Linear.
+
   Use when planning a migration, executing data transfer,
+
   or mapping workflows between issue tracking tools.
+
   Trigger: "migrate to linear", "jira to linear", "asana to linear",
+
   "import to linear", "linear migration", "github issues to linear".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, migration, workflow]
+tags:
+- saas
+- linear
+- migration
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Migration Deep Dive
 

--- a/plugins/saas-packs/linear-pack/skills/linear-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-multi-env-setup/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-multi-env-setup
-description: |
-  Configure Linear across development, staging, and production environments.
+description: 'Configure Linear across development, staging, and production environments.
+
   Use when setting up per-environment API keys, secret management,
+
   or environment-specific Linear configurations.
+
   Trigger: "linear environments", "linear staging", "linear dev prod",
+
   "linear environment setup", "multi-environment linear".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vault:*), Bash(gcloud:*), Bash(aws:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, deployment, api]
+tags:
+- saas
+- linear
+- deployment
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Multi-Environment Setup
 

--- a/plugins/saas-packs/linear-pack/skills/linear-observability/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-observability/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: linear-observability
-description: |
-  Implement monitoring, logging, and alerting for Linear integrations.
+description: 'Implement monitoring, logging, and alerting for Linear integrations.
+
   Use when setting up metrics collection, dashboards,
+
   or configuring alerts for Linear API usage.
+
   Trigger: "linear monitoring", "linear observability",
+
   "linear metrics", "linear logging", "monitor linear",
+
   "linear Prometheus", "linear Grafana".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, monitoring, observability]
+tags:
+- saas
+- linear
+- api
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Observability
 

--- a/plugins/saas-packs/linear-pack/skills/linear-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-performance-tuning
-description: |
-  Optimize Linear API queries, caching, and batching for performance.
+description: 'Optimize Linear API queries, caching, and batching for performance.
+
   Use when improving response times, reducing API calls,
+
   or implementing caching strategies for Linear data.
+
   Trigger: "linear performance", "optimize linear", "linear caching",
+
   "linear slow queries", "speed up linear", "linear N+1".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, performance]
+tags:
+- saas
+- linear
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Performance Tuning
 

--- a/plugins/saas-packs/linear-pack/skills/linear-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-prod-checklist
-description: |
-  Production readiness checklist for Linear integrations.
+description: 'Production readiness checklist for Linear integrations.
+
   Use when preparing to deploy, reviewing production requirements,
+
   or auditing existing Linear deployments.
+
   Trigger: "linear production checklist", "deploy linear",
+
   "linear production ready", "linear go live", "linear launch".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, deployment, audit]
+tags:
+- saas
+- linear
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Production Checklist
 

--- a/plugins/saas-packs/linear-pack/skills/linear-rate-limits/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-rate-limits
-description: |
-  Handle Linear API rate limiting, complexity budgets, and quotas.
+description: 'Handle Linear API rate limiting, complexity budgets, and quotas.
+
   Use when dealing with 429 errors, implementing throttling,
+
   or optimizing request patterns to stay within limits.
+
   Trigger: "linear rate limit", "linear throttling", "linear 429",
+
   "linear API quota", "linear complexity", "linear request limits".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api]
+tags:
+- saas
+- linear
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Rate Limits
 

--- a/plugins/saas-packs/linear-pack/skills/linear-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-reference-architecture
-description: |
-  Production-grade Linear integration architecture patterns.
+description: 'Production-grade Linear integration architecture patterns.
+
   Use when designing system architecture, choosing integration patterns,
+
   or reviewing architectural decisions for Linear integrations.
+
   Trigger: "linear architecture", "linear system design",
+
   "linear integration patterns", "linear best practices architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, linear-reference]
+tags:
+- saas
+- linear
+- linear-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Reference Architecture
 

--- a/plugins/saas-packs/linear-pack/skills/linear-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-sdk-patterns
-description: |
-  TypeScript/JavaScript SDK patterns and best practices for Linear.
+description: 'TypeScript/JavaScript SDK patterns and best practices for Linear.
+
   Use when learning SDK idioms, implementing pagination,
+
   filtering, relation loading, or custom GraphQL queries.
+
   Trigger: "linear SDK patterns", "linear best practices",
+
   "linear typescript", "linear API patterns", "linear pagination".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, typescript]
+tags:
+- saas
+- linear
+- api
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear SDK Patterns
 

--- a/plugins/saas-packs/linear-pack/skills/linear-security-basics/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: linear-security-basics
-description: |
-  Secure API key management, OAuth best practices, and webhook
+description: 'Secure API key management, OAuth best practices, and webhook
+
   verification for Linear integrations.
+
   Trigger: "linear security", "linear API key security",
+
   "linear OAuth", "secure linear", "linear webhook verification",
+
   "linear secrets management", "linear token refresh".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, security, authentication]
+tags:
+- saas
+- linear
+- api
+- security
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Security Basics
 

--- a/plugins/saas-packs/linear-pack/skills/linear-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: linear-upgrade-migration
-description: |
-  Upgrade Linear SDK versions and handle breaking changes safely.
+description: 'Upgrade Linear SDK versions and handle breaking changes safely.
+
   Use when updating to a new SDK version, handling deprecations,
+
   or migrating between API versions.
+
   Trigger: "upgrade linear SDK", "linear SDK migration",
+
   "update linear", "linear breaking changes", "linear deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, api, migration]
+tags:
+- saas
+- linear
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Upgrade Migration
 

--- a/plugins/saas-packs/linear-pack/skills/linear-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/linear-pack/skills/linear-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: linear-webhooks-events
-description: |
-  Configure and handle Linear webhooks for real-time event processing.
+description: 'Configure and handle Linear webhooks for real-time event processing.
+
   Use when setting up webhooks, handling issue/project/cycle events,
+
   or building real-time integrations with Linear.
+
   Trigger: "linear webhooks", "linear events", "linear real-time",
+
   "handle linear webhook", "linear webhook setup", "linear webhook payload".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(ngrok:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, linear, webhooks]
+tags:
+- saas
+- linear
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Linear Webhooks & Events
 

--- a/plugins/saas-packs/linktree-pack/skills/linktree-ci-integration/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-ci-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-ci-integration
-description: |
-  Ci Integration for Linktree.
+description: 'Ci Integration for Linktree.
+
   Trigger: "linktree ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree CI Integration
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-common-errors/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-common-errors/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-common-errors
-description: |
-  Diagnose and fix Linktree common errors.
+description: 'Diagnose and fix Linktree common errors.
+
   Trigger: "linktree error", "fix linktree", "debug linktree".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Common Errors
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-core-workflow-a/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-core-workflow-a
-description: |
-  Execute Linktree primary workflow: Profile & Links Management.
+description: 'Execute Linktree primary workflow: Profile & Links Management.
+
   Trigger: "linktree profile & links management", "primary linktree workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree — Profile & Links Management
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-core-workflow-b/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-core-workflow-b
-description: |
-  Execute Linktree secondary workflow: Analytics & Insights.
+description: 'Execute Linktree secondary workflow: Analytics & Insights.
+
   Trigger: "linktree analytics & insights", "secondary linktree workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree — Analytics & Reporting
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-cost-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-cost-tuning
-description: |
-  Cost Tuning for Linktree.
+description: 'Cost Tuning for Linktree.
+
   Trigger: "linktree cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-debug-bundle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-debug-bundle
-description: |
-  Debug Bundle for Linktree.
+description: 'Debug Bundle for Linktree.
+
   Trigger: "linktree debug bundle".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-deploy-integration
-description: |
-  Deploy Integration for Linktree.
+description: 'Deploy Integration for Linktree.
+
   Trigger: "linktree deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-hello-world/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-hello-world/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-hello-world
-description: |
-  Create a minimal working Linktree example.
+description: 'Create a minimal working Linktree example.
+
   Trigger: "linktree hello world", "linktree example", "test linktree".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Hello World
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-install-auth/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: linktree-install-auth
-description: |
-  Install and configure Linktree SDK/API authentication.
+description: 'Install and configure Linktree SDK/API authentication.
+
   Use when setting up a new Linktree integration.
+
   Trigger: "install linktree", "setup linktree", "linktree auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-local-dev-loop/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-local-dev-loop
-description: |
-  Local Dev Loop for Linktree.
+description: 'Local Dev Loop for Linktree.
+
   Trigger: "linktree local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: linktree-performance-tuning
-description: |
-  Optimize Linktree API integration performance with caching, batching, and rate limit strategies.
-  Use when Linktree API calls are slow, hitting rate limits, or profile pages serve stale link data.
+description: 'Optimize Linktree API integration performance with caching, batching,
+  and rate limit strategies.
+
+  Use when Linktree API calls are slow, hitting rate limits, or profile pages serve
+  stale link data.
+
   Trigger with "linktree performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-prod-checklist
-description: |
-  Prod Checklist for Linktree.
+description: 'Prod Checklist for Linktree.
+
   Trigger: "linktree prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-rate-limits/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-rate-limits
-description: |
-  Rate Limits for Linktree.
+description: 'Rate Limits for Linktree.
+
   Trigger: "linktree rate limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-reference-architecture/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-reference-architecture
-description: |
-  Reference Architecture for Linktree.
+description: 'Reference Architecture for Linktree.
+
   Trigger: "linktree reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-sdk-patterns/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-sdk-patterns
-description: |
-  Sdk Patterns for Linktree.
+description: 'Sdk Patterns for Linktree.
+
   Trigger: "linktree sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-security-basics/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-security-basics/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-security-basics
-description: |
-  Security Basics for Linktree.
+description: 'Security Basics for Linktree.
+
   Trigger: "linktree security basics".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Security Basics
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-upgrade-migration
-description: |
-  Upgrade Migration for Linktree.
+description: 'Upgrade Migration for Linktree.
+
   Trigger: "linktree upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/linktree-pack/skills/linktree-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/linktree-pack/skills/linktree-webhooks-events/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: linktree-webhooks-events
-description: |
-  Webhooks Events for Linktree.
+description: 'Webhooks Events for Linktree.
+
   Trigger: "linktree webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, linktree, social]
-compatible-with: claude-code
+tags:
+- saas
+- linktree
+- social
+compatibility: Designed for Claude Code
 ---
-
 # Linktree Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-ci-integration/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-ci-integration
-description: |
-  Configure Lokalise CI/CD integration with GitHub Actions and automated sync.
+description: 'Configure Lokalise CI/CD integration with GitHub Actions and automated
+  sync.
+
   Use when setting up automated translation sync, configuring CI pipelines,
+
   or integrating Lokalise into your build process.
+
   Trigger with phrases like "lokalise CI", "lokalise GitHub Actions",
+
   "lokalise automated sync", "CI lokalise", "lokalise pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, ci-cd]
+tags:
+- saas
+- lokalise
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise CI Integration
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-common-errors/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-common-errors
-description: |
-  Diagnose and fix Lokalise common errors and exceptions.
+description: 'Diagnose and fix Lokalise common errors and exceptions.
+
   Use when encountering Lokalise errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "lokalise error", "fix lokalise",
+
   "lokalise not working", "debug lokalise", "lokalise 401", "lokalise 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(lokalise2:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, debugging]
+tags:
+- saas
+- lokalise
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Common Errors
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-core-workflow-a
-description: |
-  Execute Lokalise primary workflow: Upload source files and manage translation keys.
+description: 'Execute Lokalise primary workflow: Upload source files and manage translation
+  keys.
+
   Use when uploading translation files, creating/updating keys,
+
   or managing source strings in Lokalise projects.
+
   Trigger with phrases like "lokalise upload", "lokalise push keys",
+
   "lokalise source strings", "add translations to lokalise".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(lokalise2:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, workflow]
+tags:
+- saas
+- lokalise
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Core Workflow A
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-core-workflow-b/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-core-workflow-b
-description: |
-  Manage Lokalise secondary workflow: Download translations and integrate with app.
+description: 'Manage Lokalise secondary workflow: Download translations and integrate
+  with app.
+
   Use when downloading translation files, exporting translations,
+
   or integrating Lokalise output into your application.
+
   Trigger with phrases like "lokalise download", "lokalise pull translations",
+
   "export lokalise", "get translations from lokalise".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(lokalise2:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, workflow]
+tags:
+- saas
+- lokalise
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Core Workflow B
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: lokalise-cost-tuning
-description: |
-  Optimize Lokalise costs through plan selection, usage monitoring, and efficiency.
+description: 'Optimize Lokalise costs through plan selection, usage monitoring, and
+  efficiency.
+
   Use when analyzing Lokalise billing, reducing costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "lokalise cost", "lokalise billing",
+
   "reduce lokalise costs", "lokalise pricing", "lokalise budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, monitoring, cost-optimization]
+tags:
+- saas
+- lokalise
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Cost Tuning
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-data-handling/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-data-handling/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-data-handling
-description: |
-  Implement Lokalise translation data handling, PII management, and compliance patterns.
+description: 'Implement Lokalise translation data handling, PII management, and compliance
+  patterns.
+
   Use when handling sensitive translation data, implementing data redaction,
+
   or ensuring compliance with privacy regulations for Lokalise integrations.
+
   Trigger with phrases like "lokalise data", "lokalise PII",
+
   "lokalise GDPR", "lokalise data retention", "lokalise privacy", "lokalise compliance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, compliance]
+tags:
+- saas
+- lokalise
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Data Handling
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-debug-bundle
-description: |
-  Collect Lokalise debug evidence for support tickets and troubleshooting.
+description: 'Collect Lokalise debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Lokalise problems.
+
   Trigger with phrases like "lokalise debug", "lokalise support bundle",
+
   "collect lokalise logs", "lokalise diagnostic".
-allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(lokalise2:*), Bash(node:*), Bash(npm:*), Bash(jq:*), Bash(sed:*), Bash(mkdir:*), Grep
+
+  '
+allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(lokalise2:*), Bash(node:*),
+  Bash(npm:*), Bash(jq:*), Bash(sed:*), Bash(mkdir:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, debugging]
+tags:
+- saas
+- lokalise
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Debug Bundle
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-deploy-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-deploy-integration
-description: |
-  Deploy Lokalise integrations to Vercel, Netlify, and Cloud Run platforms.
+description: 'Deploy Lokalise integrations to Vercel, Netlify, and Cloud Run platforms.
+
   Use when deploying apps with Lokalise translations to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy lokalise", "lokalise Vercel",
+
   "lokalise production deploy", "lokalise Netlify", "lokalise Cloud Run".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(netlify:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, deployment, etl]
+tags:
+- saas
+- lokalise
+- deployment
+- etl
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Deploy Integration
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-enterprise-rbac/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: lokalise-enterprise-rbac
-description: |
-  Configure Lokalise enterprise SSO, role-based access control, and team management.
+description: 'Configure Lokalise enterprise SSO, role-based access control, and team
+  management.
+
   Use when implementing SSO integration, configuring role-based permissions,
+
   or setting up organization-level controls for Lokalise.
+
   Trigger with phrases like "lokalise SSO", "lokalise RBAC",
+
   "lokalise enterprise", "lokalise roles", "lokalise permissions", "lokalise team".
-allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Bash(node:*), Bash(npm:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Bash(node:*), Bash(npm:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, rbac]
+tags:
+- saas
+- lokalise
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Enterprise RBAC
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-hello-world/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-hello-world
-description: |
-  Create a minimal working Lokalise example.
+description: 'Create a minimal working Lokalise example.
+
   Use when starting a new Lokalise integration, testing your setup,
+
   or learning basic Lokalise API patterns.
+
   Trigger with phrases like "lokalise hello world", "lokalise example",
+
   "lokalise quick start", "simple lokalise code".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api, testing]
+tags:
+- saas
+- lokalise
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Hello World
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-incident-runbook
-description: |
-  Execute Lokalise incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Lokalise incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Lokalise-related outages, investigating errors,
+
   or running post-incident reviews for Lokalise integration failures.
+
   Trigger with phrases like "lokalise incident", "lokalise outage",
+
   "lokalise down", "lokalise on-call", "lokalise emergency", "translations broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(lokalise2:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, incident-response]
+tags:
+- saas
+- lokalise
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Incident Runbook
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-install-auth/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-install-auth
-description: |
-  Install and configure Lokalise SDK/CLI authentication.
+description: 'Install and configure Lokalise SDK/CLI authentication.
+
   Use when setting up a new Lokalise integration, configuring API tokens,
+
   or initializing Lokalise in your project.
+
   Trigger with phrases like "install lokalise", "setup lokalise",
+
   "lokalise auth", "configure lokalise API token".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(lokalise2:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api, authentication]
+tags:
+- saas
+- lokalise
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Install & Auth
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-local-dev-loop/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-local-dev-loop
-description: |
-  Configure Lokalise local development with file sync and hot reload.
+description: 'Configure Lokalise local development with file sync and hot reload.
+
   Use when setting up a development environment, configuring translation sync,
+
   or establishing a fast iteration cycle with Lokalise.
+
   Trigger with phrases like "lokalise dev setup", "lokalise local development",
+
   "lokalise dev environment", "develop with lokalise", "lokalise sync".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(lokalise2:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, lokalise-local]
+tags:
+- saas
+- lokalise
+- lokalise-local
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Local Dev Loop
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: lokalise-migration-deep-dive
-description: |
-  Execute major migration to Lokalise from other TMS platforms with data migration strategies.
+description: 'Execute major migration to Lokalise from other TMS platforms with data
+  migration strategies.
+
   Use when migrating to Lokalise from competitors, performing data imports,
+
   or re-platforming existing translation management to Lokalise.
+
   Trigger with phrases like "migrate to lokalise", "lokalise migration",
+
   "switch to lokalise", "lokalise import", "lokalise replatform".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(lokalise2:*), Bash(curl:*), Bash(jq:*), Bash(node:*), Bash(python3:*), Bash(mkdir:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(lokalise2:*), Bash(curl:*), Bash(jq:*),
+  Bash(node:*), Bash(python3:*), Bash(mkdir:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, migration]
+tags:
+- saas
+- lokalise
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Migration Deep Dive
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-multi-env-setup
-description: |
-  Configure Lokalise across development, staging, and production environments.
+description: 'Configure Lokalise across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment secrets,
+
   or implementing environment-specific Lokalise configurations.
+
   Trigger with phrases like "lokalise environments", "lokalise staging",
+
   "lokalise dev prod", "lokalise environment setup", "lokalise config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, deployment]
+tags:
+- saas
+- lokalise
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Multi-Environment Setup
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-observability/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: lokalise-observability
-description: |
-  Set up comprehensive observability for Lokalise integrations with metrics, traces, and alerts.
+description: 'Set up comprehensive observability for Lokalise integrations with metrics,
+  traces, and alerts.
+
   Use when implementing monitoring for Lokalise operations, setting up dashboards,
+
   or configuring alerting for Lokalise integration health.
+
   Trigger with phrases like "lokalise monitoring", "lokalise metrics",
+
   "lokalise observability", "monitor lokalise", "lokalise alerts", "lokalise tracing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, monitoring, observability, dashboard]
+tags:
+- saas
+- lokalise
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Observability
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: lokalise-performance-tuning
-description: |
-  Optimize Lokalise API performance with caching, pagination, and bulk operations.
+description: 'Optimize Lokalise API performance with caching, pagination, and bulk
+  operations.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Lokalise integrations.
+
   Trigger with phrases like "lokalise performance", "optimize lokalise",
+
   "lokalise latency", "lokalise caching", "lokalise slow", "lokalise batch".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*), Bash(jq:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*), Bash(jq:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api, performance]
+tags:
+- saas
+- lokalise
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Performance Tuning
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-prod-checklist
-description: |
-  Execute Lokalise production deployment checklist and rollback procedures.
+description: 'Execute Lokalise production deployment checklist and rollback procedures.
+
   Use when deploying Lokalise integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "lokalise production", "deploy lokalise",
+
   "lokalise go-live", "lokalise launch checklist".
+
+  '
 allowed-tools: Read, Bash(lokalise2:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, deployment]
+tags:
+- saas
+- lokalise
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Production Checklist
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-rate-limits/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-rate-limits
-description: |
-  Implement Lokalise rate limiting, backoff, and request queuing patterns.
+description: 'Implement Lokalise rate limiting, backoff, and request queuing patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Lokalise.
+
   Trigger with phrases like "lokalise rate limit", "lokalise throttling",
+
   "lokalise 429", "lokalise retry", "lokalise backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api]
+tags:
+- saas
+- lokalise
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Rate Limits
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-reference-architecture
-description: |
-  Implement Lokalise reference architecture with best-practice project layout.
+description: 'Implement Lokalise reference architecture with best-practice project
+  layout.
+
   Use when designing new Lokalise integrations, reviewing project structure,
+
   or establishing architecture standards for Lokalise applications.
+
   Trigger with phrases like "lokalise architecture", "lokalise best practices",
+
   "lokalise project structure", "how to organize lokalise", "lokalise layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, lokalise-reference]
+tags:
+- saas
+- lokalise
+- lokalise-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Reference Architecture
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: lokalise-sdk-patterns
-description: |
-  Apply production-ready Lokalise SDK patterns for TypeScript and Node.js.
+description: 'Apply production-ready Lokalise SDK patterns for TypeScript and Node.js.
+
   Use when implementing Lokalise integrations, refactoring SDK usage,
+
   or establishing team coding standards for Lokalise.
+
   Trigger with phrases like "lokalise SDK patterns", "lokalise best practices",
+
   "lokalise code patterns", "idiomatic lokalise".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, typescript, nodejs]
+tags:
+- saas
+- lokalise
+- typescript
+- nodejs
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise SDK Patterns
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-security-basics/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: lokalise-security-basics
-description: |
-  Apply Lokalise security best practices for API tokens and access control.
+description: 'Apply Lokalise security best practices for API tokens and access control.
+
   Use when securing API tokens, implementing least privilege access,
+
   or auditing Lokalise security configuration.
+
   Trigger with phrases like "lokalise security", "lokalise secrets",
+
   "secure lokalise", "lokalise API token security".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api, security, audit]
+tags:
+- saas
+- lokalise
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Security Basics
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-upgrade-migration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: lokalise-upgrade-migration
-description: |
-  Analyze, plan, and execute Lokalise SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Lokalise SDK upgrades with breaking change
+  detection.
+
   Use when upgrading Lokalise SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade lokalise", "lokalise migration",
+
   "lokalise breaking changes", "update lokalise SDK", "analyze lokalise version".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(node:*), Bash(grep:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(node:*),
+  Bash(grep:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, api, migration]
+tags:
+- saas
+- lokalise
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Upgrade Migration
 

--- a/plugins/saas-packs/lokalise-pack/skills/lokalise-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/lokalise-pack/skills/lokalise-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: lokalise-webhooks-events
-description: |
-  Implement Lokalise webhook handling and event processing.
+description: 'Implement Lokalise webhook handling and event processing.
+
   Use when setting up webhook endpoints, handling translation events,
+
   or building automation based on Lokalise notifications.
+
   Trigger with phrases like "lokalise webhook", "lokalise events",
+
   "lokalise notifications", "handle lokalise events", "lokalise automation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, lokalise, webhooks]
+tags:
+- saas
+- lokalise
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Lokalise Webhooks Events
 

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-ci-integration/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-ci-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-ci-integration
-description: |
-  Ci Integration for Lucidchart.
+description: 'Ci Integration for Lucidchart.
+
   Trigger: "lucidchart ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart CI Integration
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-common-errors/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-common-errors/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-common-errors
-description: |
-  Diagnose and fix Lucidchart common errors.
+description: 'Diagnose and fix Lucidchart common errors.
+
   Trigger: "lucidchart error", "fix lucidchart", "debug lucidchart".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Common Errors
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-core-workflow-a/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-core-workflow-a
-description: |
-  Execute Lucidchart primary workflow: Document & Shape Creation.
+description: 'Execute Lucidchart primary workflow: Document & Shape Creation.
+
   Trigger: "lucidchart document & shape creation", "primary lucidchart workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart — Document & Diagram Management
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-core-workflow-b/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-core-workflow-b
-description: |
-  Execute Lucidchart secondary workflow: Data-Linked Diagrams.
+description: 'Execute Lucidchart secondary workflow: Data-Linked Diagrams.
+
   Trigger: "lucidchart data-linked diagrams", "secondary lucidchart workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart — Collaboration & Sharing
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-cost-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-cost-tuning
-description: |
-  Cost Tuning for Lucidchart.
+description: 'Cost Tuning for Lucidchart.
+
   Trigger: "lucidchart cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-debug-bundle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-debug-bundle
-description: |
-  Debug Bundle for Lucidchart.
+description: 'Debug Bundle for Lucidchart.
+
   Trigger: "lucidchart debug bundle".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-deploy-integration
-description: |
-  Deploy Integration for Lucidchart.
+description: 'Deploy Integration for Lucidchart.
+
   Trigger: "lucidchart deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-hello-world/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-hello-world/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-hello-world
-description: |
-  Create a minimal working Lucidchart example.
+description: 'Create a minimal working Lucidchart example.
+
   Trigger: "lucidchart hello world", "lucidchart example", "test lucidchart".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Hello World
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-install-auth/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: lucidchart-install-auth
-description: |
-  Install and configure Lucidchart SDK/API authentication.
+description: 'Install and configure Lucidchart SDK/API authentication.
+
   Use when setting up a new Lucidchart integration.
+
   Trigger: "install lucidchart", "setup lucidchart", "lucidchart auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-local-dev-loop/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-local-dev-loop
-description: |
-  Local Dev Loop for Lucidchart.
+description: 'Local Dev Loop for Lucidchart.
+
   Trigger: "lucidchart local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: lucidchart-performance-tuning
-description: |
-  Optimize Lucidchart API integration performance with caching, batch shape operations, and pagination strategies.
-  Use when diagram exports are slow, shape updates hit rate limits, or document list queries time out.
+description: 'Optimize Lucidchart API integration performance with caching, batch
+  shape operations, and pagination strategies.
+
+  Use when diagram exports are slow, shape updates hit rate limits, or document list
+  queries time out.
+
   Trigger with "lucidchart performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-prod-checklist
-description: |
-  Prod Checklist for Lucidchart.
+description: 'Prod Checklist for Lucidchart.
+
   Trigger: "lucidchart prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-rate-limits/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-rate-limits
-description: |
-  Rate Limits for Lucidchart.
+description: 'Rate Limits for Lucidchart.
+
   Trigger: "lucidchart rate limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-reference-architecture/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-reference-architecture
-description: |
-  Reference Architecture for Lucidchart.
+description: 'Reference Architecture for Lucidchart.
+
   Trigger: "lucidchart reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-sdk-patterns/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-sdk-patterns
-description: |
-  Sdk Patterns for Lucidchart.
+description: 'Sdk Patterns for Lucidchart.
+
   Trigger: "lucidchart sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-security-basics/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-security-basics/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-security-basics
-description: |
-  Security Basics for Lucidchart.
+description: 'Security Basics for Lucidchart.
+
   Trigger: "lucidchart security basics".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Security Basics
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-upgrade-migration
-description: |
-  Upgrade Migration for Lucidchart.
+description: 'Upgrade Migration for Lucidchart.
+
   Trigger: "lucidchart upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/lucidchart-pack/skills/lucidchart-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/lucidchart-pack/skills/lucidchart-webhooks-events/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: lucidchart-webhooks-events
-description: |
-  Webhooks Events for Lucidchart.
+description: 'Webhooks Events for Lucidchart.
+
   Trigger: "lucidchart webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, lucidchart, diagramming]
-compatible-with: claude-code
+tags:
+- saas
+- lucidchart
+- diagramming
+compatibility: Designed for Claude Code
 ---
-
 # Lucidchart Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-ci-integration/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-ci-integration
-description: |
-  Integrate MaintainX API testing into CI/CD pipelines.
+description: 'Integrate MaintainX API testing into CI/CD pipelines.
+
   Use when setting up automated testing, configuring CI workflows,
+
   or implementing continuous integration for MaintainX integrations.
+
   Trigger with phrases like "maintainx ci", "maintainx github actions",
+
   "maintainx pipeline", "maintainx automated testing", "maintainx ci/cd".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, testing, ci-cd]
+tags:
+- saas
+- maintainx
+- api
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX CI Integration
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-common-errors/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-common-errors
-description: |
-  Debug and resolve common MaintainX API errors.
+description: 'Debug and resolve common MaintainX API errors.
+
   Use when encountering API errors, authentication issues,
+
   or unexpected responses from the MaintainX API.
+
   Trigger with phrases like "maintainx error", "maintainx 401",
+
   "maintainx api problem", "maintainx not working", "debug maintainx".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, debugging, authentication]
+tags:
+- saas
+- maintainx
+- api
+- debugging
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Common Errors
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-core-workflow-a
-description: |
-  Execute MaintainX primary workflow: Work Order lifecycle management.
+description: 'Execute MaintainX primary workflow: Work Order lifecycle management.
+
   Use when creating, updating, and managing work orders through their full lifecycle,
+
   from creation to completion with all status transitions.
+
   Trigger with phrases like "maintainx work order", "create work order",
+
   "work order lifecycle", "maintenance task", "manage work orders".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, workflow]
+tags:
+- saas
+- maintainx
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Core Workflow A: Work Order Lifecycle
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-core-workflow-b
-description: |
-  Execute MaintainX secondary workflow: Asset and Location management.
+description: 'Execute MaintainX secondary workflow: Asset and Location management.
+
   Use when managing equipment assets, organizing locations/facilities,
+
   building asset hierarchies, and tracking equipment maintenance history.
+
   Trigger with phrases like "maintainx asset", "maintainx location",
+
   "equipment tracking", "asset management", "facility hierarchy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, workflow]
+tags:
+- saas
+- maintainx
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Core Workflow B: Asset & Location Management
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-cost-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-cost-tuning
-description: |
-  Optimize MaintainX API usage for cost efficiency.
+description: 'Optimize MaintainX API usage for cost efficiency.
+
   Use when managing API costs, optimizing request volume,
+
   or implementing cost-effective integration patterns with MaintainX.
+
   Trigger with phrases like "maintainx cost", "maintainx billing",
+
   "reduce maintainx usage", "maintainx api costs", "maintainx optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, cost-optimization]
+tags:
+- saas
+- maintainx
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Cost Tuning
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-data-handling/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-data-handling
-description: |
-  Data synchronization, ETL patterns, and data management for MaintainX.
+description: 'Data synchronization, ETL patterns, and data management for MaintainX.
+
   Use when syncing data between MaintainX and other systems,
+
   building ETL pipelines, or managing data consistency.
+
   Trigger with phrases like "maintainx data sync", "maintainx etl",
+
   "maintainx export", "maintainx data migration", "maintainx data pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, migration, data-pipeline, etl]
+tags:
+- saas
+- maintainx
+- migration
+- data-pipeline
+- etl
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Data Handling
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-debug-bundle
-description: |
-  Comprehensive debugging toolkit for MaintainX integrations.
+description: 'Comprehensive debugging toolkit for MaintainX integrations.
+
   Use when experiencing complex issues, need detailed logging,
+
   or troubleshooting integration problems with MaintainX.
+
   Trigger with phrases like "debug maintainx", "maintainx troubleshoot",
+
   "maintainx detailed logs", "diagnose maintainx", "maintainx issue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, debugging, logging]
+tags:
+- saas
+- maintainx
+- debugging
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Debug Bundle
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-deploy-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-deploy-integration
-description: |
-  Deploy MaintainX integrations to production environments.
+description: 'Deploy MaintainX integrations to production environments.
+
   Use when deploying to cloud platforms, configuring production environments,
+
   or automating deployment pipelines for MaintainX integrations.
+
   Trigger with phrases like "deploy maintainx", "maintainx deployment",
+
   "maintainx cloud deploy", "maintainx kubernetes", "maintainx docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(docker:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, deployment, docker, kubernetes]
+tags:
+- saas
+- maintainx
+- deployment
+- docker
+- kubernetes
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Deploy Integration
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-enterprise-rbac
-description: |
-  Configure enterprise role-based access control for MaintainX integrations.
+description: 'Configure enterprise role-based access control for MaintainX integrations.
+
   Use when implementing SSO, managing organization-level permissions,
+
   or setting up enterprise access controls with MaintainX.
+
   Trigger with phrases like "maintainx rbac", "maintainx sso",
+
   "maintainx enterprise", "maintainx permissions", "maintainx roles".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, rbac]
+tags:
+- saas
+- maintainx
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Enterprise RBAC
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-hello-world/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-hello-world
-description: |
-  Create a minimal working MaintainX example - your first work order.
+description: 'Create a minimal working MaintainX example - your first work order.
+
   Use when starting a new MaintainX integration, testing your setup,
+
   or learning basic MaintainX API patterns.
+
   Trigger with phrases like "maintainx hello world", "maintainx example",
+
   "maintainx quick start", "create first work order", "simple maintainx code".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, testing]
+tags:
+- saas
+- maintainx
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Hello World
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-incident-runbook
-description: |
-  Manage incident response for MaintainX integration failures.
+description: 'Manage incident response for MaintainX integration failures.
+
   Use when experiencing outages, investigating issues,
+
   or responding to MaintainX integration incidents.
+
   Trigger with phrases like "maintainx incident", "maintainx outage",
+
   "maintainx down", "maintainx emergency", "maintainx runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, incident-response]
+tags:
+- saas
+- maintainx
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Incident Runbook
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-install-auth/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-install-auth
-description: |
-  Install and configure MaintainX REST API authentication.
+description: 'Install and configure MaintainX REST API authentication.
+
   Use when setting up a new MaintainX integration, configuring API keys,
+
   or initializing MaintainX API access in your project.
+
   Trigger with phrases like "install maintainx", "setup maintainx",
+
   "maintainx auth", "configure maintainx API key", "maintainx credentials".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, authentication]
+tags:
+- saas
+- maintainx
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Install & Auth
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-local-dev-loop
-description: |
-  Set up a local development loop for MaintainX integration development.
+description: 'Set up a local development loop for MaintainX integration development.
+
   Use when configuring dev environment, testing API calls locally,
+
   or setting up a sandbox workflow for MaintainX.
+
   Trigger with phrases like "maintainx dev setup", "maintainx local",
+
   "maintainx development environment", "maintainx testing setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, testing, workflow]
+tags:
+- saas
+- maintainx
+- api
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Local Dev Loop
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-migration-deep-dive
-description: |
-  Execute complete platform migrations to or from MaintainX.
+description: 'Execute complete platform migrations to or from MaintainX.
+
   Use when migrating from legacy CMMS systems, performing major re-platforming,
+
   or transitioning to MaintainX from spreadsheets or other tools.
+
   Trigger with phrases like "migrate to maintainx", "maintainx migration",
+
   "cmms migration", "switch to maintainx", "maintainx data migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, migration]
+tags:
+- saas
+- maintainx
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Migration Deep Dive
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-multi-env-setup
-description: |
-  Configure multiple MaintainX environments (dev, staging, production).
+description: 'Configure multiple MaintainX environments (dev, staging, production).
+
   Use when setting up environment-specific configurations,
+
   managing multiple MaintainX accounts, or implementing environment promotion.
+
   Trigger with phrases like "maintainx environments", "maintainx staging",
+
   "maintainx dev prod", "maintainx multi-environment", "maintainx config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, maintainx-multi]
+tags:
+- saas
+- maintainx
+- maintainx-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Multi-Environment Setup
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-observability/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-observability
-description: |
-  Implement comprehensive observability for MaintainX integrations.
+description: 'Implement comprehensive observability for MaintainX integrations.
+
   Use when setting up monitoring, logging, tracing, and alerting
+
   for MaintainX API integrations.
+
   Trigger with phrases like "maintainx monitoring", "maintainx logging",
+
   "maintainx metrics", "maintainx observability", "maintainx alerts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, monitoring, observability]
+tags:
+- saas
+- maintainx
+- api
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Observability
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-performance-tuning/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-performance-tuning
-description: |
-  Optimize MaintainX API integration performance.
+description: 'Optimize MaintainX API integration performance.
+
   Use when experiencing slow API responses, optimizing data fetching,
+
   or improving integration throughput with MaintainX.
+
   Trigger with phrases like "maintainx performance", "maintainx slow",
+
   "optimize maintainx", "maintainx caching", "maintainx faster".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, performance]
+tags:
+- saas
+- maintainx
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Performance Tuning
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-prod-checklist
-description: |
-  Production deployment checklist for MaintainX integrations.
+description: 'Production deployment checklist for MaintainX integrations.
+
   Use when preparing to deploy a MaintainX integration to production,
+
   verifying production readiness, or auditing existing deployments.
+
   Trigger with phrases like "maintainx production", "deploy maintainx",
+
   "maintainx go-live", "maintainx production checklist", "maintainx launch".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, deployment, audit]
+tags:
+- saas
+- maintainx
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Production Checklist
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-rate-limits/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-rate-limits
-description: |
-  Implement MaintainX API rate limiting, pagination, and backoff patterns.
+description: 'Implement MaintainX API rate limiting, pagination, and backoff patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for MaintainX.
+
   Trigger with phrases like "maintainx rate limit", "maintainx throttling",
+
   "maintainx 429", "maintainx retry", "maintainx backoff", "maintainx pagination".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api]
+tags:
+- saas
+- maintainx
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Rate Limits
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-reference-architecture
-description: |
-  Production-grade architecture patterns for MaintainX integrations.
+description: 'Production-grade architecture patterns for MaintainX integrations.
+
   Use when designing system architecture, planning integrations,
+
   or building enterprise-scale MaintainX solutions.
+
   Trigger with phrases like "maintainx architecture", "maintainx design",
+
   "maintainx system design", "maintainx enterprise", "maintainx patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, scaling]
+tags:
+- saas
+- maintainx
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Reference Architecture
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-sdk-patterns
-description: |
-  Learn MaintainX REST API patterns, pagination, filtering, and client architecture.
+description: 'Learn MaintainX REST API patterns, pagination, filtering, and client
+  architecture.
+
   Use when building robust API integrations, implementing pagination,
+
   or creating reusable SDK patterns for MaintainX.
+
   Trigger with phrases like "maintainx sdk", "maintainx api patterns",
+
   "maintainx pagination", "maintainx filtering", "maintainx client design".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api]
+tags:
+- saas
+- maintainx
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX SDK Patterns
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-security-basics/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-security-basics/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: maintainx-security-basics
-description: |
-  Configure MaintainX API security, credential management, and access control.
+description: 'Configure MaintainX API security, credential management, and access
+  control.
+
   Use when securing API keys, implementing access controls,
+
   or hardening your MaintainX integration.
+
   Trigger with phrases like "maintainx security", "maintainx api key security",
+
   "secure maintainx", "maintainx credentials", "maintainx access control".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, security]
+tags:
+- saas
+- maintainx
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Security Basics
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: maintainx-upgrade-migration
-description: |
-  Migrate MaintainX API versions and handle breaking changes.
+description: 'Migrate MaintainX API versions and handle breaking changes.
+
   Use when upgrading API versions, handling deprecations,
+
   or migrating between MaintainX API releases.
+
   Trigger with phrases like "maintainx upgrade", "maintainx api version",
+
   "maintainx migration", "maintainx breaking changes", "maintainx deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, api, migration]
+tags:
+- saas
+- maintainx
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Upgrade & Migration
 

--- a/plugins/saas-packs/maintainx-pack/skills/maintainx-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/maintainx-pack/skills/maintainx-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: maintainx-webhooks-events
-description: |
-  Implement MaintainX webhook handling and event-driven integrations.
+description: 'Implement MaintainX webhook handling and event-driven integrations.
+
   Use when setting up webhooks, handling MaintainX events,
+
   or building real-time integrations with MaintainX.
+
   Trigger with phrases like "maintainx webhook", "maintainx events",
+
   "maintainx notifications", "maintainx real-time", "maintainx triggers".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, maintainx, webhooks]
+tags:
+- saas
+- maintainx
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # MaintainX Webhooks & Events
 

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-ci-integration/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-ci-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-ci-integration
-description: |
-  Ci Integration for MindTickle.
+description: 'Ci Integration for MindTickle.
+
   Trigger: "mindtickle ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle CI Integration
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-common-errors/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-common-errors/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-common-errors
-description: |
-  Diagnose and fix MindTickle common errors.
+description: 'Diagnose and fix MindTickle common errors.
+
   Trigger: "mindtickle error", "fix mindtickle", "debug mindtickle".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Common Errors
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-core-workflow-a/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-core-workflow-a
-description: |
-  Execute MindTickle primary workflow: Training Content Management.
+description: 'Execute MindTickle primary workflow: Training Content Management.
+
   Trigger: "mindtickle training content management", "primary mindtickle workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle — Course & Module Management
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-core-workflow-b/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-core-workflow-b
-description: |
-  Execute MindTickle secondary workflow: Rep Performance & Readiness.
+description: 'Execute MindTickle secondary workflow: Rep Performance & Readiness.
+
   Trigger: "mindtickle rep performance & readiness", "secondary mindtickle workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle — Quiz & Assessment
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-cost-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-cost-tuning
-description: |
-  Cost Tuning for MindTickle.
+description: 'Cost Tuning for MindTickle.
+
   Trigger: "mindtickle cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-debug-bundle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-debug-bundle
-description: |
-  Debug Bundle for MindTickle.
+description: 'Debug Bundle for MindTickle.
+
   Trigger: "mindtickle debug bundle".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-deploy-integration
-description: |
-  Deploy Integration for MindTickle.
+description: 'Deploy Integration for MindTickle.
+
   Trigger: "mindtickle deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-hello-world/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-hello-world/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-hello-world
-description: |
-  Create a minimal working MindTickle example.
+description: 'Create a minimal working MindTickle example.
+
   Trigger: "mindtickle hello world", "mindtickle example", "test mindtickle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Hello World
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-install-auth/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: mindtickle-install-auth
-description: |
-  Install and configure MindTickle SDK/API authentication.
+description: 'Install and configure MindTickle SDK/API authentication.
+
   Use when setting up a new MindTickle integration.
+
   Trigger: "install mindtickle", "setup mindtickle", "mindtickle auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-local-dev-loop/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-local-dev-loop
-description: |
-  Local Dev Loop for MindTickle.
+description: 'Local Dev Loop for MindTickle.
+
   Trigger: "mindtickle local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: mindtickle-performance-tuning
-description: |
-  Optimize MindTickle API integration performance with caching, bulk progress queries, and webhook processing.
-  Use when learner progress queries are slow, report generation times out, or completion webhooks cause backpressure.
+description: 'Optimize MindTickle API integration performance with caching, bulk progress
+  queries, and webhook processing.
+
+  Use when learner progress queries are slow, report generation times out, or completion
+  webhooks cause backpressure.
+
   Trigger with "mindtickle performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-prod-checklist
-description: |
-  Prod Checklist for MindTickle.
+description: 'Prod Checklist for MindTickle.
+
   Trigger: "mindtickle prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-rate-limits/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-rate-limits
-description: |
-  Rate Limits for MindTickle.
+description: 'Rate Limits for MindTickle.
+
   Trigger: "mindtickle rate limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-reference-architecture/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-reference-architecture
-description: |
-  Reference Architecture for MindTickle.
+description: 'Reference Architecture for MindTickle.
+
   Trigger: "mindtickle reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-sdk-patterns/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-sdk-patterns
-description: |
-  Sdk Patterns for MindTickle.
+description: 'Sdk Patterns for MindTickle.
+
   Trigger: "mindtickle sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-security-basics/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-security-basics/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-security-basics
-description: |
-  Security Basics for MindTickle.
+description: 'Security Basics for MindTickle.
+
   Trigger: "mindtickle security basics".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Security Basics
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-upgrade-migration
-description: |
-  Upgrade Migration for MindTickle.
+description: 'Upgrade Migration for MindTickle.
+
   Trigger: "mindtickle upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/mindtickle-pack/skills/mindtickle-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/mindtickle-pack/skills/mindtickle-webhooks-events/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: mindtickle-webhooks-events
-description: |
-  Webhooks Events for MindTickle.
+description: 'Webhooks Events for MindTickle.
+
   Trigger: "mindtickle webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, mindtickle, sales]
-compatible-with: claude-code
+tags:
+- saas
+- mindtickle
+- sales
+compatibility: Designed for Claude Code
 ---
-
 # MindTickle Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-ci-integration/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-ci-integration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: miro-ci-integration
-description: |
-  Configure CI/CD pipelines for Miro REST API v2 integrations with GitHub Actions,
+description: 'Configure CI/CD pipelines for Miro REST API v2 integrations with GitHub
+  Actions,
+
   test board isolation, and automated validation.
+
   Trigger with phrases like "miro CI", "miro GitHub Actions",
+
   "miro automated tests", "CI miro", "miro pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, ci-cd, github-actions]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- ci-cd
+- github-actions
+compatibility: Designed for Claude Code
 ---
-
 # Miro CI Integration
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-common-errors/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: miro-common-errors
-description: |
-  Diagnose and fix Miro REST API v2 errors by HTTP status code.
+description: 'Diagnose and fix Miro REST API v2 errors by HTTP status code.
+
   Use when encountering Miro API errors, debugging failed requests,
+
   or troubleshooting authentication and permission issues.
+
   Trigger with phrases like "miro error", "fix miro",
+
   "miro not working", "debug miro", "miro 401", "miro 403", "miro 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, errors, troubleshooting]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- errors
+- troubleshooting
+compatibility: Designed for Claude Code
 ---
-
 # Miro Common Errors
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-core-workflow-a/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: miro-core-workflow-a
-description: |
-  Manage Miro boards and items — create, read, update, delete boards,
-  sticky notes, shapes, cards, frames, and tags via REST API v2.
-  Trigger with phrases like "miro board management", "create miro board",
-  "miro items CRUD", "miro sticky notes", "organize miro board".
+description: "Manage Miro boards and items \u2014 create, read, update, delete boards,\n\
+  sticky notes, shapes, cards, frames, and tags via REST API v2.\nTrigger with phrases\
+  \ like \"miro board management\", \"create miro board\",\n\"miro items CRUD\", \"\
+  miro sticky notes\", \"organize miro board\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, boards, items]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- boards
+- items
+compatibility: Designed for Claude Code
 ---
-
 # Miro Core Workflow A — Boards & Items CRUD
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-core-workflow-b/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: miro-core-workflow-b
-description: |
-  Manage Miro connectors, images, embeds, app cards, and document items via REST API v2.
+description: 'Manage Miro connectors, images, embeds, app cards, and document items
+  via REST API v2.
+
   Use for visual workflows, embedding content, and building rich board layouts.
+
   Trigger with phrases like "miro connectors", "miro embed",
+
   "miro app card", "miro image upload", "connect miro items".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, connectors, embeds, app-cards]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- connectors
+- embeds
+- app-cards
+compatibility: Designed for Claude Code
 ---
-
 # Miro Core Workflow B — Connectors, Embeds & Rich Items
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-cost-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: miro-cost-tuning
-description: |
-  Optimize Miro API costs through credit monitoring, request reduction,
+description: 'Optimize Miro API costs through credit monitoring, request reduction,
+
   and plan selection based on the credit-based rate limiting model.
+
   Trigger with phrases like "miro cost", "miro billing",
+
   "reduce miro costs", "miro pricing", "miro credits usage".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, cost-optimization, billing]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- cost-optimization
+- billing
+compatibility: Designed for Claude Code
 ---
-
 # Miro Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-data-handling/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-data-handling/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: miro-data-handling
-description: |
-  Implement Miro REST API v2 data handling with PII detection in board content,
+description: 'Implement Miro REST API v2 data handling with PII detection in board
+  content,
+
   data export via API, retention policies, and GDPR/CCPA compliance patterns.
+
   Trigger with phrases like "miro data", "miro PII",
+
   "miro GDPR", "miro data export", "miro privacy", "miro compliance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, data-handling, privacy, compliance]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- data-handling
+- privacy
+- compliance
+compatibility: Designed for Claude Code
 ---
-
 # Miro Data Handling
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: miro-debug-bundle
-description: |
-  Collect Miro REST API v2 diagnostic evidence for support tickets.
+description: 'Collect Miro REST API v2 diagnostic evidence for support tickets.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Miro integration problems.
+
   Trigger with phrases like "miro debug", "miro support bundle",
+
   "collect miro logs", "miro diagnostic", "miro support ticket".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, debugging, diagnostics]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- debugging
+- diagnostics
+compatibility: Designed for Claude Code
 ---
-
 # Miro Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: miro-deploy-integration
-description: |
-  Deploy Miro REST API v2 integrations to Vercel, Fly.io, and Cloud Run
+description: 'Deploy Miro REST API v2 integrations to Vercel, Fly.io, and Cloud Run
+
   with proper OAuth token management and webhook configuration.
+
   Trigger with phrases like "deploy miro", "miro Vercel",
+
   "miro production deploy", "miro Cloud Run", "miro Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, deployment, cloud]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- deployment
+- cloud
+compatibility: Designed for Claude Code
 ---
-
 # Miro Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-enterprise-rbac/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: miro-enterprise-rbac
-description: |
-  Configure Miro Enterprise features: organization management, SCIM provisioning,
+description: 'Configure Miro Enterprise features: organization management, SCIM provisioning,
+
   board-level access control, audit logs, and SSO integration via REST API v2.
+
   Trigger with phrases like "miro SSO", "miro RBAC",
+
   "miro enterprise", "miro SCIM", "miro permissions", "miro organization".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, enterprise, rbac, scim]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- enterprise
+- rbac
+- scim
+compatibility: Designed for Claude Code
 ---
-
 # Miro Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-hello-world/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: miro-hello-world
-description: |
-  Create a minimal working Miro example with real board and item operations.
+description: 'Create a minimal working Miro example with real board and item operations.
+
   Use when starting a new Miro integration, testing your setup,
+
   or learning the Miro REST API v2 item model.
+
   Trigger with phrases like "miro hello world", "miro example",
+
   "miro quick start", "first miro board", "create miro sticky note".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, quickstart]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- quickstart
+compatibility: Designed for Claude Code
 ---
-
 # Miro Hello World
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: miro-incident-runbook
-description: |
-  Execute Miro REST API v2 incident response with triage, mitigation, and postmortem.
+description: 'Execute Miro REST API v2 incident response with triage, mitigation,
+  and postmortem.
+
   Use when responding to Miro-related outages, investigating API errors,
+
   or running post-incident reviews for Miro integration failures.
+
   Trigger with phrases like "miro incident", "miro outage",
+
   "miro down", "miro on-call", "miro emergency", "miro broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(jq:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, incident-response, runbook]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- incident-response
+- runbook
+compatibility: Designed for Claude Code
 ---
-
 # Miro Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-install-auth/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: miro-install-auth
-description: |
-  Install and configure Miro REST API v2 authentication with OAuth 2.0.
+description: 'Install and configure Miro REST API v2 authentication with OAuth 2.0.
+
   Use when setting up a new Miro app, configuring OAuth tokens,
+
   or initializing the @mirohq/miro-api Node.js client.
+
   Trigger with phrases like "install miro", "setup miro",
+
   "miro auth", "miro OAuth", "configure miro API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, oauth, authentication]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- oauth
+- authentication
+compatibility: Designed for Claude Code
 ---
-
 # Miro Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: miro-local-dev-loop
-description: |
-  Configure Miro local development with hot reload, testing, and ngrok tunneling.
+description: 'Configure Miro local development with hot reload, testing, and ngrok
+  tunneling.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with the Miro REST API v2.
+
   Trigger with phrases like "miro dev setup", "miro local development",
+
   "miro dev environment", "develop with miro", "miro testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, development, testing]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- development
+- testing
+compatibility: Designed for Claude Code
 ---
-
 # Miro Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-migration-deep-dive/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: miro-migration-deep-dive
-description: |
-  Execute major Miro migrations — migrate boards between teams/orgs,
-  export board content to external systems, import data into Miro,
-  and re-platform from competing whiteboard tools using REST API v2.
-  Trigger with phrases like "migrate miro", "miro migration",
-  "export miro boards", "import to miro", "miro data migration".
+description: "Execute major Miro migrations \u2014 migrate boards between teams/orgs,\n\
+  export board content to external systems, import data into Miro,\nand re-platform\
+  \ from competing whiteboard tools using REST API v2.\nTrigger with phrases like\
+  \ \"migrate miro\", \"miro migration\",\n\"export miro boards\", \"import to miro\"\
+  , \"miro data migration\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, migration, data-export]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- migration
+- data-export
+compatibility: Designed for Claude Code
 ---
-
 # Miro Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-multi-env-setup/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: miro-multi-env-setup
-description: |
-  Configure Miro REST API v2 across development, staging, and production
+description: 'Configure Miro REST API v2 across development, staging, and production
+
   with separate OAuth apps, isolated test boards, and secret management.
+
   Trigger with phrases like "miro environments", "miro staging",
+
   "miro dev prod", "miro environment setup", "miro multi env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(aws:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, environments, configuration]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- environments
+- configuration
+compatibility: Designed for Claude Code
 ---
-
 # Miro Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-observability/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-observability/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: miro-observability
-description: |
-  Set up observability for Miro REST API v2 integrations with Prometheus metrics,
+description: 'Set up observability for Miro REST API v2 integrations with Prometheus
+  metrics,
+
   OpenTelemetry traces, structured logging, and Grafana dashboards.
+
   Trigger with phrases like "miro monitoring", "miro metrics",
+
   "miro observability", "monitor miro", "miro alerts", "miro tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, observability, monitoring]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- observability
+- monitoring
+compatibility: Designed for Claude Code
 ---
-
 # Miro Observability
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-performance-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: miro-performance-tuning
-description: |
-  Optimize Miro REST API v2 performance with caching, cursor pagination,
+description: 'Optimize Miro REST API v2 performance with caching, cursor pagination,
+
   request batching, and connection pooling for high-throughput integrations.
+
   Trigger with phrases like "miro performance", "optimize miro",
+
   "miro latency", "miro caching", "miro slow", "miro batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, performance, caching]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- performance
+- caching
+compatibility: Designed for Claude Code
 ---
-
 # Miro Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: miro-prod-checklist
-description: |
-  Execute Miro REST API v2 production deployment checklist and rollback procedures.
+description: 'Execute Miro REST API v2 production deployment checklist and rollback
+  procedures.
+
   Use when deploying Miro integrations to production, preparing for launch,
+
   or implementing go-live procedures for Miro apps.
+
   Trigger with phrases like "miro production", "deploy miro",
+
   "miro go-live", "miro launch checklist", "miro production ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, production, deployment]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- production
+- deployment
+compatibility: Designed for Claude Code
 ---
-
 # Miro Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-rate-limits/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: miro-rate-limits
-description: |
-  Implement Miro REST API v2 rate limiting with the credit-based system,
+description: 'Implement Miro REST API v2 rate limiting with the credit-based system,
+
   exponential backoff, and request queuing.
+
   Trigger with phrases like "miro rate limit", "miro throttling",
+
   "miro 429", "miro retry", "miro backoff", "miro credits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, rate-limits, performance]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- rate-limits
+- performance
+compatibility: Designed for Claude Code
 ---
-
 # Miro Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-reference-architecture/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: miro-reference-architecture
-description: |
-  Implement a production-ready reference architecture for Miro REST API v2
+description: 'Implement a production-ready reference architecture for Miro REST API
+  v2
+
   integrations with layered design, caching, and event processing.
+
   Trigger with phrases like "miro architecture", "miro project structure",
+
   "how to organize miro integration", "miro design patterns".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, architecture, design]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- architecture
+- design
+compatibility: Designed for Claude Code
 ---
-
 # Miro Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: miro-sdk-patterns
-description: |
-  Apply production-ready patterns for @mirohq/miro-api client usage.
+description: 'Apply production-ready patterns for @mirohq/miro-api client usage.
+
   Use when implementing Miro integrations, refactoring SDK usage,
+
   or establishing coding standards for Miro REST API v2.
+
   Trigger with phrases like "miro SDK patterns", "miro best practices",
+
   "miro code patterns", "miro client wrapper", "miro typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, patterns, typescript]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- patterns
+- typescript
+compatibility: Designed for Claude Code
 ---
-
 # Miro SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-security-basics/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-security-basics/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: miro-security-basics
-description: |
-  Apply Miro REST API v2 security best practices — OAuth scope minimization,
-  token storage, webhook signature validation, and secret rotation.
-  Trigger with phrases like "miro security", "miro secrets",
-  "secure miro", "miro token security", "miro webhook signature".
+description: "Apply Miro REST API v2 security best practices \u2014 OAuth scope minimization,\n\
+  token storage, webhook signature validation, and secret rotation.\nTrigger with\
+  \ phrases like \"miro security\", \"miro secrets\",\n\"secure miro\", \"miro token\
+  \ security\", \"miro webhook signature\".\n"
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, security, oauth]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- security
+- oauth
+compatibility: Designed for Claude Code
 ---
-
 # Miro Security Basics
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: miro-upgrade-migration
-description: |
-  Migrate Miro integrations from REST API v1 to v2 and upgrade @mirohq/miro-api SDK.
+description: 'Migrate Miro integrations from REST API v1 to v2 and upgrade @mirohq/miro-api
+  SDK.
+
   Use when upgrading SDK versions, migrating v1 widget endpoints to v2 item endpoints,
+
   or handling breaking changes in the Miro platform.
+
   Trigger with phrases like "upgrade miro", "miro migration",
+
   "miro v1 to v2", "update miro SDK", "miro breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, migration, upgrade]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- migration
+- upgrade
+compatibility: Designed for Claude Code
 ---
-
 # Miro Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/miro-pack/skills/miro-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/miro-pack/skills/miro-webhooks-events/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: miro-webhooks-events
-description: |
-  Implement Miro REST API v2 webhooks with board subscriptions, event handling,
+description: 'Implement Miro REST API v2 webhooks with board subscriptions, event
+  handling,
+
   and signature verification for real-time board change notifications.
+
   Trigger with phrases like "miro webhook", "miro events",
+
   "miro board subscription", "miro real-time", "miro notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, miro, webhooks, events]
-compatible-with: claude-code
+tags:
+- saas
+- miro
+- webhooks
+- events
+compatibility: Designed for Claude Code
 ---
-
 # Miro Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/mistral-pack/skills/mistral-ci-integration/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-ci-integration
-description: |
-  Configure Mistral AI CI/CD integration with GitHub Actions and prompt testing.
+description: 'Configure Mistral AI CI/CD integration with GitHub Actions and prompt
+  testing.
+
   Use when setting up automated testing, prompt regression suites,
+
   or integrating Mistral AI quality gates into your build process.
+
   Trigger with phrases like "mistral CI", "mistral GitHub Actions",
+
   "mistral automated tests", "CI mistral", "prompt testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, testing, ci-cd]
+tags:
+- saas
+- mistral
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral CI Integration
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-common-errors/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-common-errors
-description: |
-  Diagnose and fix Mistral AI common errors and exceptions.
+description: 'Diagnose and fix Mistral AI common errors and exceptions.
+
   Use when encountering Mistral errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "mistral error", "fix mistral",
+
   "mistral not working", "debug mistral".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, debugging]
+tags:
+- saas
+- mistral
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Common Errors
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-core-workflow-a
-description: |
-  Execute Mistral AI chat completions with streaming, multi-turn, and guardrails.
+description: 'Execute Mistral AI chat completions with streaming, multi-turn, and
+  guardrails.
+
   Use when implementing chat interfaces, building conversational AI,
+
   or integrating Mistral for text generation.
+
   Trigger with phrases like "mistral chat", "mistral completion",
+
   "mistral streaming", "mistral conversation", "mistral guardrails".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, workflow]
+tags:
+- saas
+- mistral
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Core Workflow A: Chat Completions
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-core-workflow-b
-description: |
-  Execute Mistral AI embeddings, function calling, and RAG pipelines.
+description: 'Execute Mistral AI embeddings, function calling, and RAG pipelines.
+
   Use when implementing semantic search, RAG applications,
+
   tool-augmented LLM interactions, or code embeddings.
+
   Trigger with phrases like "mistral embeddings", "mistral function calling",
+
   "mistral tools", "mistral RAG", "mistral semantic search".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, llm, embeddings, workflow]
+tags:
+- saas
+- mistral
+- llm
+- embeddings
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Core Workflow B: Embeddings & Function Calling
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: mistral-cost-tuning
-description: |
-  Optimize Mistral AI costs through model selection, token management, and usage monitoring.
+description: 'Optimize Mistral AI costs through model selection, token management,
+  and usage monitoring.
+
   Use when analyzing Mistral billing, reducing API costs,
+
   or implementing usage monitoring and budget alerts.
+
   Trigger with phrases like "mistral cost", "mistral billing",
+
   "reduce mistral costs", "mistral pricing", "mistral budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, monitoring, cost-optimization]
+tags:
+- saas
+- mistral
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Cost Tuning
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-data-handling/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-data-handling/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-data-handling
-description: |
-  Implement Mistral AI PII handling, data retention, and GDPR/CCPA compliance patterns.
-  Use when handling sensitive data, implementing data redaction, configuring retention policies,
+description: 'Implement Mistral AI PII handling, data retention, and GDPR/CCPA compliance
+  patterns.
+
+  Use when handling sensitive data, implementing data redaction, configuring retention
+  policies,
+
   or ensuring compliance with privacy regulations for Mistral AI integrations.
+
   Trigger with phrases like "mistral data", "mistral PII",
+
   "mistral GDPR", "mistral data retention", "mistral privacy".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, compliance]
+tags:
+- saas
+- mistral
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral Data Handling
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-debug-bundle
-description: |
-  Collect Mistral AI debug evidence for support tickets and troubleshooting.
+description: 'Collect Mistral AI debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Mistral AI problems.
+
   Trigger with phrases like "mistral debug", "mistral support bundle",
+
   "collect mistral logs", "mistral diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, debugging]
+tags:
+- saas
+- mistral
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Debug Bundle
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-deploy-integration
-description: |
-  Deploy Mistral AI integrations to Vercel, Docker, and Cloud Run platforms.
+description: 'Deploy Mistral AI integrations to Vercel, Docker, and Cloud Run platforms.
+
   Use when deploying Mistral AI-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy mistral", "mistral Vercel",
+
   "mistral production deploy", "mistral Cloud Run", "mistral Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(docker:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, deployment]
+tags:
+- saas
+- mistral
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Deploy Integration
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-enterprise-rbac
-description: |
-  Configure Mistral AI enterprise access control and workspace management.
+description: 'Configure Mistral AI enterprise access control and workspace management.
+
   Use when implementing role-based API key scoping, managing team access,
+
   or setting up organization-level controls for Mistral AI.
+
   Trigger with phrases like "mistral access control", "mistral RBAC",
+
   "mistral enterprise", "mistral roles", "mistral team".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, rbac]
+tags:
+- saas
+- mistral
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Enterprise RBAC
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-hello-world/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-hello-world
-description: |
-  Create a minimal working Mistral AI chat completion example.
+description: 'Create a minimal working Mistral AI chat completion example.
+
   Use when starting a new Mistral integration, testing your setup,
+
   or learning basic Mistral API patterns.
+
   Trigger with phrases like "mistral hello world", "mistral example",
+
   "mistral quick start", "simple mistral code", "mistral chat".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, testing]
+tags:
+- saas
+- mistral
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Hello World
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-incident-runbook
-description: |
-  Execute Mistral AI incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Mistral AI incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Mistral AI-related outages, investigating errors,
+
   or running post-incident reviews.
+
   Trigger with phrases like "mistral incident", "mistral outage",
+
   "mistral down", "mistral on-call", "mistral emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, incident-response]
+tags:
+- saas
+- mistral
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Incident Runbook
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-install-auth/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-install-auth
-description: |
-  Install and configure the Mistral AI SDK with authentication.
+description: 'Install and configure the Mistral AI SDK with authentication.
+
   Use when setting up a new Mistral integration, configuring API keys,
+
   or initializing Mistral AI in your project.
+
   Trigger with phrases like "install mistral", "setup mistral",
+
   "mistral auth", "configure mistral API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, authentication]
+tags:
+- saas
+- mistral
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Install & Auth
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-local-dev-loop
-description: |
-  Configure Mistral AI local development with hot reload, testing, and mocking.
+description: 'Configure Mistral AI local development with hot reload, testing, and
+  mocking.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Mistral AI.
+
   Trigger with phrases like "mistral dev setup", "mistral local development",
+
   "mistral dev environment", "develop with mistral".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, testing, workflow]
+tags:
+- saas
+- mistral
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Local Dev Loop
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-migration-deep-dive
-description: |
-  Execute migration to Mistral AI from OpenAI, Anthropic, or other providers.
+description: 'Execute migration to Mistral AI from OpenAI, Anthropic, or other providers.
+
   Use when migrating to Mistral AI from another provider, performing major refactoring,
+
   or re-platforming existing AI integrations to Mistral AI.
+
   Trigger with phrases like "migrate to mistral", "mistral migration",
+
   "switch to mistral", "openai to mistral", "anthropic to mistral".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, migration]
+tags:
+- saas
+- mistral
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Migration Deep Dive
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-multi-env-setup
-description: |
-  Configure Mistral AI across development, staging, and production environments.
+description: 'Configure Mistral AI across development, staging, and production environments.
+
   Use when setting up multi-environment deployments, configuring per-environment secrets,
+
   or implementing environment-specific Mistral AI configurations.
+
   Trigger with phrases like "mistral environments", "mistral staging",
+
   "mistral dev prod", "mistral environment setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, deployment]
+tags:
+- saas
+- mistral
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Multi-Environment Setup
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-observability/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: mistral-observability
-description: |
-  Set up comprehensive observability for Mistral AI with metrics, traces, and alerts.
+description: 'Set up comprehensive observability for Mistral AI with metrics, traces,
+  and alerts.
+
   Use when implementing monitoring for Mistral AI operations, setting up dashboards,
+
   or configuring alerting for integration health.
+
   Trigger with phrases like "mistral monitoring", "mistral metrics",
+
   "mistral observability", "monitor mistral", "mistral alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, monitoring, observability, dashboard]
+tags:
+- saas
+- mistral
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Observability
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-performance-tuning
-description: |
-  Optimize Mistral AI performance with caching, batching, and latency reduction.
+description: 'Optimize Mistral AI performance with caching, batching, and latency
+  reduction.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Mistral AI integrations.
+
   Trigger with phrases like "mistral performance", "optimize mistral",
+
   "mistral latency", "mistral caching", "mistral slow".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, performance]
+tags:
+- saas
+- mistral
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Performance Tuning
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-prod-checklist
-description: |
-  Execute Mistral AI production deployment checklist and rollback procedures.
+description: 'Execute Mistral AI production deployment checklist and rollback procedures.
+
   Use when deploying Mistral AI integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "mistral production", "deploy mistral",
+
   "mistral go-live", "mistral launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, deployment]
+tags:
+- saas
+- mistral
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Production Checklist
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-rate-limits/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: mistral-rate-limits
-description: |
-  Implement Mistral AI rate limiting, backoff, and request management.
+description: 'Implement Mistral AI rate limiting, backoff, and request management.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for Mistral AI.
+
   Trigger with phrases like "mistral rate limit", "mistral throttling",
+
   "mistral 429", "mistral retry", "mistral backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api]
+tags:
+- saas
+- mistral
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral Rate Limits
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-reference-architecture
-description: |
-  Implement Mistral AI reference architecture with best-practice project layout.
+description: 'Implement Mistral AI reference architecture with best-practice project
+  layout.
+
   Use when designing new Mistral AI integrations, reviewing project structure,
+
   or establishing architecture standards for Mistral AI applications.
+
   Trigger with phrases like "mistral architecture", "mistral best practices",
+
   "mistral project structure", "how to organize mistral".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, mistral-reference]
+tags:
+- saas
+- mistral
+- mistral-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Reference Architecture
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: mistral-sdk-patterns
-description: |
-  Apply production-ready Mistral AI SDK patterns for TypeScript and Python.
+description: 'Apply production-ready Mistral AI SDK patterns for TypeScript and Python.
+
   Use when implementing Mistral integrations, refactoring SDK usage,
+
   or establishing team coding standards for Mistral AI.
+
   Trigger with phrases like "mistral SDK patterns", "mistral best practices",
+
   "mistral code patterns", "idiomatic mistral".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, python, typescript]
+tags:
+- saas
+- mistral
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral SDK Patterns
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-security-basics/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: mistral-security-basics
-description: |
-  Apply Mistral AI security best practices for secrets, prompt injection, and access control.
+description: 'Apply Mistral AI security best practices for secrets, prompt injection,
+  and access control.
+
   Use when securing API keys, defending against prompt injection,
+
   or auditing Mistral AI security configuration.
+
   Trigger with phrases like "mistral security", "mistral secrets",
+
   "secure mistral", "mistral prompt injection".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, security, audit]
+tags:
+- saas
+- mistral
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral Security Basics
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-upgrade-migration
-description: |
-  Analyze, plan, and execute Mistral AI SDK upgrades with breaking change detection.
+description: 'Analyze, plan, and execute Mistral AI SDK upgrades with breaking change
+  detection.
+
   Use when upgrading Mistral SDK versions, detecting deprecations,
+
   or migrating to new API versions.
+
   Trigger with phrases like "upgrade mistral", "mistral breaking changes",
+
   "update mistral SDK", "analyze mistral version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, api, migration]
+tags:
+- saas
+- mistral
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Upgrade & Migration
 

--- a/plugins/saas-packs/mistral-pack/skills/mistral-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/mistral-pack/skills/mistral-webhooks-events/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: mistral-webhooks-events
-description: |
-  Implement Mistral AI async patterns, batch API, agents, and event-driven workflows.
+description: 'Implement Mistral AI async patterns, batch API, agents, and event-driven
+  workflows.
+
   Use when building async workflows, using the Agents API, batch inference,
+
   or handling long-running Mistral AI operations.
+
   Trigger with phrases like "mistral events", "mistral async", "mistral agents",
+
   "mistral batch", "mistral queue", "mistral background jobs".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, mistral, webhooks, workflow]
+tags:
+- saas
+- mistral
+- webhooks
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Mistral AI Events, Agents & Async Patterns
 

--- a/plugins/saas-packs/navan-pack/skills/navan-ci-integration/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-ci-integration/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: navan-ci-integration
-description: |
-  Use when setting up CI/CD pipelines that validate Navan API integrations, run booking data health checks, or generate automated compliance reports.
+description: 'Use when setting up CI/CD pipelines that validate Navan API integrations,
+  run booking data health checks, or generate automated compliance reports.
+
   Trigger with "navan ci integration" or "navan pipeline" or "navan github actions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(git:*), Bash(gh:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan CI Integration
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-common-errors/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-common-errors/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-common-errors
-description: |
-  Diagnose and fix common Navan API errors with targeted fix procedures.
-  Use when an API call returns an unexpected HTTP error or when debugging production failures.
-  Trigger with "navan error", "fix navan", "debug navan", "navan 401", "navan 403", "navan 429".
+description: 'Diagnose and fix common Navan API errors with targeted fix procedures.
+
+  Use when an API call returns an unexpected HTTP error or when debugging production
+  failures.
+
+  Trigger with "navan error", "fix navan", "debug navan", "navan 401", "navan 403",
+  "navan 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Common Errors
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-core-workflow-a/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: navan-core-workflow-a
-description: |
-  Manage the complete Navan travel booking lifecycle via REST API.
-  Use when building travel dashboards, automating trip reporting, or syncing booking data to internal systems.
+description: 'Manage the complete Navan travel booking lifecycle via REST API.
+
+  Use when building travel dashboards, automating trip reporting, or syncing booking
+  data to internal systems.
+
   Trigger with "navan travel workflow", "navan booking management", "navan trip retrieval".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan — Travel Booking & Management
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-core-workflow-b/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-core-workflow-b
-description: |
-  Manage Navan expense reporting, transaction data, and ERP synchronization.
-  Use when building expense pipelines, automating approval workflows, or syncing transactions to accounting systems.
-  Trigger with "navan expense management", "navan expense workflow", "navan transaction sync".
+description: 'Manage Navan expense reporting, transaction data, and ERP synchronization.
+
+  Use when building expense pipelines, automating approval workflows, or syncing transactions
+  to accounting systems.
+
+  Trigger with "navan expense management", "navan expense workflow", "navan transaction
+  sync".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan — Expense Management
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-cost-tuning/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: navan-cost-tuning
-description: |
-  Use when optimizing travel spend with Navan's policy engine, analyzing booking patterns for savings, and configuring the Navan Rewards program.
+description: 'Use when optimizing travel spend with Navan''s policy engine, analyzing
+  booking patterns for savings, and configuring the Navan Rewards program.
+
   Trigger with "navan cost tuning" or "navan travel savings" or "navan spend optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-data-handling/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-data-handling/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-data-handling
-description: |
-  Extract and transform Navan booking and transaction data using pagination, filtering, and data pipeline connectors.
-  Use when building data warehouses, analytics dashboards, or debugging data quality issues with Navan data.
+description: 'Extract and transform Navan booking and transaction data using pagination,
+  filtering, and data pipeline connectors.
+
+  Use when building data warehouses, analytics dashboards, or debugging data quality
+  issues with Navan data.
+
   Trigger with "navan data handling", "navan data extraction", "navan pagination".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Data Handling
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-data-sync/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-data-sync/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-data-sync
-description: |
-  Implement incremental sync strategies for Navan BOOKING and TRANSACTION data with ETL pipeline patterns.
-  Use when setting up production data pipelines, debugging sync drift, or adding real-time event processing.
+description: 'Implement incremental sync strategies for Navan BOOKING and TRANSACTION
+  data with ETL pipeline patterns.
+
+  Use when setting up production data pipelines, debugging sync drift, or adding real-time
+  event processing.
+
   Trigger with "navan data sync", "navan incremental sync", "navan ETL pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan — Data Sync
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-debug-bundle/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-debug-bundle
-description: |
-  Use when collecting diagnostic data from a Navan API integration — OAuth token inspection, API response capture, connectivity testing, and request/response logging.
-  Trigger with "navan debug bundle" or "debug navan api".
-allowed-tools: Read, Bash(curl:*), Bash(jq:*), Bash(tar:*), Bash(mkdir:*), Bash(date:*), Grep
+description: "Use when collecting diagnostic data from a Navan API integration \u2014\
+  \ OAuth token inspection, API response capture, connectivity testing, and request/response\
+  \ logging.\nTrigger with \"navan debug bundle\" or \"debug navan api\".\n"
+allowed-tools: Read, Bash(curl:*), Bash(jq:*), Bash(tar:*), Bash(mkdir:*), Bash(date:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-deploy-integration/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: navan-deploy-integration
-description: |
-  Use when deploying Navan integrations with ERP systems (NetSuite, Sage Intacct, Xero), HRIS platforms (Workday, BambooHR), or identity providers (Okta, Azure AD).
+description: 'Use when deploying Navan integrations with ERP systems (NetSuite, Sage
+  Intacct, Xero), HRIS platforms (Workday, BambooHR), or identity providers (Okta,
+  Azure AD).
+
   Trigger with "navan deploy integration" or "navan erp setup" or "navan sso deployment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-enterprise-rbac/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-enterprise-rbac
-description: |
-  Configure Navan admin roles, travel policies, approval workflows, and department-level access controls.
+description: 'Configure Navan admin roles, travel policies, approval workflows, and
+  department-level access controls.
+
   Use when setting up enterprise RBAC, policy enforcement, or approval chains in Navan.
-  Trigger with "navan rbac", "navan roles", "navan travel policy", "navan approval workflow".
+
+  Trigger with "navan rbac", "navan roles", "navan travel policy", "navan approval
+  workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-entity-management/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-entity-management/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-entity-management
-description: |
-  Manage Navan users, departments, cost centers, and approval chains via API and SCIM provisioning.
-  Use when onboarding departments, integrating identity providers, or auditing user access.
+description: 'Manage Navan users, departments, cost centers, and approval chains via
+  API and SCIM provisioning.
+
+  Use when onboarding departments, integrating identity providers, or auditing user
+  access.
+
   Trigger with "navan entity management", "navan user management", "navan SCIM setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan — Entity Management
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-hello-world/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-hello-world/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: navan-hello-world
-description: |
-  Make your first Navan API call to retrieve trip and user data.
+description: 'Make your first Navan API call to retrieve trip and user data.
+
   Use when verifying a new Navan integration works end-to-end after auth setup.
-  Trigger with "navan hello world", "navan example", "test navan api", "first navan call".
+
+  Trigger with "navan hello world", "navan example", "test navan api", "first navan
+  call".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Hello World
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-incident-runbook/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: navan-incident-runbook
-description: |
-  Use when responding to Navan platform incidents — flight cancellations, booking API failures, expense sync outages, or OAuth authentication errors.
-  Trigger with "navan incident runbook" or "navan outage response".
+description: "Use when responding to Navan platform incidents \u2014 flight cancellations,\
+  \ booking API failures, expense sync outages, or OAuth authentication errors.\n\
+  Trigger with \"navan incident runbook\" or \"navan outage response\".\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-install-auth/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: navan-install-auth
-description: |
-  Set up OAuth 2.0 authentication for the Navan REST API.
+description: 'Set up OAuth 2.0 authentication for the Navan REST API.
+
   Use when configuring a new Navan integration or rotating API credentials.
+
   Trigger with "install navan", "setup navan auth", "navan credentials", "navan oauth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-local-dev-loop/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-local-dev-loop
-description: |
-  Set up a local development environment for Navan API integrations with token caching and request logging.
+description: 'Set up a local development environment for Navan API integrations with
+  token caching and request logging.
+
   Use when starting a new Navan project or debugging API issues locally.
-  Trigger with "navan local dev", "navan dev setup", "navan local dev loop", "navan dev environment".
+
+  Trigger with "navan local dev", "navan dev setup", "navan local dev loop", "navan
+  dev environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-migration-deep-dive/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-migration-deep-dive
-description: |
-  Use when planning or executing a migration from SAP Concur or legacy TMC to Navan — data migration, user provisioning, policy recreation, and cutover planning.
-  Trigger with "navan migration deep dive" or "migrate to navan from concur".
+description: "Use when planning or executing a migration from SAP Concur or legacy\
+  \ TMC to Navan \u2014 data migration, user provisioning, policy recreation, and\
+  \ cutover planning.\nTrigger with \"navan migration deep dive\" or \"migrate to\
+  \ navan from concur\".\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: navan-multi-env-setup
-description: |
-  Set up dev/staging/prod environment separation for Navan integrations without a sandbox API.
-  Use when configuring multiple environments, building CI test pipelines, or setting up local development.
-  Trigger with "navan environments", "navan multi env", "navan dev setup", "navan mock server".
+description: 'Set up dev/staging/prod environment separation for Navan integrations
+  without a sandbox API.
+
+  Use when configuring multiple environments, building CI test pipelines, or setting
+  up local development.
+
+  Trigger with "navan environments", "navan multi env", "navan dev setup", "navan
+  mock server".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-observability/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-observability/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: navan-observability
-description: |
-  Use when setting up monitoring, logging, and alerting for Navan API integrations in production environments.
+description: 'Use when setting up monitoring, logging, and alerting for Navan API
+  integrations in production environments.
+
   Trigger with "navan observability" or "navan monitoring" or "navan api dashboards".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Observability
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-performance-tuning/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-performance-tuning
-description: |
-  Use when optimizing Navan API call patterns for high-volume integrations — caching, batching, connection pooling, and pagination strategies.
-  Trigger with "navan performance tuning" or "navan api optimization" or "navan caching".
+description: "Use when optimizing Navan API call patterns for high-volume integrations\
+  \ \u2014 caching, batching, connection pooling, and pagination strategies.\nTrigger\
+  \ with \"navan performance tuning\" or \"navan api optimization\" or \"navan caching\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-prod-checklist/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-prod-checklist
-description: |
-  Use when validating production readiness for a Navan API integration — credential rotation, alerting, rate limits, SSO, SCIM, and compliance audit trails.
-  Trigger with "navan prod checklist" or "navan production readiness".
+description: "Use when validating production readiness for a Navan API integration\
+  \ \u2014 credential rotation, alerting, rate limits, SSO, SCIM, and compliance audit\
+  \ trails.\nTrigger with \"navan prod checklist\" or \"navan production readiness\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-rate-limits/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-rate-limits/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: navan-rate-limits
-description: |
-  Implement adaptive rate-limiting for the Navan REST API with exponential backoff and request queuing.
+description: 'Implement adaptive rate-limiting for the Navan REST API with exponential
+  backoff and request queuing.
+
   Use when building bulk data operations or encountering 429 errors from Navan.
+
   Trigger with "navan rate limits", "navan throttling", "navan 429".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-reference-architecture/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-reference-architecture
-description: |
-  Use when designing a production Navan API integration architecture — API gateway, token management, data sync pipelines, ERP connectors, and monitoring stack.
-  Trigger with "navan reference architecture" or "navan integration architecture".
+description: "Use when designing a production Navan API integration architecture \u2014\
+  \ API gateway, token management, data sync pipelines, ERP connectors, and monitoring\
+  \ stack.\nTrigger with \"navan reference architecture\" or \"navan integration architecture\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: navan-sdk-patterns
-description: |
-  Build a typed API wrapper around Navan REST endpoints since no official SDK exists.
-  Use when you need production-grade API access with auto token refresh, retry logic, and typed responses.
-  Trigger with "navan sdk patterns", "navan api wrapper", "navan client class", "navan typed client".
+description: 'Build a typed API wrapper around Navan REST endpoints since no official
+  SDK exists.
+
+  Use when you need production-grade API access with auto token refresh, retry logic,
+  and typed responses.
+
+  Trigger with "navan sdk patterns", "navan api wrapper", "navan client class", "navan
+  typed client".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-security-basics/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-security-basics/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: navan-security-basics
-description: |
-  Secure Navan API credentials with OAuth 2.0 best practices, SSO/SAML, and SCIM provisioning.
-  Use when hardening a Navan integration, rotating credentials, or configuring identity provider SSO.
+description: 'Secure Navan API credentials with OAuth 2.0 best practices, SSO/SAML,
+  and SCIM provisioning.
+
+  Use when hardening a Navan integration, rotating credentials, or configuring identity
+  provider SSO.
+
   Trigger with "navan security", "navan sso", "navan credentials", "navan scim".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Security Basics
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-upgrade-migration/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: navan-upgrade-migration
-description: |
-  Use when handling Navan API changes in production — defensive coding patterns, schema validation, deprecation monitoring, and gradual rollout strategies for unversioned APIs.
-  Trigger with "navan upgrade migration" or "navan api change handling".
+description: "Use when handling Navan API changes in production \u2014 defensive coding\
+  \ patterns, schema validation, deprecation monitoring, and gradual rollout strategies\
+  \ for unversioned APIs.\nTrigger with \"navan upgrade migration\" or \"navan api\
+  \ change handling\".\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/navan-pack/skills/navan-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/navan-pack/skills/navan-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: navan-webhooks-events
-description: |
-  Set up webhook listeners for real-time Navan event notifications.
-  Use when you need to receive booking, expense, or travel disruption events from Navan.
+description: 'Set up webhook listeners for real-time Navan event notifications.
+
+  Use when you need to receive booking, expense, or travel disruption events from
+  Navan.
+
   Trigger with "navan webhooks", "navan events", "navan webhook setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, navan, travel]
-compatible-with: claude-code
+tags:
+- saas
+- navan
+- travel
+compatibility: Designed for Claude Code
 ---
-
 # Navan Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-advanced-troubleshooting
-description: |
-  Deep debugging for Notion API: response inspection, permission chain tracing,
+description: 'Deep debugging for Notion API: response inspection, permission chain
+  tracing,
+
   property type mismatches, pagination edge cases, and block nesting limits.
+
   Use when standard troubleshooting fails or investigating intermittent errors.
+
   Trigger with phrases like "notion deep debug", "notion permission trace",
+
   "notion property mismatch", "notion pagination bug", "notion nesting limit".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-architecture-variants/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-architecture-variants
-description: |
-  Different Notion integration architectures: CMS (headless blog), task
+description: 'Different Notion integration architectures: CMS (headless blog), task
+
   tracker (project management), knowledge base (wiki), form submission
+
   handler, and data pipeline source.
+
   Trigger with phrases like "notion cms", "notion headless blog",
+
   "notion task tracker", "notion wiki", "notion form handler", "notion data pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-ci-integration/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-ci-integration/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: notion-ci-integration
-description: |
-  Integrate the Notion API into CI/CD pipelines for automated documentation sync,
+description: 'Integrate the Notion API into CI/CD pipelines for automated documentation
+  sync,
+
   deploy tracking, and configuration reads. Use when setting up GitHub Actions
+
   workflows that push release notes to Notion, update database entries on deploy,
+
   create incident pages from CI, or read feature flags from Notion databases.
+
   Trigger with phrases like "notion CI", "notion GitHub Actions", "notion deploy sync",
+
   "notion release notes automation", "notion CI pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*), Bash(npx:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, ci-cd, devops]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- ci-cd
+- devops
+compatibility: Designed for Claude Code
 ---
-
 # Notion CI Integration
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-common-errors/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-common-errors
-description: |
-  Diagnose and fix Notion API errors by HTTP status code and error code.
+description: 'Diagnose and fix Notion API errors by HTTP status code and error code.
+
   Use when encountering Notion errors, debugging failed requests,
+
   or troubleshooting integration access, rate limiting, or validation issues.
+
   Trigger with phrases like "notion error", "fix notion",
+
   "notion not working", "debug notion", "notion 400", "notion 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Common Errors
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-content-management/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-content-management/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: notion-content-management
-description: |
-  Create, update, archive, and compose Notion pages and block content.
+description: 'Create, update, archive, and compose Notion pages and block content.
+
   Use when building pages programmatically, appending rich content blocks,
+
   updating page properties, or managing page lifecycle (archive/restore).
+
   Trigger with phrases like "notion create page", "notion add blocks",
+
   "notion update page", "notion archive page", "notion content",
+
   "notion block types", "notion rich text".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Content Management
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-core-workflow-a/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-core-workflow-a
-description: |
-  Query, filter, and manage Notion databases and pages.
+description: 'Query, filter, and manage Notion databases and pages.
+
   Use when building database queries with filters and sorts,
+
   creating/updating pages with typed properties, or reading page content.
+
   Trigger with phrases like "notion database query", "notion filter",
+
   "notion create page", "notion update properties", "notion CRUD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Core Workflow A — Databases & Pages
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-core-workflow-b/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-core-workflow-b
-description: |
-  Work with Notion blocks, rich text, comments, and page content.
+description: 'Work with Notion blocks, rich text, comments, and page content.
+
   Use when reading/writing page content blocks, building rich text,
+
   managing comments, or working with nested block trees.
+
   Trigger with phrases like "notion blocks", "notion page content",
+
   "notion rich text", "notion comments", "notion append blocks".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Core Workflow B — Blocks, Content & Comments
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-cost-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: notion-cost-tuning
-description: |
-  Optimize Notion API usage to minimize rate-limit pressure, reduce engineering
+description: 'Optimize Notion API usage to minimize rate-limit pressure, reduce engineering
+
   overhead, and maximize throughput. Use when auditing request volume, eliminating
+
   redundant API calls, implementing caching, or restructuring queries for efficiency.
+
   Trigger with "notion cost", "notion optimize", "notion API usage", "reduce notion
+
   requests", "notion rate limit budget", "notion efficient", "notion caching".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, optimization, caching, cost]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- optimization
+- caching
+- cost
+compatibility: Designed for Claude Code
 ---
-
 # Notion Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-data-handling/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-data-handling/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-data-handling
-description: |
-  Implement data handling, PII protection, and GDPR/CCPA compliance for Notion integrations.
+description: 'Implement data handling, PII protection, and GDPR/CCPA compliance for
+  Notion integrations.
+
   Use when handling sensitive data from Notion pages, implementing data redaction,
+
   or ensuring compliance with privacy regulations.
+
   Trigger with phrases like "notion data", "notion PII",
+
   "notion GDPR", "notion data retention", "notion privacy", "notion CCPA".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Data Handling
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-debug-bundle
-description: |
-  Collect Notion API diagnostic info for troubleshooting and support tickets.
+description: 'Collect Notion API diagnostic info for troubleshooting and support tickets.
+
   Use when encountering persistent API issues, token/auth failures, page access
+
   problems, or preparing diagnostic bundles for Notion support.
+
   Trigger with phrases like "notion debug", "notion diagnostic", "notion support
+
   bundle", "collect notion logs", "notion troubleshoot".
-allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(npm:*), Bash(node:*), Grep
+
+  '
+allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Bash(npm:*), Bash(node:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: notion-deploy-integration
-description: |
-  Deploy Node.js applications that use the Notion API to production
+description: 'Deploy Node.js applications that use the Notion API to production
+
   on Vercel, Railway, or Fly.io. Use when deploying Notion-powered
+
   backends, setting up NOTION_TOKEN in production secrets, configuring
+
   serverless singleton patterns, or adding health checks that verify
+
   Notion connectivity. Trigger: "deploy notion app", "notion production",
+
   "notion vercel deploy", "notion railway", "notion fly.io".
-allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(vercel:*), Bash(railway:*), Bash(fly:*), Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(vercel:*), Bash(railway:*), Bash(fly:*),
+  Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, deployment, serverless]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- deployment
+- serverless
+compatibility: Designed for Claude Code
 ---
-
 # Deploy Notion-Integrated Applications
 
 Ship Node.js apps that talk to the Notion API to Vercel, Railway, or Fly.io. This skill covers environment variable management, the Notion client singleton pattern for serverless, rate limit handling at 3 req/sec, health check endpoints that verify Notion connectivity, and caching strategies to reduce API calls.

--- a/plugins/saas-packs/notion-pack/skills/notion-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-enterprise-rbac/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-enterprise-rbac
-description: |
-  Configure Notion enterprise access control with OAuth, workspace permissions, and audit logging.
+description: 'Configure Notion enterprise access control with OAuth, workspace permissions,
+  and audit logging.
+
   Use when implementing OAuth public integrations, managing multi-workspace access,
+
   or building permission-aware Notion applications.
+
   Trigger with phrases like "notion SSO", "notion RBAC",
+
   "notion enterprise", "notion OAuth", "notion permissions", "notion multi-workspace".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-hello-world/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-hello-world/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-hello-world
-description: |
-  Create a minimal working Notion API example.
+description: 'Create a minimal working Notion API example.
+
   Use when starting a new Notion integration, testing your setup,
+
   or learning basic Notion API patterns (search, pages, users).
+
   Trigger with phrases like "notion hello world", "notion example",
+
   "notion quick start", "simple notion code", "first notion API call".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Hello World
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-incident-runbook/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-incident-runbook
-description: |
-  Execute Notion incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Notion incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Notion API outages, investigating errors,
+
   or running post-incident reviews for Notion integration failures.
+
   Trigger with phrases like "notion incident", "notion outage",
+
   "notion down", "notion on-call", "notion emergency", "notion broken".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-install-auth/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: notion-install-auth
-description: |
-  Install and configure the Notion API SDK with authentication.
+description: 'Install and configure the Notion API SDK with authentication.
+
   Use when setting up a new Notion integration, configuring API tokens,
+
   or initializing @notionhq/client in your project.
+
   Trigger with phrases like "install notion", "setup notion",
+
   "notion auth", "configure notion API", "notion integration setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, authentication, sdk, setup]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- productivity
+- notion
+- authentication
+- sdk
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Notion Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-known-pitfalls/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: notion-known-pitfalls
-description: |
-  Common Notion API mistakes: wrong page ID format (dashes), rich text
+description: 'Common Notion API mistakes: wrong page ID format (dashes), rich text
+
   array structure, block children not returned with page, pagination
+
   required for all lists, 3 req/sec shared across endpoints, not sharing
+
   pages with integration. Use when debugging or reviewing Notion code.
+
   Trigger with phrases like "notion mistakes", "notion pitfalls",
+
   "notion common errors", "notion gotchas", "notion debugging".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-load-scale/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-load-scale/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-load-scale
-description: |
-  High-volume Notion operations: parallel requests within 3 req/sec,
+description: 'High-volume Notion operations: parallel requests within 3 req/sec,
+
   worker queues, database pagination at scale, incremental sync for
+
   large workspaces, and memory management for bulk operations.
+
   Trigger with phrases like "notion scale", "notion bulk operations",
+
   "notion high volume", "notion worker queue", "notion incremental sync".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-local-dev-loop/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: notion-local-dev-loop
-description: |
-  Configure Notion local development with a dedicated dev integration,
+description: 'Configure Notion local development with a dedicated dev integration,
+
   test mocking, and hot reload. Use when setting up a development
+
   environment, writing tests for Notion code, or establishing a fast
+
   iteration cycle with the Notion API.
+
   Trigger: "notion dev setup", "notion local development",
+
   "mock notion", "notion test environment".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-migration-deep-dive
-description: |
-  Migrate data to/from Notion or between Notion workspaces with data mapping and validation.
+description: 'Migrate data to/from Notion or between Notion workspaces with data mapping
+  and validation.
+
   Use when migrating data into Notion databases, exporting from Notion, syncing between
+
   workspaces, or building ETL pipelines with Notion as source or destination.
+
   Trigger with phrases like "migrate notion", "notion migration", "import to notion",
+
   "export from notion", "notion data migration", "notion ETL".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-multi-env-setup/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-multi-env-setup
-description: |
-  Configure Notion integrations across development, staging, and production environments.
+description: 'Configure Notion integrations across development, staging, and production
+  environments.
+
   Use when setting up multi-environment deployments, managing per-environment tokens,
+
   or implementing environment-specific Notion configurations.
+
   Trigger with phrases like "notion environments", "notion staging",
+
   "notion dev prod", "notion environment setup", "notion config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-observability/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-observability/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: notion-observability
-description: |
-  Set up observability for Notion integrations with metrics, traces, and alerts.
+description: 'Set up observability for Notion integrations with metrics, traces, and
+  alerts.
+
   Use when implementing monitoring for Notion API calls, setting up dashboards,
+
   or configuring alerting for Notion integration health.
+
   Trigger with phrases like "notion monitoring", "notion metrics",
+
   "notion observability", "monitor notion", "notion alerts", "notion tracing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Observability
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-performance-tuning/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: notion-performance-tuning
-description: |
-  Optimize Notion API performance with caching, batching, parallel requests, and incremental sync.
+description: 'Optimize Notion API performance with caching, batching, parallel requests,
+  and incremental sync.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   reducing API call volume, or tuning request patterns for Notion integrations.
+
   Trigger with phrases like "notion performance", "optimize notion api",
+
   "notion latency", "notion caching", "notion slow", "notion batch requests",
+
   "notion incremental sync", "notion reduce api calls".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-policy-guardrails/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-policy-guardrails
-description: |
-  Governance for Notion integrations: integration naming standards, page
+description: 'Governance for Notion integrations: integration naming standards, page
+
   sharing policies, property naming conventions, database schema standards,
+
   and access audit scripts.
+
   Trigger with phrases like "notion governance", "notion policy",
+
   "notion naming convention", "notion access audit", "notion schema standard".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: notion-prod-checklist
-description: |
-  Execute Notion API production deployment checklist and readiness verification.
+description: 'Execute Notion API production deployment checklist and readiness verification.
+
   Use when deploying Notion integrations to production, preparing for launch,
+
   verifying go-live readiness, or auditing an existing Notion integration.
+
   Trigger: "notion production checklist", "deploy notion integration",
+
   "notion go-live", "notion launch readiness", "notion prod audit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(grep:*), Bash(curl:*), Bash(jq:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, deployment, checklist]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- deployment
+- checklist
+compatibility: Designed for Claude Code
 ---
-
 # Notion API Production Deployment Checklist
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-rate-limits/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-rate-limits/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: notion-rate-limits
-description: |
-  Manage Notion API rate limits with exponential backoff, queue-based throttling,
+description: 'Manage Notion API rate limits with exponential backoff, queue-based
+  throttling,
+
   and batch optimization. Use when hitting 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Notion integrations.
+
   Trigger with "notion rate limit", "notion 429", "notion retry", "notion backoff",
+
   "notion throttling", "notion too many requests", "notion queue".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, rate-limiting, api, resilience]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- rate-limiting
+- api
+- resilience
+compatibility: Designed for Claude Code
 ---
-
 # Notion Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-reference-architecture/SKILL.md
@@ -1,22 +1,33 @@
 ---
 name: notion-reference-architecture
-description: |
-  Design and implement a production-ready Notion integration architecture
+description: 'Design and implement a production-ready Notion integration architecture
+
   with proper layering, caching, error handling, and testing strategies.
+
   Use when designing new Notion integrations, reviewing existing project
+
   structure, establishing architecture standards for Notion applications,
+
   or migrating from ad-hoc API calls to a layered architecture.
+
   Trigger: "notion architecture", "notion project structure", "notion
+
   reference architecture", "notion integration design", "notion layered
+
   architecture", "notion service pattern".
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, architecture]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- architecture
+compatibility: Designed for Claude Code
 ---
-
 # Notion Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-reliability-patterns/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: notion-reliability-patterns
-description: |
-  Graceful degradation when Notion is down: offline cache, retry with
+description: 'Graceful degradation when Notion is down: offline cache, retry with
+
   exponential backoff, circuit breaker, health checks, and fallback content.
+
   Use when building fault-tolerant Notion integrations for production.
+
   Trigger with phrases like "notion reliability", "notion circuit breaker",
+
   "notion offline fallback", "notion health check", "notion graceful degradation".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-sdk-patterns/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: notion-sdk-patterns
-description: |
-  Apply production-ready @notionhq/client SDK patterns for TypeScript and Python.
+description: 'Apply production-ready @notionhq/client SDK patterns for TypeScript
+  and Python.
+
   Use when implementing Notion integrations, building database queries with filters
+
   and sorts, handling pagination, constructing rich text blocks, or establishing
+
   team coding standards for Notion API usage.
+
   Trigger with "notion SDK patterns", "notion best practices", "notion code patterns",
+
   "idiomatic notion", "notion typescript", "notion python SDK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion, sdk, typescript, python]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+- sdk
+- typescript
+- python
+compatibility: Designed for Claude Code
 ---
-
 # Notion SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-search-retrieve/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-search-retrieve/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: notion-search-retrieve
-description: |
-  Search Notion workspaces and retrieve pages, databases, and block content
+description: 'Search Notion workspaces and retrieve pages, databases, and block content
+
   using the Notion API. Use when querying databases with filters, searching
+
   across a workspace, paginating large result sets, or extracting page content.
+
   Trigger with phrases like "notion search", "query notion database",
+
   "notion retrieve page", "notion pagination", "notion filter",
+
   "notion blocks", "notion get content".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Search & Data Retrieval
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-security-basics/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-security-basics/SKILL.md
@@ -1,21 +1,31 @@
 ---
 name: notion-security-basics
-description: |
-  Apply Notion API security best practices for integration tokens, OAuth2 flows,
+description: 'Apply Notion API security best practices for integration tokens, OAuth2
+  flows,
+
   least-privilege capabilities, and page-level access control.
+
   Use when securing integration tokens, configuring OAuth2 for public integrations,
+
   rotating credentials, or auditing which pages an integration can access.
+
   Trigger with phrases like "notion security", "notion secrets",
+
   "secure notion", "notion API key security", "notion token rotation",
+
   "notion OAuth2", "notion permissions audit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Security Basics
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-upgrade-migration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: notion-upgrade-migration
-description: |
-  Upgrade @notionhq/client SDK versions and migrate between Notion API versions.
+description: 'Upgrade @notionhq/client SDK versions and migrate between Notion API
+  versions.
+
   Use when updating SDK packages, handling breaking changes between API versions,
-  adopting new SDK features like comments API or status properties, or migrating Python notion-client.
-  Trigger with phrases like "upgrade notion SDK", "notion migration", "notion breaking changes",
+
+  adopting new SDK features like comments API or status properties, or migrating Python
+  notion-client.
+
+  Trigger with phrases like "upgrade notion SDK", "notion migration", "notion breaking
+  changes",
+
   "update notionhq client", "notion API version upgrade", "notion deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(git:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/notion-pack/skills/notion-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-webhooks-events/SKILL.md
@@ -1,21 +1,30 @@
 ---
 name: notion-webhooks-events
-description: |
-  Build change detection and event handling for Notion workspaces using
+description: 'Build change detection and event handling for Notion workspaces using
+
   polling, native webhooks, and third-party connectors.
+
   Use when implementing real-time sync, change feeds, incremental backup,
+
   or event-driven workflows with Notion data.
+
   Trigger with phrases like "notion webhook", "notion events",
+
   "notion change detection", "notion polling", "notion sync changes",
+
   "notion real-time", "notion watch for changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(npx:*), Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, productivity, notion]
-compatible-with: claude-code
+tags:
+- saas
+- productivity
+- notion
+compatibility: Designed for Claude Code
 ---
-
 # Notion Webhooks & Event Handling
 
 ## Overview

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-ci-integration/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: obsidian-ci-integration
-description: |
-  Set up GitHub Actions CI/CD for Obsidian plugin development.
+description: 'Set up GitHub Actions CI/CD for Obsidian plugin development.
+
   Use when automating builds, tests, and releases for your plugin,
+
   or setting up continuous integration for Obsidian projects.
+
   Trigger with phrases like "obsidian CI", "obsidian github actions",
+
   "obsidian automated build", "obsidian CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, testing, ci-cd]
+tags:
+- saas
+- obsidian
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian CI Integration
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-common-errors/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-common-errors
-description: |
-  Diagnose and fix common Obsidian plugin errors and exceptions.
+description: 'Diagnose and fix common Obsidian plugin errors and exceptions.
+
   Use when encountering plugin errors, debugging failed operations,
+
   or troubleshooting Obsidian plugin issues.
+
   Trigger with phrases like "obsidian error", "fix obsidian plugin",
+
   "obsidian not working", "debug obsidian plugin".
+
+  '
 allowed-tools: Read, Grep, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, debugging]
+tags:
+- saas
+- obsidian
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Common Errors
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-core-workflow-a/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: obsidian-core-workflow-a
-description: |
-  Create an Obsidian plugin from scratch with full project scaffolding.
+description: 'Create an Obsidian plugin from scratch with full project scaffolding.
+
   Covers Plugin class, ribbon icons, commands, settings tab, esbuild config,
+
   manifest.json, and building/testing. Use when starting a new plugin,
+
   scaffolding a project, or learning the plugin lifecycle.
+
   Trigger with "create obsidian plugin", "scaffold obsidian plugin",
+
   "new obsidian plugin", "obsidian plugin from scratch".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(mkdir:*), Bash(ln:*), Glob
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, plugin-development, typescript, scaffolding]
+tags:
+- obsidian
+- plugin-development
+- typescript
+- scaffolding
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Obsidian Core Workflow A: Create a Plugin from Scratch
 
 ## Overview

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-core-workflow-b/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: obsidian-core-workflow-b
-description: |
-  Build advanced Obsidian plugin features: custom views (ItemView), modals,
+description: 'Build advanced Obsidian plugin features: custom views (ItemView), modals,
+
   editor commands with selection manipulation, status bar, context menus,
+
   and Vault API file creation/modification. Use when adding UI components
+
   to a plugin, building sidebar views, or creating modal dialogs.
+
   Trigger with "obsidian modal", "obsidian custom view", "obsidian sidebar",
+
   "obsidian context menu", "obsidian editor command", "obsidian UI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, ui-components, views, modals, editor]
+tags:
+- obsidian
+- ui-components
+- views
+- modals
+- editor
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Obsidian Core Workflow B: Advanced Plugin Features
 
 ## Overview

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-cost-tuning/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: obsidian-cost-tuning
-description: |
-  Optimize Obsidian resource usage, sync storage, Publish hosting, and
+description: 'Optimize Obsidian resource usage, sync storage, Publish hosting, and
+
   third-party plugin API costs. Use when managing vault size, reducing
+
   Sync bandwidth, controlling Publish costs, or optimizing external API
+
   consumption from community plugins.
+
   Trigger with phrases like "obsidian costs", "obsidian sync storage",
+
   "optimize obsidian", "reduce obsidian costs", "obsidian publish costs".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(du:*), Bash(find:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, cost-optimization, sync, publish, storage]
+tags:
+- obsidian
+- cost-optimization
+- sync
+- publish
+- storage
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Cost Tuning
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-data-handling/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-data-handling/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-data-handling
-description: |
-  Implement vault data backup, sync, and recovery strategies.
+description: 'Implement vault data backup, sync, and recovery strategies.
+
   Use when building backup features, implementing data export,
+
   or handling vault synchronization in your plugin.
+
   Trigger with phrases like "obsidian backup", "obsidian sync",
+
   "obsidian data export", "vault backup strategy".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, backup]
+tags:
+- saas
+- obsidian
+- backup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Data Handling
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-debug-bundle
-description: |
-  Collect Obsidian plugin debug evidence for support and troubleshooting.
+description: 'Collect Obsidian plugin debug evidence for support and troubleshooting.
+
   Use when encountering persistent issues, preparing bug reports,
+
   or collecting diagnostic information for plugin problems.
+
   Trigger with phrases like "obsidian debug", "obsidian diagnostic",
+
   "collect obsidian logs", "obsidian support bundle".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(tar:*), Grep, Write
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, debugging]
+tags:
+- saas
+- obsidian
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Debug Bundle
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-deploy-integration
-description: |
-  Publish Obsidian plugins to the community plugin directory.
+description: 'Publish Obsidian plugins to the community plugin directory.
+
   Use when releasing your first plugin, updating existing plugins,
+
   or managing the community plugin submission process.
+
   Trigger with phrases like "publish obsidian plugin", "obsidian community plugins",
+
   "submit obsidian plugin", "obsidian plugin directory".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(git:*), Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, obsidian-deploy]
+tags:
+- saas
+- obsidian
+- obsidian-deploy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Plugin Deploy Integration
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-enterprise-rbac
-description: |
-  Implement team vault access patterns and role-based controls.
+description: 'Implement team vault access patterns and role-based controls.
+
   Use when managing shared vaults, implementing access controls,
+
   or building team collaboration features for Obsidian.
+
   Trigger with phrases like "obsidian team", "obsidian access control",
+
   "obsidian enterprise", "shared vault permissions".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, obsidian-enterprise]
+tags:
+- saas
+- obsidian
+- obsidian-enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Enterprise RBAC
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-hello-world/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: obsidian-hello-world
-description: |
-  Create a minimal working Obsidian plugin with commands, settings, modals, and ribbon icons.
+description: 'Create a minimal working Obsidian plugin with commands, settings, modals,
+  and ribbon icons.
+
   Use when building your first plugin feature, testing your setup,
+
   or learning basic Obsidian plugin patterns.
+
   Trigger with phrases like "obsidian hello world", "first obsidian plugin",
+
   "obsidian quick start", "simple obsidian plugin".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, testing, getting-started]
+tags:
+- saas
+- obsidian
+- testing
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Hello World
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: obsidian-incident-runbook
-description: |
-  Troubleshoot Obsidian plugin failures with systematic incident response.
+description: 'Troubleshoot Obsidian plugin failures with systematic incident response.
+
   Use when plugins crash, data is corrupted, or users report critical issues
+
   with your Obsidian plugin.
+
   Trigger with phrases like "obsidian crash", "obsidian plugin broken",
+
   "obsidian incident", "debug obsidian failure", "obsidian emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, debugging, incident-response]
+tags:
+- saas
+- obsidian
+- debugging
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Incident Runbook
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-install-auth/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-install-auth/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: obsidian-install-auth
-description: |
-  Set up Obsidian plugin development environment with Node.js and TypeScript.
+description: 'Set up Obsidian plugin development environment with Node.js and TypeScript.
+
   Use when starting a new plugin project, configuring the dev environment,
+
   or initializing Obsidian plugin development from scratch.
+
   Trigger with phrases like "obsidian setup", "obsidian plugin dev",
+
   "create obsidian plugin", "obsidian development environment".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*), Bash(mkdir:*), Bash(ln:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*), Bash(mkdir:*), Bash(ln:*),
+  Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, typescript, nodejs, setup]
+tags:
+- saas
+- obsidian
+- typescript
+- nodejs
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Install & Auth
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-local-dev-loop/SKILL.md
@@ -1,21 +1,33 @@
 ---
 name: obsidian-local-dev-loop
-description: |
-  Set up a fast Obsidian plugin development loop with hot reload.
+description: 'Set up a fast Obsidian plugin development loop with hot reload.
+
   Covers cloning the sample plugin, esbuild watch mode, symlinking
+
   into a vault, Ctrl+R hot reload, Chrome DevTools debugging, and
+
   testing with vitest. Use when starting plugin development or
+
   configuring a dev environment.
+
   Trigger with "obsidian dev loop", "obsidian hot reload",
+
   "obsidian development setup", "develop obsidian plugin".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(mkdir:*), Bash(ln:*), Bash(ls:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(mkdir:*), Bash(ln:*),
+  Bash(ls:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, development, hot-reload, debugging, testing]
+tags:
+- obsidian
+- development
+- hot-reload
+- debugging
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Obsidian Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-migration-deep-dive
-description: |
-  Execute major Obsidian plugin rewrites and migration strategies.
+description: 'Execute major Obsidian plugin rewrites and migration strategies.
+
   Use when migrating to or from Obsidian, performing major plugin rewrites,
+
   or re-platforming existing note systems to Obsidian.
+
   Trigger with phrases like "migrate to obsidian", "obsidian migration",
+
   "convert notes to obsidian", "obsidian replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, migration]
+tags:
+- saas
+- obsidian
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Migration Deep Dive
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: obsidian-multi-env-setup
-description: |
-  Configure multiple Obsidian environments for development, testing, and production.
+description: 'Configure multiple Obsidian environments for development, testing, and
+  production.
+
   Use when managing separate vaults, testing plugin versions,
+
   or establishing a proper development workflow with isolated environments.
+
   Trigger with phrases like "obsidian environments", "obsidian dev vault",
+
   "obsidian testing setup", "multiple obsidian vaults".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(mkdir:*), Bash(ln:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, testing, workflow]
+tags:
+- saas
+- obsidian
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Multi-Environment Setup
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-observability/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: obsidian-observability
-description: |
-  Implement structured logging, metrics, error tracking, and a debug panel
+description: 'Implement structured logging, metrics, error tracking, and a debug panel
+
   for Obsidian plugins. Use when adding debug logging, tracking plugin
+
   performance, building a diagnostics view, or setting up error reporting.
+
   Trigger with phrases like "obsidian logging", "obsidian monitoring",
+
   "obsidian debug panel", "track obsidian plugin performance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, monitoring, debugging, performance, logging]
+tags:
+- obsidian
+- monitoring
+- debugging
+- performance
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Observability
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: obsidian-performance-tuning
-description: |
-  Optimize Obsidian plugin performance for smooth operation in large vaults.
+description: 'Optimize Obsidian plugin performance for smooth operation in large vaults.
+
   Use when experiencing lag, memory issues, slow startup, or optimizing
+
   plugin code for vaults with thousands of files.
+
   Trigger with phrases like "obsidian performance", "obsidian slow",
+
   "optimize obsidian plugin", "obsidian memory usage", "obsidian lag".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, performance, optimization, memory, profiling]
+tags:
+- obsidian
+- performance
+- optimization
+- memory
+- profiling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Performance Tuning
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-prod-checklist
-description: |
-  Pre-release plugin verification checklist for Obsidian community plugins.
+description: 'Pre-release plugin verification checklist for Obsidian community plugins.
+
   Use when preparing to release, reviewing before submission,
+
   or validating plugin quality before publishing.
+
   Trigger with phrases like "obsidian release checklist", "publish obsidian plugin",
+
   "obsidian plugin submission", "obsidian prod ready".
+
+  '
 allowed-tools: Read, Grep, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, obsidian-prod]
+tags:
+- saas
+- obsidian
+- obsidian-prod
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Prod Checklist
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-rate-limits/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-rate-limits
-description: |
-  Handle Obsidian file system operations and throttling patterns.
+description: 'Handle Obsidian file system operations and throttling patterns.
+
   Use when processing many files, handling bulk operations,
+
   or preventing performance issues from excessive operations.
+
   Trigger with phrases like "obsidian rate limit", "obsidian bulk operations",
+
   "obsidian file throttling", "obsidian performance limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, performance]
+tags:
+- saas
+- obsidian
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Rate Limits
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: obsidian-reference-architecture
-description: |
-  Implement Obsidian reference architecture with best-practice project layout.
+description: 'Implement Obsidian reference architecture with best-practice project
+  layout.
+
   Use when designing new plugins, reviewing project structure,
+
   or establishing architecture standards for Obsidian development.
+
   Trigger with phrases like "obsidian architecture", "obsidian project structure",
+
   "obsidian best practices", "organize obsidian plugin".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, obsidian-reference]
+tags:
+- saas
+- obsidian
+- obsidian-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Reference Architecture
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-sdk-patterns/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: obsidian-sdk-patterns
-description: |
-  Production-ready Obsidian plugin patterns: typed settings with migration,
+description: 'Production-ready Obsidian plugin patterns: typed settings with migration,
+
   safe vault operations, event auto-cleanup, workspace layout, metadata cache,
+
   and debounced file handlers. Use when hardening a plugin for release,
+
   refactoring for reliability, or learning idiomatic Obsidian TypeScript.
+
   Trigger with "obsidian patterns", "obsidian best practices",
+
   "obsidian production code", "idiomatic obsidian plugin".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, patterns, production, typescript, best-practices]
+tags:
+- obsidian
+- patterns
+- production
+- typescript
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Obsidian SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-security-basics/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-security-basics/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: obsidian-security-basics
-description: |
-  Implement secure Obsidian plugin development practices. Covers credential
+description: 'Implement secure Obsidian plugin development practices. Covers credential
+
   storage, input validation, XSS prevention, network security, URI handler
+
   safety, and Electron security. Use when handling user data, storing API keys,
+
   making network requests, or preparing for community plugin submission.
+
   Trigger with phrases like "obsidian security", "secure obsidian plugin",
+
   "obsidian data protection", "obsidian privacy", "obsidian api key storage".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [obsidian, security, authentication, privacy, electron]
+tags:
+- obsidian
+- security
+- authentication
+- privacy
+- electron
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Security Basics
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: obsidian-upgrade-migration
-description: |
-  Migrate Obsidian plugins between API versions and handle breaking changes.
+description: 'Migrate Obsidian plugins between API versions and handle breaking changes.
+
   Use when upgrading to new Obsidian versions, handling API deprecations,
+
   or migrating plugin code to new patterns.
+
   Trigger with phrases like "obsidian upgrade", "obsidian migration",
+
   "obsidian API changes", "update obsidian plugin".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, api, migration]
+tags:
+- saas
+- obsidian
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Upgrade Migration
 

--- a/plugins/saas-packs/obsidian-pack/skills/obsidian-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/obsidian-pack/skills/obsidian-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: obsidian-webhooks-events
-description: |
-  Handle Obsidian events and workspace callbacks for plugin development.
+description: 'Handle Obsidian events and workspace callbacks for plugin development.
+
   Use when implementing reactive features, handling file changes,
+
   or responding to user interactions in your plugin.
+
   Trigger with phrases like "obsidian events", "obsidian callbacks",
+
   "obsidian file change", "obsidian workspace events".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, obsidian, react]
+tags:
+- saas
+- obsidian
+- react
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Obsidian Webhooks & Events
 

--- a/plugins/saas-packs/onenote-pack/skills/onenote-ci-integration/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-ci-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-ci-integration
-description: |
-  Set up CI/CD pipelines for OneNote integrations with Graph API testing and mock strategies.
-  Use when configuring GitHub Actions, setting up test credentials, or building mock-based CI tests.
-  Trigger with "onenote ci", "onenote github actions", "onenote test pipeline", "graph api ci".
+description: 'Set up CI/CD pipelines for OneNote integrations with Graph API testing
+  and mock strategies.
+
+  Use when configuring GitHub Actions, setting up test credentials, or building mock-based
+  CI tests.
+
+  Trigger with "onenote ci", "onenote github actions", "onenote test pipeline", "graph
+  api ci".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote CI Integration
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-common-errors/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-common-errors/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: onenote-common-errors
-description: |
-  Decode and fix every common OneNote Graph API error with root cause analysis.
+description: 'Decode and fix every common OneNote Graph API error with root cause
+  analysis.
+
   Use when debugging 400, 403, 404, 429, 500, 502, or 507 errors from OneNote API.
+
   Trigger with "onenote error", "onenote 403", "onenote debug", "graph api error onenote".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Common Errors
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-core-workflow-a/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: onenote-core-workflow-a
-description: |
-  Full CRUD lifecycle for OneNote notebooks, section groups, sections, and pages via Graph API.
-  Use when building notebook management features, creating page hierarchies, or working with XHTML content.
+description: 'Full CRUD lifecycle for OneNote notebooks, section groups, sections,
+  and pages via Graph API.
+
+  Use when building notebook management features, creating page hierarchies, or working
+  with XHTML content.
+
   Trigger with "onenote crud", "onenote page management", "onenote notebook workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote — Full CRUD Lifecycle (Notebooks, Sections, Pages)
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-core-workflow-b
-description: |
-  Search, query, and paginate OneNote content with OData filters and client-side search patterns.
-  Use when building search features, querying pages across notebooks, or handling large result sets.
-  Trigger with "onenote search", "onenote query pages", "onenote pagination", "find onenote content".
+description: 'Search, query, and paginate OneNote content with OData filters and client-side
+  search patterns.
+
+  Use when building search features, querying pages across notebooks, or handling
+  large result sets.
+
+  Trigger with "onenote search", "onenote query pages", "onenote pagination", "find
+  onenote content".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote — Search, Query, and Pagination
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-cost-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-cost-tuning
-description: |
-  Optimize costs and API usage for OneNote Graph API integrations with caching and batching strategies.
-  Use when reducing API call volume, planning capacity, or evaluating OneNote integration costs.
-  Trigger with "onenote costs", "onenote api usage", "onenote optimization", "graph api billing onenote".
+description: 'Optimize costs and API usage for OneNote Graph API integrations with
+  caching and batching strategies.
+
+  Use when reducing API call volume, planning capacity, or evaluating OneNote integration
+  costs.
+
+  Trigger with "onenote costs", "onenote api usage", "onenote optimization", "graph
+  api billing onenote".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-debug-bundle
-description: |
-  Generate comprehensive diagnostic bundles for OneNote Graph API issues with request tracing and token analysis.
-  Use when debugging OneNote API failures, filing Microsoft support tickets, or analyzing permission issues.
-  Trigger with "onenote debug", "onenote diagnostic", "onenote support ticket", "graph api troubleshoot onenote".
+description: 'Generate comprehensive diagnostic bundles for OneNote Graph API issues
+  with request tracing and token analysis.
+
+  Use when debugging OneNote API failures, filing Microsoft support tickets, or analyzing
+  permission issues.
+
+  Trigger with "onenote debug", "onenote diagnostic", "onenote support ticket", "graph
+  api troubleshoot onenote".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-deploy-integration
-description: |
-  Deploy OneNote integrations with MSAL token persistence, health checks, and container best practices.
-  Use when containerizing OneNote services, configuring health endpoints, or managing token cache in production.
-  Trigger with "onenote deploy", "onenote docker", "onenote container", "onenote health check".
+description: 'Deploy OneNote integrations with MSAL token persistence, health checks,
+  and container best practices.
+
+  Use when containerizing OneNote services, configuring health endpoints, or managing
+  token cache in production.
+
+  Trigger with "onenote deploy", "onenote docker", "onenote container", "onenote health
+  check".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-hello-world/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-hello-world/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: onenote-hello-world
-description: |
-  Create your first OneNote notebook, section, and page with correct XHTML content.
+description: 'Create your first OneNote notebook, section, and page with correct XHTML
+  content.
+
   Use when starting a new OneNote integration or testing Graph API connectivity.
+
   Trigger with "onenote hello world", "first onenote page", "create onenote notebook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Hello World
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-install-auth/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-install-auth/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-install-auth
-description: |
-  Install and configure OneNote SDK/API authentication with delegated auth (MSAL).
-  Use when setting up a new OneNote integration, configuring Azure AD app registration, or migrating from deprecated app-only auth.
-  Trigger with "install onenote", "setup onenote auth", "onenote credentials", "azure ad onenote".
+description: 'Install and configure OneNote SDK/API authentication with delegated
+  auth (MSAL).
+
+  Use when setting up a new OneNote integration, configuring Azure AD app registration,
+  or migrating from deprecated app-only auth.
+
+  Trigger with "install onenote", "setup onenote auth", "onenote credentials", "azure
+  ad onenote".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-local-dev-loop/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: onenote-local-dev-loop
-description: |
-  Set up a local development loop for OneNote integrations with mock Graph API responses.
-  Use when developing OneNote features without Azure credentials or to avoid rate limits during development.
+description: 'Set up a local development loop for OneNote integrations with mock Graph
+  API responses.
+
+  Use when developing OneNote features without Azure credentials or to avoid rate
+  limits during development.
+
   Trigger with "onenote local dev", "onenote mock", "onenote testing setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-performance-tuning/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-performance-tuning
-description: |
-  Optimize OneNote Graph API performance for large notebooks, image handling, and batch operations.
-  Use when dealing with slow API responses, large notebooks, image uploads, or HTTP 507 errors.
-  Trigger with "onenote performance", "onenote slow", "onenote large notebook", "onenote image upload".
+description: 'Optimize OneNote Graph API performance for large notebooks, image handling,
+  and batch operations.
+
+  Use when dealing with slow API responses, large notebooks, image uploads, or HTTP
+  507 errors.
+
+  Trigger with "onenote performance", "onenote slow", "onenote large notebook", "onenote
+  image upload".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote — Performance Tuning & Optimization
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-prod-checklist
-description: |
-  Production readiness checklist for OneNote Graph API integrations covering auth, rate limits, and failure modes.
-  Use when preparing a OneNote integration for production deployment or conducting a launch review.
-  Trigger with "onenote production checklist", "onenote launch review", "onenote prod ready".
+description: 'Production readiness checklist for OneNote Graph API integrations covering
+  auth, rate limits, and failure modes.
+
+  Use when preparing a OneNote integration for production deployment or conducting
+  a launch review.
+
+  Trigger with "onenote production checklist", "onenote launch review", "onenote prod
+  ready".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-rate-limits/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-rate-limits/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: onenote-rate-limits
-description: |
-  Implement proper rate limit handling for OneNote Graph API with queue-based throttling.
+description: 'Implement proper rate limit handling for OneNote Graph API with queue-based
+  throttling.
+
   Use when building high-throughput OneNote integrations or debugging 429 errors.
-  Trigger with "onenote rate limit", "onenote 429", "onenote throttling", "graph api throttle".
+
+  Trigger with "onenote rate limit", "onenote 429", "onenote throttling", "graph api
+  throttle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote — Rate Limit Handling & Request Throttling
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-reference-architecture
-description: |
-  Reference architecture for OneNote integrations covering all notebook locations and API path patterns.
-  Use when designing multi-tenant OneNote integrations or choosing between personal, SharePoint, and group notebook APIs.
-  Trigger with "onenote architecture", "onenote api paths", "onenote sharepoint vs personal".
+description: 'Reference architecture for OneNote integrations covering all notebook
+  locations and API path patterns.
+
+  Use when designing multi-tenant OneNote integrations or choosing between personal,
+  SharePoint, and group notebook APIs.
+
+  Trigger with "onenote architecture", "onenote api paths", "onenote sharepoint vs
+  personal".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-sdk-patterns/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: onenote-sdk-patterns
-description: |
-  Production SDK patterns for OneNote Graph API: retry logic, batch requests, and safe file uploads.
-  Use when building production OneNote integrations that need rate limit handling and reliable uploads.
+description: 'Production SDK patterns for OneNote Graph API: retry logic, batch requests,
+  and safe file uploads.
+
+  Use when building production OneNote integrations that need rate limit handling
+  and reliable uploads.
+
   Trigger with "onenote sdk patterns", "onenote retry logic", "onenote batch requests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-security-basics/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-security-basics/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-security-basics
-description: |
-  Implement secure authentication, token management, and permission scoping for OneNote Graph API.
-  Use when hardening OneNote integrations, implementing least-privilege permissions, or managing token lifecycle.
-  Trigger with "onenote security", "onenote permissions", "onenote token management", "onenote least privilege".
+description: 'Implement secure authentication, token management, and permission scoping
+  for OneNote Graph API.
+
+  Use when hardening OneNote integrations, implementing least-privilege permissions,
+  or managing token lifecycle.
+
+  Trigger with "onenote security", "onenote permissions", "onenote token management",
+  "onenote least privilege".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Security Basics
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-upgrade-migration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: onenote-upgrade-migration
-description: |
-  Migrate OneNote integrations across Graph SDK versions, auth deprecations, and API changes.
-  Use when upgrading Graph SDK, migrating from app-only to delegated auth, or handling deprecated endpoints.
-  Trigger with "onenote upgrade", "onenote migration", "graph sdk upgrade", "onenote breaking changes".
+description: 'Migrate OneNote integrations across Graph SDK versions, auth deprecations,
+  and API changes.
+
+  Use when upgrading Graph SDK, migrating from app-only to delegated auth, or handling
+  deprecated endpoints.
+
+  Trigger with "onenote upgrade", "onenote migration", "graph sdk upgrade", "onenote
+  breaking changes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/onenote-pack/skills/onenote-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/onenote-pack/skills/onenote-webhooks-events/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: onenote-webhooks-events
-description: |
-  Implement change detection for OneNote using polling and delta queries (webhooks decommissioned June 2023).
+description: 'Implement change detection for OneNote using polling and delta queries
+  (webhooks decommissioned June 2023).
+
   Use when building real-time sync, change monitoring, or event-driven OneNote integrations.
-  Trigger with "onenote changes", "onenote polling", "onenote sync", "onenote delta query".
+
+  Trigger with "onenote changes", "onenote polling", "onenote sync", "onenote delta
+  query".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, onenote, microsoft]
-compatible-with: claude-code
+tags:
+- saas
+- onenote
+- microsoft
+compatibility: Designed for Claude Code
 ---
-
 # OneNote — Change Detection (Polling & Delta Queries)
 
 ## Overview


### PR DESCRIPTION
## Summary

Chunk 4 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated `compatible-with` CSV-platform-list field to the spec-aligned `compatibility` free-text field per agentskills.io/specification.

**Pure schema migration. No content changes.** Same tool used in PRs #620 and #622.

### Assigned packs (chunk 4 of 6)

| Pack | Files |
|---|---|
| klaviyo-pack | 24 |
| klingai-pack | 30 |
| langchain-pack | 24 |
| langchain-py-pack | 33 |
| langfuse-pack | 24 |
| lindy-pack | 24 |
| linear-pack | 24 |
| linktree-pack | 18 |
| lokalise-pack | 24 |
| lucidchart-pack | 18 |
| maintainx-pack | 24 |
| mindtickle-pack | 18 |
| miro-pack | 24 |
| mistral-pack | 24 |
| navan-pack | 26 |
| notion-pack | 32 |
| obsidian-pack | 24 |
| onenote-pack | 18 |
| **TOTAL** | **433** |

### Side effect

`yaml.safe_dump` round-trips the entire frontmatter — so `description: |` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] `grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Refs #613

jeremy made me do it
-claude