### PR TITLE
feat(devops/engineer-design-diagram): port global skill to marketplace plugin (claude-2rb6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | ₿   | [Crypto & Web3](#crypto--web3)                     |      26 |
 | 💾  | [Database](#database)                              |      26 |
 | 🎨  | [Design](#design)                                  |       7 |
-| 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      35 |
+| 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      36 |
 | 📚  | [Examples & Templates](#examples--templates)       |       5 |
 | 🧩  | [MCP Servers](#mcp-servers)                        |      10 |
 | 📦  | [Packages](#packages)                              |       5 |
@@ -362,45 +362,46 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### DevOps & Infrastructure
 
-🔧 **35 plugins** · category slug: `devops`
+🔧 **36 plugins** · category slug: `devops`
 
-| Plugin                             | Description                                                                                                                              |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `ansible-playbook-creator`         | Create Ansible playbooks for configuration management                                                                                    |
-| `auto-scaling-configurator`        | Configure auto-scaling policies for applications and infrastructure                                                                      |
-| `backup-strategy-implementor`      | Implement backup strategies for databases and applications                                                                               |
-| `ci-cd-pipeline-builder`           | Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more                                                                   |
-| `cloud-cost-optimizer`             | Optimize cloud costs and generate cost reports                                                                                           |
-| `compliance-checker`               | Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)                                                                                   |
-| `container-registry-manager`       | Manage container registries (ECR, GCR, Harbor)                                                                                           |
-| `container-security-scanner`       | Scan containers for vulnerabilities using Trivy, Snyk, and other security tools                                                          |
-| `deployment-pipeline-orchestrator` | Orchestrate complex multi-stage deployment pipelines                                                                                     |
-| `deployment-rollback-manager`      | Manage and execute deployment rollbacks with safety checks                                                                               |
-| `disaster-recovery-planner`        | Plan and implement disaster recovery procedures                                                                                          |
-| `docker-compose-generator`         | Generate Docker Compose configurations for multi-container applications with best practices                                              |
-| `environment-config-manager`       | Manage environment configurations and secrets across deployments                                                                         |
-| `fairdb-operations-kit`            | Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and…   |
-| `gh-dash`                          | GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.            |
-| `git-commit-smart`                 | AI-powered conventional commit message generator with smart analysis                                                                     |
-| `gitops-workflow-builder`          | Build GitOps workflows with ArgoCD and Flux                                                                                              |
-| `helm-chart-generator`             | Generate Helm charts for Kubernetes applications                                                                                         |
-| `infrastructure-as-code-generator` | Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more                                                          |
-| `infrastructure-drift-detector`    | Detect infrastructure drift from desired state                                                                                           |
-| `jeremy-adk-terraform`             | Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments                                                          |
-| `jeremy-genkit-terraform`          | Terraform modules for Firebase Genkit infrastructure and deployments                                                                     |
-| `jeremy-github-actions-gcp`        | GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments                                                                |
-| `jeremy-vertex-terraform`          | Terraform configurations for Vertex AI platform and Agent Engine                                                                         |
-| `kubernetes-deployment-creator`    | Create Kubernetes deployments, services, and configurations with best practices                                                          |
-| `load-balancer-configurator`       | Configure load balancers (ALB, NLB, Nginx, HAProxy)                                                                                      |
-| `log-aggregation-setup`            | Set up log aggregation (ELK, Loki, Splunk)                                                                                               |
-| `mattyp-changelog`                 | Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release… |
-| `monitoring-stack-deployer`        | Deploy monitoring stacks (Prometheus, Grafana, Datadog)                                                                                  |
-| `network-policy-manager`           | Manage Kubernetes network policies and firewall rules                                                                                    |
-| `secrets-manager-integrator`       | Integrate with secrets managers (Vault, AWS Secrets Manager, etc)                                                                        |
-| `service-mesh-configurator`        | Configure service mesh (Istio, Linkerd) for microservices                                                                                |
-| `sugar`                            | Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow… |
-| `terraform-module-builder`         | Build reusable Terraform modules                                                                                                         |
-| `tweetclaw`                        | X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via… |
+| Plugin                             | Description                                                                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ansible-playbook-creator`         | Create Ansible playbooks for configuration management                                                                                       |
+| `auto-scaling-configurator`        | Configure auto-scaling policies for applications and infrastructure                                                                         |
+| `backup-strategy-implementor`      | Implement backup strategies for databases and applications                                                                                  |
+| `ci-cd-pipeline-builder`           | Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more                                                                      |
+| `cloud-cost-optimizer`             | Optimize cloud costs and generate cost reports                                                                                              |
+| `compliance-checker`               | Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)                                                                                      |
+| `container-registry-manager`       | Manage container registries (ECR, GCR, Harbor)                                                                                              |
+| `container-security-scanner`       | Scan containers for vulnerabilities using Trivy, Snyk, and other security tools                                                             |
+| `deployment-pipeline-orchestrator` | Orchestrate complex multi-stage deployment pipelines                                                                                        |
+| `deployment-rollback-manager`      | Manage and execute deployment rollbacks with safety checks                                                                                  |
+| `disaster-recovery-planner`        | Plan and implement disaster recovery procedures                                                                                             |
+| `docker-compose-generator`         | Generate Docker Compose configurations for multi-container applications with best practices                                                 |
+| `engineer-design-diagram`          | Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with… |
+| `environment-config-manager`       | Manage environment configurations and secrets across deployments                                                                            |
+| `fairdb-operations-kit`            | Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and…      |
+| `gh-dash`                          | GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.               |
+| `git-commit-smart`                 | AI-powered conventional commit message generator with smart analysis                                                                        |
+| `gitops-workflow-builder`          | Build GitOps workflows with ArgoCD and Flux                                                                                                 |
+| `helm-chart-generator`             | Generate Helm charts for Kubernetes applications                                                                                            |
+| `infrastructure-as-code-generator` | Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more                                                             |
+| `infrastructure-drift-detector`    | Detect infrastructure drift from desired state                                                                                              |
+| `jeremy-adk-terraform`             | Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments                                                             |
+| `jeremy-genkit-terraform`          | Terraform modules for Firebase Genkit infrastructure and deployments                                                                        |
+| `jeremy-github-actions-gcp`        | GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments                                                                   |
+| `jeremy-vertex-terraform`          | Terraform configurations for Vertex AI platform and Agent Engine                                                                            |
+| `kubernetes-deployment-creator`    | Create Kubernetes deployments, services, and configurations with best practices                                                             |
+| `load-balancer-configurator`       | Configure load balancers (ALB, NLB, Nginx, HAProxy)                                                                                         |
+| `log-aggregation-setup`            | Set up log aggregation (ELK, Loki, Splunk)                                                                                                  |
+| `mattyp-changelog`                 | Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release…    |
+| `monitoring-stack-deployer`        | Deploy monitoring stacks (Prometheus, Grafana, Datadog)                                                                                     |
+| `network-policy-manager`           | Manage Kubernetes network policies and firewall rules                                                                                       |
+| `secrets-manager-integrator`       | Integrate with secrets managers (Vault, AWS Secrets Manager, etc)                                                                           |
+| `service-mesh-configurator`        | Configure service mesh (Istio, Linkerd) for microservices                                                                                   |
+| `sugar`                            | Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow…    |
+| `terraform-module-builder`         | Build reusable Terraform modules                                                                                                            |
+| `tweetclaw`                        | X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via…    |
 
 <sub>⬆ [Back to category index](#browse-plugins-by-category)</sub>
 

--- a/plugins/devops/engineer-design-diagram/package.json
+++ b/plugins/devops/engineer-design-diagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/engineer-design-diagram",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo top",
   "keywords": [
     "architecture",


### PR DESCRIPTION
## Summary

Ports the **engineer-design-diagram** skill from \`~/.claude/skills/\` (the global reference implementation, live since 2026-04-19) into a marketplace plugin so any Claude Code user can install it.

This is the natural next step on bead epic [\`claude-2rb6\`](../../../beads-store) — the title literally says \"global/local first\". Global has been live for 2 weeks; this PR is the local (in-repo, marketplace-installable) port.

## Why this matters

The global skill at \`~/.claude/skills/engineer-design-diagram/\` is mature (v0.2.0, 23 files, 8 reference docs, 4 HTML templates, 4 helper scripts, 3 example outputs, evals.json). It has shipped four interactive modes — \`/design:generate\`, \`/design:diff\`, \`/design:trace\`, \`/design:watch\` — and is grounded in real repo topology via DCI (Discovery / Categorization / Inference). It deserves to be installable from the marketplace, not just available to one user.

## What ships

\`\`\`
plugins/devops/engineer-design-diagram/
├── .claude-plugin/plugin.json   marketplace manifest (8 keywords, MIT)
├── README.md                    install + usage + pipeline + reference table
├── LICENSE                      MIT (copied from global)
├── CHANGELOG.md                 (copied from global)
└── skills/engineer-design-diagram/
    ├── SKILL.md                 8-field marketplace-tier frontmatter — ready as-is
    ├── references/  (8 files)   DCI, drawing rules, mode playbooks, accessibility, …
    ├── templates/   (4 HTML)    base, sequence, docs-layout, mermaid-fallback
    ├── scripts/     (4 helpers) collect_dci, fingerprint, validate_html, open_in_browser
    ├── examples/    (3 outputs) aws-serverless, microservices, tiny-monorepo
    └── evals/evals.json
\`\`\`

Catalog entry added to \`.claude-plugin/marketplace.extended.json\` between \`environment-config-manager\` and \`fairdb-operations-kit\` (alphabetical position in devops cluster). \`pnpm run sync-marketplace\` ran clean.

**Plugin count: 425 → 426.**

## Validator results (marketplace tier)

\`\`\`
Average score: 96.0 / 100  (A-grade)
Errors: 0
Warnings: 8 (all non-blocking — #anchor links inside reference docs that
              the validator can't resolve without parsing markdown headings;
              one URL-heavy line over 500 chars; magic year '2026';
              3-sentence overview line)
\`\`\`

Format check + ESLint: green.

## Why \`/devops\` category

The skill sits at the intersection of devops, engineering, and documentation. \`/devops\` is the closest existing category and is where similar tooling lives (\`ci-cd-pipeline-builder\`, \`environment-config-manager\`, \`gitops-workflow-builder\`, \`docker-compose-generator\`). An \`/architecture\` category could be created later if more diagram skills land.

## Source-of-truth model (going forward)

The global \`~/.claude/skills/\` version remains the canonical reference implementation. This plugin is a copy made at port time. Future updates should be made in **both** places, OR a sync script could be added to \`scripts/\` (out of scope for this PR; tracked as part of claude-2rb6).

For now, both versions ship at v0.2.0.

## Closes / advances

- **claude-2rb6** epic — materially advances the in-repo plugin port
- **claude-2rb6.2** subtask (Plugin scaffold + SKILL.md) — DONE
- **claude-2rb6.10** subtask (README + marketplace entry + validation) — DONE
- The remaining 6 subtasks (.3 SVG components, .4 themes, .5 layout engine, .6 export, .7 a11y, .8 tooltips, .9 mermaid fallback) are all materially shipped via the global skill's existing files — bead bookkeeping to follow

## Test plan

- [ ] CI \`validate\` passes (this PR touches \`plugins/**\` so the workflow triggers)
- [ ] CI \`marketplace-validation\` passes
- [ ] No new errors from \`ccpi validate --strict\` for the new plugin path
- [ ] Marketplace site rebuilds with the new plugin page

## Credits

Design palette and arrow-masking pattern inspired by [Cocoon AI's architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (MIT). See \`skills/engineer-design-diagram/references/THIRD_PARTY_LICENSES.md\`.

jeremylongshore.com made me do it
  -claude
intentsolutions.io