### PR TITLE
feat(forms): rewire signup + nomination → Slack (forms-api on VPS) + partner-bar polish

### DIFF
--- a/marketplace/src/components/PartnerBar.astro
+++ b/marketplace/src/components/PartnerBar.astro
@@ -14,7 +14,7 @@ const { partners } = partnersData;
 ---
 
 <div class="partner-bar" aria-label="Strategic partners">
-  <span class="partner-bar-label">Strategic partners funding plugin innovation</span>
+  <span class="partner-bar-label">Strategic partners</span>
   <div class={`partner-bar-row partner-bar-count-${partners.length}`}>
     {partners.map((p) => (
       <a

--- a/marketplace/src/data/partners.json
+++ b/marketplace/src/data/partners.json
@@ -13,7 +13,7 @@
       "slug": "nixtla",
       "name": "Nixtla",
       "url": "https://nixtla.io",
-      "wordmark": "nixtla.io",
+      "wordmark": "Nixtla",
       "tagline": "Time-series forecasting"
     }
   ]

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -720,26 +720,101 @@ const currentPath = Astro.url.pathname;
         }
     </style>
 
-    <!-- Email Signup + Nomination Form Handlers — temporarily stubbed
-         Firebase Functions backend removed during VPS migration off Firebase
-         (2026-05-06). VPS-hosted form endpoints land in a follow-up PR. Form
-         HTML stays so layout is preserved; submit is a no-op with a "coming
-         back" message. -->
+    <!-- Email signup + killer-skill nomination forms.
+         Posts to /api/forms/{signup,nominate} on the same origin. The endpoint
+         is a tiny Node service on the VPS (`forms-api.service`, 127.0.0.1:8090)
+         that forwards to the Slack webhook in /etc/intentsolutions/notify.env.
+         Anti-spam: honeypot field `website`, email/URL regex, 8 KiB body cap,
+         per-IP rate limit on the server. See
+         intentsolutions-vps-runbook/docs/tonsofskills-forms-api.md. -->
     <script type="module" is:inline>
       (() => {
-        const disableForm = (form, message) => {
-          form.addEventListener('submit', (e) => e.preventDefault());
-          form.querySelectorAll('button').forEach((btn) => {
-            btn.disabled = true;
-            btn.textContent = message;
-            btn.style.opacity = '0.5';
-            btn.style.cursor = 'not-allowed';
-          });
+        const flash = (btn, msg, ok = true, restoreMs = 3000) => {
+          const orig = btn.dataset.origText ?? btn.textContent;
+          if (!btn.dataset.origText) btn.dataset.origText = orig;
+          btn.textContent = msg;
+          btn.style.opacity = ok ? '0.85' : '1';
+          btn.disabled = ok;
+          if (!ok) setTimeout(() => {
+            btn.textContent = orig;
+            btn.style.opacity = '';
+            btn.disabled = false;
+          }, restoreMs);
         };
+
+        const wireSignup = (form) => form.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const btn = form.querySelector('button[type="submit"]');
+          const emailInput = form.querySelector('input[type="email"]');
+          const honey = form.querySelector('input[name="website"]');
+          const email = (emailInput?.value || '').trim();
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            flash(btn, 'Invalid email', false);
+            return;
+          }
+          flash(btn, 'Subscribing…', true, 0);
+          try {
+            const r = await fetch('/api/forms/signup', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                email,
+                source: form.dataset.signupForm || 'unknown',
+                website: honey?.value || ''
+              })
+            });
+            if (r.ok) {
+              flash(btn, "You're in!", true, 0);
+              if (emailInput) emailInput.value = '';
+            } else if (r.status === 429) {
+              flash(btn, 'Slow down', false);
+            } else {
+              const j = await r.json().catch(() => ({}));
+              flash(btn, j.error || 'Something went wrong', false);
+            }
+          } catch {
+            flash(btn, 'Network error', false);
+          }
+        });
+
+        const wireNomination = (form) => form.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const btn = form.querySelector('button[type="submit"]');
+          const repoInput = form.querySelector('input[name="repo"]');
+          const honey = form.querySelector('input[name="website"]');
+          const repoUrl = (repoInput?.value || '').trim();
+          if (!/^https:\/\/github\.com\/[^/\s]+\/[^/\s]+/.test(repoUrl)) {
+            flash(btn, 'GitHub URL only', false);
+            return;
+          }
+          flash(btn, 'Submitting…', true, 0);
+          try {
+            const r = await fetch('/api/forms/nominate', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                repoUrl,
+                source: form.dataset.nominationForm || 'unknown',
+                website: honey?.value || ''
+              })
+            });
+            if (r.ok) {
+              flash(btn, 'Submitted!', true, 0);
+              if (repoInput) repoInput.value = '';
+            } else if (r.status === 429) {
+              flash(btn, 'Slow down', false);
+            } else {
+              const j = await r.json().catch(() => ({}));
+              flash(btn, j.error || 'Something went wrong', false);
+            }
+          } catch {
+            flash(btn, 'Network error', false);
+          }
+        });
+
         const init = () => {
-          document
-            .querySelectorAll('[data-signup-form], [data-nomination-form]')
-            .forEach((f) => disableForm(f, 'Coming back soon'));
+          document.querySelectorAll('[data-signup-form]').forEach(wireSignup);
+          document.querySelectorAll('[data-nomination-form]').forEach(wireNomination);
         };
         if (document.readyState === 'loading') {
           document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary

Closes the loop on the VPS migration — signup + nomination forms now post to the Slack webhook via a tiny Node service on the VPS.

### Frontend (this repo)

- `BaseLayout.astro` — replace the "Coming back soon" stub with real `fetch()` handlers that POST to `/api/forms/signup` and `/api/forms/nominate` on the same origin.
- Surface `429` (rate limit) as "Slow down"; surface 4xx server errors verbatim.
- Honeypot field `website` still passes through (server silently 200s on it).
- `partners.json` — Nixtla wordmark `nixtla.io` → `Nixtla` to match Kobiton's bare-brand style.
- `PartnerBar.astro` — label "Strategic partners funding plugin innovation" → "Strategic partners". The "funding" framing read weird for paying engagements.

### Backend (already deployed on VPS)

- `forms-api.service` (systemd, Node) listening on `127.0.0.1:8090`
- Caddy reverse_proxy `handle /api/forms/* { reverse_proxy 127.0.0.1:8090 }` ahead of the static `handle { ... }` block
- Reads `SLACK_WEBHOOK_URL` from `/etc/intentsolutions/notify.env`

### Anti-spam (server-side)

| Layer | What |
|---|---|
| Honeypot field `website` | non-empty → silent 200, no Slack notification |
| Email regex | `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` |
| GitHub-URL regex | `/^https:\/\/github\.com\/[^/\s]+\/[^/\s]+/` |
| Body cap | 8 KiB → 413 |
| Method | POST only → 405 on GET |
| Rate limit | per-IP sliding window, **5 req / 5 min → 429** |
| Bind | `127.0.0.1` only — Caddy is the sole public ingress |

Verified end-to-end: 5 valid signups via `https://tonsofskills.com/api/forms/signup` succeeded → Slack `#operation-hired`; the 6th hit returned 429.

## Runbook docs (separate PR in `intentsolutions-vps-runbook`)

- New `docs/tonsofskills-forms-api.md` — full setup, the **Caddyfile-ordering gotcha** (auto-directive ordering put `try_files` rewrite before `reverse_proxy`, so `/api/forms/signup` → `/index.html` → 405; fixed by explicit `handle` blocks), operations, hardening, future work.
- `docs/port-map.md` — added `127.0.0.1:8090` row.

## Test plan

- [ ] Build passes (verified locally — 3469 pages, ~26 s)
- [ ] After deploy: `curl -X POST https://tonsofskills.com/api/forms/signup -d '{"email":"smoke@example.com","source":"pr-684"}'` returns 200 and a Slack message lands in `#operation-hired`
- [ ] After deploy: invalid email returns 400, honeypot returns silent 200, 6th rapid hit from same IP returns 429
- [ ] Partner bar shows `Kobiton` and `Nixtla` (no `nixtla.io`), label reads "Strategic partners"

jeremylongshore.com made me do it
  -claude
intentsolutions.io