### PR TITLE
feat(analytics): wire Umami tracker into BaseLayout (closes empty-data gap)

### DIFF
--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -52,6 +52,11 @@ const currentPath = Astro.url.pathname;
 
     <slot name="head" />
 
+    <!-- Umami Analytics (self-hosted, privacy-friendly, no cookies, GDPR-clean by design)
+         Source of truth for site-id mapping: ~/.claude/skills/web-analytics/references/site-registry.md
+         Backend: analytics.intentsolutions.io (Contabo VPS, Watchtower-updated) -->
+    <script defer src="https://analytics.intentsolutions.io/script.js" data-website-id="0cee47ed-bee5-48da-8fed-46b3d8a2ddd3"></script>
+
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-9Z1DTMTT44"></script>
     <script is:inline>


### PR DESCRIPTION
## Summary

The Umami container at `analytics.intentsolutions.io` has been running with all 4 sites pre-registered in its DB since 2026-04-17, but the tracker `<script>` was never installed on any site. Result: zero pageviews recorded for ~2.5 weeks even though the analytics MCP, `site-registry.md`, and the `/analytics` skill are all wired to query that data. This PR closes the gap for tonsofskills.com.

## Change

One line added to `marketplace/src/layouts/BaseLayout.astro` `<head>`:

```html
<script defer src="https://analytics.intentsolutions.io/script.js" data-website-id="0cee47ed-bee5-48da-8fed-46b3d8a2ddd3"></script>
```

## Design decisions (CTO mode — least technical debt)

- **No central indirection.** Considered an env-var pattern (`UMAMI_WEBSITE_ID` per build) and a shared analytics package. Both rejected: four website-ids that change roughly never don't justify build-time complexity. The IDs are already documented in `~/.claude/skills/web-analytics/references/site-registry.md`. Industry pattern (Astro/Hugo/etc.) is one `<script>` per site.
- **Coexists with GA4 + Firebase intentionally.** GA4 = industry-baseline reporting, Firebase = first-party UTM events, Umami = self-hosted privacy-friendly source for the `/analytics` dashboard. Removing GA4/Firebase is a separate decision.
- **`defer` attribute.** Off the critical render path. ~3KB script, loaded from our own apex domain (no third-party CDN dependency).
- **No CSP impact.** BaseLayout doesn't ship a `Content-Security-Policy` header; Umami script will load without policy adjustments.
- **GDPR/cookie posture preserved.** Umami v2 uses no cookies, no PII collection, honors DNT by default. No consent banner added or needed.

## Fast-follow (other 3 sites — different repos)

After this merges and deploy verifies pageviews land, ship the same one-line snippet in each site's head template:

| Site | Repo | Path | website-id |
|---|---|---|---|
| `startaitools.com` | `jeremylongshore/startaitools` (Hugo) | `layouts/partials/head.html` | `4071f4db-4249-4ce6-a929-665598975d67` |
| `jeremylongshore.com` | `jeremylongshore/jeremylongshore.com` | head template | `3cea8ff2-5842-4090-a8a3-d2dc128f5385` |
| `intentsolutions.io` | `jeremylongshore/intentsolutions.io` | head template | `474bce85-f97d-409c-aba5-1e1ff36ee571` |

## Verification (post-merge)

```bash
# 1. Confirm script in rendered HTML after deploy
curl -s https://tonsofskills.com/ | grep 'analytics.intentsolutions.io'

# 2. Browse one page in a clean session (Cmd+Shift+N / incognito)

# 3. Confirm pageview landed in Umami
TOKEN=$(curl -s -X POST https://analytics.intentsolutions.io/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"admin","password":"<see ~/.claude.json>"}' | jq -r .token)

curl -s "https://analytics.intentsolutions.io/api/websites/0cee47ed-bee5-48da-8fed-46b3d8a2ddd3/stats?startAt=$(date -d 'today' +%s)000&endAt=$(date +%s)000" \
  -H "Authorization: Bearer $TOKEN" | jq '.pageviews'
# Expected: ≥ 1
```

## Related issues

- Tracker mirroring (separate concern): `umami-mcp-server` v2.0.0 npm package login flow appears to fail in the current Claude Code MCP session even though direct curl + JWT works. Likely a session-restart fix (re-spawn MCP with current env). Not blocking — the data layer works regardless.

## Test plan

- [ ] `validate` + `marketplace-validation` CI green
- [ ] Marketplace build picks up the BaseLayout change without route/link breakage
- [ ] Post-merge: pageview verification command above returns ≥ 1
- [ ] No console errors from the script load
- [ ] Lighthouse score unchanged (defer + 3KB shouldn't move the needle)

jeremy made me do it
-claude