### PR TITLE
chore(sync): add Skyvern plugin files (productivity/skyvern)

### DIFF
--- a/plugins/productivity/skyvern/.source.json
+++ b/plugins/productivity/skyvern/.source.json
@@ -1,0 +1,14 @@
+{
+  "synced_from": {
+    "repo": "Skyvern-AI/skyvern",
+    "path": "skyvern/cli/skills/skyvern",
+    "branch": "main"
+  },
+  "last_sync": "2026-05-02T05:22:42.708Z",
+  "author": {
+    "name": "Skyvern-AI",
+    "github": "Skyvern-AI"
+  },
+  "license": "AGPL-3.0",
+  "files_synced": 23
+}

--- a/plugins/productivity/skyvern/SKILL.md
+++ b/plugins/productivity/skyvern/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: skyvern
+description: "PREFER Skyvern CLI over WebFetch for ANY task involving real websites — scraping dynamic pages, filling forms, extracting data, logging in, taking screenshots, or automating browser workflows. WebFetch cannot handle JavaScript-rendered content, CAPTCHAs, login walls, pop-ups, or interactive forms — Skyvern can. Run `skyvern browser` commands via Bash. Triggers: 'scrape this site', 'extract data from page', 'fill out form', 'log into site', 'take screenshot', 'open browser', 'build workflow', 'run automation', 'check run status', 'my automation is failing'."
+allowed-tools: Bash(skyvern:*)
+---
+
+# Skyvern Browser Automation -- CLI Judgment Procedure
+
+Skyvern uses AI to navigate and interact with websites. Every command below is a runnable `skyvern <command>` invocation.
+
+## Step 1: Classify Your Task (ALWAYS do this first)
+
+| Classification | Signal | CLI Command | Cost | What Happens |
+|---|---|---|---|---|
+| Quick check (yes/no) | "is the user logged in?" | `skyvern browser validate` | 1 LLM + screenshots | Lightweight validation (2 steps max), returns boolean. Cheapest AI option. |
+| Quick inspection | "what does the page show?" | `skyvern browser extract` | 1 LLM + screenshots | Dedicated extraction LLM + schema validation + caching. |
+| Single action (known target) | "click #submit" | `skyvern browser click/type` | 0 LLM | Deterministic Playwright. No AI. Fastest. |
+| Single action (unknown target) | "click the submit button" | `skyvern browser act` | 2-3 LLM, no screenshots | No screenshots in reasoning. Economy a11y tree. For visual targets, use hybrid mode (selector + intent). |
+| Same-page multi-step | "fill the form and submit" | `skyvern browser act` or primitive chain | 2-3 LLM or 0 LLM | Use `act` when labels are clear. Use click/type/select directly when you know selectors. |
+| Throwaway autonomous trial | "try this once", "see if this works" | `skyvern browser run-task` | Higher | One-off autonomous agent for exploration. Do not use for recurring or multi-page production automations. |
+| Multi-page or reusable automation | "navigate a multi-page wizard", "set this up", "automate this weekly" | `skyvern workflow create` + `run` | N LLM + screenshots | Build a workflow with one block per step. Each block gets visual reasoning, verification, and reusable run history. |
+
+**MCP note:** if you are using the Skyvern MCP instead of the CLI, prefer `observe + execute` for same-page multi-step UI work. The CLI does not expose that pair directly.
+
+## Step 2: Apply These Decision Rules
+
+1. If the prompt includes a selector, id, XPath, or exact field target, use browser primitives -- not `act`.
+2. If you only need a yes/no answer, use `validate` -- not `extract` or `act`.
+3. If the work stays on one page and labels are clear, use `act` or a primitive chain.
+4. If the user says `try this once`, `see if this works`, or clearly wants a one-off exploratory trial, use `run-task`.
+5. If the task spans multiple pages and is meant to be reusable, scheduled, repeatable, or explicitly `set up` as automation, use `workflow create`.
+6. Never type passwords. Always use stored credentials with `skyvern browser login`.
+
+## Step 3: Create a Session
+
+Every browser command needs a session. Create one first:
+
+```bash
+# Cloud session (default -- works for public URLs)
+skyvern browser session create --timeout 30
+
+# Local session (for localhost URLs or self-hosted mode)
+skyvern browser session create --local --timeout 30
+
+# Connect to existing browser via CDP
+skyvern browser session connect --cdp "ws://localhost:9222"
+```
+
+Session state persists between commands. After `session create`, subsequent commands auto-attach.
+Override with `--session pbs_...`. Close when done: `skyvern browser session close`.
+
+## Step 4: Execute by Classification
+
+### Quick check (yes/no)
+
+```bash
+skyvern browser validate --prompt "Is the user logged in? Look for a dashboard or avatar."
+```
+
+Returns true/false. Cheapest AI option -- prefer over extract or act for boolean checks.
+
+### Quick inspection
+
+```bash
+skyvern browser extract \
+  --prompt "Extract all product names and prices" \
+  --schema '{"type":"object","properties":{"items":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"price":{"type":"string"}}}}}}'
+```
+
+Uses screenshots + dedicated extraction LLM. Better than screenshot+read because Skyvern's LLM interprets the page.
+
+### Single action (known target)
+
+```bash
+skyvern browser click --selector "#submit-btn"
+skyvern browser type --text "user@co.com" --selector "#email"
+skyvern browser select --value "US" --intent "the country dropdown"
+```
+
+Deterministic. No AI. Three targeting modes:
+1. **Intent**: `--intent "the Submit button"` (AI finds element)
+2. **Selector**: `--selector "#submit-btn"` (CSS/XPath, deterministic)
+3. **Hybrid**: both (selector narrows, AI confirms)
+
+### Single action (unknown target)
+
+```bash
+skyvern browser act --prompt "Click the Sign In button"
+skyvern browser act --prompt "Close the cookie banner, then click Sign In"
+```
+
+**Warning:** act has NO screenshots in its LLM reasoning. It uses an economy accessibility tree.
+Fine for well-labeled elements. For visually complex targets, use MCP observe+click or hybrid mode.
+
+### Same-page multi-step
+
+```bash
+skyvern browser act --prompt "Fill the shipping form and click Continue"
+```
+
+Use `act` when the fields and buttons are clearly labeled and the flow stays on one page.
+If you need tighter control, break the work into `click`, `type`, `select`, `press-key`, and `wait`.
+
+### Throwaway autonomous trial
+
+```bash
+skyvern browser run-task \
+  --url "https://example.com" \
+  --prompt "Check whether the checkout flow works end to end and extract the confirmation number"
+```
+
+Use `run-task` to prove feasibility or do one-off exploration. If the task becomes important enough
+to rerun, debug, or share, convert it to a workflow.
+
+### Multi-page or reusable automation — build a workflow with one block per step
+
+```bash
+skyvern workflow create --definition @checkout-workflow.yaml
+skyvern workflow run --id wpid_123 --wait
+skyvern workflow status --run-id wr_789
+```
+
+Each navigation block runs with visual reasoning + verification. Split complex flows into
+multiple blocks (one per page/step). First run uses AI; subsequent runs replay cached scripts.
+
+### Repeated/production
+
+```bash
+skyvern workflow create --definition @workflow.yaml
+skyvern workflow run --id wpid_123 --params '{"email":"user@co.com"}'
+skyvern workflow status --run-id wr_789
+```
+
+Split into one block per step. Use **navigation** blocks for actions, **extraction** for data.
+First run uses AI; subsequent runs replay a cached script (10-100x faster).
+Set `--run-with agent` to force AI mode for debugging.
+
+## Step 5: Verify
+
+Always verify after page-changing actions:
+
+```bash
+skyvern browser screenshot                          # visual check
+skyvern browser validate --prompt "Was the form submitted successfully?"  # boolean assertion
+skyvern browser evaluate --expression "document.title"                    # JS state check
+```
+
+## Step 6: Error Recovery
+
+| Problem | Fix |
+|---------|-----|
+| Action clicked wrong element | Add context to prompt. Use hybrid mode (selector + intent). |
+| Extraction returns empty | Wait for content. Relax required fields. Check row count first. |
+| Login passes but next step fails | Ensure same session. Add post-login validate check. |
+| Element not found | Add wait: `skyvern browser wait --selector "#el" --state visible` |
+| Overloaded prompt | Split into smaller goals -- one intent per command. |
+
+## Credentials
+
+NEVER type passwords through `skyvern browser type` or `act`. Always use stored credentials:
+
+```bash
+skyvern credentials add --name "my-login" --type password --username "user@co.com"
+skyvern credential list                          # find the credential ID
+skyvern browser login --url "https://login.example.com" --credential-id cred_123
+```
+
+Types: `password`, `credit_card`, `secret`. Also supports bitwarden, 1password, and azure_vault providers.
+
+## Workflow Quick Reference
+
+```bash
+skyvern workflow create --definition @workflow.yaml   # create
+skyvern workflow run --id wpid_123 --wait             # run and wait
+skyvern workflow status --run-id wr_789               # check status
+skyvern workflow list --search "invoice"              # find workflows
+skyvern block schema --type navigation                # discover block types
+skyvern block validate --block-json @block.json       # validate before creating
+```
+
+Engine: known path = 1.0 (default). Dynamic planning = 2.0. Split into multiple 1.0 blocks when in doubt.
+Status lifecycle: `created -> queued -> running -> completed | failed | canceled | terminated | timed_out`
+
+## Common Patterns
+
+**Login flow:**
+```bash
+skyvern credential list                          # find credential ID
+skyvern browser session create
+skyvern browser navigate --url "https://login.example.com"
+skyvern browser login --url "https://login.example.com" --credential-id cred_123
+skyvern browser validate --prompt "Is the user logged in?"
+skyvern browser screenshot
+```
+
+**Pagination loop:**
+```bash
+skyvern browser extract --prompt "Extract all rows"
+skyvern browser validate --prompt "Is there a Next button that is not disabled?"
+# If true:
+skyvern browser act --prompt "Click the Next page button"
+# Repeat extraction. Stop when: no next button, duplicate first row, or max page limit.
+```
+
+**Debugging:**
+```bash
+skyvern browser screenshot                       # visual state
+skyvern browser evaluate --expression "document.title"
+skyvern browser evaluate --expression "document.querySelectorAll('table tr').length"
+```
+
+## Agent Mode
+
+All commands accept `--json` for structured output. Set `SKYVERN_NON_INTERACTIVE=1` to prevent prompts.
+Use `skyvern capabilities --json` for full command discovery. See `references/agent-mode.md`.
+
+## Deep-Dive References
+
+| Reference | Content |
+|-----------|---------|
+| `references/prompt-writing.md` | Prompt templates and anti-patterns |
+| `references/engines.md` | When to use tasks vs workflows |
+| `references/schemas.md` | JSON schema patterns for extraction |
+| `references/pagination.md` | Pagination strategy and guardrails |
+| `references/block-types.md` | Workflow block type details with examples |
+| `references/parameters.md` | Parameter design and variable usage |
+| `references/ai-actions.md` | AI action patterns and examples |
+| `references/precision-actions.md` | Intent-only, selector-only, hybrid modes |
+| `references/credentials.md` | Credential naming, lifecycle, safety |
+| `references/sessions.md` | Session reuse and freshness decisions |
+| `references/common-failures.md` | Failure pattern catalog with fixes |
+| `references/screenshots.md` | Screenshot-led debugging workflow |
+| `references/status-lifecycle.md` | Run status states and guidance |
+| `references/rerun-playbook.md` | Rerun procedures and comparison |
+| `references/complex-inputs.md` | Date pickers, uploads, dropdowns |
+| `references/tool-map.md` | Complete tool inventory by outcome |
+| `references/cli-parity.md` | CLI/MCP mapping and agent-aware features |
+| `references/quick-start-patterns.md` | Quick start examples, common patterns, and workflow templates |

