### PR TITLE
chore(migration): compatible-with → compatibility (saas-packs 6/6, 416 skills)

### DIFF
--- a/plugins/saas-packs/sentry-pack/skills/sentry-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-advanced-troubleshooting/SKILL.md
@@ -1,20 +1,37 @@
 ---
 name: sentry-advanced-troubleshooting
-description: |
-  Advanced Sentry troubleshooting for complex SDK issues, silent event drops,
+description: 'Advanced Sentry troubleshooting for complex SDK issues, silent event
+  drops,
+
   source map failures, distributed tracing gaps, and SDK conflicts.
+
   Use when events silently disappear, source maps fail to resolve,
+
   traces break across service boundaries, or the SDK conflicts with
+
   other libraries like OpenTelemetry or winston.
+
   Trigger with phrases like "sentry events missing", "sentry source maps broken",
+
   "sentry debug", "sentry not capturing errors", "sentry tracing gaps",
+
   "sentry memory leak", "sentry sdk conflict".
-allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(curl:*), Bash(sentry-cli:*), Bash(dig:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(curl:*),
+  Bash(sentry-cli:*), Bash(dig:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, debugging, troubleshooting, source-maps, distributed-tracing, sdk-conflicts]
+tags:
+- saas
+- sentry
+- debugging
+- troubleshooting
+- source-maps
+- distributed-tracing
+- sdk-conflicts
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Advanced Troubleshooting
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-architecture-variants/SKILL.md
@@ -1,19 +1,35 @@
 ---
 name: sentry-architecture-variants
-description: |
-  Configure Sentry error tracking and performance monitoring for different
+description: 'Configure Sentry error tracking and performance monitoring for different
+
   application architectures. Use when setting up Sentry for monoliths,
+
   microservices, serverless functions, event-driven systems, frontend SPAs,
+
   mobile apps, or hybrid deployments.
+
   Trigger: "sentry monolith setup", "sentry microservices tracing",
+
   "sentry serverless lambda", "sentry event-driven kafka",
+
   "sentry react native", "sentry architecture pattern".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, serverless, microservices, architecture, distributed-tracing, lambda, spa, mobile]
+tags:
+- saas
+- sentry
+- serverless
+- microservices
+- architecture
+- distributed-tracing
+- lambda
+- spa
+- mobile
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Architecture Variants
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-ci-integration/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-ci-integration/SKILL.md
@@ -1,19 +1,34 @@
 ---
 name: sentry-ci-integration
-description: |
-  Integrate Sentry into CI/CD pipelines for automated release creation,
+description: 'Integrate Sentry into CI/CD pipelines for automated release creation,
+
   source map uploads, and deploy notifications.
+
   Use when setting up GitHub Actions, GitLab CI, or CircleCI to automate
+
   Sentry releases, upload source maps, or associate commits with deploys.
+
   Trigger with phrases like "sentry github actions", "sentry CI pipeline",
+
   "automate sentry releases", "sentry source map upload CI",
+
   "sentry gitlab ci", "sentry circleci".
-allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(sentry-cli:*), Bash(npm:*), Bash(npx:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(sentry-cli:*), Bash(npm:*), Bash(npx:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, ci-cd, github-actions, gitlab-ci, source-maps, deployment]
+tags:
+- saas
+- sentry
+- ci-cd
+- github-actions
+- gitlab-ci
+- source-maps
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry CI Integration
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-common-errors/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-common-errors/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: sentry-common-errors
-description: |
-  Troubleshoot common Sentry integration issues and fixes.
+description: 'Troubleshoot common Sentry integration issues and fixes.
+
   Use when encountering Sentry errors, missing events, source map
+
   failures, rate limits, or configuration problems.
+
   Trigger: "sentry not working", "sentry errors missing", "fix sentry",
+
   "sentry troubleshoot", "sentry 429", "source maps not resolving",
+
   "sentry events not showing", "sentry flush", "sentry CORS".
-allowed-tools: Read, Grep, Bash(npm:*), Bash(node:*), Bash(curl:*), Bash(npx:*), Bash(sentry-cli:*), Bash(python3:*)
+
+  '
+allowed-tools: Read, Grep, Bash(npm:*), Bash(node:*), Bash(curl:*), Bash(npx:*), Bash(sentry-cli:*),
+  Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, troubleshooting, debugging, error-monitoring]
+tags:
+- saas
+- sentry
+- troubleshooting
+- debugging
+- error-monitoring
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Common Errors
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-cost-tuning/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: sentry-cost-tuning
-description: |
-  Optimize Sentry costs, reduce event volume, and manage quota spend.
+description: 'Optimize Sentry costs, reduce event volume, and manage quota spend.
+
   Use when analyzing Sentry billing, reducing error/transaction volume,
+
   configuring sampling rates, or preventing overage charges.
+
   Trigger: "reduce sentry costs", "sentry billing optimization",
+
   "sentry quota management", "optimize sentry spend", "sentry sampling".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(curl:*), Bash(node:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, cost-optimization, billing, quotas, sampling]
+tags:
+- saas
+- sentry
+- cost-optimization
+- billing
+- quotas
+- sampling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Cost Tuning
 
 Reduce Sentry spend by 60-95% through SDK-level sampling, server-side inbound filters, `beforeSend` event dropping, and quota management — without losing visibility into production errors that matter.

--- a/plugins/saas-packs/sentry-pack/skills/sentry-data-handling/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-data-handling/SKILL.md
@@ -1,19 +1,33 @@
 ---
 name: sentry-data-handling
-description: |
-  Configure GDPR-compliant data handling, PII scrubbing, and data
+description: 'Configure GDPR-compliant data handling, PII scrubbing, and data
+
   retention policies in Sentry. Use when implementing beforeSend
+
   filters, server-side data scrubbing rules, IP anonymization,
+
   data subject deletion requests, or SOC 2 audit controls.
+
   Trigger with phrases like "sentry pii scrubbing", "sentry gdpr",
+
   "sentry data privacy", "scrub sensitive data sentry",
+
   "sentry data retention", "sentry compliance".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, security, compliance, gdpr, pii, data-privacy]
+tags:
+- saas
+- sentry
+- security
+- compliance
+- gdpr
+- pii
+- data-privacy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Data Handling
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-debug-bundle/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: sentry-debug-bundle
-description: |
-  Collect diagnostic information for Sentry troubleshooting and support tickets.
+description: 'Collect diagnostic information for Sentry troubleshooting and support
+  tickets.
+
   Use when events are not appearing in Sentry, SDK initialization seems broken,
+
   DSN connectivity fails, source maps are not resolving, or preparing a support request.
-  Trigger with "sentry debug info", "sentry diagnostics", "debug bundle", "sentry support ticket".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*), Bash(pip:*), Bash(python:*), Bash(curl:*), Bash(dig:*), Bash(sentry-cli:*), Grep, Glob
+
+  Trigger with "sentry debug info", "sentry diagnostics", "debug bundle", "sentry
+  support ticket".
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*), Bash(pip:*),
+  Bash(python:*), Bash(curl:*), Bash(dig:*), Bash(sentry-cli:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, debugging, support, diagnostics]
+tags:
+- saas
+- sentry
+- debugging
+- support
+- diagnostics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-deploy-integration/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: sentry-deploy-integration
-description: |
-  Track deployments and release health in Sentry.
+description: 'Track deployments and release health in Sentry.
+
   Use when configuring deployment tracking, release health monitoring,
+
   or connecting CI/CD deploys to error data in Sentry.
+
   Trigger with phrases like "sentry deploy tracking", "sentry release health",
+
   "track deployments sentry", "sentry deployment notification",
+
   "sentry suspect commits", "compare sentry releases".
-allowed-tools: Read, Write, Edit, Bash(sentry-cli:*), Bash(curl:*), Bash(node:*), Bash(npx:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(sentry-cli:*), Bash(curl:*), Bash(node:*),
+  Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, sentry, deployment, release-health, cicd]
+tags:
+- saas
+- sentry
+- deployment
+- release-health
+- cicd
+compatibility: Designed for Claude Code
 ---
-
 # Sentry Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-enterprise-rbac/SKILL.md
@@ -1,20 +1,35 @@
 ---
 name: sentry-enterprise-rbac
-description: |
-  Configure enterprise role-based access control, SSO/SAML2, and SCIM
+description: 'Configure enterprise role-based access control, SSO/SAML2, and SCIM
+
   provisioning in Sentry. Use when setting up organization hierarchy,
+
   team permissions, identity provider integration, API token governance,
+
   or audit logging for compliance.
+
   Trigger: "sentry rbac", "sentry permissions", "sentry team access",
+
   "sentry sso setup", "sentry scim", "sentry audit log".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*), Bash(python3:*), Bash(jq:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, rbac, sso, saml, scim, teams, permissions, audit, enterprise]
+tags:
+- saas
+- sentry
+- rbac
+- sso
+- saml
+- scim
+- teams
+- permissions
+- audit
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-error-capture/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-error-capture/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: sentry-error-capture
-description: |
-  Implement advanced error capture and context enrichment with Sentry.
+description: 'Implement advanced error capture and context enrichment with Sentry.
+
   Use when adding captureException/captureMessage calls, enriching errors
+
   with user context, tags, breadcrumbs, or custom fingerprinting.
+
   Trigger with "sentry error capture", "sentry context", "enrich sentry errors",
+
   "sentry exception handling", "sentry breadcrumbs", "sentry fingerprint".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(python:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(pip:*),
+  Bash(python:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, error-tracking, context, breadcrumbs, observability]
+tags:
+- saas
+- sentry
+- error-tracking
+- context
+- breadcrumbs
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Error Capture
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-hello-world/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-hello-world/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: sentry-hello-world
-description: |
-  Capture your first test error with Sentry and verify it appears in the dashboard.
+description: 'Capture your first test error with Sentry and verify it appears in the
+  dashboard.
+
   Use when testing a new Sentry integration, verifying error capture works after
+
   install-auth, or learning how to enrich events with user context, tags, and breadcrumbs.
+
   Trigger with phrases like "test sentry", "sentry hello world",
+
   "verify sentry", "first sentry error", "sentry capture test".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(node:*), Bash(python:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, testing, dashboard, quickstart]
+tags:
+- saas
+- sentry
+- testing
+- dashboard
+- quickstart
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Hello World
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: sentry-incident-runbook
-description: |
-  Execute incident response procedures using Sentry error monitoring.
+description: 'Execute incident response procedures using Sentry error monitoring.
+
   Use when investigating production outages, triaging error spikes,
+
   classifying incident severity, or building postmortem reports from Sentry data.
+
   Trigger with phrases like "sentry incident", "sentry triage",
+
   "investigate sentry error", "sentry runbook", "production incident sentry".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(curl:*), Bash(node:*), Bash(npx:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, sentry, incident-response, triage, observability]
+tags:
+- saas
+- sentry
+- incident-response
+- triage
+- observability
+compatibility: Designed for Claude Code
 ---
-
 # Sentry Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-install-auth/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: sentry-install-auth
-description: |
-  Install and configure Sentry SDK authentication with DSN setup.
+description: 'Install and configure Sentry SDK authentication with DSN setup.
+
   Use when setting up Sentry error tracking, configuring DSN,
+
   or initializing Sentry in a Node.js or Python project.
+
   Trigger with "install sentry", "setup sentry", "sentry auth",
+
   "configure sentry DSN".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, sentry, monitoring, error-tracking]
+tags:
+- saas
+- sentry
+- monitoring
+- error-tracking
+compatibility: Designed for Claude Code
 ---
-
 # Sentry Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-known-pitfalls/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: sentry-known-pitfalls
-description: |
-  Identify and fix common Sentry SDK pitfalls that cause silent data loss,
+description: 'Identify and fix common Sentry SDK pitfalls that cause silent data loss,
+
   cost overruns, and missed alerts. Covers 10 anti-patterns with fix code.
+
   Use when auditing Sentry config, debugging missing events, or reviewing
+
   SDK setup. Trigger: "sentry pitfalls", "sentry anti-patterns",
+
   "sentry mistakes", "why are sentry events missing".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(grep:*), Bash(find:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(node:*), Bash(npm:*), Bash(npx:*),
+  Bash(grep:*), Bash(find:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, anti-patterns, troubleshooting, best-practices, sdk, configuration]
+tags:
+- saas
+- sentry
+- anti-patterns
+- troubleshooting
+- best-practices
+- sdk
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Known Pitfalls
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-load-scale/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-load-scale/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: sentry-load-scale
-description: |
-  Scale Sentry for high-traffic applications handling millions of events per day.
+description: 'Scale Sentry for high-traffic applications handling millions of events
+  per day.
+
   Use when optimizing SDK performance at high volume, implementing adaptive sampling,
+
   managing quotas and costs at scale, or deploying Sentry across multi-region infrastructure.
-  Trigger with phrases like "sentry high traffic", "scale sentry", "sentry millions events",
+
+  Trigger with phrases like "sentry high traffic", "scale sentry", "sentry millions
+  events",
+
   "sentry high volume", "sentry quota management", "sentry load test".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(npx:*), Bash(k6:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, performance, scaling, high-traffic, enterprise]
+tags:
+- saas
+- sentry
+- performance
+- scaling
+- high-traffic
+- enterprise
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Load & Scale
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-local-dev-loop/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: sentry-local-dev-loop
-description: |
-  Configure Sentry for local development with environment-aware settings.
+description: 'Configure Sentry for local development with environment-aware settings.
+
   Use when setting up dev vs prod DSN routing, enabling debug mode,
+
   tuning sample rates for local work, or testing source maps locally.
+
   Trigger with phrases like "sentry local dev", "sentry development config",
+
   "debug sentry locally", "sentry dev environment", "sentry spotlight".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*), Bash(python:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(npx:*), Bash(python:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, development, debugging, workflow, devtools, environment]
+tags:
+- saas
+- sentry
+- development
+- debugging
+- workflow
+- devtools
+- environment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Local Dev Loop
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-migration-deep-dive/SKILL.md
@@ -1,19 +1,31 @@
 ---
 name: sentry-migration-deep-dive
-description: |
-  Migrate to Sentry from other error tracking tools like Rollbar, Bugsnag, or New Relic.
+description: 'Migrate to Sentry from other error tracking tools like Rollbar, Bugsnag,
+  or New Relic.
+
   Use when replacing an existing error tracker with Sentry, running tools in parallel
+
   during a transition, or mapping API calls between providers.
+
   Trigger with phrases like "migrate to sentry", "switch from rollbar to sentry",
+
   "replace bugsnag with sentry", "sentry migration plan".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(node:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, migration, rollbar, bugsnag, new-relic, error-tracking]
+tags:
+- saas
+- sentry
+- migration
+- rollbar
+- bugsnag
+- new-relic
+- error-tracking
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-multi-env-setup/SKILL.md
@@ -1,22 +1,37 @@
 ---
 name: sentry-multi-env-setup
-description: |
-  Configure Sentry across development, staging, and production environments
+description: 'Configure Sentry across development, staging, and production environments
+
   with separate DSNs, environment-specific sample rates, per-environment
+
   alert rules, and dashboard filtering.
+
   Use when setting up Sentry for dev/staging/production, managing
+
   environment-specific configurations, isolating data between environments,
+
   or configuring .env files for per-environment DSNs.
+
   Trigger: "sentry environments", "sentry staging setup",
+
   "multi-environment sentry", "sentry dev vs prod", "sentry DSN per env".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(sentry-cli:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*),
+  Bash(sentry-cli:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, environments, configuration, multi-env, dsn, alerts]
+tags:
+- saas
+- sentry
+- environments
+- configuration
+- multi-env
+- dsn
+- alerts
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-observability/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-observability/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: sentry-observability
-description: |
-  Integrate Sentry with your observability stack — logging, metrics, APM, and dashboards.
-  Use when connecting Sentry to winston/pino/structlog, correlating errors with business
-  metrics, deciding between Sentry performance and Datadog/New Relic, building Sentry
-  Discover dashboards, or linking events to external tools via extra context.
-  Trigger: "sentry observability", "sentry logging", "sentry metrics", "sentry grafana",
-  "sentry datadog correlation", "sentry discover dashboard".
+description: "Integrate Sentry with your observability stack \u2014 logging, metrics,\
+  \ APM, and dashboards.\nUse when connecting Sentry to winston/pino/structlog, correlating\
+  \ errors with business\nmetrics, deciding between Sentry performance and Datadog/New\
+  \ Relic, building Sentry\nDiscover dashboards, or linking events to external tools\
+  \ via extra context.\nTrigger: \"sentry observability\", \"sentry logging\", \"\
+  sentry metrics\", \"sentry grafana\",\n\"sentry datadog correlation\", \"sentry\
+  \ discover dashboard\".\n"
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(npx:*), Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, observability, logging, metrics, apm, grafana, opentelemetry]
+tags:
+- saas
+- sentry
+- observability
+- logging
+- metrics
+- apm
+- grafana
+- opentelemetry
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Observability Integration
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-performance-tracing/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-performance-tracing/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: sentry-performance-tracing
-description: |
-  Set up performance monitoring and distributed tracing with Sentry.
+description: 'Set up performance monitoring and distributed tracing with Sentry.
+
   Use when implementing performance tracking, tracing requests,
+
   or monitoring application performance.
+
   Trigger with phrases like "sentry performance", "sentry tracing",
+
   "sentry APM", "monitor performance sentry".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, monitoring, performance, tracing, spans]
+tags:
+- saas
+- sentry
+- monitoring
+- performance
+- tracing
+- spans
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Performance Tracing
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-performance-tuning/SKILL.md
@@ -1,20 +1,34 @@
 ---
 name: sentry-performance-tuning
-description: |
-  Optimize Sentry performance monitoring for lower overhead and higher signal.
+description: 'Optimize Sentry performance monitoring for lower overhead and higher
+  signal.
+
   Use when tuning tracesSampleRate vs tracesSampler, configuring continuous profiling,
+
   fixing high-cardinality transaction names, adding custom span measurements,
+
   reducing SDK overhead, or setting Web Vitals thresholds.
+
   Trigger: "sentry performance optimize", "tune sentry sampling",
+
   "reduce sentry overhead", "sentry web vitals", "sentry profiling setup".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(sentry-cli:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*),
+  Bash(sentry-cli:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, monitoring, performance, optimization, profiling, web-vitals]
+tags:
+- saas
+- sentry
+- monitoring
+- performance
+- optimization
+- profiling
+- web-vitals
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-policy-guardrails/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: sentry-policy-guardrails
-description: |
-  Enforce organizational governance and policy guardrails for Sentry usage.
+description: 'Enforce organizational governance and policy guardrails for Sentry usage.
+
   Use when standardizing Sentry configuration across services, enforcing
+
   PII scrubbing, building shared config packages, or auditing drift.
+
   Trigger with phrases like "sentry governance", "sentry policy",
