### PR TITLE
fix(homepage): drop "last 30d" total from npm marquee (cron is rate-limit broken)

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1152,7 +1152,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             {npmPublished > 0 && (
                 <div class="hero-sponsor-marquee hero-stats-marquee">
                     <span class="hero-sponsor-label">
-                        live npm downloads · {fmtNum(npmPublished)} packages · {fmtNum(npmMonth)} last 30d
+                        live npm downloads · {fmtNum(npmPublished)} packages
                     </span>
                     <div class="hero-sponsor-track">
                         {npmTop.map((p) => (


### PR DESCRIPTION
## Why

The "last 30d" total in the homepage hero marquee was stuck at **41,975** since 2026-05-02 — the daily npm-stats cron (`update-npm-stats.yml`) has been failing for 5+ days because npm's registry rate-limits us on 158 of 437 packages, and the script (correctly) refuses to publish unreliable counts.

I tried using npm's bulk-download endpoint to dodge the rate limit, but **the bulk endpoint doesn't support scoped packages** — and ~95% of our published names are `@intentsolutionsio/*`. So we're stuck with 437 individual calls per cron run.

## What changes

- Hero marquee: `live npm downloads · 340 packages · 41,975 last 30d` → `live npm downloads · 340 packages`
- Nothing else

The full day/week/month breakdown still lives in the README NPM-STATS block — that comes back online once the cron is fixed.

## Follow-up (separate PR)

Properly fix `scripts/fetch-npm-stats.mjs` for rate-limit resilience:
- Drop concurrency from 4 → 1 (sequential)
- Add a 250 ms inter-request delay (4 req/s, well under npm's per-IP cap)
- Bump max backoff from 15 s → 90 s so the cron rides through a brief 429 wave
- Estimated runtime: 437 × 0.25 s = ~110 s + retries — still under the cron's 30-min timeout

## Test plan

- [ ] Build clean
- [ ] Live homepage marquee no longer shows "last 30d ..."
- [ ] Header still shows package count

jeremylongshore.com made me do it
  -claude
intentsolutions.io