### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 5/6, 398 skills)

### DIFF
--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-ci-integration/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-ci-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-ci-integration
-description: |
-  Ci Integration for OpenEvidence.
+description: 'Ci Integration for OpenEvidence.
+
   Trigger: "openevidence ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence CI Integration
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-common-errors/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-common-errors/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-common-errors
-description: |
-  Diagnose and fix OpenEvidence common errors.
+description: 'Diagnose and fix OpenEvidence common errors.
+
   Trigger: "openevidence error", "fix openevidence", "debug openevidence".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Common Errors
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-core-workflow-a/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: openevidence-core-workflow-a
-description: |
-  Execute OpenEvidence primary workflow: Clinical Query & Decision Support.
-  Trigger: "openevidence clinical query & decision support", "primary openevidence workflow".
+description: 'Execute OpenEvidence primary workflow: Clinical Query & Decision Support.
+
+  Trigger: "openevidence clinical query & decision support", "primary openevidence
+  workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence — Evidence Search & Retrieval
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-core-workflow-b/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: openevidence-core-workflow-b
-description: |
-  Execute OpenEvidence secondary workflow: DeepConsult Research Synthesis.
-  Trigger: "openevidence deepconsult research synthesis", "secondary openevidence workflow".
+description: 'Execute OpenEvidence secondary workflow: DeepConsult Research Synthesis.
+
+  Trigger: "openevidence deepconsult research synthesis", "secondary openevidence
+  workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence — Evidence Review & Citations
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-cost-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-cost-tuning
-description: |
-  Cost Tuning for OpenEvidence.
+description: 'Cost Tuning for OpenEvidence.
+
   Trigger: "openevidence cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Cost Tuning
 
 ## Optimization Strategies

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-data-handling/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-data-handling/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-data-handling
-description: |
-  Data Handling for OpenEvidence.
+description: 'Data Handling for OpenEvidence.
+
   Trigger: "openevidence data handling".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Data Handling
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-debug-bundle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-debug-bundle
-description: |
-  Debug Bundle for OpenEvidence.
+description: 'Debug Bundle for OpenEvidence.
+
   Trigger: "openevidence debug bundle".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-deploy-integration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-deploy-integration
-description: |
-  Deploy Integration for OpenEvidence.
+description: 'Deploy Integration for OpenEvidence.
+
   Trigger: "openevidence deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-enterprise-rbac/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-enterprise-rbac
-description: |
-  Enterprise Rbac for OpenEvidence.
+description: 'Enterprise Rbac for OpenEvidence.
+
   Trigger: "openevidence enterprise rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-hello-world/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-hello-world/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-hello-world
-description: |
-  Create a minimal working OpenEvidence example.
+description: 'Create a minimal working OpenEvidence example.
+
   Trigger: "openevidence hello world", "openevidence example", "test openevidence".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Hello World
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-incident-runbook/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-incident-runbook
-description: |
-  Incident Runbook for OpenEvidence.
+description: 'Incident Runbook for OpenEvidence.
+
   Trigger: "openevidence incident runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Incident Runbook
 
 ## Severity

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-install-auth/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: openevidence-install-auth
-description: |
-  Install and configure OpenEvidence SDK/API authentication.
+description: 'Install and configure OpenEvidence SDK/API authentication.
+
   Use when setting up a new OpenEvidence integration.
+
   Trigger: "install openevidence", "setup openevidence", "openevidence auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-local-dev-loop/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-local-dev-loop
-description: |
-  Local Dev Loop for OpenEvidence.
+description: 'Local Dev Loop for OpenEvidence.
+
   Trigger: "openevidence local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-migration-deep-dive/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-migration-deep-dive
-description: |
-  Migration Deep Dive for OpenEvidence.
+description: 'Migration Deep Dive for OpenEvidence.
+
   Trigger: "openevidence migration deep dive".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Migration Deep Dive
 
 ## Migration Strategies

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-multi-env-setup/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-multi-env-setup
-description: |
-  Multi Env Setup for OpenEvidence.
+description: 'Multi Env Setup for OpenEvidence.
+
   Trigger: "openevidence multi env setup".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-observability/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-observability/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-observability
-description: |
-  Observability for OpenEvidence.
+description: 'Observability for OpenEvidence.
+
   Trigger: "openevidence observability".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Observability
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-performance-tuning/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-performance-tuning
-description: |
-  Performance Tuning for OpenEvidence.
+description: 'Performance Tuning for OpenEvidence.
+
   Trigger: "openevidence performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-prod-checklist/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-prod-checklist
-description: |
-  Prod Checklist for OpenEvidence.
+description: 'Prod Checklist for OpenEvidence.
+
   Trigger: "openevidence prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-rate-limits/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-rate-limits/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-rate-limits
-description: |
-  Rate Limits for OpenEvidence.
+description: 'Rate Limits for OpenEvidence.
+
   Trigger: "openevidence rate limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-reference-architecture/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-reference-architecture
-description: |
-  Reference Architecture for OpenEvidence.
+description: 'Reference Architecture for OpenEvidence.
+
   Trigger: "openevidence reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-sdk-patterns/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-sdk-patterns
-description: |
-  Sdk Patterns for OpenEvidence.
+description: 'Sdk Patterns for OpenEvidence.
+
   Trigger: "openevidence sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-security-basics/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-security-basics/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-security-basics
-description: |
-  Security Basics for OpenEvidence.
+description: 'Security Basics for OpenEvidence.
+
   Trigger: "openevidence security basics".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Security Basics
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-upgrade-migration/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-upgrade-migration
-description: |
-  Upgrade Migration for OpenEvidence.
+description: 'Upgrade Migration for OpenEvidence.
+
   Trigger: "openevidence upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/openevidence-pack/skills/openevidence-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/openevidence-pack/skills/openevidence-webhooks-events/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: openevidence-webhooks-events
-description: |
-  Webhooks Events for OpenEvidence.
+description: 'Webhooks Events for OpenEvidence.
+
   Trigger: "openevidence webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, openevidence, healthcare]
-compatible-with: claude-code
+tags:
+- saas
+- openevidence
+- healthcare
+compatibility: Designed for Claude Code
 ---
-
 # OpenEvidence Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-audit-logging/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-audit-logging/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-audit-logging