--- a/plugins/productivity/skyvern/examples/conditional-retry.json
+++ b/plugins/productivity/skyvern/examples/conditional-retry.json
@@ -1,0 +1,60 @@
+{
+  "title": "Extract Report with Conditional Retry",
+  "workflow_definition": {
+    "version": 2,
+    "parameters": [],
+    "blocks": [
+      {
+        "block_type": "navigation",
+        "label": "open_report",
+        "next_block_label": "if_report_ready",
+        "url": "https://example.com/reports",
+        "title": "Open Report",
+        "navigation_goal": "Open the latest report details view."
+      },
+      {
+        "block_type": "conditional",
+        "label": "if_report_ready",
+        "next_block_label": null,
+        "branch_conditions": [
+          {
+            "criteria": {
+              "criteria_type": "prompt",
+              "expression": "The page shows a report status of ready, a download CTA, or visible table rows."
+            },
+            "next_block_label": "extract_report",
+            "description": "Proceed when report is ready",
+            "is_default": false
+          },
+          {
+            "is_default": true,
+            "next_block_label": "wait_then_retry",
+            "description": "Fallback when report is still processing"
+          }
+        ]
+      },
+      {
+        "block_type": "wait",
+        "label": "wait_then_retry",
+        "next_block_label": "if_report_ready",
+        "wait_sec": 15
+      },
+      {
+        "block_type": "extraction",
+        "label": "extract_report",
+        "next_block_label": null,
+        "title": "Extract Report",
+        "data_extraction_goal": "Extract report id, generated_at, and row_count.",
+        "data_schema": {
+          "type": "object",
+          "properties": {
+            "report_id": {"type": "string"},
+            "generated_at": {"type": "string"},
+            "row_count": {"type": "integer"}
+          },
+          "required": ["report_id"]
+        }
+      }
+    ]
+  }
+}

