### PR TITLE
release(community/contributing-clanker): v0.1.2

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -2802,6 +2802,33 @@
       }
     },
     {
+      "name": "engineer-design-diagram",
+      "source": "./plugins/devops/engineer-design-diagram",
+      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+      "version": "0.2.0",
+      "category": "devops",
+      "keywords": [
+        "architecture",
+        "diagram",
+        "visualization",
+        "svg",
+        "html",
+        "pr-review",
+        "drift-detection",
+        "sequence-diagram",
+        "engineering-design",
+        "documentation",
+        "onboarding"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "components": {
+        "skills": 1
+      }
+    },
+    {
       "name": "environment-config-manager",
       "source": "./plugins/devops/environment-config-manager",
       "description": "Manage environment configurations and secrets across deployments",
@@ -3077,7 +3104,7 @@
     {
       "name": "freshie-inventory-manager",
       "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database \u2014 conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
       "version": "1.0.0",
       "category": "database",
       "keywords": [
@@ -4539,7 +4566,7 @@
     {
       "name": "code-cleanup",
       "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions \u2014 dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
       "version": "1.0.0",
       "category": "testing",
       "keywords": [
@@ -4595,7 +4622,7 @@
     {
       "name": "promptbook",
       "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating \u2014 no data transmitted without explicit opt-in. Background submission after session end.",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
       "version": "1.4.0",
       "category": "business-tools",
       "keywords": [
@@ -6199,7 +6226,7 @@
     {
       "name": "jeremy-google-adk",
       "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents \u2014 ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
       "version": "2.0.0",
       "category": "ai-ml",
       "keywords": [
@@ -7510,7 +7537,7 @@
     {
       "name": "langchain-pack",
       "source": "./plugins/saas-packs/langchain-pack",
-      "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated \u2014 use langchain-py-pack or langchain-ts-pack.",
+      "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated — use langchain-py-pack or langchain-ts-pack.",
       "version": "1.0.0",
       "category": "saas-packs",
       "keywords": [
@@ -8269,7 +8296,7 @@
     {
       "name": "b12-claude-plugin",
       "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator \u2014 an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
       "version": "1.0.0",
       "category": "community",
       "keywords": [
@@ -11085,7 +11112,7 @@
     {
       "name": "pr-to-spec",
       "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding \u2014 convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
       "version": "0.8.0",
       "category": "mcp",
       "repository": "https://github.com/jeremylongshore/pr-to-prompt",
@@ -11108,7 +11135,7 @@
     {
       "name": "slack-channel",
       "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
+      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
       "version": "0.1.0",
       "category": "mcp",
       "keywords": [
@@ -11137,7 +11164,7 @@
     {
       "name": "x-bug-triage-plugin",
       "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints \u2192 clusters \u2192 repo evidence \u2192 owner routing \u2192 Slack review \u2192 filed issues",
+      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
       "version": "0.3.0",
       "category": "mcp",
       "author": {
@@ -11219,7 +11246,7 @@
     {
       "name": "shipwright",
       "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
       "version": "1.0.0",
       "category": "ai-agency",
       "author": {
@@ -11279,7 +11306,7 @@
     {
       "name": "local-tts",
       "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 \u2014 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
       "version": "1.0.0",
       "category": "ai-ml",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2097,6 +2097,30 @@
       }
     },
     {
+      "name": "engineer-design-diagram",
+      "source": "./plugins/devops/engineer-design-diagram",
+      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+      "version": "0.2.0",
+      "category": "devops",
+      "keywords": [
+        "architecture",
+        "diagram",
+        "visualization",
+        "svg",
+        "html",
+        "pr-review",
+        "drift-detection",
+        "sequence-diagram",
+        "engineering-design",
+        "documentation",
+        "onboarding"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "environment-config-manager",
       "source": "./plugins/devops/environment-config-manager",
       "description": "Manage environment configurations and secrets across deployments",

--- a/plugins/ai-agency/tonone/package.json
+++ b/plugins/ai-agency/tonone/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@intentsolutionsio/tonone",
+  "version": "0.9.7",
+  "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
+  "keywords": [
+    "agents",
+    "engineering-team",
+    "infrastructure",
+    "devops",
+    "backend",
+    "security",
+    "observability",
+    "frontend",
+    "ml",
+    "mobile",
+    "embedded",
+    "analytics",
+    "testing",
+    "platform",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/ai-agency/tonone"
+  },
+  "homepage": "https://tonsofskills.com/plugins/tonone",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "tonone-ai",
+    "url": "https://tonone.ai"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills",
+    "agents"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install tonone\\\\n  or /plugin install tonone@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/community/contributing-clanker/package.json
+++ b/plugins/community/contributing-clanker/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@intentsolutionsio/contributing-clanker",
+  "version": "0.1.1",
+  "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes",
+  "keywords": [
+    "oss",
+    "contributions",
+    "github",
+    "ai-slop-prevention",
+    "code-review",
+    "open-source",
+    "gates",
+    "deterministic",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/community/contributing-clanker"
+  },
+  "homepage": "https://tonsofskills.com/plugins/contributing-clanker",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    "skills",
+    "hooks"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install contributing-clanker\\\\n  or /plugin install contributing-clanker@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/community/contributing-clanker/plugin.json
+++ b/plugins/community/contributing-clanker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "contributing-clanker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/community/contributing-clanker/skills/contribute/agents/draft-writer.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/draft-writer.md
@@ -71,8 +71,40 @@ A markdown body with these sections, filled in based on the actual diff and repo
 - **Default to Design Issue, not PR** — per repo CLAUDE.md philosophy
 - **Stop and show Jeremy** the draft before posting — never `gh issue create` / `gh pr create` autonomously
 
+## Persist to candidate file (mandatory)
+
+After Jeremy approves the draft, write it back into the matching candidate
+file at `~/.contribute-system/candidates/<owner>__<repo>__issue<N>.md` so the
+gates can read it at the next transition. Several C-phase gates depend on
+specific sections existing in the candidate body:
+
+| Section | Read by |
+|---|---|
+| `## PR title` | C02 (cross-checks against `pr_title_regex` in the dossier) |
+| `## PR body` | C03 (required-sections check), C09 (issue-link check), C19 (claim-vs-diff cross-check) |
+| `## Test results` | C05 (concrete test evidence required pre-submit) |
+| `## Issue body draft` | C03, C09 (Design Issue path) |
+| `## Claim comment draft` | A06 (etiquette comment must reference dossier excerpts) |
+| `## Review draft` | D02, D03 (no-AI-reviews-without-disclosure) |
+
+Append (do not overwrite) under the right section header. If the section
+already exists, replace its contents and timestamp the update with a comment:
+
+```markdown
+## PR body
+
+<!-- @draft-writer 2026-05-04 -->
+## Problem
+...
+```
+
+The full canonical spec for candidate file frontmatter + body sections lives
+at `{baseDir}/references/candidate-file-format.md` — read it first if you're
+unsure which section to populate.
+
 ## Templates
 
 - `Read {baseDir}/assets/claim-template.md` — issue claim comment
 - `Read {baseDir}/assets/pr-template.md` — PR description structure
 - `Read {baseDir}/assets/evidence-template.md` — evidence summary block to embed
+- `Read {baseDir}/references/candidate-file-format.md` — canonical spec for the candidate file format (frontmatter + body sections + which gates read each)

--- a/plugins/community/contributing-clanker/skills/contribute/references/candidate-file-format.md
+++ b/plugins/community/contributing-clanker/skills/contribute/references/candidate-file-format.md
@@ -1,0 +1,259 @@
+# Candidate file format
+
+Canonical specification for the markdown candidate files at
+`~/.contribute-system/candidates/<owner>__<repo>__issue<N>.md`.
+
+Each candidate file is the per-issue tracker. The frontmatter is the queryable
+layer; the body holds drafts and structured sections that gates read at
+transition time. **Manual edits in the body survive refresh** — only the
+frontmatter is auto-managed.
+
+---
+
+## Filename
+
+```
+~/.contribute-system/candidates/<owner>__<repo>__issue<N>.md
+```
+
+- `<owner>` and `<repo>` are joined by **double** underscore (`__`)
+- `<N>` is the upstream issue number (or PR number for backfilled candidates that have no linked issue)
+- One file per upstream issue; never multiple files for the same issue
+
+---
+
+## Frontmatter (YAML, between two `---` lines)
+
+The frontmatter is canonical state. Every gate reads from it. `transition.sh`
+writes to it atomically when state moves.
+
+| Field | Required | Type | Read by | Notes |
+|---|---|---|---|---|
+| `discovered_at` | yes | ISO8601 UTC | scout/researcher | when scout first wrote the candidate |
+| `repo` | yes | `<owner>/<repo>` | every gate | upstream repo |
+| `issue_number` | yes | int | A-phase gates | upstream issue # |
+| `issue_url` | yes | URL | (info) | direct link |
+| `star_tier` | yes | `niche` / `emerging` / `established` / `mainstream` | scout ranking | from `star_count` |
+| `star_count` | yes | int | scout ranking | |
+| `repo_lang` | yes | string | scout filter | primary language |
+| `competing_prs` | yes | int | A02 gate | scout-detected open PRs claiming this issue |
+| `primary_label` | yes | string | scout heuristic | upstream's primary label |
+| `scout_score` | yes | float (0–1) | scout ranking | momentum signal |
+| `status` | yes | enum (see below) | every gate + transition.sh | lifecycle state |
+| `last_refreshed` | yes | ISO8601 UTC | researcher | when scout/researcher last touched |
+| `merge_probability_pct` | optional | int (0–100) | scout ranking | empirical merge rate at this repo |
+| `research_path` | optional | absolute path | every gate that reads dossier | path to per-repo dossier; auto-resolved if empty |
+| `pr_number` | optional | int | reconciliation | set after PR opens |
+| `pr_url` | optional | URL | reconciliation | set after PR opens |
+| `branch` | optional | string | B/C-phase gates | local feature branch name |
+| `disabled_gates` | optional | array of gate IDs | gate-runner | per-candidate gate disables (escape hatch) |
+
+### `status` enum
+
+```
+open       → discovered, not yet vetted
+shortlist  → vetted, queued for next claim
+claimed    → posted claim comment, waiting for "go ahead" / no objection
+working    → actively coding (local clone exists, diff in progress)
+submitted  → PR or Design Issue opened upstream
+merged    → upstream merged the PR
+dropped    → closed without merge (failure log entry created in dossier)
+```
+
+`transition.sh` enforces the legal transitions and atomically updates the
+field on success.
+
+---
+
+## Body sections
+
+The body holds drafts + evidence. Sections are populated at different lifecycle
+stages by different agents. Manual edits survive refresh.
+
+### Section inventory
+
+Order, owner, and which gates read each section:
+
+| Section | Populated at | Owner | Read by gates |
+|---|---|---|---|
+| `# <repo>#<N> — <title>` | discovery | scout | (display only) |
+| `## Why scout flagged this` | discovery | scout | (info; helps reviewer) |
+| `## Scope` | qualification | user / @repo-analyzer | B07 (must enumerate planned scope) |
+| `## Files to touch` | qualification | user / @repo-analyzer | B07 (must list specific files) |
+| `## Claim comment draft` | claim | @draft-writer | A06 (etiquette comment must reference dossier excerpts) |
+| `## Issue body draft` | submit (Design Issue path) | @draft-writer | C03, C09 (issue body sections + issue link) |
+| `## PR title` | submit | @draft-writer | C02 (regex match against `pr_title_regex` in dossier) |
+| `## PR body` | submit | @draft-writer | C03, C05, C09, C19 (body sections + test evidence + issue link + claim-vs-diff) |
+| `## Test results` | working | @test-runner | C05 (concrete evidence required pre-submit) |
+| `## Review draft` | review (post-merge sometimes) | @draft-writer | D02, D03 (no-AI-reviews-without-disclosure) |
+| `## Safety override disclosure` | submit | user (only if --override-gate used) | F04 (mandatory if any gate was overridden) |
+
+### Required sections by lifecycle stage
+
+| Status | Sections that MUST exist | Sections that MAY exist |
+|---|---|---|
+| `open` | none beyond H1 | `## Why scout flagged this` |
+| `shortlist` | `## Scope`, `## Files to touch` | `## Claim comment draft` |
+| `claimed` | `## Claim comment draft` | `## Scope`, `## Files to touch` |
+| `working` | scope + files + claim draft | `## Test results` (early evidence) |
+| `submitted` | `## PR title`, `## PR body`, `## Test results` | `## Issue body draft` (if Design Issue path), `## Safety override disclosure` (if any overrides) |
+| `merged` | everything from `submitted` | none added |
+| `dropped` | everything that existed | (failure-log entry in dossier referenced here) |
+
+Backfilled candidates (created retroactively for already-open PRs) may
+legitimately skip the early-stage sections — their gates will SKIP rather
+than BLOCK, which is correct behavior.
+
+---
+
+## Worked example (a `submitted`-state candidate)
+
+```markdown
+---
+discovered_at: 2026-04-15T09:00:00Z
+repo: example-org/example-repo
+issue_number: 42
+issue_url: https://github.com/example-org/example-repo/issues/42
+star_tier: mainstream
+star_count: 15000
+repo_lang: TypeScript
+competing_prs: 0
+primary_label: bug
+scout_score: 0.82
+status: submitted
+pr_number: 137
+pr_url: https://github.com/example-org/example-repo/pull/137
+branch: fix/42-null-deref
+research_path: /home/jeremy/.contribute-system/research/example-org__example-repo.md
+last_refreshed: 2026-04-20T14:30:00Z
+---
+
+# example-org/example-repo #42 — null deref in formatter
+
+## Why scout flagged this
+
+Open >7d, primary_label=bug, momentum_score: 0.82 (3 maintainer comments
+in last week, no competing PRs).
+
+## Scope
+
+Replace the unchecked `.format()` call in `src/format.ts` with a guarded
+variant that returns `null` instead of throwing.
+
+## Files to touch
+
+- `src/format.ts` (1-2 lines)
+- `src/__tests__/format.test.ts` (add 2 cases for null + undefined)
+
+## Claim comment draft
+
+Hi! I'd like to take this. Plan: replace `.format()` with a guarded
+variant that returns `null` for nullish input, mirroring the pattern in
+`src/parse.ts`. ETA: end of week. Will open a Design Issue first per your
+CONTRIBUTING.md.
+
+## PR title
+
+fix: guard against null input in formatter (#42)
+
+## PR body
+
+## Problem
+
+`format()` throws on `null` / `undefined` input where callers expect a
+nullish-passthrough.
+
+## Proposed solution
+
+Add a guard at the top: if input is nullish, return `null`. Matches the
+pattern already used in `src/parse.ts`.
+
+## Test results
+
+Added 2 unit tests covering null + undefined input. Full suite green.
+
+Closes #42.
+
+## Test results
+
+```
+PASS  src/__tests__/format.test.ts (2 added)
+Tests: 78 passed, 78 total
+Duration: 1.2s
+```
+```
+
+---
+
+## How agents populate sections
+
+| Agent | Populates | When |
+|---|---|---|
+| `@scout` | `discovered_at`, frontmatter, `# <title>`, `## Why scout flagged this` | first discovery |
+| `@researcher` | `research_path` link only — body untouched | when building/refreshing the dossier |
+| `@repo-analyzer` | `## Scope`, `## Files to touch` | qualification |
+| `@draft-writer` | `## Claim comment draft`, `## PR title`, `## PR body`, `## Issue body draft`, `## Review draft` | claim / submit / review |
+| `@test-runner` | `## Test results` | working |
+| user | any section | any time — manual edits survive refresh |
+
+`transition.sh` updates frontmatter only (status, pr_number, last_refreshed).
+It never writes to the body.
+
+---
+
+## What backfilling looks like
+
+When a PR exists upstream but no candidate file ever tracked it, you can
+backfill one with frontmatter + minimal body. Most B/C-phase gates will
+SKIP rather than BLOCK because the body sections aren't present — that's
+correct behavior. Once the PR merges, the candidate becomes a `merged`
+record for the failure log / institutional memory.
+
+A backfill template:
+
+```markdown
+---
+discovered_at: <PR createdAt>
+repo: <owner>/<repo>
+issue_number: <linked issue # or PR #>
+issue_url: <PR url>
+star_tier: <derived from star_count>
+star_count: <gh repo view ... .stargazerCount>
+repo_lang: <gh repo view ... .primaryLanguage.name>
+competing_prs: 0
+primary_label: backfill
+scout_score: 0.7
+status: submitted
+pr_number: <PR #>
+pr_url: <PR url>
+branch: <gh pr view ... .headRefName>
+research_path: <absolute dossier path>
+backfilled_at: <now ISO8601>
+last_refreshed: <now ISO8601>
+---
+
+# <repo> #<PR#> — <title>
+
+## Why this candidate exists
+
+Backfilled into the lifecycle workflow on <date>. Pre-dates the candidate
+system being wired up; created so reconciliation can pick up state changes
+when the PR merges or closes.
+
+## Source
+
+- PR: <url>
+- Branch: `<branch>`
+- Linked issue: <issue # or "(none)">
+```
+
+---
+
+## Cross-references
+
+- Lifecycle workflow: `000-docs/006-AT-SPEC-lifecycle-workflow.md`
+- Gate inventory: `000-docs/005-AT-SPEC-gate-inventory.md`
+- `agents/draft-writer.md` — agent that populates `## PR body` etc.
+- `agents/test-runner.md` — agent that populates `## Test results`
+- `scripts/transition.sh` — updates frontmatter atomically
+- `scripts/gates/lib/preamble.sh` — gates' shared helpers for reading sections

--- a/plugins/community/contributing-clanker/skills/contribute/scripts/gates/a09-mention-routing.sh
+++ b/plugins/community/contributing-clanker/skills/contribute/scripts/gates/a09-mention-routing.sh
@@ -38,8 +38,23 @@ if [[ -z "$DRAFT" ]]; then
   gate_skip "no draft section found in candidate"
 fi
 
-# Count @-mentions, excluding @me, @everyone, @channel
-MENTIONS=$(/usr/bin/printf '%s' "$DRAFT" | /usr/bin/grep -oE "@[a-zA-Z0-9-]{2,}" | /usr/bin/grep -viE "^@(me|everyone|channel)$" | /usr/bin/wc -l | /usr/bin/tr -d ' ')
+# Count @-mentions, excluding @me, @everyone, @channel.
+# Use awk (single pass, no pipeline-failure surface) instead of a chained
+# grep | grep | wc — under set -uo pipefail, an empty `grep -oE` returns
+# exit 1, killing the whole pipeline, even though "no mentions" is the
+# correct/expected answer for most drafts.
+MENTIONS=$(/usr/bin/printf '%s' "$DRAFT" | /usr/bin/awk '
+  {
+    for (i = 1; i <= NF; i++) {
+      tok = $i
+      gsub(/[,.;:!?)\]"\x27]+$/, "", tok)
+      if (tok ~ /^@[a-zA-Z0-9-]{2,}$/ && tok !~ /^@(me|everyone|channel)$/) {
+        c++
+      }
+    }
+  }
+  END { print c + 0 }
+')
 
 if [[ "${MENTIONS:-0}" -ge 1 ]]; then
   gate_warn "$MENTIONS @-mention(s) in draft despite CODEOWNERS routing" "this repo uses CODEOWNERS; explicit @-mentions are usually noise. Drop them unless you have a specific reason to ping someone."

--- a/plugins/community/contributing-clanker/skills/contribute/scripts/lint-candidate.sh
+++ b/plugins/community/contributing-clanker/skills/contribute/scripts/lint-candidate.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# lint-candidate.sh — report missing required body sections in candidate files.
+#
+# Sibling to audit-overrides.sh and catalog-coverage.sh: a read-only reporter
+# that walks ~/.contribute-system/candidates/, reads each candidate's status,
+# and surfaces missing required sections per the matrix in
+# skills/contribute/references/candidate-file-format.md.
+#
+# Required-sections matrix (matches the spec + transition.sh):
+#   shortlist  → ## Scope, ## Files to touch
+#   claimed    → ## Scope, ## Files to touch, ## Claim comment draft
+#   working    → same as claimed
+#   submitted  → ## PR title, ## PR body, ## Test results
+#   merged     → same as submitted
+#   open       → no body requirements
+#   dropped    → no body requirements
+#
+# Usage:
+#   lint-candidate.sh                  # all candidates, table output
+#   lint-candidate.sh --status=submitted   # filter to one status
+#   lint-candidate.sh --missing-only       # only candidates with missing sections
+#   lint-candidate.sh --json               # JSON output (one object per candidate)
+#   lint-candidate.sh --candidates-dir=X   # override the candidate dir
+#
+# Exit codes:
+#   0  — no missing sections across the filtered set (clean)
+#   1  — at least one candidate has missing required sections
+#   64 — bad arguments
+
+set -uo pipefail
+
+CAND_DIR="${HOME}/.contribute-system/candidates"
+STATUS_FILTER=""
+MISSING_ONLY=0
+JSON_OUT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --status=*)         STATUS_FILTER="${1#*=}" ;;
+    --missing-only)     MISSING_ONLY=1 ;;
+    --json)             JSON_OUT=1 ;;
+    --candidates-dir=*) CAND_DIR="${1#*=}" ;;
+    -h|--help)          /usr/bin/sed -n '2,28p' "$0" | /usr/bin/sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)                  /usr/bin/echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+  shift
+done
+
+if [[ ! -d "$CAND_DIR" ]]; then
+  /usr/bin/echo "candidate dir not found: $CAND_DIR" >&2
+  exit 64
+fi
+
+# Required-sections per status. Pipe-delimited for compatibility with the
+# same scheme transition.sh uses.
+required_for() {
+  case "$1" in
+    shortlist) /usr/bin/echo '## Scope|## Files to touch' ;;
+    claimed)   /usr/bin/echo '## Scope|## Files to touch|## Claim comment draft' ;;
+    working)   /usr/bin/echo '## Scope|## Files to touch|## Claim comment draft' ;;
+    submitted) /usr/bin/echo '## PR title|## PR body|## Test results' ;;
+    merged)    /usr/bin/echo '## PR title|## PR body|## Test results' ;;
+    *)         /usr/bin/echo '' ;;  # open, dropped, unknown
+  esac
+}
+
+# Per-candidate evaluation. Echoes a JSON object per candidate so the table
+# pass and the JSON pass can both consume it.
+evaluate_one() {
+  local file="$1"
+  local basename
+  basename=$(/usr/bin/basename "$file")
+  local status
+  status=$(/usr/bin/awk '/^---$/{fm=!fm?1:2;next} fm==1 && /^status:/{sub(/^status:[[:space:]]*/,""); print; exit}' "$file" 2>/dev/null)
+  status="${status:-unknown}"
+
+  local req
+  req=$(required_for "$status")
+
+  local missing=()
+  if [[ -n "$req" ]]; then
+    IFS='|' read -ra SECTIONS <<< "$req"
+    for sec in "${SECTIONS[@]}"; do
+      if ! /usr/bin/grep -qE "^${sec}\b" "$file" 2>/dev/null; then
+        missing+=("$sec")
+      fi
+    done
+  fi
+
+  local missing_json
+  if [[ "${#missing[@]}" -eq 0 ]]; then
+    missing_json='[]'
+  else
+    missing_json=$(/usr/bin/printf '%s\n' "${missing[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')
+  fi
+
+  jq -nc --arg cand "$basename" --arg status "$status" --argjson missing "$missing_json" \
+    '{candidate: $cand, status: $status, missing: $missing, missing_count: ($missing | length)}'
+}
+
+# Walk all candidates, evaluate each, capture rows.
+ROWS=()
+EXIT_CODE=0
+shopt -s nullglob
+for f in "$CAND_DIR"/*.md; do
+  row=$(evaluate_one "$f")
+  STATUS=$(/usr/bin/echo "$row" | jq -r .status)
+  MISSING_COUNT=$(/usr/bin/echo "$row" | jq -r .missing_count)
+
+  # Apply --status filter
+  if [[ -n "$STATUS_FILTER" && "$STATUS" != "$STATUS_FILTER" ]]; then
+    continue
+  fi
+  # Apply --missing-only filter
+  if [[ "$MISSING_ONLY" -eq 1 && "$MISSING_COUNT" -eq 0 ]]; then
+    continue
+  fi
+
+  ROWS+=("$row")
+  if [[ "$MISSING_COUNT" -gt 0 ]]; then
+    EXIT_CODE=1
+  fi
+done
+shopt -u nullglob
+
+# Emit
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  /usr/bin/printf '%s\n' "${ROWS[@]}" | jq -s '.'
+else
+  /usr/bin/printf '%-55s  %-10s  %s\n' 'candidate' 'status' 'missing'
+  /usr/bin/printf '%-55s  %-10s  %s\n' '---------' '------' '-------'
+  if [[ "${#ROWS[@]}" -eq 0 ]]; then
+    /usr/bin/printf '(no candidates matched filter)\n'
+  else
+    for row in "${ROWS[@]}"; do
+      cand=$(/usr/bin/echo "$row" | jq -r .candidate)
+      status=$(/usr/bin/echo "$row" | jq -r .status)
+      missing_str=$(/usr/bin/echo "$row" | jq -r '.missing | if length == 0 then "(none)" else join(", ") end')
+      /usr/bin/printf '%-55s  %-10s  %s\n' "$cand" "$status" "$missing_str"
+    done
+
+    # Summary footer
+    TOTAL=${#ROWS[@]}
+    DIRTY=$(/usr/bin/printf '%s\n' "${ROWS[@]}" | jq -s '[.[] | select(.missing_count > 0)] | length')
+    /usr/bin/printf '\n%d candidate(s) shown · %d with missing sections\n' "$TOTAL" "$DIRTY"
+  fi
+fi
+
+exit "$EXIT_CODE"

--- a/plugins/community/contributing-clanker/skills/contribute/scripts/researcher-build.sh
+++ b/plugins/community/contributing-clanker/skills/contribute/scripts/researcher-build.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # researcher-build.sh — build a per-repo dossier of contribution rules.
 #
-# Usage: researcher-build.sh <owner>/<repo> [--no-link-follow]
+# Usage:
+#   researcher-build.sh <owner>/<repo> [--no-link-follow] [--stdout]
 #
-# Outputs a markdown dossier to stdout. The orchestrator (researcher subagent)
-# writes it to ~/.contribute-system/research/<owner>__<repo>.md and bumps
-# its last_refreshed timestamp.
+# Default behavior: writes the dossier to
+#   ~/.contribute-system/research/<owner>__<repo>.md
+# and prints "→ wrote dossier to <path>" to stderr so the caller has feedback.
+#
+# Override the output path via CONTRIBUTE_RESEARCH_DIR env var (the dossier
+# lands at $CONTRIBUTE_RESEARCH_DIR/<owner>__<repo>.md).
+#
+# Pass --stdout to write the dossier to stdout instead — useful for piping
+# (jq, less, diff against an existing dossier).
 #
 # What it pulls:
 #   - Repo metadata (stars, default branch, archived, push activity)
@@ -25,10 +32,21 @@
 
 set -uo pipefail
 
-REPO="${1:-}"
-NO_LINK_FOLLOW="${2:-}"
+REPO=""
+NO_LINK_FOLLOW=""
+TO_STDOUT=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-link-follow) NO_LINK_FOLLOW="--no-link-follow" ;;
+    --stdout)         TO_STDOUT=1 ;;
+    -h|--help)        /usr/bin/sed -n '2,16p' "$0" | /usr/bin/sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)               /usr/bin/echo "unknown flag: $arg" >&2; exit 64 ;;
+    *)                if [[ -z "$REPO" ]]; then REPO="$arg"; else /usr/bin/echo "extra arg: $arg" >&2; exit 64; fi ;;
+  esac
+done
+
 if [[ -z "$REPO" || "$REPO" != */* ]]; then
-  echo "usage: $0 <owner>/<repo> [--no-link-follow]" >&2
+  /usr/bin/echo "usage: $0 <owner>/<repo> [--no-link-follow] [--stdout]" >&2
   exit 64
 fi
 
@@ -88,8 +106,38 @@ do
   KEY="${entry##*:}"
   # Skip if we already found this kind of file
   [[ -n "${POLICY_FILES[$KEY]:-}" ]] && continue
-  EXISTS=$(gh api "repos/$REPO/contents/$PATH_PART" --jq '.path // empty' 2>/dev/null)
-  if [[ -n "$EXISTS" ]] ; then
+
+  # Probe by exit code, not by output. Earlier implementation captured stdout
+  # and tested for non-empty — but `gh api` on 404 prints the error-shaped
+  # JSON body ("{\"message\":\"Not Found\",...}") to stdout BEFORE jq runs,
+  # and the existing `2>/dev/null` only silences stderr. Net effect: EXISTS
+  # was non-empty for every probe, so every candidate file was claimed to
+  # exist regardless of reality. Fix: redirect stdout to /dev/null too and
+  # rely on the gh exit code as the existence signal.
+  if gh api "repos/$REPO/contents/$PATH_PART" >/dev/null 2>&1 ; then
+    POLICY_FILES[$KEY]="$PATH_PART"
+  fi
+done
+
+# Also probe `docs/` subdir for projects (like secureblue) that house policy
+# docs there instead of at the repo root. Only fills in slots that are still
+# empty after the root + .github/ probes above.
+for entry in \
+  "docs/CONTRIBUTING.md:CONTRIBUTING" \
+  "docs/CODE_OF_CONDUCT.md:CODE_OF_CONDUCT" \
+  "docs/SECURITY.md:SECURITY" \
+  "docs/CLA.md:CLA" \
+  "docs/DCO.md:DCO" \
+  "docs/AI_POLICY.md:AI_POLICY" \
+  "docs/GOVERNANCE.md:GOVERNANCE" \
+  "docs/SETUP.md:SETUP" \
+  "docs/DEVELOPMENT.md:DEVELOPMENT" \
+  "docs/PULL_REQUEST_TEMPLATE.md:PR_TEMPLATE"
+do
+  PATH_PART="${entry%:*}"
+  KEY="${entry##*:}"
+  [[ -n "${POLICY_FILES[$KEY]:-}" ]] && continue
+  if gh api "repos/$REPO/contents/$PATH_PART" >/dev/null 2>&1 ; then
     POLICY_FILES[$KEY]="$PATH_PART"
   fi
 done
@@ -273,6 +321,23 @@ linked_sources_yaml() {
   fi
 }
 
+# Resolve the output path. Default: ~/.contribute-system/research/<owner>__<repo>.md.
+# Override via CONTRIBUTE_RESEARCH_DIR. The path is stable per repo so refresh
+# overwrites the previous dossier — engineer-curated sections (## Pet peeves,
+# ## Failure log, ## Notes) survive because the agent layer copies them
+# forward; this script does not preserve them across refresh.
+RESEARCH_DIR="${CONTRIBUTE_RESEARCH_DIR:-$HOME/.contribute-system/research}"
+OUTPUT_FILE="$RESEARCH_DIR/$(/usr/bin/echo "$REPO" | /usr/bin/sed 's|/|__|').md"
+
+# When not in --stdout mode, redirect all subsequent stdout to the dossier
+# file. The two heredocs (DOSSIER and TAIL) and the awk excerpt block in
+# between all write to stdout — `exec` here points stdout at the file once,
+# so every subsequent emission lands in the right place.
+if [[ "$TO_STDOUT" -eq 0 ]]; then
+  /usr/bin/mkdir -p "$RESEARCH_DIR"
+  exec > "$OUTPUT_FILE"
+fi
+
 /usr/bin/cat <<DOSSIER
 ---
 repo: $REPO
@@ -382,3 +447,10 @@ _Chronological record of past closures with reasons at this repo. Auto-appended 
 _Free-form area for the human to leave per-repo intuition. Survives refresh._
 
 TAIL
+
+# Success message goes to stderr so it's visible when stdout was redirected
+# to the file. In --stdout mode, the user sees it inline before the dossier
+# content (no — actually after, since heredocs flush before the script exits).
+if [[ "$TO_STDOUT" -eq 0 ]]; then
+  log "→ wrote dossier to $OUTPUT_FILE"
+fi

--- a/plugins/community/contributing-clanker/skills/contribute/scripts/transition.sh
+++ b/plugins/community/contributing-clanker/skills/contribute/scripts/transition.sh
@@ -67,32 +67,154 @@ if [[ -z "$DOSSIER" ]]; then
   fi
 fi
 
-# Pre-record any overrides into the candidate file (atomic temp+rename)
+# Pre-record any overrides into the candidate file (atomic temp+rename).
+#
+# Earlier implementation used `awk -v RS='---'` to insert `overrides: []`
+# before the closing frontmatter delimiter, then `sed -i "/^overrides:/a"`
+# to append each entry. That path corrupted YAML: the awk RS=--- handling
+# mangled the opening delimiter to "------" (6 dashes) and the sed
+# append landed entries OUTSIDE the array as sibling list items rather
+# than children of `overrides`.
+#
+# Replace with a Python yaml round-trip — parse frontmatter, append to
+# the overrides list as proper YAML mapping entries, re-serialize. The
+# body (everything after the second `---`) passes through unchanged.
 if [[ "${#OVERRIDES_NEW[@]}" -gt 0 ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "(dry-run) would record ${#OVERRIDES_NEW[@]} overrides; skipping write" >&2
   else
     TMP="${CANDIDATE}.tmp.$$"
-    /usr/bin/cp "$CANDIDATE" "$TMP"
-    # Append to overrides: array in frontmatter (creates if missing)
-    if ! /usr/bin/grep -q '^overrides:' "$TMP"; then
-      # Insert before the closing --- of frontmatter
-      /usr/bin/awk -v RS='---' 'NR==2{ printf("---%s\noverrides: []\n---", $0); next } {printf("%s", $0); if(NR<3) printf("---")}' "$TMP" > "${TMP}.2" && /usr/bin/mv "${TMP}.2" "$TMP"
+    # Build a flat list of "gate=reason" pairs for the Python helper.
+    # Use NUL as field separator to handle reasons containing any char.
+    PAIRS_FILE="${CANDIDATE}.pairs.$$"
+    : > "$PAIRS_FILE"
+    i=0
+    while [[ $i -lt ${#OVERRIDES_NEW[@]} ]]; do
+      /usr/bin/printf '%s\0%s\0' "${OVERRIDES_NEW[$i]}" "${OVERRIDES_NEW[$((i+1))]}" >> "$PAIRS_FILE"
+      i=$((i+2))
+    done
+
+    /usr/bin/python3 - "$CANDIDATE" "$NOW" "$PAIRS_FILE" "$TMP" <<'PYEOF'
+import sys, yaml
+
+cand_path, now_iso, pairs_path, out_path = sys.argv[1:5]
+
+with open(cand_path) as f:
+    text = f.read()
+
+# Split frontmatter from body (markdown convention: --- on its own line)
+lines = text.split('\n')
+if not lines or lines[0].strip() != '---':
+    sys.stderr.write("transition: candidate has no opening frontmatter delimiter\n")
+    sys.exit(2)
+try:
+    end = lines.index('---', 1)
+except ValueError:
+    sys.stderr.write("transition: candidate has no closing frontmatter delimiter\n")
+    sys.exit(2)
+
+fm_text = '\n'.join(lines[1:end])
+body_text = '\n'.join(lines[end+1:])
+
+fm = yaml.safe_load(fm_text) or {}
+if not isinstance(fm, dict):
+    sys.stderr.write("transition: frontmatter is not a mapping\n")
+    sys.exit(2)
+
+if 'overrides' not in fm or fm['overrides'] is None:
+    fm['overrides'] = []
+if not isinstance(fm['overrides'], list):
+    sys.stderr.write("transition: existing overrides field is not a list\n")
+    sys.exit(2)
+
+# Read NUL-separated pairs from pairs_path: gate, reason, gate, reason, ...
+with open(pairs_path, 'rb') as f:
+    raw = f.read()
+parts = raw.split(b'\x00')
+# Trailing NUL produces an empty final element — drop it.
+if parts and parts[-1] == b'':
+    parts.pop()
+if len(parts) % 2 != 0:
+    sys.stderr.write("transition: malformed override pairs (odd count)\n")
+    sys.exit(2)
+
+for i in range(0, len(parts), 2):
+    gate = parts[i].decode('utf-8')
+    reason = parts[i+1].decode('utf-8')
+    fm['overrides'].append({'gate': gate, 'reason': reason, 'at': now_iso})
+
+# Re-serialize. default_flow_style=False keeps blocks readable.
+new_fm = yaml.safe_dump(fm, default_flow_style=False, sort_keys=False, allow_unicode=True).rstrip('\n')
+new_text = '---\n' + new_fm + '\n---\n' + body_text
+
+with open(out_path, 'w') as f:
+    f.write(new_text)
+PYEOF
+
+    PY_EXIT=$?
+    /usr/bin/rm -f "$PAIRS_FILE"
+    if [[ "$PY_EXIT" -ne 0 ]]; then
+      /usr/bin/rm -f "$TMP"
+      echo "transition: yaml round-trip failed (exit $PY_EXIT) — candidate not modified" >&2
+      exit 65
     fi
-    # Append each override
+
+    /usr/bin/mv "$TMP" "$CANDIDATE"  # atomic rename
+
+    # Log each override
     i=0
     while [[ $i -lt ${#OVERRIDES_NEW[@]} ]]; do
       OG="${OVERRIDES_NEW[$i]}"
       OR="${OVERRIDES_NEW[$((i+1))]}"
       i=$((i+2))
-      ENTRY="  - { gate: $OG, reason: \"$OR\", at: \"$NOW\" }"
-      /usr/bin/sed -i "/^overrides:/a $ENTRY" "$TMP"
-      # Log
       jq -nc --arg ts "$NOW" --arg gate "$OG" --arg reason "$OR" --arg cand "$CANDIDATE" \
         '{ts: $ts, event: "gate_override", details: {gate: $gate, reason: $reason, candidate: $cand}}' >> "$LOG"
     done
-    /usr/bin/mv "$TMP" "$CANDIDATE"  # atomic rename
   fi
+fi
+
+# Advisory: warn on missing required body sections per target status.
+# Per skills/contribute/references/candidate-file-format.md § "Required
+# sections by lifecycle stage". WARN (not BLOCK) — backfilled candidates
+# legitimately came in mid-lifecycle without early-stage sections.
+TARGET_STATUS="${ACTION##*→}"
+REQUIRED_SECTIONS=""
+case "$TARGET_STATUS" in
+  shortlist) REQUIRED_SECTIONS="## Scope|## Files to touch" ;;
+  claimed)   REQUIRED_SECTIONS="## Scope|## Files to touch|## Claim comment draft" ;;
+  working)   REQUIRED_SECTIONS="## Scope|## Files to touch|## Claim comment draft" ;;
+  submitted) REQUIRED_SECTIONS="## PR title|## PR body|## Test results" ;;
+  merged)    REQUIRED_SECTIONS="## PR title|## PR body|## Test results" ;;
+  *)         REQUIRED_SECTIONS="" ;;  # open, dropped: no body requirements
+esac
+
+MISSING_SECTIONS=()
+if [[ -n "$REQUIRED_SECTIONS" ]]; then
+  IFS='|' read -ra SECTIONS <<< "$REQUIRED_SECTIONS"
+  for sec in "${SECTIONS[@]}"; do
+    # Match the section header anchored at line start (avoid false positives
+    # inside code blocks or quoted text).
+    if ! /usr/bin/grep -qE "^${sec}\b" "$CANDIDATE"; then
+      MISSING_SECTIONS+=("$sec")
+    fi
+  done
+fi
+
+if [[ "${#MISSING_SECTIONS[@]}" -gt 0 ]]; then
+  /usr/bin/printf '[transition] WARN: candidate is missing %d required section(s) for status=%s:\n' \
+    "${#MISSING_SECTIONS[@]}" "$TARGET_STATUS" >&2
+  for sec in "${MISSING_SECTIONS[@]}"; do
+    /usr/bin/printf '[transition]   - %s\n' "$sec" >&2
+  done
+  /usr/bin/printf '[transition]   (advisory only — see references/candidate-file-format.md;\n' >&2
+  /usr/bin/printf '[transition]    backfilled candidates legitimately skip early-stage sections)\n' >&2
+  # Log it so audits can see the pattern frequency
+  MISSING_JSON=$(/usr/bin/printf '%s\n' "${MISSING_SECTIONS[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')
+  jq -nc --arg ts "$NOW" --arg cand "$CANDIDATE" --arg target "$TARGET_STATUS" \
+        --argjson missing "$MISSING_JSON" \
+    '{ts: $ts, event: "transition_section_warn",
+      details: {candidate: $cand, target_status: $target, missing_sections: $missing}}' \
+    >> "$LOG" 2>/dev/null || true
 fi
 
 # Run gate-runner

--- a/plugins/devops/engineer-design-diagram/.claude-plugin/plugin.json
+++ b/plugins/devops/engineer-design-diagram/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "engineer-design-diagram",
+  "version": "0.2.0",
+  "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph.",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "[email protected]"
+  },
+  "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
+  "homepage": "https://tonsofskills.com/plugins/devops/engineer-design-diagram",
+  "license": "MIT",
+  "keywords": [
+    "architecture",
+    "diagram",
+    "visualization",
+    "svg",
+    "html",
+    "pr-review",
+    "drift-detection",
+    "sequence-diagram",
+    "engineering-design",
+    "documentation",
+    "onboarding"
+  ]
+}

--- a/plugins/devops/engineer-design-diagram/CHANGELOG.md
+++ b/plugins/devops/engineer-design-diagram/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this skill are documented in this file. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.0] - 2026-04-20
+
+### Added
+- **Docs-layout output shape** for dense architecture diagrams — widescreen two-column layout (260px sticky sidebar + main column) modelled on Anthropic docs, Linear docs, and Vercel architecture pages. Hybrid HTML nodes + SVG arrow overlay so node cards stay editable without re-running collision math.
+- `templates/docs-layout.html` — parameterized widescreen starter with sidebar (version badge, on-this-page nav, architectural invariants list, legend), diagram card (two-plane stage with HTML nodes and SVG arrow overlay), 2-column detail grid, and footer.
+- `references/docs-layout.md` — full widescreen spec: when-to-use decision tree, GitHub-inspired design tokens (`#0f1117` / `#161b22` / `#1c2128` + 4 accent tokens), Inter + JetBrains Mono typography scale, sidebar anatomy, diagram stage geometry, arrow catalogue, detail grid rules, verification math (Liang-Barsky line-rect intersection + endpoint attachment + text-overflow check), anti-patterns.
+
+### Changed
+- **SKILL.md** now opens with a `Layout Philosophy` section explaining when to pick single-SVG hero vs docs-layout page. Dense content (≥ 8 nodes, multiple planes, or 4+ subcomponents per node) routes to docs-layout; simple graphs stay with the classic template.
+- Step 3 template-selection table now covers both layout shapes. Docs-layout mode is widescreen-first with no mobile breakpoints — target `min-width: 1024px` on `<html>`.
+- Feedback loop adds a collision-math step for docs-layout mode (arrow-through-node, endpoint attachment, text overflow) before re-screenshotting.
+
+### Rationale
+- Single-SVG hero doesn't scale past ~8 nodes or multi-plane topologies — text packing fights you, arrow-crossing math gets expensive, and there's nowhere to put accompanying detail without stacking below.
+- Hybrid HTML + SVG was the clear winner after two rounds of fighting pure-SVG text sizing on a real monorepo diagram (intentional-cognition-os v0.11.0): HTML cards edit cleanly, SVG arrows stay pixel-perfect, and `position: absolute` with known pixel coords makes collision math trivial to verify.
+
+## [0.1.0] - 2026-04-19
+
+### Added
+- Initial skill skeleton with SKILL.md, README, LICENSE (MIT), THIRD_PARTY_LICENSES.md
+- Four-mode command surface: `/design:generate`, `/design:diff`, `/design:trace`, `/design:watch`
+- DCI injection block for package manifests, docker-compose, k8s, terraform, git state
+- Base HTML template with OKLCH color tokens, grid background, accessibility scaffolding
+- Sequence diagram template for trace-mode output
+- Mermaid fallback template for >50-node diagrams
+- `scripts/fingerprint.py` for structural fingerprint write/read/diff
+- `scripts/validate_html.py` for ARIA + no-external-deps verification
+- `scripts/collect_dci.sh` for bounded lazy topology harvesting
+- `scripts/open_in_browser.sh` for OS-aware HTML opening
+- Reference documentation for color tokens, layout heuristics, fingerprint schema, mode playbooks, accessibility, attribution, troubleshooting
+- Eval harness with 4 scenarios (generate/diff/trace/watch) and fixture data
+- Attribution to Cocoon-AI/architecture-diagram-generator (MIT) for design pattern borrowing

--- a/plugins/devops/engineer-design-diagram/LICENSE
+++ b/plugins/devops/engineer-design-diagram/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intent Solutions / Jeremy Longshore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/devops/engineer-design-diagram/README.md
+++ b/plugins/devops/engineer-design-diagram/README.md
@@ -1,0 +1,94 @@
+# engineer-design-diagram
+
+Generate production-grade engineering design diagrams as single-file dark-themed HTML with inline SVG, grounded in real repository topology.
+
+## Why this exists
+
+Most diagramming tools produce pretty pictures disconnected from reality. This skill does the opposite: it reads the actual repo (package manifests, docker-compose, k8s, terraform, import graph) and emits a diagram that reflects the real system. It also knows how the system *changed* — PR-diff mode highlights structural deltas, trace mode turns a stack/log into a sequence diagram, and drift mode detects when the architecture has wandered from a stored fingerprint.
+
+## Installation
+
+```bash
+/plugin install engineer-design-diagram@claude-code-plugins-plus
+```
+
+## Modes
+
+| Mode | What it does | Trigger |
+|---|---|---|
+| `generate` | Diagram from a live repo's topology | `/design:generate` or "draw the architecture" |
+| `diff` | Highlight structural deltas in a PR | `/design:diff` or "diagram this PR" |
+| `trace` | Stack/log → sequence diagram | `/design:trace` |
+| `watch` | Detect drift against a stored fingerprint | `/design:watch` |
+
+## Output
+
+Single self-contained HTML file that opens in any browser, plus a Mermaid text block for copy-paste into docs. Dark theme with semantic OKLCH color coding by component role. Accessible by default (ARIA, `<title>`/`<desc>`, reduced-motion, keyboard navigation).
+
+## Usage
+
+```bash
+/design:generate                # diagram from current repo
+/design:diff PR-123             # diff a specific PR
+/design:trace ./crash.log       # sequence diagram from a stack trace
+/design:watch                   # check for drift since last fingerprint
+```
+
+Or invoke the skill directly with natural language: *"draw the architecture for this repo"*, *"diagram this PR"*, *"engineer design diagram"*.
+
+## Pipeline
+
+All four modes share a common five-step flow:
+
+1. **DCI grounding** — read real repo signals (manifests, compose files, k8s, terraform, import graph)
+2. **Node/edge graph** — build a typed graph (services, datastores, external systems, queues)
+3. **Template fill** — Astro-style HTML template with inline SVG
+4. **Fingerprint write** — store the canonical graph for future drift detection
+5. **Render** — single-file HTML output, optionally opened in the browser
+
+## Reference materials
+
+| File | Purpose |
+|---|---|
+| `references/dci-block.md` | Discovery/Categorization/Inference grounding rules |
+| `references/drawing-rules.md` | When to use which template, color semantics |
+| `references/mode-playbooks.md` | Per-mode step-by-step recipes |
+| `references/docs-layout.md` | How to embed diagrams in long-form docs |
+| `references/fingerprint-spec.md` | Drift-detection fingerprint format |
+| `references/accessibility.md` | ARIA, semantic HTML, reduced-motion |
+| `references/troubleshooting.md` | Common failure modes |
+| `references/THIRD_PARTY_LICENSES.md` | Cocoon AI palette + arrow-masking attribution |
+
+## Templates
+
+| Template | Use case |
+|---|---|
+| `templates/base.html` | General architecture diagrams |
+| `templates/sequence.html` | Sequence diagrams (trace mode) |
+| `templates/docs-layout.html` | Long-form documentation embedding |
+| `templates/mermaid-fallback.html` | When the graph is too large for inline SVG |
+
+## Scripts
+
+| Script | Use |
+|---|---|
+| `scripts/collect_dci.sh` | Gather DCI signals from a repo |
+| `scripts/fingerprint.py` | Compute architecture fingerprint |
+| `scripts/validate_html.py` | Lint generated HTML for accessibility + correctness |
+| `scripts/open_in_browser.sh` | Open the result (xdg-open / open / wslview) |
+
+## Examples
+
+`examples/aws-serverless.html`, `examples/microservices.html`, `examples/tiny-monorepo/expected-architecture.html` — reference outputs you can open directly to see what the skill produces.
+
+## Origin
+
+This is the marketplace plugin port of the global Claude Code skill at `~/.claude/skills/engineer-design-diagram`. Both maintain the same SKILL.md, references, templates, and scripts. The global version is the prototype / reference implementation; this plugin makes it installable from the marketplace for any Claude Code user.
+
+## Credits
+
+Design palette and arrow-masking pattern inspired by [Cocoon AI's architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (MIT). See `skills/engineer-design-diagram/references/THIRD_PARTY_LICENSES.md`.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/plugins/devops/engineer-design-diagram/package.json
+++ b/plugins/devops/engineer-design-diagram/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@intentsolutionsio/engineer-design-diagram",
+  "version": "0.2.0",
+  "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo top",
+  "keywords": [
+    "architecture",
+    "diagram",
+    "visualization",
+    "svg",
+    "html",
+    "pr-review",
+    "drift-detection",
+    "sequence-diagram",
+    "engineering-design",
+    "documentation",
+    "onboarding",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/devops/engineer-design-diagram"
+  },
+  "homepage": "https://tonsofskills.com/plugins/engineer-design-diagram",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "[email protected]"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install engineer-design-diagram\\\\n  or /plugin install engineer-design-diagram@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/SKILL.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: engineer-design-diagram
+description: "Generate production-grade engineering design diagrams (architecture,\
+  \ sequence, delta, drift) as\nself-contained dark-themed HTML files with accessible\
+  \ inline SVG. Grounds every diagram in real\nrepo topology via DCI \u2014 package\
+  \ manifests, docker-compose, k8s, terraform, import graph. Four\nmodes: generate\
+  \ from a live repo, diff a PR, trace a stack into a sequence diagram, or watch for\n\
+  drift against a fingerprint. Semantic OKLCH palette; Mermaid fallback for large\
+  \ graphs.\nUse when visualizing system architecture, reviewing a PR for structural\
+  \ change, diagnosing an\nincident from a trace, onboarding to a codebase, or detecting\
+  \ architectural drift.\nTrigger with \"/design:generate\", \"/design:diff\", \"\
+  /design:trace\", \"/design:watch\", \"draw the\narchitecture\", \"diagram this PR\"\
+  , \"engineer design diagram\", or \"architecture diagram\".\n"
+allowed-tools: Read,Write,Glob,Grep,Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(docker:*),Bash(kubectl:*),Bash(terraform:*),Bash(python3:*),Bash(xdg-open:*),Bash(open:*),Bash(wslview:*),AskUserQuestion
+version: 0.2.0
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+tags:
+- architecture
+- diagram
+- visualization
+- svg
+- html
+- pr-review
+- drift-detection
+- sequence-diagram
+- engineering-design
+argument-hint: '[generate|diff|trace|watch] [target-path]'
+model: inherit
+compatibility: Designed for Claude Code
+---
+# Engineer Design Diagram
+
+Generates production-grade engineering design diagrams as single-file HTML with inline SVG, grounded in real repository topology. Credit: design palette + arrow-masking pattern inspired by [Cocoon AI's architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (MIT). See [THIRD_PARTY_LICENSES.md](references/THIRD_PARTY_LICENSES.md).
+
+## Overview
+
+Most diagramming tools produce pretty pictures disconnected from reality. This skill does the opposite: it reads the actual repo (package manifests, docker-compose, k8s, terraform, import graph) and emits a diagram that reflects the real system. It also knows how the system *changed* — PR-diff mode highlights structural deltas, trace mode turns a stack/log into a sequence diagram, and drift mode detects when the architecture has wandered from a stored fingerprint.
+
+Four modes share a common pipeline (DCI grounding → node/edge graph → template fill → fingerprint write). Output is a single self-contained HTML file that opens in any browser, plus a Mermaid text block for copy-paste into docs. Dark theme with semantic OKLCH color coding by component role. Accessible by default (ARIA, `<title>`/`<desc>`, reduced-motion, keyboard navigation).
+
+## Layout Philosophy — pick the shape before you draw
+
+Dense technical systems want to render **wide**. This is how Anthropic docs, Linear docs, and Vercel architecture pages present multi-component systems: a sticky left rail for context (nav, invariants, legend) and a generous main column for the diagram itself. Mimic that pattern when your content is dense, and use the simpler single-SVG hero when it isn't.
+
+Two supported output shapes, one decision up front:
+
+| Shape | Use when | Template |
+|-------|----------|----------|
+| **Single-SVG hero** (classic) | ≤8 nodes, one-screen takeaway, no sub-grouping, no accompanying explanation needed | `templates/base.html` |
+| **Docs-layout page** (widescreen) | ≥8 nodes, multiple planes/groupings/sub-blocks, want invariants + detail cards + legend alongside the diagram | `templates/docs-layout.html` |
+
+**Widescreen-first for docs-layout.** Target `min-width: 1024px`; do *not* add mobile breakpoints for docs-layout output — it's architecture documentation, not a landing page. The diagram needs horizontal breathing room. On narrow viewports the diagram stage scrolls horizontally inside its card while the sidebar stays visible.
+
+**Hybrid rendering** in docs-layout mode: HTML/CSS for all node cards (easier to maintain, free hover states, content edits don't trigger collision math), SVG overlay positioned absolutely *over* the node grid for arrows only. Arrows are the one place SVG still wins — fixed pixel coords, clean arrowheads, no brittle CSS-line math. Pure-SVG stays the default for the single-hero shape because the payoff of HTML flex doesn't materialize at small node counts.
+
+**Layout-decision signal:** if during Step 2 the graph has any of — (a) more than one semantic lane/plane, (b) subcomponent lists of 4+ items per node, (c) the user asks for "docs page" / "architecture page" / references Anthropic/Linear/Vercel docs as exemplars — pick **docs-layout**. Otherwise stay with single-SVG.
+
+See [docs-layout.md](references/docs-layout.md) for the full widescreen spec (grid geometry, design tokens, sidebar anatomy, arrow overlay placement, hover states).
+
+## Prerequisites
+
+- Git repository (for generate/diff/watch modes)
+- At least one of: `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `docker-compose.yml`, `k8s/*.yaml`, `terraform/*.tf`
+- Python 3.9+ (for `scripts/fingerprint.py`)
+- A browser to view output
+- Optional: `kubectl` (cluster introspection), `terraform` (state parsing), `jq` (manifest parsing)
+
+## Environment Detection (DCI)
+
+!`git rev-parse --show-toplevel 2>/dev/null || echo "not a git repo"`
+!`git rev-parse --short HEAD 2>/dev/null || echo "no-head"; git branch --show-current 2>/dev/null || echo "no-branch"`
+!`ls package.json pyproject.toml Cargo.toml go.mod requirements.txt docker-compose.yml Dockerfile 2>/dev/null | head -10 || echo "no manifests"`
+!`command -v jq >/dev/null 2>&1 && jq -r '.name,(.dependencies // {} | keys[]?)' package.json 2>/dev/null | head -20 || echo "no package.json / no jq"`
+!`docker compose config --services 2>/dev/null | head -30 || echo "no docker-compose"`
+!`find . -maxdepth 3 -type d \( -name k8s -o -name kubernetes -o -name manifests \) 2>/dev/null | head -5 || echo "no k8s dir"`
+!`find . -maxdepth 3 -name '*.tf' 2>/dev/null | head -10 || echo "no terraform"`
+
+## Instructions
+
+### Step 1: Mode Detection
+
+Parse the first token of `$ARGUMENTS`:
+
+| Invocation | Mode | Playbook |
+|------------|------|----------|
+| `/design:generate` or empty | generate | [mode-playbooks.md#generate](references/mode-playbooks.md#generate) |
+| `/design:diff` | diff | [mode-playbooks.md#diff](references/mode-playbooks.md#diff) |
+| `/design:trace <path>` | trace | [mode-playbooks.md#trace](references/mode-playbooks.md#trace) |
+| `/design:watch` | watch | [mode-playbooks.md#watch](references/mode-playbooks.md#watch) |
+
+All modes share Steps 2-5. Mode-specific variations documented in the per-mode playbook.
+
+### Step 2: Build the Node/Edge Graph
+
+Use the DCI block output + targeted reads to populate a working graph:
+
+- **Nodes** from: docker-compose service names, k8s `kind: Deployment/Service/StatefulSet`, terraform resource blocks, package manifest names (for standalone apps), detected binaries in `bin/` or `cmd/`.
+- **Edges** from: docker-compose `depends_on` + exposed ports, k8s Service selectors + NetworkPolicy, terraform resource references, import-graph via Grep (`import.*from`, `require(`, `use crate::`), exposed HTTP/gRPC routes.
+- **Role classification** per node using [drawing-rules.md § Role inference](references/drawing-rules.md#role-inference). Defaults to `slate` (external/unknown) when heuristics don't match.
+- **Groups** from: k8s namespaces, terraform modules, docker-compose networks, directory boundaries for monorepos.
+
+For graphs with >50 nodes, fall back to Mermaid (see Step 3 template selection).
+
+### Step 3: Choose Template and Render
+
+Apply the layout-selection rule from **Layout Philosophy** first, then pick the template for the chosen mode:
+
+| Mode | Layout shape | Template | Output |
+|------|--------------|----------|--------|
+| generate / diff | single-SVG hero (simple graphs) | [templates/base.html](templates/base.html) | Centered SVG on dark canvas, cards row below |
+| generate / diff | docs-layout page (dense graphs) | [templates/docs-layout.html](templates/docs-layout.html) | Two-column widescreen page: sticky sidebar + main column with diagram card + detail grid |
+| diff (any shape) | — | selected template + delta classes | `delta-added` / `delta-removed` / `delta-changed` CSS markers on changed nodes/edges |
+| trace | sequence | [templates/sequence.html](templates/sequence.html) | Sequence diagram with lifelines and message arrows |
+| watch | — | none — markdown drift report | Markdown only; no HTML render |
+
+**For single-SVG hero**: fill placeholders per [drawing-rules.md](references/drawing-rules.md) — color palette, SVG arrow-masking, z-order, 40px spacing, dashed boundaries, legend placement. Keep the grid `<pattern>`, `#020617` canvas, pulsing header dot (with reduced-motion guard).
+
+**For docs-layout page**: fill placeholders per [docs-layout.md](references/docs-layout.md) — GitHub-inspired palette (`#0f1117` / `#161b22` / `#1c2128`), Inter + JetBrains Mono, 260px sticky sidebar, fixed-pixel node stage with SVG arrow overlay, hover states on node cards. No mobile breakpoints. Populate the sidebar with: (a) version badge, (b) "On this page" nav, (c) "Architectural invariants" list (surface up to 5 load-bearing constraints you inferred from the code/config — e.g. "Kernel owns durable state", "All ops return Result<T,E>"), (d) node-type legend.
+
+If node count >50 OR the model signals layout failure (overlapping boxes, arrows crossing through nodes), switch to `templates/mermaid-fallback.html` regardless of layout shape.
+
+### Step 4: Update Fingerprint State
+
+For generate/diff/watch modes, write structural state to `${CLAUDE_PLUGIN_DATA}/arch-state.json` (or `~/.claude-state/arch-state.json` fallback if the env var is unset):
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/fingerprint.py write --input /tmp/graph.json
+```
+
+Schema documented in [fingerprint-spec.md](references/fingerprint-spec.md). Fingerprint persists across sessions so `watch` mode can detect drift.
+
+### Step 5: Validate and Open
+
+Run the HTML validator before presenting output:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_html.py $CWD/.arch/<mode>-<timestamp>.html
+```
+
+Validator confirms: ARIA labels present, reduced-motion rule exists, no unexpected external script sources beyond Google Fonts. If validation fails, iterate on the template fill — don't ship an inaccessible diagram.
+
+Open the result via `${CLAUDE_SKILL_DIR}/scripts/open_in_browser.sh` (OS-aware: `xdg-open` on Linux, `open` on macOS, `wslview` on WSL). Echo the Mermaid equivalent to the chat as a copy-pasteable text block.
+
+### Feedback Loop
+
+1. Run `validate_html.py` after Step 5.
+2. If ARIA or contrast checks fail → fix template fill → re-validate.
+3. If >50 nodes rendered as overlapping boxes → restart Step 3 with Mermaid fallback.
+4. **(docs-layout only)** If arrows cross non-endpoint nodes OR text overflows a node box → re-run layout math (see [docs-layout.md § verification](references/docs-layout.md#verification)) before re-screenshotting. Don't eyeball it; collision math is cheap and catches what a thumbnail hides.
+5. Maximum 3 iterations before falling back to Mermaid and flagging for manual review.
+
+## Output
+
+- **generate / diff / trace modes**: one HTML file at `$CWD/.arch/<mode>-<timestamp>.html` (self-contained, offline-capable, Google Fonts as the sole external dep) + one Mermaid text block echoed to chat.
+- **watch mode**: markdown drift report with sections `Added`, `Removed`, `Changed`, each line citing the source file that justified the delta.
+- **All modes**: updated fingerprint at `${CLAUDE_PLUGIN_DATA}/arch-state.json`.
+
+Detailed output contracts in [mode-playbooks.md](references/mode-playbooks.md).
+
+## Examples
+
+### Example 1 — Generate architecture view from a monorepo
+
+**Input:**
+```
+/design:generate
+```
+
+**Behavior:** DCI auto-loads `docker-compose.yml` services (`web`, `api`, `db`, `cache`), classifies roles (frontend/backend/db/db), reads `web/src/lib/api-client.ts` for the HTTP edge to `api`, reads `docker-compose.yml` `depends_on` for api→db and api→cache edges. Fills `templates/base.html`, writes `~/.arch/generate-2026-04-19T12-00.html`, writes fingerprint with 4 nodes + 3 edges.
+
+**Output excerpt (Mermaid block):**
+```
+flowchart TB
+  web["Web Frontend"]:::frontend --> api["API Service"]:::backend
+  api --> db["Postgres"]:::db
+  api --> cache["Redis"]:::db
+```
+
+### Example 2 — PR delta on a branch that adds Redis
+
+**Input:**
+```
+/design:diff
+```
+
+**Behavior:** Loads prior fingerprint, re-runs DCI on working tree, computes set-diff. Renders architecture view with `class="delta-added"` on the `cache` node and the `api→cache` edge. Summary line: `Added 1 node (cache), 1 edge (api→cache)`.
+
+### Example 3 — Sequence diagram from a Sentry event
+
+**Input:**
+```
+/design:trace ./incidents/sentry-2026-04-18-payment-timeout.json
+```
+
+**Behavior:** Parses Sentry JSON (exception frames + transaction spans), infers 4 lifelines (`checkout-api`, `payment-service`, `stripe-webhook-listener`, `fraud-check`), renders sequence diagram with the timeout marked on the final arrow. No fingerprint write in trace mode.
+
+### Example 4 — Drift watch after a quiet sprint
+
+**Input:**
+```
+/design:watch
+```
+
+**Behavior:** Loads prior fingerprint, re-runs DCI, diffs. Output:
+```
+## Drift report — 2026-04-19 vs 2026-04-12
+
+### Added
+- Node `recommendations-service` (backend) — source: docker-compose.yml:services.recommendations
+- Edge `api` → `recommendations-service` — source: api/src/handlers/product.ts:44
+
+### Removed
+- Edge `api` → `legacy-search` — source: api/src/handlers/search.ts removed in f8a2c91
+```
+
+## Edge Cases
+
+- **No package manifests**: DCI returns empty. Ask the user to describe the system in prose, fall back to prompt-only generation without DCI grounding.
+- **>150 components**: Hard cap at 150 rendered nodes. Overflow bucket labeled `… +N more`; full list preserved in fingerprint.
+- **Stack trace format unknown**: Three parsers (Sentry JSON, OTel span, raw text). Unknown formats emit Mermaid-only sequence rather than failing.
+- **No `main` branch for diff**: Probe `origin/HEAD` → `main` → `master` → `trunk`. If none found, fall back to `HEAD~1`.
+- **Docker compose binary naming**: Probe both `docker compose` (modern) and `docker-compose` (legacy).
+- **${CLAUDE_PLUGIN_DATA} unset**: Fallback chain `${CLAUDE_PLUGIN_DATA}` → `${XDG_STATE_HOME}/claude/arch` → `~/.claude-state/arch`.
+- **iOS Safari large-diagram rendering**: Avoid SVG paths with >10k points per element; fall back to Mermaid for graphs that approach this limit.
+- **k8s manifests with CRDs**: Role defaults to `slate` (external/unknown) when no heuristic matches; document in the legend.
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `not a git repo` | Running outside git | Init a repo or cd to one; DCI handles the empty case but diff/watch require git |
+| `no manifests` | No package files found | Use prose-only mode; skill will ask user to describe the system |
+| `fingerprint schema mismatch` | State file from older schema version | `fingerprint.py` refuses cross-version diff and emits baseline-restart guidance |
+| `ARIA validation failed` | Template fill omitted `<title>`/`<desc>` | Re-fill with role-appropriate labels from [accessibility.md](references/accessibility.md) |
+| `overlapping boxes detected` | Too many nodes for SVG layout | Auto-switch to Mermaid fallback (node count >50 trigger) |
+| `no diff base` | `main`/`master`/`trunk` all missing | Use `HEAD~1` as base, warn user in output |
+| `kubectl not installed` | Live cluster introspection unavailable | Skip cluster overlay; diagram still renders from static manifests |
+| `trace parser unknown format` | Input file matches no known schema | Emit Mermaid-only sequence with best-effort parsing, flag for user review |
+
+## Resources
+
+- [drawing-rules.md](references/drawing-rules.md) — color palette, z-order, arrow-masking, spacing, legend placement (single-SVG hero — Cocoon-AI-inspired patterns)
+- [docs-layout.md](references/docs-layout.md) — widescreen two-column layout spec (grid geometry, design tokens, sidebar anatomy, HTML+SVG hybrid arrow overlay, verification math) — mirrors Anthropic / Linear / Vercel docs patterns
+- [mode-playbooks.md](references/mode-playbooks.md) — per-mode workflows with inputs, steps, outputs
+- [fingerprint-spec.md](references/fingerprint-spec.md) — JSON schema for structural state + diff algorithm
+- [accessibility.md](references/accessibility.md) — ARIA patterns, reduced-motion, keyboard nav
+- [dci-block.md](references/dci-block.md) — DCI command catalog with output-size budgets
+- [troubleshooting.md](references/troubleshooting.md) — iOS Safari, large graphs, schema drift
+- [templates/base.html](templates/base.html) — single-SVG hero shell (≤8 nodes, simple graphs)
+- [templates/docs-layout.html](templates/docs-layout.html) — widescreen docs-page shell (≥8 nodes, planes, sub-groupings, detail cards)
+- [templates/sequence.html](templates/sequence.html) — sequence diagram variant (trace mode)
+- [templates/mermaid-fallback.html](templates/mermaid-fallback.html) — Mermaid-only render for >50 nodes
+- [scripts/fingerprint.py](scripts/fingerprint.py) — write / read / diff structural state
+- [scripts/validate_html.py](scripts/validate_html.py) — ARIA + no-external-deps checker
+- [scripts/collect_dci.sh](scripts/collect_dci.sh) — bounded DCI harvester for large repos
+- [scripts/open_in_browser.sh](scripts/open_in_browser.sh) — OS-aware opener
+- [THIRD_PARTY_LICENSES.md](references/THIRD_PARTY_LICENSES.md) — Cocoon-AI attribution + MIT notice
+- [examples/](examples/) — Cocoon-AI sample diagrams (web-app, aws-serverless, microservices) kept as visual reference
+- External: [Cocoon-AI/architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (inspiration source, MIT)
+- External: [Mermaid diagram syntax](https://mermaid.js.org/intro/)

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/evals/evals.json
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/evals/evals.json
@@ -1,0 +1,75 @@
+{
+  "skill_name": "engineer-design-diagram",
+  "evals": [
+    {
+      "id": 1,
+      "name": "generate_from_tiny_monorepo",
+      "prompt": "/design:generate",
+      "files": ["evals/fixtures/tiny-repo/"],
+      "expected_output": "Architecture HTML for a 3-service monorepo (web/api/db) with semantic role colors",
+      "assertions": [
+        "Output HTML file is created under $CWD/.arch/generate-*.html",
+        "Output contains CSS custom property references to --role-frontend-stroke, --role-backend-stroke, and --role-db-stroke",
+        "Every node <rect> has an accompanying <title> child for accessibility",
+        "A @media (prefers-reduced-motion: reduce) rule is present in the embedded <style>",
+        "Fingerprint file at ${CLAUDE_PLUGIN_DATA}/arch-state.json (or fallback path) is written with 3 nodes and at least 2 edges",
+        "No external script src other than Google Fonts"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "diff_highlights_added_redis",
+      "prompt": "/design:diff",
+      "files": ["evals/fixtures/pr-diff/"],
+      "expected_output": "Delta diagram highlighting a new Redis cache node and a removed SQS edge",
+      "assertions": [
+        "Output HTML contains a node labeled 'redis' or similar with --role-db-stroke applied",
+        "At least one element in the output carries class 'delta-added' or 'delta-removed'",
+        "A Mermaid text block is echoed to chat for copy-paste",
+        "Fingerprint on disk reflects the POST-diff state, not the pre-diff baseline",
+        "One-line summary in chat mentions both 'added' and 'removed' counts"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "trace_sentry_event_to_sequence",
+      "prompt": "/design:trace evals/fixtures/trace-input/sentry-event.json",
+      "files": ["evals/fixtures/trace-input/sentry-event.json"],
+      "expected_output": "Sequence diagram of the failure path with 4+ lifelines and an error-marked arrow",
+      "assertions": [
+        "Output is a sequence diagram using templates/sequence.html or a Mermaid sequenceDiagram block",
+        "At least 4 lifelines are rendered",
+        "The final message arrow carries the error class or label from the input trace",
+        "No fingerprint write occurs in trace mode"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "watch_detects_drift",
+      "prompt": "/design:watch",
+      "files": [
+        "evals/fixtures/tiny-repo/",
+        "evals/fixtures/prior-fingerprint/arch-state.json"
+      ],
+      "expected_output": "Markdown drift report listing one added node and one removed edge",
+      "assertions": [
+        "Output is markdown, not HTML",
+        "Report contains the sections 'Added', 'Removed', and 'Changed'",
+        "Each delta line cites a source file that justifies the change",
+        "Final line of the report includes the new graph_fingerprint sha256 value"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "negative_skill_does_not_trigger_on_unrelated_prompt",
+      "prompt": "What's the weather tomorrow in Portland?",
+      "files": [],
+      "expected_output": "Skill does NOT activate; Claude answers the weather question without invoking engineer-design-diagram",
+      "assertions": [
+        "engineer-design-diagram skill is not loaded for this prompt",
+        "No HTML file is created",
+        "No fingerprint write occurs"
+      ]
+    }
+  ]
+}

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/aws-serverless.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/aws-serverless.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AWS Serverless Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot {
+      width: 12px; height: 12px; background: #fbbf24;
+      border-radius: 50%; animation: pulse 2s infinite;
+    }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 1rem; border: 1px solid #1e293b;
+      padding: 1.5rem; overflow-x: auto;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>AWS Serverless Architecture</h1>
+      </div>
+      <p class="subtitle">Lambda + API Gateway + DynamoDB</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 950 480">
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- AWS Region -->
+        <rect x="140" y="30" width="780" height="420" rx="12" fill="rgba(251, 191, 36, 0.05)" stroke="#fbbf24" stroke-width="1" stroke-dasharray="8,4"/>
+        <text x="155" y="52" fill="#fbbf24" font-size="10" font-weight="600">AWS Region: us-east-1</text>
+
+        <!-- Arrows -->
+        <line x1="120" y1="200" x2="188" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="310" y1="200" x2="378" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="500" y1="200" x2="568" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="690" y1="200" x2="758" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Lambda to S3 -->
+        <line x1="630" y1="240" x2="630" y2="318" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Lambda to SQS -->
+        <line x1="630" y1="160" x2="630" y2="102" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Users -->
+        <rect x="20" y="160" width="100" height="80" rx="6" fill="#0f172a"/>
+        <rect x="20" y="160" width="100" height="80" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="70" y="195" fill="white" font-size="12" font-weight="600" text-anchor="middle">Clients</text>
+        <text x="70" y="215" fill="#94a3b8" font-size="9" text-anchor="middle">Web/Mobile</text>
+
+        <!-- CloudFront -->
+        <rect x="190" y="160" width="120" height="80" rx="6" fill="#0f172a"/>
+        <rect x="190" y="160" width="120" height="80" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="250" y="195" fill="white" font-size="11" font-weight="600" text-anchor="middle">CloudFront</text>
+        <text x="250" y="215" fill="#94a3b8" font-size="9" text-anchor="middle">CDN</text>
+
+        <!-- API Gateway -->
+        <rect x="380" y="150" width="120" height="100" rx="6" fill="#0f172a"/>
+        <rect x="380" y="150" width="120" height="100" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="440" y="185" fill="white" font-size="11" font-weight="600" text-anchor="middle">API Gateway</text>
+        <text x="440" y="205" fill="#94a3b8" font-size="9" text-anchor="middle">REST API</text>
+        <text x="440" y="220" fill="#94a3b8" font-size="9" text-anchor="middle">WebSocket</text>
+        <text x="440" y="240" fill="#fbbf24" font-size="8" text-anchor="middle">HTTPS</text>
+
+        <!-- Lambda -->
+        <rect x="570" y="140" width="120" height="120" rx="6" fill="#0f172a"/>
+        <rect x="570" y="140" width="120" height="120" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="630" y="180" fill="white" font-size="11" font-weight="600" text-anchor="middle">Lambda</text>
+        <text x="630" y="200" fill="#94a3b8" font-size="9" text-anchor="middle">Functions</text>
+        <text x="630" y="215" fill="#94a3b8" font-size="9" text-anchor="middle">Node.js/Python</text>
+        <text x="630" y="248" fill="#34d399" font-size="8" text-anchor="middle">Auto-scaling</text>
+
+        <!-- DynamoDB -->
+        <rect x="760" y="150" width="130" height="100" rx="6" fill="#0f172a"/>
+        <rect x="760" y="150" width="130" height="100" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="825" y="185" fill="white" font-size="11" font-weight="600" text-anchor="middle">DynamoDB</text>
+        <text x="825" y="205" fill="#94a3b8" font-size="9" text-anchor="middle">NoSQL Database</text>
+        <text x="825" y="220" fill="#94a3b8" font-size="9" text-anchor="middle">On-demand</text>
+        <text x="825" y="240" fill="#a78bfa" font-size="8" text-anchor="middle">Single-digit ms</text>
+
+        <!-- S3 -->
+        <rect x="570" y="320" width="120" height="90" rx="6" fill="#0f172a"/>
+        <rect x="570" y="320" width="120" height="90" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="630" y="355" fill="white" font-size="11" font-weight="600" text-anchor="middle">S3</text>
+        <text x="630" y="375" fill="#94a3b8" font-size="9" text-anchor="middle">Object Storage</text>
+        <text x="630" y="400" fill="#fbbf24" font-size="8" text-anchor="middle">Static Assets</text>
+
+        <!-- SQS -->
+        <rect x="570" y="60" width="120" height="40" rx="6" fill="#0f172a"/>
+        <rect x="570" y="60" width="120" height="40" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="630" y="85" fill="white" font-size="11" font-weight="600" text-anchor="middle">SQS</text>
+
+        <!-- Legend -->
+        <text x="170" y="420" fill="white" font-size="10" font-weight="600">Legend</text>
+        <rect x="170" y="432" width="16" height="10" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="192" y="440" fill="#94a3b8" font-size="8">AWS Service</text>
+        <rect x="270" y="432" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="292" y="440" fill="#94a3b8" font-size="8">Compute</text>
+        <rect x="360" y="432" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="382" y="440" fill="#94a3b8" font-size="8">Database</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>Infrastructure</h3>
+        </div>
+        <ul>
+          <li>• CloudFront CDN distribution</li>
+          <li>• API Gateway REST endpoints</li>
+          <li>• S3 static asset hosting</li>
+          <li>• SQS message queues</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Compute</h3>
+        </div>
+        <ul>
+          <li>• Lambda functions (Node.js)</li>
+          <li>• Auto-scaling to zero</li>
+          <li>• Pay-per-invocation</li>
+          <li>• 15 min max execution</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Data</h3>
+        </div>
+        <ul>
+          <li>• DynamoDB tables</li>
+          <li>• On-demand capacity</li>
+          <li>• Global secondary indexes</li>
+          <li>• Point-in-time recovery</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">AWS Serverless Architecture • Event-driven design</p>
+  </div>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/microservices.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/microservices.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Microservices Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot {
+      width: 12px; height: 12px; background: #34d399;
+      border-radius: 50%; animation: pulse 2s infinite;
+    }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 1rem; border: 1px solid #1e293b;
+      padding: 1.5rem; overflow-x: auto;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.rose { background: #fb7185; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Microservices Architecture</h1>
+      </div>
+      <p class="subtitle">Kubernetes-orchestrated services with API Gateway</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 950 560">
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Kubernetes Cluster boundary -->
+        <rect x="280" y="30" width="640" height="460" rx="12" fill="rgba(34, 211, 238, 0.03)" stroke="#22d3ee" stroke-width="1" stroke-dasharray="8,4"/>
+        <text x="295" y="52" fill="#22d3ee" font-size="10" font-weight="600">Kubernetes Cluster</text>
+
+        <!-- Arrows to Gateway -->
+        <line x1="120" y1="150" x2="188" y2="150" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="120" y1="380" x2="188" y2="380" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Gateway to services -->
+        <line x1="370" y1="180" x2="438" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="370" y1="200" x2="438" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="370" y1="220" x2="438" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="370" y1="360" x2="438" y2="400" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Services to DBs -->
+        <line x1="560" y1="100" x2="698" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="560" y1="200" x2="698" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="560" y1="300" x2="698" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="560" y1="400" x2="698" y2="400" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Message bus connections -->
+        <line x1="500" y1="130" x2="500" y2="138" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="500" y1="162" x2="500" y2="170" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="500" y1="230" x2="500" y2="238" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="500" y1="262" x2="500" y2="270" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="500" y1="330" x2="500" y2="338" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="500" y1="362" x2="500" y2="370" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+
+        <!-- Web Client -->
+        <rect x="20" y="110" width="100" height="80" rx="6" fill="#0f172a"/>
+        <rect x="20" y="110" width="100" height="80" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="70" y="145" fill="white" font-size="11" font-weight="600" text-anchor="middle">Web App</text>
+        <text x="70" y="165" fill="#94a3b8" font-size="9" text-anchor="middle">React SPA</text>
+
+        <!-- Mobile Client -->
+        <rect x="20" y="340" width="100" height="80" rx="6" fill="#0f172a"/>
+        <rect x="20" y="340" width="100" height="80" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="70" y="375" fill="white" font-size="11" font-weight="600" text-anchor="middle">Mobile App</text>
+        <text x="70" y="395" fill="#94a3b8" font-size="9" text-anchor="middle">iOS/Android</text>
+
+        <!-- API Gateway -->
+        <rect x="190" y="140" width="180" height="120" rx="6" fill="#0f172a"/>
+        <rect x="190" y="140" width="180" height="120" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="280" y="175" fill="white" font-size="12" font-weight="600" text-anchor="middle">API Gateway</text>
+        <text x="280" y="195" fill="#94a3b8" font-size="9" text-anchor="middle">Kong / Nginx</text>
+        <text x="280" y="210" fill="#94a3b8" font-size="9" text-anchor="middle">Rate Limiting</text>
+        <text x="280" y="225" fill="#94a3b8" font-size="9" text-anchor="middle">Auth / Routing</text>
+        <text x="280" y="250" fill="#fb7185" font-size="8" text-anchor="middle">:443</text>
+
+        <!-- Auth Gateway for mobile -->
+        <rect x="190" y="340" width="180" height="80" rx="6" fill="#0f172a"/>
+        <rect x="190" y="340" width="180" height="80" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="280" y="375" fill="white" font-size="11" font-weight="600" text-anchor="middle">Auth Service</text>
+        <text x="280" y="395" fill="#94a3b8" font-size="9" text-anchor="middle">OAuth 2.0 / JWT</text>
+
+        <!-- User Service -->
+        <rect x="440" y="70" width="120" height="60" rx="6" fill="#0f172a"/>
+        <rect x="440" y="70" width="120" height="60" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="95" fill="white" font-size="10" font-weight="600" text-anchor="middle">User Service</text>
+        <text x="500" y="115" fill="#94a3b8" font-size="8" text-anchor="middle">Go :8081</text>
+
+        <!-- Order Service -->
+        <rect x="440" y="170" width="120" height="60" rx="6" fill="#0f172a"/>
+        <rect x="440" y="170" width="120" height="60" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="195" fill="white" font-size="10" font-weight="600" text-anchor="middle">Order Service</text>
+        <text x="500" y="215" fill="#94a3b8" font-size="8" text-anchor="middle">Java :8082</text>
+
+        <!-- Product Service -->
+        <rect x="440" y="270" width="120" height="60" rx="6" fill="#0f172a"/>
+        <rect x="440" y="270" width="120" height="60" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="295" fill="white" font-size="10" font-weight="600" text-anchor="middle">Product Service</text>
+        <text x="500" y="315" fill="#94a3b8" font-size="8" text-anchor="middle">Python :8083</text>
+
+        <!-- Notification Service -->
+        <rect x="440" y="370" width="120" height="60" rx="6" fill="#0f172a"/>
+        <rect x="440" y="370" width="120" height="60" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="395" fill="white" font-size="10" font-weight="600" text-anchor="middle">Notification Svc</text>
+        <text x="500" y="415" fill="#94a3b8" font-size="8" text-anchor="middle">Node.js :8084</text>
+
+        <!-- Message Bus -->
+        <rect x="440" y="140" width="120" height="20" rx="4" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1"/>
+        <text x="500" y="154" fill="#fb923c" font-size="7" text-anchor="middle">Kafka / RabbitMQ</text>
+
+        <rect x="440" y="240" width="120" height="20" rx="4" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1"/>
+        <text x="500" y="254" fill="#fb923c" font-size="7" text-anchor="middle">Event Bus</text>
+
+        <rect x="440" y="340" width="120" height="20" rx="4" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1"/>
+        <text x="500" y="354" fill="#fb923c" font-size="7" text-anchor="middle">Event Bus</text>
+
+        <!-- PostgreSQL -->
+        <rect x="700" y="70" width="100" height="60" rx="6" fill="#0f172a"/>
+        <rect x="700" y="70" width="100" height="60" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="750" y="95" fill="white" font-size="10" font-weight="600" text-anchor="middle">PostgreSQL</text>
+        <text x="750" y="115" fill="#94a3b8" font-size="8" text-anchor="middle">Users DB</text>
+
+        <!-- MongoDB -->
+        <rect x="700" y="170" width="100" height="60" rx="6" fill="#0f172a"/>
+        <rect x="700" y="170" width="100" height="60" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="750" y="195" fill="white" font-size="10" font-weight="600" text-anchor="middle">MongoDB</text>
+        <text x="750" y="215" fill="#94a3b8" font-size="8" text-anchor="middle">Orders DB</text>
+
+        <!-- Elasticsearch -->
+        <rect x="700" y="270" width="100" height="60" rx="6" fill="#0f172a"/>
+        <rect x="700" y="270" width="100" height="60" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="750" y="295" fill="white" font-size="10" font-weight="600" text-anchor="middle">Elasticsearch</text>
+        <text x="750" y="315" fill="#94a3b8" font-size="8" text-anchor="middle">Products</text>
+
+        <!-- Redis -->
+        <rect x="700" y="370" width="100" height="60" rx="6" fill="#0f172a"/>
+        <rect x="700" y="370" width="100" height="60" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="750" y="395" fill="white" font-size="10" font-weight="600" text-anchor="middle">Redis</text>
+        <text x="750" y="415" fill="#94a3b8" font-size="8" text-anchor="middle">Cache / Queue</text>
+
+        <!-- Legend (placed below all boundaries) -->
+        <text x="300" y="510" fill="white" font-size="10" font-weight="600">Legend</text>
+        <rect x="300" y="522" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="322" y="530" fill="#94a3b8" font-size="8">Service</text>
+        <rect x="380" y="522" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="402" y="530" fill="#94a3b8" font-size="8">Database</text>
+        <rect x="470" y="522" width="16" height="10" rx="2" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1"/>
+        <text x="492" y="530" fill="#94a3b8" font-size="8">Gateway</text>
+        <rect x="560" y="522" width="16" height="10" rx="2" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1"/>
+        <text x="582" y="530" fill="#94a3b8" font-size="8">Message Bus</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot cyan"></div>
+          <h3>Client Applications</h3>
+        </div>
+        <ul>
+          <li>• React SPA (Web)</li>
+          <li>• Native iOS/Android</li>
+          <li>• Unified API interface</li>
+          <li>• JWT authentication</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Microservices</h3>
+        </div>
+        <ul>
+          <li>• Polyglot (Go, Java, Python, Node)</li>
+          <li>• Independent deployments</li>
+          <li>• Event-driven communication</li>
+          <li>• Database per service</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Infrastructure</h3>
+        </div>
+        <ul>
+          <li>• Kubernetes orchestration</li>
+          <li>• Kong API Gateway</li>
+          <li>• Kafka event streaming</li>
+          <li>• Prometheus monitoring</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">Microservices Architecture • Domain-driven design</p>
+  </div>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/tiny-monorepo/expected-architecture.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/examples/tiny-monorepo/expected-architecture.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Web Application Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot {
+      width: 12px; height: 12px; background: #22d3ee;
+      border-radius: 50%; animation: pulse 2s infinite;
+    }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 1rem; border: 1px solid #1e293b;
+      padding: 1.5rem; overflow-x: auto;
+    }
+    svg { width: 100%; min-width: 800px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Web Application Architecture</h1>
+      </div>
+      <p class="subtitle">React + Node.js + PostgreSQL stack</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 400">
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Arrows (drawn first for z-order) -->
+        <line x1="130" y1="200" x2="248" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="189" y="190" fill="#94a3b8" font-size="8" text-anchor="middle">HTTPS</text>
+
+        <line x1="400" y1="200" x2="498" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="449" y="190" fill="#94a3b8" font-size="8" text-anchor="middle">REST API</text>
+
+        <line x1="650" y1="200" x2="748" y2="200" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="699" y="190" fill="#94a3b8" font-size="8" text-anchor="middle">SQL</text>
+
+        <!-- Users -->
+        <rect x="30" y="160" width="100" height="80" rx="6" fill="#0f172a"/>
+        <rect x="30" y="160" width="100" height="80" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="80" y="195" fill="white" font-size="12" font-weight="600" text-anchor="middle">Users</text>
+        <text x="80" y="215" fill="#94a3b8" font-size="9" text-anchor="middle">Browser</text>
+
+        <!-- Frontend -->
+        <rect x="250" y="140" width="150" height="120" rx="6" fill="#0f172a"/>
+        <rect x="250" y="140" width="150" height="120" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="325" y="175" fill="white" font-size="12" font-weight="600" text-anchor="middle">Frontend</text>
+        <text x="325" y="195" fill="#94a3b8" font-size="9" text-anchor="middle">React</text>
+        <text x="325" y="210" fill="#94a3b8" font-size="9" text-anchor="middle">TypeScript</text>
+        <text x="325" y="225" fill="#94a3b8" font-size="9" text-anchor="middle">Tailwind CSS</text>
+        <text x="325" y="248" fill="#22d3ee" font-size="8" text-anchor="middle">:3000</text>
+
+        <!-- Backend -->
+        <rect x="500" y="140" width="150" height="120" rx="6" fill="#0f172a"/>
+        <rect x="500" y="140" width="150" height="120" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="575" y="175" fill="white" font-size="12" font-weight="600" text-anchor="middle">Backend</text>
+        <text x="575" y="195" fill="#94a3b8" font-size="9" text-anchor="middle">Node.js</text>
+        <text x="575" y="210" fill="#94a3b8" font-size="9" text-anchor="middle">Express</text>
+        <text x="575" y="225" fill="#94a3b8" font-size="9" text-anchor="middle">REST API</text>
+        <text x="575" y="248" fill="#34d399" font-size="8" text-anchor="middle">:8080</text>
+
+        <!-- Database -->
+        <rect x="750" y="150" width="120" height="100" rx="6" fill="#0f172a"/>
+        <rect x="750" y="150" width="120" height="100" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="810" y="190" fill="white" font-size="12" font-weight="600" text-anchor="middle">PostgreSQL</text>
+        <text x="810" y="210" fill="#94a3b8" font-size="9" text-anchor="middle">Database</text>
+        <text x="810" y="238" fill="#a78bfa" font-size="8" text-anchor="middle">:5432</text>
+
+        <!-- Legend -->
+        <text x="30" y="350" fill="white" font-size="10" font-weight="600">Legend</text>
+        <rect x="30" y="362" width="16" height="10" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="52" y="370" fill="#94a3b8" font-size="8">Frontend</text>
+        <rect x="110" y="362" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="132" y="370" fill="#94a3b8" font-size="8">Backend</text>
+        <rect x="190" y="362" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="212" y="370" fill="#94a3b8" font-size="8">Database</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot cyan"></div>
+          <h3>Frontend Stack</h3>
+        </div>
+        <ul>
+          <li>• React 18 with hooks</li>
+          <li>• TypeScript for type safety</li>
+          <li>• Tailwind CSS styling</li>
+          <li>• Vite build tool</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Backend Stack</h3>
+        </div>
+        <ul>
+          <li>• Node.js runtime</li>
+          <li>• Express framework</li>
+          <li>• JWT authentication</li>
+          <li>• REST API design</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Data Layer</h3>
+        </div>
+        <ul>
+          <li>• PostgreSQL database</li>
+          <li>• Prisma ORM</li>
+          <li>• Redis caching</li>
+          <li>• S3 file storage</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">Web Application Architecture • Three-tier design</p>
+  </div>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/THIRD_PARTY_LICENSES.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,50 @@
+# Third-Party Attribution
+
+## Cocoon-AI / architecture-diagram-generator (MIT)
+
+**Source:** https://github.com/Cocoon-AI/architecture-diagram-generator
+
+Semantic color palette, arrow-masking SVG technique, and grid-background aesthetic are inspired by Cocoon-AI's skill. We do not reuse source code from the upstream repo — we borrow design patterns under the MIT license and credit the originators.
+
+### Borrowed patterns
+- Semantic OKLCH color palette by component role (cyan/emerald/violet/amber/rose/orange/slate)
+- SVG arrow-masking technique (opaque `#0f172a` rect → styled semi-transparent rect on top)
+- Grid-pattern background (40x40 units, stroke `#1e293b`, width `0.5`)
+- Dashed boundary conventions for security groups (`4,4` rose) and regions (`8,4` amber, `rx="12"`)
+- 40px minimum vertical spacing heuristic for component rows
+- JetBrains Mono typography
+
+### Original contributions (not borrowed)
+- DCI-grounded topology inference from package manifests, docker-compose, k8s, terraform
+- PR-diff delta view (`git diff` → before/after architecture)
+- Structural fingerprinting + drift detection
+- Stack-trace-to-sequence mode
+- Accessibility baseline (ARIA, `<title>`/`<desc>`, reduced-motion)
+- Four-command surface
+- Mermaid fallback routing
+
+### Upstream MIT license (verbatim)
+
+```
+MIT License
+
+Copyright (c) 2025 Cocoon AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/accessibility.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/accessibility.md
@@ -1,0 +1,104 @@
+# Accessibility Patterns
+
+Every diagram this skill emits must be screen-reader-accessible and respect motion preferences. Not a marketing feature — a correctness requirement.
+
+## Table of Contents
+
+- [ARIA Scaffolding](#aria-scaffolding)
+- [SVG Title and Desc](#svg-title-and-desc)
+- [Keyboard Navigation](#keyboard-navigation)
+- [Reduced Motion](#reduced-motion)
+- [Color Contrast](#color-contrast)
+
+## ARIA Scaffolding
+
+The top-level SVG element acts as a composite image with a meaningful label:
+
+```html
+<svg role="img"
+     aria-labelledby="diagram-title diagram-desc"
+     viewBox="0 0 1000 680"
+     xmlns="http://www.w3.org/2000/svg">
+  <title id="diagram-title">System architecture — myapp</title>
+  <desc id="diagram-desc">
+    Three-service topology: web frontend calls API, which depends on a Postgres
+    database and a Redis cache. All services in the production VPC.
+  </desc>
+  <!-- diagram content -->
+</svg>
+```
+
+Group landmarks per role:
+
+```html
+<g role="group" aria-label="Backend services">
+  <rect ...>
+    <title>API Service — Node/Express, port 3000</title>
+    <desc>Handles HTTP requests from the web frontend</desc>
+  </rect>
+</g>
+```
+
+## SVG Title and Desc
+
+Every `<rect>` that represents a node includes:
+
+- `<title>` — one-line, screen-reader announces on focus (~80 chars max)
+- `<desc>` — longer description (optional but recommended for complex components)
+
+The `<title>` also acts as a browser tooltip on hover — double duty.
+
+## Keyboard Navigation
+
+Make the diagram tab-focusable:
+
+```html
+<svg tabindex="0" ...>
+  <g tabindex="0" role="group" aria-label="api">
+    <rect .../>
+    <text .../>
+  </g>
+</svg>
+```
+
+CSS for visible focus:
+
+```css
+svg g:focus {
+  outline: 2px solid var(--focus-ring, #22d3ee);
+  outline-offset: 2px;
+}
+```
+
+## Reduced Motion
+
+The pulsing header dot and any hover transitions must honor `prefers-reduced-motion`:
+
+```css
+.header-dot {
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-dot,
+  .diagram * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+```
+
+The validator checks for the presence of this media query. Missing it is a hard fail in `validate_html.py`.
+
+## Color Contrast
+
+All text-on-background pairs must meet WCAG AA (4.5:1 for body text, 3:1 for large text):
+
+| Text | Background | Ratio | Pass? |
+|------|------------|-------|-------|
+| `white` | `#020617` (slate-950) | 17.3:1 | yes |
+| `#94a3b8` (slate-400 sublabel) | `#020617` | 7.6:1 | yes |
+| `#fb923c` (bus label, 7px) | `#020617` | 7.0:1 | yes |
+| Role strokes (all) on slate-950 | — | ≥ 7:1 | yes |
+
+Never change token values without re-checking contrast. Contrast-blind users rely on color-plus-pattern differentiation; the dashed boundary pattern for security groups is the non-color cue.

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/dci-block.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/dci-block.md
@@ -1,0 +1,68 @@
+# DCI Block Reference
+
+Catalog of Dynamic Context Injection commands used at skill activation. Each entry lists the command, the expected output size, and the fallback strategy. Total inline DCI budget: **~4.5 KB**.
+
+## Table of Contents
+
+- [Inline DCI Commands](#inline-dci-commands)
+- [Lazy Harvester (`collect_dci.sh`)](#lazy-harvester-collect_dcish)
+- [Size Budgets](#size-budgets)
+- [Output Truncation Strategy](#output-truncation-strategy)
+
+## Inline DCI Commands
+
+These run at skill activation, in order. Each ends with a fallback that handles the not-installed / not-found case cleanly.
+
+| # | Command | Expected size | Purpose |
+|---|---------|---------------|---------|
+| 1 | `git rev-parse --show-toplevel` | ~60 B | Confirm git repo + root path |
+| 2 | `git rev-parse --short HEAD; git branch --show-current` | ~100 B | SHA + branch for fingerprint metadata |
+| 3 | `ls package.json pyproject.toml Cargo.toml go.mod requirements.txt docker-compose.yml Dockerfile` | ~200 B | Manifest presence probe |
+| 4 | `jq -r '.name,.dependencies // {} | keys[]?' package.json` | ~800 B (capped) | Node dep list for role inference |
+| 5 | `docker compose config --services` | ~400 B | Docker service enumeration |
+| 6 | `find . -maxdepth 3 -type d -name k8s/kubernetes/manifests` | ~200 B | k8s manifest dir discovery |
+| 7 | `find . -maxdepth 3 -name '*.tf'` | ~400 B | Terraform file discovery |
+
+All commands have `2>/dev/null` + `|| echo "fallback message"` — the skill never sees an error, just a known string it can branch on.
+
+## Lazy Harvester (`collect_dci.sh`)
+
+When inline DCI signals that heavy data is available (manifests exist, k8s dir found, terraform present), the skill calls `scripts/collect_dci.sh` to fetch bounded extras. The harvester:
+
+- Caps each section at its documented byte limit
+- Outputs a single JSON document to stdout
+- Respects `.gitignore` via `git ls-files`
+- Skips binaries
+
+Extras it collects:
+
+| Section | Upstream command | Cap |
+|---------|------------------|-----|
+| `git_files` | `git ls-files '*.ts' '*.tsx' '*.js' '*.py' '*.go' '*.rs'` | 500 paths |
+| `compose_full` | `docker compose config` (full YAML) | 40 KB |
+| `k8s_resources` | Per file: `yq '.kind, .metadata.name'` | 20 resources |
+| `terraform_state` | `terraform show -json` if state present | 80 KB |
+
+Skill reads only the sections it needs for the current mode.
+
+## Size Budgets
+
+Stay under these caps to avoid context bloat:
+
+| Surface | Budget |
+|---------|--------|
+| Inline DCI block (SKILL.md activation) | 4.5 KB total |
+| Any single inline command | 1 KB |
+| Lazy harvester JSON output | 128 KB total |
+| Per-harvester-section | documented in table above |
+
+If a section exceeds its cap, the harvester emits `{"section": "...", "truncated": true, "reason": "size cap"}` so the skill knows to treat results as a sample, not a complete list.
+
+## Output Truncation Strategy
+
+When DCI output is truncated:
+
+1. **Don't retry with a higher limit** — caps exist to protect context.
+2. **Treat the output as a sample** — "here are the first 500 source files; the full count is N".
+3. **Surface truncation in the final diagram's legend** — e.g., "Showing 150 of 500 source files; see fingerprint for complete list."
+4. **Fingerprint always stores the complete node/edge set** — even when the rendered SVG shows only the top-150 subset.

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/docs-layout.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/docs-layout.md
@@ -1,0 +1,325 @@
+# Docs-Layout Rules
+
+Widescreen two-column layout for dense architecture diagrams. Mirrors the pattern used by [Anthropic docs](https://docs.anthropic.com/), [Linear docs](https://linear.app/docs), and [Vercel architecture pages](https://vercel.com/docs) — sticky context rail on the left, generous diagram + detail column on the right.
+
+## Table of Contents
+
+- [When to use this layout](#when-to-use-this-layout)
+- [Philosophy](#philosophy)
+- [Page structure](#page-structure)
+- [Design tokens](#design-tokens)
+- [Typography](#typography)
+- [Sidebar anatomy](#sidebar-anatomy)
+- [Main column anatomy](#main-column-anatomy)
+- [Diagram stage (HTML + SVG hybrid)](#diagram-stage-html--svg-hybrid)
+- [Node cards](#node-cards)
+- [Plane boundaries](#plane-boundaries)
+- [Arrow overlay rules](#arrow-overlay-rules)
+- [Detail grid](#detail-grid)
+- [Polish](#polish)
+- [Verification](#verification)
+- [Anti-patterns](#anti-patterns)
+
+## When to use this layout
+
+Use docs-layout when the graph has any of:
+
+- ≥ 8 nodes
+- More than one semantic lane / plane / group
+- Nodes with 4+ subcomponents each (e.g. a compiler with sub-packages)
+- User explicitly asks for a "docs page", "architecture page", or references Anthropic / Linear / Vercel as exemplars
+
+If none of those apply, fall back to `templates/base.html` (single-SVG hero). The docs-layout has higher fixed overhead (sidebar content, detail cards) that looks out of proportion for 4–5 nodes.
+
+## Philosophy
+
+**Dense systems want to render wide.** A two-plane architecture, a microservice mesh, a compiler with multiple passes — these don't compress into a vertical stack without losing relationships. Give the diagram horizontal breathing room and surround it with the context that makes it useful: a navigation rail, the invariants the system is supposed to uphold, a color legend, a sibling grid of detail cards.
+
+**Widescreen-first; no mobile breakpoints.** Architecture documentation is not a landing page. Target `min-width: 1024px` on `<html>`. On narrower viewports the diagram stage scrolls horizontally inside its card while the sidebar stays fixed. Don't fight it with responsive tricks — they always compromise the signal.
+
+**Hybrid HTML + SVG.** Node cards are HTML (flex/grid layout, free hover states, easy content edits, no brittle text-width math); the arrow overlay is a single SVG positioned absolutely over the node stage. HTML handles layout; SVG handles line geometry. This is the same split Linear and Vercel use internally.
+
+## Page structure
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  <body>   padding: 40px 48px                                │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │  <main class="layout">   max-width: 1400px              ││
+│  │  display: grid                                          ││
+│  │  grid-template-columns: 260px minmax(0, 1fr)            ││
+│  │  gap: 40px                                              ││
+│  │                                                         ││
+│  │  ┌──────────┐  ┌──────────────────────────────────┐     ││
+│  │  │ <aside>  │  │  <section class="main">          │     ││
+│  │  │ sticky   │  │  header (h1 + lede)              │     ││
+│  │  │ top:40px │  │  diagram-card (hero diagram)     │     ││
+│  │  │          │  │  details (2-col detail grid)     │     ││
+│  │  │ - badge  │  │  footer                          │     ││
+│  │  │ - nav    │  │                                  │     ││
+│  │  │ - invar. │  │                                  │     ││
+│  │  │ - legend │  │                                  │     ││
+│  │  └──────────┘  └──────────────────────────────────┘     ││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+```
+
+Spacing (8px grid):
+
+| Rule | px |
+|------|----|
+| Body padding | `40px 48px` |
+| Column gap | `40px` |
+| Section gap (within main) | `48px` |
+| Card inner padding | `24px` (detail) / `32px` (diagram) |
+| Component gap within cards | `16px` |
+| Label-to-value gap | `8px` |
+| Tight inline spacing | `4px` |
+
+## Design tokens
+
+GitHub-inspired dark palette (higher contrast than the OKLCH palette used by the single-SVG template; chosen for readability of small UI labels).
+
+```css
+:root {
+  --bg-page:       #0f1117;
+  --bg-surface:    #161b22;
+  --bg-raised:     #1c2128;
+  --bg-raised-hover: #22272e;
+  --border-subtle: #30363d;
+  --border-accent: #58a6ff;
+  --text-primary:   #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted:     #6e7681;
+  --accent-blue:    #58a6ff;  /* CLI / entry */
+  --accent-green:   #3fb950;  /* service packages */
+  --accent-orange:  #f78166;  /* external APIs */
+  --accent-purple:  #bc8cff;  /* persistence / shared libs */
+  --accent-teal:    #39c5cf;  /* reserved */
+}
+```
+
+Node-type → accent mapping:
+
+| Role | Accent token | Border on hover |
+|------|--------------|-----------------|
+| CLI / entry point | `--accent-blue` | 100% opacity |
+| Service package | `--accent-green` | 100% opacity |
+| Persistence (DB, FS, cache) | `--accent-purple` | 100% opacity |
+| External API | `--accent-orange` | 100% opacity |
+| Shared library | `--text-muted` (w/ accent-purple left-border strip) | `--text-secondary` |
+
+## Typography
+
+Load Inter (UI) + JetBrains Mono (monospace refs) from Google Fonts.
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+```
+
+Scale:
+
+| Role | Font | Size | Weight | Tracking |
+|------|------|------|--------|----------|
+| h1 (page title) | Inter | 28px | 600 | -0.015em |
+| h2 (section) | Inter | 20px | 600 | normal |
+| UI label (CAPS) | Inter | 12px | 500 | 0.08em uppercase |
+| Body | Inter | 14px | 400 | normal |
+| Lede | Inter | 15px | 400 | normal |
+| Node title (mono) | JetBrains Mono | 13px | 600 | -0.01em |
+| Node sub | Inter | 11px | 400 | 0.02em |
+| Version pill | JetBrains Mono | 12px | 400 | normal |
+| Inline `<code>` | JetBrains Mono | 12px | 400 | normal, on tinted bg |
+
+Body defaults: `-webkit-font-smoothing: antialiased`, `-moz-osx-font-smoothing: grayscale`, line-height `1.5`.
+
+## Sidebar anatomy
+
+Four stacked sections with 32px gap between them.
+
+1. **Version badge + tagline**. Monospace pill with a pulsing-dot marker (green `--accent-green` with a soft ring). Tagline below in `--text-muted`, max ~60 chars, one line.
+2. **"On this page" nav**. `UI label` header, vertical list of `<a href="#anchor">` links. Each link: 6px padding, 2px transparent left-border; on hover, border becomes `--accent-blue` and text lifts to `--text-primary`. No underline.
+3. **Architectural invariants**. `UI label` header, vertical list of 3–5 invariants. Each item has a **3px left border in `--accent-green`** and 12px left padding. This section does load-bearing work — surface the invariants a reader needs to have in mind while reading the diagram (things the code protects). Examples: "Kernel owns durable state", "All ops return Result<T,E>", "Writes are atomic (.tmp + rename)". Lead with the rule, put any qualifier inside.
+4. **Legend**. One row per node role; colored 14×10 chip + label. Always include "shared library" even if unused — helps reader calibrate color-coding.
+
+Sidebar is `position: sticky; top: 40px`. It must NOT overflow the viewport vertically at 1024×720 — keep the four sections terse.
+
+## Main column anatomy
+
+Three blocks with 48px gap:
+
+1. **Header** — `<h1>` + lede paragraph (`--text-secondary`, max-width 780px). Lede answers "what is this system, in one paragraph".
+2. **Diagram card** — `--bg-surface`, 1px `--border-subtle`, 12px radius, 32px inner padding. Card header has an `<h2>` on the left + a monospace hint on the right (e.g. "grounded in pnpm-workspace.yaml · package deps · src/ topology").
+3. **Details grid** — 2-column auto-fit grid of `--bg-surface` cards. Each detail card: 24px padding, 10px radius, `<h3>` with a colored 8px dot marker, bulleted list with em-dash prefix.
+
+## Diagram stage (HTML + SVG hybrid)
+
+Fixed-width inner stage wrapped in a horizontally-scrollable container:
+
+```html
+<div class="diagram-scroll">
+  <div class="diagram-stage">
+    <!-- plane boundaries (divs with dashed borders) -->
+    <!-- node cards (position: absolute, pixel coords) -->
+    <!-- claude api / external nodes -->
+    <!-- types bar / spanning elements -->
+    <svg class="arrows-overlay" viewBox="0 0 W H" preserveAspectRatio="none">
+      <!-- arrows -->
+    </svg>
+  </div>
+</div>
+```
+
+Geometry:
+
+- `.diagram-stage` — `position: relative; width: 1060px; height: 700px; min-width: 1060px` (pick a stage width that fits your graph; 1060 is a good default for two planes)
+- `.diagram-scroll` — `overflow-x: auto` so narrow viewports scroll horizontally without breaking layout
+- `.arrows-overlay` — `position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; overflow: visible` — the SVG viewBox matches the stage pixel dimensions 1:1 so coordinates are literal
+
+All nodes use `position: absolute; left/top` in pixels. This is deliberate: the moment you have cross-lane arrows that must land on specific node edges, flex/grid reflow becomes a liability. Fixed pixel positions are boring but correct.
+
+## Node cards
+
+```html
+<div class="node n-service" style="left: 340px; top: 90px; width: 190px;">
+  <div class="node-title">@ico/kernel</div>
+  <div class="node-sub">deterministic · Result&lt;T,E&gt;</div>
+  <ul class="node-list">
+    <li>workspace · state</li>
+    <li>tasks (state machine)</li>
+  </ul>
+  <div class="node-group-label">integrity</div>
+  <ul class="node-list">
+    <li>SHA-256 chained traces</li>
+  </ul>
+</div>
+```
+
+Rules:
+
+- Every node is `position: absolute; left/top` in pixels. Width explicit; height auto.
+- `.node-title` is monospace (package name is code, treat it as code).
+- `.node-sub` is 1 line, ≤ 40 chars.
+- `.node-list li` uses an em-dash `—` prefix via `::before`, NOT a bullet.
+- Inner group labels are small-caps mono, 10px, `--text-muted`.
+- Hover: `--bg-raised-hover` + border opacity 100%.
+
+## Plane boundaries
+
+Dashed border + floating label that breaks through the dashed line (anchored by a matching background-color on the label):
+
+```css
+.plane {
+  position: absolute;
+  border: 1px dashed;
+  border-radius: 10px;
+}
+.plane::before {
+  content: attr(data-label);
+  position: absolute;
+  top: -9px; left: 16px;
+  padding: 0 8px;
+  background: var(--bg-surface); /* matches card bg — punches through the dashed stroke */
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+}
+```
+
+Use `--accent-orange` (~0.6 opacity) for one plane and `--accent-green` (~0.6 opacity) for the other. Pick semantics that read: deterministic / probabilistic, data / control, sync / async — whatever the architecture really splits on.
+
+## Arrow overlay rules
+
+Single `<svg class="arrows-overlay">` with `<defs>` for colored markers, then `<line>` / `<path>` elements per arrow. Coords are literal pixels in the stage's coordinate space.
+
+**Arrow catalogue** (copy the pattern, pick colors by relationship semantics):
+
+| Relationship | Color token | Style |
+|--------------|-------------|-------|
+| Entry invocation | `--accent-blue` | solid |
+| Service ↔ persistence | `--text-muted` | solid, bidirectional pair |
+| Cross-plane read | `--accent-green` | **dashed** (`stroke-dasharray="5 4"`) |
+| Outbound external API | `--accent-orange` | solid |
+| Implicit/shared reference (e.g. types) | `--accent-purple` | dotted (`stroke-dasharray="3 4"`), opacity 0.55 |
+
+Marker definitions (one per color) ensure arrowheads match their line color.
+
+**Routing rule — orthogonal only for cross-component arrows.** If two nodes live in different lanes or different rows, draw the arrow as a horizontal or vertical line — never a diagonal. Diagonals cross through whatever happens to be between the endpoints. Choose a y-coordinate that passes through empty space between rows.
+
+**Label placement.** Labels sit 6–8px above the arrow line at its midpoint, same color as the line, JetBrains Mono 9–10px. For very short arrows (< 60px), omit the label.
+
+## Detail grid
+
+2-column auto-fit grid of detail cards. Each card maps to a "story" about a subsystem — roughly one card per plane + one per external surface + one per cross-cutting concern. 4–6 cards is the sweet spot.
+
+Card structure:
+
+```html
+<div class="detail-card c-green">
+  <h3>Deterministic control plane</h3>
+  <ul>
+    <li>Short claim about the subsystem.</li>
+    <li>Constraint it upholds, or invariant inherited from the diagram.</li>
+    <li>One concrete mechanism — ideally with inline <code>code</code>.</li>
+    <li>Operational property (performance, security, reliability).</li>
+  </ul>
+</div>
+```
+
+`<h3>` has a colored dot marker (`::before`). Match the dot color to the subsystem's accent. 3–5 bullets per card; each bullet ≤ 2 lines. Don't rewrite the whole node contents here — this is commentary, not a node dump.
+
+## Polish
+
+- **No shadows.** Use borders only. Shadows read as decorative in docs UI.
+- **No animations** except the single pulsing version-dot in the sidebar (wrap it in `@media (prefers-reduced-motion: reduce) { animation: none }`).
+- **Hover states** on node cards and nav links only. Never on detail cards or the page chrome.
+- **`font-feature-settings: 'ss01', 'cv11'`** on body enables Inter's stylistic alternates — subtle but raises quality.
+- **Anti-alias** via `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale`.
+- Section labels use uppercase with `letter-spacing: 0.08em` — institutional, not decorative.
+
+## Verification
+
+Pixel positioning means errors won't show up at runtime. Before shipping, run the collision math. The ICO-architecture build established this pattern:
+
+```python
+# layout_check.py — minimal collision detector
+nodes = {
+    "cli":       (170, 400, 135, 110),   # x, y, w, h
+    "kernel":    (340, 90, 190, 380),
+    "sqlite":    (570, 90, 130, 55),
+    # ...
+}
+arrows = [
+    ("cli->kernel",   "cli", "kernel", 305, 425, 338, 425),
+    ("cli->compiler", "cli", "compiler", 305, 485, 768, 485),
+    # ...
+]
+
+def seg_rect(x1,y1,x2,y2, rx,ry,rw,rh):  # Liang-Barsky line-rect intersection
+    ...
+
+# For every arrow, assert it doesn't cross any non-endpoint node.
+# Assert every endpoint lies on its source/target box edge.
+# Assert every node gap >= 40px (where axes overlap).
+# Assert every text label fits inside its parent box at the declared font size.
+```
+
+Three checks, all of which failed at least once during the ICO build:
+
+1. **Arrow-through-node**: Liang-Barsky test between each arrow and every non-endpoint node rect. Must return 0.
+2. **Endpoint attachment**: each arrow start/end must lie on (within 4px of) the corresponding node's edge, not floating in space or buried inside the box.
+3. **Text overflow**: for each text label with a declared font-size, check `len(text) * font_size * 0.60 ≤ inner_box_width` (0.60 is the empirical advance width for JetBrains Mono / Inter; good enough for monospace-like sanity checks).
+
+Only after all three pass should you screenshot. Thumbnail views hide 2-px overlaps; math doesn't.
+
+## Anti-patterns
+
+**Do not:**
+
+- Use CSS Grid to position the *node cards themselves*. It works right up until you need an arrow that lands on a specific edge, at which point you're computing grid-cell centers in JavaScript. Just use absolute positioning.
+- Let the diagram stage be responsive. At 600px wide, your 1060px diagram isn't "smaller" — it's scrolled. That's the correct behavior.
+- Animate the arrow overlay. Flow diagrams aren't slideshows.
+- Add tooltips to nodes. The detail grid already exists for that; duplicating breaks the hierarchy.
+- Paint shadows on plane boundaries. The whole visual language is flat + bordered. Stay there.
+- Pack more than ~8 sub-blocks inside a single node. If a node has 10+ children, promote it to its own plane and split it.

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/drawing-rules.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/drawing-rules.md
@@ -1,0 +1,214 @@
+# Drawing Rules
+
+Visual design rules for engineer-design-diagram output. Palette and arrow-masking pattern inspired by [Cocoon AI/architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (MIT).
+
+## Table of Contents
+
+- [Color Palette](#color-palette)
+- [Role Inference](#role-inference)
+- [Typography](#typography)
+- [Canvas & Grid](#canvas--grid)
+- [Component Boxes](#component-boxes)
+- [Arrow Masking](#arrow-masking)
+- [Z-Order](#z-order)
+- [Boundaries & Groups](#boundaries--groups)
+- [Message Buses](#message-buses)
+- [Spacing Rules](#spacing-rules)
+- [Legend Placement](#legend-placement)
+- [Delta Markers (Diff Mode)](#delta-markers-diff-mode)
+
+## Color Palette
+
+Semantic OKLCH palette by component role. Values are used as CSS custom properties on `:root` in `templates/base.html`.
+
+| Role | Fill (rgba) | Stroke (hex) | CSS tokens |
+|------|-------------|--------------|------------|
+| Frontend | `rgba(8, 51, 68, 0.4)` | `#22d3ee` | `--role-frontend-fill` / `--role-frontend-stroke` |
+| Backend | `rgba(6, 78, 59, 0.4)` | `#34d399` | `--role-backend-fill` / `--role-backend-stroke` |
+| Database | `rgba(76, 29, 149, 0.4)` | `#a78bfa` | `--role-db-fill` / `--role-db-stroke` |
+| Cloud (AWS/GCP/Azure) | `rgba(120, 53, 15, 0.3)` | `#fbbf24` | `--role-cloud-fill` / `--role-cloud-stroke` |
+| Security | `rgba(136, 19, 55, 0.4)` | `#fb7185` | `--role-security-fill` / `--role-security-stroke` |
+| Message Bus | `rgba(251, 146, 60, 0.3)` | `#fb923c` | `--role-bus-fill` / `--role-bus-stroke` |
+| External / Generic | `rgba(30, 41, 59, 0.5)` | `#94a3b8` | `--role-external-fill` / `--role-external-stroke` |
+
+## Role Inference
+
+When the DCI output doesn't explicitly name a role, apply these heuristics in order:
+
+1. **Port-based**: `80/443/3000-3999` + name contains `web|ui|app|frontend|next|react|vue|svelte` → **frontend**
+2. **Image-based** (docker-compose): `postgres|mysql|mongo|redis|cassandra|elastic|dynamo|sqlite` → **database**
+3. **Known bus images**: `kafka|rabbitmq|nats|pulsar|sqs|pubsub|eventhub` → **message-bus**
+4. **Known security services**: `auth|cognito|oauth|keycloak|vault|cert-manager` → **security**
+5. **Cloud-specific kinds**: `aws_*`, `google_*`, `azurerm_*` terraform resources → **cloud**
+6. **HTTP handler**: name contains `api|service|handler|worker|backend|server` → **backend**
+7. **Default**: **external** (slate) — documents in legend as "other / unknown"
+
+## Typography
+
+JetBrains Mono for all text — monospace, technical aesthetic:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+Font sizes:
+- Component name: `12px`, weight `600`
+- Sublabel: `9px`, weight `400`, color `#94a3b8`
+- Annotations: `8px`, weight `400`
+- Tiny labels (bus names): `7px`, weight `400`
+
+## Canvas & Grid
+
+Background: `#020617` (slate-950). Subtle grid pattern as a `<defs><pattern>`:
+
+```svg
+<defs>
+  <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+    <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+  </pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid)"/>
+```
+
+Arrow-mask background fill color (behind semi-transparent boxes): `#0f172a`.
+
+## Component Boxes
+
+Rounded rectangles with 1.5px stroke, semi-transparent fill, `rx="6"`:
+
+```svg
+<rect x="X" y="Y" width="W" height="H" rx="6"
+      fill="var(--role-backend-fill)"
+      stroke="var(--role-backend-stroke)"
+      stroke-width="1.5"/>
+<text x="CX" y="Y+20" fill="white" font-size="12" font-weight="600" text-anchor="middle">Name</text>
+<text x="CX" y="Y+36" fill="#94a3b8" font-size="9" text-anchor="middle">sublabel</text>
+```
+
+Every `<rect>` representing a node must include a `<title>` child for accessibility (see [accessibility.md](accessibility.md)).
+
+Standard dimensions:
+- Width: `180px` default, `140-220px` range
+- Height: `60px` for services, `80-120px` for larger grouped components
+
+## Arrow Masking
+
+Component boxes have semi-transparent fills (`0.3-0.5` alpha), so arrows drawn behind them show through and look messy. The fix: draw an opaque background rect first, then the semi-transparent styled rect on top.
+
+```svg
+<!-- 1. Opaque mask underlayer -->
+<rect x="X" y="Y" width="W" height="H" rx="6" fill="#0f172a"/>
+<!-- 2. Styled semi-transparent box on top -->
+<rect x="X" y="Y" width="W" height="H" rx="6"
+      fill="var(--role-db-fill)"
+      stroke="var(--role-db-stroke)"
+      stroke-width="1.5"/>
+```
+
+## Z-Order
+
+SVG elements are painted in document order. Our stacking rule:
+
+1. `<defs>` (patterns, markers, gradients)
+2. Grid background rect
+3. Group/boundary rects (dashed)
+4. Connection arrows/paths
+5. Arrow-mask underlayers (opaque)
+6. Component box rects (semi-transparent styled)
+7. Component text labels
+8. Legend
+
+Arrows drawn before components appear **behind** them — correct behavior. Arrows drawn last appear on top and obscure text — wrong.
+
+## Boundaries & Groups
+
+**Security groups:** dashed stroke, rose color, transparent fill.
+
+```svg
+<rect x="X" y="Y" width="W" height="H" rx="6"
+      fill="none" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="4,4"/>
+<text x="X+8" y="Y+14" fill="#fb7185" font-size="9" font-weight="500">Security Group</text>
+```
+
+**Region / cluster boundaries:** larger dashes, amber color, rounder corners.
+
+```svg
+<rect x="X" y="Y" width="W" height="H" rx="12"
+      fill="none" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="8,4"/>
+<text x="X+12" y="Y+18" fill="#fbbf24" font-size="10" font-weight="500">us-east-1</text>
+```
+
+## Message Buses
+
+Small inline connectors placed in the gap between services. Orange fill + stroke:
+
+```svg
+<rect x="X" y="Y" width="120" height="20" rx="4"
+      fill="var(--role-bus-fill)" stroke="var(--role-bus-stroke)" stroke-width="1"/>
+<text x="CX" y="Y+14" fill="#fb923c" font-size="7" text-anchor="middle">Kafka / RabbitMQ</text>
+```
+
+## Spacing Rules
+
+**40px minimum vertical gap** between components. Buses go *in* the gap, not overlapping.
+
+Standard component heights:
+- Service/container: `60px`
+- Grouped service (with sublabel list): `80-120px`
+- Message bus connector: `20px` (placed inside the 40px gap)
+
+Correct vertical layout:
+
+```
+Component A:  y=70,   height=60   → ends at y=130
+Gap:          y=130 → y=170       → 40px gap, bus at y=140 (20px tall, centered in 40px gap)
+Component B:  y=170,  height=60   → ends at y=230
+```
+
+Incorrect: placing a bus at `y=160` when Component B starts at `y=170` — causes overlap.
+
+## Legend Placement
+
+**Legends go OUTSIDE all boundary boxes** (regions, clusters, security groups).
+
+1. Compute `max_boundary_y = max(boundary.y + boundary.height for boundary in boundaries)`
+2. Place legend at `y = max_boundary_y + 20px` minimum
+3. Expand SVG `viewBox` height if needed
+
+Correct:
+
+```
+Kubernetes cluster boundary:  y=30,  height=460  → ends at y=490
+Legend:                       y=510  (20px below boundary)
+SVG viewBox height:           ≥ 560 (fits legend + padding)
+```
+
+Incorrect: legend at `y=470` inside a cluster boundary ending at `y=490`.
+
+## Delta Markers (Diff Mode)
+
+For PR-diff output, apply CSS classes to added/removed/changed elements:
+
+```css
+.delta-added {
+  stroke-dasharray: none;
+  filter: drop-shadow(0 0 6px #22c55e);
+}
+.delta-removed {
+  opacity: 0.4;
+  stroke-dasharray: 4,2;
+  filter: grayscale(1);
+}
+.delta-changed {
+  filter: drop-shadow(0 0 6px #fbbf24);
+}
+```
+
+And add a delta legend row next to the main legend:
+
+```svg
+<rect class="delta-added" x="X" y="Y" width="16" height="16" rx="3"/>
+<text x="X+22" y="Y+12" font-size="9">Added in this PR</text>
+```

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/fingerprint-spec.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/fingerprint-spec.md
@@ -1,0 +1,155 @@
+# Fingerprint Specification
+
+Structural state schema for `${CLAUDE_PLUGIN_DATA}/arch-state.json`. Written by generate/diff, read by diff/watch.
+
+## Table of Contents
+
+- [File Location](#file-location)
+- [Schema (JSON)](#schema-json)
+- [Stable Hash Algorithm](#stable-hash-algorithm)
+- [Graph Fingerprint](#graph-fingerprint)
+- [Diff Algorithm](#diff-algorithm)
+- [Schema Versioning](#schema-versioning)
+
+## File Location
+
+Fallback chain (first writable wins):
+
+1. `${CLAUDE_PLUGIN_DATA}/arch-state.json` (preferred — plugin-managed state dir, survives updates)
+2. `${XDG_STATE_HOME}/claude/arch/arch-state.json`
+3. `~/.claude-state/arch/arch-state.json` (final fallback — auto-created)
+
+One state file per active workspace, keyed by `repo.root` in the document.
+
+## Schema (JSON)
+
+```json
+{
+  "schema_version": "1",
+  "generated_at": "2026-04-19T14:05:11Z",
+  "repo": {
+    "root": "/home/jeremy/000-projects/my-app",
+    "git_sha": "a1b2c3d4",
+    "branch": "main",
+    "remote": "git@github.com:org/repo.git"
+  },
+  "nodes": [
+    {
+      "id": "api",
+      "label": "API Service",
+      "role": "backend",
+      "source": "docker-compose.yml:services.api",
+      "tech": ["node", "express"],
+      "ports": [3000],
+      "stable_hash": "sha256:7f3a...e2"
+    }
+  ],
+  "edges": [
+    {
+      "from": "web",
+      "to": "api",
+      "kind": "http",
+      "label": "/v1/*",
+      "source": "web/src/lib/api-client.ts:12",
+      "stable_hash": "sha256:4c9d...11"
+    }
+  ],
+  "groups": [
+    {
+      "id": "vpc-prod",
+      "label": "Production VPC",
+      "kind": "region",
+      "members": ["api", "db", "cache"]
+    }
+  ],
+  "annotations": [
+    {
+      "node_id": "payment-service",
+      "kind": "git-blame",
+      "text": "added in v4.2 by @alice (2025-11-03)",
+      "source": "git log --diff-filter=A --follow"
+    }
+  ],
+  "tech_inventory": {
+    "package_managers": ["npm", "pip"],
+    "orchestrators": ["docker-compose"],
+    "iac": [],
+    "cloud_providers_detected": []
+  },
+  "graph_fingerprint": "sha256:9b8a...cd"
+}
+```
+
+### Node fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | yes | Unique within graph; kebab-case |
+| `label` | string | yes | Display name |
+| `role` | enum | yes | One of: `frontend`, `backend`, `database`, `cloud`, `security`, `message-bus`, `external` |
+| `source` | string | yes | `file:line` citation for where this node was inferred from |
+| `tech` | string[] | no | Tags like `["node", "express"]`, `["python", "fastapi"]` |
+| `ports` | number[] | no | Exposed ports |
+| `stable_hash` | string | yes | `sha256(role + label + sorted-neighbors)` — identity preserved across position changes |
+
+### Edge fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `from` | string | yes | Source node id |
+| `to` | string | yes | Destination node id |
+| `kind` | enum | yes | `http`, `grpc`, `queue`, `db`, `import`, `fs`, `auth`, `unknown` |
+| `label` | string | no | Edge annotation (route, protocol) |
+| `source` | string | yes | `file:line` citation |
+| `stable_hash` | string | yes | `sha256(from + to + kind)` |
+
+## Stable Hash Algorithm
+
+Per-element hash preserves identity when a node shifts position or a label is cosmetic-only.
+
+```python
+def node_stable_hash(node, neighbor_ids):
+    canonical = f"{node['role']}|{node['label']}|{'|'.join(sorted(neighbor_ids))}"
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+def edge_stable_hash(edge):
+    canonical = f"{edge['from']}|{edge['to']}|{edge['kind']}"
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+```
+
+Rename a node label (e.g., "API Service" → "Core API") → hash changes → treated as a change, not add+remove.
+
+Change a node's neighbors → hash changes → surfaces as a `changed` node in diff output.
+
+## Graph Fingerprint
+
+A single rollup hash of the sorted set of all stable_hash values. Lets watch mode answer "did anything change?" in O(1) without a full diff.
+
+```python
+def graph_fingerprint(nodes, edges):
+    all_hashes = sorted([n["stable_hash"] for n in nodes] + [e["stable_hash"] for e in edges])
+    return "sha256:" + hashlib.sha256("".join(all_hashes).encode()).hexdigest()
+```
+
+## Diff Algorithm
+
+Given `old_state` and `new_state`:
+
+1. **Added nodes** = `{n in new_state.nodes where n.id not in old_state.nodes}`
+2. **Removed nodes** = `{n in old_state.nodes where n.id not in new_state.nodes}`
+3. **Changed nodes** = `{n where n.id exists in both but n.stable_hash differs}`
+4. **Added edges** = `{e in new_state.edges where e.stable_hash not in old_state.edges.stable_hashes}`
+5. **Removed edges** = symmetric
+6. **Changed edges** = edges with matching `from|to` but different `kind` or `label`
+
+Return four lists + the new fingerprint.
+
+## Schema Versioning
+
+`schema_version` is a **string** so bumps are non-destructive. Rules:
+
+- `fingerprint.py` **refuses** to diff across schema versions — emits "baseline restart required" instead.
+- Migration: when `schema_version` changes, next run writes a fresh state and archives the prior one to `arch-state.json.v<old>.bak`.
+- Policy: bump `schema_version` whenever adding a required field or changing a field's semantics.
+
+Current version: **`"1"`**.

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/mode-playbooks.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/mode-playbooks.md
@@ -1,0 +1,122 @@
+# Mode Playbooks
+
+Per-mode workflows for engineer-design-diagram. Each playbook covers input contract, steps, output contract, and failure modes.
+
+## Table of Contents
+
+- [generate](#generate)
+- [diff](#diff)
+- [trace](#trace)
+- [watch](#watch)
+
+## generate
+
+Produce an architecture view of the current repository.
+
+**Input contract:**
+- Current working directory is a git repo (or has discoverable manifests)
+- Optional: `$ARGUMENTS[1]` = path to scope (default: repo root)
+
+**Steps:**
+1. Read DCI block output from SKILL.md activation.
+2. Build node set from docker-compose services, k8s Deployments/Services, terraform resources, package manifest names.
+3. Build edge set from `depends_on`, exposed ports + HTTP client imports (via Grep), k8s Service selectors, terraform resource references.
+4. Classify each node's role per [drawing-rules.md § Role inference](drawing-rules.md#role-inference).
+5. Fill `templates/base.html` per [drawing-rules.md](drawing-rules.md). Write to `$CWD/.arch/generate-<timestamp>.html`.
+6. Write fingerprint via `scripts/fingerprint.py write`.
+7. Run `scripts/validate_html.py` on output. If ARIA or no-externals check fails, re-fill template.
+8. Echo Mermaid equivalent to chat.
+9. Open HTML via `scripts/open_in_browser.sh`.
+
+**Output contract:**
+- `$CWD/.arch/generate-<ISO-timestamp>.html` — single-file HTML, offline-capable
+- Mermaid text block in chat
+- Updated `${CLAUDE_PLUGIN_DATA}/arch-state.json`
+
+**Failure modes:**
+- No manifests detected → ask user to describe system in prose, render prose-only diagram
+- >50 nodes → auto-switch to `templates/mermaid-fallback.html`
+- Layout collision detected → retry with Mermaid
+
+## diff
+
+Produce a before/after architecture view with delta highlighting, for PR review.
+
+**Input contract:**
+- Current branch is NOT the default branch
+- Default branch discoverable via `origin/HEAD`, `main`, `master`, or `trunk`
+
+**Steps:**
+1. Probe default branch: `git symbolic-ref refs/remotes/origin/HEAD` → fallback chain.
+2. Read prior fingerprint from `${CLAUDE_PLUGIN_DATA}/arch-state.json` if it exists, else generate from default branch checkout.
+3. Re-run DCI on working tree (current branch).
+4. Compute diff: `added_nodes`, `removed_nodes`, `changed_nodes` (role change), `added_edges`, `removed_edges`.
+5. Fill `templates/base.html` with all nodes from the NEW state. Apply `class="delta-added"` / `delta-removed` / `delta-changed` per [drawing-rules.md § Delta Markers](drawing-rules.md#delta-markers-diff-mode).
+6. Write output to `$CWD/.arch/diff-<timestamp>.html`.
+7. Update fingerprint to reflect the new state.
+8. Emit summary line: `Added N nodes, M edges. Removed X nodes, Y edges.`
+
+**Output contract:**
+- `$CWD/.arch/diff-<ISO-timestamp>.html` with delta classes on changed elements
+- Mermaid text block
+- One-line delta summary in chat
+- Updated fingerprint
+
+**Failure modes:**
+- No default branch found → use `HEAD~1` as base, warn user
+- Both branches have identical structure → output "No structural changes detected" and exit without writing
+
+## trace
+
+Render a sequence diagram from a stack trace, log span, or incident event.
+
+**Input contract:**
+- `$ARGUMENTS[1]` = path to trace file (required)
+- Supported formats: Sentry JSON, OpenTelemetry span JSON, raw stack trace text
+
+**Steps:**
+1. Detect format by file shape: `.json` → inspect top-level keys; `.txt` or no extension → assume raw stack trace.
+2. Parse using appropriate parser:
+   - **Sentry**: extract `exception.values[].stacktrace.frames[]` + `spans[]`
+   - **OTel**: parse `resourceSpans[].scopeSpans[].spans[]` by `parentSpanId` for call order
+   - **Raw**: regex `at ServiceName.methodName(file.ext:line)` lines
+3. Collapse frames into lifelines (one per service/module).
+4. Build message list with timestamps where available.
+5. Fill `templates/sequence.html`. Mark the final/error arrow with `class="error"`.
+6. Write to `$CWD/.arch/trace-<timestamp>.html`.
+7. **Do not write fingerprint** (trace mode doesn't alter architectural state).
+
+**Output contract:**
+- `$CWD/.arch/trace-<ISO-timestamp>.html` with sequence diagram
+- Mermaid `sequenceDiagram` text block
+- No fingerprint write
+
+**Failure modes:**
+- Unknown format → emit Mermaid-only sequence with best-effort parsing, flag for user review
+- <2 lifelines parseable → output "Trace too shallow for sequence diagram" with raw trace excerpt
+
+## watch
+
+Detect architectural drift by comparing current repo state against last stored fingerprint.
+
+**Input contract:**
+- `${CLAUDE_PLUGIN_DATA}/arch-state.json` exists (from a prior generate/diff run)
+
+**Steps:**
+1. Load prior fingerprint.
+2. Re-run DCI on current working tree.
+3. Build new node/edge graph.
+4. Compute structural diff (same algorithm as diff mode, Step 4).
+5. For each delta, cite the source file + line that justifies it (from DCI output and Grep).
+6. Emit markdown report — **no HTML render** in watch mode.
+
+**Output contract:**
+- Markdown report with sections `Added`, `Removed`, `Changed`
+- Each bullet cites `source:file:line`
+- Final line: `New graph_fingerprint: <sha256>`
+- Updated fingerprint (optional — ask user before overwriting if drift is significant)
+
+**Failure modes:**
+- No prior fingerprint → output "No baseline found. Run `/design:generate` first to establish a fingerprint."
+- Schema version mismatch → output "Fingerprint schema drift. Run `/design:generate` to re-baseline."
+- No drift detected → output "No structural drift since <prior timestamp>."

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/troubleshooting.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/references/troubleshooting.md
@@ -1,0 +1,90 @@
+# Troubleshooting
+
+Known issues and recovery paths.
+
+## Table of Contents
+
+- [iOS Safari Rendering](#ios-safari-rendering)
+- [Large Graphs (>50 nodes)](#large-graphs-50-nodes)
+- [Fingerprint Schema Drift](#fingerprint-schema-drift)
+- [DCI Output Truncated](#dci-output-truncated)
+- [LLM Produces Overlapping Layout](#llm-produces-overlapping-layout)
+- [${CLAUDE_PLUGIN_DATA} Not Set](#claude_plugin_data-not-set)
+- [Unknown Stack Trace Format](#unknown-stack-trace-format)
+
+## iOS Safari Rendering
+
+**Symptom:** diagram renders blank or truncated on iPhone/iPad.
+
+**Cause:** iOS Safari has a known limit on SVG path length (~10k points per element) and a line-length cap on embedded CSS (>5000 chars per line can fail to paint).
+
+**Fix:**
+- Keep SVG paths short — split long polylines into multiple `<path>` elements.
+- Break inline `<style>` into multiple lines; never emit one megaline of CSS.
+- For any graph exceeding these limits, fall back to `templates/mermaid-fallback.html`.
+
+## Large Graphs (>50 nodes)
+
+**Symptom:** SVG layout becomes a tangle of overlapping boxes and crossing arrows.
+
+**Cause:** The base template uses hand-placed coordinates. At >50 nodes, layout quality collapses.
+
+**Fix:** auto-switch to Mermaid fallback. Trigger conditions (any one):
+- Node count > 50
+- Detected layout collision (two nodes overlap in output)
+- Heuristic flag: sum of `(node.width * node.height)` exceeds 60% of canvas area
+
+## Fingerprint Schema Drift
+
+**Symptom:** `watch` or `diff` emits "baseline restart required".
+
+**Cause:** The `schema_version` field in `arch-state.json` differs from the current skill's schema.
+
+**Fix:**
+- Archive the old state: `mv arch-state.json arch-state.json.v<old>.bak`
+- Run `/design:generate` to write a fresh baseline with the current schema
+- Future diffs compare against the new baseline
+
+## DCI Output Truncated
+
+**Symptom:** a manifest file exists but the diagram is missing services from it.
+
+**Cause:** inline DCI has size caps (see [dci-block.md § Size Budgets](dci-block.md#size-budgets)). Large `package.json` files, sprawling `docker-compose.yml`, or giant `terraform show` output may be truncated.
+
+**Fix:** call `scripts/collect_dci.sh` to fetch bounded extras. Treat the harvester output as authoritative over the inline DCI sample.
+
+## LLM Produces Overlapping Layout
+
+**Symptom:** `validate_html.py` reports overlapping `<rect>` elements.
+
+**Cause:** LLM hand-placing coordinates missed the 40px gap rule or placed a message bus outside the gap.
+
+**Fix (automated):**
+- Validator emits the overlap coordinates in its error message
+- Re-run template fill with an added constraint: "Move node X to y=N+40" based on validator output
+- Max 3 iterations; on 4th failure, fall back to Mermaid
+
+## ${CLAUDE_PLUGIN_DATA} Not Set
+
+**Symptom:** `fingerprint.py` can't find a writable location for state.
+
+**Cause:** env var not set (skill running outside plugin context, or v<2.1.78 Claude Code).
+
+**Fix (automatic fallback chain):**
+1. `${CLAUDE_PLUGIN_DATA}/arch-state.json`
+2. `${XDG_STATE_HOME}/claude/arch/arch-state.json`
+3. `~/.claude-state/arch/arch-state.json` (auto-created)
+
+Script probes each in order; first writable wins.
+
+## Unknown Stack Trace Format
+
+**Symptom:** `/design:trace <file>` outputs "trace parser unknown format".
+
+**Cause:** the input doesn't match Sentry JSON, OpenTelemetry span JSON, or a recognizable raw-text pattern.
+
+**Fix:**
+- Inspect input file manually to identify format
+- If it's a supported format with unusual shape, report the format to the skill maintainer
+- As a workaround: reformat input as raw stack trace (`at ServiceName.methodName(file.ext:line)` per line)
+- Fallback: emit Mermaid-only sequence with best-effort parsing; accuracy not guaranteed

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/collect_dci.sh
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/collect_dci.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# collect_dci.sh — bounded DCI harvester for engineer-design-diagram.
+# Emits a JSON document to stdout with topology signals, respecting size caps
+# documented in references/dci-block.md.
+#
+# Usage: collect_dci.sh [repo-root]
+# Default repo-root: $(pwd)
+#
+# Required: bash 4+, git, jq. Optional: yq, docker, terraform.
+
+set -eu
+set -o pipefail
+
+ROOT="${1:-$(pwd)}"
+cd "$ROOT" || { echo '{"error":"cannot cd to root"}' && exit 1; }
+
+# Size-capped constants (documented in references/dci-block.md § Size Budgets)
+GIT_FILES_CAP=500
+COMPOSE_BYTES_CAP=40960
+K8S_RESOURCE_CAP=20
+TERRAFORM_BYTES_CAP=81920
+
+emit() { jq -n --argjson v "$1" --arg k "$2" '{($k): $v}'; }
+
+# Git file inventory (capped at 500 paths, filtered by extension)
+GIT_FILES_JSON="[]"
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  GIT_FILES_JSON=$(
+    git ls-files '*.ts' '*.tsx' '*.js' '*.py' '*.go' '*.rs' '*.java' '*.rb' 2>/dev/null \
+      | head -n "$GIT_FILES_CAP" \
+      | jq -R -s 'split("\n") | map(select(length > 0))'
+  )
+fi
+
+# Docker-compose config (capped at 40 KB)
+COMPOSE_JSON='null'
+if command -v docker >/dev/null 2>&1 && [ -f docker-compose.yml -o -f compose.yml ]; then
+  RAW=$(docker compose config 2>/dev/null | head -c "$COMPOSE_BYTES_CAP" || true)
+  if [ -n "$RAW" ]; then
+    COMPOSE_JSON=$(jq -Rs . <<< "$RAW")
+  fi
+fi
+
+# k8s manifests (capped at 20 resources across detected dirs)
+K8S_JSON="[]"
+K8S_DIRS=$(find . -maxdepth 3 -type d \( -name k8s -o -name kubernetes -o -name manifests \) 2>/dev/null | head -5)
+if [ -n "$K8S_DIRS" ] && command -v yq >/dev/null 2>&1; then
+  K8S_RAW=$(
+    for d in $K8S_DIRS; do
+      find "$d" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n "$K8S_RESOURCE_CAP"
+    done \
+      | xargs -I {} yq -o=json '{"file": "{}", "kind": .kind, "name": .metadata.name}' {} 2>/dev/null \
+      | jq -s '.' 2>/dev/null
+  )
+  [ -n "$K8S_RAW" ] && K8S_JSON="$K8S_RAW"
+fi
+
+# Terraform state snapshot (capped at 80 KB)
+TF_JSON='null'
+if command -v terraform >/dev/null 2>&1 && [ -f terraform.tfstate ]; then
+  TF_RAW=$(terraform show -json 2>/dev/null | head -c "$TERRAFORM_BYTES_CAP" || true)
+  if [ -n "$TF_RAW" ]; then
+    TF_JSON=$(jq -Rs . <<< "$TF_RAW")
+  fi
+fi
+
+# Compose final JSON document
+jq -n \
+  --argjson git_files "$GIT_FILES_JSON" \
+  --argjson compose "$COMPOSE_JSON" \
+  --argjson k8s "$K8S_JSON" \
+  --argjson tf "$TF_JSON" \
+  --arg root "$ROOT" \
+  '{
+    root: $root,
+    git_files: $git_files,
+    git_files_count: ($git_files | length),
+    docker_compose_config: $compose,
+    k8s_resources: $k8s,
+    terraform_state: $tf,
+    truncated: false
+  }'

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/fingerprint.py
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/fingerprint.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+fingerprint.py — write, read, and diff structural fingerprints for engineer-design-diagram.
+
+Usage:
+    fingerprint.py write --input graph.json          # write new state
+    fingerprint.py read                                # dump current state
+    fingerprint.py diff --input graph.json            # diff current state against provided graph
+    fingerprint.py path                                # print the resolved state file path
+
+State file location (fallback chain):
+    1. ${CLAUDE_PLUGIN_DATA}/arch-state.json
+    2. ${XDG_STATE_HOME}/claude/arch/arch-state.json
+    3. ~/.claude-state/arch/arch-state.json
+
+Schema documented in references/fingerprint-spec.md. Current schema_version: "1".
+
+Required packages: Python 3.9+ standard library only (hashlib, json, pathlib, os, sys, argparse).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1"
+STATE_FILENAME = "arch-state.json"
+
+
+def resolve_state_path() -> Path:
+    """Return first writable location for the state file, creating parent dirs if needed."""
+    candidates = []
+
+    if "CLAUDE_PLUGIN_DATA" in os.environ:
+        candidates.append(Path(os.environ["CLAUDE_PLUGIN_DATA"]) / STATE_FILENAME)
+
+    xdg = os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local" / "state"))
+    candidates.append(Path(xdg) / "claude" / "arch" / STATE_FILENAME)
+
+    candidates.append(Path.home() / ".claude-state" / "arch" / STATE_FILENAME)
+
+    for path in candidates:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            return path
+        except OSError:
+            continue
+
+    raise RuntimeError("No writable state location found")
+
+
+def node_stable_hash(node: dict[str, Any], neighbor_ids: list[str]) -> str:
+    canonical = f"{node.get('role', '')}|{node.get('label', '')}|{'|'.join(sorted(neighbor_ids))}"
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def edge_stable_hash(edge: dict[str, Any]) -> str:
+    canonical = f"{edge['from']}|{edge['to']}|{edge.get('kind', 'unknown')}"
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def graph_fingerprint(nodes: list[dict], edges: list[dict]) -> str:
+    all_hashes = sorted([n["stable_hash"] for n in nodes] + [e["stable_hash"] for e in edges])
+    return "sha256:" + hashlib.sha256("".join(all_hashes).encode()).hexdigest()
+
+
+def enrich(graph: dict[str, Any]) -> dict[str, Any]:
+    """Add stable_hash fields and graph_fingerprint to a bare graph."""
+    nodes = graph.get("nodes", [])
+    edges = graph.get("edges", [])
+
+    # Build neighbor map for stable node hashing
+    neighbors: dict[str, set[str]] = {n["id"]: set() for n in nodes}
+    for e in edges:
+        if e["from"] in neighbors:
+            neighbors[e["from"]].add(e["to"])
+        if e["to"] in neighbors:
+            neighbors[e["to"]].add(e["from"])
+
+    for n in nodes:
+        n["stable_hash"] = node_stable_hash(n, sorted(neighbors.get(n["id"], [])))
+    for e in edges:
+        e["stable_hash"] = edge_stable_hash(e)
+
+    graph["graph_fingerprint"] = graph_fingerprint(nodes, edges)
+    graph["schema_version"] = SCHEMA_VERSION
+    graph["generated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return graph
+
+
+def cmd_write(input_path: str) -> int:
+    with open(input_path) as f:
+        graph = json.load(f)
+    enriched = enrich(graph)
+    state_path = resolve_state_path()
+    with open(state_path, "w") as f:
+        json.dump(enriched, f, indent=2)
+        f.write("\n")
+    print(f"Wrote fingerprint to {state_path}")
+    print(f"graph_fingerprint: {enriched['graph_fingerprint']}")
+    return 0
+
+
+def cmd_read() -> int:
+    state_path = resolve_state_path()
+    if not state_path.exists():
+        print(f"No state file at {state_path}", file=sys.stderr)
+        return 2
+    with open(state_path) as f:
+        print(f.read())
+    return 0
+
+
+def cmd_diff(input_path: str) -> int:
+    state_path = resolve_state_path()
+    if not state_path.exists():
+        print(f"No prior state at {state_path} — run `write` first to establish baseline.", file=sys.stderr)
+        return 2
+
+    with open(state_path) as f:
+        old = json.load(f)
+    with open(input_path) as f:
+        new = json.load(f)
+    new = enrich(new)
+
+    if old.get("schema_version") != SCHEMA_VERSION:
+        print(f"Schema mismatch: prior={old.get('schema_version')} current={SCHEMA_VERSION}", file=sys.stderr)
+        print("Refusing to diff across schema versions. Re-baseline with `write`.", file=sys.stderr)
+        return 3
+
+    old_node_ids = {n["id"]: n for n in old.get("nodes", [])}
+    new_node_ids = {n["id"]: n for n in new.get("nodes", [])}
+    old_edge_hashes = {e["stable_hash"]: e for e in old.get("edges", [])}
+    new_edge_hashes = {e["stable_hash"]: e for e in new.get("edges", [])}
+
+    added_nodes = [n for nid, n in new_node_ids.items() if nid not in old_node_ids]
+    removed_nodes = [n for nid, n in old_node_ids.items() if nid not in new_node_ids]
+    changed_nodes = [
+        n for nid, n in new_node_ids.items()
+        if nid in old_node_ids and old_node_ids[nid]["stable_hash"] != n["stable_hash"]
+    ]
+    added_edges = [e for h, e in new_edge_hashes.items() if h not in old_edge_hashes]
+    removed_edges = [e for h, e in old_edge_hashes.items() if h not in new_edge_hashes]
+
+    diff = {
+        "prior_fingerprint": old.get("graph_fingerprint"),
+        "new_fingerprint": new["graph_fingerprint"],
+        "changed": old.get("graph_fingerprint") != new["graph_fingerprint"],
+        "added_nodes": added_nodes,
+        "removed_nodes": removed_nodes,
+        "changed_nodes": changed_nodes,
+        "added_edges": added_edges,
+        "removed_edges": removed_edges,
+    }
+    print(json.dumps(diff, indent=2))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="fingerprint.py — structural state for engineer-design-diagram")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_write = sub.add_parser("write", help="Write new state from a graph JSON input")
+    p_write.add_argument("--input", required=True, help="Path to graph JSON")
+
+    sub.add_parser("read", help="Dump current state file to stdout")
+
+    p_diff = sub.add_parser("diff", help="Diff current state against a new graph JSON")
+    p_diff.add_argument("--input", required=True, help="Path to graph JSON")
+
+    sub.add_parser("path", help="Print resolved state file path")
+
+    args = parser.parse_args()
+
+    if args.cmd == "write":
+        return cmd_write(args.input)
+    if args.cmd == "read":
+        return cmd_read()
+    if args.cmd == "diff":
+        return cmd_diff(args.input)
+    if args.cmd == "path":
+        print(resolve_state_path())
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/open_in_browser.sh
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/open_in_browser.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# open_in_browser.sh — OS-aware HTML file opener for engineer-design-diagram output.
+# Usage: open_in_browser.sh path/to/file.html
+# Exits 0 on launch attempt, non-zero if no opener found.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 path/to/file.html" >&2
+  exit 2
+fi
+
+FILE="$1"
+if [ ! -f "$FILE" ]; then
+  echo "File not found: $FILE" >&2
+  exit 2
+fi
+
+# Probe openers in priority order: xdg-open (Linux), open (macOS), wslview (WSL), start (Git Bash on Windows)
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$FILE" >/dev/null 2>&1 &
+  echo "Opened via xdg-open: $FILE"
+elif command -v open >/dev/null 2>&1; then
+  open "$FILE"
+  echo "Opened via macOS open: $FILE"
+elif command -v wslview >/dev/null 2>&1; then
+  wslview "$FILE"
+  echo "Opened via wslview: $FILE"
+elif command -v start >/dev/null 2>&1; then
+  start "$FILE"
+  echo "Opened via start: $FILE"
+else
+  echo "No browser opener found. Open manually: $FILE" >&2
+  exit 1
+fi

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/validate_html.py
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/scripts/validate_html.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+validate_html.py — accessibility + no-external-deps check for engineer-design-diagram output.
+
+Usage:
+    validate_html.py path/to/diagram.html
+
+Checks:
+    1. SVG root has role="img" and aria-labelledby
+    2. <title> element is present in SVG
+    3. At least one <rect> has a <title> child (component labeling)
+    4. prefers-reduced-motion media query exists in <style>
+    5. No external script src (Google Fonts links are allowed)
+
+Exits 0 on pass, 1 on fail with details printed to stderr.
+Required packages: Python 3.9+ standard library only (re, sys, pathlib).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def validate(html: str) -> list[str]:
+    errors = []
+
+    # 1. SVG with role="img" + aria-labelledby
+    svg_match = re.search(r"<svg[^>]*>", html, re.IGNORECASE)
+    if not svg_match:
+        errors.append("No <svg> element found")
+    else:
+        svg_tag = svg_match.group(0)
+        if 'role="img"' not in svg_tag and "role='img'" not in svg_tag:
+            errors.append('SVG root missing role="img"')
+        if "aria-labelledby" not in svg_tag and "aria-label" not in svg_tag:
+            errors.append("SVG root missing aria-labelledby or aria-label")
+
+    # 2. <title> in SVG body
+    if not re.search(r"<title[^>]*>", html, re.IGNORECASE):
+        errors.append("No <title> element found in SVG")
+
+    # 3. At least one <rect> with accompanying <title> or aria-label (sampling check)
+    rect_count = len(re.findall(r"<rect\b", html, re.IGNORECASE))
+    titled_rect_pattern = re.compile(
+        r"<rect[^>]*>\s*<title>", re.IGNORECASE | re.DOTALL
+    )
+    aria_rect_pattern = re.compile(r"<rect[^>]*aria-label", re.IGNORECASE)
+    if rect_count > 2:  # skip background/grid rects
+        titled = len(titled_rect_pattern.findall(html)) + len(aria_rect_pattern.findall(html))
+        if titled == 0:
+            errors.append(f"Found {rect_count} <rect> elements but none have <title> or aria-label")
+
+    # 4. prefers-reduced-motion media query
+    if "prefers-reduced-motion" not in html:
+        errors.append("Missing @media (prefers-reduced-motion: reduce) rule")
+
+    # 5. No external scripts beyond allowed CDN allowlist
+    # Allowed: Google Fonts CSS, jsdelivr for Mermaid (fallback template)
+    allowed_hosts = ("fonts.googleapis.com", "fonts.gstatic.com", "cdn.jsdelivr.net")
+    for src_match in re.finditer(r'<script[^>]+src=["\']([^"\']+)["\']', html, re.IGNORECASE):
+        src = src_match.group(1)
+        if not any(host in src for host in allowed_hosts):
+            errors.append(f"Disallowed external script: {src}")
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} path/to/diagram.html", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 2
+
+    html = path.read_text(encoding="utf-8")
+    errors = validate(html)
+
+    if errors:
+        print(f"VALIDATION FAILED: {path}", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {path} passes accessibility + no-external-deps checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/base.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/base.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[PROJECT NAME] Architecture Diagram</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    
+    .header {
+      margin-bottom: 2rem;
+    }
+    
+    .header-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 0.5rem;
+    }
+    
+    .pulse-dot {
+      width: 12px;
+      height: 12px;
+      background: #22d3ee;
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+    
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.025em;
+    }
+    
+    .subtitle {
+      color: #94a3b8;
+      font-size: 0.875rem;
+      margin-left: 1.75rem;
+    }
+    
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 1rem;
+      border: 1px solid #1e293b;
+      padding: 1.5rem;
+      overflow-x: auto;
+    }
+    
+    svg {
+      width: 100%;
+      min-width: 900px;
+      display: block;
+    }
+    
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin-top: 2rem;
+    }
+    
+    .card {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 0.75rem;
+      border: 1px solid #1e293b;
+      padding: 1.25rem;
+    }
+    
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    .card-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+    
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.rose { background: #fb7185; }
+    
+    .card h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+    
+    .card ul {
+      list-style: none;
+      color: #94a3b8;
+      font-size: 0.75rem;
+    }
+    
+    .card li {
+      margin-bottom: 0.375rem;
+    }
+    
+    .footer {
+      text-align: center;
+      margin-top: 1.5rem;
+      color: #475569;
+      font-size: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>[PROJECT NAME] Architecture</h1>
+      </div>
+      <p class="subtitle">[Subtitle description]</p>
+    </div>
+
+    <!-- Main Diagram -->
+    <div class="diagram-container">
+      <svg viewBox="0 0 1000 680">
+        <!-- Definitions -->
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <!-- Background Grid -->
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- =================================================================
+             COMPONENT EXAMPLES - Copy and customize these patterns
+             ================================================================= -->
+
+        <!-- External/Generic Component -->
+        <rect x="30" y="280" width="100" height="50" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="80" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Users</text>
+        <text x="80" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">Browser/Mobile</text>
+
+        <!-- Security Component -->
+        <rect x="30" y="80" width="100" height="60" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="80" y="105" fill="white" font-size="11" font-weight="600" text-anchor="middle">Auth Provider</text>
+        <text x="80" y="121" fill="#94a3b8" font-size="9" text-anchor="middle">OAuth 2.0</text>
+
+        <!-- Region/Cloud Boundary -->
+        <rect x="160" y="40" width="820" height="620" rx="12" fill="rgba(251, 191, 36, 0.05)" stroke="#fbbf24" stroke-width="1" stroke-dasharray="8,4"/>
+        <text x="172" y="58" fill="#fbbf24" font-size="10" font-weight="600">AWS Region: us-west-2</text>
+
+        <!-- AWS/Cloud Service -->
+        <rect x="200" y="280" width="110" height="50" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="255" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">CloudFront</text>
+        <text x="255" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">CDN</text>
+
+        <!-- Multi-line AWS Component (S3 Buckets example) -->
+        <rect x="200" y="380" width="110" height="100" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="255" y="400" fill="white" font-size="11" font-weight="600" text-anchor="middle">S3 Buckets</text>
+        <text x="255" y="420" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-one</text>
+        <text x="255" y="434" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-two</text>
+        <text x="255" y="448" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-three</text>
+        <text x="255" y="466" fill="#fbbf24" font-size="7" text-anchor="middle">OAI Protected</text>
+
+        <!-- Security Group (dashed boundary) -->
+        <rect x="350" y="265" width="120" height="80" rx="8" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <text x="358" y="279" fill="#fb7185" font-size="8">sg-name :port</text>
+        
+        <!-- Component inside security group -->
+        <rect x="360" y="280" width="100" height="50" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="410" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Load Balancer</text>
+        <text x="410" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">HTTPS :443</text>
+
+        <!-- Backend Component -->
+        <rect x="510" y="280" width="110" height="50" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="565" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">API Server</text>
+        <text x="565" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">FastAPI :8000</text>
+
+        <!-- Database Component -->
+        <rect x="700" y="280" width="120" height="50" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="760" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Database</text>
+        <text x="760" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">PostgreSQL</text>
+
+        <!-- Frontend Component -->
+        <rect x="200" y="520" width="200" height="110" rx="8" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="300" y="545" fill="white" font-size="12" font-weight="600" text-anchor="middle">Frontend</text>
+        <text x="300" y="565" fill="#94a3b8" font-size="9" text-anchor="middle">React + TypeScript</text>
+        <text x="300" y="580" fill="#94a3b8" font-size="9" text-anchor="middle">Additional detail</text>
+        <text x="300" y="595" fill="#94a3b8" font-size="9" text-anchor="middle">More info</text>
+        <text x="300" y="615" fill="#22d3ee" font-size="8" text-anchor="middle">domain.example.com</text>
+
+        <!-- =================================================================
+             ARROW EXAMPLES
+             ================================================================= -->
+
+        <!-- Standard arrow with label -->
+        <line x1="130" y1="305" x2="198" y2="305" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="164" y="299" fill="#94a3b8" font-size="9" text-anchor="middle">HTTPS</text>
+        
+        <!-- Simple arrow (no label) -->
+        <line x1="310" y1="305" x2="358" y2="305" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        
+        <!-- Vertical arrow -->
+        <line x1="255" y1="330" x2="255" y2="378" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="270" y="358" fill="#94a3b8" font-size="9">OAI</text>
+        
+        <!-- Dashed arrow (for auth/security flows) -->
+        <line x1="460" y1="305" x2="508" y2="305" stroke="#34d399" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="620" y1="305" x2="698" y2="305" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="655" y="299" fill="#94a3b8" font-size="9">TLS</text>
+
+        <!-- Curved path for auth flow -->
+        <path d="M 80 140 L 80 200 Q 80 220 100 220 L 200 220 Q 220 220 220 240 L 220 278" fill="none" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="5,5"/>
+        <text x="150" y="210" fill="#fb7185" font-size="8">JWT + PKCE</text>
+
+        <!-- =================================================================
+             LEGEND
+             ================================================================= -->
+        <text x="720" y="70" fill="white" font-size="10" font-weight="600">Legend</text>
+        
+        <rect x="720" y="82" width="16" height="10" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="742" y="90" fill="#94a3b8" font-size="8">Frontend</text>
+        
+        <rect x="720" y="98" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="742" y="106" fill="#94a3b8" font-size="8">Backend</text>
+        
+        <rect x="720" y="114" width="16" height="10" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="742" y="122" fill="#94a3b8" font-size="8">Cloud Service</text>
+        
+        <rect x="720" y="130" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="742" y="138" fill="#94a3b8" font-size="8">Database</text>
+        
+        <rect x="720" y="146" width="16" height="10" rx="2" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1"/>
+        <text x="742" y="154" fill="#94a3b8" font-size="8">Security</text>
+        
+        <line x1="720" y1="168" x2="736" y2="168" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3"/>
+        <text x="742" y="171" fill="#94a3b8" font-size="8">Auth Flow</text>
+        
+        <rect x="720" y="178" width="16" height="10" rx="2" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3"/>
+        <text x="742" y="186" fill="#94a3b8" font-size="8">Security Group</text>
+      </svg>
+    </div>
+
+    <!-- Info Cards -->
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Card Title 1</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>Card Title 2</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Card Title 3</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <p class="footer">
+      [Project Name] • [Additional metadata]
+    </p>
+  </div>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/docs-layout.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/docs-layout.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<!--
+  Widescreen docs-layout template for engineer-design-diagram.
+  Fill placeholders [IN BRACKETS] per references/docs-layout.md.
+  Target: min-width 1024px. No mobile breakpoints. Widescreen-first.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[PROJECT NAME] Architecture · [VERSION]</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-page: #0f1117;
+      --bg-surface: #161b22;
+      --bg-raised: #1c2128;
+      --bg-raised-hover: #22272e;
+      --border-subtle: #30363d;
+      --border-accent: #58a6ff;
+      --text-primary: #e6edf3;
+      --text-secondary: #8b949e;
+      --text-muted: #6e7681;
+      --accent-blue: #58a6ff;
+      --accent-green: #3fb950;
+      --accent-orange: #f78166;
+      --accent-purple: #bc8cff;
+      --accent-teal: #39c5cf;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { min-width: 1024px; }
+    /* No animations in docs-layout; rule present for validator + future-proofing. */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
+    }
+    body {
+      font-family: 'Inter', -apple-system, system-ui, sans-serif;
+      background: var(--bg-page);
+      color: var(--text-primary);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      font-feature-settings: 'ss01', 'cv11';
+      padding: 40px 48px;
+      line-height: 1.5;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 260px minmax(0, 1fr);
+      gap: 40px;
+      max-width: 1400px;
+      margin: 0 auto;
+      align-items: start;
+    }
+
+    /* ===== Sidebar ===== */
+    .sidebar { position: sticky; top: 40px; display: flex; flex-direction: column; gap: 32px; }
+    .version-badge {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 4px 10px; border: 1px solid var(--accent-blue); border-radius: 999px;
+      font-family: 'JetBrains Mono', monospace; font-size: 12px;
+      color: var(--accent-blue); background: rgba(88, 166, 255, 0.06); align-self: flex-start;
+    }
+    .version-badge::before {
+      content: ''; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--accent-green); box-shadow: 0 0 0 2px rgba(63, 185, 80, 0.18);
+    }
+    .tagline { font-size: 13px; color: var(--text-muted); line-height: 1.55; margin-top: 4px; }
+    .sidebar section { display: flex; flex-direction: column; gap: 12px; }
+    .label {
+      font-size: 12px; font-weight: 500; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--text-muted);
+    }
+    .nav-list { list-style: none; display: flex; flex-direction: column; gap: 2px; }
+    .nav-list a {
+      display: block; padding: 6px 10px; font-size: 13px;
+      color: var(--text-secondary); text-decoration: none; border-radius: 6px;
+      border-left: 2px solid transparent; margin-left: -12px; padding-left: 12px;
+      transition: color .15s, border-color .15s;
+    }
+    .nav-list a:hover { color: var(--text-primary); border-left-color: var(--accent-blue); }
+    .invariants { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+    .invariants li {
+      font-size: 14px; color: var(--text-secondary);
+      padding-left: 12px; border-left: 3px solid var(--accent-green); line-height: 1.45;
+    }
+    .invariants li strong { color: var(--text-primary); font-weight: 600; }
+    .legend { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+    .legend li { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--text-secondary); }
+    .chip { width: 14px; height: 10px; border-radius: 3px; border: 1px solid; flex-shrink: 0; }
+    .chip.cli     { border-color: var(--accent-blue);   background: rgba(88, 166, 255, 0.15); }
+    .chip.service { border-color: var(--accent-green);  background: rgba(63, 185, 80, 0.15); }
+    .chip.store   { border-color: var(--accent-purple); background: rgba(188, 140, 255, 0.15); }
+    .chip.api     { border-color: var(--accent-orange); background: rgba(247, 129, 102, 0.15); }
+    .chip.shared  { border-color: var(--text-muted);    background: rgba(110, 118, 129, 0.15); }
+
+    /* ===== Main ===== */
+    .main { display: flex; flex-direction: column; gap: 48px; min-width: 0; }
+    .main-header { display: flex; flex-direction: column; gap: 8px; }
+    .main-header h1 { font-size: 28px; font-weight: 600; letter-spacing: -0.015em; }
+    .main-header .lede { color: var(--text-secondary); font-size: 15px; max-width: 780px; }
+
+    /* ===== Diagram card ===== */
+    .diagram-card {
+      background: var(--bg-surface); border: 1px solid var(--border-subtle);
+      border-radius: 12px; padding: 32px;
+    }
+    .diagram-card header {
+      display: flex; justify-content: space-between; align-items: baseline;
+      margin-bottom: 24px; gap: 16px;
+    }
+    .diagram-card h2 { font-size: 20px; font-weight: 600; }
+    .diagram-card .hint {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px;
+      color: var(--text-muted); letter-spacing: 0.02em;
+    }
+    .diagram-scroll { overflow-x: auto; overflow-y: hidden; margin: 0 -32px; padding: 0 32px; }
+    .diagram-stage {
+      position: relative;
+      /* TODO: set to match your stage geometry. Defaults for two-plane diagrams. */
+      width: 1060px; height: 700px; min-width: 1060px;
+    }
+    .arrows-overlay {
+      position: absolute; inset: 0; width: 100%; height: 100%;
+      pointer-events: none; overflow: visible;
+    }
+
+    /* ===== Nodes ===== */
+    .node {
+      position: absolute; background: var(--bg-raised);
+      border: 1px solid; border-radius: 8px; padding: 14px 16px;
+      transition: background .15s, border-color .15s;
+    }
+    .node:hover { background: var(--bg-raised-hover); }
+    .node-title { font-family: 'JetBrains Mono', monospace; font-size: 13px; font-weight: 600; letter-spacing: -0.01em; }
+    .node-sub { margin-top: 2px; font-size: 11px; color: var(--text-muted); letter-spacing: 0.02em; }
+    .node-list { list-style: none; margin-top: 10px; display: flex; flex-direction: column; gap: 4px; }
+    .node-list li { font-size: 12px; color: var(--text-secondary); padding-left: 10px; position: relative; }
+    .node-list li::before { content: '—'; position: absolute; left: 0; color: var(--text-muted); }
+    .node-group-label {
+      font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500;
+      letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted);
+      margin-top: 12px; margin-bottom: 4px;
+    }
+    .node-group-label:first-of-type { margin-top: 8px; }
+
+    .n-cli     { border-color: rgba(88, 166, 255, 0.4); }
+    .n-cli:hover { border-color: var(--accent-blue); }
+    .n-cli .node-title { color: var(--accent-blue); }
+
+    .n-service { border-color: rgba(63, 185, 80, 0.4); }
+    .n-service:hover { border-color: var(--accent-green); }
+    .n-service .node-title { color: var(--accent-green); }
+
+    .n-store   { border-color: rgba(188, 140, 255, 0.4); }
+    .n-store:hover { border-color: var(--accent-purple); }
+    .n-store .node-title { color: var(--accent-purple); }
+
+    .n-api     { border-color: rgba(247, 129, 102, 0.4); }
+    .n-api:hover { border-color: var(--accent-orange); }
+    .n-api .node-title { color: var(--accent-orange); }
+
+    .n-shared  {
+      border-color: rgba(110, 118, 129, 0.5);
+      border-left-width: 3px; border-left-color: var(--accent-purple);
+    }
+    .n-shared:hover { border-color: var(--text-secondary); border-left-color: var(--accent-purple); }
+    .n-shared .node-title { color: var(--text-primary); }
+
+    /* ===== Plane boundaries ===== */
+    .plane { position: absolute; border: 1px dashed; border-radius: 10px; }
+    .plane::before {
+      content: attr(data-label); position: absolute; top: -9px; left: 16px;
+      padding: 0 8px; font-family: 'JetBrains Mono', monospace;
+      font-size: 11px; font-weight: 500; letter-spacing: 0.04em;
+      background: var(--bg-surface);
+    }
+    .plane-a { border-color: rgba(247, 129, 102, 0.6); }
+    .plane-a::before { color: var(--accent-orange); }
+    .plane-b { border-color: rgba(63, 185, 80, 0.6); }
+    .plane-b::before { color: var(--accent-green); }
+
+    /* ===== Compiler-style sub-grid (optional) ===== */
+    .sub-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 12px; }
+    .subblock {
+      background: rgba(22, 27, 34, 0.6); border: 1px solid var(--border-subtle);
+      border-radius: 6px; padding: 8px 10px;
+    }
+    .subblock-head {
+      font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500;
+      letter-spacing: 0.06em; text-transform: uppercase;
+      color: var(--accent-green); margin-bottom: 6px;
+    }
+    .subblock-list { list-style: none; font-size: 11px; color: var(--text-secondary); line-height: 1.45; }
+    .subblock-list li { padding-left: 8px; position: relative; }
+    .subblock-list li::before { content: '·'; position: absolute; left: 0; color: var(--text-muted); }
+
+    /* ===== Detail grid ===== */
+    .details h2 { font-size: 20px; font-weight: 600; margin-bottom: 20px; }
+    .detail-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+    .detail-card {
+      background: var(--bg-surface); border: 1px solid var(--border-subtle);
+      border-radius: 10px; padding: 24px;
+    }
+    .detail-card h3 {
+      font-size: 14px; font-weight: 600; margin-bottom: 16px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .detail-card h3::before { content: ''; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+    .detail-card.c-blue   h3::before { background: var(--accent-blue); }
+    .detail-card.c-green  h3::before { background: var(--accent-green); }
+    .detail-card.c-purple h3::before { background: var(--accent-purple); }
+    .detail-card.c-orange h3::before { background: var(--accent-orange); }
+    .detail-card ul { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+    .detail-card li { font-size: 13px; color: var(--text-secondary); padding-left: 16px; position: relative; line-height: 1.45; }
+    .detail-card li::before { content: '—'; position: absolute; left: 0; color: var(--text-muted); }
+    .detail-card code {
+      font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--accent-blue);
+      background: rgba(88, 166, 255, 0.08); padding: 1px 4px; border-radius: 3px;
+    }
+
+    .footer {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-muted);
+      padding-top: 24px; border-top: 1px solid var(--border-subtle); letter-spacing: 0.02em;
+    }
+    .footer a { color: var(--accent-blue); text-decoration: none; }
+    .footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="layout">
+    <!-- ===== SIDEBAR ===== -->
+    <aside class="sidebar">
+      <div>
+        <span class="version-badge">[VERSION]</span>
+        <p class="tagline">[ONE-LINE TAGLINE ~60 CHARS]</p>
+      </div>
+
+      <section>
+        <h2 class="label">On this page</h2>
+        <ul class="nav-list">
+          <li><a href="#diagram">Architecture diagram</a></li>
+          <li><a href="#details">Component details</a></li>
+          <li><a href="#invariants">Invariants</a></li>
+        </ul>
+      </section>
+
+      <section id="invariants">
+        <h2 class="label">Architectural invariants</h2>
+        <ul class="invariants">
+          <li><strong>[INVARIANT 1 HEADLINE.]</strong></li>
+          <li><strong>[INVARIANT 2 HEADLINE.]</strong></li>
+          <li><strong>[INVARIANT 3 HEADLINE.]</strong></li>
+          <li><strong>[INVARIANT 4 HEADLINE.]</strong></li>
+          <li><strong>[INVARIANT 5]</strong> [optional qualifier].</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="label">Legend</h2>
+        <ul class="legend">
+          <li><span class="chip cli"></span>CLI / entry</li>
+          <li><span class="chip service"></span>Service package</li>
+          <li><span class="chip store"></span>Persistence</li>
+          <li><span class="chip api"></span>External API</li>
+          <li><span class="chip shared"></span>Shared library</li>
+        </ul>
+      </section>
+    </aside>
+
+    <!-- ===== MAIN ===== -->
+    <section class="main">
+      <header class="main-header">
+        <h1>[PROJECT NAME] Architecture</h1>
+        <p class="lede">[ONE-PARAGRAPH LEDE — what is this system, in 2–3 sentences.]</p>
+      </header>
+
+      <section class="diagram-card" id="diagram">
+        <header>
+          <h2>System topology</h2>
+          <span class="hint">grounded in [GROUNDING SOURCES — e.g. package.json · docker-compose.yml · src/]</span>
+        </header>
+
+        <div class="diagram-scroll">
+          <div class="diagram-stage">
+
+            <!--
+              STAGE GEOMETRY: width=1060 height=700.
+              Positioning model: every .node uses style="left: Xpx; top: Ypx; width: Wpx;"
+              with pixel-literal coords. Heights auto. Verify with the math check in
+              references/docs-layout.md#verification before screenshotting.
+            -->
+
+            <!-- ===== Plane boundaries (drawn first) ===== -->
+            <div class="plane plane-a"
+                 data-label="[PLANE A LABEL]"
+                 style="left: 200px; top: 20px; width: 420px; height: 640px;"></div>
+            <div class="plane plane-b"
+                 data-label="[PLANE B LABEL]"
+                 style="left: 660px; top: 20px; width: 380px; height: 560px;"></div>
+
+            <!-- ===== CLI / entry node ===== -->
+            <div class="node n-cli" style="left: 0; top: 280px; width: 180px;">
+              <div class="node-title">[@pkg/cli]</div>
+              <div class="node-sub">[framework · binary]</div>
+              <ul class="node-list">
+                <li>[command group 1]</li>
+                <li>[command group 2]</li>
+              </ul>
+            </div>
+
+            <!-- ===== Service node (plane A) ===== -->
+            <div class="node n-service" style="left: 220px; top: 60px; width: 190px;">
+              <div class="node-title">[@pkg/service-a]</div>
+              <div class="node-sub">[role line]</div>
+              <ul class="node-list">
+                <li>[responsibility 1]</li>
+                <li>[responsibility 2]</li>
+              </ul>
+            </div>
+
+            <!-- ===== Persistence nodes (plane A) ===== -->
+            <div class="node n-store" style="left: 440px; top: 60px; width: 160px;">
+              <div class="node-title">[store-1]</div>
+              <div class="node-sub">[driver · migrations]</div>
+            </div>
+            <div class="node n-store" style="left: 440px; top: 170px; width: 160px;">
+              <div class="node-title">[store-2]</div>
+              <div class="node-sub">[role line]</div>
+            </div>
+
+            <!-- ===== Service node (plane B) with sub-grid ===== -->
+            <div class="node n-service" style="left: 680px; top: 60px; width: 340px;">
+              <div class="node-title">[@pkg/service-b]</div>
+              <div class="node-sub">[role line]</div>
+              <div class="sub-grid">
+                <div class="subblock">
+                  <div class="subblock-head">[Group 1]</div>
+                  <ul class="subblock-list"><li>[item]</li><li>[item]</li></ul>
+                </div>
+                <div class="subblock">
+                  <div class="subblock-head">[Group 2]</div>
+                  <ul class="subblock-list"><li>[item]</li><li>[item]</li></ul>
+                </div>
+                <div class="subblock">
+                  <div class="subblock-head">[Group 3]</div>
+                  <ul class="subblock-list"><li>[item]</li><li>[item]</li></ul>
+                </div>
+              </div>
+            </div>
+
+            <!-- ===== External API (outside planes) ===== -->
+            <div class="node n-api" style="left: 840px; top: 610px; width: 200px;">
+              <div class="node-title">[External API]</div>
+              <div class="node-sub">[sdk · models]</div>
+            </div>
+
+            <!-- ===== Shared library bar (spans under both planes) ===== -->
+            <div class="node n-shared" style="left: 200px; top: 670px; width: 840px;">
+              <div class="node-title">[@pkg/types]</div>
+              <div class="node-sub">[schemas · shared types · consumers]</div>
+            </div>
+
+            <!-- ===== ARROW OVERLAY ===== -->
+            <svg class="arrows-overlay" viewBox="0 0 1060 700" preserveAspectRatio="none"
+                 role="img" aria-labelledby="arrows-title arrows-desc">
+              <title id="arrows-title">[PROJECT NAME] component connection overlay</title>
+              <desc id="arrows-desc">Directional edges between the architecture nodes: entry invocation (blue), persistence access (muted), cross-plane reads (green dashed), external API calls (orange), shared-library references (purple dotted).</desc>
+              <defs>
+                <marker id="a-blue"   markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#58a6ff"/></marker>
+                <marker id="a-green"  markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3fb950"/></marker>
+                <marker id="a-orange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#f78166"/></marker>
+                <marker id="a-muted"  markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#6e7681"/></marker>
+              </defs>
+
+              <!-- Replace with your edges. Every arrow is horizontal or vertical;
+                   no diagonals across node rows. Labels 6–8px above midpoint. -->
+
+              <!-- cli → service-a -->
+              <line x1="180" y1="315" x2="218" y2="315" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#a-blue)"/>
+              <text x="199" y="309" fill="#58a6ff" font-family="JetBrains Mono" font-size="10" text-anchor="middle">cli</text>
+
+              <!-- service-a ↔ store-1 (bidirectional) -->
+              <line x1="412" y1="92"  x2="438" y2="92"  stroke="#6e7681" stroke-width="1.2" marker-end="url(#a-muted)"/>
+              <line x1="438" y1="100" x2="412" y2="100" stroke="#6e7681" stroke-width="1.2" marker-end="url(#a-muted)"/>
+
+              <!-- service-a → store-2 -->
+              <line x1="412" y1="230" x2="438" y2="230" stroke="#6e7681" stroke-width="1.2" marker-end="url(#a-muted)"/>
+
+              <!-- service-b ← store-2 (cross-plane read, dashed) -->
+              <line x1="602" y1="320" x2="678" y2="320" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#a-green)"/>
+              <text x="640" y="313" fill="#3fb950" font-family="JetBrains Mono" font-size="10" text-anchor="middle">[edge label]</text>
+
+              <!-- service-b → external api -->
+              <line x1="940" y1="580" x2="940" y2="608" stroke="#f78166" stroke-width="1.5" marker-end="url(#a-orange)"/>
+              <text x="948" y="598" fill="#f78166" font-family="JetBrains Mono" font-size="10" text-anchor="start">[sdk name]</text>
+
+              <!-- shared types implicit references (dotted) -->
+              <line x1="410" y1="660" x2="410" y2="580" stroke="#bc8cff" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"/>
+              <line x1="850" y1="660" x2="850" y2="580" stroke="#bc8cff" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"/>
+            </svg>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== Detail grid ===== -->
+      <section class="details" id="details">
+        <h2>Component details</h2>
+        <div class="detail-grid">
+          <div class="detail-card c-green">
+            <h3>[Plane A story]</h3>
+            <ul>
+              <li>[claim]</li>
+              <li>[constraint or invariant]</li>
+              <li>[mechanism with <code>code</code>]</li>
+              <li>[operational property]</li>
+            </ul>
+          </div>
+          <div class="detail-card c-green">
+            <h3>[Plane B story]</h3>
+            <ul>
+              <li>[claim]</li>
+              <li>[mechanism]</li>
+              <li>[budget / limit]</li>
+              <li>[hand-off rule]</li>
+            </ul>
+          </div>
+          <div class="detail-card c-blue">
+            <h3>[CLI / entry story]</h3>
+            <ul>
+              <li>[claim]</li>
+              <li>[claim]</li>
+              <li>[claim]</li>
+            </ul>
+          </div>
+          <div class="detail-card c-purple">
+            <h3>[Shared library story]</h3>
+            <ul>
+              <li>[claim]</li>
+              <li>[claim]</li>
+              <li>[claim]</li>
+            </ul>
+          </div>
+          <div class="detail-card c-orange">
+            <h3>[External surface story]</h3>
+            <ul>
+              <li>[claim]</li>
+              <li>[claim]</li>
+            </ul>
+          </div>
+          <div class="detail-card c-blue">
+            <h3>Tooling</h3>
+            <ul>
+              <li>[build + test stack]</li>
+              <li>[CI gates]</li>
+              <li>[release process]</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <p class="footer">
+        [PROJECT NAME] · <a href="[REPO URL]">[REPO URL]</a> · generated [DATE]
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/mermaid-fallback.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/mermaid-fallback.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}} — Mermaid Fallback</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      padding: 24px;
+      background: #020617;
+      color: #f8fafc;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+    }
+    header { margin-bottom: 24px; }
+    h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    .subtitle { color: #94a3b8; font-size: 12px; margin-top: 4px; }
+    .note {
+      padding: 12px 16px;
+      background: rgba(251, 191, 36, 0.1);
+      border-left: 3px solid #fbbf24;
+      color: #fbbf24;
+      font-size: 12px;
+      margin-bottom: 16px;
+    }
+    .mermaid-card {
+      background: #0f172a;
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+      padding: 24px;
+    }
+    .mermaid { text-align: center; }
+    @media (prefers-reduced-motion: reduce) {
+      * { animation: none !important; transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{TITLE}}</h1>
+    <div class="subtitle">{{SUBTITLE}}</div>
+  </header>
+
+  <div class="note">
+    Rendered via Mermaid fallback — node count exceeded the 50-node SVG layout budget,
+    or a layout collision was detected. See references/troubleshooting.md for details.
+  </div>
+
+  <div class="mermaid-card" role="img" aria-label="{{TITLE}} diagram">
+    <pre class="mermaid">
+{{MERMAID_SOURCE}}
+    </pre>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script>
+    // Minimal Mermaid config — respects reduced-motion via the base CSS above.
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+        background: '#020617',
+        primaryColor: 'rgba(6, 78, 59, 0.4)',
+        primaryBorderColor: '#34d399',
+        primaryTextColor: '#f8fafc',
+        lineColor: '#64748b',
+        fontFamily: 'JetBrains Mono, monospace'
+      }
+    });
+  </script>
+</body>
+</html>

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/sequence.html
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/templates/sequence.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}} — Sequence Diagram</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --canvas-bg: #020617;
+      --panel-bg: #0f172a;
+      --grid-stroke: #1e293b;
+      --text: #f8fafc;
+      --text-muted: #94a3b8;
+      --lifeline: #64748b;
+      --activation: rgba(34, 211, 238, 0.25);
+      --activation-stroke: #22d3ee;
+      --msg-normal: #34d399;
+      --msg-error: #fb7185;
+      --msg-return: #a78bfa;
+      --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 24px;
+      background: var(--canvas-bg);
+      color: var(--text);
+      font-family: var(--font-mono);
+    }
+    header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+    .header-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--msg-normal);
+      animation: pulse 2s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: 0.6; transform: scale(1.2); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .header-dot { animation: none; }
+    }
+    h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    .subtitle { color: var(--text-muted); font-size: 12px; margin-top: 4px; }
+    .diagram-card {
+      background: var(--panel-bg);
+      border: 1px solid var(--grid-stroke);
+      border-radius: 12px;
+      padding: 24px;
+    }
+    text { font-family: var(--font-mono); fill: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-dot" aria-hidden="true"></div>
+    <div>
+      <h1>{{TITLE}}</h1>
+      <div class="subtitle">{{SUBTITLE}}</div>
+    </div>
+  </header>
+
+  <div class="diagram-card">
+    <svg
+      role="img"
+      aria-labelledby="seq-title seq-desc"
+      viewBox="0 0 {{VIEWBOX_W}} {{VIEWBOX_H}}"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title id="seq-title">{{TITLE}}</title>
+      <desc id="seq-desc">{{DESCRIPTION}}</desc>
+
+      <defs>
+        <marker id="arrow-normal" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+          <polygon points="0 0, 10 3.5, 0 7" fill="var(--msg-normal)"/>
+        </marker>
+        <marker id="arrow-error" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+          <polygon points="0 0, 10 3.5, 0 7" fill="var(--msg-error)"/>
+        </marker>
+        <marker id="arrow-return" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+          <polygon points="0 0, 10 3.5, 0 7" fill="var(--msg-return)"/>
+        </marker>
+      </defs>
+
+      <!-- Lifelines: vertical dashed lines labeled with participant names -->
+      {{LIFELINES}}
+
+      <!-- Activation boxes: shaded rectangles along lifelines -->
+      {{ACTIVATIONS}}
+
+      <!-- Messages: arrows between lifelines with labels -->
+      {{MESSAGES}}
+    </svg>
+  </div>
+</body>
+</html>

--- a/plugins/productivity/claudebase/package.json
+++ b/plugins/productivity/claudebase/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@intentsolutionsio/claudebase",
+  "version": "0.2.0",
+  "description": "Back up and restore your entire Claude Code environment to a private GitHub repo",
+  "keywords": [
+    "github",
+    "sync",
+    "backup",
+    "config",
+    "profiles",
+    "settings",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/productivity/claudebase"
+  },
+  "homepage": "https://tonsofskills.com/plugins/claudebase",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Rohit Hazra",
+    "url": "https://github.com/rohithzr"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills",
+    "hooks",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install claudebase\\\\n  or /plugin install claudebase@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}


### PR DESCRIPTION
Patch release. Source tag: [`jeremylongshore/contributing-clanker@v0.1.2`](https://github.com/jeremylongshore/contributing-clanker/releases/tag/v0.1.2).

## What changed (vs. v0.1.1)

Three runtime correctness fixes (source PR jeremylongshore/contributing-clanker#27):

1. **`researcher-build.sh`** — stopped fabricating `policy_files` inventory (was capturing `gh api` 404 error JSON as "exists"; now probes by exit code). Added `docs/` subdir probing for projects that house policy docs there instead of repo root.
2. **`transition.sh`** — fixed YAML corruption when adding `--override-gate` entries (was producing `------` opening delimiter and orphaned list items). Replaced awk+sed insertion with Python `yaml` round-trip.
3. **`a09-mention-routing` gate** — fixed false-positive BLOCK on every claim/PR draft without an `@-mention` (chained grep pipeline killed under `pipefail` on empty match). Replaced with single awk pass.

This release also picks up everything from v0.1.1's CHANGELOG plus the candidate-file-format spec + lint-candidate.sh + transition.sh advisory WARN that landed in PRs #18, #21, #22, #23.

## Synced via

`bin/release-plugin.sh 0.1.2` from contributing-clanker master (commit on master after PRs #27 + #28 merge).

jeremylongshore.com made me do it
  -claude
intentsolutions.io