-description: |
-  Implement audit logging for OpenRouter API calls. Use when building compliance trails, debugging production issues, or tracking model usage. Triggers: 'openrouter audit', 'openrouter logging', 'audit trail openrouter', 'log openrouter requests'.
+description: 'Implement audit logging for OpenRouter API calls. Use when building
+  compliance trails, debugging production issues, or tracking model usage. Triggers:
+  ''openrouter audit'', ''openrouter logging'', ''audit trail openrouter'', ''log
+  openrouter requests''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, security, logging, compliance]
+tags:
+- saas
+- openrouter
+- security
+- logging
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Audit Logging
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-caching-strategy/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-caching-strategy/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-caching-strategy
-description: |
-  Implement caching for OpenRouter API responses to reduce cost and latency. Use when optimizing repeat queries, building RAG systems, or reducing API spend. Triggers: 'openrouter cache', 'cache llm responses', 'openrouter caching', 'reduce openrouter cost'.
+description: 'Implement caching for OpenRouter API responses to reduce cost and latency.
+  Use when optimizing repeat queries, building RAG systems, or reducing API spend.
+  Triggers: ''openrouter cache'', ''cache llm responses'', ''openrouter caching'',
+  ''reduce openrouter cost''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, caching, cost-optimization]
+tags:
+- saas
+- openrouter
+- caching
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Caching Strategy
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-common-errors/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-common-errors/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-common-errors
-description: |
-  Diagnose and fix common OpenRouter API errors. Use when encountering error codes, unexpected failures, or debugging API responses. Triggers: 'openrouter error', 'openrouter 401', 'openrouter 429', 'openrouter 402', 'fix openrouter'.
+description: 'Diagnose and fix common OpenRouter API errors. Use when encountering
+  error codes, unexpected failures, or debugging API responses. Triggers: ''openrouter
+  error'', ''openrouter 401'', ''openrouter 429'', ''openrouter 402'', ''fix openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, errors, debugging, troubleshooting]
+tags:
+- saas
+- openrouter
+- errors
+- debugging
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Common Errors
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-compliance-review/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-compliance-review/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-compliance-review
-description: |
-  Review OpenRouter integration for regulatory compliance (SOC2, GDPR, HIPAA). Use when preparing for audits, evaluating data handling, or documenting compliance posture. Triggers: 'openrouter compliance', 'openrouter gdpr', 'openrouter soc2', 'openrouter data residency'.
+description: 'Review OpenRouter integration for regulatory compliance (SOC2, GDPR,
+  HIPAA). Use when preparing for audits, evaluating data handling, or documenting
+  compliance posture. Triggers: ''openrouter compliance'', ''openrouter gdpr'', ''openrouter
+  soc2'', ''openrouter data residency''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, compliance, security, governance]
+tags:
+- saas
+- openrouter
+- compliance
+- security
+- governance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Compliance Review
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-context-optimization/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-context-optimization/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-context-optimization
-description: |
-  Optimize context window usage for OpenRouter models to reduce cost and improve quality. Use when hitting context limits, managing long conversations, or building RAG systems. Triggers: 'openrouter context', 'context window', 'openrouter token limit', 'reduce tokens openrouter'.
+description: 'Optimize context window usage for OpenRouter models to reduce cost and
+  improve quality. Use when hitting context limits, managing long conversations, or
+  building RAG systems. Triggers: ''openrouter context'', ''context window'', ''openrouter
+  token limit'', ''reduce tokens openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, optimization, context-window]
+tags:
+- saas
+- openrouter
+- optimization
+- context-window
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Context Optimization
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-cost-controls/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-cost-controls/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-cost-controls
-description: |
-  Implement cost controls for OpenRouter API usage. Use when setting budgets, preventing overspend, or managing per-key limits. Triggers: 'openrouter budget', 'openrouter cost limit', 'openrouter spending', 'control openrouter cost'.
+description: 'Implement cost controls for OpenRouter API usage. Use when setting budgets,
+  preventing overspend, or managing per-key limits. Triggers: ''openrouter budget'',
+  ''openrouter cost limit'', ''openrouter spending'', ''control openrouter cost''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, cost-optimization, budgets]
+tags:
+- saas
+- openrouter
+- cost-optimization
+- budgets
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Cost Controls
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-data-privacy/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-data-privacy/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-data-privacy
-description: |
-  Implement data privacy controls for OpenRouter API usage. Use when handling PII, meeting GDPR/CCPA requirements, or protecting sensitive data in prompts. Triggers: 'openrouter privacy', 'openrouter pii', 'openrouter gdpr', 'openrouter data handling'.
+description: 'Implement data privacy controls for OpenRouter API usage. Use when handling
+  PII, meeting GDPR/CCPA requirements, or protecting sensitive data in prompts. Triggers:
+  ''openrouter privacy'', ''openrouter pii'', ''openrouter gdpr'', ''openrouter data
+  handling''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, privacy, security, compliance]
+tags:
+- saas
+- openrouter
+- privacy
+- security
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Data Privacy
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-debug-bundle/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-debug-bundle
-description: |
-  Create debug bundles for troubleshooting OpenRouter API issues. Use when diagnosing failures, unexpected responses, or latency problems. Triggers: 'openrouter debug', 'openrouter troubleshoot', 'debug openrouter request', 'openrouter issue'.
+description: 'Create debug bundles for troubleshooting OpenRouter API issues. Use
+  when diagnosing failures, unexpected responses, or latency problems. Triggers: ''openrouter
+  debug'', ''openrouter troubleshoot'', ''debug openrouter request'', ''openrouter
+  issue''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, debugging, troubleshooting]
+tags:
+- saas
+- openrouter
+- debugging
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Debug Bundle
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-fallback-config/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-fallback-config/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-fallback-config
-description: |
-  Configure automatic model fallbacks for high availability on OpenRouter. Use when building resilient systems that need to survive provider outages. Triggers: 'openrouter fallback', 'model fallback', 'openrouter failover', 'openrouter backup model'.
+description: 'Configure automatic model fallbacks for high availability on OpenRouter.
+  Use when building resilient systems that need to survive provider outages. Triggers:
+  ''openrouter fallback'', ''model fallback'', ''openrouter failover'', ''openrouter
+  backup model''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, reliability, fallback, high-availability]
+tags:
+- saas
+- openrouter
+- reliability
+- fallback
+- high-availability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Fallback Config
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-function-calling/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-function-calling/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-function-calling
-description: |
-  Implement function/tool calling with OpenRouter models. Use when building agents, structured output, or tool-augmented LLM workflows. Triggers: 'openrouter function calling', 'openrouter tools', 'openrouter agent tools', 'tool use openrouter'.
+description: 'Implement function/tool calling with OpenRouter models. Use when building
+  agents, structured output, or tool-augmented LLM workflows. Triggers: ''openrouter
+  function calling'', ''openrouter tools'', ''openrouter agent tools'', ''tool use
+  openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, function-calling, agents, tools]
+tags:
+- saas
+- openrouter
+- function-calling
+- agents
+- tools
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Function Calling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-hello-world/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-hello-world/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-hello-world
-description: |
-  Send your first OpenRouter API request and understand the response. Use when learning OpenRouter, testing setup, or verifying connectivity. Triggers: 'openrouter hello world', 'openrouter first request', 'test openrouter', 'openrouter quickstart'.
+description: 'Send your first OpenRouter API request and understand the response.
+  Use when learning OpenRouter, testing setup, or verifying connectivity. Triggers:
+  ''openrouter hello world'', ''openrouter first request'', ''test openrouter'', ''openrouter
+  quickstart''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, api, quickstart]
+tags:
+- saas
+- openrouter
+- api
+- quickstart
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Hello World
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-install-auth/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-install-auth/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-install-auth
-description: |
-  Set up OpenRouter API authentication and configure API keys. Use when starting a new OpenRouter integration, rotating keys, or troubleshooting auth issues. Triggers: 'openrouter setup', 'openrouter api key', 'configure openrouter auth', 'sk-or key'.
+description: 'Set up OpenRouter API authentication and configure API keys. Use when
+  starting a new OpenRouter integration, rotating keys, or troubleshooting auth issues.
+  Triggers: ''openrouter setup'', ''openrouter api key'', ''configure openrouter auth'',
+  ''sk-or key''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, api, authentication, setup]
+tags:
+- saas
+- openrouter
+- api
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Install & Auth
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-known-pitfalls/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-known-pitfalls
-description: |
-  Avoid common OpenRouter integration mistakes and gotchas. Use proactively when starting a new integration or reviewing existing code. Triggers: 'openrouter pitfalls', 'openrouter gotchas', 'openrouter mistakes', 'openrouter best practices'.
+description: 'Avoid common OpenRouter integration mistakes and gotchas. Use proactively
+  when starting a new integration or reviewing existing code. Triggers: ''openrouter
+  pitfalls'', ''openrouter gotchas'', ''openrouter mistakes'', ''openrouter best practices''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, best-practices, pitfalls]
+tags:
+- saas
+- openrouter
+- best-practices
+- pitfalls
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Known Pitfalls
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-load-balancing/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-load-balancing/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-load-balancing
-description: |
-  Distribute OpenRouter requests across multiple keys and models for high throughput. Use when scaling beyond single-key rate limits or building high-availability systems. Triggers: 'openrouter load balance', 'openrouter scaling', 'distribute openrouter requests', 'multiple api keys'.
+description: 'Distribute OpenRouter requests across multiple keys and models for high
+  throughput. Use when scaling beyond single-key rate limits or building high-availability
+  systems. Triggers: ''openrouter load balance'', ''openrouter scaling'', ''distribute
+  openrouter requests'', ''multiple api keys''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, scaling, high-availability, load-balancing]
+tags:
+- saas
+- openrouter
+- scaling
+- high-availability
+- load-balancing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Load Balancing
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-availability/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-availability/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-model-availability
-description: |
-  Monitor OpenRouter model availability and implement health checks. Use when building systems that depend on specific models being online. Triggers: 'openrouter model status', 'is model available', 'openrouter health check', 'model availability'.
+description: 'Monitor OpenRouter model availability and implement health checks. Use
+  when building systems that depend on specific models being online. Triggers: ''openrouter
+  model status'', ''is model available'', ''openrouter health check'', ''model availability''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, monitoring, availability]
+tags:
+- saas
+- openrouter
+- monitoring
+- availability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Model Availability
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-catalog/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-catalog/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-model-catalog
-description: |
-  Query, filter, and select from OpenRouter's 400+ model catalog. Use when choosing models, comparing pricing, or checking capabilities. Triggers: 'openrouter models', 'list models', 'model catalog', 'compare models', 'available models'.
+description: 'Query, filter, and select from OpenRouter''s 400+ model catalog. Use
+  when choosing models, comparing pricing, or checking capabilities. Triggers: ''openrouter
+  models'', ''list models'', ''model catalog'', ''compare models'', ''available models''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, models, catalog]
+tags:
+- saas
+- openrouter
+- models
+- catalog
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Model Catalog
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-routing/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-routing/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-model-routing
-description: |
-  Implement intelligent model routing to optimize cost, quality, and latency on OpenRouter. Use when building multi-model systems or optimizing spend across task types. Triggers: 'openrouter routing', 'model routing', 'route to model', 'model selection openrouter'.
+description: 'Implement intelligent model routing to optimize cost, quality, and latency
+  on OpenRouter. Use when building multi-model systems or optimizing spend across
+  task types. Triggers: ''openrouter routing'', ''model routing'', ''route to model'',
+  ''model selection openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, routing, cost-optimization, model-selection]
+tags:
+- saas
+- openrouter
+- routing
+- cost-optimization
+- model-selection
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Model Routing
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-multi-provider/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-multi-provider/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-multi-provider
-description: |
-  Use multiple AI providers (OpenAI, Anthropic, Google, Meta) through OpenRouter's unified API. Use when comparing providers, building cross-provider workflows, or maximizing availability. Triggers: 'openrouter providers', 'multi provider', 'openrouter openai anthropic', 'compare models openrouter'.
+description: 'Use multiple AI providers (OpenAI, Anthropic, Google, Meta) through
+  OpenRouter''s unified API. Use when comparing providers, building cross-provider
+  workflows, or maximizing availability. Triggers: ''openrouter providers'', ''multi
+  provider'', ''openrouter openai anthropic'', ''compare models openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, multi-provider, comparison]
+tags:
+- saas
+- openrouter
+- multi-provider
+- comparison
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Multi-Provider
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-openai-compat/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-openai-compat/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-openai-compat
-description: |
-  Migrate from OpenAI to OpenRouter with minimal code changes. Use when switching to OpenRouter or maintaining dual compatibility. Triggers: 'openrouter openai compatible', 'openrouter drop-in', 'openai to openrouter', 'openrouter migration'.
+description: 'Migrate from OpenAI to OpenRouter with minimal code changes. Use when
+  switching to OpenRouter or maintaining dual compatibility. Triggers: ''openrouter
+  openai compatible'', ''openrouter drop-in'', ''openai to openrouter'', ''openrouter
+  migration''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, api, migration, openai]
+tags:
+- saas
+- openrouter
+- api
+- migration
+- openai
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter OpenAI Compatibility
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-performance-tuning/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-performance-tuning
-description: |
-  Optimize OpenRouter request latency and throughput. Use when building real-time applications, reducing TTFT, or scaling request volume. Triggers: 'openrouter performance', 'openrouter latency', 'openrouter speed', 'optimize openrouter throughput'.
+description: 'Optimize OpenRouter request latency and throughput. Use when building
+  real-time applications, reducing TTFT, or scaling request volume. Triggers: ''openrouter
+  performance'', ''openrouter latency'', ''openrouter speed'', ''optimize openrouter
+  throughput''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, performance, latency, optimization]
+tags:
+- saas
+- openrouter
+- performance
+- latency
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Performance Tuning
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-pricing-basics/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-pricing-basics/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-pricing-basics
-description: |
-  Understand OpenRouter pricing, calculate costs, and optimize spend. Use when budgeting, comparing model costs, or tracking spend. Triggers: 'openrouter pricing', 'openrouter cost', 'model pricing', 'openrouter budget', 'how much does openrouter cost'.
+description: 'Understand OpenRouter pricing, calculate costs, and optimize spend.
+  Use when budgeting, comparing model costs, or tracking spend. Triggers: ''openrouter
+  pricing'', ''openrouter cost'', ''model pricing'', ''openrouter budget'', ''how
+  much does openrouter cost''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, pricing, cost-optimization]
+tags:
+- saas
+- openrouter
+- pricing
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Pricing Basics
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-prod-checklist/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-prod-checklist
-description: |
-  Validate production readiness of your OpenRouter integration. Use before launching to production or during operational reviews. Triggers: 'openrouter production', 'openrouter launch', 'production checklist openrouter', 'openrouter deploy'.
+description: 'Validate production readiness of your OpenRouter integration. Use before
+  launching to production or during operational reviews. Triggers: ''openrouter production'',
+  ''openrouter launch'', ''production checklist openrouter'', ''openrouter deploy''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, production, deployment, checklist]
+tags:
+- saas
+- openrouter
+- production
+- deployment
+- checklist
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Production Checklist
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-rate-limits/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-rate-limits/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-rate-limits
-description: |
-  Understand and handle OpenRouter rate limits. Use when hitting 429 errors, building high-throughput systems, or implementing retry logic. Triggers: 'openrouter rate limit', 'openrouter 429', 'openrouter throttle', 'rate limiting openrouter'.
+description: 'Understand and handle OpenRouter rate limits. Use when hitting 429 errors,
+  building high-throughput systems, or implementing retry logic. Triggers: ''openrouter
+  rate limit'', ''openrouter 429'', ''openrouter throttle'', ''rate limiting openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, rate-limits, throttling]
+tags:
+- saas
+- openrouter
+- rate-limits
+- throttling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Rate Limits
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-reference-architecture/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-reference-architecture
-description: |
-  Design production architectures using OpenRouter as the LLM gateway. Use when planning system design, reviewing architecture, or scaling AI applications. Triggers: 'openrouter architecture', 'openrouter system design', 'openrouter at scale', 'llm gateway architecture'.
+description: 'Design production architectures using OpenRouter as the LLM gateway.
+  Use when planning system design, reviewing architecture, or scaling AI applications.
+  Triggers: ''openrouter architecture'', ''openrouter system design'', ''openrouter
+  at scale'', ''llm gateway architecture''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, architecture, system-design, scaling]
+tags:
+- saas
+- openrouter
+- architecture
+- system-design
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Reference Architecture
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-routing-rules/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-routing-rules/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-routing-rules
-description: |
-  Define custom routing rules for OpenRouter requests based on user tier, task type, cost budget, and availability. Triggers: 'openrouter rules', 'routing rules', 'custom routing openrouter', 'conditional model selection'.
+description: 'Define custom routing rules for OpenRouter requests based on user tier,
+  task type, cost budget, and availability. Triggers: ''openrouter rules'', ''routing
+  rules'', ''custom routing openrouter'', ''conditional model selection''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, routing, rules-engine]
+tags:
+- saas
+- openrouter
+- routing
+- rules-engine
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Routing Rules
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-sdk-patterns/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-sdk-patterns
-description: |
-  Build reusable OpenRouter client wrappers with retries, typing, and middleware. Use when creating SDKs or client libraries. Triggers: 'openrouter sdk', 'openrouter client wrapper', 'openrouter patterns', 'openrouter library'.
+description: 'Build reusable OpenRouter client wrappers with retries, typing, and
+  middleware. Use when creating SDKs or client libraries. Triggers: ''openrouter sdk'',
+  ''openrouter client wrapper'', ''openrouter patterns'', ''openrouter library''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, sdk, patterns]
+tags:
+- saas
+- openrouter
+- sdk
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter SDK Patterns
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-streaming-setup/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-streaming-setup/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-streaming-setup
-description: |
-  Implement streaming responses with OpenRouter for real-time UIs. Use when building chat interfaces, reducing time-to-first-token, or processing long completions. Triggers: 'openrouter streaming', 'openrouter sse', 'stream response openrouter', 'real-time openrouter'.
+description: 'Implement streaming responses with OpenRouter for real-time UIs. Use
+  when building chat interfaces, reducing time-to-first-token, or processing long
+  completions. Triggers: ''openrouter streaming'', ''openrouter sse'', ''stream response
+  openrouter'', ''real-time openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, streaming, real-time]
+tags:
+- saas
+- openrouter
+- streaming
+- real-time
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Streaming Setup
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-team-setup/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-team-setup/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: openrouter-team-setup
-description: |
-  Configure OpenRouter for multi-user teams with per-user keys, budget controls, and usage attribution. Triggers: 'openrouter team', 'openrouter multi-user', 'openrouter organization', 'team api keys openrouter'.
+description: 'Configure OpenRouter for multi-user teams with per-user keys, budget
+  controls, and usage attribution. Triggers: ''openrouter team'', ''openrouter multi-user'',
+  ''openrouter organization'', ''team api keys openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, team, organization, governance]
+tags:
+- saas
+- openrouter
+- team
+- organization
+- governance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Team Setup
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-upgrade-migration/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: openrouter-upgrade-migration
-description: |
-  Migrate to OpenRouter from direct provider APIs or upgrade between SDK/model versions. Triggers: 'openrouter migrate', 'openrouter upgrade', 'switch to openrouter', 'migrate from openai to openrouter'.
+description: 'Migrate to OpenRouter from direct provider APIs or upgrade between SDK/model
+  versions. Triggers: ''openrouter migrate'', ''openrouter upgrade'', ''switch to
+  openrouter'', ''migrate from openai to openrouter''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, migration, upgrade]
+tags:
+- saas
+- openrouter
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Upgrade & Migration
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-usage-analytics/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-usage-analytics/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: openrouter-usage-analytics
-description: |
-  Track and analyze OpenRouter API usage patterns, costs, and performance. Use when building dashboards, optimizing spend, or reporting on AI usage. Triggers: 'openrouter analytics', 'openrouter usage', 'openrouter metrics', 'track openrouter spend'.
+description: 'Track and analyze OpenRouter API usage patterns, costs, and performance.
+  Use when building dashboards, optimizing spend, or reporting on AI usage. Triggers:
+  ''openrouter analytics'', ''openrouter usage'', ''openrouter metrics'', ''track
+  openrouter spend''.
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, openrouter, analytics, cost-optimization, monitoring]
+tags:
+- saas
+- openrouter
+- analytics
+- cost-optimization
+- monitoring
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # OpenRouter Usage Analytics
 

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-ci-integration/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-ci-integration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-ci-integration
-description: |
-  Configure CI/CD pipelines for OCI with Terraform and GitHub Actions.
-  Use when setting up automated infrastructure deployments, running Terraform plans in CI, or configuring OCI authentication for GitHub Actions.
-  Trigger with "oraclecloud ci", "oci terraform ci", "oci github actions", "oracle cloud ci integration".
+description: 'Configure CI/CD pipelines for OCI with Terraform and GitHub Actions.
+
+  Use when setting up automated infrastructure deployments, running Terraform plans
+  in CI, or configuring OCI authentication for GitHub Actions.
+
+  Trigger with "oraclecloud ci", "oci terraform ci", "oci github actions", "oracle
+  cloud ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(terraform:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud CI Integration
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-common-errors/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-common-errors
-description: |
-  Diagnose and fix Oracle Cloud Infrastructure API errors with real error codes and proven fixes.
-  Use when encountering OCI ServiceError exceptions, auth failures, SSL issues, or timeout errors.
-  Trigger with "oci error", "fix oraclecloud", "debug oci", "NotAuthorizedOrNotFound", "oci 401".
+description: 'Diagnose and fix Oracle Cloud Infrastructure API errors with real error
+  codes and proven fixes.
+
+  Use when encountering OCI ServiceError exceptions, auth failures, SSL issues, or
+  timeout errors.
+
+  Trigger with "oci error", "fix oraclecloud", "debug oci", "NotAuthorizedOrNotFound",
+  "oci 401".
+
+  '
 allowed-tools: Read, Grep, Bash(oci:*), Bash(pip:*), Bash(openssl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Common Errors
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-core-workflow-a/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-core-workflow-a
-description: |
-  Launch, manage, and scale OCI compute instances with capacity retry logic.
-  Use when provisioning VMs, selecting instance shapes, or handling "out of capacity" errors.
+description: 'Launch, manage, and scale OCI compute instances with capacity retry
+  logic.
+
+  Use when provisioning VMs, selecting instance shapes, or handling "out of capacity"
+  errors.
+
   Trigger with "oci compute", "launch instance", "out of capacity", "instance shapes".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # OCI Compute — Launch, Manage & Scale
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-core-workflow-b/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: oraclecloud-core-workflow-b
-description: |
-  Build OCI networking from scratch — VCN, subnets, gateways, and security rules.
-  Use when creating a new VCN, debugging connectivity issues, or setting up security lists and NSGs.
-  Trigger with "oci networking", "vcn setup", "security list", "nsg rules", "oci subnet".
+description: "Build OCI networking from scratch \u2014 VCN, subnets, gateways, and\
+  \ security rules.\nUse when creating a new VCN, debugging connectivity issues, or\
+  \ setting up security lists and NSGs.\nTrigger with \"oci networking\", \"vcn setup\"\
+  , \"security list\", \"nsg rules\", \"oci subnet\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # OCI Networking — VCN, Subnets & Security Rules
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-cost-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-cost-tuning
-description: |
-  Track OCI spend with the Usage API and set up budget alerts.
-  Use when monitoring Oracle Cloud costs, creating budgets, analyzing spend by compartment or service, or optimizing Universal Credits consumption.
-  Trigger with "oraclecloud cost", "oci budget", "oci usage api", "oci spending", "oracle cloud cost tuning".
+description: 'Track OCI spend with the Usage API and set up budget alerts.
+
+  Use when monitoring Oracle Cloud costs, creating budgets, analyzing spend by compartment
+  or service, or optimizing Universal Credits consumption.
+
+  Trigger with "oraclecloud cost", "oci budget", "oci usage api", "oci spending",
+  "oracle cloud cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-data-handling/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-data-handling/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: oraclecloud-data-handling
-description: |
-  Manage OCI Object Storage — buckets, uploads, PARs, and lifecycle policies.
-  Use when uploading objects, creating pre-authenticated requests, or configuring lifecycle rules.
-  Trigger with "oci object storage", "oci bucket", "par url", "multipart upload", "oci lifecycle".
+description: "Manage OCI Object Storage \u2014 buckets, uploads, PARs, and lifecycle\
+  \ policies.\nUse when uploading objects, creating pre-authenticated requests, or\
+  \ configuring lifecycle rules.\nTrigger with \"oci object storage\", \"oci bucket\"\
+  , \"par url\", \"multipart upload\", \"oci lifecycle\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # OCI Object Storage — Buckets, PARs & Lifecycle
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-debug-bundle/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: oraclecloud-debug-bundle
-description: |
-  Collect OCI instance diagnostics — serial console, cloud-init logs, metadata, and VCN flow logs — into a single debug bundle.
-  Use when an OCI instance is unresponsive, stuck in provisioning, or showing infrastructure errors.
-  Trigger with "oraclecloud debug bundle", "oci diagnostics", "oci serial console", "oci instance debug".
+description: "Collect OCI instance diagnostics \u2014 serial console, cloud-init logs,\
+  \ metadata, and VCN flow logs \u2014 into a single debug bundle.\nUse when an OCI\
+  \ instance is unresponsive, stuck in provisioning, or showing infrastructure errors.\n\
+  Trigger with \"oraclecloud debug bundle\", \"oci diagnostics\", \"oci serial console\"\
+  , \"oci instance debug\".\n"
 allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-deploy-integration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-deploy-integration
-description: |
-  Deploy containers to OCI using OKE (Kubernetes) or Container Instances.
-  Use when deploying applications to Oracle Cloud, pushing images to OCIR, or configuring OKE clusters.
-  Trigger with "oraclecloud deploy", "oci kubernetes", "oke deploy", "oci container instances", "oracle cloud deploy integration".
+description: 'Deploy containers to OCI using OKE (Kubernetes) or Container Instances.
+
+  Use when deploying applications to Oracle Cloud, pushing images to OCIR, or configuring
+  OKE clusters.
+
+  Trigger with "oraclecloud deploy", "oci kubernetes", "oke deploy", "oci container
+  instances", "oracle cloud deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(kubectl:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-enterprise-rbac/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-enterprise-rbac
-description: |
-  Design OCI compartment hierarchies, dynamic groups, and cross-tenancy access patterns.
-  Use when planning enterprise RBAC, setting up Instance Principal auth, or debugging policy inheritance.
-  Trigger with "oraclecloud enterprise rbac", "oci compartments", "oci dynamic groups", "oci policy inheritance".
+description: 'Design OCI compartment hierarchies, dynamic groups, and cross-tenancy
+  access patterns.
+
+  Use when planning enterprise RBAC, setting up Instance Principal auth, or debugging
+  policy inheritance.
+
+  Trigger with "oraclecloud enterprise rbac", "oci compartments", "oci dynamic groups",
+  "oci policy inheritance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-hello-world/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-hello-world/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-hello-world
-description: |
-  Launch your first OCI compute instance with capacity retry logic.
-  Use when creating a new compute instance, testing OCI connectivity, or hitting "Out of host capacity" errors on Always Free ARM shapes.
-  Trigger with "oraclecloud hello world", "launch oci instance", "oci compute example", "out of capacity oci".
+description: 'Launch your first OCI compute instance with capacity retry logic.
+
+  Use when creating a new compute instance, testing OCI connectivity, or hitting "Out
+  of host capacity" errors on Always Free ARM shapes.
+
+  Trigger with "oraclecloud hello world", "launch oci instance", "oci compute example",
+  "out of capacity oci".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Hello World
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-incident-runbook/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: oraclecloud-incident-runbook
-description: |
-  Self-service incident runbook for OCI outages — health probes, instance recovery, cross-AD/region failover.
-  Use when OCI instances go down, the status page is silent, or you need automated recovery without waiting for support.
-  Trigger with "oraclecloud incident", "oci outage runbook", "oci failover", "oci instance recovery".
+description: "Self-service incident runbook for OCI outages \u2014 health probes,\
+  \ instance recovery, cross-AD/region failover.\nUse when OCI instances go down,\
+  \ the status page is silent, or you need automated recovery without waiting for\
+  \ support.\nTrigger with \"oraclecloud incident\", \"oci outage runbook\", \"oci\
+  \ failover\", \"oci instance recovery\".\n"
 allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-install-auth/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-install-auth/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-install-auth
-description: |
-  Install and configure Oracle Cloud Infrastructure (OCI) SDK and CLI authentication.
-  Use when setting up a new OCI integration, generating API signing keys, or debugging config file errors.
-  Trigger with "install oraclecloud", "setup oci auth", "oraclecloud credentials", "oci config".
+description: 'Install and configure Oracle Cloud Infrastructure (OCI) SDK and CLI
+  authentication.
+
+  Use when setting up a new OCI integration, generating API signing keys, or debugging
+  config file errors.
+
+  Trigger with "install oraclecloud", "setup oci auth", "oraclecloud credentials",
+  "oci config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-local-dev-loop/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-local-dev-loop
-description: |
-  Set up a productive local OCI development workflow using CLI and SDK instead of the web console.
-  Use when the OCI Console is too slow, setting up CLI profiles, or building shell aliases for common operations.
-  Trigger with "oci local dev", "oci cli setup", "oraclecloud dev workflow", "avoid oci console".
+description: 'Set up a productive local OCI development workflow using CLI and SDK
+  instead of the web console.
+
+  Use when the OCI Console is too slow, setting up CLI profiles, or building shell
+  aliases for common operations.
+
+  Trigger with "oci local dev", "oci cli setup", "oraclecloud dev workflow", "avoid
+  oci console".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-migration-deep-dive/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: oraclecloud-migration-deep-dive
-description: |
-  Migrate workloads from AWS or Azure to OCI — IAM translation, networking mapping, compute image import, and data migration.
-  Use when planning an AWS-to-OCI or Azure-to-OCI migration, translating cloud concepts, or importing custom images.
-  Trigger with "oraclecloud migration", "aws to oci", "azure to oci", "oci migration deep dive".
-allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Bash(terraform:*), Grep
+description: "Migrate workloads from AWS or Azure to OCI \u2014 IAM translation, networking\
+  \ mapping, compute image import, and data migration.\nUse when planning an AWS-to-OCI\
+  \ or Azure-to-OCI migration, translating cloud concepts, or importing custom images.\n\
+  Trigger with \"oraclecloud migration\", \"aws to oci\", \"azure to oci\", \"oci\
+  \ migration deep dive\".\n"
+allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Bash(terraform:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-multi-env-setup
-description: |
-  Configure multi-environment OCI workflows with config profiles and compartment-per-environment patterns.
-  Use when setting up dev/staging/prod separation, switching between OCI profiles, or preventing accidental production deployments.
-  Trigger with "oraclecloud multi env setup", "oci profiles", "oci environments", "oci config profiles".
+description: 'Configure multi-environment OCI workflows with config profiles and compartment-per-environment
+  patterns.
+
+  Use when setting up dev/staging/prod separation, switching between OCI profiles,
+  or preventing accidental production deployments.
+
+  Trigger with "oraclecloud multi env setup", "oci profiles", "oci environments",
+  "oci config profiles".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-observability/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-observability/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-observability
-description: |
-  Set up programmatic monitoring, logging, and alarms for OCI resources.
-  Use when configuring OCI Monitoring metrics, creating alarm rules, publishing custom metrics, or searching logs via the Logging service.
-  Trigger with "oraclecloud observability", "oci monitoring", "oci alarms", "oci logging", "oracle cloud observability".
+description: 'Set up programmatic monitoring, logging, and alarms for OCI resources.
+
+  Use when configuring OCI Monitoring metrics, creating alarm rules, publishing custom
+  metrics, or searching logs via the Logging service.
+
+  Trigger with "oraclecloud observability", "oci monitoring", "oci alarms", "oci logging",
+  "oracle cloud observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Observability
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-performance-tuning
-description: |
-  Optimize OCI compute shapes, block volume tiers, and network throughput.
-  Use when choosing instance shapes, configuring block volume performance, or benchmarking OCI infrastructure.
-  Trigger with "oraclecloud performance", "oci shape comparison", "oci block volume iops", "oracle cloud performance tuning".
+description: 'Optimize OCI compute shapes, block volume tiers, and network throughput.
+
+  Use when choosing instance shapes, configuring block volume performance, or benchmarking
+  OCI infrastructure.
+
+  Trigger with "oraclecloud performance", "oci shape comparison", "oci block volume
+  iops", "oracle cloud performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-prod-checklist/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: oraclecloud-prod-checklist
-description: |
-  Pre-production readiness checklist for OCI — backup policies, security audit, key rotation, encryption, and Cloud Guard.
-  Use when preparing an OCI environment for production workloads or auditing an existing deployment.
-  Trigger with "oraclecloud prod checklist", "oci production ready", "oci security audit", "oci well-architected".
+description: "Pre-production readiness checklist for OCI \u2014 backup policies, security\
+  \ audit, key rotation, encryption, and Cloud Guard.\nUse when preparing an OCI environment\
+  \ for production workloads or auditing an existing deployment.\nTrigger with \"\
+  oraclecloud prod checklist\", \"oci production ready\", \"oci security audit\",\
+  \ \"oci well-architected\".\n"
 allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-query-transform/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-query-transform/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-query-transform
-description: |
-  Query OCI metrics with MQL and create monitoring alarms via the Python SDK.
+description: 'Query OCI metrics with MQL and create monitoring alarms via the Python
+  SDK.
+
   Use when building dashboards, querying CPU/memory/network metrics, or creating alarms.
-  Trigger with "oci monitoring", "mql query", "oci metrics", "oci alarm", "cpu utilization oci".
+
+  Trigger with "oci monitoring", "mql query", "oci metrics", "oci alarm", "cpu utilization
+  oci".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # OCI Monitoring — MQL Queries & Alarms
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-rate-limits/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-rate-limits
-description: |
-  Handle OCI API rate limits with defensive retry patterns and known limits by service.
-  Use when automating bulk OCI operations, hitting 429 TooManyRequests errors, or building resilient API clients.
-  Trigger with "oraclecloud rate limits", "oci 429 error", "oci throttling", "oci backoff".
+description: 'Handle OCI API rate limits with defensive retry patterns and known limits
+  by service.
+
+  Use when automating bulk OCI operations, hitting 429 TooManyRequests errors, or
+  building resilient API clients.
+
+  Trigger with "oraclecloud rate limits", "oci 429 error", "oci throttling", "oci
+  backoff".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: oraclecloud-reference-architecture
-description: |
-  Standard 3-tier OCI reference architecture with VCN, subnets, gateways, load balancer, compute, and Autonomous DB.
-  Use when designing a new OCI deployment, translating AWS/Azure patterns, or creating Terraform for OCI infrastructure.
-  Trigger with "oraclecloud architecture", "oci reference design", "oci 3 tier", "oci vpc design".
-allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Bash(terraform:*), Grep
+description: 'Standard 3-tier OCI reference architecture with VCN, subnets, gateways,
+  load balancer, compute, and Autonomous DB.
+
+  Use when designing a new OCI deployment, translating AWS/Azure patterns, or creating
+  Terraform for OCI infrastructure.
+
+  Trigger with "oraclecloud architecture", "oci reference design", "oci 3 tier", "oci
+  vpc design".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(oci:*), Bash(python3:*), Bash(terraform:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-schema-migration/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-schema-migration/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: oraclecloud-schema-migration
-description: |
-  Migrate to OCI Autonomous Database — wallet setup, mTLS, Data Pump, and python-oracledb.
-  Use when provisioning Autonomous DB, downloading wallets, or migrating data with Data Pump.
-  Trigger with "autonomous database", "oci adb", "wallet download", "data pump oci", "mtls oracle".
+description: "Migrate to OCI Autonomous Database \u2014 wallet setup, mTLS, Data Pump,\
+  \ and python-oracledb.\nUse when provisioning Autonomous DB, downloading wallets,\
+  \ or migrating data with Data Pump.\nTrigger with \"autonomous database\", \"oci\
+  \ adb\", \"wallet download\", \"data pump oci\", \"mtls oracle\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # OCI Autonomous Database — Migration & Connection
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: oraclecloud-sdk-patterns
-description: |
-  Production-grade OCI SDK patterns for client lifecycle, retry logic, and memory leak avoidance.
-  Use when building long-running OCI services, fixing memory leaks with Instance Principal auth, or implementing retry/backoff.
-  Trigger with "oci sdk patterns", "oci retry", "oci memory leak", "oraclecloud client lifecycle".
+description: 'Production-grade OCI SDK patterns for client lifecycle, retry logic,
+  and memory leak avoidance.
+
+  Use when building long-running OCI services, fixing memory leaks with Instance Principal
+  auth, or implementing retry/backoff.
+
+  Trigger with "oci sdk patterns", "oci retry", "oci memory leak", "oraclecloud client
+  lifecycle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-security-basics/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-security-basics/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-security-basics
-description: |
-  Master OCI IAM policy syntax, common policy patterns, and API key management.
-  Use when writing IAM policies, granting access to compartments, or managing API keys.
-  Trigger with "oraclecloud security basics", "oci iam policy", "oci policy syntax", "oci api key setup".
+description: 'Master OCI IAM policy syntax, common policy patterns, and API key management.
+
+  Use when writing IAM policies, granting access to compartments, or managing API
+  keys.
+
+  Trigger with "oraclecloud security basics", "oci iam policy", "oci policy syntax",
+  "oci api key setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Security Basics
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-upgrade-migration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: oraclecloud-upgrade-migration
-description: |
-  Safely upgrade OCI Python SDK and Terraform provider — version pinning, breaking change detection, and rollback.
-  Use when upgrading oci pip packages, updating the Terraform OCI provider, or debugging post-upgrade failures.
-  Trigger with "oraclecloud upgrade", "oci sdk upgrade", "oci terraform provider update", "oci version migration".
-allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Bash(terraform:*), Bash(python3:*), Grep
+description: "Safely upgrade OCI Python SDK and Terraform provider \u2014 version\
+  \ pinning, breaking change detection, and rollback.\nUse when upgrading oci pip\
+  \ packages, updating the Terraform OCI provider, or debugging post-upgrade failures.\n\
+  Trigger with \"oraclecloud upgrade\", \"oci sdk upgrade\", \"oci terraform provider\
+  \ update\", \"oci version migration\".\n"
+allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Bash(terraform:*), Bash(python3:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/oraclecloud-pack/skills/oraclecloud-webhooks-events/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: oraclecloud-webhooks-events
-description: |
-  Wire up event-driven workflows with OCI Events, Notifications, and Functions.
-  Use when building serverless event processing, subscribing to instance lifecycle changes, or routing audit events to alerting systems.
-  Trigger with "oraclecloud webhooks events", "oci events rules", "oci notifications", "oci ons topics".
+description: 'Wire up event-driven workflows with OCI Events, Notifications, and Functions.
+
+  Use when building serverless event processing, subscribing to instance lifecycle
+  changes, or routing audit events to alerting systems.
+
+  Trigger with "oraclecloud webhooks events", "oci events rules", "oci notifications",
+  "oci ons topics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(oci:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, oraclecloud, oci]
-compatible-with: claude-code
+tags:
+- saas
+- oraclecloud
+- oci
+compatibility: Designed for Claude Code
 ---
-
 # Oracle Cloud Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-ci-integration/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-ci-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-ci-integration
-description: |
-  Configure CI/CD pipelines for Palantir Foundry integrations with GitHub Actions.
+description: 'Configure CI/CD pipelines for Palantir Foundry integrations with GitHub
+  Actions.
+
   Use when setting up automated testing, running transforms validation,
+
   or integrating Foundry SDK tests into your build process.
+
   Trigger with phrases like "palantir CI", "foundry GitHub Actions",
+
   "palantir automated tests", "CI foundry".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, ci-cd, github-actions]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- ci-cd
+- github-actions
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir CI Integration
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-common-errors/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-common-errors/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: palantir-common-errors
-description: |
-  Diagnose and fix Palantir Foundry common errors and API exceptions.
+description: 'Diagnose and fix Palantir Foundry common errors and API exceptions.
+
   Use when encountering Foundry errors, debugging failed API calls,
+
   or troubleshooting transform build failures.
+
   Trigger with phrases like "palantir error", "fix palantir",
+
   "foundry not working", "debug foundry", "palantir 401 403".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, debugging, errors]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Common Errors
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-core-workflow-a
-description: |
-  Build Palantir Foundry data pipelines using Python transforms.
+description: 'Build Palantir Foundry data pipelines using Python transforms.
+
   Use when creating ETL pipelines, writing @transform decorators,
+
   or building dataset-to-dataset processing in Foundry.
+
   Trigger with phrases like "palantir pipeline", "foundry transform",
+
   "palantir ETL", "palantir data pipeline", "foundry python transform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, transforms, pipelines, spark]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- transforms
+- pipelines
+- spark
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Core Workflow A — Data Pipelines with Transforms
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-core-workflow-b/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: palantir-core-workflow-b
-description: |
-  Work with Palantir Foundry Ontology objects, actions, and queries via SDK.
+description: 'Work with Palantir Foundry Ontology objects, actions, and queries via
+  SDK.
+
   Use when querying objects, applying actions, linking objects,
+
   or building Ontology-driven applications.
+
   Trigger with phrases like "palantir ontology", "foundry objects",
+
   "palantir actions", "ontology query", "OSDK objects".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, ontology, osdk, actions]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- ontology
+- osdk
+- actions
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Core Workflow B — Ontology Objects & Actions
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-cost-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-cost-tuning
-description: |
-  Optimize Palantir Foundry costs through compute tuning, incremental builds, and usage monitoring.
+description: 'Optimize Palantir Foundry costs through compute tuning, incremental
+  builds, and usage monitoring.
+
   Use when analyzing Foundry compute costs, reducing API usage,
+
   or implementing cost monitoring for Foundry workloads.
+
   Trigger with phrases like "palantir cost", "foundry billing",
+
   "reduce foundry costs", "foundry pricing", "foundry expensive".
+
+  '
 allowed-tools: Read, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, cost, optimization]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- cost
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-data-handling/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-data-handling/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: palantir-data-handling
-description: |
-  Implement Palantir Foundry data handling with PII protection, markings, and GDPR compliance.
+description: 'Implement Palantir Foundry data handling with PII protection, markings,
+  and GDPR compliance.
+
   Use when handling sensitive data in Foundry, implementing data classifications,
+
   or ensuring compliance with privacy regulations.
+
   Trigger with phrases like "palantir data", "foundry PII",
+
   "palantir GDPR", "foundry data protection", "palantir markings".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, data, privacy, compliance]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- data
