### PR TITLE
fix(ci): use --no-frozen-lockfile in sync-external post-sync install

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -86,8 +86,12 @@ jobs:
 
       - name: Sync marketplace catalog
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
+        # Use --no-frozen-lockfile here intentionally: the sync step above can
+        # overwrite synced plugins' package.json from upstream, which legitimately
+        # diverges from the committed pnpm-lock.yaml. The auto-PR this workflow
+        # creates is reviewable, so allowing lockfile updates is safe.
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --no-frozen-lockfile
           node scripts/sync-marketplace.cjs
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

Fourth and (hopefully) final blocker in the sync-external revival chain. The post-sync `Sync marketplace catalog` step was running `pnpm install --frozen-lockfile`, but the sync step ABOVE it can overwrite synced plugins' `package.json` files from upstream — legitimately diverging from the committed `pnpm-lock.yaml`.

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/plugins/mcp/slack-channel/package.json

specifiers in the lockfile ({"@modelcontextprotocol/sdk":"^1.0.0", ...}) don't match
specs in package.json ({"@modelcontextprotocol/sdk":"1.27.1", ...})
```

## Fix

Switch to `pnpm install --no-frozen-lockfile` in this specific step. This is exactly the case the flag exists for: a sync workflow that legitimately introduces package.json changes from upstream. The auto-PR the workflow creates is reviewable, so any lockfile update lands as part of that PR for human approval.

## Sync-external revival series

| PR | Layer | What it fixed |
|---|---|---|
| #635 | Workflow Setup pnpm | Removed conflicting `version: 9` |
| #636 | Workflow Install deps | `pnpm add` → `pnpm install` |
| #637 | Script behavior | Empty files + submodules + partial-failure exit |
| **#638 (this)** | Workflow post-sync install | `--frozen-lockfile` → `--no-frozen-lockfile` |

After this lands and a manual sync runs, the auto-PR should refresh 270+ marketplace mirror files (wondelai/* etc.) and auto-resolve #630.

jeremy made me do it
-claude