### PR TITLE
fix(hero): space + speed up partners + npm-stats marquees

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -128,22 +128,23 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         .hero-sponsor-marquee {
             margin-top: 0.5rem;
             overflow: hidden;
-            max-width: 400px;
+            max-width: 480px;
             animation: fadeInUp 0.7s var(--ease-out) 0.1s forwards;
             opacity: 0;
         }
         .hero-sponsor-label {
+            display: block;
             font-family: 'DM Mono', monospace;
-            font-size: 0.55rem;
+            font-size: 0.6rem;
             color: var(--text-3);
             text-transform: uppercase;
             letter-spacing: 0.12em;
-            margin-bottom: 0.35rem;
+            margin-bottom: 0.55rem;
         }
         .hero-sponsor-track {
             display: flex;
             gap: 3rem;
-            animation: sponsorScroll 18s linear infinite;
+            animation: sponsorScroll 11s linear infinite;
         }
         .hero-sponsor-link {
             flex-shrink: 0;
@@ -158,14 +159,20 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             color: var(--primary);
             opacity: 1;
         }
-        /* Stats marquee (second row, under partners) — runs slightly slower
-           so the longer text strings stay readable. */
+        /* Stats marquee (second row, under partners). Visually separated from
+           the partner marquee with a subtle divider + breathing room — they
+           used to stack at margin-top: 0.35rem (~5.6px) which read as one
+           jammed element. Speed bumped from 28s → 16s per design feedback;
+           still slower than partners (11s) because the text strings are longer
+           and need to stay readable. */
         .hero-stats-marquee {
-            margin-top: 0.35rem;
+            margin-top: 1.25rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border);
             max-width: 520px;
         }
         .hero-stats-marquee .hero-sponsor-track {
-            animation-duration: 28s;
+            animation-duration: 16s;
         }
         .hero-stats-link .hero-sponsor-text {
             font-family: 'DM Mono', monospace;


### PR DESCRIPTION
## Summary

Two hero marquees (partners, npm downloads) were visually jammed on top of each other and scrolling too slowly. Pure CSS fix.

## Before vs After

| | Before | After |
|---|---|---|
| Vertical gap between marquees | 0.35rem (~5.6px) | 1.25rem + 1rem padding + 1px divider |
| Partners scroll speed | 18s/cycle | 11s/cycle |
| NPM-stats scroll speed | 28s/cycle | 16s/cycle |
| Partners max-width | 400px | 480px (less awkward off-balance vs 520px stats below) |
| Partners label margin | 0.35rem | 0.55rem |
| Partners label size | 0.55rem | 0.6rem |

The 1px \`--border\` divider above the npm-stats row visually separates the two rows so they read as distinct content, not one mashed-together strip.

## NPM data currency

Verified: \`marketplace/src/data/npm-stats.json\` regenerated 2026-05-02 04:09 UTC by \`update-npm-stats.yml\` cron. Shows 340 published packages / 41,975 last-30d downloads. Display logic unchanged — data was already current, layout was the only issue.

## Test plan

- [ ] CI green on \`validate\` + \`marketplace-validation\` (Astro build)
- [ ] After deploy: tonsofskills.com hero shows clear separation between partners + npm-stats rows
- [ ] Both marquees scroll noticeably faster (each ~halved cycle time)
- [ ] No regression on mobile (max-width didn't grow past viewport)

jeremy made me do it
-claude