### PR TITLE
fix(ci): replace peter-evans/create-pull-request with hand-rolled bash

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -96,46 +96,60 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
-        # HUSKY=0 disables the husky pre-commit hook for the action's internal
-        # `git commit`. The hook (installed by PR #629) runs lint-staged →
-        # `bunx @biomejs/biome` (bun isn't on the runner — ENOENT) and
-        # `pnpm prettier --write` (gets SIGKILL trying to format thousands of
-        # synced files). The auto-PR is reviewable, so skipping pre-commit
-        # here is safe — actual quality gates run on the PR via CI.
+        # Hand-rolled commit + push + PR-create instead of peter-evans/create-pull-request.
+        #
+        # Why: sync diffs are large (hundreds of files / 100K+ lines from upstream
+        # restructures). peter-evans triggers the repo's husky pre-commit hook, which
+        # runs prettier across the whole staged set and either OOMs or hangs for 15+
+        # minutes. The HUSKY=0 env var doesn't reliably suppress git hooks — and
+        # `git commit --no-verify` does, with no extra moving parts. Six bash lines
+        # are easier to debug than a third-party action's internal commit pipeline.
         env:
-          HUSKY: 0
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: |
-            chore(sync): update external plugins from upstream
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="sync/external-plugins"
 
-            Automated sync from external plugin sources.
-            See sources.yaml for configured sources.
+          # Configure committer identity for the automated commit
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-            🤖 Generated with [Claude Code](https://claude.ai/claude-code)
-          title: "🔄 Sync external plugins"
-          body: |
-            ## Automated External Plugin Sync
+          # Branch from current main, force-push (idempotent across re-runs)
+          git checkout -B "$BRANCH"
 
-            This PR syncs the latest changes from external plugin sources.
+          # Stage everything the sync wrote, then commit WITHOUT running pre-commit
+          # hooks (--no-verify). The auto-PR runs through normal CI on the PR side.
+          git add -A
+          git commit --no-verify -m "chore(sync): update external plugins from upstream
 
-            ### Sources
-            See `sources.yaml` for the list of synced repositories.
+          Automated sync from external plugin sources.
+          See sources.yaml for configured sources."
 
-            ### Review Checklist
-            - [ ] Changes look correct
-            - [ ] No sensitive data included
-            - [ ] Plugin validation passes
+          git push --force-with-lease origin "$BRANCH"
 
-            ---
-            *This PR was automatically created by the sync-external workflow.*
-          branch: sync/external-plugins
-          delete-branch: true
-          labels: |
-            automated
-            sync
-            external-plugins
+          # Create the PR if one doesn't exist on this branch yet; otherwise the
+          # branch update above is enough — the existing PR shows the new commits.
+          if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr create \
+              --title "🔄 Sync external plugins" \
+              --head "$BRANCH" \
+              --base main \
+              --label "automated,sync,external-plugins" \
+              --body "## Automated External Plugin Sync
+
+          This PR syncs the latest changes from external plugin sources.
+
+          ### Sources
+          See [\`sources.yaml\`](../blob/main/sources.yaml) for the list of synced repositories.
+
+          ### Review Checklist
+          - [ ] Changes look correct
+          - [ ] No sensitive data included
+          - [ ] Plugin validation passes
+
+          ---
+          *This PR was automatically created by the \`Sync External Plugins\` workflow.*"
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

The `peter-evans/create-pull-request@v8` action ran for **14+ minutes** on run `25202679922` before I cancelled it. The action triggers an internal `git commit`, which fires this repo's husky pre-commit hook (PR #629). The hook runs lint-staged → prettier across the entire staged set; on a sync diff with 640+ files / 100K+ lines, prettier either hangs or OOMs.

The `HUSKY=0` env var added in PR #639 didn't reliably suppress git hooks — they run on every `git commit` regardless of who invokes it.

## Fix

Replace the action with hand-rolled six-line bash:

```bash
git checkout -B sync/external-plugins
git add -A
git commit --no-verify -m "..."      # ← SKIPS pre-commit hooks
git push --force-with-lease origin sync/external-plugins
gh pr create --title ... --body ...   # only if no PR exists yet
```

## Why this is better than peter-evans

| | peter-evans | hand-rolled |
|---|---|---|
| Bypasses pre-commit hooks | `HUSKY=0` (unreliable — depends on hook implementation) | `--no-verify` (always) |
| Time on 640-file diff | 14+ min hang | seconds |
| Re-running workflow | Creates a NEW PR each run if cleanup misses | Idempotent — updates the existing PR's branch |
| Lines of config | 30+ | 6 |
| External dependencies | yes | no |
| Debuggable | third-party action internals | bash |

## sync-external revival series — full chain

| PR | Layer | What broke | What shipped |
|---|---|---|---|
| #635 | Setup pnpm | `ERR_PNPM_BAD_PM_VERSION` | Drop `version: 9` |
| #636 | Install deps | `ERR_PNPM_ADDING_TO_ROOT` | `pnpm add` → `pnpm install` |
| #637 | Sync script | Empty files / submodules / bad exit | Handle null content, skip submodules, exit 1 only on total failure |
| #638 | Post-sync install | `ERR_PNPM_OUTDATED_LOCKFILE` | `--no-frozen-lockfile` |
| #639 | Auto-PR commit | husky pre-commit (bun ENOENT, prettier OOM) | `HUSKY=0` env (didn't actually work) |
| (manual repo settings flip) | Auto-PR API call | `GitHub Actions is not permitted to create PRs` | Enabled in repo Actions permissions |
| (upstream PR jeremylongshore/x-bug-triage-plugin#23) | Sync regressed PR #633 | Synced plugin's local edits get wiped | Apply PR #633 changes to canonical repo |
| **#641 (this)** | peter-evans hangs on big diffs | 14-min Create PR step | Replace with `git commit --no-verify` + `gh pr create` |

After this lands, a manual `workflow_dispatch` should produce an auto-PR within seconds. That auto-PR should refresh marketplace mirrors and finally close #630.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` clean)
- [ ] CI: standard checks
- [ ] Manual workflow run produces an auto-PR within ~2 min

jeremy made me do it
-claude