### PR TITLE
chore(docs): pull v4.3 doc-filing standard + fix gitignore re-include bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,19 @@ build/
 coverage/
 
 # Private documentation and business documents (NEVER commit)
-000-docs/
-# EXCEPT: 6767 canonical standards (cross-repo standards)
+#
+# Two-part rule because git can't re-include files inside an excluded *directory*:
+# 1) Ignore nested 000-docs/ everywhere (e.g. plugins/saas-packs/*/000-docs/)
+#    — these are per-pack private docs, never tracked.
+# 2) For ROOT-level 000-docs/, ignore at file level so we can re-include the
+#    canonical cross-repo standards via `!` rules below.
+**/000-docs/
+000-docs/*
+000-docs/**/*
+# EXCEPT root-level canonical cross-repo standards:
+#   v4.3 standard: 000-* prefix (current — see 000-DR-STND-document-filing-system.md)
+#   v3.x legacy:   6767-* prefix (kept tracked during transition; will deprecate)
+!000-docs/000-*.md
 !000-docs/6767*.md
 website/
 

--- a/000-docs/000-DR-STND-document-filing-system.md
+++ b/000-docs/000-DR-STND-document-filing-system.md
@@ -1,0 +1,309 @@
+# DOCUMENT FILING SYSTEM STANDARD v4.3 (LLM/AI-ASSISTANT FRIENDLY)
+**Purpose:** Universal, deterministic naming + filing standard for project docs with canonical cross-repo "000-*" standards series
+**Status:** Production Standard (v3-compatible, v4.0-compatible, v4.2-compatible)
+**Last Updated:** 2026-02-05
+**Changelog:** v4.3 migrates from 6767 prefix to 000-* prefix for canonical standards
+**Applies To:** All projects in `/home/jeremy/000-projects/` and all canonical standards in the 000-* series
+
+---
+
+## 0) ONE-SCREEN RULES (AI SHOULD MEMORIZE THESE)
+1) **Two filename families only:**
+   - **Project docs:** `NNN-CC-ABCD-short-description.ext` (001-999)
+   - **Canonical standards:** `000-CC-ABCD-short-description.ext`
+2) **NNN is chronological** (001-999). **000 is reserved for canonical cross-repo standards.**
+3) **All codes are mandatory:** `CC` (category) + `ABCD` (type).
+4) **Description is short:** 1-4 words (project), 1-5 words (000-*), **kebab-case**, lowercase.
+5) **Subdocs:** either `005a` letter suffix or `006-1` numeric suffix.
+6) **000-* files MUST be identical across all repos using this standard.**
+
+---
+
+## 1) FILENAME SPEC (DETERMINISTIC)
+### 1.1 Project Docs (001-999 series)
+**Pattern**
+
+NNN-CC-ABCD-short-description.ext
+
+**Fields**
+- `NNN`: 001-999 (zero padded, chronological)
+- `CC`: 2-letter category code (table below)
+- `ABCD`: 4-letter doc type abbreviation (tables below)
+- `short-description`: 1-4 words, kebab-case
+- `ext`: `.md` preferred; others allowed (`.pdf`, `.txt`, `.xlsx`, etc.)
+
+**Examples**
+
+001-AT-ADEC-initial-architecture.md
+005-PM-TASK-api-endpoints.md
+009-AA-AACR-sprint-1-review.md
+
+### 1.2 Sub-Docs (same parent number)
+**Option A — letter suffix**
+
+005-PM-TASK-api-endpoints.md
+005a-PM-TASK-auth-endpoints.md
+005b-PM-TASK-payment-endpoints.md
+
+**Option B — numeric suffix**
+
+006-PM-RISK-security-audit.md
+006-1-PM-RISK-encryption-review.md
+006-2-PM-RISK-access-controls.md
+
+### 1.3 Canonical Standards (000-* series)
+**Purpose:** Cross-repo reusable SOPs, standards, patterns, architectures.
+
+**Pattern**
+
+000-CC-ABCD-short-description.ext
+
+**Fields**
+- `000`: fixed prefix for canonical cross-repo standards
+- `CC`: 2-letter category code (same as NNN series)
+- `ABCD`: 4-letter type code (same master tables)
+- `short-description`: 1-5 words, kebab-case
+
+**Key Rule:** 000-* files MUST be identical across all repos. Use drift checking.
+
+**Correct examples**
+
+000-DR-STND-document-filing-system.md
+000-TM-STND-secrets-handling.md
+000-DR-INDX-standards-catalog.md
+
+**Incorrect (banned)**
+
+000-a-DR-STND-document-filing-system.md   ❌ No letter suffix needed
+000-120-DR-INDEX-standards-catalog.md     ❌ No numeric ID after 000
+
+---
+
+## 2) FAST DECISION: WHICH SERIES DO I USE?
+Use this rule of thumb:
+
+| If the doc is… | Use… |
+|---|---|
+| reusable standard/process/pattern across multiple repos | **000-*** |
+| specific to one repo/app/phase/sprint/implementation | **NNN (001-999)** |
+
+---
+
+## 3) CANONICAL STORAGE LOCATIONS (DEFAULTS)
+- **Project docs:** `<repo>/000-docs/` (flat, no subdirectories)
+- **000-* canonical docs:** `<repo>/000-docs/` (same folder as NNN docs)
+
+---
+
+## 3.1) 000-docs Flatness Rule (Strict)
+
+**Purpose:** Keep all documentation in a single flat directory for simplicity and discoverability.
+
+**Rules:**
+- `000-docs/` contains all docs (NNN and 000-*) at one level.
+- **No subdirectories allowed under `000-docs/`.**
+- If assets are needed, store them adjacent to the doc file (same folder) and keep naming clear.
+
+**Folder Structure:**
+```
+000-docs/
+├── 001-PP-PROD-mvp-requirements.md       # NNN project docs
+├── 002-AT-ADEC-architecture.md
+├── 010-AA-AACR-phase-1-review.md
+├── 000-DR-STND-document-filing-system.md # 000-* canonical docs
+├── 000-DR-INDX-standards-catalog.md
+└── 000-AA-TMPL-after-action-report.md
+```
+
+---
+
+## 3.2) Cross-Repo Synchronization
+
+**Source of Truth:** One repo is designated as canonical source (e.g., `irsb-solver`).
+
+**Drift Detection:** All repos should include `scripts/check-canonical-drift.sh`:
+```bash
+#!/bin/bash
+# Check that 000-* files match the canonical source
+for file in 000-docs/000-*.md; do
+  if [ -f "$file" ]; then
+    echo "$(shasum -a 256 "$file" | cut -d' ' -f1) $file"
+  fi
+done
+```
+
+**Rule:** If checksums differ between repos, sync from the source of truth.
+
+---
+
+## 4) CATEGORIES (CC) — 2 LETTERS
+| Code | Category |
+|---|---|
+| PP | Product & Planning |
+| AT | Architecture & Technical |
+| DC | Development & Code |
+| TQ | Testing & Quality |
+| OD | Operations & Deployment |
+| LS | Logs & Status |
+| RA | Reports & Analysis |
+| MC | Meetings & Communication |
+| PM | Project Management |
+| DR | Documentation & Reference |
+| UC | User & Customer |
+| BL | Business & Legal |
+| RL | Research & Learning |
+| AA | After Action & Review |
+| WA | Workflows & Automation |
+| DD | Data & Datasets |
+| MS | Miscellaneous |
+| PR | Product Requirements |
+| TM | Technical Model |
+| AD | Architecture Decision |
+| OP | Operations |
+| RP | Report |
+| PL | Plan |
+
+---
+
+## 5) DOCUMENT TYPES (ABCD) — 4 LETTERS (MASTER TABLES)
+> Keep this section authoritative. Do not invent new type codes without updating this standard.
+
+### PP — Product & Planning
+PROD, PLAN, RMAP, BREQ, FREQ, SOWK, KPIS, OKRS
+
+### AT — Architecture & Technical
+ADEC, ARCH, DSGN, APIS, SDKS, INTG, DIAG
+
+### DC — Development & Code
+DEVN, CODE, LIBR, MODL, COMP, UTIL
+
+### TQ — Testing & Quality
+TEST, CASE, QAPL, BUGR, PERF, SECU, PENT
+
+### OD — Operations & Deployment
+OPNS, DEPL, INFR, CONF, ENVR, RELS, CHNG, INCD, POST
+
+### LS — Logs & Status
+LOGS, WORK, PROG, STAT, CHKP
+
+### RA — Reports & Analysis
+REPT, ANLY, AUDT, REVW, RCAS, DATA, METR, BNCH
+
+### MC — Meetings & Communication
+MEET, AGND, ACTN, SUMM, MEMO, PRES, WKSP
+
+### PM — Project Management
+TASK, BKLG, SPRT, RETR, STND, RISK, ISSU
+
+### DR — Documentation & Reference
+REFF, GUID, MANL, FAQS, GLOS, SOPS, TMPL, CHKL, STND, INDEX, INDX
+
+### UC — User & Customer
+USER, ONBD, TRNG, FDBK, SURV, INTV, PERS
+
+### BL — Business & Legal
+CNTR, NDAS, LICN, CMPL, POLI, TERM, PRIV
+
+### RL — Research & Learning
+RSRC, LERN, EXPR, PROP, WHIT, CSES
+
+### AA — After Action & Review
+AACR, LESN, PMRT, REPT
+
+### WA — Workflows & Automation
+WFLW, N8NS, AUTO, HOOK
+
+### DD — Data & Datasets
+DSET, CSVS, SQLS, EXPT
+
+### MS — Miscellaneous
+MISC, DRFT, ARCH, OLDV, WIPS, INDX
+
+### PR — Product Requirements
+PRDC
+
+### TM — Technical Model
+MODL
+
+### AD — Architecture Decision
+ADRD
+
+### OP — Operations
+RUNB
+
+### PL — Plan
+POLC
+
+---
+
+## 6) NAMING CONSTRAINTS (HARD RULES)
+**DO**
+- lowercase kebab-case descriptions
+- keep descriptions short (avoid sentence titles)
+- use `.md` for most docs
+- keep `NNN` chronological (001-999)
+- keep `000-*` for cross-repo standards only
+- ensure `000-*` files are identical across all repos
+
+**DON'T**
+- no underscores / camelCase in descriptions
+- no special chars except hyphens
+- no missing category or type codes
+- no additional prefixes or suffixes on 000-* files
+
+---
+
+## 7) EXAMPLES (COPY/PASTE)
+### Project docs
+
+000-docs/
+001-PP-PROD-mvp-requirements.md
+002-AT-ADEC-auth-decision.md
+003-AT-ARCH-system-design.md
+004-PM-TASK-api-endpoints.md
+004a-PM-TASK-auth-endpoints.md
+010-AA-AACR-sprint-1-review.md
+
+### Canonical standards
+
+000-docs/
+000-DR-STND-document-filing-system.md
+000-DR-INDX-standards-catalog.md
+000-TM-STND-secrets-handling.md
+
+---
+
+## 8) MIGRATION NOTES (V4.2 → V4.3)
+- **Breaking change:** `6767-*` prefix replaced with `000-*`
+- **Action required:** Rename all `6767-*` files to `000-*` format
+- **Simplification:** No letter suffixes required for 000-* files
+- **Cross-repo sync:** All 000-* files must be identical across repos
+
+**Migration command:**
+```bash
+# In each repo
+cd 000-docs
+for f in 6767-*.md; do
+  new_name=$(echo "$f" | sed 's/^6767-[a-z]-/000-/' | sed 's/^6767-/000-/')
+  mv "$f" "$new_name"
+done
+```
+
+---
+
+## 9) AI ASSISTANT OPERATING INSTRUCTIONS (STRICT)
+When creating or renaming a document:
+1) Decide series: **000-*** if cross-repo standard; else **NNN (001-999)**.
+2) Pick `CC` from Category table.
+3) Pick `ABCD` from Type tables (do not invent).
+4) Create filename using the exact pattern rules.
+5) Keep description short and kebab-case.
+6) **Place ALL docs (both NNN and 000-*) directly in `000-docs/`** — no subdirectories.
+7) **After every phase, create an AAR:** `NNN-AA-AACR-phase-<n>-short-description.md`
+8) **For 000-* files:** Verify content matches canonical source before committing.
+
+---
+
+**DOCUMENT FILING SYSTEM STANDARD v4.3**
+*Fully compatible with v3.0, v4.0, v4.2; optimized for AI assistants and deterministic naming.*
+*v4.3 migrates from 6767 to 000-* prefix for canonical cross-repo standards.*

