### PR TITLE
fix(sync): handle empty files + submodules + partial failures (third sync-external fix)

### DIFF
--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -80,15 +80,20 @@ async function fetchFromGitHub(repo, filePath, branch = 'main') {
         if (res.statusCode === 200) {
           try {
             const json = JSON.parse(data);
-            if (json.content) {
-              // Decode base64 content
-              const content = Buffer.from(json.content, 'base64').toString('utf8');
+            // File response — `content` may be an empty string for 0-byte
+            // files (e.g. .gitkeep, blank __init__.py) which is still a valid
+            // file we want to copy. Use type === 'file' as the truth-source.
+            if (json.type === 'file' || typeof json.content === 'string') {
+              const content = Buffer.from(json.content || '', 'base64').toString('utf8');
               resolve({ content, sha: json.sha, path: json.path });
             } else if (Array.isArray(json)) {
               // Directory listing
               resolve({ type: 'directory', files: json });
+            } else if (json.type === 'submodule' || json.type === 'symlink') {
+              // Skip submodules and symlinks — can't safely mirror these as plain files
+              resolve(null);
             } else {
-              reject(new Error(`Unexpected response format for ${filePath}`));
+              reject(new Error(`Unexpected response format for ${filePath} (type=${json.type ?? 'none'})`));
             }
           } catch (e) {
             reject(new Error(`Failed to parse response: ${e.message}`));
@@ -327,7 +332,11 @@ async function main() {
   }
 
   log('\n');
-  process.exit(errors.length > 0 ? 1 : 0);
+  // Exit 1 only on TOTAL failure (no source succeeded). Partial failures
+  // print warnings and are surfaced via the GitHub Actions summary, but they
+  // shouldn't block downstream steps that need to commit the partial sync.
+  const totalFailures = errors.length === sourcesToSync.length;
+  process.exit(totalFailures ? 1 : 0);
 }
 
 // Run


### PR DESCRIPTION
## Summary

After [#635](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/635) (Setup pnpm) and [#636](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/636) (Install dependencies) unblocked the workflow scaffolding, a manual run revealed three more script-level edge cases. **270 files synced successfully** but 3 of 35 sources errored, causing `process.exit(1)` and preventing the auto-PR from being created.

## Three fixes

**1. Empty files (0-byte)**

GitHub API returns `content: ""` for 0-byte files like `.gitkeep` and blank `__init__.py`. Old check `if (json.content)` rejected these as 'unexpected format' because empty string is falsy. New check keys off `type === 'file' || typeof content === 'string'` and decodes `json.content || ''`.
- Affected sources: `x-bug-triage` (agents/.gitkeep), `tonone` (lib/uiux/tests/__init__.py)

**2. Submodules and symlinks**

GitHub API returns `{ type: 'submodule', submodule_git_url, ... }` (no `content`, not an array). Old code rejected these. New code treats them like 404 (resolve null, log skip).
- Affected source: `Claudebase` (tests/bats — Bats test framework as submodule)

**3. Partial-failure exit code**

Old: `process.exit(errors.length > 0 ? 1 : 0)` — exits 1 if ANY source errors. This prevented the workflow's 'Check for changes' → 'Create PR' chain from running because they're gated on the previous step succeeding.

New: exit 1 only when ALL sources failed (true catastrophic case). Partial failures print warnings + propagate via the workflow summary but exit 0 so downstream commit + PR steps run.

## Together with #635 + #636 → revives sync-external

| PR | Layer | What it fixed |
|---|---|---|
| #635 | Workflow Setup pnpm | Removed conflicting `version: 9` |
| #636 | Workflow Install deps | `pnpm add` → `pnpm install --frozen-lockfile` |
| **#637 (this)** | Script behavior | Empty files + submodules + partial-failure exit |

After this lands and a manual sync runs, marketplace mirrors of all externally-synced plugins should refresh — auto-resolving [#630](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/630).

## Test plan
- [x] Logic verified against actual failure cases from run `25199912677`
- [ ] Trigger sync after merge → expect 35 sources succeed (or 32 succeed + 3 logged warnings, depending on whether the 3 had OTHER issues besides .gitkeep/submodule)
- [ ] Auto-PR opened by workflow with marketplace mirror cleanup

jeremy made me do it
-claude