+
   "sentry standards", "enforce sentry config", "sentry compliance".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(curl:*), Bash(grep:*), Bash(git:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(node:*), Bash(npm:*), Bash(npx:*),
+  Bash(curl:*), Bash(grep:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, compliance, governance, policy, ci, cost-governance]
+tags:
+- saas
+- sentry
+- compliance
+- governance
+- policy
+- ci
+- cost-governance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Policy Guardrails
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-prod-checklist/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: sentry-prod-checklist
-description: |
-  Production deployment checklist for Sentry integration.
+description: 'Production deployment checklist for Sentry integration.
+
   Use when preparing a production deployment, auditing an existing
+
   Sentry setup, or running a go-live readiness review.
+
   Trigger: "sentry production checklist", "deploy sentry",
+
   "sentry go-live", "audit sentry config", "production readiness sentry".
-allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(curl:*), Bash(sentry-cli:*)
+
+  '
+allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(curl:*),
+  Bash(sentry-cli:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, deployment, production, checklist, operations]
+tags:
+- saas
+- sentry
+- deployment
+- production
+- checklist
+- operations
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Production Deployment Checklist
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-rate-limits/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-rate-limits/SKILL.md
@@ -1,21 +1,34 @@
 ---
 name: sentry-rate-limits
-description: |
-  Manage Sentry rate limits, quotas, and event volume optimization.
+description: 'Manage Sentry rate limits, quotas, and event volume optimization.
+
   Use when hitting 429 errors, tuning sampleRate/tracesSampleRate,
+
   filtering noisy browser errors with beforeSend, configuring
+
   inbound data filters, setting per-key rate limits, or monitoring
+
   quota usage via the Sentry stats API.
+
   Trigger: "sentry rate limit", "sentry quota", "reduce sentry events",
+
   "sentry 429", "sentry spike protection", "sentry sampling".
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(curl:*), Bash(node:*), Bash(python3:*), Bash(pip:*)
+
+  '
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(curl:*), Bash(node:*), Bash(python3:*),
+  Bash(pip:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, cost-optimization, rate-limiting, quotas, observability]
+tags:
+- saas
+- sentry
+- cost-optimization
+- rate-limiting
+- quotas
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Rate Limits & Quota Optimization
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-reference-architecture/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: sentry-reference-architecture
-description: |
-  Design production-grade Sentry architecture for multi-service organizations.
+description: 'Design production-grade Sentry architecture for multi-service organizations.
+
   Use when planning Sentry rollout, structuring projects across teams,
+
   building shared config modules, or setting up distributed tracing.
+
   Trigger: "sentry architecture", "sentry project structure",
+
   "sentry reference design", "sentry distributed tracing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, architecture, enterprise, distributed-tracing, microservices]
+tags:
+- saas
+- sentry
+- architecture
+- enterprise
+- distributed-tracing
+- microservices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-release-management/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-release-management/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: sentry-release-management
-description: |
-  Manage Sentry releases with versioning, commit association, and source map uploads.
+description: 'Manage Sentry releases with versioning, commit association, and source
+  map uploads.
+
   Use when creating releases, linking commits to errors, uploading release artifacts,
+
   monitoring release health, or cleaning up old releases.
+
   Trigger with phrases like "sentry release", "create sentry version",
+
   "sentry source maps", "sentry suspect commits", "release health".
-allowed-tools: Read, Write, Edit, Bash(sentry-cli:*), Bash(npx:*), Bash(node:*), Bash(git:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(sentry-cli:*), Bash(npx:*), Bash(node:*), Bash(git:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, releases, source-maps, ci-cd, versioning]
+tags:
+- saas
+- sentry
+- releases
+- source-maps
+- ci-cd
+- versioning
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Release Management
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-reliability-patterns/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: sentry-reliability-patterns
-description: |
-  Build reliable Sentry integrations with graceful degradation, circuit breakers, and offline queuing.
-  Use when implementing fault-tolerant error tracking, handling SDK initialization failures,
+description: 'Build reliable Sentry integrations with graceful degradation, circuit
+  breakers, and offline queuing.
+
+  Use when implementing fault-tolerant error tracking, handling SDK initialization
+  failures,
+
   building retry logic for Sentry transports, or ensuring apps survive Sentry outages.
+
   Trigger with "sentry reliability", "sentry circuit breaker", "sentry offline queue",
+
   "sentry graceful degradation", "sentry failover", or "resilient sentry setup".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(node:*), Bash(pip:*), Bash(python*:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, reliability, resilience, circuit-breaker, offline-queue, graceful-degradation]
+tags:
+- saas
+- sentry
+- reliability
+- resilience
+- circuit-breaker
+- offline-queue
+- graceful-degradation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-sdk-patterns/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: sentry-sdk-patterns
-description: |
-  Best practices for using Sentry SDK in TypeScript and Python.
+description: 'Best practices for using Sentry SDK in TypeScript and Python.
+
   Use when implementing structured error context with scopes, breadcrumb
+
   strategies, beforeSend/beforeBreadcrumb filtering, custom fingerprinting,
+
   user context, or performance span creation.
+
   Trigger: "sentry best practices", "sentry patterns", "sentry sdk usage",
+
   "sentry scope", "sentry breadcrumbs", "sentry beforeSend", "sentry fingerprint".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, python, typescript, best-practices, error-handling]
+tags:
+- saas
+- sentry
+- python
+- typescript
+- best-practices
+- error-handling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/sentry-pack/skills/sentry-security-basics/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: sentry-security-basics
-description: |
-  Configure Sentry security settings and data protection.
+description: 'Configure Sentry security settings and data protection.
+
   Use when setting up PII scrubbing, managing sensitive data,
+
   configuring data scrubbing rules, or hardening Sentry for compliance.
+
   Trigger with phrases like "sentry security", "sentry PII",
+
   "sentry data scrubbing", "secure sentry", "sentry GDPR".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(grep:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, security, pii, data-scrubbing, gdpr]
+tags:
+- saas
+- sentry
+- security
+- pii
+- data-scrubbing
+- gdpr
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Security Basics
 

--- a/plugins/saas-packs/sentry-pack/skills/sentry-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-upgrade-migration/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: sentry-upgrade-migration
-description: |
-  Upgrade Sentry SDK versions and migrate breaking API changes.
+description: 'Upgrade Sentry SDK versions and migrate breaking API changes.
+
   Use when upgrading from Sentry v7 to v8, migrating Python SDK v1 to v2,
+
   replacing deprecated Hub/Transaction APIs, or running the migr8 codemod.
+
   Trigger: "upgrade sentry", "sentry migration", "sentry breaking changes",
+
   "migrate sentry v7 to v8", "update sentry sdk".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(node:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(node:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, sentry, migration, upgrade, sdk, breaking-changes]
+tags:
+- saas
+- sentry
+- migration
+- upgrade
+- sdk
+- breaking-changes
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Sentry Upgrade Migration
 
 Detect installed Sentry SDK versions, identify breaking API changes, apply automated codemods, and verify the upgrade succeeds with test events and traces.

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-ci-integration/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-ci-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-ci-integration
-description: |
-  Set up CI/CD for SerpApi integrations with fixture-based testing.
+description: 'Set up CI/CD for SerpApi integrations with fixture-based testing.
+
   Use when automating SerpApi tests without consuming credits,
+
   or validating search result parsing in CI.
+
   Trigger: "serpapi CI", "serpapi GitHub Actions", "serpapi automated tests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi CI Integration
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-common-errors/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-common-errors/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: serpapi-common-errors
-description: |
-  Diagnose and fix SerpApi errors: invalid keys, exhausted credits, blocked searches.
+description: 'Diagnose and fix SerpApi errors: invalid keys, exhausted credits, blocked
+  searches.
+
   Use when SerpApi returns errors, empty results, or unexpected status codes.
+
   Trigger: "serpapi error", "fix serpapi", "serpapi not working", "serpapi empty results".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Common Errors
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-core-workflow-a/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-core-workflow-a
-description: |
-  Google Search scraping with SerpApi -- organic results, knowledge graph, answer boxes.
+description: 'Google Search scraping with SerpApi -- organic results, knowledge graph,
+  answer boxes.
+
   Use when building search-powered features, SEO monitoring,
+
   or extracting structured data from Google results.
+
   Trigger: "serpapi google search", "scrape google", "serpapi organic results".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Core Workflow A: Google Search
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-core-workflow-b/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-core-workflow-b
-description: |
-  Search Bing, YouTube, Google Shopping, Google News, and Google Maps with SerpApi.
+description: 'Search Bing, YouTube, Google Shopping, Google News, and Google Maps
+  with SerpApi.
+
   Use when scraping non-Google engines, building multi-engine search,
+
   or extracting video/news/shopping/maps data.
+
   Trigger: "serpapi youtube", "serpapi bing", "serpapi news", "serpapi shopping".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Core Workflow B: Multi-Engine Search
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-cost-tuning/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-cost-tuning
-description: |
-  Optimize SerpApi costs by reducing credit consumption and choosing the right plan.
+description: 'Optimize SerpApi costs by reducing credit consumption and choosing the
+  right plan.
+
   Use when analyzing search usage, reducing monthly costs,
+
   or implementing credit-saving strategies.
+
   Trigger: "serpapi cost", "serpapi pricing", "reduce serpapi costs", "serpapi credits".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-debug-bundle/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-debug-bundle
-description: |
-  Collect SerpApi debug diagnostics: account status, recent searches, and error logs.
+description: 'Collect SerpApi debug diagnostics: account status, recent searches,
+  and error logs.
+
   Use when troubleshooting SerpApi issues, checking credit usage,
+
   or preparing support tickets.
+
   Trigger: "serpapi debug", "serpapi diagnostic", "serpapi support".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-deploy-integration
-description: |
-  Deploy SerpApi-powered search features to production platforms.
+description: 'Deploy SerpApi-powered search features to production platforms.
+
   Use when deploying search APIs, configuring backend proxies,
+
   or setting up SerpApi in serverless environments.
+
   Trigger: "deploy serpapi", "serpapi Vercel", "serpapi production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-hello-world/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-hello-world/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-hello-world
-description: |
-  Run your first SerpApi search -- Google, Bing, or YouTube results as JSON.
+description: 'Run your first SerpApi search -- Google, Bing, or YouTube results as
+  JSON.
+
   Use when starting with SerpApi, testing search queries,
+
   or learning the structured result format.
+
   Trigger: "serpapi hello world", "serpapi example", "serpapi first search".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Hello World
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-install-auth/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-install-auth
-description: |
-  Install SerpApi client and configure API key authentication.
+description: 'Install SerpApi client and configure API key authentication.
+
   Use when setting up SerpApi for search result scraping, configuring API keys,
+
   or initializing the serpapi Python/Node package.
+
   Trigger: "install serpapi", "setup serpapi", "serpapi auth", "serpapi API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-local-dev-loop/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-local-dev-loop
-description: |
-  Configure SerpApi local development with cached responses and test fixtures.
+description: 'Configure SerpApi local development with cached responses and test fixtures.
+
   Use when building search integrations, avoiding API calls during development,
+
   or setting up reproducible test data from SerpApi.
+
   Trigger: "serpapi dev setup", "serpapi local", "test serpapi locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-performance-tuning/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: serpapi-performance-tuning
-description: |
-  Optimize SerpApi performance with caching, async searches, and result filtering.
+description: 'Optimize SerpApi performance with caching, async searches, and result
+  filtering.
+
   Use when reducing latency, minimizing credit consumption,
+
   or optimizing search throughput.
-  Trigger: "serpapi performance", "optimize serpapi", "serpapi caching", "serpapi slow".
+
+  Trigger: "serpapi performance", "optimize serpapi", "serpapi caching", "serpapi
+  slow".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-prod-checklist/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-prod-checklist
-description: |
-  Production readiness checklist for SerpApi integrations.
+description: 'Production readiness checklist for SerpApi integrations.
+
   Use when deploying search features, validating credit budgets,
+
   or preparing SerpApi-powered apps for launch.
+
   Trigger: "serpapi production", "deploy serpapi", "serpapi go-live".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Production Checklist
 
 ## Checklist

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-rate-limits/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-rate-limits
-description: |
-  Handle SerpApi rate limits and credit-based usage quotas.
+description: 'Handle SerpApi rate limits and credit-based usage quotas.
+
   Use when managing API credit consumption, implementing request throttling,
+
   or optimizing search volume for your plan tier.
+
   Trigger: "serpapi rate limit", "serpapi credits", "serpapi quota", "serpapi throttle".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-reference-architecture/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-reference-architecture
-description: |
-  Production architecture for SerpApi search services with caching, monitoring, and multi-engine support.
+description: 'Production architecture for SerpApi search services with caching, monitoring,
+  and multi-engine support.
+
   Use when designing search features, building SERP tracking systems,
+
   or architecting search-powered applications.
+
   Trigger: "serpapi architecture", "serpapi project structure", "serpapi design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-sdk-patterns/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-sdk-patterns
-description: |
-  Production-ready SerpApi client patterns with caching, typing, and multi-engine support.
+description: 'Production-ready SerpApi client patterns with caching, typing, and multi-engine
+  support.
+
   Use when building search services, implementing result caching,
+
   or wrapping SerpApi with typed responses.
+
   Trigger: "serpapi patterns", "serpapi best practices", "serpapi client wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-security-basics/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-security-basics/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-security-basics
-description: |
-  Secure SerpApi API keys and prevent credit abuse.
+description: 'Secure SerpApi API keys and prevent credit abuse.
+
   Use when storing API keys, implementing backend proxies,
+
   or auditing SerpApi access patterns.
+
   Trigger: "serpapi security", "serpapi API key security", "secure serpapi".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Security Basics
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-upgrade-migration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: serpapi-upgrade-migration
-description: |
-  Migrate between SerpApi client versions and handle package changes.
+description: 'Migrate between SerpApi client versions and handle package changes.
+
   Use when upgrading from google-search-results to serpapi package,
+
   or handling API response schema changes.
+
   Trigger: "upgrade serpapi", "serpapi migration", "serpapi new package".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/serpapi-pack/skills/serpapi-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/serpapi-pack/skills/serpapi-webhooks-events/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: serpapi-webhooks-events
-description: |
-  Implement SerpApi async search callbacks and scheduled search monitoring.
+description: 'Implement SerpApi async search callbacks and scheduled search monitoring.
+
   Use when setting up search monitoring, SERP tracking pipelines,
+
   or async search result retrieval.
-  Trigger: "serpapi webhooks", "serpapi monitoring", "serpapi scheduled search", "serpapi async".
+
+  Trigger: "serpapi webhooks", "serpapi monitoring", "serpapi scheduled search", "serpapi
+  async".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, search, seo, serpapi]
-compatible-with: claude-code
+tags:
+- saas
+- search
+- seo
+- serpapi
+compatibility: Designed for Claude Code
 ---
-
 # SerpApi Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-advanced-troubleshooting/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-advanced-troubleshooting
-description: |
-  Debug complex Shopify API issues using cost analysis, request tracing,
+description: 'Debug complex Shopify API issues using cost analysis, request tracing,
+
   webhook delivery inspection, and GraphQL introspection.
-  Use when encountering intermittent failures, throttling mysteries, or webhook delivery gaps.
+
+  Use when encountering intermittent failures, throttling mysteries, or webhook delivery
+  gaps.
+
   Trigger with phrases like "shopify hard bug", "shopify mystery error",
+
   "shopify deep debug", "difficult shopify issue", "shopify intermittent failure".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ai-toolkit-wrapper/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-ai-toolkit-wrapper
-description: |
-  Integrate Shopify's AI Toolkit MCP server with Claude Code for GraphQL validation,
+description: 'Integrate Shopify''s AI Toolkit MCP server with Claude Code for GraphQL
+  validation,
+
   Liquid linting, and documentation search.
+
   Use when setting up Shopify MCP integration, validating GraphQL queries,
+
   or linting Liquid templates.
+
   Trigger with phrases like "shopify ai toolkit", "shopify mcp",
+
   "shopify claude integration", "shopify graphql validation", "shopify liquid lint".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify AI Toolkit Wrapper
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-architecture-variants/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: shopify-architecture-variants
-description: |
-  Choose between Shopify app architectures: embedded Remix app, headless storefront with
+description: 'Choose between Shopify app architectures: embedded Remix app, headless
+  storefront with
+
   Hydrogen, standalone integration, or theme app extension.
-  Use when starting a new Shopify project and deciding which architecture pattern to follow.
-  Trigger with phrases like "shopify architecture decision", "shopify embedded vs headless",
+
+  Use when starting a new Shopify project and deciding which architecture pattern
+  to follow.
+
+  Trigger with phrases like "shopify architecture decision", "shopify embedded vs
+  headless",
+
   "shopify Hydrogen", "shopify app types", "which shopify architecture".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-b2b-wholesale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-b2b-wholesale
-description: |
-  Build Shopify Plus B2B features with companies, catalogs, and wholesale pricing.
+description: 'Build Shopify Plus B2B features with companies, catalogs, and wholesale
+  pricing.
+
   Use when setting up wholesale accounts, creating price lists,
+
   or configuring B2B checkout with purchase orders.
+
   Trigger with phrases like "shopify b2b", "shopify wholesale",
+
   "shopify company api", "shopify price lists", "shopify catalog api".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify B2B & Wholesale
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-checkout-extensions/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: shopify-checkout-extensions
-description: |
-  Build Checkout UI Extensions to customize Shopify checkout with sandboxed React-like components.
-  Use when replacing checkout.liquid (deprecated Aug 2025), adding custom fields to checkout,
+description: 'Build Checkout UI Extensions to customize Shopify checkout with sandboxed
+  React-like components.
+
+  Use when replacing checkout.liquid (deprecated Aug 2025), adding custom fields to
+  checkout,
+
   displaying banners, or reading checkout state with hooks.
+
   Trigger with phrases like "shopify checkout extension", "shopify checkout ui",
-  "checkout customization shopify", "checkout.liquid migration", "shopify checkout components".
+
+  "checkout customization shopify", "checkout.liquid migration", "shopify checkout
+  components".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Checkout UI Extensions
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-ci-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-ci-integration
-description: |
-  Configure CI/CD pipelines for Shopify apps with GitHub Actions, API version testing,
+description: 'Configure CI/CD pipelines for Shopify apps with GitHub Actions, API
+  version testing,
+
   and Shopify CLI deployment.
-  Use when setting up automated testing, deployment pipelines, or API version monitoring for Shopify apps.
+
+  Use when setting up automated testing, deployment pipelines, or API version monitoring
+  for Shopify apps.
+
   Trigger with phrases like "shopify CI", "shopify GitHub Actions",
+
   "shopify automated tests", "CI shopify", "shopify deploy pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify CI Integration
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-common-errors
-description: |
-  Diagnose and fix common Shopify API errors including 401, 403, 422, 429, and GraphQL errors.
+description: 'Diagnose and fix common Shopify API errors including 401, 403, 422,
+  429, and GraphQL errors.
+
   Use when encountering Shopify errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "shopify error", "fix shopify",
+
   "shopify not working", "debug shopify", "shopify 422".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Common Errors
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-a/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-core-workflow-a
-description: |
-  Manage Shopify products, variants, and collections using the GraphQL Admin API.
+description: 'Manage Shopify products, variants, and collections using the GraphQL
+  Admin API.
+
   Use when creating, updating, or querying products, managing inventory,
+
   or building product catalog integrations.
+
   Trigger with phrases like "shopify products", "create shopify product",
+
   "shopify variants", "shopify collections", "shopify inventory".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Products & Catalog Management
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-core-workflow-b/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-core-workflow-b
-description: |
-  Manage Shopify orders, customers, and fulfillments using the GraphQL Admin API.
+description: 'Manage Shopify orders, customers, and fulfillments using the GraphQL
+  Admin API.
+
   Use when querying orders, processing fulfillments, managing customers,
+
   or building order management integrations.
+
   Trigger with phrases like "shopify orders", "shopify customers",
+
   "shopify fulfillment", "process shopify order", "shopify checkout".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Orders & Customer Management
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-cost-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-cost-tuning
-description: |
-  Optimize Shopify app costs through plan selection, API usage monitoring,
+description: 'Optimize Shopify app costs through plan selection, API usage monitoring,
+
   and Shopify Plus upgrade analysis.
-  Use when analyzing API spend, choosing between Shopify plans, or reducing billable API calls.
+
+  Use when analyzing API spend, choosing between Shopify plans, or reducing billable
+  API calls.
+
   Trigger with phrases like "shopify cost", "shopify billing",
-  "shopify pricing", "shopify Plus worth it", "shopify API usage", "reduce shopify costs".
+
+  "shopify pricing", "shopify Plus worth it", "shopify API usage", "reduce shopify
+  costs".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-data-handling/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-data-handling
-description: |
-  Handle Shopify customer PII, implement GDPR/CCPA compliance, and manage data retention
-  with Shopify's mandatory privacy webhooks.
-  Use when building apps that store customer data, preparing for App Store review, or implementing deletion workflows.
+description: 'Handle Shopify customer PII, implement GDPR/CCPA compliance, and manage
+  data retention
+
+  with Shopify''s mandatory privacy webhooks.
+
+  Use when building apps that store customer data, preparing for App Store review,
+  or implementing deletion workflows.
+
   Trigger with phrases like "shopify data", "shopify PII", "shopify GDPR",
+
   "shopify customer data", "shopify privacy", "shopify CCPA", "shopify data request".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Data Handling
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-debug-bundle
-description: |
-  Collect Shopify debug evidence including API versions, scopes, rate limit state, and request logs.
+description: 'Collect Shopify debug evidence including API versions, scopes, rate
+  limit state, and request logs.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Shopify problems.
+
   Trigger with phrases like "shopify debug", "shopify support bundle",
+
   "collect shopify logs", "shopify diagnostic".
+
+  '
 allowed-tools: Read, Bash(curl:*), Bash(tar:*), Bash(node:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-deploy-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-deploy-integration
-description: |
-  Deploy Shopify apps to Vercel, Fly.io, Railway, and Cloud Run with proper environment configuration.
+description: 'Deploy Shopify apps to Vercel, Fly.io, Railway, and Cloud Run with proper
+  environment configuration.
+
   Use when deploying Shopify-powered applications to production,
+
   configuring platform-specific secrets, or setting up hosting.
+
   Trigger with phrases like "deploy shopify", "shopify hosting",
+
   "shopify Vercel", "shopify production deploy", "shopify Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*), Bash(shopify:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-enterprise-rbac/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-enterprise-rbac
-description: |
-  Implement Shopify Plus access control patterns with staff permissions,
+description: 'Implement Shopify Plus access control patterns with staff permissions,
+
   multi-location management, and Shopify Organization features.
-  Use when building apps for Shopify Plus merchants, implementing per-staff permissions, or managing multi-store organizations.
+
+  Use when building apps for Shopify Plus merchants, implementing per-staff permissions,
+  or managing multi-store organizations.
+
   Trigger with phrases like "shopify permissions", "shopify staff",
+
   "shopify Plus organization", "shopify roles", "shopify multi-location".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-functions/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-functions/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-functions
-description: |
-  Build Shopify Functions for custom discount, payment, and delivery logic in a WASM sandbox.
+description: 'Build Shopify Functions for custom discount, payment, and delivery logic
+  in a WASM sandbox.
+
   Use when creating custom discount rules, payment customizations, delivery options,
+
   or cart transformations that run server-side at checkout.
+
   Trigger with phrases like "shopify functions", "shopify discounts",
+
   "shopify wasm", "custom discount function", "shopify checkout customization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Functions
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-graphql-cost-optimizer/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: shopify-graphql-cost-optimizer
-description: |
-  Master Shopify's calculated query cost system to avoid throttling.
+description: 'Master Shopify''s calculated query cost system to avoid throttling.
+
   Use when hitting THROTTLED errors, optimizing GraphQL queries,
+
   or deciding when to use bulk operations instead.
+
   Trigger with phrases like "shopify query cost", "shopify graphql cost",
+
   "shopify rate limit graphql", "shopify throttled", "shopify bulk operations".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify GraphQL Cost Optimizer
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-hello-world
-description: |
-  Create a minimal working Shopify app that queries products via GraphQL Admin API.
+description: 'Create a minimal working Shopify app that queries products via GraphQL
+  Admin API.
+
   Use when starting a new Shopify integration, testing your setup,
+
   or learning basic Shopify API patterns.
+
   Trigger with phrases like "shopify hello world", "shopify example",
+
   "shopify quick start", "simple shopify app", "first shopify API call".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Hello World
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-incident-runbook/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-incident-runbook
-description: |
-  Execute Shopify incident response with triage using Shopify status page,
+description: 'Execute Shopify incident response with triage using Shopify status page,
+
   API health checks, and rate limit diagnosis.
-  Use when a Shopify integration is down, returning errors, or behaving unexpectedly in production.
+
+  Use when a Shopify integration is down, returning errors, or behaving unexpectedly
+  in production.
+
   Trigger with phrases like "shopify incident", "shopify outage",
+
   "shopify down", "shopify on-call", "shopify emergency", "shopify not responding".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-install-auth/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-install-auth
-description: |
-  Install and configure Shopify app authentication with OAuth, session tokens, and the @shopify/shopify-api SDK.
+description: 'Install and configure Shopify app authentication with OAuth, session
+  tokens, and the @shopify/shopify-api SDK.
+
   Use when setting up a new Shopify app, configuring API credentials,
+
   or initializing authentication for Admin or Storefront API access.
+
   Trigger with phrases like "install shopify", "setup shopify",
+
   "shopify auth", "shopify OAuth", "configure shopify API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-known-pitfalls/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-known-pitfalls
-description: |
-  Identify and avoid Shopify API anti-patterns: ignoring userErrors, wrong API version,
+description: 'Identify and avoid Shopify API anti-patterns: ignoring userErrors, wrong
+  API version,
+
   REST instead of GraphQL, missing GDPR webhooks, and webhook timeout issues.
-  Use when reviewing a Shopify codebase, preparing for App Store submission, or debugging mysterious API failures.
+
+  Use when reviewing a Shopify codebase, preparing for App Store submission, or debugging
+  mysterious API failures.
+
   Trigger with phrases like "shopify mistakes", "shopify anti-patterns",
+
   "shopify pitfalls", "shopify what not to do", "shopify code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-load-scale/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-load-scale
-description: |
-  Load test Shopify integrations respecting API rate limits, plan capacity with
+description: 'Load test Shopify integrations respecting API rate limits, plan capacity
+  with
+
   k6, and scale for Shopify Plus burst events (flash sales, BFCM).
-  Use when preparing for high-traffic events, benchmarking API throughput, or sizing infrastructure for Shopify webhook volume.
+
+  Use when preparing for high-traffic events, benchmarking API throughput, or sizing
+  infrastructure for Shopify webhook volume.
+
   Trigger with phrases like "shopify load test", "shopify scale",
+
   "shopify BFCM", "shopify flash sale", "shopify capacity", "shopify k6 test".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(k6:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: shopify-local-dev-loop
-description: |
-  Configure Shopify local development with Shopify CLI, hot reload, and ngrok tunneling.
+description: 'Configure Shopify local development with Shopify CLI, hot reload, and
+  ngrok tunneling.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with Shopify.
+
   Trigger with phrases like "shopify dev setup", "shopify local development",
+
   "shopify dev environment", "develop with shopify", "shopify CLI dev".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Bash(shopify:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Bash(shopify:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-metafields-metaobjects/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-metafields-metaobjects
-description: |
-  Model custom data with Shopify metafields and metaobjects via the GraphQL Admin API.
+description: 'Model custom data with Shopify metafields and metaobjects via the GraphQL
+  Admin API.
+
   Use when adding custom fields to products/orders, creating custom content types,
-  or building structured data models beyond Shopify's default schema.
+
+  or building structured data models beyond Shopify''s default schema.
+
   Trigger with phrases like "shopify metafields", "shopify metaobjects",
+
   "custom data shopify", "shopify custom fields", "metafield definition".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Metafields & Metaobjects
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-migration-deep-dive/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-migration-deep-dive
-description: |
-  Migrate e-commerce data to Shopify using bulk operations, product imports,
+description: 'Migrate e-commerce data to Shopify using bulk operations, product imports,
+
   and the strangler fig pattern for gradual platform migration.
-  Use when replatforming to Shopify, importing product catalogs, or migrating customer and order data from another e-commerce system.
+
+  Use when replatforming to Shopify, importing product catalogs, or migrating customer
+  and order data from another e-commerce system.
+
   Trigger with phrases like "migrate to shopify", "shopify data migration",
+
   "import products shopify", "shopify replatform", "move to shopify".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-multi-env-setup/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: shopify-multi-env-setup
-description: |
-  Configure Shopify apps across development, staging, and production environments
+description: 'Configure Shopify apps across development, staging, and production environments
+
   with separate stores, API credentials, and app instances.
+
   Use when setting up isolated dev/staging/prod environments for a Shopify app,
+
   managing multiple development stores, or configuring per-environment credentials.
+
   Trigger with phrases like "shopify environments", "shopify staging",
+
   "shopify dev vs prod", "shopify multi-store", "shopify environment setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(shopify:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-observability/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-observability/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: shopify-observability
-description: |
-  Set up observability for Shopify app integrations with query cost tracking,
+description: 'Set up observability for Shopify app integrations with query cost tracking,
+
   rate limit monitoring, webhook delivery metrics, and structured logging.
+
   Use when instrumenting a Shopify app for production monitoring, setting up
+
   Prometheus metrics for API health, or configuring alerts for rate limit issues.
+
   Trigger with phrases like "shopify monitoring", "shopify metrics",
+
   "shopify observability", "monitor shopify API", "shopify alerts", "shopify dashboard".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Observability
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-performance-tuning/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-performance-tuning
-description: |
-  Optimize Shopify API performance with GraphQL query cost reduction, bulk operations,
+description: 'Optimize Shopify API performance with GraphQL query cost reduction,
+  bulk operations,
+
   caching strategies, and Storefront API for high-traffic storefronts.
+
   Use when queries are slow or hitting THROTTLED errors, exporting large datasets,
+
   or optimizing API throughput for a high-traffic storefront.
+
   Trigger with phrases like "shopify performance", "optimize shopify",
+
   "shopify slow", "shopify caching", "shopify bulk operation", "shopify query cost".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-policy-guardrails/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-policy-guardrails
-description: |
-  Implement Shopify app policy enforcement with ESLint rules for API key detection,
+description: 'Implement Shopify app policy enforcement with ESLint rules for API key
+  detection,
+
   query cost budgets, and App Store compliance checks.
+
   Use when hardening a Shopify app against secret leaks, enforcing query cost limits,
+
   or preparing for App Store submission review.
+
   Trigger with phrases like "shopify policy", "shopify lint",
+
   "shopify guardrails", "shopify compliance", "shopify eslint", "shopify app review".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-prod-checklist/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-prod-checklist
-description: |
-  Execute Shopify app production deployment checklist covering App Store requirements,
+description: 'Execute Shopify app production deployment checklist covering App Store
+  requirements,
+
   mandatory webhooks, API versioning, and rollback procedures.
+
   Use when preparing a Shopify app for production launch, submitting to the App Store,
+
   or auditing an existing deployment for compliance gaps.
+
   Trigger with phrases like "shopify production", "deploy shopify",
+
   "shopify go-live", "shopify launch checklist", "shopify app store submit".
+
+  '
 allowed-tools: Read, Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-rate-limits/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: shopify-rate-limits
-description: |
-  Handle Shopify API rate limits for both REST (leaky bucket) and GraphQL (calculated query cost).
-  Use when hitting 429 errors, implementing retry logic, or optimizing API request throughput.
+description: 'Handle Shopify API rate limits for both REST (leaky bucket) and GraphQL
+  (calculated query cost).
+
+  Use when hitting 429 errors, implementing retry logic, or optimizing API request
+  throughput.
+
   Trigger with phrases like "shopify rate limit", "shopify throttling",
+
   "shopify 429", "shopify THROTTLED", "shopify query cost", "shopify backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reference-architecture/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-reference-architecture
-description: |
-  Implement Shopify app reference architecture with Remix, Prisma session storage,
+description: 'Implement Shopify app reference architecture with Remix, Prisma session
+  storage,
+
   and the official app template patterns.
+
   Use when setting up a new Shopify app, structuring a Remix-based project,
+
   or configuring Prisma session storage for production.
+
   Trigger with phrases like "shopify architecture", "shopify app structure",
+
   "shopify project layout", "shopify Remix template", "shopify app design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-reliability-patterns/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: shopify-reliability-patterns
-description: |
-  Implement reliability patterns for Shopify apps including circuit breakers
+description: 'Implement reliability patterns for Shopify apps including circuit breakers
+
   for API outages, webhook retry handling, and graceful degradation.
+
   Use when building fault-tolerant Shopify integrations, handling webhook retry storms,
+
   or adding resilience to API calls.
+
   Trigger with phrases like "shopify reliability", "shopify circuit breaker",
+
   "shopify resilience", "shopify fallback", "shopify retry webhook".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-sdk-patterns/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-sdk-patterns
-description: |
-  Apply production-ready patterns for @shopify/shopify-api including typed GraphQL clients,
+description: 'Apply production-ready patterns for @shopify/shopify-api including typed
+  GraphQL clients,
+
   session management, and retry logic.
+
   Use when implementing Shopify integrations, refactoring SDK usage,
+
   or establishing team coding standards for Shopify.
+
   Trigger with phrases like "shopify SDK patterns", "shopify best practices",
+
   "shopify code patterns", "idiomatic shopify", "shopify client wrapper".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-security-basics/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: shopify-security-basics
-description: |
-  Apply Shopify security best practices for API credentials, webhook HMAC validation,
+description: 'Apply Shopify security best practices for API credentials, webhook HMAC
+  validation,
+
   and access scope management.
+
   Use when securing API keys, validating webhook signatures,
+
   or auditing Shopify security configuration.
+
   Trigger with phrases like "shopify security", "shopify secrets",
+
   "secure shopify", "shopify HMAC", "shopify webhook verify".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Security Basics
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-storefront-headless/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: shopify-storefront-headless
-description: |
-  Build headless storefronts with Shopify's Storefront API and Cart API.
+description: 'Build headless storefronts with Shopify''s Storefront API and Cart API.
+
   Use when building custom frontends, setting up Hydrogen, querying products
+
   for customer-facing apps, or managing cart operations programmatically.
+
   Trigger with phrases like "shopify headless", "shopify storefront api",
+
   "shopify hydrogen", "shopify cart api", "headless commerce shopify".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Storefront & Headless Commerce
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-theme-performance/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: shopify-theme-performance
-description: |
-  Optimize Shopify theme performance for Core Web Vitals (LCP, CLS, INP).
+description: 'Optimize Shopify theme performance for Core Web Vitals (LCP, CLS, INP).
+
   Use when diagnosing slow page loads, fixing lazy-loaded hero images,
+
   profiling Liquid render times, or optimizing image delivery.
+
   Trigger with phrases like "shopify theme performance", "shopify core web vitals",
+
   "shopify lcp", "shopify liquid profiler", "shopify image optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Theme Performance
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-upgrade-migration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-upgrade-migration
-description: |
-  Upgrade Shopify API versions and migrate from REST to GraphQL with breaking change detection.
+description: 'Upgrade Shopify API versions and migrate from REST to GraphQL with breaking
+  change detection.
+
   Use when upgrading API versions, migrating from deprecated REST endpoints,
-  or handling Shopify's quarterly API release cycle.
+
+  or handling Shopify''s quarterly API release cycle.
+
   Trigger with phrases like "upgrade shopify", "shopify API version",
+
   "shopify breaking changes", "migrate REST to GraphQL", "shopify deprecation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/shopify-pack/skills/shopify-webhooks-events/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: shopify-webhooks-events
-description: |
-  Register and handle Shopify webhooks including mandatory GDPR compliance topics.
+description: 'Register and handle Shopify webhooks including mandatory GDPR compliance
+  topics.
+
   Use when setting up webhook subscriptions, handling order/product events,
+
   or implementing the required GDPR webhooks for app store submission.
+
   Trigger with phrases like "shopify webhook", "shopify events",
+
   "shopify GDPR webhook", "handle shopify notifications", "shopify webhook register".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ecommerce, shopify]
-compatible-with: claude-code
+tags:
+- saas
+- ecommerce
+- shopify
+compatibility: Designed for Claude Code
 ---
-
 # Shopify Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-advanced-troubleshooting/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: snowflake-advanced-troubleshooting
-description: |
-  Apply advanced Snowflake debugging with query profiling, spill analysis,
+description: 'Apply advanced Snowflake debugging with query profiling, spill analysis,
+
   lock contention, and performance deep-dives using ACCOUNT_USAGE views.
+
   Use when standard troubleshooting fails, investigating slow queries,
+
   or diagnosing warehouse performance issues.
+
   Trigger with phrases like "snowflake hard bug", "snowflake slow query debug",
+
   "snowflake query profile", "snowflake spilling", "snowflake deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(snowsql:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-architecture-variants/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-architecture-variants
-description: |
-  Choose and implement Snowflake architecture blueprints: data lakehouse, data mesh,
+description: 'Choose and implement Snowflake architecture blueprints: data lakehouse,
+  data mesh,
+
   data sharing, and Snowpark-native patterns for different scales.
+
   Use when designing Snowflake data platforms, choosing between architectures,
+
   or implementing data sharing and Snowpark patterns.
+
   Trigger with phrases like "snowflake architecture", "snowflake lakehouse",
+
   "snowflake data mesh", "snowflake data sharing", "snowflake Snowpark".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-ci-integration/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-ci-integration/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-ci-integration
-description: |
-  Configure Snowflake CI/CD with GitHub Actions, SchemaChange, and Terraform.
+description: 'Configure Snowflake CI/CD with GitHub Actions, SchemaChange, and Terraform.
+
   Use when setting up automated schema migrations, CI pipelines for Snowflake,
+
   or integrating SchemaChange/Terraform into your deployment workflow.
+
   Trigger with phrases like "snowflake CI", "snowflake GitHub Actions",
+
   "snowflake SchemaChange", "snowflake terraform", "snowflake CI/CD".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake CI Integration
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-common-errors/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-common-errors/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-common-errors
-description: |
-  Diagnose and fix common Snowflake errors and SQL compilation failures.
+description: 'Diagnose and fix common Snowflake errors and SQL compilation failures.
+
   Use when encountering Snowflake error codes, failed queries,
+
   authentication issues, or warehouse/connection problems.
+
   Trigger with phrases like "snowflake error", "fix snowflake",
+
   "snowflake not working", "snowflake SQL error", "snowflake 002003".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Common Errors
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-core-workflow-a/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-core-workflow-a
-description: |
-  Execute Snowflake primary workflow: data loading via stages and COPY INTO.
+description: 'Execute Snowflake primary workflow: data loading via stages and COPY
+  INTO.
+
   Use when loading data from S3/GCS/Azure into Snowflake tables,
+
   setting up Snowpipe for continuous ingestion, or bulk loading files.
+
   Trigger with phrases like "snowflake load data", "snowflake COPY INTO",
+
   "snowflake stage", "snowflake ingest", "snowflake S3 load", "snowpipe".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Core Workflow A — Data Loading
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-core-workflow-b/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-core-workflow-b
-description: |
-  Execute Snowflake data transformation with streams, tasks, and dynamic tables.
+description: 'Execute Snowflake data transformation with streams, tasks, and dynamic
+  tables.
+
   Use when building ELT pipelines, scheduling transformations,
+
   or implementing change data capture with Snowflake streams.
+
   Trigger with phrases like "snowflake transform", "snowflake ELT",
+
   "snowflake stream", "snowflake task", "snowflake pipeline",
+
   "snowflake dynamic table", "snowflake CDC".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Core Workflow B — Data Transformation
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-cost-tuning/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-cost-tuning
-description: |
-  Optimize Snowflake costs with resource monitors, warehouse auto-suspend,
+description: 'Optimize Snowflake costs with resource monitors, warehouse auto-suspend,
+
   right-sizing, and credit consumption analysis.
+
   Use when analyzing Snowflake billing, reducing credit consumption,
+
   or implementing cost controls and budget alerts.
+
   Trigger with phrases like "snowflake cost", "snowflake billing",
-  "reduce snowflake cost", "snowflake credits", "snowflake expensive", "snowflake budget".
+
+  "reduce snowflake cost", "snowflake credits", "snowflake expensive", "snowflake
+  budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-data-handling/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-data-handling/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-data-handling
-description: |
-  Implement Snowflake data governance with masking policies, row access policies,
+description: 'Implement Snowflake data governance with masking policies, row access
+  policies,
+
   tagging, and GDPR/CCPA compliance patterns.
+
   Use when handling PII, implementing column masking, configuring data classification,
+
   or ensuring compliance with privacy regulations in Snowflake.
+
   Trigger with phrases like "snowflake data governance", "snowflake masking",
+
   "snowflake PII", "snowflake GDPR", "snowflake row access policy", "snowflake tags".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Data Handling
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-debug-bundle
-description: |
-  Collect Snowflake debug evidence for support tickets and troubleshooting.
+description: 'Collect Snowflake debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support cases,
+
   or collecting diagnostic information from QUERY_HISTORY and ACCOUNT_USAGE.
+
   Trigger with phrases like "snowflake debug", "snowflake support bundle",
+
   "snowflake diagnostic", "snowflake query history", "snowflake troubleshoot".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-deploy-integration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-deploy-integration
-description: |
-  Deploy Snowflake-powered applications with proper connection management and secrets.
+description: 'Deploy Snowflake-powered applications with proper connection management
+  and secrets.
+
   Use when deploying apps that query Snowflake, configuring connection pools
+
   for serverless/container platforms, or managing Snowflake credentials in production.
+
   Trigger with phrases like "deploy snowflake", "snowflake serverless",
+
   "snowflake production deploy", "snowflake Cloud Run", "snowflake Lambda".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gcloud:*), Bash(aws:*), Bash(docker:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-enterprise-rbac/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: snowflake-enterprise-rbac
-description: |
-  Configure Snowflake enterprise RBAC with system roles, custom role hierarchies,
+description: 'Configure Snowflake enterprise RBAC with system roles, custom role hierarchies,
+
   SSO/SCIM integration, and least-privilege access patterns.
+
   Use when implementing role-based access control, configuring SSO with SAML/OIDC,
+
   or setting up organization-level governance in Snowflake.
+
   Trigger with phrases like "snowflake RBAC", "snowflake roles",
+
   "snowflake SSO", "snowflake SCIM", "snowflake permissions", "snowflake access control".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-hello-world/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-hello-world/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-hello-world
-description: |
-  Create a minimal working Snowflake example with real SQL queries.
+description: 'Create a minimal working Snowflake example with real SQL queries.
+
   Use when testing your Snowflake setup, running first queries,
+
   or learning basic snowflake-sdk and snowflake-connector-python patterns.
+
   Trigger with phrases like "snowflake hello world", "snowflake example",
+
   "snowflake quick start", "first snowflake query".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Hello World
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-incident-runbook/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-incident-runbook
-description: |
-  Execute Snowflake incident response with triage, rollback, and postmortem using real SQL diagnostics.
+description: 'Execute Snowflake incident response with triage, rollback, and postmortem
+  using real SQL diagnostics.
+
   Use when responding to Snowflake outages, investigating query failures,
+
   or running post-incident reviews for pipeline failures.
+
   Trigger with phrases like "snowflake incident", "snowflake outage",
+
   "snowflake down", "snowflake on-call", "snowflake emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(snowsql:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-install-auth/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-install-auth/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-install-auth
-description: |
-  Install and configure Snowflake driver authentication for Node.js and Python.
+description: 'Install and configure Snowflake driver authentication for Node.js and
+  Python.
+
   Use when setting up snowflake-sdk, snowflake-connector-python, key pair auth,
+
   OAuth, or SSO browser authentication.
+
   Trigger with phrases like "install snowflake", "setup snowflake",
+
   "snowflake auth", "snowflake connection", "snowflake key pair".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(openssl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-known-pitfalls/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: snowflake-known-pitfalls
-description: |
-  Identify and avoid Snowflake anti-patterns and common mistakes in SQL,
+description: 'Identify and avoid Snowflake anti-patterns and common mistakes in SQL,
+
   warehouse management, data loading, and access control.
+
   Use when reviewing Snowflake configurations, onboarding new users,
+
   or auditing existing Snowflake deployments for best practices.
+
   Trigger with phrases like "snowflake mistakes", "snowflake anti-patterns",
+
   "snowflake pitfalls", "snowflake what not to do", "snowflake code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-load-scale/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-load-scale/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-load-scale
-description: |
-  Implement Snowflake load testing, warehouse scaling, and capacity planning.
+description: 'Implement Snowflake load testing, warehouse scaling, and capacity planning.
+
   Use when testing query performance at scale, configuring multi-cluster warehouses,
+
   or planning capacity for production Snowflake workloads.
+
   Trigger with phrases like "snowflake load test", "snowflake scale",
+
   "snowflake capacity", "snowflake benchmark", "snowflake multi-cluster".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(python3:*), Bash(snowsql:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-local-dev-loop/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-local-dev-loop
-description: |
-  Configure Snowflake local development with testing, mocking, and fast iteration.
+description: 'Configure Snowflake local development with testing, mocking, and fast
+  iteration.
+
   Use when setting up dev environment, writing tests against Snowflake,
+
   or establishing a fast iteration cycle with SnowSQL and dev warehouses.
+
   Trigger with phrases like "snowflake dev setup", "snowflake local development",
+
   "snowflake dev environment", "develop with snowflake", "snowflake testing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-migration-deep-dive/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: snowflake-migration-deep-dive
-description: |
-  Execute migration to Snowflake from Redshift, BigQuery, or on-prem databases
+description: 'Execute migration to Snowflake from Redshift, BigQuery, or on-prem databases
+
   with data transfer, schema conversion, and validation strategies.
+
   Use when migrating to Snowflake from another platform, planning data transfers,
+
   or re-platforming existing data warehouses to Snowflake.
+
   Trigger with phrases like "migrate to snowflake", "snowflake migration",
+
   "redshift to snowflake", "bigquery to snowflake", "snowflake replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-multi-env-setup/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: snowflake-multi-env-setup
-description: |
-  Configure Snowflake across dev, staging, and production with account-level isolation,
+description: 'Configure Snowflake across dev, staging, and production with account-level
+  isolation,
+
   zero-copy clones, and environment-specific RBAC.
+
   Trigger with phrases like "snowflake environments", "snowflake staging",
+
   "snowflake dev prod", "snowflake clone", "snowflake environment setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-observability/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-observability/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: snowflake-observability
-description: |
-  Set up Snowflake observability using ACCOUNT_USAGE views, alerts, and external monitoring.
-  Use when implementing Snowflake monitoring dashboards, setting up query performance tracking,
+description: 'Set up Snowflake observability using ACCOUNT_USAGE views, alerts, and
+  external monitoring.
+
+  Use when implementing Snowflake monitoring dashboards, setting up query performance
+  tracking,
+
   or configuring alerting for warehouse and pipeline health.
+
   Trigger with phrases like "snowflake monitoring", "snowflake metrics",
+
   "snowflake observability", "snowflake dashboard", "snowflake alerts".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Observability
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-performance-tuning
-description: |
-  Optimize Snowflake query performance with clustering, materialized views, caching, and query profiling.
+description: 'Optimize Snowflake query performance with clustering, materialized views,
+  caching, and query profiling.
+
   Use when queries are slow, analyzing QUERY_HISTORY for bottlenecks,
+
   or optimizing warehouse utilization and data scanning.
+
   Trigger with phrases like "snowflake performance", "optimize snowflake",
+
   "snowflake slow query", "snowflake clustering", "snowflake query profile".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-policy-guardrails/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-policy-guardrails
-description: |
-  Implement Snowflake governance guardrails with network rules, session policies,
+description: 'Implement Snowflake governance guardrails with network rules, session
+  policies,
+
   authentication policies, and automated compliance checks.
+
   Use when enforcing security policies, implementing data governance,
+
   or configuring automated compliance for Snowflake.
+
   Trigger with phrases like "snowflake policy", "snowflake guardrails",
+
   "snowflake governance", "snowflake compliance", "snowflake enforce".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Policy & Guardrails
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-prod-checklist/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-prod-checklist
-description: |
-  Execute Snowflake production readiness checklist with monitoring and rollback.
+description: 'Execute Snowflake production readiness checklist with monitoring and
+  rollback.
+
   Use when deploying Snowflake pipelines to production, preparing for go-live,
+
   or validating production Snowflake configuration.
+
   Trigger with phrases like "snowflake production", "snowflake go-live",
+
   "snowflake launch checklist", "snowflake prod ready".
+
+  '
 allowed-tools: Read, Bash(kubectl:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-rate-limits/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-rate-limits/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: snowflake-rate-limits
-description: |
-  Handle Snowflake concurrency limits, warehouse queuing, and query throttling.
+description: 'Handle Snowflake concurrency limits, warehouse queuing, and query throttling.
+
   Use when queries are queuing, hitting concurrency limits,
+
   or needing to optimize warehouse sizing for throughput.
+
   Trigger with phrases like "snowflake rate limit", "snowflake throttling",
+
   "snowflake queuing", "snowflake concurrency", "snowflake warehouse sizing".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Rate Limits & Concurrency
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-reference-architecture/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: snowflake-reference-architecture
-description: |
-  Implement Snowflake reference architecture with medallion pattern and Snowflake-native design.
-  Use when designing a new Snowflake data platform, setting up bronze/silver/gold layers,
+description: 'Implement Snowflake reference architecture with medallion pattern and
+  Snowflake-native design.
+
+  Use when designing a new Snowflake data platform, setting up bronze/silver/gold
+  layers,
+
   or establishing architecture standards for a Snowflake deployment.
+
   Trigger with phrases like "snowflake architecture", "snowflake medallion",
+
   "snowflake best practices layout", "snowflake data platform design".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-reliability-patterns/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: snowflake-reliability-patterns
-description: |
-  Implement Snowflake reliability patterns: replication, failover, Time Travel recovery,
+description: 'Implement Snowflake reliability patterns: replication, failover, Time
+  Travel recovery,
+
   and application-level resilience for Snowflake integrations.
+
   Use when building fault-tolerant pipelines, configuring disaster recovery,
+
   or adding resilience to production Snowflake services.
+
   Trigger with phrases like "snowflake reliability", "snowflake failover",
+
   "snowflake replication", "snowflake disaster recovery", "snowflake Time Travel".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-sdk-patterns/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-sdk-patterns
-description: |
-  Apply production-ready Snowflake SDK patterns for snowflake-sdk and snowflake-connector-python.
+description: 'Apply production-ready Snowflake SDK patterns for snowflake-sdk and
+  snowflake-connector-python.
+
   Use when implementing connection pooling, async execute wrappers, streaming results,
+
   or establishing team coding standards for Snowflake.
+
   Trigger with phrases like "snowflake SDK patterns", "snowflake best practices",
+
   "snowflake code patterns", "idiomatic snowflake", "snowflake connection pool".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-security-basics/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-security-basics/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: snowflake-security-basics
-description: |
-  Apply Snowflake security best practices: network policies, key rotation,
+description: 'Apply Snowflake security best practices: network policies, key rotation,
+
   MFA, encryption, and least-privilege access.
+
   Use when securing Snowflake access, implementing network policies,
+
   or auditing security configuration.
+
   Trigger with phrases like "snowflake security", "snowflake network policy",
+
   "secure snowflake", "snowflake MFA", "snowflake encryption".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Security Basics
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-upgrade-migration/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-upgrade-migration
-description: |
-  Upgrade Snowflake drivers, handle breaking changes, and migrate between editions.
+description: 'Upgrade Snowflake drivers, handle breaking changes, and migrate between
+  editions.
+
   Use when upgrading snowflake-sdk or snowflake-connector-python versions,
+
   migrating between Snowflake editions, or handling deprecations.
+
   Trigger with phrases like "upgrade snowflake", "snowflake migration",
+
   "snowflake breaking changes", "update snowflake driver", "snowflake version".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/snowflake-pack/skills/snowflake-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/snowflake-pack/skills/snowflake-webhooks-events/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: snowflake-webhooks-events
-description: |
-  Implement Snowflake event-driven patterns with alerts, notifications, and external functions.
+description: 'Implement Snowflake event-driven patterns with alerts, notifications,
+  and external functions.
+
   Use when setting up Snowflake alerts, email notifications, external API calls,
+
   or event-driven pipelines triggered by Snowflake data changes.
+
   Trigger with phrases like "snowflake alerts", "snowflake notifications",
+
   "snowflake events", "snowflake external function", "snowflake email".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, data-warehouse, analytics, snowflake]
-compatible-with: claude-code
+tags:
+- saas
+- data-warehouse
+- analytics
+- snowflake
+compatibility: Designed for Claude Code
 ---
-
 # Snowflake Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/speak-pack/skills/speak-ci-integration/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-ci-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-ci-integration
-description: |
-  GitHub Actions pipeline for Speak integrations with mocked API tests and audio validation.
+description: 'GitHub Actions pipeline for Speak integrations with mocked API tests
+  and audio validation.
+
   Use when implementing ci integration,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak ci integration", "speak ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak CI Integration
 

--- a/plugins/saas-packs/speak-pack/skills/speak-common-errors/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-common-errors/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-common-errors
-description: |
-  Diagnose and fix common Speak API errors: authentication failures, audio format issues, rate limits, and session management problems.
+description: 'Diagnose and fix common Speak API errors: authentication failures, audio
+  format issues, rate limits, and session management problems.
+
   Use when implementing common errors features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak common errors", "speak common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, debugging]
+tags:
+- saas
+- speak
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Common Errors
 

--- a/plugins/saas-packs/speak-pack/skills/speak-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: speak-core-workflow-a
-description: |
-  Execute Speak primary workflow: AI Conversation Practice with real-time feedback.
+description: 'Execute Speak primary workflow: AI Conversation Practice with real-time
+  feedback.
+
   Use when implementing conversation practice features, building AI tutor interactions,
+
   or core language learning dialogue systems.
+
   Trigger with phrases like "speak conversation practice",
+
   "speak AI tutor", "speak dialogue", "primary speak workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, workflow]
+tags:
+- saas
+- speak
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Core Workflow A: AI Conversation Practice
 

--- a/plugins/saas-packs/speak-pack/skills/speak-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-core-workflow-b/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: speak-core-workflow-b
-description: |
-  Execute Speak secondary workflow: Pronunciation Training with phoneme-level analysis.
+description: 'Execute Speak secondary workflow: Pronunciation Training with phoneme-level
+  analysis.
+
   Use when implementing pronunciation drills, speech scoring,
+
   or targeted pronunciation improvement features.
+
   Trigger with phrases like "speak pronunciation training",
+
   "speak speech scoring", "speak phoneme analysis".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, voice-ai, workflow]
+tags:
+- saas
+- speak
+- voice-ai
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Core Workflow B: Pronunciation Training
 

--- a/plugins/saas-packs/speak-pack/skills/speak-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-cost-tuning/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-cost-tuning
-description: |
-  Optimize Speak API costs through usage monitoring, tier selection, and efficient audio processing.
+description: 'Optimize Speak API costs through usage monitoring, tier selection, and
+  efficient audio processing.
+
   Use when implementing cost tuning,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak cost tuning", "speak cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Cost Tuning
 

--- a/plugins/saas-packs/speak-pack/skills/speak-data-handling/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-data-handling/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-data-handling
-description: |
-  Handle student audio data, assessment records, and learning progress with GDPR/COPPA compliance.
+description: 'Handle student audio data, assessment records, and learning progress
+  with GDPR/COPPA compliance.
+
   Use when implementing data handling,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak data handling", "speak data handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Data Handling
 

--- a/plugins/saas-packs/speak-pack/skills/speak-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-debug-bundle/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-debug-bundle
-description: |
-  Collect diagnostic information for Speak API issues: auth verification, audio format validation, session inspection, and network testing.
+description: 'Collect diagnostic information for Speak API issues: auth verification,
+  audio format validation, session inspection, and network testing.
+
   Use when implementing debug bundle features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak debug bundle", "speak debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, debugging]
+tags:
+- saas
+- speak
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Debug Bundle
 

--- a/plugins/saas-packs/speak-pack/skills/speak-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-deploy-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-deploy-integration
-description: |
-  Deploy Speak language learning features to Vercel, Cloud Run, or containerized environments.
+description: 'Deploy Speak language learning features to Vercel, Cloud Run, or containerized
+  environments.
+
   Use when implementing deploy integration,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak deploy integration", "speak deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, deployment]
+tags:
+- saas
+- speak
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Deploy Integration
 

--- a/plugins/saas-packs/speak-pack/skills/speak-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-enterprise-rbac/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-enterprise-rbac
-description: |
-  Configure Speak for schools and organizations: SSO, teacher/student roles, class management, and usage reporting.
+description: 'Configure Speak for schools and organizations: SSO, teacher/student
+  roles, class management, and usage reporting.
+
   Use when implementing enterprise rbac,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak enterprise rbac", "speak enterprise rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Enterprise RBAC
 

--- a/plugins/saas-packs/speak-pack/skills/speak-hello-world/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: speak-hello-world
-description: |
-  Create your first Speak AI tutoring session with pronunciation feedback.
+description: 'Create your first Speak AI tutoring session with pronunciation feedback.
+
   Use when starting a new Speak integration, testing your setup,
+
   or learning basic language learning API patterns.
+
   Trigger with phrases like "speak hello world", "speak example",
+
   "speak quick start", "first speak lesson".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api, testing]
+tags:
+- saas
+- speak
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Hello World
 

--- a/plugins/saas-packs/speak-pack/skills/speak-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-incident-runbook/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-incident-runbook
-description: |
-  Incident response for Speak API outages: triage, fallback to offline mode, and recovery procedures.
+description: 'Incident response for Speak API outages: triage, fallback to offline
+  mode, and recovery procedures.
+
   Use when implementing incident runbook,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak incident runbook", "speak incident runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Incident Runbook
 

--- a/plugins/saas-packs/speak-pack/skills/speak-install-auth/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: speak-install-auth
-description: |
-  Set up Speak language learning API integration and authentication.
+description: 'Set up Speak language learning API integration and authentication.
+
   Use when configuring Speak API access, setting up OAuth with OpenAI
+
   Realtime API for speech, or initializing a language tutoring application.
+
   Trigger with phrases like "install speak", "setup speak",
+
   "speak auth", "configure speak API", "speak language learning setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api, authentication]
+tags:
+- saas
+- speak
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Install & Auth
 

--- a/plugins/saas-packs/speak-pack/skills/speak-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: speak-local-dev-loop
-description: |
-  Configure Speak local development with mocked tutors and audio testing.
+description: 'Configure Speak local development with mocked tutors and audio testing.
+
   Use when setting up a development environment, configuring test workflows,
+
   or building language learning features locally.
+
   Trigger with phrases like "speak dev setup", "speak local development",
+
   "speak dev environment", "develop with speak".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, testing, workflow]
+tags:
+- saas
+- speak
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Local Dev Loop
 

--- a/plugins/saas-packs/speak-pack/skills/speak-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-migration-deep-dive/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-migration-deep-dive
-description: |
-  Migrate between language learning platforms, import student progress, and transition from legacy speech APIs.
+description: 'Migrate between language learning platforms, import student progress,
+  and transition from legacy speech APIs.
+
   Use when implementing migration deep dive,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak migration deep dive", "speak migration deep dive".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Migration Deep Dive
 

--- a/plugins/saas-packs/speak-pack/skills/speak-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-multi-env-setup/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-multi-env-setup
-description: |
-  Configure Speak across dev, staging, and production with separate API keys and mock modes.
+description: 'Configure Speak across dev, staging, and production with separate API
+  keys and mock modes.
+
   Use when implementing multi env setup,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak multi env setup", "speak multi env setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Multi-Environment Setup
 

--- a/plugins/saas-packs/speak-pack/skills/speak-observability/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-observability/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-observability
-description: |
-  Monitor Speak API health, assessment latency, session metrics, and pronunciation score distributions.
+description: 'Monitor Speak API health, assessment latency, session metrics, and pronunciation
+  score distributions.
+
   Use when implementing observability,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak observability", "speak observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Observability
 

--- a/plugins/saas-packs/speak-pack/skills/speak-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-performance-tuning/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-performance-tuning
-description: |
-  Optimize Speak API latency with audio preprocessing, response caching, and connection pooling.
+description: 'Optimize Speak API latency with audio preprocessing, response caching,
+  and connection pooling.
+
   Use when implementing performance tuning,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak performance tuning", "speak performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Performance Tuning
 

--- a/plugins/saas-packs/speak-pack/skills/speak-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-prod-checklist/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-prod-checklist
-description: |
-  Production readiness checklist for Speak language learning integrations: auth, audio pipeline, monitoring, and compliance.
+description: 'Production readiness checklist for Speak language learning integrations:
+  auth, audio pipeline, monitoring, and compliance.
+
   Use when implementing prod checklist features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak prod checklist", "speak prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Production Checklist
 

--- a/plugins/saas-packs/speak-pack/skills/speak-rate-limits/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-rate-limits/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-rate-limits
-description: |
-  Handle Speak API rate limits with exponential backoff, request queuing, and optimization strategies.
+description: 'Handle Speak API rate limits with exponential backoff, request queuing,
+  and optimization strategies.
+
   Use when implementing rate limits features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak rate limits", "speak rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Rate Limits
 

--- a/plugins/saas-packs/speak-pack/skills/speak-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-reference-architecture/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-reference-architecture
-description: |
-  Production architecture for Speak language learning apps: client, API gateway, assessment engine, and progress store.
+description: 'Production architecture for Speak language learning apps: client, API
+  gateway, assessment engine, and progress store.
+
   Use when implementing reference architecture,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak reference architecture", "speak reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Reference Architecture
 

--- a/plugins/saas-packs/speak-pack/skills/speak-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-sdk-patterns/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-sdk-patterns
-description: |
-  Production patterns for Speak language learning API: conversation sessions, pronunciation assessment, audio preprocessing, and batch operations.
+description: 'Production patterns for Speak language learning API: conversation sessions,
+  pronunciation assessment, audio preprocessing, and batch operations.
+
   Use when implementing sdk patterns features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak sdk patterns", "speak sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak SDK Patterns
 

--- a/plugins/saas-packs/speak-pack/skills/speak-security-basics/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-security-basics/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-security-basics
-description: |
-  Security best practices for Speak API keys, audio data privacy, student data protection, and COPPA/FERPA compliance.
+description: 'Security best practices for Speak API keys, audio data privacy, student
+  data protection, and COPPA/FERPA compliance.
+
   Use when implementing security basics features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak security basics", "speak security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Security Basics
 

--- a/plugins/saas-packs/speak-pack/skills/speak-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-upgrade-migration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-upgrade-migration
-description: |
-  Upgrade Speak SDK versions, migrate between language learning platforms, and handle API version changes.
+description: 'Upgrade Speak SDK versions, migrate between language learning platforms,
+  and handle API version changes.
+
   Use when implementing upgrade migration features,
+
   or troubleshooting Speak language learning integration issues.
+
   Trigger with phrases like "speak upgrade migration", "speak upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Upgrade & Migration
 

--- a/plugins/saas-packs/speak-pack/skills/speak-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/speak-pack/skills/speak-webhooks-events/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: speak-webhooks-events
-description: |
-  Handle Speak lesson completion events, progress webhooks, and achievement notifications.
+description: 'Handle Speak lesson completion events, progress webhooks, and achievement
+  notifications.
+
   Use when implementing webhooks events,
+
   or managing Speak language learning platform operations.
+
   Trigger with phrases like "speak webhooks events", "speak webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, speak, api]
+tags:
+- saas
+- speak
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Speak Webhooks & Events
 

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-ci-integration/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-ci-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-ci-integration
-description: |
-  CI testing for WebContainer apps with Playwright browser tests.
+description: 'CI testing for WebContainer apps with Playwright browser tests.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz CI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-common-errors/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-common-errors/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: stackblitz-common-errors
-description: |
-  Fix WebContainer and StackBlitz errors: COOP/COEP, SharedArrayBuffer, boot failures.
-  Use when WebContainers fail to boot, embeds don't load,
+description: 'Fix WebContainer and StackBlitz errors: COOP/COEP, SharedArrayBuffer,
+  boot failures.
+
+  Use when WebContainers fail to boot, embeds don''t load,
+
   or processes crash inside WebContainers.
+
   Trigger: "stackblitz error", "webcontainer error", "SharedArrayBuffer not defined".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Common Errors
 
 ## Error Reference

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-core-workflow-a/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: stackblitz-core-workflow-a
-description: |
-  Build a browser-based code editor with WebContainers: file tree, editor, terminal, and preview.
+description: 'Build a browser-based code editor with WebContainers: file tree, editor,
+  terminal, and preview.
+
   Use when creating interactive coding environments, building educational tools,
+
   or embedding development environments in web apps.
+
   Trigger: "webcontainer IDE", "browser IDE", "stackblitz editor", "code playground".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Core Workflow A: Browser IDE
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-core-workflow-b/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: stackblitz-core-workflow-b
-description: |
-  Embed StackBlitz projects and manage WebContainer snapshots for sharing.
+description: 'Embed StackBlitz projects and manage WebContainer snapshots for sharing.
+
   Use when embedding code playgrounds in docs, creating shareable examples,
+
   or building interactive tutorials with StackBlitz.
+
   Trigger: "embed stackblitz", "stackblitz embed", "stackblitz share project".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Core Workflow B: Embedding & Sharing
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-cost-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: stackblitz-cost-tuning
-description: |
-  StackBlitz pricing tiers: free embedding, WebContainer API commercial licensing.
+description: 'StackBlitz pricing tiers: free embedding, WebContainer API commercial
+  licensing.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz cost".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-debug-bundle/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: stackblitz-debug-bundle
-description: |
-  Collect WebContainer diagnostic info: boot state, file system, process list.
+description: 'Collect WebContainer diagnostic info: boot state, file system, process
+  list.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz debug".
+
+  '
 allowed-tools: Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-deploy-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-deploy-integration
-description: |
-  Deploy WebContainer apps to Vercel, Netlify with proper COOP/COEP headers.
+description: 'Deploy WebContainer apps to Vercel, Netlify with proper COOP/COEP headers.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "deploy stackblitz".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-hello-world/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-hello-world/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: stackblitz-hello-world
-description: |
-  Boot a WebContainer, mount files, install npm packages, and run a dev server in the browser.
+description: 'Boot a WebContainer, mount files, install npm packages, and run a dev
+  server in the browser.
+
   Use when learning WebContainers, building browser-based IDEs,
+
   or running Node.js without a backend server.
+
   Trigger: "stackblitz hello world", "webcontainer example", "run node in browser".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Hello World
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-install-auth/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-install-auth/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: stackblitz-install-auth
-description: |
-  Install the WebContainer API and configure StackBlitz SDK for browser-based Node.js.
+description: 'Install the WebContainer API and configure StackBlitz SDK for browser-based
+  Node.js.
+
   Use when setting up WebContainers, embedding StackBlitz projects,
+
   or initializing the @stackblitz/sdk package.
+
   Trigger: "install stackblitz", "setup webcontainers", "stackblitz SDK".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-local-dev-loop/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: stackblitz-local-dev-loop
-description: |
-  Configure local development for WebContainer applications with hot reload and testing.
+description: 'Configure local development for WebContainer applications with hot reload
+  and testing.
+
   Use when building browser-based IDEs, testing WebContainer file operations,
+
   or setting up development workflows for WebContainer projects.
+
   Trigger: "stackblitz dev setup", "webcontainer local", "test webcontainers locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-performance-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-performance-tuning
-description: |
-  Optimize WebContainer boot time, file system mounts, and process spawning.
+description: 'Optimize WebContainer boot time, file system mounts, and process spawning.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz performance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-prod-checklist/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: stackblitz-prod-checklist
-description: |
-  Production checklist for WebContainer apps: headers, browser support, fallbacks.
+description: 'Production checklist for WebContainer apps: headers, browser support,
+  fallbacks.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz production".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-rate-limits/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-rate-limits/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: stackblitz-rate-limits
-description: |
-  WebContainer resource limits: memory, CPU, file system size, process count.
+description: 'WebContainer resource limits: memory, CPU, file system size, process
+  count.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "webcontainer limits".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-reference-architecture/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-reference-architecture
-description: |
-  Production architecture for WebContainer-powered browser IDEs and playgrounds.
+description: 'Production architecture for WebContainer-powered browser IDEs and playgrounds.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz architecture".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-sdk-patterns/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: stackblitz-sdk-patterns
-description: |
-  Production patterns for WebContainer API: file system operations, process management, and jsh shell.
+description: 'Production patterns for WebContainer API: file system operations, process
+  management, and jsh shell.
+
   Use when building browser IDEs, managing WebContainer lifecycle,
+
   or implementing terminal emulation with jsh.
-  Trigger: "webcontainer patterns", "stackblitz best practices", "webcontainer file system".
+
+  Trigger: "webcontainer patterns", "stackblitz best practices", "webcontainer file
+  system".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-security-basics/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-security-basics/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: stackblitz-security-basics
-description: |
-  Secure WebContainer deployments: CSP headers, sandbox isolation, input validation.
+description: 'Secure WebContainer deployments: CSP headers, sandbox isolation, input
+  validation.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "stackblitz security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Security Basics
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-upgrade-migration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-upgrade-migration
-description: |
-  Migrate between WebContainer API versions and StackBlitz SDK updates.
+description: 'Migrate between WebContainer API versions and StackBlitz SDK updates.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "upgrade stackblitz".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/stackblitz-pack/skills/stackblitz-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/stackblitz-pack/skills/stackblitz-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: stackblitz-webhooks-events
-description: |
-  WebContainer lifecycle events: server-ready, port changes, error handling.
+description: 'WebContainer lifecycle events: server-ready, port changes, error handling.
+
   Use when working with WebContainers or StackBlitz SDK.
+
   Trigger: "webcontainer events".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ide, webcontainers, stackblitz]