+- privacy
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Data Handling
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-debug-bundle/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: palantir-debug-bundle
-description: |
-  Collect Palantir Foundry debug evidence for support tickets and troubleshooting.
+description: 'Collect Palantir Foundry debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent Foundry issues, preparing support tickets,
+
   or collecting diagnostic information for Foundry problems.
+
   Trigger with phrases like "palantir debug", "foundry support bundle",
+
   "collect palantir logs", "foundry diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, debugging, diagnostics]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- debugging
+- diagnostics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-deploy-integration/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-deploy-integration
-description: |
-  Deploy Palantir Foundry integrations to cloud platforms with secrets management.
+description: 'Deploy Palantir Foundry integrations to cloud platforms with secrets
+  management.
+
   Use when deploying Foundry-powered applications to production,
+
   configuring platform-specific secrets, or setting up deployment pipelines.
+
   Trigger with phrases like "deploy palantir", "foundry deploy",
+
   "palantir production deploy", "foundry Cloud Run".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(docker:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, deployment, cloud]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- deployment
+- cloud
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-enterprise-rbac/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: palantir-enterprise-rbac
-description: |
-  Configure Palantir Foundry enterprise access control with project roles, markings, and service users.
+description: 'Configure Palantir Foundry enterprise access control with project roles,
+  markings, and service users.
+
   Use when implementing role-based access, configuring project permissions,
+
   or setting up service user accounts for Foundry integrations.
+
   Trigger with phrases like "palantir RBAC", "foundry roles",
+
   "palantir permissions", "foundry access control", "foundry service user".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, rbac, enterprise, security]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- rbac
+- enterprise
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-hello-world/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-hello-world
-description: |
-  Create a minimal working Palantir Foundry example querying Ontology objects.
+description: 'Create a minimal working Palantir Foundry example querying Ontology
+  objects.
+
   Use when starting a new Foundry integration, testing your setup,
+
   or learning basic Foundry API and Ontology patterns.
+
   Trigger with phrases like "palantir hello world", "palantir example",
+
   "palantir quick start", "foundry first query".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, ontology, getting-started]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- ontology
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Hello World
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-incident-runbook/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-incident-runbook
-description: |
-  Execute Palantir Foundry incident response with triage, mitigation, and postmortem.
+description: 'Execute Palantir Foundry incident response with triage, mitigation,
+  and postmortem.
+
   Use when responding to Foundry-related outages, API failures,
+
   or build pipeline incidents.
+
   Trigger with phrases like "palantir incident", "foundry outage",
+
   "palantir down", "foundry emergency", "palantir broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, incident, runbook]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- incident
+- runbook
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-install-auth/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-install-auth
-description: |
-  Install and configure Palantir Foundry SDK authentication with OAuth2 or token auth.
+description: 'Install and configure Palantir Foundry SDK authentication with OAuth2
+  or token auth.
+
   Use when setting up a new Foundry integration, configuring API credentials,
+
   or initializing the foundry-platform-sdk in your project.
+
   Trigger with phrases like "install palantir", "setup palantir",
+
   "palantir auth", "configure palantir API key", "foundry SDK setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, authentication, setup]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- authentication
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-local-dev-loop/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-local-dev-loop
-description: |
-  Configure Palantir Foundry local development with Python transforms and testing.
+description: 'Configure Palantir Foundry local development with Python transforms
+  and testing.
+
   Use when setting up a development environment, running transforms locally,
+
   or establishing a fast iteration cycle with Foundry.
+
   Trigger with phrases like "palantir dev setup", "palantir local development",
+
   "foundry local dev", "develop with palantir".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, development, testing]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- development
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-migration-deep-dive/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: palantir-migration-deep-dive
-description: |
-  Execute major Palantir Foundry migration strategies including data migration,
+description: 'Execute major Palantir Foundry migration strategies including data migration,
+
   API version upgrades, and platform transitions.
+
   Use when migrating data into Foundry, upgrading between API versions,
+
   or re-platforming existing integrations.
+
   Trigger with phrases like "migrate to palantir", "foundry migration",
+
   "palantir data migration", "foundry replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, migration, data-migration]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- migration
+- data-migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-multi-env-setup/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-multi-env-setup
-description: |
-  Configure Palantir Foundry across development, staging, and production environments.
+description: 'Configure Palantir Foundry across development, staging, and production
+  environments.
+
   Use when setting up multi-environment Foundry deployments, managing per-environment
+
   credentials, or implementing environment-specific configurations.
+
   Trigger with phrases like "palantir environments", "foundry staging",
+
   "foundry dev prod", "palantir environment setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, environments, configuration]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- environments
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-observability/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-observability/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-observability
-description: |
-  Set up observability for Palantir Foundry integrations with metrics, logging, and alerts.
+description: 'Set up observability for Palantir Foundry integrations with metrics,
+  logging, and alerts.
+
   Use when implementing monitoring for Foundry API calls, setting up dashboards,
+
   or configuring alerting for Foundry integration health.
+
   Trigger with phrases like "palantir monitoring", "foundry metrics",
+
   "palantir observability", "monitor foundry", "foundry alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, observability, monitoring]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- observability
+- monitoring
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Observability
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-performance-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-performance-tuning
-description: |
-  Optimize Palantir Foundry API performance with caching, batching, and pagination.
+description: 'Optimize Palantir Foundry API performance with caching, batching, and
+  pagination.
+
   Use when experiencing slow API responses, optimizing transform builds,
+
   or improving request throughput for Foundry integrations.
+
   Trigger with phrases like "palantir performance", "optimize foundry",
+
   "foundry slow", "palantir caching", "foundry batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, performance, optimization]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-prod-checklist/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-prod-checklist
-description: |
-  Execute Palantir Foundry production deployment checklist and rollback procedures.
+description: 'Execute Palantir Foundry production deployment checklist and rollback
+  procedures.
+
   Use when deploying Foundry integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "palantir production", "deploy foundry",
+
   "palantir go-live", "foundry launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, production, deployment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- production
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-rate-limits/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-rate-limits/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: palantir-rate-limits
-description: |
-  Implement Palantir Foundry API rate limiting, backoff, and request queuing.
+description: 'Implement Palantir Foundry API rate limiting, backoff, and request queuing.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Foundry.
+
   Trigger with phrases like "palantir rate limit", "foundry throttling",
+
   "palantir 429", "foundry retry", "palantir backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, rate-limits, reliability]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- rate-limits
+- reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-reference-architecture/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-reference-architecture
-description: |
-  Implement Palantir Foundry reference architecture with best-practice project layout.
+description: 'Implement Palantir Foundry reference architecture with best-practice
+  project layout.
+
   Use when designing new Foundry integrations, planning data pipeline architecture,
+
   or establishing patterns for Ontology-driven applications.
+
   Trigger with phrases like "palantir architecture", "foundry best practices",
+
   "foundry project structure", "how to organize palantir".
+
+  '
 allowed-tools: Read, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, architecture, patterns]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- architecture
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-sdk-patterns/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: palantir-sdk-patterns
-description: |
-  Apply production-ready Palantir Foundry SDK patterns for Python and TypeScript.
+description: 'Apply production-ready Palantir Foundry SDK patterns for Python and
+  TypeScript.
+
   Use when implementing Foundry integrations, refactoring SDK usage,
+
   or establishing team coding standards for Foundry API calls.
+
   Trigger with phrases like "palantir SDK patterns", "foundry best practices",
+
   "palantir code patterns", "idiomatic foundry SDK".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, sdk, patterns, typescript]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- sdk
+- patterns
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-security-basics/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-security-basics/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: palantir-security-basics
-description: |
-  Apply Palantir Foundry security best practices for credentials, scopes, and access control.
+description: 'Apply Palantir Foundry security best practices for credentials, scopes,
+  and access control.
+
   Use when securing API tokens, implementing least privilege access,
+
   or auditing Foundry security configuration.
+
   Trigger with phrases like "palantir security", "foundry secrets",
+
   "secure palantir", "palantir API key security", "foundry scopes".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, security, oauth]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- security
+- oauth
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Security Basics
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: palantir-upgrade-migration
-description: |
-  Upgrade Palantir Foundry SDK versions and handle breaking changes.
+description: 'Upgrade Palantir Foundry SDK versions and handle breaking changes.
+
   Use when upgrading foundry-platform-sdk, migrating between API versions,
+
   or detecting deprecations in Foundry integrations.
+
   Trigger with phrases like "upgrade palantir", "palantir migration",
+
   "foundry breaking changes", "update foundry SDK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(git:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, upgrade, migration]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- upgrade
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/palantir-pack/skills/palantir-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/palantir-pack/skills/palantir-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: palantir-webhooks-events
-description: |
-  Implement Palantir Foundry webhook handling for Ontology change events.
+description: 'Implement Palantir Foundry webhook handling for Ontology change events.
+
   Use when reacting to Ontology object changes, dataset updates,
+
   or build completion events from Foundry.
+
   Trigger with phrases like "palantir webhook", "foundry events",
+
   "palantir notifications", "ontology change events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, palantir, foundry, webhooks, events]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- palantir
+- foundry
+- webhooks
+- events
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Palantir Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: perplexity-advanced-troubleshooting
-description: |
-  Apply advanced debugging techniques for hard-to-diagnose Perplexity Sonar API issues.
+description: 'Apply advanced debugging techniques for hard-to-diagnose Perplexity
+  Sonar API issues.
+
   Use when standard troubleshooting fails, investigating inconsistent citations,
+
   or preparing evidence for support escalation.
+
   Trigger with phrases like "perplexity hard bug", "perplexity mystery error",
-  "perplexity inconsistent results", "difficult perplexity issue", "perplexity deep debug".
+
+  "perplexity inconsistent results", "difficult perplexity issue", "perplexity deep
+  debug".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*), Bash(tcpdump:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, debugging, scaling]
+tags:
+- saas
+- perplexity
+- debugging
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Advanced Troubleshooting
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-architecture-variants/SKILL.md
@@ -1,16 +1,26 @@
 ---
 name: perplexity-architecture-variants
-description: |
-  Choose and implement Perplexity architecture blueprints for different scales:
+description: 'Choose and implement Perplexity architecture blueprints for different
+  scales:
+
   direct search widget, cached research layer, and multi-query pipeline.
+
   Trigger with phrases like "perplexity architecture", "perplexity blueprint",
+
   "how to structure perplexity", "perplexity project layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, migration, scaling, microservices]
+tags:
+- saas
+- perplexity
+- migration
+- scaling
+- microservices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Architecture Variants
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-ci-integration/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-ci-integration
-description: |
-  Configure CI/CD for Perplexity Sonar API integrations with GitHub Actions.
+description: 'Configure CI/CD for Perplexity Sonar API integrations with GitHub Actions.
+
   Use when setting up automated testing, configuring CI pipelines,
+
   or integrating Perplexity tests into your build process.
+
   Trigger with phrases like "perplexity CI", "perplexity GitHub Actions",
+
   "perplexity automated tests", "CI perplexity pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, testing, ci-cd]
+tags:
+- saas
+- perplexity
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity CI Integration
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-common-errors/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-common-errors
-description: |
-  Diagnose and fix Perplexity Sonar API errors and exceptions.
+description: 'Diagnose and fix Perplexity Sonar API errors and exceptions.
+
   Use when encountering Perplexity errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "perplexity error", "fix perplexity",
+
   "perplexity not working", "debug perplexity", "perplexity 429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, debugging]
+tags:
+- saas
+- perplexity
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Common Errors
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-core-workflow-a/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-core-workflow-a
-description: |
-  Execute Perplexity primary workflow: single-query search with citations.
+description: 'Execute Perplexity primary workflow: single-query search with citations.
+
   Use when implementing AI search, building fact-checking tools,
+
   or integrating web-grounded answers into your application.
+
   Trigger with phrases like "perplexity search", "perplexity query",
+
   "search with citations", "perplexity main workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, workflow]
+tags:
+- saas
+- perplexity
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Core Workflow A: Search with Citations
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-core-workflow-b/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-core-workflow-b
-description: |
-  Execute Perplexity multi-turn research sessions and batch query pipelines.
+description: 'Execute Perplexity multi-turn research sessions and batch query pipelines.
+
   Use when conducting in-depth investigations, generating research briefs,
+
   or processing multiple related search queries.
+
   Trigger with phrases like "perplexity research", "perplexity batch search",
+
   "multi-query perplexity", "perplexity deep dive", "perplexity report".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, workflow]
+tags:
+- saas
+- perplexity
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Core Workflow B: Multi-Query Research
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: perplexity-cost-tuning
-description: |
-  Optimize Perplexity costs through model routing, caching, token limits, and budget monitoring.
+description: 'Optimize Perplexity costs through model routing, caching, token limits,
+  and budget monitoring.
+
   Use when analyzing Perplexity billing, reducing API costs,
+
   or implementing budget alerts for Perplexity Sonar API.
+
   Trigger with phrases like "perplexity cost", "perplexity billing",
+
   "reduce perplexity costs", "perplexity pricing", "perplexity budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, monitoring, cost-optimization]
+tags:
+- saas
+- perplexity
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Cost Tuning
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-data-handling/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-data-handling/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: perplexity-data-handling
-description: |
-  Implement Perplexity query sanitization, citation validation, result caching,
+description: 'Implement Perplexity query sanitization, citation validation, result
+  caching,
+
   and conversation context management for search workflows.
+
   Trigger with phrases like "perplexity data", "perplexity PII",
+
   "perplexity citations", "perplexity cache", "perplexity context".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, compliance]
+tags:
+- saas
+- perplexity
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Data Handling
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-debug-bundle
-description: |
-  Collect Perplexity debug evidence for support tickets and troubleshooting.
+description: 'Collect Perplexity debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Perplexity problems.
+
   Trigger with phrases like "perplexity debug", "perplexity support bundle",
+
   "collect perplexity logs", "perplexity diagnostic".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, debugging]
+tags:
+- saas
+- perplexity
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Debug Bundle
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-deploy-integration
-description: |
-  Deploy Perplexity Sonar API integrations to Vercel, Cloud Run, and Docker.
+description: 'Deploy Perplexity Sonar API integrations to Vercel, Cloud Run, and Docker.
+
   Use when deploying Perplexity-powered applications to production,
+
   configuring platform-specific secrets, or setting up edge functions.
+
   Trigger with phrases like "deploy perplexity", "perplexity Vercel",
+
   "perplexity production deploy", "perplexity Cloud Run", "perplexity Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, deployment]
+tags:
+- saas
+- perplexity
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Deploy Integration
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-enterprise-rbac/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: perplexity-enterprise-rbac
-description: |
-  Configure Perplexity API key scoping, per-team model access, cost controls,
+description: 'Configure Perplexity API key scoping, per-team model access, cost controls,
+
   and search domain restrictions for enterprise deployments.
+
   Trigger with phrases like "perplexity enterprise", "perplexity RBAC",
+
   "perplexity team access", "perplexity roles", "perplexity permissions".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, rbac]
+tags:
+- saas
+- perplexity
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Enterprise RBAC
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-hello-world/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-hello-world
-description: |
-  Create a minimal working Perplexity Sonar search example with citations.
+description: 'Create a minimal working Perplexity Sonar search example with citations.
+
   Use when starting a new Perplexity integration, testing your setup,
+
   or learning basic search-with-citations patterns.
+
   Trigger with phrases like "perplexity hello world", "perplexity example",
+
   "perplexity quick start", "simple perplexity search".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, testing]
+tags:
+- saas
+- perplexity
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Hello World
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-incident-runbook/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-incident-runbook
-description: |
-  Execute Perplexity incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Perplexity incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Perplexity API outages, investigating search failures,
+
   or running post-incident reviews for Perplexity integration issues.
+
   Trigger with phrases like "perplexity incident", "perplexity outage",
+
   "perplexity down", "perplexity on-call", "perplexity emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, incident-response]
+tags:
+- saas
+- perplexity
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Incident Runbook
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-install-auth/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-install-auth
-description: |
-  Install and configure Perplexity Sonar API authentication.
+description: 'Install and configure Perplexity Sonar API authentication.
+
   Use when setting up a new Perplexity integration, configuring API keys,
+
   or initializing the OpenAI-compatible client for Perplexity.
+
   Trigger with phrases like "install perplexity", "setup perplexity",
+
   "perplexity auth", "configure perplexity API key", "perplexity sonar setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, authentication]
+tags:
+- saas
+- perplexity
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Install & Auth
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-known-pitfalls/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-known-pitfalls
-description: |
-  Identify and avoid Perplexity anti-patterns and common integration mistakes.
+description: 'Identify and avoid Perplexity anti-patterns and common integration mistakes.
+
   Use when reviewing Perplexity code, onboarding new developers,
+
   or auditing existing integrations for best practices violations.
+
   Trigger with phrases like "perplexity mistakes", "perplexity anti-patterns",
+
   "perplexity pitfalls", "perplexity code review", "perplexity gotchas".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, audit]
+tags:
+- saas
+- perplexity
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Known Pitfalls
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-load-scale/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-load-scale/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: perplexity-load-scale
-description: |
-  Load test Perplexity Sonar API integrations and plan capacity.
+description: 'Load test Perplexity Sonar API integrations and plan capacity.
+
   Use when running performance tests, planning for traffic growth,
+
   or benchmarking Perplexity latency under load.
+
   Trigger with phrases like "perplexity load test", "perplexity scale",
+
   "perplexity performance test", "perplexity capacity", "perplexity benchmark".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, testing, performance, scaling]
+tags:
+- saas
+- perplexity
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Load & Scale
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: perplexity-local-dev-loop
-description: |
-  Configure Perplexity local development with mocking, testing, and hot reload.
+description: 'Configure Perplexity local development with mocking, testing, and hot
+  reload.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Perplexity Sonar API.
+
   Trigger with phrases like "perplexity dev setup", "perplexity local development",
+
   "perplexity dev environment", "develop with perplexity", "mock perplexity".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, testing, workflow]
+tags:
+- saas
+- perplexity
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Local Dev Loop
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-migration-deep-dive/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-migration-deep-dive
-description: |
-  Migrate to Perplexity Sonar from other search/LLM APIs using the strangler fig pattern.
+description: 'Migrate to Perplexity Sonar from other search/LLM APIs using the strangler
+  fig pattern.
+
   Use when switching from Google Custom Search, Bing API, or other LLMs to Perplexity,
+
   or migrating from legacy pplx-api models.
+
   Trigger with phrases like "migrate to perplexity", "switch to perplexity",
+
   "replace search API with perplexity", "perplexity replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, migration]
+tags:
+- saas
+- perplexity
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Migration Deep Dive
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: perplexity-multi-env-setup
-description: |
-  Configure Perplexity Sonar API across development, staging, and production environments.
+description: 'Configure Perplexity Sonar API across development, staging, and production
+  environments.
+
   Use when setting up multi-environment search integrations, managing API keys
+
   per environment, or controlling cost through model routing by env.
+
   Trigger with phrases like "perplexity environments", "perplexity staging",
+
   "perplexity dev prod", "perplexity environment config".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, cost-optimization]
+tags:
+- saas
+- perplexity
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Multi-Environment Setup
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-observability/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: perplexity-observability
-description: |
-  Set up monitoring for Perplexity Sonar API with latency, cost, citation quality, and error tracking.
+description: 'Set up monitoring for Perplexity Sonar API with latency, cost, citation
+  quality, and error tracking.
+
   Use when implementing monitoring dashboards, setting up alerts,
+
   or tracking Perplexity API health in production.
+
   Trigger with phrases like "perplexity monitoring", "perplexity metrics",
+
   "perplexity observability", "monitor perplexity", "perplexity dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, monitoring, observability, dashboard]
+tags:
+- saas
+- perplexity
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Observability
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: perplexity-performance-tuning
-description: |
-  Optimize Perplexity Sonar API performance with caching, streaming, model routing, and batching.
+description: 'Optimize Perplexity Sonar API performance with caching, streaming, model
+  routing, and batching.
+
   Use when experiencing slow API responses, implementing caching strategies,
+
   or optimizing request throughput for Perplexity integrations.
+
   Trigger with phrases like "perplexity performance", "optimize perplexity",
+
   "perplexity latency", "perplexity caching", "perplexity slow".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, performance]
+tags:
+- saas
+- perplexity
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Performance Tuning
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-policy-guardrails/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: perplexity-policy-guardrails
-description: |
-  Implement content moderation, model selection policy, citation quality enforcement,
+description: 'Implement content moderation, model selection policy, citation quality
+  enforcement,
+
   and per-user usage quotas for Perplexity Sonar API.
+
   Trigger with phrases like "perplexity policy", "perplexity guardrails",
+
   "perplexity content moderation", "perplexity usage limits", "perplexity safety".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, perplexity-policy]
+tags:
+- saas
+- perplexity
+- perplexity-policy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Policy Guardrails
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-prod-checklist
-description: |
-  Execute Perplexity production deployment checklist for Sonar API integrations.
+description: 'Execute Perplexity production deployment checklist for Sonar API integrations.
+
   Use when deploying Perplexity integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "perplexity production", "deploy perplexity",