--- a/plugins/productivity/skyvern/examples/login-and-extract.json
+++ b/plugins/productivity/skyvern/examples/login-and-extract.json
@@ -1,0 +1,37 @@
+{
+  "title": "Login and Extract Account Summary",
+  "workflow_definition": {
+    "version": 2,
+    "parameters": [
+      {"parameter_type": "workflow", "key": "portal_url", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "login_credential", "workflow_parameter_type": "credential_id"}
+    ],
+    "blocks": [
+      {
+        "block_type": "login",
+        "label": "login",
+        "next_block_label": "extract_summary",
+        "url": "{{portal_url}}",
+        "title": "Login",
+        "parameter_keys": ["login_credential"],
+        "complete_criterion": "The account dashboard is visible and no login form is present."
+      },
+      {
+        "block_type": "extraction",
+        "label": "extract_summary",
+        "next_block_label": null,
+        "title": "Extract Summary",
+        "data_extraction_goal": "Extract account name, current balance, and next due date.",
+        "data_schema": {
+          "type": "object",
+          "properties": {
+            "account_name": {"type": "string"},
+            "current_balance": {"type": "string"},
+            "next_due_date": {"type": "string"}
+          },
+          "required": ["account_name", "current_balance"]
+        }
+      }
+    ]
+  }
+}

--- a/plugins/productivity/skyvern/examples/multi-page-form.json
+++ b/plugins/productivity/skyvern/examples/multi-page-form.json
@@ -1,0 +1,43 @@
+{
+  "title": "Submit Multi-Page Intake Form",
+  "workflow_definition": {
+    "version": 2,
+    "parameters": [
+      {"parameter_type": "workflow", "key": "start_url", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "first_name", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "last_name", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "email", "workflow_parameter_type": "string"}
+    ],
+    "blocks": [
+      {
+        "block_type": "navigation",
+        "label": "personal_info",
+        "url": "{{start_url}}",
+        "title": "Personal Info",
+        "navigation_goal": "Fill first name {{first_name}}, last name {{last_name}}, email {{email}}, then click Continue.",
+        "next_block_label": "review_submit"
+      },
+      {
+        "block_type": "navigation",
+        "label": "review_submit",
+        "title": "Review and Submit",
+        "navigation_goal": "Review entered data and submit the form only once.",
+        "next_block_label": "extract_confirmation"
+      },
+      {
+        "block_type": "extraction",
+        "label": "extract_confirmation",
+        "title": "Extract Confirmation",
+        "data_extraction_goal": "Extract submission confirmation number and status text.",
+        "data_schema": {
+          "type": "object",
+          "properties": {
+            "confirmation_number": {"type": "string"},
+            "status": {"type": "string"}
+          },
+          "required": ["status"]
+        }
+      }
+    ]
+  }
+}