-compatible-with: claude-code
+tags:
+- saas
+- ide
+- webcontainers
+- stackblitz
+compatibility: Designed for Claude Code
 ---
-
 # StackBlitz Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-advanced-troubleshooting/SKILL.md
@@ -1,21 +1,35 @@
 ---
 name: supabase-advanced-troubleshooting
-description: |
-  Deep Supabase diagnostics: pg_stat_statements for slow queries, lock debugging with
+description: 'Deep Supabase diagnostics: pg_stat_statements for slow queries, lock
+  debugging with
+
   pg_locks, connection leak detection, RLS policy conflicts, Edge Function cold starts,
+
   and Realtime connection drop analysis.
-  Use when standard troubleshooting fails, investigating performance regressions, debugging
+
+  Use when standard troubleshooting fails, investigating performance regressions,
+  debugging
+
   race conditions, or building evidence for Supabase support escalation.
+
   Trigger: "supabase deep debug", "supabase slow query", "supabase lock contention",
+
   "supabase connection leak", "supabase RLS conflict", "supabase cold start".
+
+  '
 allowed-tools: Read, Grep, Bash(npx supabase:*), Bash(supabase:*), Bash(curl:*), Bash(psql:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, debugging, advanced, performance, troubleshooting]
+tags:
+- saas
+- supabase
+- debugging
+- advanced
+- performance
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Advanced Troubleshooting
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-architecture-variants/SKILL.md
@@ -1,25 +1,44 @@
 ---
 name: supabase-architecture-variants