+
   "perplexity go-live", "perplexity launch checklist".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, deployment]
+tags:
+- saas
+- perplexity
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Production Checklist
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-rate-limits/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: perplexity-rate-limits
-description: |
-  Implement Perplexity rate limiting, backoff, and request queuing.
+description: 'Implement Perplexity rate limiting, backoff, and request queuing.
+
   Use when handling 429 errors, implementing retry logic,
+
   or optimizing API request throughput for Perplexity Sonar.
+
   Trigger with phrases like "perplexity rate limit", "perplexity throttling",
+
   "perplexity 429", "perplexity retry", "perplexity backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api]
+tags:
+- saas
+- perplexity
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Rate Limits
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-reference-architecture/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-reference-architecture
-description: |
-  Implement Perplexity reference architecture with model routing, citation pipeline,
+description: 'Implement Perplexity reference architecture with model routing, citation
+  pipeline,
+
   and research automation. Use when designing new Perplexity integrations,
+
   reviewing project structure, or establishing architecture for search-augmented apps.
+
   Trigger with phrases like "perplexity architecture", "perplexity project structure",
+
   "how to organize perplexity", "perplexity design patterns".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, perplexity-reference]
+tags:
+- saas
+- perplexity
+- perplexity-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Reference Architecture
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-reliability-patterns/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: perplexity-reliability-patterns
-description: |
-  Implement reliability patterns for Perplexity Sonar API: circuit breaker, model fallback,
+description: 'Implement reliability patterns for Perplexity Sonar API: circuit breaker,
+  model fallback,
+
   streaming timeout, and citation validation.
+
   Trigger with phrases like "perplexity reliability", "perplexity circuit breaker",
+
   "perplexity fallback", "perplexity resilience", "perplexity timeout".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, perplexity-reliability]
+tags:
+- saas
+- perplexity
+- perplexity-reliability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Reliability Patterns
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: perplexity-sdk-patterns
-description: |
-  Apply production-ready Perplexity Sonar API patterns for TypeScript and Python.
+description: 'Apply production-ready Perplexity Sonar API patterns for TypeScript
+  and Python.
+
   Use when implementing Perplexity integrations, refactoring SDK usage,
+
   or establishing team coding standards for search-augmented generation.
+
   Trigger with phrases like "perplexity SDK patterns", "perplexity best practices",
+
   "perplexity code patterns", "idiomatic perplexity", "perplexity wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, python, typescript]
+tags:
+- saas
+- perplexity
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity SDK Patterns
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-security-basics/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: perplexity-security-basics
-description: |
-  Apply Perplexity security best practices for API key management and query safety.
+description: 'Apply Perplexity security best practices for API key management and
+  query safety.
+
   Use when securing API keys, implementing query sanitization,
+
   or auditing Perplexity security configuration.
+
   Trigger with phrases like "perplexity security", "perplexity secrets",
+
   "secure perplexity", "perplexity API key security", "perplexity PII".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, security, audit]
+tags:
+- saas
+- perplexity
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Security Basics
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: perplexity-upgrade-migration
-description: |
-  Migrate between Perplexity model generations and API parameter changes.
+description: 'Migrate between Perplexity model generations and API parameter changes.
+
   Use when upgrading to new Sonar models, handling deprecated parameters,
+
   or migrating from legacy pplx-api models.
+
   Trigger with phrases like "upgrade perplexity", "perplexity migration",
+
   "perplexity model change", "update perplexity", "perplexity deprecated".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, api, migration]
+tags:
+- saas
+- perplexity
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Upgrade & Migration
 

--- a/plugins/saas-packs/perplexity-pack/skills/perplexity-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/perplexity-pack/skills/perplexity-webhooks-events/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: perplexity-webhooks-events
-description: |
-  Build event-driven architectures around Perplexity Sonar API with streaming,
+description: 'Build event-driven architectures around Perplexity Sonar API with streaming,
+
   batch pipelines, and scheduled search monitoring.
+
   Trigger with phrases like "perplexity streaming", "perplexity events",
+
   "perplexity batch search", "perplexity news monitor", "perplexity SSE".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, perplexity, webhooks]
+tags:
+- saas
+- perplexity
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Perplexity Events & Async Patterns
 

--- a/plugins/saas-packs/persona-pack/skills/persona-ci-integration/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-ci-integration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-ci-integration
-description: |
-  CI/CD pipeline for Persona integrations with sandbox API testing.
+description: 'CI/CD pipeline for Persona integrations with sandbox API testing.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona ci-integration", "persona ci-integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona ci integration | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-common-errors/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: persona-common-errors
-description: |
-  Fix top Persona API errors: 401, 422, webhook signature failures, inquiry state issues.
+description: 'Fix top Persona API errors: 401, 422, webhook signature failures, inquiry
+  state issues.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona common-errors", "persona common-errors".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona common errors | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-core-workflow-a/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: persona-core-workflow-a
-description: |
-  Build a complete KYC verification flow with Persona inquiries and embedded UI.
+description: 'Build a complete KYC verification flow with Persona inquiries and embedded
+  UI.
+
   Use when implementing identity verification, building KYC onboarding,
-  or integrating Persona's hosted flow into your application.
+
+  or integrating Persona''s hosted flow into your application.
+
   Trigger with phrases like "persona KYC flow", "identity verification",
+
   "persona inquiry workflow", "onboarding verification".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, kyc, verification, onboarding]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- kyc
+- verification
+- onboarding
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Persona Core Workflow A — KYC Inquiry Flow
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-core-workflow-b/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: persona-core-workflow-b
-description: |
-  Work with Persona verification types: government ID, selfie, database checks.
+description: 'Work with Persona verification types: government ID, selfie, database
+  checks.
+
   Use when implementing specific verification checks, reviewing verification results,
+
   or building custom verification workflows.
+
   Trigger with phrases like "persona verification", "government ID check",
+
   "selfie verification", "persona database check", "verification results".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, verification, government-id, selfie, kyc]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- verification
+- government-id
+- selfie
+- kyc
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Persona Core Workflow B — Verification Checks
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-cost-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-cost-tuning
-description: |
-  Optimize Persona verification costs with template selection and caching.
+description: 'Optimize Persona verification costs with template selection and caching.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona cost-tuning", "persona cost-tuning".
+
+  '
 allowed-tools: Read, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona cost tuning | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: persona-debug-bundle
-description: |
-  Collect Persona diagnostic info: inquiry IDs, API responses, webhook logs.
+description: 'Collect Persona diagnostic info: inquiry IDs, API responses, webhook
+  logs.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona debug-bundle", "persona debug-bundle".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona debug bundle | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-deploy-integration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-deploy-integration
-description: |
-  Deploy Persona verification service to cloud platforms.
+description: 'Deploy Persona verification service to cloud platforms.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona deploy-integration", "persona deploy-integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona deploy integration | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-hello-world/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: persona-hello-world
-description: |
-  Create your first Persona identity verification inquiry and check its status.
+description: 'Create your first Persona identity verification inquiry and check its
+  status.
+
   Use when learning Persona API basics, testing inquiry creation,
+
   or building a simple verification flow.
+
   Trigger with phrases like "persona hello world", "first persona inquiry",
+
   "persona quick start", "test identity verification".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, getting-started]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Persona Hello World
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-install-auth/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: persona-install-auth
-description: |
-  Configure Persona API authentication with sandbox and production API keys.
+description: 'Configure Persona API authentication with sandbox and production API
+  keys.
+
   Use when setting up identity verification, configuring API credentials,
+
   or initializing Persona in your project.
+
   Trigger with phrases like "install persona", "setup persona",
+
   "persona auth", "persona API key", "KYC setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, authentication]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Persona Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-local-dev-loop/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-local-dev-loop
-description: |
-  Local development with Persona sandbox, ngrok for webhooks, mock verifications.
+description: 'Local development with Persona sandbox, ngrok for webhooks, mock verifications.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona local-dev-loop", "persona local-dev-loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona local dev loop | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-performance-tuning
-description: |
-  Optimize Persona API performance with batching and caching.
+description: 'Optimize Persona API performance with batching and caching.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona performance-tuning", "persona performance-tuning".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona performance tuning | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-prod-checklist/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-prod-checklist
-description: |
-  Production deployment checklist for Persona identity verification.
+description: 'Production deployment checklist for Persona identity verification.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona prod-checklist", "persona prod-checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona prod checklist | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-rate-limits/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: persona-rate-limits
-description: |
-  Handle Persona API rate limits with exponential backoff and request queuing.
+description: 'Handle Persona API rate limits with exponential backoff and request
+  queuing.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona rate-limits", "persona rate-limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona rate limits | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-reference-architecture/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-reference-architecture
-description: |
-  KYC service architecture with Persona as verification provider.
+description: 'KYC service architecture with Persona as verification provider.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona reference-architecture", "persona reference-architecture".
+
+  '
 allowed-tools: Read, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona reference architecture | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: persona-sdk-patterns
-description: |
-  Production Persona API client wrapper with retry, pagination, typed responses.
+description: 'Production Persona API client wrapper with retry, pagination, typed
+  responses.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona sdk-patterns", "persona sdk-patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona sdk patterns | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-security-basics/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-security-basics/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: persona-security-basics
-description: |
-  Secure Persona API keys, webhook secrets, PII handling in verification data.
+description: 'Secure Persona API keys, webhook secrets, PII handling in verification
+  data.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona security-basics", "persona security-basics".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona security basics | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-upgrade-migration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-upgrade-migration
-description: |
-  Upgrade Persona API versions and handle breaking changes.
+description: 'Upgrade Persona API versions and handle breaking changes.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona upgrade-migration", "persona upgrade-migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona upgrade migration | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/persona-pack/skills/persona-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/persona-pack/skills/persona-webhooks-events/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: persona-webhooks-events
-description: |
-  Handle Persona webhook events for inquiry and verification status changes.
+description: 'Handle Persona webhook events for inquiry and verification status changes.
+
   Use when working with Persona identity verification.
+
   Trigger with phrases like "persona webhooks-events", "persona webhooks-events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, persona, identity, kyc, verification]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- persona
+- identity
+- kyc
+- verification
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # persona webhooks events | sed 's/\b\(.\)/\u\1/g'
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-ci-integration/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-ci-integration/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-ci-integration
-description: |
-  Podium ci integration — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium ci integration", "podium-ci-integration".
+description: "Podium ci integration \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium ci integration\", \"podium-ci-integration\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-common-errors/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-common-errors/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-common-errors
-description: |
-  Podium common errors — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium common errors", "podium-common-errors".
+description: "Podium common errors \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium common errors\", \"podium-common-errors\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Common Errors
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-core-workflow-a/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-core-workflow-a
-description: |
-  Podium core workflow a — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium core workflow a", "podium-core-workflow-a".
+description: "Podium core workflow a \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium core workflow a\", \"podium-core-workflow-a\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-core-workflow-b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-core-workflow-b
-description: |
-  Podium core workflow b — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium core workflow b", "podium-core-workflow-b".
+description: "Podium core workflow b \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium core workflow b\", \"podium-core-workflow-b\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-cost-tuning/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-cost-tuning
-description: |
-  Podium cost tuning — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium cost tuning", "podium-cost-tuning".
+description: "Podium cost tuning \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium cost tuning\", \"podium-cost-tuning\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-debug-bundle/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-debug-bundle
-description: |
-  Podium debug bundle — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium debug bundle", "podium-debug-bundle".
+description: "Podium debug bundle \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium debug bundle\", \"podium-debug-bundle\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-deploy-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-deploy-integration
-description: |
-  Podium deploy integration — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium deploy integration", "podium-deploy-integration".
+description: "Podium deploy integration \u2014 business messaging and communication\
+  \ platform integration.\nUse when working with Podium API for messaging, reviews,\
+  \ or payments.\nTrigger with phrases like \"podium deploy integration\", \"podium-deploy-integration\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-hello-world/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-hello-world/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-hello-world
-description: |
-  Podium hello world — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium hello world", "podium-hello-world".
+description: "Podium hello world \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium hello world\", \"podium-hello-world\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Hello World
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-install-auth/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-install-auth/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-install-auth
-description: |
-  Podium install auth — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium install auth", "podium-install-auth".
+description: "Podium install auth \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium install auth\", \"podium-install-auth\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Install Auth
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-local-dev-loop/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-local-dev-loop
-description: |
-  Podium local dev loop — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium local dev loop", "podium-local-dev-loop".
+description: "Podium local dev loop \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium local dev loop\", \"podium-local-dev-loop\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-performance-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-performance-tuning
-description: |
-  Podium performance tuning — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium performance tuning", "podium-performance-tuning".
+description: "Podium performance tuning \u2014 business messaging and communication\
+  \ platform integration.\nUse when working with Podium API for messaging, reviews,\
+  \ or payments.\nTrigger with phrases like \"podium performance tuning\", \"podium-performance-tuning\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-prod-checklist/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-prod-checklist
-description: |
-  Podium prod checklist — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium prod checklist", "podium-prod-checklist".
+description: "Podium prod checklist \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium prod checklist\", \"podium-prod-checklist\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-rate-limits/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-rate-limits/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-rate-limits
-description: |
-  Podium rate limits — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium rate limits", "podium-rate-limits".
+description: "Podium rate limits \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium rate limits\", \"podium-rate-limits\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-reference-architecture/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-reference-architecture
-description: |
-  Podium reference architecture — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium reference architecture", "podium-reference-architecture".
+description: "Podium reference architecture \u2014 business messaging and communication\
+  \ platform integration.\nUse when working with Podium API for messaging, reviews,\
+  \ or payments.\nTrigger with phrases like \"podium reference architecture\", \"\
+  podium-reference-architecture\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-sdk-patterns/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: podium-sdk-patterns
-description: |
-  Podium sdk patterns — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium sdk patterns", "podium-sdk-patterns".
+description: "Podium sdk patterns \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium sdk patterns\", \"podium-sdk-patterns\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-security-basics/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-security-basics/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-security-basics
-description: |
-  Podium security basics — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium security basics", "podium-security-basics".
+description: "Podium security basics \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium security basics\", \"podium-security-basics\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Security Basics
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-upgrade-migration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-upgrade-migration
-description: |
-  Podium upgrade migration — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium upgrade migration", "podium-upgrade-migration".
+description: "Podium upgrade migration \u2014 business messaging and communication\
+  \ platform integration.\nUse when working with Podium API for messaging, reviews,\
+  \ or payments.\nTrigger with phrases like \"podium upgrade migration\", \"podium-upgrade-migration\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/podium-pack/skills/podium-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/podium-pack/skills/podium-webhooks-events/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: podium-webhooks-events
-description: |
-  Podium webhooks events — business messaging and communication platform integration.
-  Use when working with Podium API for messaging, reviews, or payments.
-  Trigger with phrases like "podium webhooks events", "podium-webhooks-events".
+description: "Podium webhooks events \u2014 business messaging and communication platform\
+  \ integration.\nUse when working with Podium API for messaging, reviews, or payments.\n\
+  Trigger with phrases like \"podium webhooks events\", \"podium-webhooks-events\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, podium, messaging, reviews, payments]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- podium
+- messaging
+- reviews
+- payments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Podium Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-ci-integration/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-ci-integration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: posthog-ci-integration
-description: |
-  Configure PostHog CI/CD with GitHub Actions: unit tests with mocked PostHog,
+description: 'Configure PostHog CI/CD with GitHub Actions: unit tests with mocked
+  PostHog,
+
   integration tests against a dev project, and deployment annotations.
+
   Trigger: "posthog CI", "posthog GitHub Actions", "posthog automated tests",
+
   "CI posthog", "posthog pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, testing, ci-cd]
+tags:
+- saas
+- posthog
+- testing
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog CI Integration
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-common-errors/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-common-errors/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: posthog-common-errors
-description: |
-  Diagnose and fix common PostHog errors: events not appearing, flags returning
+description: 'Diagnose and fix common PostHog errors: events not appearing, flags
+  returning
+
   undefined, 401/429 errors, SDK initialization failures, and identity issues.
+
   Trigger: "posthog error", "fix posthog", "posthog not working",
+
   "debug posthog", "posthog events missing", "posthog broken".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, debugging]
+tags:
+- saas
+- posthog
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Common Errors
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: posthog-core-workflow-a
-description: |
-  Implement PostHog product analytics: event capture, user identification,
+description: 'Implement PostHog product analytics: event capture, user identification,
+
   group analytics, and property management using posthog-js and posthog-node.
+
   Trigger: "posthog analytics", "capture events", "track users posthog",
+
   "posthog identify", "posthog group analytics", "product analytics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, workflow, analytics]
+tags:
+- saas
+- posthog
+- workflow
+- analytics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Core Workflow A — Product Analytics
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-core-workflow-b/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: posthog-core-workflow-b
-description: |
-  Implement PostHog feature flags, A/B experiments, and cohort management.
+description: 'Implement PostHog feature flags, A/B experiments, and cohort management.
+
   Use when rolling out features with flags, running A/B tests, creating cohorts,
+
   or evaluating multivariate experiments with PostHog.
+
   Trigger: "posthog feature flag", "posthog experiment", "posthog A/B test",
+
   "posthog cohort", "feature rollout posthog", "posthog multivariate".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, workflow, feature-flags, experiments]
+tags:
+- saas
+- posthog
+- workflow
+- feature-flags
+- experiments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Core Workflow B — Feature Flags & Experiments
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-cost-tuning/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: posthog-cost-tuning
-description: |
-  Optimize PostHog costs: autocapture tuning, event sampling with before_send,
+description: 'Optimize PostHog costs: autocapture tuning, event sampling with before_send,
+
   bot filtering, session recording sampling, and billing monitoring.
+
   Trigger: "posthog cost", "posthog billing", "reduce posthog costs",
+
   "posthog pricing", "posthog expensive", "posthog budget", "posthog free tier".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, monitoring, cost-optimization]
+tags:
+- saas
+- posthog
+- api
+- monitoring
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-data-handling/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-data-handling/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: posthog-data-handling
-description: |
-  PostHog PII handling, GDPR compliance, consent management, data deletion,
+description: 'PostHog PII handling, GDPR compliance, consent management, data deletion,
+
   property sanitization, and privacy-safe analytics configuration.
+
   Trigger: "posthog data", "posthog PII", "posthog GDPR", "posthog data
+
   retention", "posthog privacy", "posthog CCPA", "posthog consent".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, compliance]
+tags:
+- saas
+- posthog
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Data Handling
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-debug-bundle/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: posthog-debug-bundle
-description: |
-  Collect PostHog debug evidence for support tickets and troubleshooting.
+description: 'Collect PostHog debug evidence for support tickets and troubleshooting.
+
   Gathers SDK versions, API connectivity, event flow status, flag definitions,
+
   and redacted configuration into a support-ready archive.
+
   Trigger: "posthog debug", "posthog support bundle", "collect posthog logs",
+
   "posthog diagnostic", "posthog not working debug".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, debugging]
+tags:
+- saas
+- posthog
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Debug Bundle
 
 ## Current State

--- a/plugins/saas-packs/posthog-pack/skills/posthog-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-deploy-integration/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: posthog-deploy-integration
-description: |
-  Deploy PostHog to Vercel, Docker (self-hosted), and Cloud Run.
+description: 'Deploy PostHog to Vercel, Docker (self-hosted), and Cloud Run.
+
   Covers Next.js reverse proxy, server-side capture in edge functions,
+
   self-hosted PostHog setup, and platform-specific environment configuration.
+
   Trigger: "deploy posthog", "posthog Vercel", "posthog production deploy",
+
   "posthog Cloud Run", "posthog self-hosted", "posthog Docker".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, deployment]
+tags:
+- saas
+- posthog
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-enterprise-rbac/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: posthog-enterprise-rbac
-description: |
-  PostHog enterprise access control: organization/project hierarchy, member roles,
+description: 'PostHog enterprise access control: organization/project hierarchy, member
+  roles,
+
   scoped API keys, SSO/SAML configuration, and activity audit logging.
+
   Trigger: "posthog SSO", "posthog RBAC", "posthog enterprise",
+
   "posthog roles", "posthog permissions", "posthog SAML", "posthog access".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, rbac]
+tags:
+- saas
+- posthog
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-hello-world/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-hello-world/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: posthog-hello-world
-description: |
-  Create a minimal working PostHog example with event capture, identify, and feature flags.
+description: 'Create a minimal working PostHog example with event capture, identify,
+  and feature flags.
+
   Use when starting a new PostHog integration, testing your setup,
+
   or learning basic posthog-js and posthog-node patterns.
+
   Trigger: "posthog hello world", "posthog example", "posthog quick start",
+
   "simple posthog code", "first posthog event".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, testing]
+tags:
+- saas
+- posthog
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Hello World
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-incident-runbook/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: posthog-incident-runbook
-description: |
-  PostHog incident response: triage decision tree, immediate actions for
+description: 'PostHog incident response: triage decision tree, immediate actions for
+
   401/429/500 errors, graceful degradation, evidence collection, and postmortem.
+
   Trigger: "posthog incident", "posthog outage", "posthog down",
+
   "posthog on-call", "posthog emergency", "posthog broken production".
+
+  '
 allowed-tools: Read, Grep, Bash(kubectl:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, incident-response]
+tags:
+- saas
+- posthog
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-install-auth/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: posthog-install-auth
-description: |
-  Install and configure PostHog SDKs with authentication.
+description: 'Install and configure PostHog SDKs with authentication.
+
   Use when setting up posthog-js (browser), posthog-node (server),
+
   or configuring API keys for a new PostHog integration.
+
   Trigger: "install posthog", "setup posthog", "posthog auth",
+
   "configure posthog API key", "posthog init".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, authentication]
+tags:
+- saas
+- posthog
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: posthog-local-dev-loop
-description: |
-  Configure PostHog local development with mocking, debug mode, and testing.
+description: 'Configure PostHog local development with mocking, debug mode, and testing.
+
   Use when setting up a development environment, mocking PostHog for tests,
+
   or establishing a fast iteration cycle with posthog-js or posthog-node.
+
   Trigger: "posthog dev setup", "posthog local development",
+
   "posthog dev environment", "mock posthog", "test posthog".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, testing, workflow]
+tags:
+- saas
+- posthog
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-migration-deep-dive/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: posthog-migration-deep-dive
-description: |
-  Migrate to PostHog from Google Analytics, Mixpanel, Amplitude, or Segment.
+description: 'Migrate to PostHog from Google Analytics, Mixpanel, Amplitude, or Segment.
+
   Covers dual-write strategy, historical data import, event name mapping,
+
   identity resolution, and feature flag based traffic shifting.
+
   Trigger: "migrate posthog", "posthog migration", "switch to posthog",
+
   "posthog from mixpanel", "posthog from GA", "posthog replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(kubectl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, migration]
+tags:
+- saas
+- posthog
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Migration Deep Dive
 
 ## Current State

--- a/plugins/saas-packs/posthog-pack/skills/posthog-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-multi-env-setup/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: posthog-multi-env-setup
-description: |
-  Configure PostHog across development, staging, and production environments.
+description: 'Configure PostHog across development, staging, and production environments.
+
   Separate PostHog projects per environment, environment-specific SDK config,
