### PR TITLE
feat(community): add contributing-clanker plugin scaffold (v0.1.0)

### DIFF
--- a/plugins/community/contributing-clanker/README.md
+++ b/plugins/community/contributing-clanker/README.md
@@ -2,36 +2,139 @@
 
 > Local-only OSS contribution command center. 41 deterministic gates against AI-slop failure modes.
 
+A Claude Code plugin that turns `/contribute` into a discipline tool: every external action (claim, design issue, PR open, comment) passes through phase-appropriate gates that BLOCK or WARN on traps real maintainers complain about. Markdown-only state. No daemons. No SQLite. Filesystem is the tracker.
+
 [![version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/jeremylongshore/contributing-clanker)
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/jeremylongshore/contributing-clanker/blob/master/LICENSE)
 [![gates](https://img.shields.io/badge/gates-41%20installed-orange.svg)](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md)
+[![failure modes](https://img.shields.io/badge/catalog-62%20modes-red.svg)](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md)
 
-**Links:** [source repo](https://github.com/jeremylongshore/contributing-clanker) · [gate inventory](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md) · [failure-mode catalog](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md) · [risk register](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/010-OD-RISK-operations-and-risk.md)
+**Links:** [source repo](https://github.com/jeremylongshore/contributing-clanker) · [gate inventory](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md) · [failure-mode catalog](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md) · [risk register](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/010-OD-RISK-operations-and-risk.md) · [architecture](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/002-AT-ARCH-system-architecture.md)
 
 ---
 
-## What it does
+## One-Pager
 
-`/contribute` becomes available in Claude Code. It walks any candidate issue through `open → shortlist → claimed → working → submitted → merged`, running phase-appropriate deterministic gates at each transition. Gates BLOCK on real-world AI-slop traps:
+### The Problem
 
-| Trap | Gate | What it catches |
+OSS maintainers are drowning in AI-generated low-quality contributions. The pattern is consistent:
+
+- Bots and AI-assisted contributors **claim issues without checking** if they're already shipped, already assigned, or against repo policy
+- They **open PRs against `CONTRIBUTING.md` rules** they didn't read (wrong base branch, wrong commit format, missing CLA, banned `Co-Authored-By` lines)
+- They **auto-respond to maintainer feedback** in ways that violate the repo's etiquette norms
+- They **edit vendored code, version files, or changelogs** because the AI didn't recognize "do not touch" boundaries
+
+The damage isn't always rejection — sometimes the contribution is technically fine, but the surrounding behavior burns maintainer trust, gets the contributor a soft-ban, and feeds the public "AI ruins OSS" narrative.
+
+### The Solution
+
+`contributing-clanker` is a **local-first discipline tool** for AI-assisted OSS contribution. Three layers:
+
+1. **Per-repo dossiers** — `@researcher` reads each upstream's `CONTRIBUTING.md`, linked policy docs, and bot-detected review patterns into a markdown dossier at `~/.contribute-system/research/<owner>__<repo>.md`. Cached. Refreshed on a 14-day staleness threshold.
+2. **41 deterministic gates** — one bash script per failure mode. `(candidate, dossier, intended action) → PASS / WARN / BLOCK / INFORM`. Read-only. Pluggable. The gates read the dossier, not live `gh` (latency dominates: most pre-PR sweeps complete in single-digit seconds).
+3. **Lifecycle workflow** — `/contribute` walks each candidate through `open → shortlist → claimed → working → submitted → merged`. At each transition, the orchestrator runs the relevant gate set. BLOCK refuses the transition; WARN surfaces in the briefing.
+
+Default behavior: **open a Design Issue first, not a PR**. The skill defaults to design-issue-then-PR because auto-PRs generate "whack-a-mole slopfests" for maintainers. PR comes after maintainer approval of the approach.
+
+### W5 — Who, What, When, Where, Why
+
+| | |
+|---|---|
+| **Who** | Solo OSS contributors using AI assistance who want to contribute *well*, not just contribute. |
+| **What** | A Claude Code plugin (`/contribute`) + a 41-gate runtime under `~/.contribute-system/`. |
+| **When** | Every transition: claim, comment, open Design Issue, open PR. Background scout sweeps for ranked candidates. |
+| **Where** | Entirely local. Reads live GitHub state via `gh` for the few queries that demand it; everything else hits the cached markdown dossier. |
+| **Why** | Because shipping faster than maintainers can review is a failure mode, not a feature. The catalog of 62 enumerated AI-slop patterns is the receipt. |
+
+### Stack
+
+| Layer | Tool |
+|---|---|
+| Skill orchestration | Claude Code (`/contribute`) + 5 subagents (`@scout`, `@researcher`, `@draft-writer`, `@test-runner`, `@repo-analyzer`) |
+| Gate execution | bash + `jq` + `gh` CLI; one script per failure mode under `~/.contribute-system/gates/` |
+| State | Markdown candidate files + per-repo markdown dossiers + JSONL append-only event log |
+| Prereqs | `gh` authenticated, `jq` on PATH, Claude Code 1.x |
+
+### Key Differentiators
+
+- **Catalog-anchored gates.** Every gate maps to one of 62 enumerated failure modes ([catalog](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md)). New gates require a real-world trigger — speculative guards are rejected in review.
+- **Override with audit trail.** `--override-gate <ID> "reason"` is an explicit escape hatch. Reasons land in `~/.contribute-system/log.jsonl`. The bundled `audit-overrides.sh` reports gates overridden ≥50% of the time — those are wrong, not yours.
+- **Filesystem-only.** No SQLite. No Cloud Functions. No daemons. The candidate file IS the tracker. Greppable. Git-trackable. Survives any tool.
+- **Default to design-issue first.** PRs come after maintainer approval. The skill explicitly refuses to auto-submit external content.
+- **Per-repo opt-out.** A dossier can disable specific gates with `disabled_gates: [...]`. Honors weird-but-legitimate repo conventions without forking the gate set.
+
+---
+
+## Operator-Grade System Analysis
+
+### Architecture summary
+
+Three layers, deliberately uncoupled. Each can be disabled independently without breaking the others:
+
+```
+                      ┌──────────────────────────┐
+                      │  /contribute (the skill) │   Layer 3 — lifecycle
+                      │  open → shortlist →      │   walks transitions,
+                      │  claimed → working →     │   invokes gate-runner
+                      │  submitted → merged      │   per transition
+                      └────────────┬─────────────┘
+                                   │
+                      ┌────────────▼─────────────┐
+                      │  gate-runner.sh          │   Layer 2 — gates
+                      │  41 scripts × phase A-G  │   stateless,
+                      │  → PASS/WARN/BLOCK/SKIP  │   read-only,
+                      └────────────┬─────────────┘   plug-in
+                                   │
+                      ┌────────────▼─────────────┐
+                      │  Per-repo dossiers       │   Layer 1 — knowledge
+                      │  ~/.contribute-system/   │   built by @researcher,
+                      │  research/<o>__<r>.md    │   refreshed @ 14d
+                      └──────────────────────────┘
+```
+
+### Trust boundaries
+
+| Boundary | Trust posture |
+|---|---|
+| User → skill | Full. The skill is the user's tool. |
+| Skill → gates | Full read-trust on the dossier; treats `gh` output as untrusted (validates JSON shape via `jq`). |
+| Gates → external (GitHub) | `gh_safe` retry wrapper: 3 retries + exponential backoff + 30s per-call timeout. On exhausted retries, gate returns SKIP, not BLOCK. |
+| User data | Lives only at `~/.contribute-system/`. Plugin install creates the dirs; uninstall removes plugin-shipped scripts but **leaves user data intact**. |
+
+### Failure modes the system itself can hit
+
+| Mode | Detection | Response |
 |---|---|---|
-| Issue already assigned to a human | `a01-already-assigned` | Stops scout from queuing duplicate work |
-| PR already shipped, issue stale | `a02-already-shipped` | Catches "AI didn't notice this is closed" |
-| Repo forbids AI-generated content | `e02-ai-strike-track` | Reads dossier policy, blocks claim |
-| Branch name violates repo convention | `b02-branch-naming` | Cross-checks against dossier-cached convention |
-| CI red before submit | `c12-ci-green` | Live `gh` query, blocks PR open |
-| Maintainer reopened a closed issue against bot policy | `d05-no-reopen` | Blocks unilateral reopen |
-| AI editor accidentally edits vendored code | `g01-no-vendored-edits` | Local-clone diff scan |
+| Gate has a bug, exits non-zero unexpectedly | `lib/preamble.sh` ERR trap converts to fail-closed BLOCK with reason "gate crashed at line N" | Engineer reviews log.jsonl, fixes the bug; user-side, the candidate is just blocked, not silently passed |
+| Gate latency exceeds 10s | Per-gate `timeout 10` in gate-runner | Gate returns SKIP with reason "gate timed out"; user warned, transition continues |
+| Dossier is stale (>14d) | Skill Step 0.5 checks `last_refreshed:` field at runtime | Auto-invokes `@researcher refresh` before transition; if refresh fails, surfaces a WARN |
+| User overrides a gate routinely (≥50%) | `audit-overrides.sh --since=30` cron-style report | Surface to user; the gate is wrong, not the user — refine or retire |
+| Candidate state drifts vs. live GitHub | Reconciliation step in skill (manual: "reconcile candidates") | Walks candidates with `pr_number:`, calls `gh pr view`, updates `status:` field atomically |
 
-Full inventory + rationale: [`005-AT-SPEC-gate-inventory.md`](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md). Each gate maps to one of 62 enumerated [failure modes](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md) — every gate has a real-world trigger, no speculative guards.
+### Observability surface
 
-## How it stays out of your way
+- `~/.contribute-system/log.jsonl` — append-only event log: every gate run, every transition attempt, every override, every scout/researcher invocation, with UTC timestamps
+- `audit-overrides.sh [--since=N --scope=org:X --gate=ID --json]` — per-gate override-rate report
+- `catalog-coverage.sh` — coverage of installed gates against the 62-mode catalog (currently 41 of 65 = 63%)
 
-- **Markdown-only state.** Per-repo dossiers at `~/.contribute-system/research/<owner>__<repo>.md` cache the rules (branch convention, CLA, AI policy, draft-first preference). Gates read the dossier, not live `gh`. A full pre-PR sweep is single-digit seconds.
-- **No daemons.** Filesystem only. Survives any tool. Greppable, git-trackable.
-- **Override with audit.** `--override-gate <ID> "reason"` for false positives. Reasons land in `~/.contribute-system/log.jsonl`. `audit-overrides.sh` reports gates you override ≥50% of the time — those are wrong, not yours.
-- **Default to Design Issue, not PR.** Auto-PRs generate maintainer "whack-a-mole slopfests." The skill defaults to opening a design issue first; PR comes after maintainer approval of the approach.
+### Recovery posture
+
+| Failure | Recovery |
+|---|---|
+| One gate over-fires across all repos | `chmod -x ~/.contribute-system/gates/<gate>.sh` (runner skips it) |
+| One gate over-fires on a specific repo | Edit dossier: `disabled_gates: [<gate>]` |
+| Dossier mis-reads a repo | `rm` the dossier, `@researcher build` from scratch |
+| Lifecycle workflow misbehaves | Edit `~/.claude/skills/contribute/SKILL.md` (markdown — surgical edit safe) |
+| Whole system is wrong | Skip the skill — `gh issue comment` / `gh pr create` directly. Opt-in via `/contribute`; nothing forces its use. |
+
+### What this is NOT
+
+- A bounty board — pre-2026-04-30 versions had Algora/Gumroad framing; that's gone
+- A tracker — no SQLite, no dashboard, no cloud backend
+- A multi-user system — Phase 1 is single-user. Phase 3 (containerized service) only triggers if multi-user demand surfaces
+- An auto-PR generator — defaults to design-issue-first; never auto-submits without explicit human approval
+
+---
 
 ## Install
 
@@ -39,9 +142,9 @@ Full inventory + rationale: [`005-AT-SPEC-gate-inventory.md`](https://github.com
 /plugin install contributing-clanker
 ```
 
-The post-install hook creates `~/.contribute-system/{candidates,research,gates,gates/lib,bin,check-runs}` and copies the runtime scripts in. Your candidate state and dossier history are yours — uninstall preserves them.
+The post-install hook creates `~/.contribute-system/{candidates,research,gates,gates/lib,bin,check-runs,test-logs}` and copies the runtime scripts in. Your candidate state and dossier history are yours — uninstall preserves them.
 
-Prerequisites: `gh` authenticated (`gh auth status`) and `jq` on PATH.
+**Prerequisites**: `gh` authenticated (`gh auth status`) and `jq` on `PATH`.
 
 ## Verify
 
@@ -53,21 +156,6 @@ After install, in any Claude Code session:
 
 The skill activates, reports state (PRs in flight, claimed candidates, ready-to-pick queue), and stays out of the way until you give it work.
 
-## Three layers
-
-1. **Per-repo dossiers.** What the upstream expects of contributors — branch convention, CLA/DCO, AI policy, PR template requirements, review bots, etc. Built by `@researcher` from `CONTRIBUTING.md` + linked policy docs + bot detection. Cached, refreshable on a 14-day staleness threshold.
-
-2. **Deterministic gates.** One small script per failure mode. `(candidate, dossier, intended action) → PASS / WARN / BLOCK / INFORM`. Read-only. Pluggable: drop a script in `~/.contribute-system/gates/`, the runner discovers it.
-
-3. **Lifecycle workflow.** The skill itself walks each candidate through transitions, running the right gate set per transition. BLOCK refuses; WARN surfaces in the briefing.
-
-## What this is NOT
-
-- A bounty board — pre-2026-04-30 versions had Algora/Gumroad framing; that's gone.
-- A tracker — no SQLite, no dashboard, no cloud backend. Filesystem is the tracker.
-- A multi-user system — Phase 1 is single-user. Phase 3 (containerized service) only triggers if multi-user demand surfaces.
-- An AI auto-PR generator — defaults to design-issue-first; never auto-submits without explicit human approval.
-
 ## Troubleshooting
 
 | Symptom | Fix |
@@ -75,9 +163,10 @@ The skill activates, reports state (PRs in flight, claimed candidates, ready-to-
 | `/contribute` doesn't activate after install | Restart Claude Code |
 | `gh: not logged in` | `gh auth login` |
 | `jq: command not found` | `apt-get install jq` (or equivalent for your platform) |
-| Gate BLOCKs unexpectedly | Run `audit-overrides.sh` to see if it's a known false-positive cluster; override with `--override-gate <ID> "reason"` if so |
+| Gate BLOCKs unexpectedly | Run `audit-overrides.sh --gate=<ID>` to see if it's a known false-positive cluster; override with `--override-gate <ID> "reason"` if the BLOCK is wrong; submit a refinement to the source repo if the gate itself needs fixing |
 | Dossier missing for a repo | First contribution to that repo; `@researcher` auto-builds on first transition |
 | Stale dossier (>14 days) | Auto-refresh on next gate run; or `@researcher refresh <owner>/<repo>` |
+| Want to disable one gate for one repo | Edit the dossier: `disabled_gates: [<gate-id>]` |
 
 ## License
 

--- a/plugins/community/contributing-clanker/README.md
+++ b/plugins/community/contributing-clanker/README.md
@@ -1,0 +1,84 @@
+# contributing-clanker
+
+> Local-only OSS contribution command center. 41 deterministic gates against AI-slop failure modes.
+
+[![version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/jeremylongshore/contributing-clanker)
+[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/jeremylongshore/contributing-clanker/blob/master/LICENSE)
+[![gates](https://img.shields.io/badge/gates-41%20installed-orange.svg)](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md)
+
+**Links:** [source repo](https://github.com/jeremylongshore/contributing-clanker) · [gate inventory](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md) · [failure-mode catalog](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md) · [risk register](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/010-OD-RISK-operations-and-risk.md)
+
+---
+
+## What it does
+
+`/contribute` becomes available in Claude Code. It walks any candidate issue through `open → shortlist → claimed → working → submitted → merged`, running phase-appropriate deterministic gates at each transition. Gates BLOCK on real-world AI-slop traps:
+
+| Trap | Gate | What it catches |
+|---|---|---|
+| Issue already assigned to a human | `a01-already-assigned` | Stops scout from queuing duplicate work |
+| PR already shipped, issue stale | `a02-already-shipped` | Catches "AI didn't notice this is closed" |
+| Repo forbids AI-generated content | `e02-ai-strike-track` | Reads dossier policy, blocks claim |
+| Branch name violates repo convention | `b02-branch-naming` | Cross-checks against dossier-cached convention |
+| CI red before submit | `c12-ci-green` | Live `gh` query, blocks PR open |
+| Maintainer reopened a closed issue against bot policy | `d05-no-reopen` | Blocks unilateral reopen |
+| AI editor accidentally edits vendored code | `g01-no-vendored-edits` | Local-clone diff scan |
+
+Full inventory + rationale: [`005-AT-SPEC-gate-inventory.md`](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/005-AT-SPEC-gate-inventory.md). Each gate maps to one of 62 enumerated [failure modes](https://github.com/jeremylongshore/contributing-clanker/blob/master/000-docs/007-DR-CATG-failure-mode-catalog.md) — every gate has a real-world trigger, no speculative guards.
+
+## How it stays out of your way
+
+- **Markdown-only state.** Per-repo dossiers at `~/.contribute-system/research/<owner>__<repo>.md` cache the rules (branch convention, CLA, AI policy, draft-first preference). Gates read the dossier, not live `gh`. A full pre-PR sweep is single-digit seconds.
+- **No daemons.** Filesystem only. Survives any tool. Greppable, git-trackable.
+- **Override with audit.** `--override-gate <ID> "reason"` for false positives. Reasons land in `~/.contribute-system/log.jsonl`. `audit-overrides.sh` reports gates you override ≥50% of the time — those are wrong, not yours.
+- **Default to Design Issue, not PR.** Auto-PRs generate maintainer "whack-a-mole slopfests." The skill defaults to opening a design issue first; PR comes after maintainer approval of the approach.
+
+## Install
+
+```bash
+/plugin install contributing-clanker
+```
+
+The post-install hook creates `~/.contribute-system/{candidates,research,gates,gates/lib,bin,check-runs}` and copies the runtime scripts in. Your candidate state and dossier history are yours — uninstall preserves them.
+
+Prerequisites: `gh` authenticated (`gh auth status`) and `jq` on PATH.
+
+## Verify
+
+After install, in any Claude Code session:
+
+```
+/contribute
+```
+
+The skill activates, reports state (PRs in flight, claimed candidates, ready-to-pick queue), and stays out of the way until you give it work.
+
+## Three layers
+
+1. **Per-repo dossiers.** What the upstream expects of contributors — branch convention, CLA/DCO, AI policy, PR template requirements, review bots, etc. Built by `@researcher` from `CONTRIBUTING.md` + linked policy docs + bot detection. Cached, refreshable on a 14-day staleness threshold.
+
+2. **Deterministic gates.** One small script per failure mode. `(candidate, dossier, intended action) → PASS / WARN / BLOCK / INFORM`. Read-only. Pluggable: drop a script in `~/.contribute-system/gates/`, the runner discovers it.
+
+3. **Lifecycle workflow.** The skill itself walks each candidate through transitions, running the right gate set per transition. BLOCK refuses; WARN surfaces in the briefing.
+
+## What this is NOT
+
+- A bounty board — pre-2026-04-30 versions had Algora/Gumroad framing; that's gone.
+- A tracker — no SQLite, no dashboard, no cloud backend. Filesystem is the tracker.
+- A multi-user system — Phase 1 is single-user. Phase 3 (containerized service) only triggers if multi-user demand surfaces.
+- An AI auto-PR generator — defaults to design-issue-first; never auto-submits without explicit human approval.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `/contribute` doesn't activate after install | Restart Claude Code |
+| `gh: not logged in` | `gh auth login` |
+| `jq: command not found` | `apt-get install jq` (or equivalent for your platform) |
+| Gate BLOCKs unexpectedly | Run `audit-overrides.sh` to see if it's a known false-positive cluster; override with `--override-gate <ID> "reason"` if so |
+| Dossier missing for a repo | First contribution to that repo; `@researcher` auto-builds on first transition |
+| Stale dossier (>14 days) | Auto-refresh on next gate run; or `@researcher refresh <owner>/<repo>` |
+
+## License
+
+MIT — see [LICENSE](https://github.com/jeremylongshore/contributing-clanker/blob/master/LICENSE) in the source repo.

--- a/plugins/community/contributing-clanker/plugin.json
+++ b/plugins/community/contributing-clanker/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "contributing-clanker",
+  "version": "0.1.0",
+  "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "homepage": "https://github.com/jeremylongshore/contributing-clanker",
+  "repository": "https://github.com/jeremylongshore/contributing-clanker",
+  "license": "MIT",
+  "keywords": [
+    "oss",
+    "contributions",
+    "github",
+    "ai-slop-prevention",
+    "code-review",
+    "open-source",
+    "gates",
+    "deterministic"
+  ],
+  "requires": {
+    "claude-code": ">=1.0.0"
+  },
+  "capabilities": {
+    "skills": true,
+    "agents": true,
+    "hooks": true
+  },
+  "installation": {
+    "prerequisites": [
+      "gh CLI authenticated (gh auth status)",
+      "jq on PATH"
+    ],
+    "verification": [
+      "gh auth status",
+      "command -v jq"
+    ]
+  },
+  "configuration": {
+    "runtime_dir": "~/.contribute-system",
+    "preserves_user_data_on_uninstall": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **contributing-clanker** plugin scaffold under `plugins/community/`. Companion PR in source repo: jeremylongshore/contributing-clanker#11.

## What this is

`contributing-clanker` is a local-only OSS contribution command center with **41 deterministic gates** against AI-slop failure modes. Source repo: https://github.com/jeremylongshore/contributing-clanker.

The plugin activates `/contribute` in Claude Code, walks any candidate issue through `open → shortlist → claimed → working → submitted → merged`, running phase-appropriate gates at each transition. BLOCK gates refuse the transition; WARN gates surface in the briefing. Markdown-only state — no daemons, no SQLite, greppable, git-trackable.

## What this PR lands

- `plugins/community/contributing-clanker/plugin.json` — manifest (v0.1.0, schema matches existing community plugins)
- `plugins/community/contributing-clanker/README.md` — landing page (gist publishing Pattern A: title → tagline → links → 3-layer breakdown → install + verify + troubleshooting)
- `plugins/community/contributing-clanker/hooks/` — empty dir (`.gitkeep`); install.sh + uninstall.sh land via the release script

## What this PR does NOT land

The skill bundle (`skills/contribute/{SKILL.md,agents/,scripts/,assets/}`) and the install/uninstall hooks. Those get **synced in by the release script in the source repo** on a tagged release:

```bash
# in the contributing-clanker source repo
bin/release-plugin.sh 0.1.0
```

The release script:
1. rsync `skills/contribute/` → this plugin dir
2. Copies `release/hooks/{install,uninstall}.sh` → `hooks/`
3. Updates `plugin.json#version`
4. Tags source repo
5. Opens the companion publish PR here

This separation means **the plugin directory is a build artifact, not parallel-maintained code** — drift between source and marketplace is impossible by construction.

## Test plan

- [x] `plugin.json` validates as JSON
- [x] Manifest schema matches `plugins/devops/sugar/plugin.json` and `plugins/ai-ml/jeremy-google-adk/plugin.json` (community plugin pattern)
- [ ] First end-to-end install test on a clean target user — open as `yvb.4` in source repo, follow-up PR
- [ ] v0.1.0 publish — open as `yvb.6` in source repo, follow-up PR (depends on install test)

## Prerequisites for users installing this plugin

- `gh` authenticated (`gh auth status`)
- `jq` on PATH
- Claude Code 1.x

jeremylongshore.com made me do it
  -claude
intentsolutions.io