-description: |
-  Implement Supabase across different app architectures: Next.js SSR with
+description: 'Implement Supabase across different app architectures: Next.js SSR with
+
   server components using service_role and client components with anon key,
+
   SPA (React/Vue), mobile (React Native), serverless (Edge Functions),
+
   and multi-tenant with schema-per-tenant or RLS isolation.
+
   Use when choosing how to integrate Supabase into your specific stack,
+
   setting up SSR auth flows, configuring mobile deep links,
+
   or designing multi-tenant data isolation.
+
   Trigger with phrases like "supabase next.js", "supabase SSR",
+
   "supabase react native", "supabase SPA", "supabase serverless",
+
   "supabase multi-tenant", "supabase server component",
+
   "supabase architecture", "supabase service_role server".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, architecture, nextjs, ssr, spa, mobile, multi-tenant, serverless]
+tags:
+- saas
+- supabase
+- architecture
+- nextjs
+- ssr
+- spa
+- mobile
+- multi-tenant
+- serverless
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Architecture Variants
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-auth-storage-realtime-core/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-auth-storage-realtime-core/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: supabase-auth-storage-realtime-core
-description: |
-  Implement Supabase Auth (signUp, signIn, OAuth, session management), Storage
+description: 'Implement Supabase Auth (signUp, signIn, OAuth, session management),
+  Storage
+
   (upload, download, signed URLs, bucket policies), and Realtime (Postgres changes,
+
   broadcast, presence). Use when building user auth flows, file upload features,
+
   or live-updating UIs with Supabase. Trigger with phrases like "supabase auth",
+
   "supabase storage upload", "supabase realtime subscribe", "supabase oauth",
+
   "supabase file upload", "supabase presence", "supabase rls storage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(supabase:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, cursor
-tags: [saas, supabase, auth, storage, realtime, rls]
+tags:
+- saas
+- supabase
+- auth
+- storage
+- realtime
+- rls
+compatibility: Designed for Claude Code, also compatible with Cursor
 ---
-
 # Supabase Auth + Storage + Realtime Core
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-ci-integration/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-ci-integration/SKILL.md
@@ -1,21 +1,32 @@
 ---
 name: supabase-ci-integration
-description: |
-  Configure Supabase CI/CD pipelines with GitHub Actions: link projects,
+description: 'Configure Supabase CI/CD pipelines with GitHub Actions: link projects,
+
   push migrations, deploy Edge Functions, generate types, and run tests
+
   against local Supabase instances.
+
   Use when setting up CI pipelines for Supabase, automating database
+
   migrations, deploying Edge Functions in CI, or running integration tests.
+
   Trigger with phrases like "supabase CI", "supabase GitHub Actions",
+
   "supabase deploy pipeline", "CI supabase migrations", "supabase preview branches".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(gh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, ci-cd, github-actions, devops]
+tags:
+- saas
+- supabase
+- ci-cd
+- github-actions
+- devops
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase CI Integration
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-common-errors/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-common-errors/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: supabase-common-errors
-description: |
-  Diagnose and fix Supabase errors across PostgREST, PostgreSQL, Auth, Storage, and Realtime.
+description: 'Diagnose and fix Supabase errors across PostgREST, PostgreSQL, Auth,
+  Storage, and Realtime.
+
   Use when encountering error codes like PGRST301, 42501, 23505, or auth failures.
+
   Use when debugging failed queries, RLS policy violations, or HTTP 4xx/5xx responses.
-  Trigger with "supabase error", "fix supabase", "PGRST", "supabase 403", "RLS not working",
+
+  Trigger with "supabase error", "fix supabase", "PGRST", "supabase 403", "RLS not
+  working",
+
   "supabase auth error", "unique constraint", "foreign key violation".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*), Bash(supabase:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, debugging, errors, postgrest, rls, auth]
+tags:
+- saas
+- supabase
+- debugging
+- errors
+- postgrest
+- rls
+- auth
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Common Errors
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-cost-tuning/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: supabase-cost-tuning
-description: |
-  Optimize Supabase costs through plan selection, database tuning, storage cleanup,
+description: 'Optimize Supabase costs through plan selection, database tuning, storage
+  cleanup,
+
   connection pooling, and Edge Function optimization.
+
   Use when analyzing Supabase billing, reducing costs, right-sizing compute,
+
   or implementing usage tracking and budget alerts.
+
   Trigger with phrases like "supabase cost", "supabase billing",
+
   "reduce supabase costs", "supabase pricing", "supabase expensive", "supabase budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(supabase:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, cost-optimization]
+tags:
+- saas
+- supabase
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-data-handling/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-data-handling/SKILL.md
@@ -1,21 +1,37 @@
 ---
 name: supabase-data-handling
-description: |
-  Implement GDPR/CCPA compliance with Supabase: RLS for data isolation, user deletion
+description: 'Implement GDPR/CCPA compliance with Supabase: RLS for data isolation,
+  user deletion
+
   via auth.admin.deleteUser(), data export via SQL, PII column management,
+
   backup/restore workflows, and retention policies.
-  Use when handling sensitive data, implementing right-to-deletion, configuring data retention,
+
+  Use when handling sensitive data, implementing right-to-deletion, configuring data
+  retention,
+
   or auditing PII in Supabase database columns.
+
   Trigger: "supabase GDPR", "supabase data handling", "supabase PII", "supabase compliance",
+
   "supabase data retention", "supabase delete user", "supabase data export".
-allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, gdpr, ccpa, compliance, data-handling, privacy]
+tags:
+- saas
+- supabase
+- gdpr
+- ccpa
+- compliance
+- data-handling
+- privacy
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Data Handling
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: supabase-debug-bundle
-description: |
-  Collect Supabase diagnostic info for troubleshooting and support tickets.
+description: 'Collect Supabase diagnostic info for troubleshooting and support tickets.
+
   Use when debugging connection failures, auth issues, Realtime drops, Storage
+
   errors, RLS misconfigurations, or preparing a support escalation.
+
   Trigger: "supabase debug", "supabase diagnostics", "supabase support bundle",
+
   "collect supabase logs", "debug supabase connection".
-allowed-tools: Read, Bash(npx:*), Bash(node:*), Bash(curl:*), Bash(supabase:*), Bash(tar:*), Grep, Glob
+
+  '
+allowed-tools: Read, Bash(npx:*), Bash(node:*), Bash(curl:*), Bash(supabase:*), Bash(tar:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, debugging, support, diagnostics]
+tags:
+- saas
+- supabase
+- debugging
+- support
+- diagnostics
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Debug Bundle
 
 Collect a comprehensive, redacted diagnostic bundle from a Supabase project. Tests connectivity, auth, Realtime, Storage, RLS policy behavior, and database health — then packages everything into a single archive safe for sharing with Supabase support.

--- a/plugins/saas-packs/supabase-pack/skills/supabase-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-deploy-integration/SKILL.md
@@ -1,21 +1,33 @@
 ---
 name: supabase-deploy-integration
-description: |
-  Deploy and manage Supabase projects in production. Covers database migrations,
+description: 'Deploy and manage Supabase projects in production. Covers database migrations,
+
   Edge Functions deployment, secrets management, zero-downtime rollouts,
+
   blue/green branching, rollback procedures, and post-deploy health checks.
+
   Use when deploying Supabase to production, running migrations, deploying
+
   Edge Functions, managing secrets, or implementing zero-downtime deployments.
+
   Trigger: "deploy supabase", "supabase migration push", "deploy edge function",
+
   "supabase rollback", "supabase blue green", "supabase health check".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, deployment, migrations, edge-functions, devops]
+tags:
+- saas
+- supabase
+- deployment
+- migrations
+- edge-functions
+- devops
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-enterprise-rbac/SKILL.md
@@ -1,20 +1,36 @@
 ---
 name: supabase-enterprise-rbac
-description: |
-  Implement custom role-based access control via JWT claims in Supabase: app_metadata.role,
-  RLS policies with auth.jwt() role extraction, organization-scoped access, and API key scoping.
+description: 'Implement custom role-based access control via JWT claims in Supabase:
+  app_metadata.role,
+
+  RLS policies with auth.jwt() role extraction, organization-scoped access, and API
+  key scoping.
+
   Use when implementing role-based permissions, configuring organization-level access,
+
   building admin/member/viewer hierarchies, or scoping API keys per role.
-  Trigger: "supabase RBAC", "supabase roles", "supabase permissions", "supabase JWT claims",
+
+  Trigger: "supabase RBAC", "supabase roles", "supabase permissions", "supabase JWT
+  claims",
+
   "supabase organization access", "supabase custom roles", "supabase app_metadata".
-allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, rbac, security, enterprise, roles, permissions]
+tags:
+- saas
+- supabase
+- rbac
+- security
+- enterprise
+- roles
+- permissions
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-hello-world/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-hello-world/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: supabase-hello-world
-description: |
-  Run your first Supabase query — insert a row and read it back.
-  Use when starting a new Supabase project, verifying your connection works,
-  or learning the basic insert-then-select pattern with @supabase/supabase-js.
-  Trigger with phrases like "supabase hello world", "first supabase query",
-  "supabase quick start", "test supabase connection", "supabase insert and select".
+description: "Run your first Supabase query \u2014 insert a row and read it back.\n\
+  Use when starting a new Supabase project, verifying your connection works,\nor learning\
+  \ the basic insert-then-select pattern with @supabase/supabase-js.\nTrigger with\
+  \ phrases like \"supabase hello world\", \"first supabase query\",\n\"supabase quick\
+  \ start\", \"test supabase connection\", \"supabase insert and select\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(supabase:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, database, getting-started]
+tags:
+- saas
+- supabase
+- database
+- getting-started
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Hello World — First Query
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-incident-runbook/SKILL.md
@@ -1,20 +1,33 @@
 ---
 name: supabase-incident-runbook
-description: |
-  Execute Supabase incident response: dashboard health checks, connection pool status,
-  pg_stat_activity queries, RLS debugging, Edge Function logs, storage health, and escalation.
+description: 'Execute Supabase incident response: dashboard health checks, connection
+  pool status,
+
+  pg_stat_activity queries, RLS debugging, Edge Function logs, storage health, and
+  escalation.
+
   Use when responding to Supabase outages, investigating production errors, debugging
+
   connection issues, or preparing evidence for Supabase support escalation.
+
   Trigger: "supabase incident", "supabase outage", "supabase down", "supabase on-call",
+
   "supabase emergency", "supabase broken", "supabase connection issues".
+
+  '
 allowed-tools: Read, Grep, Bash(npx supabase:*), Bash(supabase:*), Bash(curl:*), Bash(psql:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, incident-response, debugging, operations, runbook]
+tags:
+- saas
+- supabase
+- incident-response
+- debugging
+- operations
+- runbook
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-install-auth/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-install-auth/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: supabase-install-auth
-description: |
-  Install and configure Supabase SDK, CLI, and project authentication.
+description: 'Install and configure Supabase SDK, CLI, and project authentication.
+
   Use when setting up a new Supabase project, installing @supabase/supabase-js,
+
   configuring environment variables, or initializing the Supabase client.
+
   Trigger with "install supabase", "setup supabase", "supabase auth config",
+
   "configure supabase", "supabase init", "add supabase to project".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Bash(pip:*), Bash(supabase:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Bash(pip:*),
+  Bash(supabase:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, setup, authentication, sdk]
+tags:
+- saas
+- supabase
+- setup
+- authentication
+- sdk
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-known-pitfalls/SKILL.md
@@ -1,24 +1,41 @@
 ---
 name: supabase-known-pitfalls
-description: |
-  Avoid and fix the most common Supabase mistakes: exposing service_role key
+description: 'Avoid and fix the most common Supabase mistakes: exposing service_role
+  key
+
   in client bundles, forgetting to enable RLS, not using connection pooling
+
   in serverless, .single() throwing on empty results, missing .select() after
+
   insert/update, not destructuring { data, error }, creating multiple client
+
   instances, and not using generated types.
+
   Use when reviewing Supabase code, onboarding developers, auditing an
+
   existing project, or debugging unexpected behavior.
+
   Trigger with phrases like "supabase mistakes", "supabase anti-patterns",
+
   "supabase pitfalls", "supabase code review", "supabase gotchas",
+
   "supabase debugging", "what not to do supabase", "supabase common errors".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, anti-patterns, code-review, debugging, security, pitfalls]
+tags:
+- saas
+- supabase
+- anti-patterns
+- code-review
+- debugging
+- security
+- pitfalls
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Known Pitfalls
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-load-scale/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-load-scale/SKILL.md
@@ -1,23 +1,39 @@
 ---
 name: supabase-load-scale
-description: |
-  Scale Supabase projects for production load: read replicas, connection pooling
+description: 'Scale Supabase projects for production load: read replicas, connection
+  pooling
+
   tuning via Supavisor, compute size upgrades, CDN caching for Storage,
+
   Edge Function regional deployment, and database table partitioning.
+
   Use when preparing for traffic spikes, optimizing connection limits,
+
   setting up read replicas for analytics queries, or partitioning large tables.
+
   Trigger with phrases like "supabase scale", "supabase read replica",
+
   "supabase connection pooling", "supabase compute upgrade",
+
   "supabase CDN storage", "supabase edge function regions",
+
   "supabase partitioning", "supavisor", "supabase pool mode".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(psql:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, scaling, performance, connection-pooling, read-replicas, partitioning]
+tags:
+- saas
+- supabase
+- scaling
+- performance
+- connection-pooling
+- read-replicas
+- partitioning
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Load & Scale
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-local-dev-loop/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: supabase-local-dev-loop
-description: |
-  Configure Supabase local development with the CLI, Docker, and migration workflow.
+description: 'Configure Supabase local development with the CLI, Docker, and migration
+  workflow.
+
   Use when initializing a Supabase project locally, starting the local stack,
+
   writing migrations, seeding data, or iterating on schema changes.
+
   Trigger with phrases like "supabase local dev", "supabase start",
+
   "supabase init", "supabase db reset", "supabase local setup".
-allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(supabase:*), Bash(docker:*), Bash(curl:*), Grep
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(supabase:*), Bash(docker:*), Bash(curl:*),
+  Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, supabase, local-development, docker, postgres]
+tags:
+- saas
+- supabase
+- local-development
+- docker
+- postgres
+compatibility: Designed for Claude Code
 ---
-
 # Supabase Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-migration-deep-dive/SKILL.md
@@ -1,20 +1,36 @@
 ---
 name: supabase-migration-deep-dive
-description: |
-  Database migration patterns with Supabase CLI: npx supabase migration new, zero-downtime
-  migrations, data backfill strategies, schema versioning, rollback strategies, and type generation.
-  Use when creating database migrations, performing zero-downtime schema changes, backfilling
+description: 'Database migration patterns with Supabase CLI: npx supabase migration
+  new, zero-downtime
+
+  migrations, data backfill strategies, schema versioning, rollback strategies, and
+  type generation.
+
+  Use when creating database migrations, performing zero-downtime schema changes,
+  backfilling
+
   data in production, managing schema versions, or planning rollback strategies.
+
   Trigger: "supabase migration", "supabase schema change", "supabase zero downtime",
+
   "supabase rollback", "supabase db push", "supabase migration new".
-allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(psql:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, migration, database, schema, zero-downtime, rollback]
+tags:
+- saas
+- supabase
+- migration
+- database
+- schema
+- zero-downtime
+- rollback
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-multi-env-setup/SKILL.md
@@ -1,20 +1,33 @@
 ---
 name: supabase-multi-env-setup
-description: |
-  Configure Supabase across development, staging, and production with separate projects,
+description: 'Configure Supabase across development, staging, and production with
+  separate projects,
+
   environment-specific secrets, and safe migration promotion.
+
   Use when setting up multi-environment deployments, isolating dev from prod data,
+
   configuring per-environment Supabase projects, or promoting migrations through environments.
+
   Trigger: "supabase environments", "supabase staging", "supabase dev prod",
+
   "supabase multi-project", "supabase env config", "database branching".
-allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(vercel:*), Grep, Glob
+
+  '
+allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Bash(vercel:*),
+  Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, deployment, environments, multi-env, devops]
+tags:
+- saas
+- supabase
+- deployment
+- environments
+- multi-env
+- devops
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-observability/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-observability/SKILL.md
@@ -1,21 +1,31 @@
 ---
 name: supabase-observability
-description: |
-  Set up monitoring and observability for Supabase projects using Dashboard
+description: 'Set up monitoring and observability for Supabase projects using Dashboard
+
   reports, CLI inspect commands, pg_stat_statements, log drains, and alerting.
+
   Use when implementing monitoring, diagnosing slow queries, forwarding logs,
+
   or configuring alerts for Supabase project health.
+
   Trigger with phrases like "supabase monitoring", "supabase metrics",
+
   "supabase observability", "supabase logs", "supabase alerts",
+
   "supabase inspect", "supabase log drain".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(supabase:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code
-tags: [saas, supabase, monitoring, observability]
+tags:
+- saas
+- supabase
+- monitoring
+- observability
+compatibility: Designed for Claude Code
 ---
-
 # Supabase Observability
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-performance-tuning/SKILL.md
@@ -1,21 +1,33 @@
 ---
 name: supabase-performance-tuning
-description: |
-  Optimize Supabase query performance with indexes, EXPLAIN ANALYZE, connection pooling,
+description: 'Optimize Supabase query performance with indexes, EXPLAIN ANALYZE, connection
+  pooling,
+
   column selection, pagination, RPC functions, materialized views, and diagnostics.
+
   Use when queries are slow, connections are exhausted, response payloads are bloated,
+
   or when preparing a Supabase project for production-scale traffic.
+
   Trigger with phrases like "supabase performance", "supabase slow queries",
+
   "optimize supabase", "supabase index", "supabase connection pool",
+
   "supabase pagination", "supabase explain analyze".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, performance, optimization, postgres]
+tags:
+- saas
+- supabase
+- performance
+- optimization
+- postgres
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
@@ -1,24 +1,41 @@
 ---
 name: supabase-policy-guardrails
-description: |
-  Enforce organizational governance for Supabase projects: shared RLS policy
+description: 'Enforce organizational governance for Supabase projects: shared RLS
+  policy
+
   library with reusable templates, table and column naming conventions,
+
   migration review process with CI checks, cost alert thresholds,
+
   and security audit scripts scanning for common misconfigurations.
+
   Use when establishing Supabase standards across teams, creating RLS
+
   policy templates, setting up migration review workflows, or auditing
+
   existing projects for security and cost issues.
+
   Trigger with phrases like "supabase governance", "supabase policy library",
+
   "supabase naming convention", "supabase migration review",
+
   "supabase cost alert", "supabase security audit", "supabase RLS template".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(psql:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, governance, security, rls, naming-conventions, cost-management]
+tags:
+- saas
+- supabase
+- governance
+- security
+- rls
+- naming-conventions
+- cost-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Policy Guardrails
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-prod-checklist/SKILL.md
@@ -1,21 +1,33 @@
 ---
 name: supabase-prod-checklist
-description: |
-  Execute Supabase production deployment checklist covering RLS, key hygiene,
+description: 'Execute Supabase production deployment checklist covering RLS, key hygiene,
+
   connection pooling, backups, monitoring, Edge Functions, and Storage policies.
+
   Use when deploying to production, preparing for launch,
+
   or auditing a live Supabase project for security and performance gaps.
+
   Trigger with "supabase production", "supabase go-live",
+
   "supabase launch checklist", "supabase prod ready", "deploy supabase",
+
   "supabase production readiness".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx supabase:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, deployment, production, security, rls]
+tags:
+- saas
+- supabase
+- deployment
+- production
+- security
+- rls
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Production Deployment Checklist
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-rate-limits/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-rate-limits/SKILL.md
@@ -1,18 +1,29 @@
 ---
 name: supabase-rate-limits
-description: |
-  Manage Supabase rate limits and quotas across all plan tiers.
+description: 'Manage Supabase rate limits and quotas across all plan tiers.
+
   Use when hitting 429 errors, configuring connection pooling,
+
   optimizing API throughput, or understanding tier-specific quotas
+
   for Auth, Storage, Realtime, and Edge Functions.
+
   Trigger: "supabase rate limit", "supabase 429", "supabase throttle",
+
   "supabase quota", "supabase connection pool", "supabase too many requests".
+
+  '
 allowed-tools: Read, Write, Edit, Bash, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, rate-limiting, reliability, quotas]
+tags:
+- saas
+- supabase
+- rate-limiting
+- reliability
+- quotas
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Supabase Rate Limits
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-reference-architecture/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: supabase-reference-architecture
-description: |
-  Implement enterprise Supabase reference architectures — monorepo layout, multi-tenant RLS,
-  microservices with cross-project access, framework integration, edge functions, caching,
-  queue patterns, and audit logging.
-  Use when designing a new Supabase project from scratch, reviewing project structure for
-  production readiness, planning multi-tenant isolation, or establishing team architecture standards.
-  Trigger with phrases like "supabase architecture", "supabase project structure",
-  "supabase monorepo", "supabase multi-tenant", "supabase reference design",
-  "how to organize supabase at scale".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(supabase:*), Grep, Glob
+description: "Implement enterprise Supabase reference architectures \u2014 monorepo\
+  \ layout, multi-tenant RLS,\nmicroservices with cross-project access, framework\
+  \ integration, edge functions, caching,\nqueue patterns, and audit logging.\nUse\
+  \ when designing a new Supabase project from scratch, reviewing project structure\
+  \ for\nproduction readiness, planning multi-tenant isolation, or establishing team\
+  \ architecture standards.\nTrigger with phrases like \"supabase architecture\",\
+  \ \"supabase project structure\",\n\"supabase monorepo\", \"supabase multi-tenant\"\
+  , \"supabase reference design\",\n\"how to organize supabase at scale\".\n"
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(supabase:*), Grep,
+  Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, architecture, patterns, multi-tenant, monorepo]
+tags:
+- saas
+- supabase
+- architecture
+- patterns
+- multi-tenant
+- monorepo
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
@@ -1,23 +1,38 @@
 ---
 name: supabase-reliability-patterns
