### PR TITLE
fix(ci): install workspace deps instead of pnpm-add in sync-external

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -49,7 +49,10 @@ jobs:
         # to error with ERR_PNPM_BAD_PM_VERSION)
 
       - name: Install dependencies
-        run: pnpm add js-yaml
+        # js-yaml is already in devDependencies; just install the workspace.
+        # Previously this was `pnpm add js-yaml` which fails with
+        # ERR_PNPM_ADDING_TO_ROOT once the repo is a real workspace.
+        run: pnpm install --frozen-lockfile
 
       - name: Run sync script
         id: sync


### PR DESCRIPTION
## Summary

After [PR #635](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/635) fixed the Setup pnpm step, the next step (Install dependencies) was still failing with `ERR_PNPM_ADDING_TO_ROOT` because pnpm refuses to add a package directly to a workspace root without `-w`.

```
ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root,
which might not be what you want - if you really meant it, make it explicit by running this
command again with the -w flag (or --workspace-root).
```

## Root cause

`js-yaml` is already in root `package.json` devDependencies (`^4.1.1`), so `pnpm add js-yaml` was both redundant AND broken.

## Fix

Replace with `pnpm install --frozen-lockfile` — the standard pattern used by every other workflow in this repo (validate-plugins.yml, marketplace-validation, etc.). Same one-liner that ran successfully in the later "Sync marketplace catalog" step within this same workflow.

## Why this is the second fix

The original sync-external workflow had two layers of breakage. PR #635 fixed Setup pnpm; this PR fixes Install dependencies.

After this lands and a successful sync runs, marketplace mirrors of all 30 externally-synced plugins (wondelai/*, gastown, zai-cli, sugar, etc.) should refresh, auto-resolving [#630](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/630).

## Test plan
- [x] `pnpm install --frozen-lockfile` is the same idiom used by validate-plugins.yml
- [ ] Trigger `workflow_dispatch` after merge → first run should succeed past Install dependencies
- [ ] If sync detects mirror drift, it auto-PRs the cleanup

jeremy made me do it
-claude