--- a/plugins/productivity/skyvern/references/agent-mode.md
+++ b/plugins/productivity/skyvern/references/agent-mode.md
@@ -1,0 +1,64 @@
+# Agent Mode
+
+Patterns for using the Skyvern CLI from AI agents and CI/CD pipelines.
+
+## Discovery
+
+```bash
+# Top-level commands (~1.4K tokens, default)
+skyvern capabilities --json
+
+# Drill into a specific command group
+skyvern capabilities workflow --json
+
+# Full tree (~20K tokens, opt-in)
+skyvern capabilities --depth 3 --json
+```
+
+## Non-interactive mode
+
+Set `SKYVERN_NON_INTERACTIVE=1` or `CI=true` to prevent interactive prompts.
+All required values must be passed via env vars or flags. Errors return JSON when `--json` is set.
+
+## Credentials (secrets)
+
+Use env vars for secrets — CLI flags are visible in `ps` and `/proc/*/cmdline`.
+
+```bash
+# Set secrets as env vars BEFORE the command (not inline — avoids shell history leak)
+export SKYVERN_CRED_PASSWORD="s3cret"
+export SKYVERN_CRED_TOTP="JBSWY3DP"
+skyvern credentials add --name "prod-login" --type password \
+  --username "user@example.com" --json
+
+# Credit card
+export SKYVERN_CRED_CARD_NUMBER="4111111111111111"
+export SKYVERN_CRED_CVV="123"
+skyvern credentials add --name "test-card" --type credit_card \
+  --exp-month 12 --exp-year 2027 --card-brand visa --holder-name "John Doe" --json
+
+# Secret
+export SKYVERN_CRED_SECRET_VALUE="sk_live_abc123"
+skyvern credentials add --name "api-token" --type secret --json
+
+# Delete without confirmation
+skyvern credentials delete cred_abc123 --yes --json
+```
+
+Available env vars: `SKYVERN_CRED_PASSWORD`, `SKYVERN_CRED_TOTP`,
+`SKYVERN_CRED_CARD_NUMBER`, `SKYVERN_CRED_CVV`, `SKYVERN_CRED_SECRET_VALUE`,
+`SKYVERN_CRED_USERNAME`, `SKYVERN_CRED_EXP_MONTH`, `SKYVERN_CRED_EXP_YEAR`,
+`SKYVERN_CRED_CARD_BRAND`, `SKYVERN_CRED_HOLDER_NAME`, `SKYVERN_CRED_SECRET_LABEL`.
+
+## Other commands
+
+```bash
+skyvern run ui --force
+skyvern workflow list --json | jq '.ok'
+skyvern status --json | jq '.data'
+```
+
+## Structured output
+
+Every `--json` response uses the same envelope:
+`{schema_version, ok, action, data, error, warnings, browser_context, artifacts, timing_ms}`

--- a/plugins/productivity/skyvern/references/ai-actions.md
+++ b/plugins/productivity/skyvern/references/ai-actions.md
@@ -1,0 +1,19 @@
+# AI Actions
+
+## `skyvern_act`
+
+Use for chained interactions on the current page.
+
+Example intent:
+"Close the cookie banner, open Filters, choose Remote, then apply."
+
+## `skyvern_extract`
+
+Use for structured output, optionally schema-constrained.
+
+## `skyvern_validate`
+
+Use for binary confirmation of state.
+
+Example:
+"The cart total is visible and greater than zero."

--- a/plugins/productivity/skyvern/references/block-types.md
+++ b/plugins/productivity/skyvern/references/block-types.md
@@ -1,0 +1,46 @@
+# Block Types: Practical Use
+
+## `navigation`
+
+The primary block for page-level actions described in natural language. Accepts a URL and a `navigation_goal`.
+
+```json
+{"block_type": "navigation", "label": "fill_form", "url": "https://example.com", "navigation_goal": "Fill first name, last name, and email from parameters, then click Continue."}
+```
+
+## `extraction`
+
+Use to convert visible page state into structured output. Pair with a `data_extraction_goal` and `data_schema`.
+
+```json
+{"block_type": "extraction", "label": "get_order", "url": "https://example.com/orders", "data_extraction_goal": "Extract order number, status, and estimated delivery date."}
+```
+
+## `login`
+
+Handles credential-based authentication flows. Pairs with a `credential_id` workflow parameter to securely log in before downstream blocks execute. Use a `complete_criterion` to confirm login success.
+
+```json
+{"block_type": "login", "label": "login", "url": "{{portal_url}}", "parameter_keys": ["login_credential"], "complete_criterion": "The dashboard is visible."}
+```
+
+## `wait`
+
+Use when page transitions are asynchronous.
+
+Use conditions like:
+- spinner disappears
+- success banner appears
+- table row count is non-zero
+
+## `conditional`
+
+Use for known branching states (e.g., optional MFA prompt).
+
+Keep conditions narrow and testable.
+
+## `for_loop`
+
+Use for repeated structures such as paginated rows or item cards.
+
+Avoid nested loops unless absolutely necessary; they increase run variance.