-description: |
-  Build resilient Supabase integrations: circuit breakers wrapping createClient
+description: 'Build resilient Supabase integrations: circuit breakers wrapping createClient
+
   calls, offline queue with IndexedDB, graceful degradation with cached fallbacks,
+
   health check endpoints, retry with exponential backoff and jitter,
+
   and dual-write patterns for critical data.
+
   Use when building fault-tolerant apps, handling Supabase outages gracefully,
+
   implementing offline-first patterns, or adding retry logic to SDK calls.
+
   Trigger with phrases like "supabase circuit breaker", "supabase offline",
+
   "supabase retry", "supabase health check", "supabase fallback",
+
   "supabase resilience", "supabase dual write", "supabase outage".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, reliability, resilience, circuit-breaker, offline, retry]
+tags:
+- saas
+- supabase
+- reliability
+- resilience
+- circuit-breaker
+- offline
+- retry
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Reliability Patterns
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-schema-from-requirements/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-schema-from-requirements/SKILL.md
@@ -1,17 +1,30 @@
 ---
 name: supabase-schema-from-requirements
-description: |
-  Design Supabase Postgres schema from business requirements with migrations, RLS, and types.
+description: 'Design Supabase Postgres schema from business requirements with migrations,
+  RLS, and types.
+
   Use when translating specifications into database tables, creating migration files,
+
   adding Row Level Security policies, or generating TypeScript types from schema.
+
   Trigger with phrases like "supabase schema", "design database supabase",
+
   "schema from requirements", "supabase migration", "supabase tables from spec".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, database, migration, schema-design, postgres, rls]
+tags:
+- saas
+- supabase
+- database
+- migration
+- schema-design
+- postgres
+- rls
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Supabase Schema from Requirements
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-sdk-patterns/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: supabase-sdk-patterns
-description: |
-  Apply production-ready Supabase SDK patterns for TypeScript and Python projects.
+description: 'Apply production-ready Supabase SDK patterns for TypeScript and Python
+  projects.
+
   Use when implementing queries, auth, realtime, storage, or RPC calls
+
   with @supabase/supabase-js or supabase-py.
+
   Trigger with phrases like "supabase SDK patterns", "supabase query",
+
   "supabase typescript", "supabase python", "supabase client setup",
+
   "supabase realtime", "supabase auth", "supabase storage".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, cursor
-tags: [saas, supabase, typescript, python, sdk, patterns]
+tags:
+- saas
+- supabase
+- typescript
+- python
+- sdk
+- patterns
+compatibility: Designed for Claude Code, also compatible with Cursor
 ---
-
 # Supabase SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-security-basics/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-security-basics/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: supabase-security-basics
-description: |
-  Apply Supabase security best practices: anon vs service_role key separation,
+description: 'Apply Supabase security best practices: anon vs service_role key separation,
+
   RLS enforcement, policy patterns, JWT verification, and API hardening.
+
   Use when securing a Supabase project, auditing API key usage,
+
   implementing Row Level Security, or running a production security checklist.
+
   Trigger with phrases like "supabase security", "supabase RLS",
+
   "secure supabase", "supabase API key", "supabase hardening",
+
   "row level security", "service role key".
+
+  '
 allowed-tools: Read, Write, Edit, Grep, Bash(supabase:*), Bash(npx supabase:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, security, rls, jwt, api-keys]
+tags:
+- saas
+- supabase
+- security
+- rls
+- jwt
+- api-keys
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Supabase Security Basics
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-upgrade-migration/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: supabase-upgrade-migration
-description: |
-  Upgrade Supabase SDK and CLI versions with breaking-change detection and automated code migration.
-  Use when upgrading @supabase/supabase-js (v1→v2 or minor bumps), migrating auth/realtime/storage
-  APIs, or updating the Supabase CLI. Trigger with phrases like "upgrade supabase",
-  "supabase breaking changes", "migrate supabase v2", "update supabase SDK".
-allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(supabase:*), Bash(git:*), Grep, Glob
+description: "Upgrade Supabase SDK and CLI versions with breaking-change detection\
+  \ and automated code migration.\nUse when upgrading @supabase/supabase-js (v1\u2192\
+  v2 or minor bumps), migrating auth/realtime/storage\nAPIs, or updating the Supabase\
+  \ CLI. Trigger with phrases like \"upgrade supabase\",\n\"supabase breaking changes\"\
+  , \"migrate supabase v2\", \"update supabase SDK\".\n"
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(supabase:*),
+  Bash(git:*), Grep, Glob
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, migration, upgrade, sdk]
+tags:
+- saas
+- supabase
+- migration
+- upgrade
+- sdk
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/supabase-pack/skills/supabase-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-webhooks-events/SKILL.md
@@ -1,22 +1,36 @@
 ---
 name: supabase-webhooks-events
-description: |
-  Implement Supabase database webhooks, pg_net async HTTP, LISTEN/NOTIFY,
+description: 'Implement Supabase database webhooks, pg_net async HTTP, LISTEN/NOTIFY,
+
   and Edge Function event handlers with signature verification.
+
   Use when setting up database webhooks for INSERT/UPDATE/DELETE events,
+
   sending HTTP requests from PostgreSQL triggers, handling Realtime
+
   postgres_changes as an event source, or building event-driven architectures.
+
   Trigger with phrases like "supabase webhook", "database events",
+
   "pg_net trigger", "supabase LISTEN NOTIFY", "webhook signature verify",
+
   "supabase event-driven", "supabase_functions.http_request".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(curl:*), Bash(psql:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, supabase, webhooks, events, triggers, pg_net, realtime]
+tags:
+- saas
+- supabase
+- webhooks
+- events
+- triggers
+- pg_net
+- realtime
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
-
 # Supabase Webhooks & Database Events
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-ci-integration/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-ci-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-ci-integration
-description: |
-  TechSmith ci integration for Snagit COM API and Camtasia automation.
+description: 'TechSmith ci integration for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-common-errors/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-common-errors/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-common-errors
-description: |
-  TechSmith common errors for Snagit COM API and Camtasia automation.
+description: 'TechSmith common errors for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Common Errors
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-core-workflow-a/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-core-workflow-a
-description: |
-  TechSmith core workflow a for Snagit COM API and Camtasia automation.
+description: 'TechSmith core workflow a for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith core workflow a".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-core-workflow-b/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-core-workflow-b
-description: |
-  TechSmith core workflow b for Snagit COM API and Camtasia automation.
+description: 'TechSmith core workflow b for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith core workflow b".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-cost-tuning
-description: |
-  TechSmith cost tuning for Snagit COM API and Camtasia automation.
+description: 'TechSmith cost tuning for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-debug-bundle/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-debug-bundle
-description: |
-  TechSmith debug bundle for Snagit COM API and Camtasia automation.
+description: 'TechSmith debug bundle for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-deploy-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-deploy-integration
-description: |
-  TechSmith deploy integration for Snagit COM API and Camtasia automation.
+description: 'TechSmith deploy integration for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-hello-world/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-hello-world/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: techsmith-hello-world
-description: |
-  Capture a screenshot with Snagit COM API and produce a Camtasia video.
+description: 'Capture a screenshot with Snagit COM API and produce a Camtasia video.
+
   Use when automating screen captures, batch-processing recordings,
+
   or building documentation pipelines with TechSmith tools.
+
   Trigger: "techsmith hello world, snagit capture, camtasia render".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Hello World
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-install-auth/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: techsmith-install-auth
-description: |
-  Install TechSmith Snagit COM API and register the COM server for automation.
+description: 'Install TechSmith Snagit COM API and register the COM server for automation.
+
   Use when setting up Snagit automation, configuring COM interop,
+
   or initializing Camtasia batch processing.
+
   Trigger: "install techsmith, setup snagit, techsmith COM API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-local-dev-loop/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-local-dev-loop
-description: |
-  TechSmith local dev loop for Snagit COM API and Camtasia automation.
+description: 'TechSmith local dev loop for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-performance-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-performance-tuning
-description: |
-  TechSmith performance tuning for Snagit COM API and Camtasia automation.
+description: 'TechSmith performance tuning for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-prod-checklist/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-prod-checklist
-description: |
-  TechSmith prod checklist for Snagit COM API and Camtasia automation.
+description: 'TechSmith prod checklist for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-rate-limits/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-rate-limits/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-rate-limits
-description: |
-  TechSmith rate limits for Snagit COM API and Camtasia automation.
+description: 'TechSmith rate limits for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-reference-architecture/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-reference-architecture
-description: |
-  TechSmith reference architecture for Snagit COM API and Camtasia automation.
+description: 'TechSmith reference architecture for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-sdk-patterns/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-sdk-patterns
-description: |
-  TechSmith sdk patterns for Snagit COM API and Camtasia automation.
+description: 'TechSmith sdk patterns for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-security-basics/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-security-basics/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-security-basics
-description: |
-  TechSmith security basics for Snagit COM API and Camtasia automation.
+description: 'TechSmith security basics for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Security Basics
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-upgrade-migration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-upgrade-migration
-description: |
-  TechSmith upgrade migration for Snagit COM API and Camtasia automation.
+description: 'TechSmith upgrade migration for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/techsmith-pack/skills/techsmith-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/techsmith-pack/skills/techsmith-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: techsmith-webhooks-events
-description: |
-  TechSmith webhooks events for Snagit COM API and Camtasia automation.
+description: 'TechSmith webhooks events for Snagit COM API and Camtasia automation.
+
   Use when working with TechSmith screen capture and video editing automation.
+
   Trigger: "techsmith webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(powershell:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, screen-capture, video, techsmith]
-compatible-with: claude-code
+tags:
+- saas
+- screen-capture
+- video
+- techsmith
+compatibility: Designed for Claude Code
 ---
-
 # TechSmith Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-ci-integration/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-ci-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-ci-integration
-description: |
-  Together AI ci integration for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI ci integration for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI CI Integration
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-common-errors/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-common-errors/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-common-errors
-description: |
-  Together AI common errors for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI common errors for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Common Errors
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-core-workflow-a/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-core-workflow-a
-description: |
-  Together AI core workflow a for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI core workflow a for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together core workflow a".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-core-workflow-b/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-core-workflow-b
-description: |
-  Together AI core workflow b for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI core workflow b for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together core workflow b".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI — Fine-Tuning & Model Management
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-cost-tuning
-description: |
-  Together AI cost tuning for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI cost tuning for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-debug-bundle/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-debug-bundle
-description: |
-  Together AI debug bundle for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI debug bundle for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-deploy-integration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: together-deploy-integration
-description: |
-  Together AI deploy integration for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI deploy integration for inference, fine-tuning, and model
+  deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-hello-world/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-hello-world/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: together-hello-world
-description: |
-  Run inference with Together AI -- chat completions, streaming, and model selection.
+description: 'Run inference with Together AI -- chat completions, streaming, and model
+  selection.
+
   Use when testing open-source models, comparing model performance,
+
   or learning the Together AI API.
+
   Trigger: "together hello world, together AI example, run llama".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(python3:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Hello World
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-install-auth/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: together-install-auth
-description: |
-  Install Together AI SDK and configure API key for inference and fine-tuning.
+description: 'Install Together AI SDK and configure API key for inference and fine-tuning.
+
   Use when setting up Together AI, configuring the OpenAI-compatible API,
+
   or initializing the together Python package.
+
   Trigger: "install together, setup together ai, together API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-local-dev-loop/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-local-dev-loop
-description: |
-  Together AI local dev loop for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI local dev loop for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-performance-tuning/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: together-performance-tuning
-description: |
-  Together AI performance tuning for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI performance tuning for inference, fine-tuning, and model
+  deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-prod-checklist/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-prod-checklist
-description: |
-  Together AI prod checklist for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI prod checklist for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-rate-limits/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-rate-limits/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-rate-limits
-description: |
-  Together AI rate limits for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI rate limits for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-reference-architecture/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: together-reference-architecture
-description: |
-  Together AI reference architecture for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI reference architecture for inference, fine-tuning, and model
+  deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-sdk-patterns/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-sdk-patterns
-description: |
-  Together AI sdk patterns for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI sdk patterns for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-security-basics/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-security-basics/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-security-basics
-description: |
-  Together AI security basics for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI security basics for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Security Basics
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-upgrade-migration/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: together-upgrade-migration
-description: |
-  Together AI upgrade migration for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI upgrade migration for inference, fine-tuning, and model
+  deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/together-pack/skills/together-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/together-pack/skills/together-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: together-webhooks-events
-description: |
-  Together AI webhooks events for inference, fine-tuning, and model deployment.
-  Use when working with Together AI's OpenAI-compatible API.
+description: 'Together AI webhooks events for inference, fine-tuning, and model deployment.
+
+  Use when working with Together AI''s OpenAI-compatible API.
+
   Trigger: "together webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, ai, inference, together]
-compatible-with: claude-code
+tags:
+- saas
+- ai
+- inference
+- together
+compatibility: Designed for Claude Code
 ---
-
 # Together AI Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-ci-integration/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-ci-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-ci-integration
-description: |
-  Integrate TwinMind meeting transcription workflows into CI/CD pipelines for automated meeting documentation and action item tracking.
+description: 'Integrate TwinMind meeting transcription workflows into CI/CD pipelines
+  for automated meeting documentation and action item tracking.
+
   Use when implementing ci integration,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind ci integration", "twinmind ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'ci-cd']
+tags:
+- saas
+- twinmind
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind CI Integration
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-common-errors/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: twinmind-common-errors
-description: |
-  Diagnose and fix TwinMind common errors and exceptions.
+description: 'Diagnose and fix TwinMind common errors and exceptions.
+
   Use when encountering transcription errors, debugging failed requests,
+
   or troubleshooting integration issues.
+
   Trigger with phrases like "twinmind error", "fix twinmind",
+
   "twinmind not working", "debug twinmind", "transcription failed".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, debugging, transcription]
+tags:
+- saas
+- twinmind
+- debugging
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Common Errors
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-core-workflow-a/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: twinmind-core-workflow-a
-description: |
-  Execute TwinMind primary workflow: Meeting transcription and summary generation.
+description: 'Execute TwinMind primary workflow: Meeting transcription and summary
+  generation.
+
   Use when implementing meeting capture, building transcription features,
+
   or automating meeting documentation.
+
   Trigger with phrases like "twinmind transcription workflow",
+
   "meeting transcription", "capture meeting with twinmind".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, transcription, workflow]
+tags:
+- saas
+- twinmind
+- transcription
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Core Workflow A: Meeting Transcription & Summary
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-core-workflow-b/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: twinmind-core-workflow-b
-description: |
-  Execute TwinMind secondary workflow: Action item extraction and follow-up automation.
+description: 'Execute TwinMind secondary workflow: Action item extraction and follow-up
+  automation.
+
   Use when automating meeting follow-ups, extracting tasks,
+
   or integrating with project management tools.
+
   Trigger with phrases like "twinmind action items",
+
   "meeting follow-up automation", "extract tasks from meeting".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, workflow]
+tags:
+- saas
+- twinmind
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Core Workflow B: Action Items & Follow-ups
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-cost-tuning/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-cost-tuning
-description: |
-  Optimize TwinMind costs across Free, Pro ($10/mo), and Enterprise tiers with usage monitoring and tier selection guidance.
+description: 'Optimize TwinMind costs across Free, Pro ($10/mo), and Enterprise tiers
+  with usage monitoring and tier selection guidance.
+
   Use when implementing cost tuning,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind cost tuning", "twinmind cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'cost-optimization']
+tags:
+- saas
+- twinmind
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Cost Tuning
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-data-handling/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-data-handling/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-data-handling
-description: |
-  Handle TwinMind meeting data with GDPR compliance: transcript storage, memory vault management, data export, and deletion policies.
+description: 'Handle TwinMind meeting data with GDPR compliance: transcript storage,
+  memory vault management, data export, and deletion policies.
+
   Use when implementing data handling,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind data handling", "twinmind data handling".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'compliance']
+tags:
+- saas
+- twinmind
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Data Handling
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: twinmind-debug-bundle
-description: |
-  Collect comprehensive diagnostic information for TwinMind issues.
+description: 'Collect comprehensive diagnostic information for TwinMind issues.
+
   Use when preparing support requests, investigating complex problems,
+
   or gathering evidence for bug reports.
+
   Trigger with phrases like "twinmind debug", "twinmind diagnostics",
+
   "collect twinmind info", "twinmind support bundle".
+
+  '
 allowed-tools: Read, Write, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, debugging]
+tags:
+- saas
+- twinmind
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Debug Bundle
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-deploy-integration/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-deploy-integration
-description: |
-  Deploy TwinMind integrations to production environments with Chrome extension deployment, mobile app configuration, and API access setup.
+description: 'Deploy TwinMind integrations to production environments with Chrome
+  extension deployment, mobile app configuration, and API access setup.
+
   Use when implementing deploy integration,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind deploy integration", "twinmind deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'deployment']
+tags:
+- saas
+- twinmind
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Deploy Integration
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-enterprise-rbac/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-enterprise-rbac
-description: |
-  Configure TwinMind Enterprise with on-premise deployment, custom AI models, SSO integration, and team-wide transcript sharing.
+description: 'Configure TwinMind Enterprise with on-premise deployment, custom AI
+  models, SSO integration, and team-wide transcript sharing.
+
   Use when implementing enterprise rbac,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind enterprise rbac", "twinmind enterprise rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'rbac']
+tags:
+- saas
+- twinmind
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Enterprise RBAC
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-hello-world/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: twinmind-hello-world
-description: |
-  Create your first TwinMind meeting transcription and AI summary.
+description: 'Create your first TwinMind meeting transcription and AI summary.
+
   Use when starting with TwinMind, testing your setup,
+
   or learning basic transcription and summary patterns.
+
   Trigger with phrases like "twinmind hello world", "first twinmind meeting",
+
   "twinmind quick start", "test twinmind transcription".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, testing, transcription]
+tags:
+- saas
+- twinmind
+- testing
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Hello World
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-incident-runbook/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-incident-runbook
-description: |
-  Incident response for TwinMind failures: transcription not starting, audio not captured, sync failures, and calendar disconnect.
+description: 'Incident response for TwinMind failures: transcription not starting,
+  audio not captured, sync failures, and calendar disconnect.
+
   Use when implementing incident runbook,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind incident runbook", "twinmind incident runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'incident-response']
+tags:
+- saas
+- twinmind
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Incident Runbook
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-install-auth/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-install-auth/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: twinmind-install-auth
-description: |
-  Install and configure TwinMind Chrome extension, mobile app, and API access.
+description: 'Install and configure TwinMind Chrome extension, mobile app, and API
+  access.
+
   Use when setting up TwinMind for meeting transcription, configuring calendar
+
   integration, or initializing TwinMind in your workflow.
+
   Trigger with phrases like "install twinmind", "setup twinmind",
+
   "twinmind auth", "configure twinmind", "twinmind chrome extension".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, api, authentication, transcription]
+tags:
+- saas
+- twinmind
+- api
+- authentication
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Install & Auth
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-local-dev-loop/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: twinmind-local-dev-loop
-description: |
-  Set up local development workflow with TwinMind API integration.
+description: 'Set up local development workflow with TwinMind API integration.
+
   Use when building applications that integrate TwinMind transcription,
+
   testing API calls locally, or developing meeting automation tools.
+
   Trigger with phrases like "twinmind dev setup", "twinmind local development",
+
   "twinmind API testing", "build with twinmind".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pip:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, api, testing, transcription]
+tags:
+- saas
+- twinmind
+- api
+- testing
+- transcription
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Local Dev Loop
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-migration-deep-dive/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-migration-deep-dive
-description: |
-  Migrate from other meeting AI tools (Otter.
+description: 'Migrate from other meeting AI tools (Otter.
+
   Use when implementing migration deep dive,
+
   or managing TwinMind meeting AI operations.
-  Trigger with phrases like "twinmind migration deep dive", "twinmind migration deep dive".
+
+  Trigger with phrases like "twinmind migration deep dive", "twinmind migration deep
+  dive".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'migration']
+tags:
+- saas
+- twinmind
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Migration Deep Dive
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-multi-env-setup/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-multi-env-setup
-description: |
-  Configure TwinMind across development, staging, and production environments with separate accounts and API key management.
+description: 'Configure TwinMind across development, staging, and production environments
+  with separate accounts and API key management.
+
   Use when implementing multi env setup,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind multi env setup", "twinmind multi env setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'deployment']
+tags:
+- saas
+- twinmind
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Multi-Environment Setup
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-observability/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-observability/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-observability
-description: |
-  Monitor TwinMind transcription quality, meeting coverage, action item extraction rates, and memory vault health.
+description: 'Monitor TwinMind transcription quality, meeting coverage, action item
+  extraction rates, and memory vault health.
+
   Use when implementing observability,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind observability", "twinmind observability".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'monitoring']
+tags:
+- saas
+- twinmind
+- monitoring
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Observability
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-performance-tuning/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-performance-tuning
-description: |
-  Optimize TwinMind transcription accuracy and speed with Ear-3 model configuration, audio quality tuning, and caching strategies.
+description: 'Optimize TwinMind transcription accuracy and speed with Ear-3 model
+  configuration, audio quality tuning, and caching strategies.
+
   Use when implementing performance tuning,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind performance tuning", "twinmind performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'performance']
+tags:
+- saas
+- twinmind
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Performance Tuning
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-prod-checklist/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: twinmind-prod-checklist
-description: |
-  Complete production deployment checklist for TwinMind integrations.
+description: 'Complete production deployment checklist for TwinMind integrations.
+
   Use when preparing to deploy, auditing production readiness,
+
   or ensuring best practices are followed.
+
   Trigger with phrases like "twinmind production", "deploy twinmind",
+
   "twinmind go-live checklist", "twinmind production ready".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, deployment, audit]
+tags:
+- saas
+- twinmind
+- deployment
+- audit
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Production Checklist
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-rate-limits/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: twinmind-rate-limits
-description: |
-  Implement TwinMind rate limiting, backoff, and optimization patterns.
+description: 'Implement TwinMind rate limiting, backoff, and optimization patterns.
+
   Use when handling rate limit errors, implementing retry logic,
+
   or optimizing API request throughput for TwinMind.
+
   Trigger with phrases like "twinmind rate limit", "twinmind throttling",
+
   "twinmind 429", "twinmind retry", "twinmind backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, api]
+tags:
+- saas
+- twinmind
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Rate Limits
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-reference-architecture/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: twinmind-reference-architecture
-description: |
-  Production architecture for meeting AI systems using TwinMind: transcription pipeline, memory vault, action item workflow, and calendar integration.
+description: 'Production architecture for meeting AI systems using TwinMind: transcription
+  pipeline, memory vault, action item workflow, and calendar integration.
+
   Use when implementing reference architecture,
+
   or managing TwinMind meeting AI operations.
-  Trigger with phrases like "twinmind reference architecture", "twinmind reference architecture".
+
+  Trigger with phrases like "twinmind reference architecture", "twinmind reference
+  architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'architecture']
+tags:
+- saas
+- twinmind
+- architecture
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Reference Architecture
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-sdk-patterns/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: twinmind-sdk-patterns
-description: |
-  Apply production-ready TwinMind SDK patterns for TypeScript and Python.
+description: 'Apply production-ready TwinMind SDK patterns for TypeScript and Python.
+
   Use when implementing TwinMind integrations, refactoring API usage,
+
   or establishing team coding standards for meeting AI integration.
+
   Trigger with phrases like "twinmind SDK patterns", "twinmind best practices",
+
   "twinmind code patterns", "idiomatic twinmind".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, api, python, typescript]
+tags:
+- saas
+- twinmind
+- api
+- python
+- typescript
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind SDK Patterns
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-security-basics/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-security-basics/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-security-basics
-description: |
-  Security best practices for TwinMind: on-device audio processing, encrypted cloud backups, microphone permissions, and data privacy controls.
+description: 'Security best practices for TwinMind: on-device audio processing, encrypted
+  cloud backups, microphone permissions, and data privacy controls.
+
   Use when implementing security basics,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind security basics", "twinmind security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'security']
+tags:
+- saas
+- twinmind
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Security Basics
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-upgrade-migration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: twinmind-upgrade-migration
-description: |
-  Upgrade between TwinMind plan tiers and migrate configurations.
+description: 'Upgrade between TwinMind plan tiers and migrate configurations.
+
   Use when upgrading from Free to Pro, Pro to Enterprise,
+
   or migrating between TwinMind environments.
+
   Trigger with phrases like "upgrade twinmind", "twinmind pro",
+
   "twinmind enterprise", "migrate twinmind", "twinmind tier change".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, twinmind, migration]
+tags:
+- saas
+- twinmind
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Upgrade & Migration
 

--- a/plugins/saas-packs/twinmind-pack/skills/twinmind-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/twinmind-pack/skills/twinmind-webhooks-events/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: twinmind-webhooks-events
-description: |
-  Handle TwinMind meeting events including transcription completion, action item extraction, and calendar sync notifications.
+description: 'Handle TwinMind meeting events including transcription completion, action
+  item extraction, and calendar sync notifications.
+
   Use when implementing webhooks events,
+
   or managing TwinMind meeting AI operations.
+
   Trigger with phrases like "twinmind webhooks events", "twinmind webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: ['saas', 'twinmind', 'webhooks']
+tags:
+- saas
+- twinmind
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # TwinMind Webhooks & Events
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-ci-integration/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-ci-integration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-ci-integration
-description: |
-  Configure Vast.ai CI/CD integration with GitHub Actions and automated GPU testing.
+description: 'Configure Vast.ai CI/CD integration with GitHub Actions and automated
+  GPU testing.
+
   Use when setting up automated testing on GPU instances,
+
   or integrating Vast.ai provisioning into CI/CD pipelines.
+
   Trigger with phrases like "vastai CI", "vastai github actions",
+
   "vastai automated testing", "vastai pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, ci-cd]
+tags:
+- saas
+- vast-ai
+- ci-cd
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai CI Integration
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-common-errors/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-common-errors/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-common-errors
-description: |
-  Diagnose and fix Vast.ai common errors and exceptions.
+description: 'Diagnose and fix Vast.ai common errors and exceptions.
+
   Use when encountering Vast.ai errors, debugging failed instances,
+
   or troubleshooting GPU rental issues.
+
   Trigger with phrases like "vastai error", "fix vastai",
+
   "vastai not working", "debug vastai", "vastai instance failed".
+
+  '
 allowed-tools: Read, Grep, Bash(vastai:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, debugging]
+tags:
+- saas
+- vast-ai
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Common Errors
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-core-workflow-a/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-core-workflow-a
-description: |
-  Execute Vast.ai primary workflow: GPU instance provisioning and job execution.
+description: 'Execute Vast.ai primary workflow: GPU instance provisioning and job
+  execution.
+
   Use when renting GPUs for training, searching offers by price and specs,
+
   or managing the full instance lifecycle from search to teardown.
+
   Trigger with phrases like "vastai rent gpu", "vastai training job",
+
   "vastai provision instance", "run job on vastai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(curl:*), Bash(ssh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, workflow]
+tags:
+- saas
+- vast-ai
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Core Workflow A: Instance Provisioning & Job Execution
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-core-workflow-b/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-core-workflow-b
-description: |
-  Execute Vast.ai secondary workflow: multi-instance orchestration, spot recovery, and cost optimization.
+description: 'Execute Vast.ai secondary workflow: multi-instance orchestration, spot
+  recovery, and cost optimization.
+
   Use when running distributed training, handling spot preemption,
+
   or optimizing GPU spend across multiple instances.
+
   Trigger with phrases like "vastai distributed training", "vastai spot recovery",
+
   "vastai multi-gpu", "vastai cost optimization".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, workflow]
