### PR TITLE
fix(ci): remove pnpm version conflict in sync-external workflow

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        # version is read from package.json `packageManager` field
+        # (specifying both `version: 9` and `packageManager` causes pnpm/action-setup
+        # to error with ERR_PNPM_BAD_PM_VERSION)
 
       - name: Install dependencies
         run: pnpm add js-yaml


### PR DESCRIPTION
## Summary

The Sync External Plugins workflow has been failing every run since this repo's pnpm version got pinned in `package.json`'s `packageManager` field. `pnpm/action-setup@v4` errors with `ERR_PNPM_BAD_PM_VERSION` when both `version: 9` (in the workflow) AND `packageManager: pnpm@9.x.x` (in package.json) are specified.

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.15.9+sha512.68046141893c66fad01... in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

## Fix

Drop the workflow-level `version: 9` and let `pnpm/action-setup@v4` read pnpm version from `package.json`. Same pattern used by `validate-plugins.yml`.

## Why now

Discovered while triaging #630 (cross-repo `compatible-with` → `compatibility` migration). Most external upstreams (`wondelai/skills`, `numman-ali/n-skills`, `roboticforce/sugar`) have ALREADY migrated past `compatible-with` — but the marketplace mirrors are stale because this workflow has been failing every run. Fixing this unblocks the marketplace from refreshing automatically.

## Test plan
- [x] Local workflow file syntax-checks clean (no other action references the dropped version)
- [ ] Trigger `workflow_dispatch` after merge → first run should succeed past Setup pnpm
- [ ] If sync detects external changes, it auto-PRs them per the workflow's own logic

jeremy made me do it
-claude