--- a/000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md
+++ b/000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md
@@ -1,0 +1,229 @@
+# Global Master Standard – Claude Code Extensions (Plugins + Skills) Specification
+
+**Document ID**: 6767-h-SPEC-DR-STND-claude-code-extensions-master
+**Version**: 1.0.0
+**Status**: AUTHORITATIVE - Single Source of Truth
+**Created**: 2025-12-28
+**Updated**: 2025-12-28
+**Supersedes**: 6767-a (plugins/marketplace), 6767-b (skills), 6767-c (unified enterprise rules)
+**Authority**: Intent Solutions (claudecodeplugins.io)
+
+**Audited Against**:
+- Claude Code docs: plugins + marketplaces + hooks + skills
+- Anthropic Agent Skills docs + best practices
+- Anthropic Engineering blog post on skills
+- This repository’s enforcement validators and marketplace build pipeline
+
+**Sources**:
+- https://code.claude.com/docs/en/plugins-reference
+- https://code.claude.com/docs/en/plugin-marketplaces
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/skills
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+- https://www.claude.com/blog/claude-code-plugins
+- https://github.com/anthropics/claude-code
+- https://github.com/anthropics/claude-plugins-official
+- https://github.com/anthropics/skills
+
+---
+
+## Executive Summary
+
+### What Is a Claude Code Extension?
+
+In practice, “Claude Code extensions” are delivered as **plugins**. A plugin is a container that can bundle:
+- **Skills** (auto-invoked workflows)
+- **Commands** (slash commands)
+- **Agents** (subagents)
+- **Hooks** (lifecycle automation)
+- **MCP servers** (external tool integrations)
+
+### What Is a Skill?
+
+A skill is a **filesystem-defined capability** described by `skills/<skill-name>/SKILL.md` with YAML frontmatter plus a markdown instruction body. Skills are:
+- **Discoverable** by description intent matching
+- **Composable** across plugins
+- **Context-efficient** via progressive disclosure (`references/` loaded only when needed)
+
+### Non‑Negotiable Invariants (Enterprise Mode)
+
+These are enforced in this repo (see `scripts/validate-skills-schema.py`, `scripts/validate-frontmatter.py`):
+
+1) **`allowed-tools` is a CSV string (NOT a YAML array)**
+   - ✅ `allowed-tools: "Read, Write, Grep, Glob"`
+   - ❌ `allowed-tools: [Read, Write, Grep]`
+
+2) **`Bash` must be scoped**
+   - ✅ `Bash(git:*)`, `Bash(npm:*)`, `Bash(python:*)`
+   - ❌ `Bash`
+
+3) **Paths must be portable**
+   - ✅ `${CLAUDE_PLUGIN_ROOT}/...` (plugin-root portability)
+   - ✅ `{baseDir}/...` (skill-root portability)
+   - ❌ absolute paths (`/home/...`, `~/...`)
+
+4) **Progressive disclosure**
+   - SKILL.md stays concise; heavy content goes in `references/`
+   - Skill body must have required sections and at least one line of real text per section (not just code fences)
+
+---
+
+## 1) Canonical Directory Structure
+
+### 1.1 Plugin Root Anatomy (Repository Standard)
+
+```
+plugins/<category>/<plugin-name>/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── <skill-name>/
+│       ├── SKILL.md
+│       ├── scripts/        (optional)
+│       ├── references/     (optional)
+│       └── assets/         (optional)
+├── commands/               (optional)
+├── agents/                 (optional)
+├── hooks/                  (optional)
+└── README.md               (recommended)
+```
+
+**Hard rule**: `.claude-plugin/` contains ONLY `plugin.json`. No commands/skills/scripts inside `.claude-plugin/`.
+
+### 1.2 Skill Folder Anatomy
+
+```
+skills/<skill-name>/
+├── SKILL.md                 # REQUIRED
+├── scripts/                 # OPTIONAL (executed via Bash tool)
+├── references/              # OPTIONAL (loaded via Read tool)
+└── assets/                  # OPTIONAL (templates; referenced by path)
+```
+
+---
+
+## 2) Plugin Manifest: `.claude-plugin/plugin.json`
+
+### 2.1 Required Fields (Enterprise Marketplace)
+
+`plugin.json` is the plugin identity contract:
+
+- `name` (kebab-case, <= 64 chars)
+- `version` (SemVer `X.Y.Z`)
+- `description` (human description)
+- `author` (object with `name` + `email`)
+- `license` (SPDX-like string)
+- `keywords` (array of strings)
+
+### 2.2 Path Resolution
+
+Inside a plugin, prefer `${CLAUDE_PLUGIN_ROOT}` for paths that need to be portable across installs.
+
+---
+
+## 3) Skill Definition: `skills/<skill-name>/SKILL.md`
+
+### 3.1 YAML Frontmatter (Required)
+
+Frontmatter is a YAML mapping at the top of the file:
+
+```yaml
+---
+name: my-skill
+description: Does X and Y. Use when [scenario]. Trigger with "phrase 1", "phrase 2".
+allowed-tools: "Read, Grep, Glob, Bash(git:*), Bash(python:*)"
+version: "1.0.0"
+author: "Name <email@domain>"
+license: "MIT"
+---
+```
+
+**Rules**:
+- `allowed-tools` MUST be a **CSV string**
+- `description` MUST include **“Use when …”** and **“Trigger with …”**
+- Avoid first/second person in `description` (third-person voice)
+
+### 3.2 Instruction Body (Required Sections)
+
+The validator expects these sections to exist and contain real prose:
+- `## Overview`
+- `## Prerequisites`
+- `## Instructions`
+- `## Output`
+- `## Error Handling`
+- `## Examples`
+- `## Resources`
+
+### 3.3 `{baseDir}` and Bundled Files (References/Assets/Scripts)
+
+Within SKILL.md, reference bundled files using `{baseDir}`:
+- Scripts: `{baseDir}/scripts/<script>`
+- References: `{baseDir}/references/<doc>`
+- Assets/templates: `{baseDir}/assets/<file>`
+
+**Semantics**:
+- `scripts/` are executed (no token cost until output).
+- `references/` are loaded into context on demand (token cost when read).
+- `assets/` are path-addressable templates/configs (generally not loaded unless read).
+
+---
+
+## 4) Marketplace & Website (claudecodeplugins.io) Safety Contract
+
+### 4.1 Source of Truth for Published Plugins
+
+In this repo:
+- Marketplace source of truth: `.claude-plugin/marketplace.extended.json`
+- CLI-compatible catalog: `.claude-plugin/marketplace.json` (generated via `node scripts/sync-marketplace.cjs`)
+
+### 4.2 Skills/Explore Index Generation
+
+Marketplace build performs:
+- Skills discovery: `marketplace/scripts/discover-skills.mjs`
+- Catalog sync for Explore: `marketplace/scripts/sync-catalog.mjs`
+- Unified search index: `marketplace/scripts/generate-unified-search.mjs`
+- Static build: `astro build`
+
+### 4.3 Required Website Gates (Zero Warnings Policy)
+
+Run these before claiming “site-safe” changes:
+
+```bash
+python scripts/validate-skills-schema.py --fail-on-warn
+python scripts/validate-frontmatter.py
+corepack pnpm -C marketplace build
+node scripts/check-routes.mjs
+node scripts/check-official-links.mjs
+```
+
+These gates enforce:
+- No schema warnings (treat warnings as failures)
+- No missing routes for published plugins
+- No stale `/explore` links pointing at missing plugin pages
+
+---
+
+## 5) Compliance Checklist (PASS/FAIL)
+
+- [ ] Plugin manifests exist at `.claude-plugin/plugin.json`
+- [ ] Skill frontmatter includes `name`, `description`, `allowed-tools`, `version`, `author`, `license`
+- [ ] `allowed-tools` is CSV string; no YAML arrays
+- [ ] No unscoped `Bash`
+- [ ] Skill body includes required sections with real prose
+- [ ] All `{baseDir}` references resolve to real files
+- [ ] Marketplace build produces catalogs with no orphaned skills
+- [ ] `/explore` plugin links map to real `/plugins/<name>/` pages
+- [ ] Route + official link gates are green
+
+---
+
+## Appendix A: In-Repo Canonical References
+
+- `000-docs/6767-d-AT-APIS-claude-code-extensions-schema.md` (error codes + schema)
+- `000-docs/6767-e-WA-WFLW-extensions-validation-ci-gates.md` (CI gates)
+- `000-docs/6767-f-AT-ARCH-plugin-scaffold-diagrams.md` + diagrams
+- `000-docs/6767-g-AT-ARCH-skill-scaffold-diagrams.md` + diagrams
+