+tags:
+- saas
+- vast-ai
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Core Workflow B: Multi-Instance & Cost Optimization
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-cost-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vastai-cost-tuning
-description: |
-  Optimize Vast.ai GPU cloud costs through smart instance selection and lifecycle management.
+description: 'Optimize Vast.ai GPU cloud costs through smart instance selection and
+  lifecycle management.
+
   Use when analyzing GPU spending, reducing training costs,
+
   or implementing budget controls for Vast.ai workloads.
+
   Trigger with phrases like "vastai cost", "vastai billing",
+
   "reduce vastai costs", "vastai pricing", "vastai budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, cost-optimization]
+tags:
+- saas
+- vast-ai
+- api
+- cost-optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Cost Tuning
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-data-handling/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-data-handling/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-data-handling
-description: |
-  Manage training data and model artifacts securely on Vast.ai GPU instances.
+description: 'Manage training data and model artifacts securely on Vast.ai GPU instances.
+
   Use when transferring data to instances, managing checkpoints,
+
   or implementing secure data lifecycle on rented hardware.
+
   Trigger with phrases like "vastai data", "vastai upload data",
+
   "vastai checkpoints", "vastai data security", "vastai artifacts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(ssh:*), Bash(scp:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, compliance, data]
+tags:
+- saas
+- vast-ai
+- compliance
+- data
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Data Handling
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-debug-bundle/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-debug-bundle
-description: |
-  Collect Vast.ai debug evidence for support tickets and troubleshooting.
+description: 'Collect Vast.ai debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Vast.ai problems.
+
   Trigger with phrases like "vastai debug", "vastai support bundle",
+
   "collect vastai logs", "vastai diagnostic".
+
+  '
 allowed-tools: Read, Bash(vastai:*), Bash(curl:*), Bash(ssh:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, debugging]
+tags:
+- saas
+- vast-ai
+- debugging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Debug Bundle
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-deploy-integration/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-deploy-integration
-description: |
-  Deploy ML training jobs and inference services on Vast.ai GPU cloud.
+description: 'Deploy ML training jobs and inference services on Vast.ai GPU cloud.
+
   Use when deploying GPU workloads, configuring Docker images,
+
   or setting up automated deployment scripts.
+
   Trigger with phrases like "deploy vastai", "vastai deployment",
+
   "vastai docker", "vastai production deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(docker:*), Bash(ssh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, deployment]
+tags:
+- saas
+- vast-ai
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Deploy Integration
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-enterprise-rbac/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-enterprise-rbac
-description: |
-  Implement team access control and spending governance for Vast.ai GPU cloud.
+description: 'Implement team access control and spending governance for Vast.ai GPU
+  cloud.
+
   Use when managing multi-team GPU access, implementing spending controls,
+
   or setting up API key separation for different teams.
+
   Trigger with phrases like "vastai team access", "vastai RBAC",
+
   "vastai enterprise", "vastai spending controls", "vastai permissions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, rbac]
+tags:
+- saas
+- vast-ai
+- rbac
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Enterprise RBAC
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-hello-world/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-hello-world/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-hello-world
-description: |
-  Rent your first GPU instance on Vast.ai and run a workload.
+description: 'Rent your first GPU instance on Vast.ai and run a workload.
+
   Use when starting a new Vast.ai integration, testing your setup,
+
   or learning basic Vast.ai GPU rental patterns.
+
   Trigger with phrases like "vastai hello world", "vastai example",
+
   "vastai quick start", "rent first gpu", "vastai first instance".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(curl:*), Bash(ssh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, testing]
+tags:
+- saas
+- vast-ai
+- api
+- testing
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Hello World
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-incident-runbook/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-incident-runbook
-description: |
-  Execute Vast.ai incident response for GPU instance failures and outages.
+description: 'Execute Vast.ai incident response for GPU instance failures and outages.
+
   Use when responding to instance failures, investigating training crashes,
+
   or handling spot preemption emergencies.
+
   Trigger with phrases like "vastai incident", "vastai outage",
+
   "vastai down", "vastai emergency", "vastai instance failed".
+
+  '
 allowed-tools: Read, Grep, Bash(vastai:*), Bash(curl:*), Bash(ssh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, incident-response]
+tags:
+- saas
+- vast-ai
+- incident-response
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Incident Runbook
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-install-auth/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-install-auth/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-install-auth
-description: |
-  Install and configure Vast.ai CLI and REST API authentication.
+description: 'Install and configure Vast.ai CLI and REST API authentication.
+
   Use when setting up a new Vast.ai integration, configuring API keys,
+
   or initializing Vast.ai GPU cloud access in your project.
+
   Trigger with phrases like "install vastai", "setup vastai",
+
   "vastai auth", "configure vastai API key", "vastai gpu setup".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(vastai:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, authentication]
+tags:
+- saas
+- vast-ai
+- api
+- authentication
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Install & Auth
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-local-dev-loop/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-local-dev-loop
-description: |
-  Configure Vast.ai local development with testing and fast iteration.
+description: 'Configure Vast.ai local development with testing and fast iteration.
+
   Use when setting up a development environment, testing instance provisioning,
+
   or building a fast iteration cycle for GPU workloads.
+
   Trigger with phrases like "vastai dev setup", "vastai local development",
+
   "vastai dev environment", "develop with vastai".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(pip:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, testing, workflow]
+tags:
+- saas
+- vast-ai
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Local Dev Loop
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-migration-deep-dive/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-migration-deep-dive
-description: |
-  Migrate GPU workloads to or from Vast.ai, or between GPU providers.
+description: 'Migrate GPU workloads to or from Vast.ai, or between GPU providers.
+
   Use when switching from AWS/GCP/Azure GPU instances to Vast.ai,
+
   migrating between GPU types, or re-platforming ML infrastructure.
+
   Trigger with phrases like "migrate to vastai", "vastai migration",
+
   "switch to vastai", "vastai from aws", "vastai from lambda".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(docker:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, migration]
+tags:
+- saas
+- vast-ai
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Migration Deep Dive
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-multi-env-setup/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-multi-env-setup
-description: |
-  Configure Vast.ai GPU cloud across dev, staging, and production environments.
+description: 'Configure Vast.ai GPU cloud across dev, staging, and production environments.
+
   Use when isolating GPU pools per team, managing API key separation by env,
+
   or implementing spending controls per deployment tier.
+
   Trigger with phrases like "vastai environments", "vastai staging",
+
   "vastai dev prod", "vastai multi-env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, deployment]
+tags:
+- saas
+- vast-ai
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Multi-Environment Setup
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-observability/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-observability/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-observability
-description: |
-  Monitor Vast.ai GPU instance health, utilization, and costs.
+description: 'Monitor Vast.ai GPU instance health, utilization, and costs.
+
   Use when setting up monitoring dashboards, configuring alerts,
+
   or tracking GPU utilization and spending.
+
   Trigger with phrases like "vastai monitoring", "vastai metrics",
+
   "vastai observability", "monitor vastai", "vastai alerts".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, monitoring, observability]
+tags:
+- saas
+- vast-ai
+- monitoring
+- observability
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Observability
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-performance-tuning/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vastai-performance-tuning
-description: |
-  Optimize Vast.ai GPU instance selection, startup time, and training throughput.
+description: 'Optimize Vast.ai GPU instance selection, startup time, and training
+  throughput.
+
   Use when optimizing instance selection, reducing startup latency,
+
   or maximizing GPU utilization on rented hardware.
+
   Trigger with phrases like "vastai performance", "optimize vastai",
+
   "vastai slow", "vastai gpu utilization", "vastai throughput".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(ssh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, performance]
+tags:
+- saas
+- vast-ai
+- api
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Performance Tuning
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-prod-checklist/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-prod-checklist
-description: |
-  Execute Vast.ai production deployment checklist for GPU workloads.
+description: 'Execute Vast.ai production deployment checklist for GPU workloads.
+
   Use when deploying training pipelines to production, preparing for
+
   large-scale GPU jobs, or auditing production readiness.
+
   Trigger with phrases like "vastai production", "deploy vastai",
+
   "vastai go-live", "vastai launch checklist".
+
+  '
 allowed-tools: Read, Bash(vastai:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, deployment]
+tags:
+- saas
+- vast-ai
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Production Checklist
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-rate-limits/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-rate-limits/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-rate-limits
-description: |
-  Handle Vast.ai API rate limits with backoff and request optimization.
+description: 'Handle Vast.ai API rate limits with backoff and request optimization.
+
   Use when encountering 429 errors, implementing retry logic,
+
   or optimizing API request throughput.
+
   Trigger with phrases like "vastai rate limit", "vastai throttling",
+
   "vastai 429", "vastai retry", "vastai backoff".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api]
+tags:
+- saas
+- vast-ai
+- api
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Rate Limits
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-reference-architecture/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-reference-architecture
-description: |
-  Implement Vast.ai reference architecture for GPU compute workflows.
+description: 'Implement Vast.ai reference architecture for GPU compute workflows.
+
   Use when designing ML training pipelines, structuring GPU orchestration,
+
   or establishing architecture patterns for Vast.ai applications.
+
   Trigger with phrases like "vastai architecture", "vastai design pattern",
+
   "vastai project structure", "vastai ml pipeline".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, architecture]
+tags:
+- saas
+- vast-ai
+- architecture
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Reference Architecture
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-sdk-patterns/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-sdk-patterns
-description: |
-  Apply production-ready Vast.ai SDK patterns for Python and REST API.
+description: 'Apply production-ready Vast.ai SDK patterns for Python and REST API.
+
   Use when implementing Vast.ai integrations, refactoring SDK usage,
+
   or establishing coding standards for GPU cloud operations.
+
   Trigger with phrases like "vastai SDK patterns", "vastai best practices",
+
   "vastai code patterns", "idiomatic vastai".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, python, patterns]
+tags:
+- saas
+- vast-ai
+- python
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai SDK Patterns
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-security-basics/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-security-basics/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-security-basics
-description: |
-  Apply Vast.ai security best practices for API keys and instance access.
+description: 'Apply Vast.ai security best practices for API keys and instance access.
+
   Use when securing API keys, hardening SSH access to GPU instances,
+
   or auditing Vast.ai security configuration.
+
   Trigger with phrases like "vastai security", "vastai secrets",
+
   "secure vastai", "vastai API key security", "vastai ssh security".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, security]
+tags:
+- saas
+- vast-ai
+- api
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Security Basics
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-upgrade-migration/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vastai-upgrade-migration
-description: |
-  Upgrade Vast.ai CLI, migrate API versions, and handle breaking changes.
+description: 'Upgrade Vast.ai CLI, migrate API versions, and handle breaking changes.
+
   Use when upgrading vastai CLI, detecting deprecations,
+
   or migrating between API versions.
+
   Trigger with phrases like "upgrade vastai", "vastai migration",
+
   "vastai breaking changes", "update vastai CLI".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(pip:*), Bash(vastai:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, api, migration]
+tags:
+- saas
+- vast-ai
+- api
+- migration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Upgrade & Migration
 

--- a/plugins/saas-packs/vastai-pack/skills/vastai-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/vastai-pack/skills/vastai-webhooks-events/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: vastai-webhooks-events
-description: |
-  Build event-driven workflows around Vast.ai instance lifecycle events.
+description: 'Build event-driven workflows around Vast.ai instance lifecycle events.
+
   Use when monitoring instance status changes, implementing auto-recovery,
+
   or building event-driven GPU orchestration.
+
   Trigger with phrases like "vastai events", "vastai instance monitoring",
+
   "vastai status changes", "vastai lifecycle events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vastai:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vast-ai, webhooks]
+tags:
+- saas
+- vast-ai
+- webhooks
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vast.ai Webhooks & Events
 

--- a/plugins/saas-packs/veeva-pack/skills/veeva-ci-integration/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-ci-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-ci-integration
-description: |
-  Veeva Vault ci integration for REST API and clinical operations.
+description: 'Veeva Vault ci integration for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-common-errors/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-common-errors/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-common-errors
-description: |
-  Veeva Vault common errors for REST API and clinical operations.
+description: 'Veeva Vault common errors for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Common Errors
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-core-workflow-a/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-core-workflow-a
-description: |
-  Veeva Vault core workflow a for REST API and clinical operations.
+description: 'Veeva Vault core workflow a for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva core workflow a".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-core-workflow-b/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-core-workflow-b
-description: |
-  Veeva Vault core workflow b for REST API and clinical operations.
+description: 'Veeva Vault core workflow b for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva core workflow b".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-cost-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-cost-tuning
-description: |
-  Veeva Vault cost tuning for REST API and clinical operations.
+description: 'Veeva Vault cost tuning for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-data-handling/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-data-handling/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-data-handling
-description: |
-  Veeva Vault data handling for enterprise operations.
+description: 'Veeva Vault data handling for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva data handling".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Data Handling
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-debug-bundle/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-debug-bundle
-description: |
-  Veeva Vault debug bundle for REST API and clinical operations.
+description: 'Veeva Vault debug bundle for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-deploy-integration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-deploy-integration
-description: |
-  Veeva Vault deploy integration for REST API and clinical operations.
+description: 'Veeva Vault deploy integration for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-enterprise-rbac/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-enterprise-rbac
-description: |
-  Veeva Vault enterprise rbac for enterprise operations.
+description: 'Veeva Vault enterprise rbac for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva enterprise rbac".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Enterprise Rbac
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-hello-world/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-hello-world/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-hello-world
-description: |
-  Veeva Vault hello world with REST API and VQL.
+description: 'Veeva Vault hello world with REST API and VQL.
+
   Use when integrating with Veeva Vault for life sciences document management.
+
   Trigger: "veeva hello world".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Hello World
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-incident-runbook/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-incident-runbook
-description: |
-  Veeva Vault incident runbook for enterprise operations.
+description: 'Veeva Vault incident runbook for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva incident runbook".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-install-auth/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-install-auth/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-install-auth
-description: |
-  Veeva Vault install auth with REST API and VQL.
+description: 'Veeva Vault install auth with REST API and VQL.
+
   Use when integrating with Veeva Vault for life sciences document management.
+
   Trigger: "veeva install auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-local-dev-loop/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-local-dev-loop
-description: |
-  Veeva Vault local dev loop for REST API and clinical operations.
+description: 'Veeva Vault local dev loop for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-migration-deep-dive/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-migration-deep-dive
-description: |
-  Veeva Vault migration deep dive for enterprise operations.
+description: 'Veeva Vault migration deep dive for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva migration deep dive".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-multi-env-setup/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-multi-env-setup
-description: |
-  Veeva Vault multi env setup for enterprise operations.
+description: 'Veeva Vault multi env setup for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva multi env setup".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Multi Env Setup
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-observability/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-observability/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-observability
-description: |
-  Veeva Vault observability for enterprise operations.
+description: 'Veeva Vault observability for enterprise operations.
+
   Use when implementing advanced Veeva Vault patterns.
+
   Trigger: "veeva observability".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Observability
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-performance-tuning/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-performance-tuning
-description: |
-  Veeva Vault performance tuning for REST API and clinical operations.
+description: 'Veeva Vault performance tuning for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-prod-checklist/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-prod-checklist
-description: |
-  Veeva Vault prod checklist for REST API and clinical operations.
+description: 'Veeva Vault prod checklist for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-rate-limits/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-rate-limits/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-rate-limits
-description: |
-  Veeva Vault rate limits for REST API and clinical operations.
+description: 'Veeva Vault rate limits for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-reference-architecture/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-reference-architecture
-description: |
-  Veeva Vault reference architecture for REST API and clinical operations.
+description: 'Veeva Vault reference architecture for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-sdk-patterns/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-sdk-patterns
-description: |
-  Veeva Vault sdk patterns for REST API and clinical operations.
+description: 'Veeva Vault sdk patterns for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-security-basics/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-security-basics/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-security-basics
-description: |
-  Veeva Vault security basics for REST API and clinical operations.
+description: 'Veeva Vault security basics for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Security Basics
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-upgrade-migration/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-upgrade-migration
-description: |
-  Veeva Vault upgrade migration for REST API and clinical operations.
+description: 'Veeva Vault upgrade migration for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/veeva-pack/skills/veeva-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/veeva-pack/skills/veeva-webhooks-events/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: veeva-webhooks-events
-description: |
-  Veeva Vault webhooks events for REST API and clinical operations.
+description: 'Veeva Vault webhooks events for REST API and clinical operations.
+
   Use when working with Veeva Vault document management and CRM.
+
   Trigger: "veeva webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, life-sciences, crm, veeva]
-compatible-with: claude-code
+tags:
+- saas
+- life-sciences
+- crm
+- veeva
+compatibility: Designed for Claude Code
 ---
-
 # Veeva Vault Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/vercel-pack/skills/vercel-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-advanced-troubleshooting
-description: |
-  Advanced debugging for hard-to-diagnose Vercel issues including cold starts, edge errors, and function tracing.
+description: 'Advanced debugging for hard-to-diagnose Vercel issues including cold
+  starts, edge errors, and function tracing.
+
   Use when standard troubleshooting fails, investigating intermittent failures,
+
   or preparing evidence for Vercel support escalation.
+
   Trigger with phrases like "vercel hard bug", "vercel mystery error",
+
   "vercel intermittent failure", "difficult vercel issue", "vercel deep debug".
+
+  '
 allowed-tools: Read, Grep, Bash(vercel:*), Bash(curl:*), Bash(jq:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, debugging, advanced, troubleshooting]
+tags:
+- saas
+- vercel
+- debugging
+- advanced
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Advanced Troubleshooting
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-architecture-variants/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: vercel-architecture-variants
-description: |
-  Choose and implement Vercel architecture blueprints for different scales and use cases.
-  Use when designing new Vercel projects, choosing between static, serverless, and edge architectures,
+description: 'Choose and implement Vercel architecture blueprints for different scales
+  and use cases.
+
+  Use when designing new Vercel projects, choosing between static, serverless, and
+  edge architectures,
+
   or planning how to structure a multi-project Vercel deployment.
+
   Trigger with phrases like "vercel architecture", "vercel blueprint",
+
   "how to structure vercel", "vercel monorepo", "vercel multi-project".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, architecture, scaling, patterns]
+tags:
+- saas
+- vercel
+- architecture
+- scaling
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Architecture Variants
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-ci-integration/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-ci-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-ci-integration
-description: |
-  Configure Vercel CI/CD with GitHub Actions, preview deployments, and automated testing.
+description: 'Configure Vercel CI/CD with GitHub Actions, preview deployments, and
+  automated testing.
+
   Use when setting up automated deployments, configuring preview bots,
+
   or integrating Vercel into your CI pipeline.
+
   Trigger with phrases like "vercel CI", "vercel GitHub Actions",
+
   "vercel automated deploy", "CI vercel", "vercel pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(vercel:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, ci-cd, github-actions, automation]
+tags:
+- saas
+- vercel
+- ci-cd
+- github-actions
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel CI Integration
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-common-errors/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vercel-common-errors
-description: |
-  Diagnose and fix common Vercel deployment and function errors.
+description: 'Diagnose and fix common Vercel deployment and function errors.
+
   Use when encountering Vercel errors, debugging failed deployments,
+
   or troubleshooting serverless function issues.
+
   Trigger with phrases like "vercel error", "fix vercel",
+
   "vercel not working", "debug vercel", "vercel 500", "vercel build failed".
+
+  '
 allowed-tools: Read, Grep, Bash(vercel:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, debugging, errors]
+tags:
+- saas
+- vercel
+- debugging
+- errors
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Common Errors
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-cost-tuning
-description: |
-  Optimize Vercel costs through plan selection, function efficiency, and usage monitoring.
+description: 'Optimize Vercel costs through plan selection, function efficiency, and
+  usage monitoring.
+
   Use when analyzing Vercel billing, reducing function execution costs,
+
   or implementing spend management and budget alerts.
+
   Trigger with phrases like "vercel cost", "vercel billing",
+
   "reduce vercel costs", "vercel pricing", "vercel expensive", "vercel budget".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, cost-optimization, billing, monitoring]
+tags:
+- saas
+- vercel
+- cost-optimization
+- billing
+- monitoring
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Cost Tuning
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-data-handling/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-data-handling/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-data-handling
-description: |
-  Implement data handling, PII protection, and GDPR/CCPA compliance for Vercel deployments.
+description: 'Implement data handling, PII protection, and GDPR/CCPA compliance for
+  Vercel deployments.
+
   Use when handling sensitive data in serverless functions, implementing data redaction,
+
   or ensuring privacy compliance on Vercel.
+
   Trigger with phrases like "vercel data", "vercel PII",
+
   "vercel GDPR", "vercel data retention", "vercel privacy", "vercel compliance".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, compliance, privacy, security]
+tags:
+- saas
+- vercel
+- compliance
+- privacy
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Data Handling
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-debug-bundle/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: vercel-debug-bundle
-description: |
-  Collect Vercel debug evidence for support tickets and troubleshooting.
+description: 'Collect Vercel debug evidence for support tickets and troubleshooting.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic information for Vercel problems.
+
   Trigger with phrases like "vercel debug", "vercel support bundle",
+
   "collect vercel logs", "vercel diagnostic".
+
+  '
 allowed-tools: Read, Bash(vercel:*), Bash(curl:*), Bash(tar:*), Bash(jq:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, debugging, support]
+tags:
+- saas
+- vercel
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Debug Bundle
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-deploy-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-deploy-integration
-description: |
-  Deploy and manage Vercel production deployments with promotion, rollback, and multi-region strategies.
+description: 'Deploy and manage Vercel production deployments with promotion, rollback,
+  and multi-region strategies.
+
   Use when deploying to production, configuring deployment regions,
+
   or setting up blue-green deployment patterns on Vercel.
+
   Trigger with phrases like "deploy vercel", "vercel production deploy",
+
   "vercel promote", "vercel rollback", "vercel regions".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, deployment, production, rollback]
+tags:
+- saas
+- vercel
+- deployment
+- production
+- rollback
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Deploy Integration
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-deploy-preview/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-deploy-preview/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-deploy-preview
-description: |
-  Create and manage Vercel preview deployments for branches and pull requests.
+description: 'Create and manage Vercel preview deployments for branches and pull requests.
+
   Use when deploying a preview for a pull request, testing changes before production,
+
   or sharing preview URLs with stakeholders.
+
   Trigger with phrases like "vercel deploy preview", "vercel preview URL",
+
   "create preview deployment", "vercel PR preview".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(curl:*), Bash(git:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, deployment, preview, workflow]
+tags:
+- saas
+- vercel
+- deployment
+- preview
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Deploy Preview
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-edge-functions/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-edge-functions/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-edge-functions
-description: |
-  Build and deploy Vercel Edge Functions for ultra-low latency at the edge.
+description: 'Build and deploy Vercel Edge Functions for ultra-low latency at the
+  edge.
+
   Use when creating API routes with minimal latency, geolocation-based routing,
+
   A/B testing, or authentication at the edge.
+
   Trigger with phrases like "vercel edge function", "vercel edge runtime",
+
   "deploy edge function", "vercel middleware", "@vercel/edge".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, edge, serverless, performance]
+tags:
+- saas
+- vercel
+- edge
+- serverless
+- performance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Edge Functions
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-enterprise-rbac
-description: |
-  Configure Vercel enterprise RBAC, access groups, SSO integration, and audit logging.
+description: 'Configure Vercel enterprise RBAC, access groups, SSO integration, and
+  audit logging.
+
   Use when implementing team access control, configuring SAML SSO,
+
   or setting up role-based permissions for Vercel projects.
+
   Trigger with phrases like "vercel SSO", "vercel RBAC",
+
   "vercel enterprise", "vercel roles", "vercel permissions", "vercel access groups".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, rbac, enterprise, sso]
+tags:
+- saas
+- vercel
+- rbac
+- enterprise
+- sso
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Enterprise RBAC
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-hello-world/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-hello-world
-description: |
-  Create a minimal working Vercel deployment with a serverless API route.
+description: 'Create a minimal working Vercel deployment with a serverless API route.
+
   Use when starting a new Vercel project, testing your setup,
+
   or learning basic Vercel deployment and API route patterns.
+
   Trigger with phrases like "vercel hello world", "vercel example",
+
   "vercel quick start", "simple vercel project", "first vercel deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npm:*), Bash(npx:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, api, quickstart, deployment]
+tags:
+- saas
+- vercel
+- api
+- quickstart
+- deployment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Hello World
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-incident-runbook/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-incident-runbook
-description: |
-  Vercel incident response procedures with triage, instant rollback, and postmortem.
+description: 'Vercel incident response procedures with triage, instant rollback, and
+  postmortem.
+
   Use when responding to Vercel-related outages, investigating production errors,
+
   or running post-incident reviews for deployment failures.
+
   Trigger with phrases like "vercel incident", "vercel outage",
+
   "vercel down", "vercel on-call", "vercel emergency", "vercel broken".
+
+  '
 allowed-tools: Read, Grep, Bash(vercel:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, incident-response, runbook]
+tags:
+- saas
+- vercel
+- incident-response
+- runbook
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Incident Runbook
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-install-auth/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-install-auth
-description: |
-  Install Vercel CLI and configure API token authentication.
+description: 'Install Vercel CLI and configure API token authentication.
+
   Use when setting up Vercel for the first time, creating access tokens,
+
   or initializing a project with vercel link.
+
   Trigger with phrases like "install vercel", "setup vercel",
+
   "vercel auth", "configure vercel token", "vercel login".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(vercel:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, authentication, cli, setup]
+tags:
+- saas
+- vercel
+- authentication
+- cli
+- setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Install & Auth
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-known-pitfalls/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-known-pitfalls
-description: |
-  Identify and avoid Vercel anti-patterns and common integration mistakes.
+description: 'Identify and avoid Vercel anti-patterns and common integration mistakes.
+
   Use when reviewing Vercel code for issues, onboarding new developers,
+
   or auditing existing Vercel deployments for best practice violations.
+
   Trigger with phrases like "vercel mistakes", "vercel anti-patterns",
+
   "vercel pitfalls", "vercel what not to do", "vercel code review".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, audit, anti-patterns, best-practices]
+tags:
+- saas
+- vercel
+- audit
+- anti-patterns
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Known Pitfalls
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-load-scale/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-load-scale
-description: |
-  Load test and scale Vercel deployments with concurrency tuning and capacity planning.
+description: 'Load test and scale Vercel deployments with concurrency tuning and capacity
+  planning.
+
   Use when running performance tests, planning for traffic spikes,
+
   or optimizing serverless function scaling on Vercel.
+
   Trigger with phrases like "vercel load test", "vercel scale",
+
   "vercel performance test", "vercel capacity", "vercel benchmark".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(vercel:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, testing, performance, scaling]
+tags:
+- saas
+- vercel
+- testing
+- performance
+- scaling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Load & Scale
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-local-dev-loop/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-local-dev-loop
-description: |
-  Configure Vercel local development with vercel dev, environment variables, and hot reload.
+description: 'Configure Vercel local development with vercel dev, environment variables,
+  and hot reload.
+
   Use when setting up a development environment, testing serverless functions locally,
+
   or establishing a fast iteration cycle with Vercel.
+
   Trigger with phrases like "vercel dev setup", "vercel local development",
+
   "vercel dev environment", "develop with vercel locally".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, development, testing, workflow]
+tags:
+- saas
+- vercel
+- development
+- testing
+- workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Local Dev Loop
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-migration-deep-dive/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-migration-deep-dive
-description: |
-  Migrate to Vercel from other platforms or re-architecture existing Vercel deployments.
+description: 'Migrate to Vercel from other platforms or re-architecture existing Vercel
+  deployments.
+
   Use when migrating from Netlify, AWS, or Cloudflare to Vercel,
+
   or when re-platforming an existing Vercel application.
+
   Trigger with phrases like "migrate to vercel", "vercel migration",
+
   "switch to vercel", "netlify to vercel", "aws to vercel", "vercel replatform".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, migration, replatform]