+
   feature flag rollout per env, and session recording controls.
+
   Trigger: "posthog environments", "posthog staging", "posthog dev prod",
+
   "posthog environment setup", "posthog project per env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, posthog-multi]
+tags:
+- saas
+- posthog
+- posthog-multi
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-observability/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-observability/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: posthog-observability
-description: |
-  Monitor PostHog integration health: event ingestion rates, feature flag
+description: 'Monitor PostHog integration health: event ingestion rates, feature flag
+
   evaluation latency, billing volume tracking, and Prometheus/Grafana alerting.
+
   Trigger: "posthog monitoring", "posthog metrics", "posthog observability",
+
   "monitor posthog", "posthog alerts", "posthog dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, monitoring, observability, dashboard]
+tags:
+- saas
+- posthog
+- monitoring
+- observability
+- dashboard
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Observability
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-performance-tuning/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: posthog-performance-tuning
-description: |
-  Optimize PostHog performance: local flag evaluation, client batching config,
+description: 'Optimize PostHog performance: local flag evaluation, client batching
+  config,
+
   event sampling, efficient HogQL queries, and serverless flush patterns.
+
   Trigger: "posthog performance", "optimize posthog", "posthog latency",
+
   "posthog caching", "posthog slow", "posthog batch", "posthog fast".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, performance]
+tags:
+- saas
+- posthog
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-prod-checklist/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: posthog-prod-checklist
-description: |
-  Production readiness checklist for PostHog integrations: SDK configuration,
+description: 'Production readiness checklist for PostHog integrations: SDK configuration,
+
   graceful degradation, health checks, shutdown hooks, and rollback procedures.
+
   Trigger: "posthog production", "deploy posthog", "posthog go-live",
+
   "posthog launch checklist", "posthog production ready".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, deployment]
+tags:
+- saas
+- posthog
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-rate-limits/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-rate-limits/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: posthog-rate-limits
-description: |
-  Handle PostHog API rate limits with exponential backoff, request queuing,
-  and understanding PostHog's actual limit tiers (240/min analytics, 600/min flags).
+description: 'Handle PostHog API rate limits with exponential backoff, request queuing,
+
+  and understanding PostHog''s actual limit tiers (240/min analytics, 600/min flags).
+
   Trigger: "posthog rate limit", "posthog throttling", "posthog 429",
+
   "posthog retry", "posthog backoff", "posthog too many requests".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api]
+tags:
+- saas
+- posthog
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-reference-architecture/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: posthog-reference-architecture
-description: |
-  Production PostHog architecture: event taxonomy, SDK layering, feature flag
+description: 'Production PostHog architecture: event taxonomy, SDK layering, feature
+  flag
+
   strategy, analytics module layout, and data pipeline integration patterns.
+
   Trigger: "posthog architecture", "posthog best practices", "posthog project
+
   structure", "how to organize posthog", "posthog design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, posthog-reference]
+tags:
+- saas
+- posthog
+- posthog-reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-sdk-patterns/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: posthog-sdk-patterns
-description: |
-  Production-ready PostHog SDK patterns: singleton client, typed events,
+description: 'Production-ready PostHog SDK patterns: singleton client, typed events,
+
   React hooks, Next.js App Router integration, and Python patterns.
+
   Trigger: "posthog SDK patterns", "posthog best practices",
+
   "posthog React hook", "posthog Next.js", "posthog typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, python, typescript]
+tags:
+- saas
+- posthog
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-security-basics/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-security-basics/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: posthog-security-basics
-description: |
-  Secure PostHog integration: API key management, project key vs personal key
+description: 'Secure PostHog integration: API key management, project key vs personal
+  key
+
   separation, secret rotation, scoped keys, and git-leak prevention.
+
   Trigger: "posthog security", "posthog secrets", "secure posthog",
+
   "posthog API key security", "posthog key rotation".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, security, audit]
+tags:
+- saas
+- posthog
+- api
+- security
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Security Basics
 
 ## Overview

--- a/plugins/saas-packs/posthog-pack/skills/posthog-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: posthog-upgrade-migration
-description: |
-  Upgrade posthog-js and posthog-node SDKs with breaking change detection.
+description: 'Upgrade posthog-js and posthog-node SDKs with breaking change detection.
+
   Covers v4 to v5 posthog-node migration (sendFeatureFlags change),
+
   posthog-js autocapture API changes, and version-specific gotchas.
+
   Trigger: "upgrade posthog", "posthog breaking changes",
+
   "update posthog SDK", "posthog version", "posthog migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, api, migration]
+tags:
+- saas
+- posthog
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Upgrade & Migration
 
 ## Current State

--- a/plugins/saas-packs/posthog-pack/skills/posthog-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/posthog-pack/skills/posthog-webhooks-events/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: posthog-webhooks-events
-description: |
-  Implement PostHog webhook destinations, Action-triggered notifications,
+description: 'Implement PostHog webhook destinations, Action-triggered notifications,
+
   and event querying via the Events API and HogQL.
+
   Trigger: "posthog webhook", "posthog events API", "posthog actions",
+
   "posthog notifications", "posthog event query", "posthog HogQL".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, posthog, webhooks]
+tags:
+- saas
+- posthog
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # PostHog Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-ci-integration/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-ci-integration/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-ci-integration
-description: |
-  Procore ci integration — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore ci integration", "procore-ci-integration".
+description: "Procore ci integration \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore ci integration\", \"procore-ci-integration\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-common-errors/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-common-errors/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-common-errors
-description: |
-  Procore common errors — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore common errors", "procore-common-errors".
+description: "Procore common errors \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore common errors\", \"procore-common-errors\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Common Errors
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-core-workflow-a/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-core-workflow-a
-description: |
-  Procore core workflow a — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore core workflow a", "procore-core-workflow-a".
+description: "Procore core workflow a \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore core workflow a\", \"procore-core-workflow-a\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-core-workflow-b/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-core-workflow-b
-description: |
-  Procore core workflow b — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore core workflow b", "procore-core-workflow-b".
+description: "Procore core workflow b \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore core workflow b\", \"procore-core-workflow-b\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-cost-tuning/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-cost-tuning
-description: |
-  Procore cost tuning — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore cost tuning", "procore-cost-tuning".
+description: "Procore cost tuning \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore cost tuning\", \"procore-cost-tuning\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-data-handling/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-data-handling/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-data-handling
-description: |
-  Procore data handling — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore data handling", "procore-data-handling".
+description: "Procore data handling \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore data handling\", \"procore-data-handling\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Data Handling
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-debug-bundle/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-debug-bundle
-description: |
-  Procore debug bundle — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore debug bundle", "procore-debug-bundle".
+description: "Procore debug bundle \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore debug bundle\", \"procore-debug-bundle\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-deploy-integration/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-deploy-integration
-description: |
-  Procore deploy integration — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore deploy integration", "procore-deploy-integration".
+description: "Procore deploy integration \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore deploy integration\", \"procore-deploy-integration\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-enterprise-rbac/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-enterprise-rbac
-description: |
-  Procore enterprise rbac — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore enterprise rbac", "procore-enterprise-rbac".
+description: "Procore enterprise rbac \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore enterprise rbac\", \"procore-enterprise-rbac\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Enterprise Rbac
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-hello-world/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-hello-world/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-hello-world
-description: |
-  Procore hello world — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore hello world", "procore-hello-world".
+description: "Procore hello world \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore hello world\", \"procore-hello-world\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Hello World
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-incident-runbook/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-incident-runbook
-description: |
-  Procore incident runbook — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore incident runbook", "procore-incident-runbook".
+description: "Procore incident runbook \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore incident runbook\", \"procore-incident-runbook\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-install-auth/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-install-auth/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-install-auth
-description: |
-  Procore install auth — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore install auth", "procore-install-auth".
+description: "Procore install auth \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore install auth\", \"procore-install-auth\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Install Auth
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-local-dev-loop/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-local-dev-loop
-description: |
-  Procore local dev loop — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore local dev loop", "procore-local-dev-loop".
+description: "Procore local dev loop \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore local dev loop\", \"procore-local-dev-loop\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-migration-deep-dive/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-migration-deep-dive
-description: |
-  Procore migration deep dive — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore migration deep dive", "procore-migration-deep-dive".
+description: "Procore migration deep dive \u2014 construction management platform\
+  \ integration.\nUse when working with Procore API for project management, RFIs,\
+  \ or submittals.\nTrigger with phrases like \"procore migration deep dive\", \"\
+  procore-migration-deep-dive\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-multi-env-setup/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-multi-env-setup
-description: |
-  Procore multi env setup — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore multi env setup", "procore-multi-env-setup".
+description: "Procore multi env setup \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore multi env setup\", \"procore-multi-env-setup\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Multi Env Setup
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-observability/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-observability/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-observability
-description: |
-  Procore observability — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore observability", "procore-observability".
+description: "Procore observability \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore observability\", \"procore-observability\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Observability
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-performance-tuning/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-performance-tuning
-description: |
-  Procore performance tuning — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore performance tuning", "procore-performance-tuning".
+description: "Procore performance tuning \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore performance tuning\", \"procore-performance-tuning\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-prod-checklist/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-prod-checklist
-description: |
-  Procore prod checklist — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore prod checklist", "procore-prod-checklist".
+description: "Procore prod checklist \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore prod checklist\", \"procore-prod-checklist\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-rate-limits/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-rate-limits/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-rate-limits
-description: |
-  Procore rate limits — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore rate limits", "procore-rate-limits".
+description: "Procore rate limits \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore rate limits\", \"procore-rate-limits\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-reference-architecture/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-reference-architecture
-description: |
-  Procore reference architecture — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore reference architecture", "procore-reference-architecture".
+description: "Procore reference architecture \u2014 construction management platform\
+  \ integration.\nUse when working with Procore API for project management, RFIs,\
+  \ or submittals.\nTrigger with phrases like \"procore reference architecture\",\
+  \ \"procore-reference-architecture\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-sdk-patterns/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: procore-sdk-patterns
-description: |
-  Procore sdk patterns — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore sdk patterns", "procore-sdk-patterns".
+description: "Procore sdk patterns \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore sdk patterns\", \"procore-sdk-patterns\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-security-basics/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-security-basics/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-security-basics
-description: |
-  Procore security basics — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore security basics", "procore-security-basics".
+description: "Procore security basics \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore security basics\", \"procore-security-basics\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Security Basics
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-upgrade-migration/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-upgrade-migration
-description: |
-  Procore upgrade migration — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore upgrade migration", "procore-upgrade-migration".
+description: "Procore upgrade migration \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore upgrade migration\", \"procore-upgrade-migration\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/procore-pack/skills/procore-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/procore-pack/skills/procore-webhooks-events/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: procore-webhooks-events
-description: |
-  Procore webhooks events — construction management platform integration.
-  Use when working with Procore API for project management, RFIs, or submittals.
-  Trigger with phrases like "procore webhooks events", "procore-webhooks-events".
+description: "Procore webhooks events \u2014 construction management platform integration.\n\
+  Use when working with Procore API for project management, RFIs, or submittals.\n\
+  Trigger with phrases like \"procore webhooks events\", \"procore-webhooks-events\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, procore, construction, project-management]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- procore
+- construction
+- project-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Procore Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-ci-integration/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-ci-integration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-ci-integration
-description: |
-  QuickNode ci integration — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode ci integration", "quicknode-ci-integration", "blockchain RPC".
+description: "QuickNode ci integration \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode ci integration\", \"quicknode-ci-integration\",\
+  \ \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-common-errors/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: quicknode-common-errors
-description: |
-  Diagnose and fix QuickNode RPC errors: nonce issues, gas failures, rate limits.
-  Use when encountering blockchain RPC errors, failed transactions, or connection issues.
-  Trigger with phrases like "quicknode error", "RPC error", "nonce too low", "gas estimation failed".
+description: 'Diagnose and fix QuickNode RPC errors: nonce issues, gas failures, rate
+  limits.
+
+  Use when encountering blockchain RPC errors, failed transactions, or connection
+  issues.
+
+  Trigger with phrases like "quicknode error", "RPC error", "nonce too low", "gas
+  estimation failed".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, debugging]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Common Errors
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-core-workflow-a/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-core-workflow-a
-description: |
-  QuickNode core workflow a — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode core workflow a", "quicknode-core-workflow-a", "blockchain RPC".
+description: "QuickNode core workflow a \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode core workflow a\", \"quicknode-core-workflow-a\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: quicknode-core-workflow-b
-description: |
-  Work with NFT and token APIs via QuickNode: metadata, balances, transfer history.
+description: 'Work with NFT and token APIs via QuickNode: metadata, balances, transfer
+  history.
+
   Use when building NFT or token features, checking balances, or tracking transfers.
-  Trigger with phrases like "quicknode NFT", "token balance", "NFT metadata", "ERC-20 balance".
+
+  Trigger with phrases like "quicknode NFT", "token balance", "NFT metadata", "ERC-20
+  balance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, nft, tokens, web3]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- nft
+- tokens
+- web3
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Core Workflow B — NFT & Token APIs
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-cost-tuning/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-cost-tuning
-description: |
-  QuickNode cost tuning — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode cost tuning", "quicknode-cost-tuning", "blockchain RPC".
+description: "QuickNode cost tuning \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode cost tuning\", \"quicknode-cost-tuning\", \"blockchain\
+  \ RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-debug-bundle/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-debug-bundle
-description: |
-  QuickNode debug bundle — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode debug bundle", "quicknode-debug-bundle", "blockchain RPC".
+description: "QuickNode debug bundle \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode debug bundle\", \"quicknode-debug-bundle\", \"blockchain\
+  \ RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-deploy-integration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-deploy-integration
-description: |
-  QuickNode deploy integration — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode deploy integration", "quicknode-deploy-integration", "blockchain RPC".
+description: "QuickNode deploy integration \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode deploy integration\", \"quicknode-deploy-integration\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-hello-world/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-hello-world/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-hello-world
-description: |
-  QuickNode hello world — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode hello world", "quicknode-hello-world", "blockchain RPC".
+description: "QuickNode hello world \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode hello world\", \"quicknode-hello-world\", \"blockchain\
+  \ RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Hello World
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-install-auth/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-install-auth
-description: |
-  QuickNode install auth — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode install auth", "quicknode-install-auth", "blockchain RPC".
+description: "QuickNode install auth \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode install auth\", \"quicknode-install-auth\", \"blockchain\
+  \ RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Install Auth
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-local-dev-loop/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-local-dev-loop
-description: |
-  QuickNode local dev loop — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode local dev loop", "quicknode-local-dev-loop", "blockchain RPC".
+description: "QuickNode local dev loop \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode local dev loop\", \"quicknode-local-dev-loop\",\
+  \ \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-performance-tuning/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-performance-tuning
-description: |
-  QuickNode performance tuning — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode performance tuning", "quicknode-performance-tuning", "blockchain RPC".
+description: "QuickNode performance tuning \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode performance tuning\", \"quicknode-performance-tuning\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-prod-checklist/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-prod-checklist
-description: |
-  QuickNode prod checklist — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode prod checklist", "quicknode-prod-checklist", "blockchain RPC".
+description: "QuickNode prod checklist \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode prod checklist\", \"quicknode-prod-checklist\",\
+  \ \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-rate-limits/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-rate-limits/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-rate-limits
-description: |
-  QuickNode rate limits — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode rate limits", "quicknode-rate-limits", "blockchain RPC".
+description: "QuickNode rate limits \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode rate limits\", \"quicknode-rate-limits\", \"blockchain\
+  \ RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-reference-architecture/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-reference-architecture
-description: |
-  QuickNode reference architecture — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode reference architecture", "quicknode-reference-architecture", "blockchain RPC".
+description: "QuickNode reference architecture \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode reference architecture\", \"quicknode-reference-architecture\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-sdk-patterns/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: quicknode-sdk-patterns
-description: |
-  Production-ready QuickNode SDK and ethers.js patterns for blockchain applications.
+description: 'Production-ready QuickNode SDK and ethers.js patterns for blockchain
+  applications.
+
   Use when building production dApps, implementing retry logic, or establishing patterns.
+
   Trigger with phrases like "quicknode patterns", "ethers best practices", "web3 patterns".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, patterns]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-security-basics/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-security-basics/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-security-basics
-description: |
-  QuickNode security basics — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode security basics", "quicknode-security-basics", "blockchain RPC".
+description: "QuickNode security basics \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode security basics\", \"quicknode-security-basics\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Security Basics
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-upgrade-migration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-upgrade-migration
-description: |
-  QuickNode upgrade migration — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode upgrade migration", "quicknode-upgrade-migration", "blockchain RPC".
+description: "QuickNode upgrade migration \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode upgrade migration\", \"quicknode-upgrade-migration\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/quicknode-pack/skills/quicknode-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/quicknode-pack/skills/quicknode-webhooks-events/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: quicknode-webhooks-events
-description: |
-  QuickNode webhooks events — blockchain RPC and Web3 infrastructure integration.
-  Use when working with QuickNode for blockchain development.
-  Trigger with phrases like "quicknode webhooks events", "quicknode-webhooks-events", "blockchain RPC".
+description: "QuickNode webhooks events \u2014 blockchain RPC and Web3 infrastructure\
+  \ integration.\nUse when working with QuickNode for blockchain development.\nTrigger\
+  \ with phrases like \"quicknode webhooks events\", \"quicknode-webhooks-events\"\
+  , \"blockchain RPC\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, quicknode, blockchain, web3, rpc, ethereum]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- quicknode
+- blockchain
+- web3
+- rpc
+- ethereum
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # QuickNode Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-ci-integration/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-ci-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-ci-integration
-description: |
-  Ramp ci integration — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp ci integration", "ramp-ci-integration", "corporate card API".
+description: "Ramp ci integration \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp ci integration\", \"ramp-ci-integration\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-common-errors/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-common-errors/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-common-errors
-description: |
-  Ramp common errors — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp common errors", "ramp-common-errors", "corporate card API".
+description: "Ramp common errors \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp common errors\", \"ramp-common-errors\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Common Errors
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-core-workflow-a/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-core-workflow-a
-description: |
-  Ramp core workflow a — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp core workflow a", "ramp-core-workflow-a", "corporate card API".
+description: "Ramp core workflow a \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp core workflow a\", \"ramp-core-workflow-a\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-core-workflow-b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-core-workflow-b
-description: |
-  Ramp core workflow b — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp core workflow b", "ramp-core-workflow-b", "corporate card API".
+description: "Ramp core workflow b \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp core workflow b\", \"ramp-core-workflow-b\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-cost-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-cost-tuning
-description: |
-  Ramp cost tuning — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp cost tuning", "ramp-cost-tuning", "corporate card API".
+description: "Ramp cost tuning \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp cost tuning\", \"ramp-cost-tuning\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-data-handling/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-data-handling/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-data-handling
-description: |
-  Ramp data handling — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp data handling", "ramp-data-handling", "corporate card API".
+description: "Ramp data handling \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp data handling\", \"ramp-data-handling\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Data Handling
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-debug-bundle/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-debug-bundle
-description: |
-  Ramp debug bundle — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp debug bundle", "ramp-debug-bundle", "corporate card API".
+description: "Ramp debug bundle \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp debug bundle\", \"ramp-debug-bundle\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-deploy-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-deploy-integration
-description: |
-  Ramp deploy integration — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp deploy integration", "ramp-deploy-integration", "corporate card API".
+description: "Ramp deploy integration \u2014 corporate card and expense management\
+  \ API integration.\nUse when working with Ramp for card management, expenses, or\
+  \ accounting sync.\nTrigger with phrases like \"ramp deploy integration\", \"ramp-deploy-integration\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-enterprise-rbac/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-enterprise-rbac
-description: |
-  Ramp enterprise rbac — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp enterprise rbac", "ramp-enterprise-rbac", "corporate card API".
+description: "Ramp enterprise rbac \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp enterprise rbac\", \"ramp-enterprise-rbac\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Enterprise Rbac
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-hello-world/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-hello-world/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-hello-world
-description: |
-  Ramp hello world — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp hello world", "ramp-hello-world", "corporate card API".
+description: "Ramp hello world \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp hello world\", \"ramp-hello-world\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Hello World
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-incident-runbook/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-incident-runbook
-description: |
-  Ramp incident runbook — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp incident runbook", "ramp-incident-runbook", "corporate card API".
+description: "Ramp incident runbook \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp incident runbook\", \"ramp-incident-runbook\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-install-auth/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-install-auth/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-install-auth
-description: |
-  Ramp install auth — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp install auth", "ramp-install-auth", "corporate card API".
+description: "Ramp install auth \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp install auth\", \"ramp-install-auth\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Install Auth
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-local-dev-loop/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-local-dev-loop
-description: |
-  Ramp local dev loop — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp local dev loop", "ramp-local-dev-loop", "corporate card API".
+description: "Ramp local dev loop \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp local dev loop\", \"ramp-local-dev-loop\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-migration-deep-dive/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-migration-deep-dive
-description: |
-  Ramp migration deep dive — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp migration deep dive", "ramp-migration-deep-dive", "corporate card API".
+description: "Ramp migration deep dive \u2014 corporate card and expense management\
+  \ API integration.\nUse when working with Ramp for card management, expenses, or\
+  \ accounting sync.\nTrigger with phrases like \"ramp migration deep dive\", \"ramp-migration-deep-dive\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-multi-env-setup/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-multi-env-setup
-description: |
-  Ramp multi env setup — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp multi env setup", "ramp-multi-env-setup", "corporate card API".
+description: "Ramp multi env setup \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp multi env setup\", \"ramp-multi-env-setup\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Multi Env Setup
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-observability/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-observability/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-observability
-description: |
-  Ramp observability — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp observability", "ramp-observability", "corporate card API".
+description: "Ramp observability \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp observability\", \"ramp-observability\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Observability
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-performance-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-performance-tuning
-description: |
-  Ramp performance tuning — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp performance tuning", "ramp-performance-tuning", "corporate card API".
+description: "Ramp performance tuning \u2014 corporate card and expense management\
+  \ API integration.\nUse when working with Ramp for card management, expenses, or\
+  \ accounting sync.\nTrigger with phrases like \"ramp performance tuning\", \"ramp-performance-tuning\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-prod-checklist/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-prod-checklist
-description: |
-  Ramp prod checklist — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp prod checklist", "ramp-prod-checklist", "corporate card API".
+description: "Ramp prod checklist \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp prod checklist\", \"ramp-prod-checklist\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-rate-limits/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-rate-limits/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-rate-limits
-description: |
-  Ramp rate limits — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp rate limits", "ramp-rate-limits", "corporate card API".
+description: "Ramp rate limits \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp rate limits\", \"ramp-rate-limits\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-reference-architecture/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-reference-architecture
-description: |
-  Ramp reference architecture — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp reference architecture", "ramp-reference-architecture", "corporate card API".
+description: "Ramp reference architecture \u2014 corporate card and expense management\
+  \ API integration.\nUse when working with Ramp for card management, expenses, or\
+  \ accounting sync.\nTrigger with phrases like \"ramp reference architecture\", \"\
+  ramp-reference-architecture\", \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-sdk-patterns/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-sdk-patterns
-description: |
-  Ramp sdk patterns — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp sdk patterns", "ramp-sdk-patterns", "corporate card API".
+description: "Ramp sdk patterns \u2014 corporate card and expense management API integration.\n\
+  Use when working with Ramp for card management, expenses, or accounting sync.\n\
+  Trigger with phrases like \"ramp sdk patterns\", \"ramp-sdk-patterns\", \"corporate\
+  \ card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-security-basics/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-security-basics/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-security-basics
-description: |
-  Ramp security basics — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp security basics", "ramp-security-basics", "corporate card API".
+description: "Ramp security basics \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp security basics\", \"ramp-security-basics\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Security Basics
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-upgrade-migration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-upgrade-migration
-description: |
-  Ramp upgrade migration — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp upgrade migration", "ramp-upgrade-migration", "corporate card API".
+description: "Ramp upgrade migration \u2014 corporate card and expense management\
+  \ API integration.\nUse when working with Ramp for card management, expenses, or\
+  \ accounting sync.\nTrigger with phrases like \"ramp upgrade migration\", \"ramp-upgrade-migration\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/ramp-pack/skills/ramp-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/ramp-pack/skills/ramp-webhooks-events/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ramp-webhooks-events
-description: |
-  Ramp webhooks events — corporate card and expense management API integration.
-  Use when working with Ramp for card management, expenses, or accounting sync.
-  Trigger with phrases like "ramp webhooks events", "ramp-webhooks-events", "corporate card API".
+description: "Ramp webhooks events \u2014 corporate card and expense management API\
+  \ integration.\nUse when working with Ramp for card management, expenses, or accounting\
+  \ sync.\nTrigger with phrases like \"ramp webhooks events\", \"ramp-webhooks-events\"\
+  , \"corporate card API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ramp, fintech, expenses, corporate-cards]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- ramp
+- fintech
+- expenses
+- corporate-cards
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Ramp Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-common-errors/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-common-errors/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-common-errors
-description: |
-  RemoFirst common errors — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst common errors", "remofirst-common-errors", "global HR API".
+description: "RemoFirst common errors \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst common errors\", \"remofirst-common-errors\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Common Errors
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-core-workflow-a/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-core-workflow-a
-description: |
-  RemoFirst core workflow a — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst core workflow a", "remofirst-core-workflow-a", "global HR API".
+description: "RemoFirst core workflow a \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst core workflow a\", \"remofirst-core-workflow-a\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-core-workflow-b/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-core-workflow-b
-description: |
-  RemoFirst core workflow b — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst core workflow b", "remofirst-core-workflow-b", "global HR API".
+description: "RemoFirst core workflow b \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst core workflow b\", \"remofirst-core-workflow-b\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-debug-bundle/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-debug-bundle
-description: |
-  RemoFirst debug bundle — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst debug bundle", "remofirst-debug-bundle", "global HR API".
+description: "RemoFirst debug bundle \u2014 global HR, EOR, and payroll platform integration.\n\
+  Use when working with RemoFirst for global employment, payroll, or compliance.\n\
+  Trigger with phrases like \"remofirst debug bundle\", \"remofirst-debug-bundle\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-hello-world/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-hello-world/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-hello-world
-description: |
-  RemoFirst hello world — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst hello world", "remofirst-hello-world", "global HR API".
+description: "RemoFirst hello world \u2014 global HR, EOR, and payroll platform integration.\n\
+  Use when working with RemoFirst for global employment, payroll, or compliance.\n\
+  Trigger with phrases like \"remofirst hello world\", \"remofirst-hello-world\",\
+  \ \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Hello World
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-install-auth/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-install-auth/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-install-auth
-description: |
-  RemoFirst install auth — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst install auth", "remofirst-install-auth", "global HR API".
+description: "RemoFirst install auth \u2014 global HR, EOR, and payroll platform integration.\n\
+  Use when working with RemoFirst for global employment, payroll, or compliance.\n\
+  Trigger with phrases like \"remofirst install auth\", \"remofirst-install-auth\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Install Auth
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-local-dev-loop/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-local-dev-loop
-description: |
-  RemoFirst local dev loop — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst local dev loop", "remofirst-local-dev-loop", "global HR API".
+description: "RemoFirst local dev loop \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst local dev loop\", \"remofirst-local-dev-loop\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-prod-checklist/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-prod-checklist
-description: |
-  RemoFirst prod checklist — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst prod checklist", "remofirst-prod-checklist", "global HR API".
+description: "RemoFirst prod checklist \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst prod checklist\", \"remofirst-prod-checklist\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-rate-limits/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-rate-limits/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-rate-limits
-description: |
-  RemoFirst rate limits — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst rate limits", "remofirst-rate-limits", "global HR API".
+description: "RemoFirst rate limits \u2014 global HR, EOR, and payroll platform integration.\n\
+  Use when working with RemoFirst for global employment, payroll, or compliance.\n\
+  Trigger with phrases like \"remofirst rate limits\", \"remofirst-rate-limits\",\
+  \ \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-sdk-patterns/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-sdk-patterns
-description: |
-  RemoFirst sdk patterns — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst sdk patterns", "remofirst-sdk-patterns", "global HR API".
+description: "RemoFirst sdk patterns \u2014 global HR, EOR, and payroll platform integration.\n\
+  Use when working with RemoFirst for global employment, payroll, or compliance.\n\
+  Trigger with phrases like \"remofirst sdk patterns\", \"remofirst-sdk-patterns\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-security-basics/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-security-basics/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-security-basics
-description: |
-  RemoFirst security basics — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst security basics", "remofirst-security-basics", "global HR API".
+description: "RemoFirst security basics \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst security basics\", \"remofirst-security-basics\"\
+  , \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Security Basics
 
 ## Overview