### PR DESCRIPTION
## Summary

User flagged the local doc-filing standard reference at `000-docs/091-DR-REFF-filing-system-standard-v2.md` was stale (v2.0). Global CLAUDE.md and the doc-filing skill registry both confirm **v4.3** is current. While installing v4.3 I found a long-standing `.gitignore` bug silently dropping new canonical standards from tracking.

## Changes

| File | Change |
|---|---|
| `000-docs/000-DR-STND-document-filing-system.md` | **Add.** v4.3 canonical standard (verbatim from `~/.claude/skills/doc-filing/references/`). Per v4.3 the canonical-standards prefix migrated from `6767-*` to `000-*`. |
| `000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md` | **Add to tracking.** Existed locally but was silently ignored — see gitignore bug below. |
| `.gitignore` | **Fix re-include bug.** See below. |

## The gitignore bug

Old rule:

```gitignore
000-docs/
!000-docs/6767*.md
```

Per git's gitignore docs:

> It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn't list excluded directories for performance reasons, so any patterns on contained files have no effect.

So `!000-docs/6767*.md` was **a silent no-op** because the line above excluded the entire directory. The existing 6767-a..g files were tracked because they pre-dated the gitignore rule; 6767-h was added afterward and got dropped without anyone noticing.

## The fix

Split by depth so the negation actually works:

```gitignore
**/000-docs/           # nested 000-docs in saas-packs etc. — still ignored
000-docs/*             # root 000-docs/* — file-level, allows negation
000-docs/**/*
!000-docs/000-*.md     # v4.3 canonical standards
!000-docs/6767*.md     # v3.x legacy standards (now actually working)
```

Verified via `git check-ignore -v`:

| Path | Result |
|---|---|
| `000-docs/000-DR-STND-document-filing-system.md` | NOT ignored ✓ |
| `000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md` | NOT ignored ✓ |
| `000-docs/264-AA-PMRT-autonomous-cto-session-2026-04-30.md` | IGNORED (correct: private AAR) |
| `plugins/saas-packs/abridge-pack/000-docs/001-BL-LICN-license.txt` | IGNORED (correct: nested per-pack docs) |

## Sweep report

A local-only sweep report at `000-docs/265-RA-REPT-doc-filing-v43-sweep.md` documents the **24 non-conforming filenames** in `000-docs/` and recommends deferring big renames to dedicated PRs:

| Defer | Why |
|---|---|
| Rename 22 `6767-*` files to `000-*` | ~50–100 cross-references across CONTRIBUTING.md, CLAUDE.md, SKILL.md files, blog posts. v4.3 keeps backward-compat — rename only when one needs a breaking revision. |
| Rename `SCHEMA_CHANGELOG.md` | High blast radius (CLAUDE.md, scripts, tests). Deserves its own dedicated PR. |
| Rename `20260131-RL-REPT-...` | Low value; bundle with next release-report cleanup. |

## Test plan
- [x] `git check-ignore -v` confirms exception rules work
- [x] Sweep report identifies all v4.3 non-conformers
- [ ] CI: validate, marketplace-validation pass

[bz claude-8qrt]

jeremy made me do it
-claude