+tags:
+- saas
+- vercel
+- migration
+- replatform
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Migration Deep Dive
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-multi-env-setup/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: vercel-multi-env-setup
-description: |
-  Configure Vercel across development, preview, and production environments with scoped secrets.
-  Use when setting up per-environment configuration, managing environment-specific variables,
+description: 'Configure Vercel across development, preview, and production environments
+  with scoped secrets.
+
+  Use when setting up per-environment configuration, managing environment-specific
+  variables,
+
   or implementing environment isolation on Vercel.
+
   Trigger with phrases like "vercel environments", "vercel staging",
+
   "vercel dev prod", "vercel environment setup", "vercel env scoping".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, deployment, environments, configuration]
+tags:
+- saas
+- vercel
+- deployment
+- environments
+- configuration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Multi-Env Setup
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-observability/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-observability/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-observability
-description: |
-  Set up Vercel observability with runtime logs, analytics, log drains, and OpenTelemetry tracing.
+description: 'Set up Vercel observability with runtime logs, analytics, log drains,
+  and OpenTelemetry tracing.
+
   Use when implementing monitoring for Vercel deployments, setting up log drains,
+
   or configuring alerting for function errors and performance.
+
   Trigger with phrases like "vercel monitoring", "vercel metrics",
+
   "vercel observability", "vercel logs", "vercel alerts", "vercel tracing".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, monitoring, observability, logging]
+tags:
+- saas
+- vercel
+- monitoring
+- observability
+- logging
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Observability
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-performance-tuning
-description: |
-  Optimize Vercel deployment performance with caching, bundle optimization, and cold start reduction.
+description: 'Optimize Vercel deployment performance with caching, bundle optimization,
+  and cold start reduction.
+
   Use when experiencing slow page loads, optimizing Core Web Vitals,
+
   or reducing serverless function cold start times.
+
   Trigger with phrases like "vercel performance", "optimize vercel",
+
   "vercel latency", "vercel caching", "vercel slow", "vercel cold start".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, performance, caching, optimization]
+tags:
+- saas
+- vercel
+- performance
+- caching
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Performance Tuning
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-policy-guardrails/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-policy-guardrails
-description: |
-  Implement lint rules, CI policy checks, and automated guardrails for Vercel projects.
+description: 'Implement lint rules, CI policy checks, and automated guardrails for
+  Vercel projects.
+
   Use when setting up code quality rules, preventing secret exposure,
+
   or enforcing deployment policies for Vercel applications.
+
   Trigger with phrases like "vercel policy", "vercel lint",
+
   "vercel guardrails", "vercel best practices check", "vercel secret scan".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, policy, linting, security]
+tags:
+- saas
+- vercel
+- policy
+- linting
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Policy Guardrails
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-prod-checklist/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-prod-checklist
-description: |
-  Vercel production deployment checklist with rollback and promotion procedures.
+description: 'Vercel production deployment checklist with rollback and promotion procedures.
+
   Use when deploying to production, preparing for launch,
+
   or implementing go-live and instant rollback procedures.
+
   Trigger with phrases like "vercel production", "deploy vercel prod",
+
   "vercel go-live", "vercel launch checklist", "vercel promote".
+
+  '
 allowed-tools: Read, Bash(vercel:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, deployment, production, checklist]
+tags:
+- saas
+- vercel
+- deployment
+- production
+- checklist
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Prod Checklist
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-rate-limits/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-rate-limits/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-rate-limits
-description: |
-  Handle Vercel API rate limits, implement retry logic, and configure WAF rate limiting.
+description: 'Handle Vercel API rate limits, implement retry logic, and configure
+  WAF rate limiting.
+
   Use when hitting 429 errors, implementing retry logic,
+
   or setting up rate limiting for your Vercel-deployed API endpoints.
+
   Trigger with phrases like "vercel rate limit", "vercel throttling",
+
   "vercel 429", "vercel retry", "vercel backoff", "vercel WAF rate limit".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, api, rate-limiting, security]
+tags:
+- saas
+- vercel
+- api
+- rate-limiting
+- security
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Rate Limits
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-reference-architecture/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-reference-architecture
-description: |
-  Implement a Vercel reference architecture with layered project structure and best practices.
+description: 'Implement a Vercel reference architecture with layered project structure
+  and best practices.
+
   Use when designing new Vercel projects, reviewing project structure,
+
   or establishing architecture standards for Vercel applications.
+
   Trigger with phrases like "vercel architecture", "vercel project structure",
+
   "vercel best practices layout", "how to organize vercel project".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, architecture, best-practices]
+tags:
+- saas
+- vercel
+- architecture
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Reference Architecture
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-reliability-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-reliability-patterns
-description: |
-  Implement reliability patterns for Vercel deployments including circuit breakers, retry logic, and graceful degradation.
+description: 'Implement reliability patterns for Vercel deployments including circuit
+  breakers, retry logic, and graceful degradation.
+
   Use when building fault-tolerant serverless functions, implementing retry strategies,
+
   or adding resilience to production Vercel services.
+
   Trigger with phrases like "vercel reliability", "vercel circuit breaker",
+
   "vercel resilience", "vercel fallback", "vercel graceful degradation".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, reliability, resilience, patterns]
+tags:
+- saas
+- vercel
+- reliability
+- resilience
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Reliability Patterns
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-sdk-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-sdk-patterns
-description: |
-  Production-ready Vercel REST API patterns with typed fetch wrappers and error handling.
+description: 'Production-ready Vercel REST API patterns with typed fetch wrappers
+  and error handling.
+
   Use when integrating with the Vercel API programmatically, building deployment tools,
+
   or establishing team coding standards for Vercel API calls.
+
   Trigger with phrases like "vercel SDK patterns", "vercel API wrapper",
+
   "vercel REST API client", "vercel best practices", "idiomatic vercel API".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, api, typescript, patterns]
+tags:
+- saas
+- vercel
+- api
+- typescript
+- patterns
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel SDK Patterns
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-security-basics/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-security-basics
-description: |
-  Apply Vercel security best practices for secrets, headers, and access control.
+description: 'Apply Vercel security best practices for secrets, headers, and access
+  control.
+
   Use when securing API keys, configuring security headers,
+
   or auditing Vercel security configuration.
+
   Trigger with phrases like "vercel security", "vercel secrets",
+
   "secure vercel", "vercel headers", "vercel CSP".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, security, headers, secrets]
+tags:
+- saas
+- vercel
+- security
+- headers
+- secrets
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Security Basics
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-upgrade-migration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: vercel-upgrade-migration
-description: |
-  Upgrade Vercel CLI, Node.js runtime, and Next.js framework versions with breaking change detection.
+description: 'Upgrade Vercel CLI, Node.js runtime, and Next.js framework versions
+  with breaking change detection.
+
   Use when upgrading Vercel CLI versions, migrating Node.js runtimes,
+
   or updating Next.js between major versions on Vercel.
+
   Trigger with phrases like "upgrade vercel", "vercel migration",
+
   "vercel breaking changes", "update vercel CLI", "next.js upgrade on vercel".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(npm:*), Bash(npx:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, migration, upgrade]
+tags:
+- saas
+- vercel
+- migration
+- upgrade
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Upgrade Migration
 

--- a/plugins/saas-packs/vercel-pack/skills/vercel-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/vercel-pack/skills/vercel-webhooks-events/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: vercel-webhooks-events
-description: |
-  Implement Vercel webhook handling with signature verification and event processing.
+description: 'Implement Vercel webhook handling with signature verification and event
+  processing.
+
   Use when setting up webhook endpoints, processing deployment events,
+
   or building integrations that react to Vercel deployment lifecycle.
+
   Trigger with phrases like "vercel webhook", "vercel events",
+
   "vercel deployment.ready", "handle vercel events", "vercel webhook signature".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, vercel, webhooks, events, integration]
+tags:
+- saas
+- vercel
+- webhooks
+- events
+- integration
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Vercel Webhooks & Events
 

--- a/plugins/saas-packs/webflow-pack/skills/webflow-ci-integration/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-ci-integration/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: webflow-ci-integration
-description: |
-  Configure Webflow CI/CD with GitHub Actions — automated CMS validation,
-  integration tests with test tokens, and publish-on-merge workflows.
-  Use when setting up automated testing or CI pipelines for Webflow integrations.
-  Trigger with phrases like "webflow CI", "webflow GitHub Actions",
-  "webflow automated tests", "CI webflow", "webflow pipeline".
+description: "Configure Webflow CI/CD with GitHub Actions \u2014 automated CMS validation,\n\
+  integration tests with test tokens, and publish-on-merge workflows.\nUse when setting\
+  \ up automated testing or CI pipelines for Webflow integrations.\nTrigger with phrases\
+  \ like \"webflow CI\", \"webflow GitHub Actions\",\n\"webflow automated tests\"\
+  , \"CI webflow\", \"webflow pipeline\".\n"
 allowed-tools: Read, Write, Edit, Bash(gh:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow CI Integration
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-common-errors/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-common-errors/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: webflow-common-errors
-description: |
-  Diagnose and fix Webflow Data API v2 errors — 400, 401, 403, 404, 409, 429, 500.
-  Use when encountering Webflow API errors, debugging failed requests,
-  or troubleshooting integration issues.
-  Trigger with phrases like "webflow error", "fix webflow",
-  "webflow not working", "debug webflow", "webflow 429", "webflow 401".
+description: "Diagnose and fix Webflow Data API v2 errors \u2014 400, 401, 403, 404,\
+  \ 409, 429, 500.\nUse when encountering Webflow API errors, debugging failed requests,\n\
+  or troubleshooting integration issues.\nTrigger with phrases like \"webflow error\"\
+  , \"fix webflow\",\n\"webflow not working\", \"debug webflow\", \"webflow 429\"\
+  , \"webflow 401\".\n"
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Common Errors
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-core-workflow-a/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-core-workflow-a
-description: |
-  Execute the primary Webflow workflow — CMS content management: list collections,
-  CRUD items, publish items, and manage content lifecycle via the Data API v2.
-  Use when working with Webflow CMS collections and items, managing blog posts,
-  team members, or any dynamic content.
-  Trigger with phrases like "webflow CMS", "webflow collections", "webflow items",
-  "create webflow content", "manage webflow CMS", "webflow content management".
+description: "Execute the primary Webflow workflow \u2014 CMS content management:\
+  \ list collections,\nCRUD items, publish items, and manage content lifecycle via\
+  \ the Data API v2.\nUse when working with Webflow CMS collections and items, managing\
+  \ blog posts,\nteam members, or any dynamic content.\nTrigger with phrases like\
+  \ \"webflow CMS\", \"webflow collections\", \"webflow items\",\n\"create webflow\
+  \ content\", \"manage webflow CMS\", \"webflow content management\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Core Workflow A — CMS Content Management
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-core-workflow-b/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-core-workflow-b
-description: |
-  Execute Webflow secondary workflows — Sites management, Pages API, Forms submissions,
-  Ecommerce (products/orders/inventory), and Custom Code via the Data API v2.
-  Use when managing sites, reading pages, handling form data, or working with
-  Webflow Ecommerce products and orders.
-  Trigger with phrases like "webflow sites", "webflow pages", "webflow forms",
-  "webflow ecommerce", "webflow products", "webflow orders".
+description: "Execute Webflow secondary workflows \u2014 Sites management, Pages API,\
+  \ Forms submissions,\nEcommerce (products/orders/inventory), and Custom Code via\
+  \ the Data API v2.\nUse when managing sites, reading pages, handling form data,\
+  \ or working with\nWebflow Ecommerce products and orders.\nTrigger with phrases\
+  \ like \"webflow sites\", \"webflow pages\", \"webflow forms\",\n\"webflow ecommerce\"\
+  , \"webflow products\", \"webflow orders\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Core Workflow B — Sites, Pages, Forms & Ecommerce
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-cost-tuning/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: webflow-cost-tuning
-description: |
-  Optimize Webflow costs through plan selection, CDN read optimization, bulk endpoint
+description: 'Optimize Webflow costs through plan selection, CDN read optimization,
+  bulk endpoint
+
   usage, and API usage monitoring with budget alerts.
+
   Use when analyzing Webflow billing, reducing API costs,
+
   or implementing usage monitoring for Webflow integrations.
+
   Trigger with phrases like "webflow cost", "webflow billing",
+
   "reduce webflow costs", "webflow pricing", "webflow budget".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-data-handling/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-data-handling/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: webflow-data-handling
-description: |
-  Implement Webflow data handling — CMS content delivery patterns, PII redaction in
-  form submissions, GDPR/CCPA compliance for ecommerce data, and data retention policies.
-  Trigger with phrases like "webflow data", "webflow PII", "webflow GDPR",
-  "webflow data retention", "webflow privacy", "webflow CCPA", "webflow forms data".
+description: "Implement Webflow data handling \u2014 CMS content delivery patterns,\
+  \ PII redaction in\nform submissions, GDPR/CCPA compliance for ecommerce data, and\
+  \ data retention policies.\nTrigger with phrases like \"webflow data\", \"webflow\
+  \ PII\", \"webflow GDPR\",\n\"webflow data retention\", \"webflow privacy\", \"\
+  webflow CCPA\", \"webflow forms data\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Data Handling
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-debug-bundle/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: webflow-debug-bundle
-description: |
-  Collect Webflow debug evidence for support tickets and troubleshooting.
+description: 'Collect Webflow debug evidence for support tickets and troubleshooting.
+
   Gathers SDK version, token validation, rate limit status, site connectivity,
+
   CMS health, and error logs into a single diagnostic bundle.
+
   Trigger with phrases like "webflow debug", "webflow support bundle",
+
   "collect webflow logs", "webflow diagnostic", "webflow troubleshoot".
+
+  '
 allowed-tools: Read, Bash(npm:*), Bash(npx:*), Bash(curl:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-deploy-integration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: webflow-deploy-integration
-description: |
-  Deploy Webflow-powered applications to Vercel, Fly.io, and Google Cloud Run
+description: 'Deploy Webflow-powered applications to Vercel, Fly.io, and Google Cloud
+  Run
+
   with proper secrets management and Webflow-specific health checks.
+
   Trigger with phrases like "deploy webflow", "webflow Vercel",
+
   "webflow production deploy", "webflow Cloud Run", "webflow Fly.io".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(fly:*), Bash(gcloud:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-enterprise-rbac/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: webflow-enterprise-rbac
-description: |
-  Configure Webflow enterprise access control — OAuth 2.0 app authorization,
-  scope-based RBAC, per-site token isolation, workspace member management,
-  and audit logging for compliance.
-  Trigger with phrases like "webflow RBAC", "webflow enterprise",
-  "webflow roles", "webflow permissions", "webflow OAuth scopes",
-  "webflow access control", "webflow workspace members".
+description: "Configure Webflow enterprise access control \u2014 OAuth 2.0 app authorization,\n\
+  scope-based RBAC, per-site token isolation, workspace member management,\nand audit\
+  \ logging for compliance.\nTrigger with phrases like \"webflow RBAC\", \"webflow\
+  \ enterprise\",\n\"webflow roles\", \"webflow permissions\", \"webflow OAuth scopes\"\
+  ,\n\"webflow access control\", \"webflow workspace members\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-hello-world/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-hello-world/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: webflow-hello-world
-description: |
-  Create a minimal working Webflow Data API v2 example.
-  Use when starting a new Webflow integration, testing your setup,
-  or learning basic Webflow API patterns — list sites, read CMS collections, create items.
-  Trigger with phrases like "webflow hello world", "webflow example",
-  "webflow quick start", "simple webflow code", "first webflow API call".
+description: "Create a minimal working Webflow Data API v2 example.\nUse when starting\
+  \ a new Webflow integration, testing your setup,\nor learning basic Webflow API\
+  \ patterns \u2014 list sites, read CMS collections, create items.\nTrigger with\
+  \ phrases like \"webflow hello world\", \"webflow example\",\n\"webflow quick start\"\
+  , \"simple webflow code\", \"first webflow API call\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Hello World
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-incident-runbook/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: webflow-incident-runbook
-description: |
-  Execute Webflow incident response — triage by HTTP status (401/403/429/500),
-  circuit breaker activation, cached fallback, Webflow status page checks,
-  communication templates, and postmortem process.
-  Trigger with phrases like "webflow incident", "webflow outage",
-  "webflow down", "webflow on-call", "webflow emergency", "webflow broken".
+description: "Execute Webflow incident response \u2014 triage by HTTP status (401/403/429/500),\n\
+  circuit breaker activation, cached fallback, Webflow status page checks,\ncommunication\
+  \ templates, and postmortem process.\nTrigger with phrases like \"webflow incident\"\
+  , \"webflow outage\",\n\"webflow down\", \"webflow on-call\", \"webflow emergency\"\
+  , \"webflow broken\".\n"
 allowed-tools: Read, Grep, Bash(curl:*), Bash(npm:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-install-auth/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-install-auth/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: webflow-install-auth
-description: |
-  Install the Webflow JS SDK (webflow-api) and configure OAuth 2.0 or API token authentication.
+description: 'Install the Webflow JS SDK (webflow-api) and configure OAuth 2.0 or
+  API token authentication.
+
   Use when setting up a new Webflow integration, configuring access tokens,
+
   or initializing the WebflowClient in your project.
+
   Trigger with phrases like "install webflow", "setup webflow",
+
   "webflow auth", "configure webflow API token", "webflow OAuth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-local-dev-loop/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: webflow-local-dev-loop
-description: |
-  Configure a Webflow local development workflow with TypeScript, hot reload, mocked API tests,
+description: 'Configure a Webflow local development workflow with TypeScript, hot
+  reload, mocked API tests,
+
   and webhook tunneling via ngrok.
+
   Use when setting up a development environment, configuring test workflows,
+
   or establishing a fast iteration cycle with the Webflow Data API.
+
   Trigger with phrases like "webflow dev setup", "webflow local development",
+
   "webflow dev environment", "develop with webflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-migration-deep-dive/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-migration-deep-dive
-description: |
-  Execute major Webflow migrations — from other CMS platforms to Webflow CMS,
-  between Webflow sites, or large-scale content re-architecture using the Data API v2
-  bulk endpoints, strangler fig pattern, and data validation.
-  Trigger with phrases like "migrate to webflow", "webflow migration",
-  "import into webflow", "webflow replatform", "move content to webflow",
-  "webflow bulk import", "wordpress to webflow".
+description: "Execute major Webflow migrations \u2014 from other CMS platforms to\
+  \ Webflow CMS,\nbetween Webflow sites, or large-scale content re-architecture using\
+  \ the Data API v2\nbulk endpoints, strangler fig pattern, and data validation.\n\
+  Trigger with phrases like \"migrate to webflow\", \"webflow migration\",\n\"import\
+  \ into webflow\", \"webflow replatform\", \"move content to webflow\",\n\"webflow\
+  \ bulk import\", \"wordpress to webflow\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-multi-env-setup/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: webflow-multi-env-setup
-description: |
-  Configure Webflow across development, staging, and production environments with
+description: 'Configure Webflow across development, staging, and production environments
+  with
+
   per-environment API tokens, site IDs, and secret management via Vault/AWS/GCP.
+
   Trigger with phrases like "webflow environments", "webflow staging",
+
   "webflow dev prod", "webflow environment setup", "webflow config by env".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(aws:*), Bash(gcloud:*), Bash(vault:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-observability/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-observability/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: webflow-observability
-description: |
-  Set up observability for Webflow integrations — Prometheus metrics for API calls,
-  OpenTelemetry tracing, structured logging with pino, Grafana dashboards,
-  and alerting for rate limits, errors, and latency.
-  Trigger with phrases like "webflow monitoring", "webflow metrics",
-  "webflow observability", "monitor webflow", "webflow alerts", "webflow tracing".
+description: "Set up observability for Webflow integrations \u2014 Prometheus metrics\
+  \ for API calls,\nOpenTelemetry tracing, structured logging with pino, Grafana dashboards,\n\
+  and alerting for rate limits, errors, and latency.\nTrigger with phrases like \"\
+  webflow monitoring\", \"webflow metrics\",\n\"webflow observability\", \"monitor\
+  \ webflow\", \"webflow alerts\", \"webflow tracing\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Observability
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-performance-tuning/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: webflow-performance-tuning
-description: |
-  Optimize Webflow API performance with response caching, bulk endpoint batching,
+description: 'Optimize Webflow API performance with response caching, bulk endpoint
+  batching,
+
   CDN-cached live item reads, pagination optimization, and connection pooling.
+
   Use when experiencing slow API responses or optimizing request throughput.
+
   Trigger with phrases like "webflow performance", "optimize webflow",
+
   "webflow latency", "webflow caching", "webflow slow", "webflow batch".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-prod-checklist/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: webflow-prod-checklist
-description: |
-  Execute Webflow production deployment checklist — token security, rate limit hardening,
-  health checks, circuit breakers, gradual rollout, and rollback procedures.
-  Use when deploying Webflow integrations to production or preparing for launch.
-  Trigger with phrases like "webflow production", "deploy webflow",
-  "webflow go-live", "webflow launch checklist", "webflow production ready".
+description: "Execute Webflow production deployment checklist \u2014 token security,\
+  \ rate limit hardening,\nhealth checks, circuit breakers, gradual rollout, and rollback\
+  \ procedures.\nUse when deploying Webflow integrations to production or preparing\
+  \ for launch.\nTrigger with phrases like \"webflow production\", \"deploy webflow\"\
+  ,\n\"webflow go-live\", \"webflow launch checklist\", \"webflow production ready\"\
+  .\n"
 allowed-tools: Read, Write, Edit, Bash(curl:*), Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-rate-limits/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-rate-limits/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-rate-limits
-description: |
-  Handle Webflow Data API v2 rate limits — per-key limits, Retry-After headers,
-  exponential backoff, request queuing, and bulk endpoint optimization.
-  Use when hitting 429 errors, implementing retry logic,
-  or optimizing API request throughput.
-  Trigger with phrases like "webflow rate limit", "webflow throttling",
-  "webflow 429", "webflow retry", "webflow backoff", "webflow too many requests".
+description: "Handle Webflow Data API v2 rate limits \u2014 per-key limits, Retry-After\
+  \ headers,\nexponential backoff, request queuing, and bulk endpoint optimization.\n\
+  Use when hitting 429 errors, implementing retry logic,\nor optimizing API request\
+  \ throughput.\nTrigger with phrases like \"webflow rate limit\", \"webflow throttling\"\
+  ,\n\"webflow 429\", \"webflow retry\", \"webflow backoff\", \"webflow too many requests\"\
+  .\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-reference-architecture/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: webflow-reference-architecture
-description: |
-  Implement Webflow reference architecture — layered project structure, client wrapper,
-  CMS sync service, webhook handlers, and caching layer for production integrations.
-  Trigger with phrases like "webflow architecture", "webflow project structure",
-  "how to organize webflow", "webflow integration design", "webflow best practices".
+description: "Implement Webflow reference architecture \u2014 layered project structure,\
+  \ client wrapper,\nCMS sync service, webhook handlers, and caching layer for production\
+  \ integrations.\nTrigger with phrases like \"webflow architecture\", \"webflow project\
+  \ structure\",\n\"how to organize webflow\", \"webflow integration design\", \"\
+  webflow best practices\".\n"
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-sdk-patterns/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-sdk-patterns
-description: |
-  Apply production-ready Webflow SDK patterns — singleton client, typed error handling,
-  pagination helpers, and raw response access for the webflow-api package.
-  Use when implementing Webflow integrations, refactoring SDK usage,
-  or establishing team coding standards.
-  Trigger with phrases like "webflow SDK patterns", "webflow best practices",
-  "webflow code patterns", "idiomatic webflow", "webflow typescript".
+description: "Apply production-ready Webflow SDK patterns \u2014 singleton client,\
+  \ typed error handling,\npagination helpers, and raw response access for the webflow-api\
+  \ package.\nUse when implementing Webflow integrations, refactoring SDK usage,\n\
+  or establishing team coding standards.\nTrigger with phrases like \"webflow SDK\
+  \ patterns\", \"webflow best practices\",\n\"webflow code patterns\", \"idiomatic\
+  \ webflow\", \"webflow typescript\".\n"
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-security-basics/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-security-basics/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: webflow-security-basics
-description: |
-  Apply Webflow API security best practices — token management, scope least privilege,
-  OAuth 2.0 secret rotation, webhook signature verification, and audit logging.
-  Use when securing API tokens, implementing least privilege access,
-  or auditing Webflow security configuration.
-  Trigger with phrases like "webflow security", "webflow secrets",
-  "secure webflow", "webflow API key security", "webflow token rotation".
+description: "Apply Webflow API security best practices \u2014 token management, scope\
+  \ least privilege,\nOAuth 2.0 secret rotation, webhook signature verification, and\
+  \ audit logging.\nUse when securing API tokens, implementing least privilege access,\n\
+  or auditing Webflow security configuration.\nTrigger with phrases like \"webflow\
+  \ security\", \"webflow secrets\",\n\"secure webflow\", \"webflow API key security\"\
+  , \"webflow token rotation\".\n"
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Security Basics
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-upgrade-migration/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: webflow-upgrade-migration
-description: |
-  Analyze, plan, and execute Webflow SDK upgrades (webflow-api v1 to v3) with
+description: 'Analyze, plan, and execute Webflow SDK upgrades (webflow-api v1 to v3)
+  with
+
   breaking change detection, API v1-to-v2 migration, and deprecation handling.
+
   Trigger with phrases like "upgrade webflow", "webflow migration",
+
   "webflow breaking changes", "update webflow SDK", "webflow v1 to v2".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/webflow-pack/skills/webflow-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/webflow-pack/skills/webflow-webhooks-events/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: webflow-webhooks-events
-description: |
-  Implement Webflow webhook registration, signature verification, and event handling
+description: 'Implement Webflow webhook registration, signature verification, and
+  event handling
+
   for form_submission, site_publish, ecomm_new_order, page_created, and more.
+
   Use when setting up webhook endpoints, implementing event-driven workflows,
+
   or handling Webflow notifications.
+
   Trigger with phrases like "webflow webhook", "webflow events",
+
   "webflow webhook signature", "handle webflow events", "webflow notifications".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, design, no-code, webflow]
-compatible-with: claude-code
+tags:
+- saas
+- design
+- no-code
+- webflow
+compatibility: Designed for Claude Code
 ---
-
 # Webflow Webhooks & Events
 
 ## Overview

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-advanced-troubleshooting/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-advanced-troubleshooting/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-advanced-troubleshooting
-description: |
-  Advanced Windsurf debugging for hard-to-diagnose IDE, Cascade, and indexing issues.
+description: 'Advanced Windsurf debugging for hard-to-diagnose IDE, Cascade, and indexing
+  issues.
+
   Use when standard troubleshooting fails, Cascade produces consistently wrong output,
+
   or investigating deep configuration problems.
+
   Trigger with phrases like "windsurf deep debug", "windsurf mystery error",
+
   "windsurf impossible to fix", "cascade keeps failing", "windsurf advanced debug".
+
+  '
 allowed-tools: Read, Grep, Bash(ls:*), Bash(curl:*), Bash(find:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, debugging, advanced, troubleshooting]
+tags:
+- saas
+- windsurf
+- debugging
+- advanced
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Advanced Troubleshooting
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-architecture-variants/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-architecture-variants
-description: |
-  Choose workspace architectures for different project scales in Windsurf.
+description: 'Choose workspace architectures for different project scales in Windsurf.
+
   Use when deciding how to structure Windsurf workspaces for monorepos,
+
   multi-service setups, or polyglot codebases.
+
   Trigger with phrases like "windsurf workspace strategy", "windsurf monorepo",
+
   "windsurf project layout", "windsurf multi-service", "windsurf workspace size".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, architecture, workspace, monorepo]
+tags:
+- saas
+- windsurf
+- architecture
+- workspace
+- monorepo
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Architecture Variants
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-ci-integration/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-ci-integration/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-ci-integration
-description: |
-  Integrate Windsurf Cascade workflows into CI/CD pipelines and team automation.
+description: 'Integrate Windsurf Cascade workflows into CI/CD pipelines and team automation.
+
   Use when automating Cascade tasks in GitHub Actions, enforcing AI code quality gates,
+
   or setting up Windsurf config validation in CI.
+
   Trigger with phrases like "windsurf CI", "windsurf GitHub Actions",
+
   "windsurf automation", "cascade CI", "windsurf pipeline".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, ci-cd, github-actions, automation]
+tags:
+- saas
+- windsurf
+- ci-cd
+- github-actions
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf CI Integration
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-common-errors/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-common-errors/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: windsurf-common-errors
-description: |
-  Diagnose and fix common Windsurf IDE and Cascade errors.
+description: 'Diagnose and fix common Windsurf IDE and Cascade errors.
+
   Use when Cascade stops working, Supercomplete fails, indexing hangs,
+
   or encountering Windsurf-specific issues.
+
   Trigger with phrases like "windsurf error", "fix windsurf",
+
   "windsurf not working", "cascade broken", "windsurf slow".
+
+  '
 allowed-tools: Read, Grep, Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, debugging, troubleshooting]
+tags:
+- saas
+- windsurf
+- debugging
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Common Errors
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-core-workflow-a/SKILL.md
@@ -1,16 +1,27 @@
 ---
 name: windsurf-core-workflow-a
-description: |
-  Execute Windsurf's primary workflow: Cascade Write mode for multi-file agentic coding.
-  Use when building features, refactoring across files, or performing complex code tasks.
+description: 'Execute Windsurf''s primary workflow: Cascade Write mode for multi-file
+  agentic coding.
+
+  Use when building features, refactoring across files, or performing complex code
+  tasks.
+
   Trigger with phrases like "windsurf cascade write", "windsurf agentic coding",
+
   "windsurf multi-file edit", "cascade write mode", "windsurf build feature".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, cascade, write-mode, agentic]