--- a/plugins/productivity/skyvern/references/cli-parity.md
+++ b/plugins/productivity/skyvern/references/cli-parity.md
@@ -1,0 +1,25 @@
+# CLI and MCP Parity Summary
+
+Common mappings:
+
+- `skyvern browser navigate` -> `skyvern_navigate`
+- `skyvern browser act` -> `skyvern_act`
+- `skyvern browser extract` -> `skyvern_extract`
+- `skyvern workflow run` -> `skyvern_workflow_run`
+- `skyvern credential list` -> `skyvern_credential_list`
+
+Use CLI for local operator workflows and MCP tools for agent-driven integrations.
+
+## Agent-Aware CLI
+
+The CLI supports structured JSON output and non-interactive mode for AI agents:
+
+| Feature | CLI flag | Env var |
+|---------|----------|---------|
+| Structured JSON output | `--json` on any command | - |
+| Non-interactive mode | - | `SKYVERN_NON_INTERACTIVE=1` or `CI=true` |
+| Skip confirmations | `--yes` or `--force` | - |
+| Discover commands | `skyvern capabilities --json` | - |
+
+All `--json` responses use the same envelope:
+`{schema_version, ok, action, data, error, warnings, browser_context, artifacts, timing_ms}`

--- a/plugins/productivity/skyvern/references/common-failures.md
+++ b/plugins/productivity/skyvern/references/common-failures.md
@@ -1,0 +1,26 @@
+# Common Failure Patterns
+
+## Symptom: action clicked wrong element
+
+Likely cause: ambiguous intent or crowded UI.
+
+Fix:
+- add stronger context in prompt (position, label, section)
+- fall back to hybrid selector + intent when necessary
+
+## Symptom: extraction returns empty arrays
+
+Likely cause: content not loaded or schema too strict.
+
+Fix:
+- wait for content-ready condition
+- temporarily relax required fields
+- validate visible row/card count before extract
+
+## Symptom: login passes but next step fails as logged out
+
+Likely cause: session mismatch or redirect race.
+
+Fix:
+- ensure same `session_id` across steps
+- add post-login `validate` check before continuing

--- a/plugins/productivity/skyvern/references/complex-inputs.md
+++ b/plugins/productivity/skyvern/references/complex-inputs.md
@@ -1,0 +1,22 @@
+# Complex Input Handling
+
+## Date pickers
+
+- Prefer intent: "set start date to 2026-03-15".
+- If widget blocks typing, click field then choose date from calendar controls.
+
+## File uploads
+
+- Ensure file path exists before automation.
+- Confirm uploaded filename appears in UI before submit.
+
+## Dependent dropdowns
+
+- Select parent option first.
+- Wait for child options to refresh.
+- Validate chosen value is still selected before moving on.
+
+## Rich text editors
+
+- Use focused intent like "enter summary text in the message editor".
+- Validate rendered value, not only keystroke success.

--- a/plugins/productivity/skyvern/references/credentials.md
+++ b/plugins/productivity/skyvern/references/credentials.md
@@ -1,0 +1,56 @@
+# Credential Management
+
+## Create credentials (non-interactive)
+
+Use env vars for secrets — CLI flags are visible in `ps` and `/proc/*/cmdline`.
+
+```bash
+# Set secrets as env vars BEFORE the command (not inline — avoids shell history leak)
+export SKYVERN_CRED_PASSWORD="s3cret"
+skyvern credentials add --name "prod-login" --type password \
+  --username "user@example.com" --json
+
+# With TOTP
+export SKYVERN_CRED_PASSWORD="s3cret"
+export SKYVERN_CRED_TOTP="JBSWY3DPEHPK3PXP"
+skyvern credentials add --name "prod-mfa" --type password \
+  --username "user@example.com" --json
+
+# Credit card (sensitive fields via env vars)
+export SKYVERN_CRED_CARD_NUMBER="4111111111111111"
+export SKYVERN_CRED_CVV="123"
+skyvern credentials add --name "test-card" --type credit_card \
+  --exp-month "12" --exp-year "2027" --card-brand "visa" \
+  --holder-name "John Doe" --json
+
+# Secret (API key, token, etc.)
+export SKYVERN_CRED_SECRET_VALUE="sk_live_abc123"
+skyvern credentials add --name "api-token" --type secret \
+  --secret-label "Stripe key" --json
+```
+
+Set `SKYVERN_NON_INTERACTIVE=1` to ensure prompts never fire.
+
+## List and lookup
+
+```bash
+skyvern credential list --json
+skyvern credential get --id cred_abc123 --json
+```
+
+## Delete
+
+```bash
+skyvern credentials delete cred_abc123 --yes --json
+```
+
+## Naming convention
+
+Use environment and target domain: `prod-salesforce-primary`, `staging-hubspot-sandbox`.
+
+## Safety
+
+- Use env vars for secrets, not CLI flags.
+- Never print secrets in logs.
+- Confirm credential IDs map to the expected system.
+- Delete stale credentials proactively.

