### PR TITLE
fix(ci): disable husky pre-commit in sync-external auto-PR step (5th and final layer)

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -96,6 +96,14 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
+        # HUSKY=0 disables the husky pre-commit hook for the action's internal
+        # `git commit`. The hook (installed by PR #629) runs lint-staged →
+        # `bunx @biomejs/biome` (bun isn't on the runner — ENOENT) and
+        # `pnpm prettier --write` (gets SIGKILL trying to format thousands of
+        # synced files). The auto-PR is reviewable, so skipping pre-commit
+        # here is safe — actual quality gates run on the PR via CI.
+        env:
+          HUSKY: 0
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fifth and final layer of breakage in the sync-external workflow chain.

After PRs #635 → #636 → #637 → #638 unblocked Setup pnpm → Install deps → script → post-sync install, run `25200217902` revealed the auto-PR step itself was failing because `peter-evans/create-pull-request@v8` does an internal `git commit`, which fires the husky pre-commit hook (installed by #629). Two failure modes:

```
✖ Task failed to spawn: bunx @biomejs/biome check --write --no-errors-on-unmatched
ENOENT
✖ Task killed: pnpm prettier --write   (SIGKILL — OOM)
husky - pre-commit script failed (code 1)
```

1. lint-staged invokes `bunx @biomejs/biome` — `bun` isn't installed on the runner.
2. lint-staged invokes `pnpm prettier --write` against thousands of synced files — the runner OOMs and SIGKILLs the prettier process.

## Fix

Set `HUSKY=0` env var on the Create Pull Request step. Pre-commit hooks exist for human commits; they are the wrong gate for automation that batches hundreds of synced files. Quality is still enforced — the auto-PR runs through normal CI before merge.

## sync-external revival series complete

| PR | Layer | What broke | What shipped |
|---|---|---|---|
| #635 | Setup pnpm | `ERR_PNPM_BAD_PM_VERSION` | Drop `version: 9` from action |
| #636 | Install deps | `ERR_PNPM_ADDING_TO_ROOT` | `pnpm add` → `pnpm install` |
| #637 | Sync script | Empty files + submodules + bad exit code | Handle null content, skip submodules, exit 1 only on total failure |
| #638 | Post-sync install | `ERR_PNPM_OUTDATED_LOCKFILE` | `--no-frozen-lockfile` for legitimate upstream package.json drift |
| **#639 (this)** | Auto-PR commit | husky pre-commit kills auto-commit | `HUSKY=0` env on the action |

After this lands and a `workflow_dispatch` runs, expect a reviewable auto-PR with marketplace mirror cleanup that auto-resolves #630.

jeremy made me do it
-claude