--- a/plugins/saas-packs/remofirst-pack/skills/remofirst-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/remofirst-pack/skills/remofirst-upgrade-migration/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: remofirst-upgrade-migration
-description: |
-  RemoFirst upgrade migration — global HR, EOR, and payroll platform integration.
-  Use when working with RemoFirst for global employment, payroll, or compliance.
-  Trigger with phrases like "remofirst upgrade migration", "remofirst-upgrade-migration", "global HR API".
+description: "RemoFirst upgrade migration \u2014 global HR, EOR, and payroll platform\
+  \ integration.\nUse when working with RemoFirst for global employment, payroll,\
+  \ or compliance.\nTrigger with phrases like \"remofirst upgrade migration\", \"\
+  remofirst-upgrade-migration\", \"global HR API\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, remofirst, hr, eor, payroll, global-employment]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- remofirst
+- hr
+- eor
+- payroll
+- global-employment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # RemoFirst Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/replit-pack/skills/replit-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-advanced-troubleshooting
-description: |
-  Debug hard Replit issues: container lifecycle, Nix build failures, deployment crashes, and memory leaks.
+description: 'Debug hard Replit issues: container lifecycle, Nix build failures, deployment
+  crashes, and memory leaks.
+
   Use when standard troubleshooting fails, investigating intermittent failures,
+
   or diagnosing complex Replit platform behavior.
+
   Trigger with phrases like "replit hard bug", "replit mystery error",
+
   "replit impossible to debug", "replit intermittent", "replit deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, debugging, advanced]
+tags:
+- saas
+- replit
+- debugging
+- advanced
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Advanced Troubleshooting
 

--- a/plugins/saas-packs/replit-pack/skills/replit-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-architecture-variants/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-architecture-variants
-description: |
-  Choose and implement Replit architecture blueprints: single-file script, modular app, and multi-service.
+description: 'Choose and implement Replit architecture blueprints: single-file script,
+  modular app, and multi-service.
+
   Use when designing new Replit apps, choosing the right architecture scale,
+
   or planning migration paths as your app grows.
+
   Trigger with phrases like "replit architecture options", "replit blueprint",
+
   "how to structure replit app", "replit monolith vs service", "replit app scale".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, architecture, scaling]
+tags:
+- saas
+- replit
+- architecture
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Architecture Variants
 

--- a/plugins/saas-packs/replit-pack/skills/replit-ci-integration/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-ci-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-ci-integration
-description: |
-  Configure CI/CD for Replit with GitHub Actions, automated testing, and deploy-on-push.
+description: 'Configure CI/CD for Replit with GitHub Actions, automated testing, and
+  deploy-on-push.
+
   Use when setting up automated testing, GitHub integration for Replit,
+
   or continuous deployment pipelines that deploy to Replit.
+
   Trigger with phrases like "replit CI", "replit GitHub Actions",
+
   "replit automated deploy", "CI replit", "replit GitHub".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, ci-cd, github-actions, automation]
+tags:
+- saas
+- replit
+- ci-cd
+- github-actions
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit CI Integration
 

--- a/plugins/saas-packs/replit-pack/skills/replit-common-errors/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-common-errors
-description: |
-  Diagnose and fix the top Replit errors: container sleep, port binding, Nix failures, DB limits.
+description: 'Diagnose and fix the top Replit errors: container sleep, port binding,
+  Nix failures, DB limits.
+
   Use when encountering Replit errors, debugging failed deployments,
+
   or troubleshooting workspace and hosting issues.
+
   Trigger with phrases like "replit error", "fix replit", "replit not working",
+
   "debug replit", "replit broken", "replit deploy failed".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, debugging, errors]
+tags:
+- saas
+- replit
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Common Errors
 

--- a/plugins/saas-packs/replit-pack/skills/replit-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-core-workflow-a
-description: |
-  Build a full-stack web app on Replit with Express/Flask, PostgreSQL, Auth, and deployment.
+description: 'Build a full-stack web app on Replit with Express/Flask, PostgreSQL,
+  Auth, and deployment.
+
   Use when creating a new production app on Replit from scratch,
+
   building the primary user-facing workflow, or following Replit best practices.
+
   Trigger with phrases like "build replit app", "replit full stack",
+
   "replit web app", "create replit project", "replit express flask".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, workflow, full-stack]
+tags:
+- saas
+- replit
+- workflow
+- full-stack
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Core Workflow A — Full-Stack App
 

--- a/plugins/saas-packs/replit-pack/skills/replit-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-core-workflow-b
-description: |
-  Manage Replit Teams, member permissions, deployment promotion, and bulk Repl admin.
+description: 'Manage Replit Teams, member permissions, deployment promotion, and bulk
+  Repl admin.
+
   Use when managing team access, configuring deployment environments,
+
   auditing Repls, or administering organization settings.
+
   Trigger with phrases like "replit team management", "replit admin",
+
   "replit permissions", "replit bulk operations", "manage replit members".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, workflow, admin, teams]
+tags:
+- saas
+- replit
+- workflow
+- admin
+- teams
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Core Workflow B — Teams & Admin
 

--- a/plugins/saas-packs/replit-pack/skills/replit-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-cost-tuning
-description: |
-  Optimize Replit costs: deployment sizing, seat audit, egress control, and plan selection.
+description: 'Optimize Replit costs: deployment sizing, seat audit, egress control,
+  and plan selection.
+
   Use when analyzing Replit billing, reducing deployment costs,
+
   or implementing usage monitoring and budget controls.
+
   Trigger with phrases like "replit cost", "replit billing",
+
   "reduce replit costs", "replit pricing", "replit expensive", "replit budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, cost-optimization, billing]
+tags:
+- saas
+- replit
+- cost-optimization
+- billing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Cost Tuning
 

--- a/plugins/saas-packs/replit-pack/skills/replit-data-handling/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-data-handling/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: replit-data-handling
-description: |
-  Implement secure data handling on Replit: PostgreSQL, KV Database, Object Storage, and data security patterns.
-  Use when handling sensitive data, connecting databases, implementing data access patterns,
+description: 'Implement secure data handling on Replit: PostgreSQL, KV Database, Object
+  Storage, and data security patterns.
+
+  Use when handling sensitive data, connecting databases, implementing data access
+  patterns,
+
   or ensuring secure data flow in Replit-hosted applications.
+
   Trigger with phrases like "replit data", "replit database",
+
   "replit PostgreSQL", "replit storage", "replit data security", "replit GDPR".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, database, storage, security]
+tags:
+- saas
+- replit
+- database
+- storage
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Data Handling
 

--- a/plugins/saas-packs/replit-pack/skills/replit-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-debug-bundle/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-debug-bundle
-description: |
-  Collect Replit diagnostic info for debugging deployments, workspace issues, and support tickets.
+description: 'Collect Replit diagnostic info for debugging deployments, workspace
+  issues, and support tickets.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting system state for troubleshooting Replit problems.
+
   Trigger with phrases like "replit debug", "replit support bundle",
+
   "collect replit logs", "replit diagnostic", "replit troubleshoot".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, debugging, support]
+tags:
+- saas
+- replit
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Debug Bundle
 

--- a/plugins/saas-packs/replit-pack/skills/replit-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-deploy-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-deploy-integration
-description: |
-  Deploy Replit apps with Autoscale, Reserved VM, and Static deployment types.
+description: 'Deploy Replit apps with Autoscale, Reserved VM, and Static deployment
+  types.
+
   Use when deploying to production, configuring deployment settings, setting up
+
   custom domains, or managing deployment secrets and health checks.
+
   Trigger with phrases like "deploy replit", "replit deployment",
-  "replit autoscale", "replit reserved VM", "replit static deploy", "replit custom domain".
+
+  "replit autoscale", "replit reserved VM", "replit static deploy", "replit custom
+  domain".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, deployment, hosting]
+tags:
+- saas
+- replit
+- deployment
+- hosting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Deploy Integration
 

--- a/plugins/saas-packs/replit-pack/skills/replit-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-enterprise-rbac
-description: |
-  Configure Replit Teams roles, SSO/SAML, custom groups, and organization-level access control.
+description: 'Configure Replit Teams roles, SSO/SAML, custom groups, and organization-level
+  access control.
+
   Use when setting up team permissions, configuring SSO, managing deployment access,
+
   or auditing organization security on Replit.
+
   Trigger with phrases like "replit SSO", "replit RBAC", "replit enterprise",
+
   "replit roles", "replit permissions", "replit SAML", "replit teams admin".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, rbac, enterprise, sso]
+tags:
+- saas
+- replit
+- rbac
+- enterprise
+- sso
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Enterprise RBAC
 

--- a/plugins/saas-packs/replit-pack/skills/replit-hello-world/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-hello-world/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-hello-world
-description: |
-  Create a minimal working Replit app with database, object storage, and auth.
+description: 'Create a minimal working Replit app with database, object storage, and
+  auth.
+
   Use when starting a new Replit project, testing your setup,
-  or learning Replit's built-in services (DB, Auth, Object Storage).
+
+  or learning Replit''s built-in services (DB, Auth, Object Storage).
+
   Trigger with phrases like "replit hello world", "replit starter",
+
   "replit quick start", "first replit app", "replit example".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, starter, database, api]
+tags:
+- saas
+- replit
+- starter
+- database
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Hello World
 

--- a/plugins/saas-packs/replit-pack/skills/replit-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-incident-runbook/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-incident-runbook
-description: |
-  Execute Replit incident response: triage deployment failures, database issues, and platform outages.
+description: 'Execute Replit incident response: triage deployment failures, database
+  issues, and platform outages.
+
   Use when responding to Replit-related outages, investigating deployment crashes,
+
   or running post-incident reviews for Replit app failures.
+
   Trigger with phrases like "replit incident", "replit outage",
+
   "replit down", "replit emergency", "replit broken", "replit crash".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, incident-response, debugging]
+tags:
+- saas
+- replit
+- incident-response
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Incident Runbook
 

--- a/plugins/saas-packs/replit-pack/skills/replit-install-auth/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-install-auth/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: replit-install-auth
-description: |
-  Set up a Replit project with .replit + replit.nix configuration, Secrets, and Replit Auth.
+description: 'Set up a Replit project with .replit + replit.nix configuration, Secrets,
+  and Replit Auth.
+
   Use when creating a new Replit App, configuring Nix packages, managing secrets,
+
   or adding user authentication with Replit Auth.
+
   Trigger with phrases like "setup replit", "replit auth", "replit nix config",
+
   "replit secrets", "configure replit", "new replit project".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(nix:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, authentication, nix, secrets, configuration]
+tags:
+- saas
+- replit
+- authentication
+- nix
+- secrets
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Install & Auth
 

--- a/plugins/saas-packs/replit-pack/skills/replit-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-known-pitfalls/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-known-pitfalls
-description: |
-  Avoid the top Replit anti-patterns: ephemeral filesystem, public secrets, port binding, Nix gotchas, and database limits.
+description: 'Avoid the top Replit anti-patterns: ephemeral filesystem, public secrets,
+  port binding, Nix gotchas, and database limits.
+
   Use when reviewing Replit code, onboarding developers,
+
   or auditing existing Replit apps for common mistakes.
+
   Trigger with phrases like "replit mistakes", "replit anti-patterns",
+
   "replit pitfalls", "replit what not to do", "replit code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, audit, anti-patterns]
+tags:
+- saas
+- replit
+- audit
+- anti-patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Known Pitfalls
 

--- a/plugins/saas-packs/replit-pack/skills/replit-load-scale/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-load-scale
-description: |
-  Load test and scale Replit deployments with Autoscale tuning, Reserved VM sizing, and capacity planning.
+description: 'Load test and scale Replit deployments with Autoscale tuning, Reserved
+  VM sizing, and capacity planning.
+
   Use when load testing Replit apps, optimizing Autoscale behavior,
+
   or planning capacity for production traffic.
+
   Trigger with phrases like "replit load test", "replit scale",
+
   "replit capacity", "replit performance test", "replit autoscale tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, testing, performance, scaling]
+tags:
+- saas
+- replit
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Load & Scale
 

--- a/plugins/saas-packs/replit-pack/skills/replit-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-local-dev-loop/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-local-dev-loop
-description: |
-  Configure Replit development workflow with hot reload, Webview, and Replit Agent.
+description: 'Configure Replit development workflow with hot reload, Webview, and
+  Replit Agent.
+
   Use when setting up dev server, configuring run commands, debugging in Workspace,
+
   or using Replit Agent for AI-assisted development.
+
   Trigger with phrases like "replit dev server", "replit hot reload",
+
   "replit local development", "replit agent", "replit workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, development, workflow, agent]
+tags:
+- saas
+- replit
+- development
+- workflow
+- agent
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Local Dev Loop
 

--- a/plugins/saas-packs/replit-pack/skills/replit-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-migration-deep-dive/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-migration-deep-dive
-description: |
-  Migrate to Replit from Heroku, Railway, Vercel, or local development environments.
+description: 'Migrate to Replit from Heroku, Railway, Vercel, or local development
+  environments.
+
   Use when moving an existing app to Replit, migrating databases,
-  or converting Docker/buildpack apps to Replit's Nix-based system.
+
+  or converting Docker/buildpack apps to Replit''s Nix-based system.
+
   Trigger with phrases like "migrate to replit", "heroku to replit",
+
   "move to replit", "replit migration", "railway to replit", "convert to replit".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, migration, heroku, railway]
+tags:
+- saas
+- replit
+- migration
+- heroku
+- railway
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Migration Deep Dive
 

--- a/plugins/saas-packs/replit-pack/skills/replit-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-multi-env-setup
-description: |
-  Configure Replit dev/staging/production environments with separate databases, secrets, and deployment tiers.
+description: 'Configure Replit dev/staging/production environments with separate databases,
+  secrets, and deployment tiers.
+
   Use when setting up multi-environment deployments, managing per-environment secrets,
+
   or implementing environment-specific Replit configurations.
+
   Trigger with phrases like "replit environments", "replit staging",
+
   "replit dev prod", "replit environment setup", "replit separate databases".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, deployment, environments]
+tags:
+- saas
+- replit
+- deployment
+- environments
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Multi-Environment Setup
 

--- a/plugins/saas-packs/replit-pack/skills/replit-observability/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-observability
-description: |
-  Monitor Replit deployments with health checks, uptime tracking, resource usage, and alerting.
+description: 'Monitor Replit deployments with health checks, uptime tracking, resource
+  usage, and alerting.
+
   Use when setting up monitoring for Replit apps, building health dashboards,
+
   or configuring alerting for deployment health and performance.
+
   Trigger with phrases like "replit monitoring", "replit metrics",
+
   "replit observability", "monitor replit", "replit alerts", "replit uptime".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, monitoring, observability, alerting]
+tags:
+- saas
+- replit
+- monitoring
+- observability
+- alerting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Observability
 

--- a/plugins/saas-packs/replit-pack/skills/replit-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-performance-tuning
-description: |
-  Optimize Replit app performance: cold start, memory, Nix caching, and deployment speed.
+description: 'Optimize Replit app performance: cold start, memory, Nix caching, and
+  deployment speed.
+
   Use when experiencing slow startup, high memory usage, deployment timeouts,
+
   or optimizing Replit container resource usage.
+
   Trigger with phrases like "replit performance", "optimize replit",
+
   "replit slow", "replit cold start", "replit memory", "replit startup time".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, performance, optimization]
+tags:
+- saas
+- replit
+- performance
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Performance Tuning
 

--- a/plugins/saas-packs/replit-pack/skills/replit-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-policy-guardrails/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: replit-policy-guardrails
-description: |
-  Enforce security and resource policies for Replit-hosted apps: secrets exposure prevention,
+description: 'Enforce security and resource policies for Replit-hosted apps: secrets
+  exposure prevention,
+
   resource limits, deployment visibility, and database access controls.
+
   Use when hardening a Replit app for production, auditing security posture,
+
   or setting up guardrails for team development.
+
   Trigger with phrases like "replit policy", "replit guardrails",
+
   "replit security audit", "replit hardening", "replit best practices check".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, security, policy]
+tags:
+- saas
+- replit
+- security
+- policy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Policy Guardrails
 

--- a/plugins/saas-packs/replit-pack/skills/replit-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-prod-checklist
-description: |
-  Execute Replit production deployment checklist with rollback and health monitoring.
+description: 'Execute Replit production deployment checklist with rollback and health
+  monitoring.
+
   Use when deploying Replit apps to production, preparing for launch,
+
   or implementing go-live procedures with Autoscale or Reserved VM.
+
   Trigger with phrases like "replit production", "deploy replit",
+
   "replit go-live", "replit launch checklist", "replit prod ready".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, deployment, production]
+tags:
+- saas
+- replit
+- deployment
+- production
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Production Checklist
 

--- a/plugins/saas-packs/replit-pack/skills/replit-rate-limits/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-rate-limits/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-rate-limits
-description: |
-  Handle Replit resource limits: KV database caps, deployment quotas, and request throttling.
+description: 'Handle Replit resource limits: KV database caps, deployment quotas,
+  and request throttling.
+
   Use when hitting storage limits, managing deployment resources,
+
   or implementing rate limiting in your Replit-hosted app.
+
   Trigger with phrases like "replit rate limit", "replit throttling",
+
   "replit 429", "replit storage limit", "replit quota".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, api, limits, database]
+tags:
+- saas
+- replit
+- api
+- limits
+- database
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Rate Limits
 

--- a/plugins/saas-packs/replit-pack/skills/replit-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-reference-architecture
-description: |
-  Implement Replit reference architecture with best-practice project layout, data layer, and deployment.
+description: 'Implement Replit reference architecture with best-practice project layout,
+  data layer, and deployment.
+
   Use when designing new Replit apps, reviewing project structure,