--- a/plugins/productivity/skyvern/references/engines.md
+++ b/plugins/productivity/skyvern/references/engines.md
@@ -1,0 +1,20 @@
+# Choosing Between `run_task` and Workflows
+
+Default to workflows for real automation work. Reach for `skyvern_run_task` only when you are
+doing a throwaway trial and do not want to keep the result.
+
+## Prefer `skyvern_workflow_create`
+
+- The task spans multiple pages.
+- The user says `set this up`, `automate`, `workflow`, `reusable`, `repeat`, or `schedule`.
+- You want block-level observability, reruns, parameters, or cached scripts.
+- You expect to debug or hand the automation to someone else later.
+
+## Prefer `skyvern_run_task`
+
+- You need a one-off exploratory trial right now.
+- The result is disposable and not worth saving.
+- You are checking feasibility before deciding whether to build a workflow.
+
+Rule of thumb: if the task crosses page boundaries or sounds like real automation instead of a trial,
+build a workflow first.

--- a/plugins/productivity/skyvern/references/pagination.md
+++ b/plugins/productivity/skyvern/references/pagination.md
@@ -1,0 +1,17 @@
+# Pagination Strategy
+
+## Stable sequence
+
+1. Extract data on current page.
+2. Validate non-empty result.
+3. Advance using intent ("Next page"), not hardcoded selectors.
+4. Stop on explicit condition:
+- no next page,
+- duplicate first row,
+- max page limit reached.
+
+## Guardrails
+
+- Record page index in output metadata.
+- Deduplicate by a stable key (`id`, `url`, `title+date`).
+- Fail fast if extraction shape changes unexpectedly.

--- a/plugins/productivity/skyvern/references/parameters.md
+++ b/plugins/productivity/skyvern/references/parameters.md
@@ -1,0 +1,31 @@
+# Parameter Design
+
+## Rules
+
+- Keep parameter names explicit (`customer_email`, not `value1`).
+- Set required vs optional parameters intentionally.
+- Pass parameters only to blocks that need them.
+- Avoid leaking secrets into descriptions or run logs.
+
+## Example parameter set
+
+```json
+[
+  {"parameter_type":"workflow","key":"portal_url","workflow_parameter_type":"string"},
+  {"parameter_type":"workflow","key":"username","workflow_parameter_type":"string"},
+  {"parameter_type":"workflow","key":"password","workflow_parameter_type":"string"}
+]
+```
+
+## Variable usage
+
+Use `{{parameter_key}}` in block text fields.
+
+Example:
+`"Open {{portal_url}} and complete login with the provided credential values."`
+
+## Run-time checklist
+
+- Validate parameter JSON before invoking runs.
+- Include defaults only when behavior is predictable.
+- Record sample payloads in `examples/`.

--- a/plugins/productivity/skyvern/references/precision-actions.md
+++ b/plugins/productivity/skyvern/references/precision-actions.md
@@ -1,0 +1,17 @@
+# Precision Actions
+
+## Intent-only mode
+
+Best default when page labels are stable and human-readable.
+
+## Selector-only mode
+
+Use when element identity is deterministic and stable.
+
+## Hybrid mode
+
+Use selector + intent together when pages are noisy.
+
+Example:
+- selector narrows search to checkout form
+- intent specifies "primary Place Order button"

--- a/plugins/productivity/skyvern/references/prompt-writing.md
+++ b/plugins/productivity/skyvern/references/prompt-writing.md
@@ -1,0 +1,27 @@
+# Prompt Writing for Running Tasks
+
+## Outcome-first template
+
+```text
+Goal: <business outcome>
+Site: <url>
+Constraints: <what must or must not happen>
+Success criteria: <verifiable completion state>
+Output: <exact fields to return>
+```
+
+## Good prompts
+
+- "Open the pricing page, extract plan name and monthly price for each visible tier, return JSON array."
+- "Submit the lead form with provided fields and confirm success toast text is visible."
+
+## Weak prompts
+
+- "Click around and get data." (no outcome)
+- "Find the button with selector #submit" (overly brittle unless required)
+
+## Reliability guardrails
+
+- Add explicit navigation scope when pages can redirect.
+- Ask for evidence in output (`page title`, confirmation text, extracted row count).
+- Keep schema small for first pass; expand only after stable execution.