+tags:
+- saas
+- windsurf
+- cascade
+- write-mode
+- agentic
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Core Workflow A — Cascade Write Mode
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-core-workflow-b/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-core-workflow-b
-description: |
-  Execute Windsurf's secondary workflow: Workflows, Memories, and reusable automation.
+description: 'Execute Windsurf''s secondary workflow: Workflows, Memories, and reusable
+  automation.
+
   Use when creating reusable Cascade workflows, managing persistent memories,
+
   or automating repetitive development tasks.
+
   Trigger with phrases like "windsurf workflow", "windsurf automation",
+
   "windsurf memories", "cascade workflow", "windsurf slash command".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, workflows, memories, automation]
+tags:
+- saas
+- windsurf
+- workflows
+- memories
+- automation
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Core Workflow B — Workflows & Memories
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-cost-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-cost-tuning
-description: |
-  Optimize Windsurf licensing costs through seat management, tier selection, and credit monitoring.
+description: 'Optimize Windsurf licensing costs through seat management, tier selection,
+  and credit monitoring.
+
   Use when analyzing Windsurf billing, reducing per-seat costs,
+
   or implementing usage monitoring and budget controls.
+
   Trigger with phrases like "windsurf cost", "windsurf billing",
+
   "reduce windsurf costs", "windsurf pricing", "windsurf budget".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, cost-optimization, licensing, teams]
+tags:
+- saas
+- windsurf
+- cost-optimization
+- licensing
+- teams
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Cost Tuning
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-data-handling/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-data-handling/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-data-handling
-description: |
-  Control what code and data Windsurf AI can access and process in your workspace.
+description: 'Control what code and data Windsurf AI can access and process in your
+  workspace.
+
   Use when handling sensitive data, implementing data exclusion patterns,
+
   or ensuring compliance with privacy regulations in Windsurf environments.
+
   Trigger with phrases like "windsurf data privacy", "windsurf PII",
+
   "windsurf GDPR", "windsurf compliance", "codeium data", "windsurf telemetry".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, privacy, compliance, data-handling]
+tags:
+- saas
+- windsurf
+- privacy
+- compliance
+- data-handling
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Data Handling
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-debug-bundle/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-debug-bundle
-description: |
-  Collect Windsurf diagnostic information for troubleshooting and support tickets.
+description: 'Collect Windsurf diagnostic information for troubleshooting and support
+  tickets.
+
   Use when encountering persistent issues, preparing support tickets,
+
   or collecting diagnostic data for Windsurf problems.
+
   Trigger with phrases like "windsurf debug", "windsurf support",
+
   "windsurf diagnostic", "windsurf logs", "windsurf not working".
+
+  '
 allowed-tools: Read, Bash(grep:*), Bash(ls:*), Bash(tar:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, debugging, support]
+tags:
+- saas
+- windsurf
+- debugging
+- support
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Debug Bundle
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-deploy-integration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-deploy-integration
-description: |
-  Deploy applications using Windsurf's built-in deployment features and Cascade automation.
+description: 'Deploy applications using Windsurf''s built-in deployment features and
+  Cascade automation.
+
   Use when deploying apps from Windsurf, configuring Netlify/Vercel integration,
+
   or building deployment workflows with Cascade.
+
   Trigger with phrases like "deploy windsurf", "windsurf deploy",
+
   "windsurf netlify", "windsurf vercel", "cascade deploy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, deployment, netlify, vercel]
+tags:
+- saas
+- windsurf
+- deployment
+- netlify
+- vercel
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Deploy Integration
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-enterprise-rbac/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-enterprise-rbac
-description: |
-  Configure Windsurf enterprise SSO, RBAC, and organization-level controls.
+description: 'Configure Windsurf enterprise SSO, RBAC, and organization-level controls.
+
   Use when implementing SSO/SAML, configuring role-based seat management,
+
   or setting up organization-wide Windsurf policies.
+
   Trigger with phrases like "windsurf SSO", "windsurf RBAC",
+
   "windsurf enterprise", "windsurf admin", "windsurf SAML", "windsurf team management".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, enterprise, sso, rbac, admin]
+tags:
+- saas
+- windsurf
+- enterprise
+- sso
+- rbac
+- admin
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Enterprise RBAC
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-hello-world/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-hello-world/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-hello-world
-description: |
-  Create your first Windsurf Cascade interaction and Supercomplete experience.
+description: 'Create your first Windsurf Cascade interaction and Supercomplete experience.
+
   Use when starting with Windsurf, testing your setup,
+
   or learning basic Cascade and Supercomplete workflows.
+
   Trigger with phrases like "windsurf hello world", "windsurf example",
+
   "windsurf quick start", "first windsurf project", "try windsurf".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, cascade, supercomplete, quickstart]
+tags:
+- saas
+- windsurf
+- cascade
+- supercomplete
+- quickstart
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Hello World
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-incident-runbook/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-incident-runbook
-description: |
-  Execute Windsurf incident response when AI features fail or cause production issues.
+description: 'Execute Windsurf incident response when AI features fail or cause production
+  issues.
+
   Use when Cascade breaks code, Windsurf service is down, AI-generated code causes
+
   production incidents, or team needs emergency Windsurf troubleshooting.
+
   Trigger with phrases like "windsurf incident", "windsurf outage",
+
   "windsurf broke production", "cascade caused bug", "windsurf emergency".
+
+  '
 allowed-tools: Read, Grep, Bash(git:*), Bash(curl:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, incident-response, runbook, troubleshooting]
+tags:
+- saas
+- windsurf
+- incident-response
+- runbook
+- troubleshooting
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Incident Runbook
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-install-auth/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-install-auth/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-install-auth
-description: |
-  Install Windsurf IDE and configure Codeium authentication.
+description: 'Install Windsurf IDE and configure Codeium authentication.
+
   Use when setting up Windsurf for the first time, logging in to Codeium,
+
   or configuring API keys for team/enterprise deployments.
+
   Trigger with phrases like "install windsurf", "setup windsurf",
+
   "windsurf auth", "codeium login", "windsurf API key".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(brew:*), Bash(curl:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, codeium, authentication, ide-setup]
+tags:
+- saas
+- windsurf
+- codeium
+- authentication
+- ide-setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Install & Auth
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-known-pitfalls/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-known-pitfalls
-description: |
-  Identify and avoid Windsurf anti-patterns and common mistakes.
+description: 'Identify and avoid Windsurf anti-patterns and common mistakes.
+
   Use when onboarding new developers to Windsurf, reviewing AI workflow practices,
+
   or auditing Windsurf configuration for issues.
+
   Trigger with phrases like "windsurf mistakes", "windsurf anti-patterns",
+
   "windsurf pitfalls", "windsurf what not to do", "windsurf gotchas".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, anti-patterns, gotchas, best-practices]
+tags:
+- saas
+- windsurf
+- anti-patterns
+- gotchas
+- best-practices
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Known Pitfalls
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-load-scale/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-load-scale/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-load-scale
-description: |
-  Scale Windsurf adoption across large organizations with workspace strategies and performance tuning.
+description: 'Scale Windsurf adoption across large organizations with workspace strategies
+  and performance tuning.
+
   Use when rolling out Windsurf to 50+ developers, managing large monorepo workspaces,
+
   or planning enterprise-scale deployment.
+
   Trigger with phrases like "windsurf at scale", "windsurf large team",
+
   "windsurf monorepo", "windsurf organization", "windsurf 100 developers".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, scaling, enterprise, large-team]
+tags:
+- saas
+- windsurf
+- scaling
+- enterprise
+- large-team
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Load & Scale
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-local-dev-loop/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-local-dev-loop
-description: |
-  Configure Windsurf local development workflow with Cascade, Previews, and terminal integration.
+description: 'Configure Windsurf local development workflow with Cascade, Previews,
+  and terminal integration.
+
   Use when setting up a development environment, configuring Turbo mode,
+
   or establishing a fast iteration cycle with Windsurf AI.
+
   Trigger with phrases like "windsurf dev setup", "windsurf local development",
+
   "windsurf dev environment", "windsurf workflow", "develop with windsurf".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, workflow, development, turbo-mode]
+tags:
+- saas
+- windsurf
+- workflow
+- development
+- turbo-mode
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Local Dev Loop
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-migration-deep-dive/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-migration-deep-dive
-description: |
-  Migrate to Windsurf from VS Code, Cursor, or other AI IDEs with full configuration transfer.
+description: 'Migrate to Windsurf from VS Code, Cursor, or other AI IDEs with full
+  configuration transfer.
+
   Use when migrating a team to Windsurf, transferring Cursor rules,
+
   or evaluating Windsurf against other AI editors.
+
   Trigger with phrases like "migrate to windsurf", "switch to windsurf",
+
   "windsurf from cursor", "windsurf from copilot", "windsurf evaluation".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, migration, cursor, vscode]
+tags:
+- saas
+- windsurf
+- migration
+- cursor
+- vscode
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Migration Deep Dive
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-multi-env-setup/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-multi-env-setup
-description: |
-  Configure Windsurf IDE and Cascade AI across team members and project environments.
+description: 'Configure Windsurf IDE and Cascade AI across team members and project
+  environments.
+
   Use when onboarding teams to Windsurf, setting up per-project Cascade configuration,
+
   or managing Windsurf settings across development, staging, and production contexts.
+
   Trigger with phrases like "windsurf team setup", "windsurf environments",
+
   "windsurf multi-project", "windsurf team config", "cascade rules per env".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, team-setup, multi-environment]
+tags:
+- saas
+- windsurf
+- team-setup
+- multi-environment
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Multi-Environment Setup
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-observability/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-observability/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-observability
-description: |
-  Monitor Windsurf AI adoption, feature usage, and team productivity metrics.
+description: 'Monitor Windsurf AI adoption, feature usage, and team productivity metrics.
+
   Use when tracking AI feature usage, measuring ROI, setting up dashboards,
+
   or analyzing Cascade effectiveness across your team.
+
   Trigger with phrases like "windsurf monitoring", "windsurf metrics",
+
   "windsurf analytics", "windsurf usage", "windsurf adoption".
+
+  '
 allowed-tools: Read, Write, Edit
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, monitoring, analytics, team-management]
+tags:
+- saas
+- windsurf
+- monitoring
+- analytics
+- team-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Observability
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-performance-tuning/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-performance-tuning
-description: |
-  Optimize Windsurf IDE performance: indexing speed, Cascade responsiveness, and memory usage.
+description: 'Optimize Windsurf IDE performance: indexing speed, Cascade responsiveness,
+  and memory usage.
+
   Use when Windsurf is slow, indexing takes too long, Cascade times out,
+
   or the IDE uses too much memory.
+
   Trigger with phrases like "windsurf slow", "windsurf performance",
+
   "optimize windsurf", "windsurf memory", "cascade slow", "indexing slow".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, performance, indexing, optimization]
+tags:
+- saas
+- windsurf
+- performance
+- indexing
+- optimization
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Performance Tuning
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-policy-guardrails/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: windsurf-policy-guardrails
-description: |
-  Implement team-wide Windsurf usage policies, code quality gates, and Cascade guardrails.
-  Use when setting up code review policies for AI-generated code, configuring Turbo mode
+description: 'Implement team-wide Windsurf usage policies, code quality gates, and
+  Cascade guardrails.
+
+  Use when setting up code review policies for AI-generated code, configuring Turbo
+  mode
+
   safety controls, or implementing CI gates for Cascade output.
+
   Trigger with phrases like "windsurf policy", "windsurf guardrails",
+
   "cascade safety rules", "windsurf team rules", "AI code policy".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, policy, guardrails, team-management]
+tags:
+- saas
+- windsurf
+- policy
+- guardrails
+- team-management
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Policy Guardrails
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-prod-checklist/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-prod-checklist
-description: |
-  Execute Windsurf production readiness checklist for team and enterprise deployments.
+description: 'Execute Windsurf production readiness checklist for team and enterprise
+  deployments.
+
   Use when rolling out Windsurf to a team, preparing for enterprise deployment,
+
   or auditing production configuration.
+
   Trigger with phrases like "windsurf production", "windsurf team rollout",
+
   "windsurf go-live", "windsurf enterprise deploy", "windsurf checklist".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, deployment, enterprise, checklist]
+tags:
+- saas
+- windsurf
+- deployment
+- enterprise
+- checklist
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Production Checklist
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-rate-limits/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-rate-limits/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-rate-limits
-description: |
-  Understand and manage Windsurf credit system, usage limits, and model selection.
+description: 'Understand and manage Windsurf credit system, usage limits, and model
+  selection.
+
   Use when running out of credits, optimizing AI usage costs,
+
   or understanding the credit-per-model pricing structure.
+
   Trigger with phrases like "windsurf credits", "windsurf rate limit",
+
   "windsurf usage", "windsurf out of credits", "windsurf model costs".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, credits, pricing, usage]
+tags:
+- saas
+- windsurf
+- credits
+- pricing
+- usage
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Rate Limits & Credits
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-reference-architecture/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-reference-architecture
-description: |
-  Implement Windsurf reference architecture with optimal project structure and AI configuration.
+description: 'Implement Windsurf reference architecture with optimal project structure
+  and AI configuration.
+
   Use when designing workspace configuration for Windsurf, setting up team standards,
+
   or establishing architecture patterns that maximize Cascade effectiveness.
+
   Trigger with phrases like "windsurf architecture", "windsurf project structure",
+
   "windsurf best practices", "windsurf team setup", "optimize for cascade".
+
+  '
 allowed-tools: Read, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, architecture, configuration, team-setup]
+tags:
+- saas
+- windsurf
+- architecture
+- configuration
+- team-setup
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Reference Architecture
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-reliability-patterns/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: windsurf-reliability-patterns
-description: |
-  Implement reliable Cascade workflows with checkpoints, rollback, and incremental editing.
-  Use when building fault-tolerant AI coding workflows, preventing Cascade from breaking builds,
+description: 'Implement reliable Cascade workflows with checkpoints, rollback, and
+  incremental editing.
+
+  Use when building fault-tolerant AI coding workflows, preventing Cascade from breaking
+  builds,
+
   or establishing safe practices for multi-file AI edits.
+
   Trigger with phrases like "windsurf reliability", "cascade safety",
+
   "windsurf rollback", "cascade checkpoint", "safe cascade workflow".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, reliability, safety, git-workflow]
+tags:
+- saas
+- windsurf
+- reliability
+- safety
+- git-workflow
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Reliability Patterns
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-sdk-patterns/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-sdk-patterns
-description: |
-  Apply production-ready Windsurf workspace configuration and Cascade interaction patterns.
+description: 'Apply production-ready Windsurf workspace configuration and Cascade
+  interaction patterns.
+
   Use when configuring .windsurfrules, workspace rules, MCP servers,
+
   or establishing team coding standards for Windsurf AI.
+
   Trigger with phrases like "windsurf patterns", "windsurf best practices",
+
   "windsurf config patterns", "windsurfrules", "windsurf workspace".
+
+  '
 allowed-tools: Read, Write, Edit, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, configuration, rules, mcp]
+tags:
+- saas
+- windsurf
+- configuration
+- rules
+- mcp
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Configuration Patterns
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-security-basics/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-security-basics/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-security-basics
-description: |
-  Apply Windsurf security best practices for workspace isolation, data privacy, and secret protection.
+description: 'Apply Windsurf security best practices for workspace isolation, data
+  privacy, and secret protection.
+
   Use when securing sensitive code from AI indexing, configuring telemetry,
+
   or auditing Windsurf security posture.
+
   Trigger with phrases like "windsurf security", "windsurf secrets",
+
   "windsurf privacy", "windsurf data protection", "codeiumignore".
+
+  '
 allowed-tools: Read, Write, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, security, privacy, compliance]
+tags:
+- saas
+- windsurf
+- security
+- privacy
+- compliance
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Security Basics
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-upgrade-migration/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: windsurf-upgrade-migration
-description: |
-  Upgrade Windsurf IDE, migrate settings from VS Code or Cursor, and handle breaking changes.
+description: 'Upgrade Windsurf IDE, migrate settings from VS Code or Cursor, and handle
+  breaking changes.
+
   Use when upgrading Windsurf versions, migrating from another editor,
+
   or handling configuration changes after updates.
+
   Trigger with phrases like "upgrade windsurf", "windsurf update",
+
   "migrate to windsurf", "windsurf from cursor", "windsurf from vscode".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(git:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, migration, upgrade, vscode]
+tags:
+- saas
+- windsurf
+- migration
+- upgrade
+- vscode
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Upgrade & Migration
 

--- a/plugins/saas-packs/windsurf-pack/skills/windsurf-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/windsurf-pack/skills/windsurf-webhooks-events/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: windsurf-webhooks-events
-description: |
-  Build Windsurf extensions and integrate with VS Code extension API events.
+description: 'Build Windsurf extensions and integrate with VS Code extension API events.
+
   Use when building custom Windsurf extensions, tracking editor events,
+
   or integrating Windsurf with external tools via extension development.
+
   Trigger with phrases like "windsurf extension", "windsurf events",
+
   "windsurf plugin", "build windsurf extension", "windsurf API".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*)
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-compatible-with: claude-code, codex, openclaw
-tags: [saas, windsurf, extensions, vscode-api, development]
+tags:
+- saas
+- windsurf
+- extensions
+- vscode-api
+- development
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Windsurf Extension Development & Events
 

--- a/plugins/saas-packs/wispr-pack/skills/wispr-ci-integration/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-ci-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-ci-integration
-description: |
-  Wispr Flow ci integration for voice-to-text API integration.
+description: 'Wispr Flow ci integration for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-common-errors/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-common-errors/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-common-errors
-description: |
-  Wispr Flow common errors for voice-to-text API integration.
+description: 'Wispr Flow common errors for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Common Errors
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-core-workflow-a
-description: |
-  Wispr Flow core workflow a for voice-to-text API integration.
+description: 'Wispr Flow core workflow a for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr core workflow a".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-core-workflow-b/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-core-workflow-b
-description: |
-  Wispr Flow core workflow b for voice-to-text API integration.
+description: 'Wispr Flow core workflow b for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr core workflow b".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-cost-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-cost-tuning
-description: |
-  Wispr Flow cost tuning for voice-to-text API integration.
+description: 'Wispr Flow cost tuning for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-debug-bundle/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-debug-bundle
-description: |
-  Wispr Flow debug bundle for voice-to-text API integration.
+description: 'Wispr Flow debug bundle for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-deploy-integration
-description: |
-  Wispr Flow deploy integration for voice-to-text API integration.
+description: 'Wispr Flow deploy integration for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-hello-world/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-hello-world/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-hello-world
-description: |
-  Wispr Flow hello world for voice-to-text API integration.
+description: 'Wispr Flow hello world for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr hello world".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Hello World
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-install-auth/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-install-auth
-description: |
-  Wispr Flow install auth for voice-to-text API integration.
+description: 'Wispr Flow install auth for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr install auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-local-dev-loop/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-local-dev-loop
-description: |
-  Wispr Flow local dev loop for voice-to-text API integration.
+description: 'Wispr Flow local dev loop for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-performance-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-performance-tuning
-description: |
-  Wispr Flow performance tuning for voice-to-text API integration.
+description: 'Wispr Flow performance tuning for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-prod-checklist/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-prod-checklist
-description: |
-  Wispr Flow prod checklist for voice-to-text API integration.
+description: 'Wispr Flow prod checklist for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-rate-limits/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-rate-limits
-description: |
-  Wispr Flow rate limits for voice-to-text API integration.
+description: 'Wispr Flow rate limits for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-reference-architecture/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-reference-architecture
-description: |
-  Wispr Flow reference architecture for voice-to-text API integration.
+description: 'Wispr Flow reference architecture for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-sdk-patterns/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-sdk-patterns
-description: |
-  Wispr Flow sdk patterns for voice-to-text API integration.
+description: 'Wispr Flow sdk patterns for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-security-basics/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-security-basics/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-security-basics
-description: |
-  Wispr Flow security basics for voice-to-text API integration.
+description: 'Wispr Flow security basics for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Security Basics
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-upgrade-migration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-upgrade-migration
-description: |
-  Wispr Flow upgrade migration for voice-to-text API integration.
+description: 'Wispr Flow upgrade migration for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/wispr-pack/skills/wispr-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/wispr-pack/skills/wispr-webhooks-events/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: wispr-webhooks-events
-description: |
-  Wispr Flow webhooks events for voice-to-text API integration.
+description: 'Wispr Flow webhooks events for voice-to-text API integration.
+
   Use when integrating Wispr Flow dictation, WebSocket streaming,
+
   or building voice-powered applications.
+
   Trigger: "wispr webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, voice, dictation, wispr]
-compatible-with: claude-code
+tags:
+- saas
+- voice
+- dictation
+- wispr
+compatibility: Designed for Claude Code
 ---
-
 # Wispr Flow Webhooks Events
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-ci-integration/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-ci-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-ci-integration
-description: |
-  Workhuman ci integration for employee recognition and rewards API.
+description: 'Workhuman ci integration for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman ci integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Ci Integration
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-common-errors/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-common-errors/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-common-errors
-description: |
-  Workhuman common errors for employee recognition and rewards API.
+description: 'Workhuman common errors for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman common errors".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Common Errors
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-core-workflow-a/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-core-workflow-a
-description: |
-  Workhuman core workflow a for employee recognition and rewards API.
+description: 'Workhuman core workflow a for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman core workflow a".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Core Workflow A
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-core-workflow-b/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-core-workflow-b
-description: |
-  Workhuman core workflow b for employee recognition and rewards API.
+description: 'Workhuman core workflow b for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman core workflow b".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Core Workflow B
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-cost-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-cost-tuning
-description: |
-  Workhuman cost tuning for employee recognition and rewards API.
+description: 'Workhuman cost tuning for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman cost tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-debug-bundle/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-debug-bundle
-description: |
-  Workhuman debug bundle for employee recognition and rewards API.
+description: 'Workhuman debug bundle for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman debug bundle".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Debug Bundle
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-deploy-integration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-deploy-integration
-description: |
-  Workhuman deploy integration for employee recognition and rewards API.
+description: 'Workhuman deploy integration for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman deploy integration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-hello-world/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-hello-world/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-hello-world
-description: |
-  Workhuman hello world for employee recognition and rewards API.
+description: 'Workhuman hello world for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman hello world".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Hello World
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-install-auth/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-install-auth/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-install-auth
-description: |
-  Workhuman install auth for employee recognition and rewards API.
+description: 'Workhuman install auth for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman install auth".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-local-dev-loop/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-local-dev-loop
-description: |
-  Workhuman local dev loop for employee recognition and rewards API.
+description: 'Workhuman local dev loop for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman local dev loop".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-performance-tuning/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-performance-tuning
-description: |
-  Workhuman performance tuning for employee recognition and rewards API.
+description: 'Workhuman performance tuning for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman performance tuning".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-prod-checklist/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-prod-checklist
-description: |
-  Workhuman prod checklist for employee recognition and rewards API.
+description: 'Workhuman prod checklist for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman prod checklist".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Prod Checklist
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-rate-limits/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-rate-limits/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-rate-limits
-description: |
-  Workhuman rate limits for employee recognition and rewards API.
+description: 'Workhuman rate limits for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman rate limits".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-reference-architecture/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: workhuman-reference-architecture
-description: |
-  Workhuman reference architecture for employee recognition and rewards API.
+description: 'Workhuman reference architecture for employee recognition and rewards
+  API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman reference architecture".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-sdk-patterns/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-sdk-patterns
-description: |
-  Workhuman sdk patterns for employee recognition and rewards API.
+description: 'Workhuman sdk patterns for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman sdk patterns".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Sdk Patterns
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-security-basics/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-security-basics/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-security-basics
-description: |
-  Workhuman security basics for employee recognition and rewards API.
+description: 'Workhuman security basics for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman security basics".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Security Basics
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-upgrade-migration/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-upgrade-migration
-description: |
-  Workhuman upgrade migration for employee recognition and rewards API.
+description: 'Workhuman upgrade migration for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman upgrade migration".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Upgrade Migration
 
 ## Overview

--- a/plugins/saas-packs/workhuman-pack/skills/workhuman-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/workhuman-pack/skills/workhuman-webhooks-events/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: workhuman-webhooks-events
-description: |
-  Workhuman webhooks events for employee recognition and rewards API.
+description: 'Workhuman webhooks events for employee recognition and rewards API.
+
   Use when integrating Workhuman Social Recognition,
+
   or building recognition workflows with HRIS systems.
+
   Trigger: "workhuman webhooks events".
+
+  '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
-tags: [saas, hr, recognition, workhuman]
-compatible-with: claude-code
+tags:
+- saas
+- hr
+- recognition
+- workhuman
+compatibility: Designed for Claude Code
 ---
-
 # Workhuman Webhooks Events
 
 ## Overview


### PR DESCRIPTION
## Summary

Chunk 6 of 6 of the saas-packs portion of issue #613 — bulk migration of the deprecated `compatible-with` CSV-platform-list field to the spec-aligned `compatibility` free-text field per agentskills.io/specification.

This is the **last** Phase 3 chunk; once this PR + the previous 7 (#620, #622, and saas-packs 1–5) all merge, every `compatible-with` field in the repo has been migrated to `compatibility`. `grep -rl '^compatible-with:' plugins/` will return 0 results across the whole tree.

**Pure schema migration. No content changes.** Same tool used in all prior Phase 3 PRs.

### Assigned packs (chunk 6 of 6)

| Pack | Files |
|---|---|
| sentry-pack | 30 |
| serpapi-pack | 18 |
| shopify-pack | 38 |
| snowflake-pack | 30 |
| speak-pack | 24 |
| stackblitz-pack | 18 |
| supabase-pack | 30 |
| techsmith-pack | 18 |
| together-pack | 18 |
| twinmind-pack | 24 |
| vastai-pack | 24 |
| veeva-pack | 24 |
| vercel-pack | 30 |
| webflow-pack | 24 |
| windsurf-pack | 30 |
| wispr-pack | 18 |
| workhuman-pack | 18 |
| **TOTAL** | **416** |

### Side effect

`yaml.safe_dump` round-trips the entire frontmatter — so `description: |` literal blocks come out as single-quoted or folded scalars. **The rendered description text is unchanged; only the YAML representation differs.**

## Test plan

- [x] `grep -rl '^compatible-with:' plugins/saas-packs/<each-pack>/` returns 0 results post-migration
- [ ] CI: validate-plugins.yml passes
- [ ] CI: marketplace-validation passes

Closes #613

jeremy made me do it
-claude