+
   or establishing architecture standards for production Replit applications.
+
   Trigger with phrases like "replit architecture", "replit best practices",
+
   "replit project structure", "how to organize replit", "replit production layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, architecture, reference]
+tags:
+- saas
+- replit
+- architecture
+- reference
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Reference Architecture
 

--- a/plugins/saas-packs/replit-pack/skills/replit-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-reliability-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: replit-reliability-patterns
-description: |
-  Implement reliability patterns for Replit: cold start handling, graceful shutdown, persistent state, and keep-alive.
+description: 'Implement reliability patterns for Replit: cold start handling, graceful
+  shutdown, persistent state, and keep-alive.
+
   Use when building fault-tolerant Replit apps, handling container restarts,
+
   or adding resilience to production Replit deployments.
+
   Trigger with phrases like "replit reliability", "replit container restart",
+
   "replit data persistence", "replit always on", "replit graceful shutdown".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, reliability, resilience]
+tags:
+- saas
+- replit
+- reliability
+- resilience
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Reliability Patterns
 

--- a/plugins/saas-packs/replit-pack/skills/replit-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-sdk-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-sdk-patterns
-description: |
-  Apply production-ready patterns for Replit Database, Object Storage, and Auth APIs.
+description: 'Apply production-ready patterns for Replit Database, Object Storage,
+  and Auth APIs.
+
   Use when implementing Replit integrations, structuring data access layers,
+
   or establishing team coding standards for Replit services.
+
   Trigger with phrases like "replit patterns", "replit best practices",
+
   "replit code patterns", "idiomatic replit", "replit SDK".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, python, typescript, patterns]
+tags:
+- saas
+- replit
+- python
+- typescript
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit SDK Patterns
 

--- a/plugins/saas-packs/replit-pack/skills/replit-security-basics/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-security-basics
-description: |
-  Apply Replit security best practices: Secrets management, REPL_IDENTITY tokens, Auth headers, and public Repl safety.
+description: 'Apply Replit security best practices: Secrets management, REPL_IDENTITY
+  tokens, Auth headers, and public Repl safety.
+
   Use when securing API keys, validating request identity,
+
   or auditing Replit security configuration.
+
   Trigger with phrases like "replit security", "replit secrets",
+
   "secure replit", "replit public safety", "replit identity token".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, security, secrets, audit]
+tags:
+- saas
+- replit
+- security
+- secrets
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Security Basics
 

--- a/plugins/saas-packs/replit-pack/skills/replit-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-upgrade-migration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-upgrade-migration
-description: |
-  Upgrade Replit Nix channels, migrate between database types, and update deployment targets.
+description: 'Upgrade Replit Nix channels, migrate between database types, and update
+  deployment targets.
+
   Use when upgrading Nix channel versions, migrating from Replit DB to PostgreSQL,
+
   switching deployment types, or updating system dependencies.
+
   Trigger with phrases like "upgrade replit", "replit nix upgrade",
+
   "migrate replit database", "replit version update", "replit channel update".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, migration, nix, upgrade]
+tags:
+- saas
+- replit
+- migration
+- nix
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Upgrade & Migration
 

--- a/plugins/saas-packs/replit-pack/skills/replit-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/replit-pack/skills/replit-webhooks-events/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: replit-webhooks-events
-description: |
-  Handle Replit deployment events, build Replit Extensions, and set up Agents & Automations.
+description: 'Handle Replit deployment events, build Replit Extensions, and set up
+  Agents & Automations.
+
   Use when integrating with Replit deployment lifecycle, building workspace extensions,
+
   or creating automated workflows with Replit Agent.
+
   Trigger with phrases like "replit webhook", "replit events", "replit extension",
+
   "replit automation", "replit notifications", "replit agent automation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, replit, webhooks, extensions, automation]
+tags:
+- saas
+- replit
+- webhooks
+- extensions
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Replit Webhooks & Events
 

--- a/plugins/saas-packs/retellai-pack/skills/retellai-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-advanced-troubleshooting
-description: |
-  Retell AI advanced troubleshooting — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell advanced troubleshooting", "retellai-advanced-troubleshooting", "voice agent".
+description: "Retell AI advanced troubleshooting \u2014 AI voice agent and phone call\
+  \ automation.\nUse when working with Retell AI for voice agents, phone calls, or\
+  \ telephony.\nTrigger with phrases like \"retell advanced troubleshooting\", \"\
+  retellai-advanced-troubleshooting\", \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-architecture-variants/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-architecture-variants
-description: |
-  Retell AI architecture variants — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell architecture variants", "retellai-architecture-variants", "voice agent".
+description: "Retell AI architecture variants \u2014 AI voice agent and phone call\
+  \ automation.\nUse when working with Retell AI for voice agents, phone calls, or\
+  \ telephony.\nTrigger with phrases like \"retell architecture variants\", \"retellai-architecture-variants\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-ci-integration/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-ci-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-ci-integration
-description: |
-  Retell AI ci integration — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell ci integration", "retellai-ci-integration", "voice agent".
+description: "Retell AI ci integration \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell ci integration\", \"retellai-ci-integration\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-common-errors/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-common-errors/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: retellai-common-errors
-description: |
-  Diagnose and fix Retell AI voice agent errors: call failures, webhook issues, voice quality.
-  Use when encountering Retell AI errors, debugging call issues, or troubleshooting agents.
-  Trigger with phrases like "retell error", "call failed", "voice agent not working", "retell debug".
+description: 'Diagnose and fix Retell AI voice agent errors: call failures, webhook
+  issues, voice quality.
+
+  Use when encountering Retell AI errors, debugging call issues, or troubleshooting
+  agents.
+
+  Trigger with phrases like "retell error", "call failed", "voice agent not working",
+  "retell debug".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, debugging]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Common Errors
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-core-workflow-a/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-core-workflow-a
-description: |
-  Retell AI core workflow a — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell core workflow a", "retellai-core-workflow-a", "voice agent".
+description: "Retell AI core workflow a \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell core workflow a\", \"retellai-core-workflow-a\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-core-workflow-b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-core-workflow-b
-description: |
-  Retell AI core workflow b — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell core workflow b", "retellai-core-workflow-b", "voice agent".
+description: "Retell AI core workflow b \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell core workflow b\", \"retellai-core-workflow-b\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-cost-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-cost-tuning
-description: |
-  Retell AI cost tuning — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell cost tuning", "retellai-cost-tuning", "voice agent".
+description: "Retell AI cost tuning \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell cost tuning\", \"retellai-cost-tuning\", \"voice agent\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-data-handling/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-data-handling/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-data-handling
-description: |
-  Retell AI data handling — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell data handling", "retellai-data-handling", "voice agent".
+description: "Retell AI data handling \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell data handling\", \"retellai-data-handling\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Data Handling
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-debug-bundle/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-debug-bundle
-description: |
-  Retell AI debug bundle — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell debug bundle", "retellai-debug-bundle", "voice agent".
+description: "Retell AI debug bundle \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell debug bundle\", \"retellai-debug-bundle\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-deploy-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-deploy-integration
-description: |
-  Retell AI deploy integration — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell deploy integration", "retellai-deploy-integration", "voice agent".
+description: "Retell AI deploy integration \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell deploy integration\", \"retellai-deploy-integration\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-enterprise-rbac/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-enterprise-rbac
-description: |
-  Retell AI enterprise rbac — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell enterprise rbac", "retellai-enterprise-rbac", "voice agent".
+description: "Retell AI enterprise rbac \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell enterprise rbac\", \"retellai-enterprise-rbac\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Enterprise Rbac
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-hello-world/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-hello-world/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-hello-world
-description: |
-  Retell AI hello world — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell hello world", "retellai-hello-world", "voice agent".
+description: "Retell AI hello world \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell hello world\", \"retellai-hello-world\", \"voice agent\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Hello World
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-incident-runbook/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-incident-runbook
-description: |
-  Retell AI incident runbook — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell incident runbook", "retellai-incident-runbook", "voice agent".
+description: "Retell AI incident runbook \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell incident runbook\", \"retellai-incident-runbook\",\
+  \ \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-install-auth/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-install-auth/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-install-auth
-description: |
-  Retell AI install auth — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell install auth", "retellai-install-auth", "voice agent".
+description: "Retell AI install auth \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell install auth\", \"retellai-install-auth\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Install Auth
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-known-pitfalls/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-known-pitfalls
-description: |
-  Retell AI known pitfalls — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell known pitfalls", "retellai-known-pitfalls", "voice agent".
+description: "Retell AI known pitfalls \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell known pitfalls\", \"retellai-known-pitfalls\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-load-scale/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-load-scale/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-load-scale
-description: |
-  Retell AI load scale — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell load scale", "retellai-load-scale", "voice agent".
+description: "Retell AI load scale \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell load scale\", \"retellai-load-scale\", \"voice agent\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Load Scale
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-local-dev-loop/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-local-dev-loop
-description: |
-  Retell AI local dev loop — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell local dev loop", "retellai-local-dev-loop", "voice agent".
+description: "Retell AI local dev loop \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell local dev loop\", \"retellai-local-dev-loop\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-migration-deep-dive/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-migration-deep-dive
-description: |
-  Retell AI migration deep dive — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell migration deep dive", "retellai-migration-deep-dive", "voice agent".
+description: "Retell AI migration deep dive \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell migration deep dive\", \"retellai-migration-deep-dive\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-multi-env-setup/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-multi-env-setup
-description: |
-  Retell AI multi env setup — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell multi env setup", "retellai-multi-env-setup", "voice agent".
+description: "Retell AI multi env setup \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell multi env setup\", \"retellai-multi-env-setup\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Multi Env Setup
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-observability/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-observability/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-observability
-description: |
-  Retell AI observability — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell observability", "retellai-observability", "voice agent".
+description: "Retell AI observability \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell observability\", \"retellai-observability\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Observability
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-performance-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-performance-tuning
-description: |
-  Retell AI performance tuning — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell performance tuning", "retellai-performance-tuning", "voice agent".
+description: "Retell AI performance tuning \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell performance tuning\", \"retellai-performance-tuning\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-policy-guardrails/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-policy-guardrails
-description: |
-  Retell AI policy guardrails — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell policy guardrails", "retellai-policy-guardrails", "voice agent".
+description: "Retell AI policy guardrails \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell policy guardrails\", \"retellai-policy-guardrails\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Policy Guardrails
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-prod-checklist/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-prod-checklist
-description: |
-  Retell AI prod checklist — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell prod checklist", "retellai-prod-checklist", "voice agent".
+description: "Retell AI prod checklist \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell prod checklist\", \"retellai-prod-checklist\", \"voice\
+  \ agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-rate-limits/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-rate-limits/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-rate-limits
-description: |
-  Retell AI rate limits — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell rate limits", "retellai-rate-limits", "voice agent".
+description: "Retell AI rate limits \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell rate limits\", \"retellai-rate-limits\", \"voice agent\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-reference-architecture/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-reference-architecture
-description: |
-  Retell AI reference architecture — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell reference architecture", "retellai-reference-architecture", "voice agent".
+description: "Retell AI reference architecture \u2014 AI voice agent and phone call\
+  \ automation.\nUse when working with Retell AI for voice agents, phone calls, or\
+  \ telephony.\nTrigger with phrases like \"retell reference architecture\", \"retellai-reference-architecture\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-reliability-patterns/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-reliability-patterns
-description: |
-  Retell AI reliability patterns — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell reliability patterns", "retellai-reliability-patterns", "voice agent".
+description: "Retell AI reliability patterns \u2014 AI voice agent and phone call\
+  \ automation.\nUse when working with Retell AI for voice agents, phone calls, or\
+  \ telephony.\nTrigger with phrases like \"retell reliability patterns\", \"retellai-reliability-patterns\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: retellai-sdk-patterns
-description: |
-  Production-ready Retell AI SDK patterns for voice agent applications.
-  Use when building production voice agents, implementing retry logic, or establishing patterns.
-  Trigger with phrases like "retell patterns", "voice agent patterns", "retell best practices".
+description: 'Production-ready Retell AI SDK patterns for voice agent applications.
+
+  Use when building production voice agents, implementing retry logic, or establishing
+  patterns.
+
+  Trigger with phrases like "retell patterns", "voice agent patterns", "retell best
+  practices".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, patterns]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-security-basics/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-security-basics/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-security-basics
-description: |
-  Retell AI security basics — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell security basics", "retellai-security-basics", "voice agent".
+description: "Retell AI security basics \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell security basics\", \"retellai-security-basics\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Security Basics
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-upgrade-migration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-upgrade-migration
-description: |
-  Retell AI upgrade migration — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell upgrade migration", "retellai-upgrade-migration", "voice agent".
+description: "Retell AI upgrade migration \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell upgrade migration\", \"retellai-upgrade-migration\"\
+  , \"voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/retellai-pack/skills/retellai-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/retellai-pack/skills/retellai-webhooks-events/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: retellai-webhooks-events
-description: |
-  Retell AI webhooks events — AI voice agent and phone call automation.
-  Use when working with Retell AI for voice agents, phone calls, or telephony.
-  Trigger with phrases like "retell webhooks events", "retellai-webhooks-events", "voice agent".
+description: "Retell AI webhooks events \u2014 AI voice agent and phone call automation.\n\
+  Use when working with Retell AI for voice agents, phone calls, or telephony.\nTrigger\
+  \ with phrases like \"retell webhooks events\", \"retellai-webhooks-events\", \"\
+  voice agent\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, retellai, voice, telephony, ai-agents]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- retellai
+- voice
+- telephony
+- ai-agents
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Retell AI Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-ci-integration/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-ci-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-ci-integration
-description: |
-  Runway ci integration — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway ci integration", "runway-ci-integration", "AI video generation".
+description: "Runway ci integration \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway ci integration\", \"runway-ci-integration\",\
+  \ \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-common-errors/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-common-errors/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-common-errors
-description: |
-  Runway common errors — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway common errors", "runway-common-errors", "AI video generation".
+description: "Runway common errors \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway common errors\", \"runway-common-errors\", \"\
+  AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Common Errors
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-core-workflow-a/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-core-workflow-a
-description: |
-  Runway core workflow a — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway core workflow a", "runway-core-workflow-a", "AI video generation".
+description: "Runway core workflow a \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway core workflow a\", \"runway-core-workflow-a\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-core-workflow-b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-core-workflow-b
-description: |
-  Runway core workflow b — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway core workflow b", "runway-core-workflow-b", "AI video generation".
+description: "Runway core workflow b \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway core workflow b\", \"runway-core-workflow-b\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-cost-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-cost-tuning
-description: |
-  Runway cost tuning — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway cost tuning", "runway-cost-tuning", "AI video generation".
+description: "Runway cost tuning \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway cost tuning\", \"runway-cost-tuning\", \"AI video\
+  \ generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-debug-bundle/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-debug-bundle
-description: |
-  Runway debug bundle — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway debug bundle", "runway-debug-bundle", "AI video generation".
+description: "Runway debug bundle \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway debug bundle\", \"runway-debug-bundle\", \"AI\
+  \ video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-deploy-integration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-deploy-integration
-description: |
-  Runway deploy integration — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway deploy integration", "runway-deploy-integration", "AI video generation".
+description: "Runway deploy integration \u2014 AI video generation and creative AI\
+  \ platform.\nUse when working with Runway for video generation, image editing, or\
+  \ creative AI.\nTrigger with phrases like \"runway deploy integration\", \"runway-deploy-integration\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-hello-world/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-hello-world/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-hello-world
-description: |
-  Runway hello world — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway hello world", "runway-hello-world", "AI video generation".
+description: "Runway hello world \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway hello world\", \"runway-hello-world\", \"AI video\
+  \ generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Hello World
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-install-auth/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-install-auth/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-install-auth
-description: |
-  Runway install auth — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway install auth", "runway-install-auth", "AI video generation".
+description: "Runway install auth \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway install auth\", \"runway-install-auth\", \"AI\
+  \ video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Install Auth
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-local-dev-loop/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-local-dev-loop
-description: |
-  Runway local dev loop — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway local dev loop", "runway-local-dev-loop", "AI video generation".
+description: "Runway local dev loop \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway local dev loop\", \"runway-local-dev-loop\",\
+  \ \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-performance-tuning/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-performance-tuning
-description: |
-  Runway performance tuning — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway performance tuning", "runway-performance-tuning", "AI video generation".
+description: "Runway performance tuning \u2014 AI video generation and creative AI\
+  \ platform.\nUse when working with Runway for video generation, image editing, or\
+  \ creative AI.\nTrigger with phrases like \"runway performance tuning\", \"runway-performance-tuning\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-prod-checklist/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-prod-checklist
-description: |
-  Runway prod checklist — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway prod checklist", "runway-prod-checklist", "AI video generation".
+description: "Runway prod checklist \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway prod checklist\", \"runway-prod-checklist\",\
+  \ \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-rate-limits/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-rate-limits/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-rate-limits
-description: |
-  Runway rate limits — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway rate limits", "runway-rate-limits", "AI video generation".
+description: "Runway rate limits \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway rate limits\", \"runway-rate-limits\", \"AI video\
+  \ generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-reference-architecture/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-reference-architecture
-description: |
-  Runway reference architecture — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway reference architecture", "runway-reference-architecture", "AI video generation".
+description: "Runway reference architecture \u2014 AI video generation and creative\
+  \ AI platform.\nUse when working with Runway for video generation, image editing,\
+  \ or creative AI.\nTrigger with phrases like \"runway reference architecture\",\
+  \ \"runway-reference-architecture\", \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-sdk-patterns/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-sdk-patterns
-description: |
-  Runway sdk patterns — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway sdk patterns", "runway-sdk-patterns", "AI video generation".
+description: "Runway sdk patterns \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway sdk patterns\", \"runway-sdk-patterns\", \"AI\
+  \ video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-security-basics/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-security-basics/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-security-basics
-description: |
-  Runway security basics — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway security basics", "runway-security-basics", "AI video generation".
+description: "Runway security basics \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway security basics\", \"runway-security-basics\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Security Basics
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-upgrade-migration/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-upgrade-migration
-description: |
-  Runway upgrade migration — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway upgrade migration", "runway-upgrade-migration", "AI video generation".
+description: "Runway upgrade migration \u2014 AI video generation and creative AI\
+  \ platform.\nUse when working with Runway for video generation, image editing, or\
+  \ creative AI.\nTrigger with phrases like \"runway upgrade migration\", \"runway-upgrade-migration\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/runway-pack/skills/runway-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/runway-pack/skills/runway-webhooks-events/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: runway-webhooks-events
-description: |
-  Runway webhooks events — AI video generation and creative AI platform.
-  Use when working with Runway for video generation, image editing, or creative AI.
-  Trigger with phrases like "runway webhooks events", "runway-webhooks-events", "AI video generation".
+description: "Runway webhooks events \u2014 AI video generation and creative AI platform.\n\
+  Use when working with Runway for video generation, image editing, or creative AI.\n\
+  Trigger with phrases like \"runway webhooks events\", \"runway-webhooks-events\"\
+  , \"AI video generation\".\n"
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(npm:*), Bash(curl:*), Grep
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, runway, ai, video-generation, creative]
-compatible-with: claude-code, codex, openclaw
+tags:
+- saas
+- runway
+- ai
+- video-generation
+- creative
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Runway Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-advanced-troubleshooting
-description: |
-  Apply Salesforce advanced debugging with debug logs, SOQL query plans, and EventLogFile analysis.
+description: 'Apply Salesforce advanced debugging with debug logs, SOQL query plans,
+  and EventLogFile analysis.
+
   Use when standard troubleshooting fails, investigating SOQL performance issues,
+
   or analyzing Apex governor limit violations.
+
   Trigger with phrases like "salesforce hard bug", "salesforce debug log",