--- a/plugins/productivity/skyvern/references/quick-start-patterns.md
+++ b/plugins/productivity/skyvern/references/quick-start-patterns.md
@@ -1,0 +1,120 @@
+# Quick Start Patterns
+
+Examples for each tool classification. See the MCP server instructions for the classification table.
+
+## Quick check (yes/no)
+```
+skyvern_validate(prompt="Is the user logged in?")
+```
+
+## Quick inspection (structured data)
+```
+skyvern_extract(prompt="Extract all prices", schema='{"type":"object","properties":{...}}')
+```
+
+## Single action (known selector)
+```
+skyvern_click(selector="#submit") or skyvern_type(selector="#email", text="user@co.com")
+```
+
+## Single action (unknown target)
+```
+skyvern_act(prompt="Click the Sign In button")
+```
+
+## Multi-step (simple, PREFERRED for forms)
+1. `skyvern_observe()` returns element refs (`e0`, `e1`, ...)
+2. Your LLM decides which refs to interact with
+3. Run `skyvern_execute(...)` with those refs, for example:
+
+```python
+skyvern_execute(
+    steps=[
+        {"tool": "click", "params": {"ref": "e0"}},
+        {"tool": "type", "params": {"ref": "e1", "text": "hello"}},
+    ]
+)
+```
+
+## Throwaway autonomous trial
+```
+skyvern_run_task(prompt="Try the checkout flow once and tell me whether it succeeds")
+```
+
+## Multi-step (complex, workflow)
+```
+skyvern_workflow_create(
+  definition='{"title":"Checkout","workflow_definition":{"blocks":[
+    {"block_type":"navigation","label":"shipping","navigation_goal":"Fill shipping info"},
+    {"block_type":"navigation","label":"payment","navigation_goal":"Select payment and submit"},
+    {"block_type":"extraction","label":"confirm","data_extraction_goal":"Extract order number"}
+  ]}}',
+  format="json"
+) -> skyvern_workflow_run(workflow_id="wpid_...") -> skyvern_workflow_status(run_id="wr_...")
+```
+
+## QA testing
+Use the qa_test prompt to test frontend changes — reads git diff, generates + runs browser tests.
+
+## Common Patterns
+
+### Logging in securely
+1. `skyvern_credential_list` -- find the credential
+2. `skyvern_browser_session_create` -- start session
+3. `skyvern_navigate(url="https://login.example.com")` -- go to login page
+4. `skyvern_login(credential_id="cred_...")` -- AI handles the full login flow
+5. `skyvern_screenshot` -- verify login succeeded
+
+### Debugging browser issues
+`skyvern_browser_session_create` -> `skyvern_navigate` -> perform actions ->
+`skyvern_console_messages(level="error")` for JS errors, `skyvern_network_requests` for API calls
+
+### Testing feasibility before building a workflow
+Walk through the site interactively — use `skyvern_act` on each page and `skyvern_screenshot` to verify.
+Once confirmed, compose steps into a workflow with `skyvern_workflow_create`.
+
+## Writing Scripts
+
+Use the Skyvern Python SDK: `from skyvern import Skyvern`.
+NEVER import from `skyvern.cli.mcp_tools` — those are internal server modules.
+In verbose mode (`--verbose`), every tool response includes an `sdk_equivalent` field for script conversion.
+
+### Hybrid xpath+prompt pattern (recommended for production scripts)
+```python
+await page.click("xpath=//button[@id='submit']", prompt="the Submit button")
+await page.fill("xpath=//input[@name='email']", "user@example.com", prompt="email input field")
+```
+
+## Workflow Example (multi-block form application)
+```json
+{
+  "title": "Multi-Step Form Application",
+  "workflow_definition": {
+    "parameters": [
+      {"parameter_type": "workflow", "key": "business_name", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "owner_name", "workflow_parameter_type": "string"},
+      {"parameter_type": "workflow", "key": "owner_id", "workflow_parameter_type": "string"}
+    ],
+    "blocks": [
+      {"block_type": "navigation", "label": "select_entity_type",
+       "url": "https://example.com/form/step1",
+       "title": "Select Entity Type",
+       "navigation_goal": "Select 'Sole Proprietor' as the entity type and click Continue."},
+      {"block_type": "navigation", "label": "enter_business_info",
+       "title": "Enter Business Info",
+       "navigation_goal": "Fill in the business name as '{{business_name}}' and click Continue.",
+       "parameter_keys": ["business_name"]},
+      {"block_type": "navigation", "label": "enter_owner_info",
+       "title": "Enter Owner Info",
+       "navigation_goal": "Enter the responsible party name '{{owner_name}}' and ID '{{owner_id}}'. Click Continue.",
+       "parameter_keys": ["owner_name", "owner_id"]},
+      {"block_type": "extraction", "label": "extract_confirmation",
+       "title": "Extract Confirmation",
+       "data_extraction_goal": "Extract the confirmation number from the success page",
+       "data_schema": {"type": "object", "properties": {"confirmation_number": {"type": "string"}}}}
+    ]
+  }
+}
+```
+Use `{{parameter_key}}` to reference workflow input parameters in any block field.
+Blocks in the same run share the same browser session automatically.

--- a/plugins/productivity/skyvern/references/rerun-playbook.md
+++ b/plugins/productivity/skyvern/references/rerun-playbook.md
@@ -1,0 +1,14 @@
+# Rerun Playbook
+
+## Before rerun
+
+- Confirm root cause hypothesis.
+- Adjust parameters or environment assumptions.
+- Decide whether prior run should be canceled.
+
+## Rerun steps
+
+1. Launch new run with corrected inputs.
+2. Monitor until terminal state.
+3. Compare outputs against expected invariants.
+4. Record outcome and next action.

--- a/plugins/productivity/skyvern/references/schemas.md
+++ b/plugins/productivity/skyvern/references/schemas.md
@@ -1,0 +1,30 @@
+# Schema Patterns for Extraction
+
+## Minimal list schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "price": {"type": "string"}
+        },
+        "required": ["name"]
+      }
+    }
+  },
+  "required": ["items"]
+}
+```
+
+## Practical guidance
+
+- Keep required fields to truly required business data.
+- Use strings first for prices/dates unless typed values are guaranteed.
+- Add numeric typing only after site formatting is known to be consistent.
+- Do not request every visible field in the first pass.

--- a/plugins/productivity/skyvern/references/screenshots.md
+++ b/plugins/productivity/skyvern/references/screenshots.md
@@ -1,0 +1,20 @@
+# Screenshot-led Debugging
+
+## Capture points
+
+- before the failing action
+- immediately after the failing action
+- after wait/validation conditions
+
+## What to inspect
+
+- visibility of target controls
+- modal overlays blocking interaction
+- error banners or toast messages
+- unexpected route changes
+
+## Fast loop
+
+1. Capture screenshot.
+2. Adjust one variable (prompt, wait, selector).
+3. Rerun and compare screenshot delta.

--- a/plugins/productivity/skyvern/references/sessions.md
+++ b/plugins/productivity/skyvern/references/sessions.md
@@ -1,0 +1,20 @@
+# Session Reuse
+
+## When to reuse a session
+
+- Multiple actions on one authenticated site.
+- Workflow chains that depend on retained state.
+- Follow-up extraction immediately after login.
+
+## When to start fresh
+
+- Session appears invalid or expired.
+- Site has strict anti-automation lockouts.
+- Running independent tasks in parallel.
+
+## Validation step
+
+After login, run `skyvern_validate` with a concrete condition:
+- user avatar visible,
+- logout button present,
+- account dashboard heading shown.

--- a/plugins/productivity/skyvern/references/status-lifecycle.md
+++ b/plugins/productivity/skyvern/references/status-lifecycle.md
@@ -1,0 +1,18 @@
+# Run Status Lifecycle
+
+Typical flow:
+
+1. `created`
+2. `queued`
+3. `running`
+4. terminal status: `completed`, `failed`, `canceled`, `terminated`, or `timed_out`
+
+Additional states:
+
+- `paused` — non-terminal; the run is suspended and can be resumed.
+
+Operational guidance:
+
+- Define max runtime per workflow class.
+- Alert on runs stuck in non-terminal states beyond threshold.
+- Track failure signatures for prioritization.

--- a/plugins/productivity/skyvern/references/tool-map.md
+++ b/plugins/productivity/skyvern/references/tool-map.md
@@ -1,0 +1,77 @@
+# Tool Map by Outcome
+
+## Quick check or extraction
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_validate` | Answer a yes/no question about the current page |
+| `skyvern_extract` | Pull structured data from the current page |
+
+## Single action
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_click` | Click an element when you know the target |
+| `skyvern_type` | Type text into an element when you know the target |
+| `skyvern_select_option` | Select a dropdown option |
+| `skyvern_act` | Perform a natural-language action when you do not know exact selectors |
+
+## Throwaway autonomous trial
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_run_task` | Execute a one-off exploratory automation with a prompt and URL |
+
+## Open and operate a website
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_browser_session_create` | Start a new browser session |
+| `skyvern_browser_session_connect` | Attach to an existing session |
+| `skyvern_browser_session_list` | List active sessions |
+| `skyvern_browser_session_get` | Get session details |
+| `skyvern_browser_session_close` | Close a session |
+| `skyvern_navigate` | Navigate to a URL |
+| `skyvern_act` | Perform an AI-driven action |
+| `skyvern_extract` | Extract structured data |
+| `skyvern_validate` | Assert a condition on the page |
+| `skyvern_screenshot` | Capture a screenshot |
+
+## Browser primitives
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_hover` | Hover over an element |
+| `skyvern_scroll` | Scroll the page |
+| `skyvern_press_key` | Press a keyboard key |
+| `skyvern_wait` | Wait for a condition or duration |
+| `skyvern_evaluate` | Execute JavaScript in the page |
+
+## Build reusable or multi-page automation
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_workflow_create` | Create a workflow definition |
+| `skyvern_workflow_list` | List workflows |
+| `skyvern_workflow_get` | Get workflow details |
+| `skyvern_workflow_update` | Update a workflow |
+| `skyvern_workflow_delete` | Delete a workflow |
+| `skyvern_workflow_run` | Execute a workflow |
+| `skyvern_workflow_status` | Check run status |
+| `skyvern_workflow_cancel` | Cancel a running workflow |
+
+## Workflow blocks
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_block_schema` | Get the schema for a block type |
+| `skyvern_block_validate` | Validate a block definition |
+
+## Operate credentials
+
+| Tool | Purpose |
+|------|---------|
+| `skyvern_credential_list` | List stored credentials |
+| `skyvern_credential_get` | Get credential details |
+| `skyvern_credential_delete` | Delete a credential |
+| `skyvern_login` | Use a credential in a browser session |


### PR DESCRIPTION
## Summary

Pulls in the Skyvern external skill files synced by \`sync-external.yml\` after #547 merged.

- 23 files under \`plugins/productivity/skyvern/\`: SKILL.md, references/, examples/, plus \`.source.json\` provenance
- Source: \`Skyvern-AI/skyvern\` (\`skyvern/cli/skills/skyvern\`), AGPL-3.0
- Auto-generated by \`.github/workflows/sync-external.yml\` (run [25244672498](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/25244672498))

## Why a PR (not a direct push)

\`main\` is branch-protected. \`sync-external.yml\` lands its diff on \`sync/external-plugins\` and waits for a maintainer to open the PR — same idempotent pattern as #643, #641 before it. Re-runs of the sync force-push to the same branch so this PR auto-updates as new sources land.

## Related

- Source-config registration: #547 (merged)
- Spotlight promotion: #648 (in flight)

Once both #547 + this merge, the spotlight link in #648 can be flipped from the upstream GitHub URL to \`/plugins/skyvern\` in a one-line follow-up.

jeremy made me do it
-claude