-  "salesforce governor limit", "salesforce query plan", "salesforce deep debug", "SOQL slow".
+
+  "salesforce governor limit", "salesforce query plan", "salesforce deep debug", "SOQL
+  slow".
+
+  '
 allowed-tools: Read, Grep, Bash(sf:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-architecture-variants/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: salesforce-architecture-variants
-description: |
-  Choose and implement Salesforce integration architecture patterns for different scales.
-  Use when designing new Salesforce integrations, choosing between polling/event-driven/Heroku Connect,
+description: 'Choose and implement Salesforce integration architecture patterns for
+  different scales.
+
+  Use when designing new Salesforce integrations, choosing between polling/event-driven/Heroku
+  Connect,
+
   or planning migration paths for Salesforce applications.
+
   Trigger with phrases like "salesforce architecture", "salesforce integration pattern",
-  "how to structure salesforce integration", "salesforce event-driven", "salesforce Heroku Connect".
+
+  "how to structure salesforce integration", "salesforce event-driven", "salesforce
+  Heroku Connect".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-ci-integration/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-ci-integration
-description: |
-  Configure Salesforce CI/CD with GitHub Actions, SFDX deployments, and Apex testing.
+description: 'Configure Salesforce CI/CD with GitHub Actions, SFDX deployments, and
+  Apex testing.
+
   Use when setting up automated testing, configuring CI pipelines for metadata deployment,
+
   or integrating Salesforce tests into your build process.
+
   Trigger with phrases like "salesforce CI", "salesforce GitHub Actions",
+
   "salesforce automated tests", "CI salesforce", "sfdx deploy CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(sf:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce CI Integration
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-common-errors/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-common-errors/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: salesforce-common-errors
-description: |
-  Diagnose and fix Salesforce common errors, SOQL issues, and API exceptions.
+description: 'Diagnose and fix Salesforce common errors, SOQL issues, and API exceptions.
+
   Use when encountering Salesforce errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "salesforce error", "fix salesforce",
+
   "salesforce not working", "debug salesforce", "SOQL error", "salesforce exception".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(sf:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Common Errors
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-core-workflow-a
-description: |
-  Execute Salesforce CRUD operations on standard sObjects with SOQL and REST API.
+description: 'Execute Salesforce CRUD operations on standard sObjects with SOQL and
+  REST API.
+
   Use when creating, reading, updating, or deleting Accounts, Contacts, Leads,
+
   or Opportunities via the Salesforce API.
+
   Trigger with phrases like "salesforce CRUD", "salesforce create record",
+
   "salesforce update account", "salesforce SOQL query", "salesforce REST API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Core Workflow A — CRUD & SOQL
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-core-workflow-b
-description: |
-  Execute Salesforce Bulk API 2.0 and Composite API operations for high-volume data.
+description: 'Execute Salesforce Bulk API 2.0 and Composite API operations for high-volume
+  data.
+
   Use when importing/exporting large datasets, performing multi-object transactions,
+
   or chaining dependent API calls.
+
   Trigger with phrases like "salesforce bulk API", "salesforce composite",
+
   "salesforce batch", "salesforce mass import", "salesforce large data".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Core Workflow B — Bulk & Composite API
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-cost-tuning
-description: |
-  Optimize Salesforce costs through API call reduction, edition selection, and license management.
+description: 'Optimize Salesforce costs through API call reduction, edition selection,
+  and license management.
+
   Use when analyzing Salesforce costs, reducing API consumption,
+
   or choosing the right Salesforce edition for your integration needs.
+
   Trigger with phrases like "salesforce cost", "salesforce pricing",
-  "reduce salesforce costs", "salesforce license", "salesforce API usage", "salesforce budget".
+
+  "reduce salesforce costs", "salesforce license", "salesforce API usage", "salesforce
+  budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-data-handling/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-data-handling/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-data-handling
-description: |
-  Implement Salesforce data privacy, GDPR/CCPA compliance, and field-level encryption patterns.
+description: 'Implement Salesforce data privacy, GDPR/CCPA compliance, and field-level
+  encryption patterns.
+
   Use when handling PII in Salesforce records, implementing data subject access requests,
+
   or configuring Salesforce Shield encryption.
+
   Trigger with phrases like "salesforce data privacy", "salesforce PII",
-  "salesforce GDPR", "salesforce data retention", "salesforce encryption", "salesforce CCPA".
+
+  "salesforce GDPR", "salesforce data retention", "salesforce encryption", "salesforce
+  CCPA".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Data Handling
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-debug-bundle
-description: |
-  Collect Salesforce debug evidence including API limits, debug logs, and org info for support tickets.
+description: 'Collect Salesforce debug evidence including API limits, debug logs,
+  and org info for support tickets.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Salesforce problems.
+
   Trigger with phrases like "salesforce debug", "salesforce support bundle",
+
   "collect salesforce logs", "salesforce diagnostic", "salesforce debug log".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(sf:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-deploy-integration
-description: |
-  Deploy Salesforce-connected applications to Heroku, Vercel, and Cloud Run with proper credential management.
+description: 'Deploy Salesforce-connected applications to Heroku, Vercel, and Cloud
+  Run with proper credential management.
+
   Use when deploying Salesforce-powered applications to production,
+
   configuring platform-specific secrets, or setting up Heroku Connect.
+
   Trigger with phrases like "deploy salesforce app", "salesforce Heroku",
+
   "salesforce production deploy", "salesforce Cloud Run", "Heroku Connect".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(heroku:*), Bash(vercel:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-enterprise-rbac/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-enterprise-rbac
-description: |
-  Configure Salesforce Profiles, Permission Sets, and Sharing Rules for enterprise access control.
+description: 'Configure Salesforce Profiles, Permission Sets, and Sharing Rules for
+  enterprise access control.
+
   Use when implementing role-based access, configuring SSO with Salesforce,
+
   or setting up organization-wide sharing defaults.
+
   Trigger with phrases like "salesforce permissions", "salesforce RBAC",
-  "salesforce profiles", "salesforce SSO", "salesforce sharing rules", "salesforce OWD".
+
+  "salesforce profiles", "salesforce SSO", "salesforce sharing rules", "salesforce
+  OWD".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-hello-world/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-hello-world
-description: |
-  Create a minimal working Salesforce example with SOQL queries and sObject CRUD.
+description: 'Create a minimal working Salesforce example with SOQL queries and sObject
+  CRUD.
+
   Use when starting a new Salesforce integration, testing your setup,
+
   or learning basic Salesforce API patterns.
+
   Trigger with phrases like "salesforce hello world", "salesforce example",
+
   "salesforce quick start", "first salesforce query", "salesforce SOQL".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Hello World
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-incident-runbook/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-incident-runbook
-description: |
-  Execute Salesforce incident response procedures with triage, mitigation, and postmortem.
+description: 'Execute Salesforce incident response procedures with triage, mitigation,
+  and postmortem.
+
   Use when responding to Salesforce-related outages, investigating API errors,
+
   or running post-incident reviews for Salesforce integration failures.
+
   Trigger with phrases like "salesforce incident", "salesforce outage",
+
   "salesforce down", "salesforce on-call", "salesforce emergency", "salesforce broken".
+
+  '
 allowed-tools: Read, Grep, Bash(sf:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-install-auth/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-install-auth
-description: |
-  Install and configure Salesforce SDK/CLI authentication with jsforce or Salesforce CLI.
+description: 'Install and configure Salesforce SDK/CLI authentication with jsforce
+  or Salesforce CLI.
+
   Use when setting up a new Salesforce integration, configuring OAuth flows,
+
   or initializing Salesforce connectivity in your project.
+
   Trigger with phrases like "install salesforce", "setup salesforce",
+
   "salesforce auth", "configure salesforce", "jsforce setup", "sf cli login".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(sf:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-known-pitfalls/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-known-pitfalls
-description: |
-  Identify and avoid Salesforce anti-patterns including SOQL N+1, governor limit violations, and API waste.
+description: 'Identify and avoid Salesforce anti-patterns including SOQL N+1, governor
+  limit violations, and API waste.
+
   Use when reviewing Salesforce code for issues, onboarding new developers,
+
   or auditing existing Salesforce integrations for best practices violations.
+
   Trigger with phrases like "salesforce mistakes", "salesforce anti-patterns",
+
   "salesforce pitfalls", "salesforce what not to do", "salesforce code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-load-scale/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-load-scale/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-load-scale
-description: |
-  Implement Salesforce load testing, API limit capacity planning, and Bulk API scaling.
+description: 'Implement Salesforce load testing, API limit capacity planning, and
+  Bulk API scaling.
+
   Use when running performance tests against Salesforce, planning API consumption,
+
   or scaling high-volume Salesforce integrations.
+
   Trigger with phrases like "salesforce load test", "salesforce scale",
-  "salesforce performance test", "salesforce capacity planning", "salesforce high volume".
+
+  "salesforce performance test", "salesforce capacity planning", "salesforce high
+  volume".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(sf:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-local-dev-loop/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-local-dev-loop
-description: |
-  Configure Salesforce local development with scratch orgs, SFDX, and testing.
+description: 'Configure Salesforce local development with scratch orgs, SFDX, and
+  testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Salesforce.
+
   Trigger with phrases like "salesforce dev setup", "salesforce local development",
+
   "salesforce scratch org", "sfdx project", "develop with salesforce".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(sf:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-migration-deep-dive
-description: |
-  Execute Salesforce data migrations using Bulk API, Data Loader, and ETL patterns.
+description: 'Execute Salesforce data migrations using Bulk API, Data Loader, and
+  ETL patterns.
+
   Use when migrating data to/from Salesforce, performing org-to-org migrations,
+
   or re-platforming CRM data into Salesforce.
+
   Trigger with phrases like "migrate to salesforce", "salesforce data migration",
+
   "salesforce import data", "salesforce ETL", "CRM migration to salesforce".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(sf:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-multi-env-setup/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-multi-env-setup
-description: |
-  Configure Salesforce across Developer, Sandbox, and Production environments with proper org management.
+description: 'Configure Salesforce across Developer, Sandbox, and Production environments
+  with proper org management.
+
   Use when setting up multi-environment deployments, configuring per-environment credentials,
+
   or implementing sandbox-to-production promotion flows.
+
   Trigger with phrases like "salesforce environments", "salesforce sandbox",
+
   "salesforce dev prod", "salesforce org management", "salesforce sandbox types".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(sf:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-observability/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-observability/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-observability
-description: |
-  Set up observability for Salesforce integrations with API limit monitoring, error tracking, and alerting.
+description: 'Set up observability for Salesforce integrations with API limit monitoring,
+  error tracking, and alerting.
+
   Use when implementing monitoring for Salesforce operations, tracking API consumption,
+
   or configuring alerting for Salesforce integration health.
+
   Trigger with phrases like "salesforce monitoring", "salesforce metrics",
-  "salesforce observability", "monitor salesforce", "salesforce alerts", "salesforce API usage dashboard".
+
+  "salesforce observability", "monitor salesforce", "salesforce alerts", "salesforce
+  API usage dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Observability
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-performance-tuning/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-performance-tuning
-description: |
-  Optimize Salesforce API performance with SOQL tuning, Composite API batching, and caching.
+description: 'Optimize Salesforce API performance with SOQL tuning, Composite API
+  batching, and caching.
+
   Use when experiencing slow API responses, optimizing SOQL queries,
+
   or reducing API call count for Salesforce integrations.
+
   Trigger with phrases like "salesforce performance", "optimize salesforce",
+
   "salesforce latency", "salesforce caching", "salesforce slow", "SOQL optimization".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-policy-guardrails/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-policy-guardrails
-description: |
-  Implement Salesforce lint rules, SOQL injection prevention, and API usage guardrails.
+description: 'Implement Salesforce lint rules, SOQL injection prevention, and API
+  usage guardrails.
+
   Use when enforcing Salesforce integration code quality, preventing SOQL injection,
+
   or configuring CI policy checks for Salesforce best practices.
+
   Trigger with phrases like "salesforce policy", "salesforce lint",
-  "salesforce guardrails", "SOQL injection", "salesforce eslint", "salesforce code review".
+
+  "salesforce guardrails", "SOQL injection", "salesforce eslint", "salesforce code
+  review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-prod-checklist/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-prod-checklist
-description: |
-  Execute Salesforce production deployment checklist with sandbox testing and rollback.
+description: 'Execute Salesforce production deployment checklist with sandbox testing
+  and rollback.
+
   Use when deploying Salesforce integrations to production, preparing for launch,
+
   or implementing go-live procedures.
+
   Trigger with phrases like "salesforce production", "deploy salesforce",
+
   "salesforce go-live", "salesforce launch checklist", "salesforce sandbox to prod".
+
+  '
 allowed-tools: Read, Bash(sf:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-rate-limits/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-rate-limits/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: salesforce-rate-limits
-description: |
-  Implement Salesforce API limit management, backoff, and quota monitoring.
+description: 'Implement Salesforce API limit management, backoff, and quota monitoring.
+
   Use when handling REQUEST_LIMIT_EXCEEDED errors, implementing retry logic,
+
   or optimizing API request throughput for Salesforce.
+
   Trigger with phrases like "salesforce rate limit", "salesforce API limit",
+
   "salesforce 403", "salesforce retry", "salesforce governor limits", "API quota".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-reference-architecture/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-reference-architecture
-description: |
-  Implement Salesforce integration reference architecture with jsforce, SFDX, and event-driven patterns.
+description: 'Implement Salesforce integration reference architecture with jsforce,
+  SFDX, and event-driven patterns.
+
   Use when designing new Salesforce integrations, reviewing project structure,
+
   or establishing architecture standards for Salesforce-connected applications.
+
   Trigger with phrases like "salesforce architecture", "salesforce project structure",
-  "salesforce integration design", "how to organize salesforce code", "salesforce layout".
+
+  "salesforce integration design", "how to organize salesforce code", "salesforce
+  layout".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-reliability-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-reliability-patterns
-description: |
-  Implement Salesforce reliability patterns including circuit breakers, idempotent upserts, and fallback caching.
+description: 'Implement Salesforce reliability patterns including circuit breakers,
+  idempotent upserts, and fallback caching.
+
   Use when building fault-tolerant Salesforce integrations, implementing retry strategies,
+
   or adding resilience to production Salesforce services.
+
   Trigger with phrases like "salesforce reliability", "salesforce circuit breaker",
-  "salesforce idempotent", "salesforce resilience", "salesforce fallback", "salesforce retry".
+
+  "salesforce idempotent", "salesforce resilience", "salesforce fallback", "salesforce
+  retry".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-sdk-patterns/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-sdk-patterns
-description: |
-  Apply production-ready Salesforce jsforce patterns for TypeScript and Python.
+description: 'Apply production-ready Salesforce jsforce patterns for TypeScript and
+  Python.
+
   Use when implementing Salesforce integrations, refactoring SDK usage,
+
   or establishing team coding standards for Salesforce.
+
   Trigger with phrases like "salesforce SDK patterns", "jsforce best practices",
+
   "salesforce code patterns", "idiomatic salesforce", "salesforce typescript".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-security-basics/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-security-basics/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-security-basics
-description: |
-  Apply Salesforce security best practices for Connected Apps, OAuth, and field-level security.
+description: 'Apply Salesforce security best practices for Connected Apps, OAuth,
+  and field-level security.
+
   Use when securing API credentials, implementing least privilege access,
+
   or auditing Salesforce security configuration.
+
   Trigger with phrases like "salesforce security", "salesforce secrets",
+
   "secure salesforce", "salesforce connected app security", "salesforce FLS".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Security Basics
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: salesforce-upgrade-migration
-description: |
-  Analyze, plan, and execute Salesforce API version upgrades and jsforce major version migrations.
+description: 'Analyze, plan, and execute Salesforce API version upgrades and jsforce
+  major version migrations.
+
   Use when upgrading Salesforce API versions, migrating jsforce v1 to v3,
+
   or adapting to deprecated API changes.
+
   Trigger with phrases like "upgrade salesforce", "salesforce API version",
+
   "jsforce upgrade", "salesforce deprecation", "salesforce version migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(sf:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/salesforce-pack/skills/salesforce-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/salesforce-pack/skills/salesforce-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: salesforce-webhooks-events
-description: |
-  Implement Salesforce Platform Events, Change Data Capture (CDC), and Outbound Messages.
+description: 'Implement Salesforce Platform Events, Change Data Capture (CDC), and
+  Outbound Messages.
+
   Use when building real-time integrations, listening for record changes,
+
   or implementing event-driven architecture with Salesforce.
+
   Trigger with phrases like "salesforce events", "salesforce CDC",
-  "salesforce platform events", "salesforce streaming", "salesforce outbound message", "salesforce real-time".
+
+  "salesforce platform events", "salesforce streaming", "salesforce outbound message",
+  "salesforce real-time".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(sf:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, crm, salesforce]
-compatible-with: claude-code
+tags:
+- saas
+- crm
+- salesforce
+compatibility: Designed for Claude Code
 ---
-
 # Salesforce Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-ci-integration/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-ci-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-ci-integration
-description: |
-  Set up CI/CD pipelines for SalesLoft integrations with GitHub Actions.
+description: 'Set up CI/CD pipelines for SalesLoft integrations with GitHub Actions.
+
   Use when automating SalesLoft integration tests, validating OAuth tokens,
+
   or running cadence sync validation in CI.
+
   Trigger: "salesloft CI", "salesloft GitHub Actions", "salesloft automated tests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft CI Integration
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-common-errors/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-common-errors/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-common-errors
-description: |
-  Diagnose and fix SalesLoft API errors: 401, 403, 422, 429, and 5xx.
+description: 'Diagnose and fix SalesLoft API errors: 401, 403, 422, 429, and 5xx.
+
   Use when encountering SalesLoft errors, debugging failed requests,
+
   or troubleshooting OAuth token issues.
-  Trigger: "salesloft error", "fix salesloft", "salesloft not working", "salesloft 429".
+
+  Trigger: "salesloft error", "fix salesloft", "salesloft not working", "salesloft
+  429".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Common Errors
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-core-workflow-a
-description: |
-  Manage SalesLoft people, cadences, and email steps via the REST API.
+description: 'Manage SalesLoft people, cadences, and email steps via the REST API.
+
   Use when building prospect management, enrolling people in cadences,
+
   or automating outbound sales sequences.
+
   Trigger: "salesloft cadence", "salesloft people", "salesloft outbound sequence".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Core Workflow A: People & Cadences
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-core-workflow-b/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: salesloft-core-workflow-b
-description: |
-  Track SalesLoft activities, emails, calls, and analytics via the REST API.
+description: 'Track SalesLoft activities, emails, calls, and analytics via the REST
+  API.
+
   Use when reading email engagement data, logging call dispositions,
+
   or building sales activity dashboards.
-  Trigger: "salesloft activities", "salesloft emails", "salesloft calls", "salesloft analytics".
+
+  Trigger: "salesloft activities", "salesloft emails", "salesloft calls", "salesloft
+  analytics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Core Workflow B: Activities & Analytics
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-cost-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-cost-tuning
-description: |
-  Optimize SalesLoft API costs by reducing request volume and deep pagination.
+description: 'Optimize SalesLoft API costs by reducing request volume and deep pagination.
+
   Use when analyzing API usage, reducing rate limit consumption,
+
   or planning capacity for bulk operations.
+
   Trigger: "salesloft cost", "salesloft billing", "reduce salesloft API usage".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-debug-bundle/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-debug-bundle
-description: |
-  Collect SalesLoft debug evidence for support tickets and troubleshooting.
+description: 'Collect SalesLoft debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic info for SalesLoft API problems.
+
   Trigger: "salesloft debug", "salesloft diagnostic", "salesloft support bundle".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-deploy-integration
-description: |
-  Deploy SalesLoft integrations to Vercel, Fly.io, and Cloud Run.
+description: 'Deploy SalesLoft integrations to Vercel, Fly.io, and Cloud Run.
+
   Use when deploying SalesLoft-powered apps to production,
+
   configuring platform secrets, or setting up webhook endpoints.
+
   Trigger: "deploy salesloft", "salesloft Vercel", "salesloft Cloud Run".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-hello-world/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-hello-world/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: salesloft-hello-world
-description: |
-  Create a minimal working SalesLoft example — list people and create a person.
-  Use when starting a new SalesLoft integration, testing your setup,
-  or learning the People and Cadences API patterns.
-  Trigger: "salesloft hello world", "salesloft example", "salesloft quick start".
+description: "Create a minimal working SalesLoft example \u2014 list people and create\
+  \ a person.\nUse when starting a new SalesLoft integration, testing your setup,\n\
+  or learning the People and Cadences API patterns.\nTrigger: \"salesloft hello world\"\
+  , \"salesloft example\", \"salesloft quick start\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Hello World
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-install-auth/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-install-auth/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-install-auth
-description: |
-  Set up SalesLoft API authentication with OAuth 2.0 or API key.
+description: 'Set up SalesLoft API authentication with OAuth 2.0 or API key.
+
   Use when configuring a new SalesLoft integration, setting up OAuth flows,
+
   or initializing API access to the SalesLoft REST API v2.
-  Trigger: "install salesloft", "setup salesloft", "salesloft auth", "salesloft API key".
+
+  Trigger: "install salesloft", "setup salesloft", "salesloft auth", "salesloft API
+  key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-local-dev-loop/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-local-dev-loop
-description: |
-  Configure SalesLoft local development with API mocking and sandbox testing.
+description: 'Configure SalesLoft local development with API mocking and sandbox testing.
+
   Use when setting up a development environment, building integration tests,
+
   or creating mock SalesLoft API responses for offline development.
+
   Trigger: "salesloft dev setup", "salesloft local", "test salesloft locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-performance-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: salesloft-performance-tuning
-description: |
-  Optimize SalesLoft API performance with caching, pagination strategies, and connection pooling.
+description: 'Optimize SalesLoft API performance with caching, pagination strategies,
+  and connection pooling.
+
   Use when experiencing slow API responses, reducing latency for bulk operations,
+
   or optimizing cadence sync throughput.
-  Trigger: "salesloft performance", "optimize salesloft", "salesloft slow", "salesloft caching".
+
+  Trigger: "salesloft performance", "optimize salesloft", "salesloft slow", "salesloft
+  caching".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-prod-checklist/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-prod-checklist
-description: |
-  Production readiness checklist for SalesLoft API integrations.
+description: 'Production readiness checklist for SalesLoft API integrations.
+
   Use when deploying SalesLoft integrations to production, preparing for launch,
+
   or validating go-live requirements.
+
   Trigger: "salesloft production", "deploy salesloft", "salesloft go-live checklist".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-rate-limits/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-rate-limits
-description: |
-  Handle SalesLoft cost-based rate limiting with backoff and request budgeting.
+description: 'Handle SalesLoft cost-based rate limiting with backoff and request budgeting.
+
   Use when hitting 429 errors, optimizing API throughput,
+
   or implementing pagination-aware rate limit strategies.
+
   Trigger: "salesloft rate limit", "salesloft 429", "salesloft throttling".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-reference-architecture/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-reference-architecture
-description: |
-  Production architecture for SalesLoft API integrations with service layer,
+description: 'Production architecture for SalesLoft API integrations with service
+  layer,
+
   webhook processing, and CRM sync patterns.
+
   Use when designing new SalesLoft integrations or reviewing project structure.
+
   Trigger: "salesloft architecture", "salesloft project structure", "salesloft design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-sdk-patterns/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-sdk-patterns
-description: |
-  Apply production-ready SalesLoft API patterns for TypeScript and Python.
+description: 'Apply production-ready SalesLoft API patterns for TypeScript and Python.
+
   Use when building SalesLoft integrations, implementing pagination,
+
   or wrapping the REST API v2 with typed clients.
-  Trigger: "salesloft SDK patterns", "salesloft best practices", "salesloft client wrapper".
+
+  Trigger: "salesloft SDK patterns", "salesloft best practices", "salesloft client
+  wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-security-basics/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-security-basics/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-security-basics
-description: |
-  Secure SalesLoft OAuth tokens, API keys, and webhook signatures.
+description: 'Secure SalesLoft OAuth tokens, API keys, and webhook signatures.
+
   Use when implementing token rotation, securing webhook endpoints,
+
   or auditing SalesLoft API access controls.
-  Trigger: "salesloft security", "salesloft secrets", "secure salesloft", "salesloft token rotation".
+
+  Trigger: "salesloft security", "salesloft secrets", "secure salesloft", "salesloft
+  token rotation".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Security Basics
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-upgrade-migration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: salesloft-upgrade-migration
-description: |
-  Migrate between SalesLoft API versions and handle breaking changes.
+description: 'Migrate between SalesLoft API versions and handle breaking changes.
+
   Use when SalesLoft announces API deprecations, upgrading OAuth flows,
+
   or transitioning from legacy endpoints.
+
   Trigger: "upgrade salesloft", "salesloft migration", "salesloft API version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/salesloft-pack/skills/salesloft-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/salesloft-pack/skills/salesloft-webhooks-events/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: salesloft-webhooks-events
-description: |
-  Implement SalesLoft webhook handling with signature verification and event routing.
+description: 'Implement SalesLoft webhook handling with signature verification and
+  event routing.
+
   Use when setting up webhook endpoints, handling activity notifications,
+
   or syncing SalesLoft data to external systems in real-time.
+
   Trigger: "salesloft webhook", "salesloft events", "salesloft notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, sales, outreach, salesloft]
-compatible-with: claude-code
+tags:
+- saas
+- sales
+- outreach
+- salesloft
+compatibility: Designed for Claude Code
 ---
-
 # SalesLoft Webhooks & Events
 
 ## Overview


### PR DESCRIPTION
## Summary

Chunk 5 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated `compatible-with` CSV-platform-list field to the spec-aligned `compatibility` free-text field per agentskills.io/specification.

**Pure schema migration. No content changes.** Same tool used in PRs #620 and #622.

### Assigned packs (chunk 5 of 6)

| Pack | Files |
|---|---|
| openevidence-pack | 24 |
| openrouter-pack | 30 |
| oraclecloud-pack | 26 |
| palantir-pack | 24 |
| perplexity-pack | 30 |
| persona-pack | 18 |
| podium-pack | 18 |
| posthog-pack | 24 |
| procore-pack | 24 |
| quicknode-pack | 18 |
| ramp-pack | 24 |
| remofirst-pack | 12 |
| replit-pack | 30 |
| retellai-pack | 30 |
| runway-pack | 18 |
| salesforce-pack | 30 |
| salesloft-pack | 18 |
| **TOTAL** | **398** |

### Side effect

`yaml.safe_dump` round-trips the entire frontmatter — so `description: |` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] `grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Refs #613

jeremy made me do it
-claude