### PR TITLE
fix(stats): throttled npm fetch + real number on marquee (53,237 / 30d, 418 pkgs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,31 +70,33 @@ ccpi update                     # Pull latest versions
 
 ### 📦 Live npm Downloads
 
-Across **340 published packages** in the
+Across **418 published packages** in the 
 [claude-code-plugins](https://www.npmjs.com/~jeremylongshore) namespace. Updated daily by GitHub Actions.
 
-| Window        | Downloads |
-| ------------- | --------: |
-| Last 24 hours |       366 |
-| Last 7 days   |     3,937 |
-| Last 30 days  |    41,975 |
+| Window | All packages | Established (>30d) |
+|--------|-------------:|-------------------:|
+| Last 24 hours | 128 | 36 |
+| Last 7 days | 2,757 | 206 |
+| Last 30 days | 53,237 | 990 |
+
+<sub>"Established" excludes packages first published within the last 30 days, so a bulk-publish event doesn't dominate the headline.</sub>
 
 **Top 10 by last 30 days:**
 
-| #   | Package                                                                                                                    | Last 30d |
-| --- | -------------------------------------------------------------------------------------------------------------------------- | -------: |
-| 1   | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi)                                         |      339 |
-| 2   | [`@intentsolutionsio/market-price-tracker`](https://www.npmjs.com/package/@intentsolutionsio/market-price-tracker)         |      202 |
-| 3   | [`@intentsolutionsio/excel-analyst-pro`](https://www.npmjs.com/package/@intentsolutionsio/excel-analyst-pro)               |      181 |
-| 4   | [`@intentsolutionsio/openbb-terminal`](https://www.npmjs.com/package/@intentsolutionsio/openbb-terminal)                   |      166 |
-| 5   | [`@intentsolutionsio/crypto-portfolio-tracker`](https://www.npmjs.com/package/@intentsolutionsio/crypto-portfolio-tracker) |      161 |
-| 6   | [`@intentsolutionsio/skill-creator`](https://www.npmjs.com/package/@intentsolutionsio/skill-creator)                       |      155 |
-| 7   | [`@intentsolutionsio/crypto-tax-calculator`](https://www.npmjs.com/package/@intentsolutionsio/crypto-tax-calculator)       |      154 |
-| 8   | [`@intentsolutionsio/blockchain-explorer-cli`](https://www.npmjs.com/package/@intentsolutionsio/blockchain-explorer-cli)   |      153 |
-| 9   | [`@intentsolutionsio/ml-model-trainer`](https://www.npmjs.com/package/@intentsolutionsio/ml-model-trainer)                 |      153 |
-| 10  | [`@intentsolutionsio/compliance-checker`](https://www.npmjs.com/package/@intentsolutionsio/compliance-checker)             |      152 |
+| # | Package | Last 30d |
+|---|---------|---------:|
+| 1 | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi) | 346 |
+| 2 | [`@intentsolutionsio/guidewire-pack`](https://www.npmjs.com/package/@intentsolutionsio/guidewire-pack) | 324 |
+| 3 | [`@intentsolutionsio/engineer-design-diagram`](https://www.npmjs.com/package/@intentsolutionsio/engineer-design-diagram) | 242 |
+| 4 | [`@intentsolutionsio/market-price-tracker`](https://www.npmjs.com/package/@intentsolutionsio/market-price-tracker) | 224 |
+| 5 | [`@intentsolutionsio/excel-analyst-pro`](https://www.npmjs.com/package/@intentsolutionsio/excel-analyst-pro) | 189 |
+| 6 | [`@intentsolutionsio/openbb-terminal`](https://www.npmjs.com/package/@intentsolutionsio/openbb-terminal) | 182 |
+| 7 | [`@intentsolutionsio/options-flow-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/options-flow-analyzer) | 181 |
+| 8 | [`@intentsolutionsio/crypto-portfolio-tracker`](https://www.npmjs.com/package/@intentsolutionsio/crypto-portfolio-tracker) | 175 |
+| 9 | [`@intentsolutionsio/nft-rarity-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/nft-rarity-analyzer) | 174 |
+| 10 | [`@intentsolutionsio/arbitrage-opportunity-finder`](https://www.npmjs.com/package/@intentsolutionsio/arbitrage-opportunity-finder) | 167 |
 
-<sub>Last refreshed 2026-05-02T04:09:18.799Z.</sub>
+<sub>Last refreshed 2026-05-07T15:28:44.521Z.</sub>
 
 <!-- NPM-STATS:END -->
 

--- a/marketplace/src/data/npm-stats.json
+++ b/marketplace/src/data/npm-stats.json
@@ -1,2050 +1,3785 @@
 {
-  "generatedAt": "2026-05-02T04:09:18.799Z",
-  "publishedCount": 340,
-  "candidateCount": 429,
-  "totalDay": 366,
-  "totalWeek": 3937,
-  "totalMonth": 41975,
+  "generatedAt": "2026-05-07T15:28:44.521Z",
+  "publishedCount": 418,
+  "establishedCount": 32,
+  "candidateCount": 438,
+  "totalDay": 128,
+  "totalWeek": 2757,
+  "totalMonth": 53237,
+  "establishedDay": 36,
+  "establishedWeek": 206,
+  "establishedMonth": 990,
   "top": [
     {
       "name": "@intentsolutionsio/ccpi",
+      "status": "published",
       "lastDay": 14,
-      "lastWeek": 130,
-      "lastMonth": 339
-    },
-    {
-      "name": "@intentsolutionsio/market-price-tracker",
-      "lastDay": 1,
-      "lastWeek": 79,
-      "lastMonth": 202
-    },
-    {
-      "name": "@intentsolutionsio/excel-analyst-pro",
-      "lastDay": 3,
-      "lastWeek": 62,
-      "lastMonth": 181
-    },
-    {
-      "name": "@intentsolutionsio/openbb-terminal",
-      "lastDay": 1,
-      "lastWeek": 44,
-      "lastMonth": 166
-    },
-    {
-      "name": "@intentsolutionsio/crypto-portfolio-tracker",
-      "lastDay": 2,
-      "lastWeek": 18,
-      "lastMonth": 161
-    },
-    {
-      "name": "@intentsolutionsio/skill-creator",
-      "lastDay": 5,
-      "lastWeek": 20,
-      "lastMonth": 155
-    },
-    {
-      "name": "@intentsolutionsio/crypto-tax-calculator",
-      "lastDay": 1,
-      "lastWeek": 27,
-      "lastMonth": 154
-    },
-    {
-      "name": "@intentsolutionsio/blockchain-explorer-cli",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 153
-    },
-    {
-      "name": "@intentsolutionsio/ml-model-trainer",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 153
-    },
-    {
-      "name": "@intentsolutionsio/compliance-checker",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 152
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-design-everyday-things",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 151
-    },
-    {
-      "name": "@intentsolutionsio/market-movers-scanner",
-      "lastDay": 3,
-      "lastWeek": 28,
-      "lastMonth": 150
-    },
-    {
-      "name": "@intentsolutionsio/contract-test-validator",
-      "lastDay": 2,
-      "lastWeek": 16,
-      "lastMonth": 149
-    },
-    {
-      "name": "@intentsolutionsio/crypto-news-aggregator",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 149
-    },
-    {
-      "name": "@intentsolutionsio/database-health-monitor",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 149
-    },
-    {
-      "name": "@intentsolutionsio/wallet-portfolio-tracker",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 149
-    },
-    {
-      "name": "@intentsolutionsio/claude-pack",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/cohere-pack",
-      "lastDay": 5,
-      "lastWeek": 10,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/database-archival-system",
-      "lastDay": 3,
-      "lastWeek": 14,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/database-diff-tool",
-      "lastDay": 2,
-      "lastWeek": 17,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-engine",
-      "lastDay": 2,
-      "lastWeek": 27,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/unit-test-generator",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/wallet-security-auditor",
-      "lastDay": 2,
-      "lastWeek": 15,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/zai-cli",
-      "lastDay": 1,
-      "lastWeek": 17,
-      "lastMonth": 148
-    },
-    {
-      "name": "@intentsolutionsio/defi-yield-optimizer",
-      "lastDay": 2,
-      "lastWeek": 16,
-      "lastMonth": 147
-    },
-    {
-      "name": "@intentsolutionsio/neural-network-builder",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 147
-    },
-    {
-      "name": "@intentsolutionsio/persona-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 147
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-negotiation",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 147
-    },
-    {
-      "name": "@intentsolutionsio/arbitrage-opportunity-finder",
-      "lastDay": 3,
-      "lastWeek": 25,
-      "lastMonth": 146
-    },
-    {
-      "name": "@intentsolutionsio/database-backup-automator",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 146
-    },
-    {
-      "name": "@intentsolutionsio/performance-test-suite",
-      "lastDay": 3,
-      "lastWeek": 14,
-      "lastMonth": 146
-    },
-    {
-      "name": "@intentsolutionsio/browser-compatibility-tester",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 145
-    },
-    {
-      "name": "@intentsolutionsio/executive-assistant-skills",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 145
-    },
-    {
-      "name": "@intentsolutionsio/visual-regression-tester",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 145
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-hooked-ux",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 145
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-one-page-marketing",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 145
-    },
-    {
-      "name": "@intentsolutionsio/devops-automation-pack",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 144
-    },
-    {
-      "name": "@intentsolutionsio/vibe-guide",
-      "lastDay": 3,
-      "lastWeek": 16,
-      "lastMonth": 144
-    },
-    {
-      "name": "@intentsolutionsio/whale-alert-monitor",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 144
-    },
-    {
-      "name": "@intentsolutionsio/database-cache-layer",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/database-deadlock-detector",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-drift-detector",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/market-sentiment-analyzer",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/model-deployment-helper",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/recommendation-engine",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 143
-    },
-    {
-      "name": "@intentsolutionsio/cache-performance-optimizer",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/container-registry-manager",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/container-security-scanner",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/data-privacy-scanner",
-      "lastDay": 3,
-      "lastWeek": 14,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/database-connection-pooler",
-      "lastDay": 0,
-      "lastWeek": 15,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/database-test-manager",
-      "lastDay": 4,
-      "lastWeek": 18,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/gh-dash",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/model-versioning-tracker",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/regression-test-tracker",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/token-launch-tracker",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-design-sprint",
-      "lastDay": 2,
-      "lastWeek": 17,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-obviously-awesome",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 142
-    },
-    {
-      "name": "@intentsolutionsio/application-profiler",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/boycott-filter",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-adk-orchestrator",
-      "lastDay": 1,
-      "lastWeek": 25,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/trading-strategy-backtester",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-made-to-stick",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-ux-heuristics",
-      "lastDay": 0,
-      "lastWeek": 16,
-      "lastMonth": 141
-    },
-    {
-      "name": "@intentsolutionsio/crypto-derivatives-tracker",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/database-schema-designer",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/distributed-tracing-setup",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/model-evaluation-suite",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/quicknode-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-drive-motivation",
-      "lastDay": 0,
-      "lastWeek": 18,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-predictable-revenue",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 140
-    },
-    {
-      "name": "@intentsolutionsio/ci-cd-pipeline-builder",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/csrf-protection-validator",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/gas-fee-optimizer",
-      "lastDay": 0,
-      "lastWeek": 17,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/graphql-server-builder",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/liquidity-pool-analyzer",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/mempool-analyzer",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/model-explainability-tool",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/orm-code-generator",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/stored-procedure-generator",
-      "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-top-design",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 139
-    },
-    {
-      "name": "@intentsolutionsio/api-error-handler",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/cpu-usage-monitor",
-      "lastDay": 1,
-      "lastWeek": 17,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/data-validation-engine",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/data-seeder-generator",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/database-documentation-gen",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/database-transaction-monitor",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/deployment-rollback-manager",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/flash-loan-simulator",
-      "lastDay": 2,
-      "lastWeek": 11,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-genkit-terraform",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-validator",
-      "lastDay": 2,
-      "lastWeek": 17,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/on-chain-analytics",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/penetration-tester",
-      "lastDay": 4,
-      "lastWeek": 8,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/secret-scanner",
-      "lastDay": 3,
-      "lastWeek": 16,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/test-orchestrator",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-blue-ocean-strategy",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 138
-    },
-    {
-      "name": "@intentsolutionsio/git-commit-smart",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 137
-    },
-    {
-      "name": "@intentsolutionsio/podium-pack",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 137
-    },
-    {
-      "name": "@intentsolutionsio/ramp-pack",
-      "lastDay": 1,
-      "lastWeek": 9,
-      "lastMonth": 137
-    },
-    {
-      "name": "@intentsolutionsio/test-report-generator",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 137
-    },
-    {
-      "name": "@intentsolutionsio/webhook-handler-creator",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 137
-    },
-    {
-      "name": "@intentsolutionsio/database-migration-manager",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/database-replication-manager",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/database-sharding-manager",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/databricks-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/encryption-tool",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/geepers-agents",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-adk-terraform",
-      "lastDay": 2,
-      "lastWeek": 18,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-firestore",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/security-incident-responder",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/session-security-checker",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/techsmith-pack",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/sugar",
-      "lastDay": 2,
-      "lastWeek": 20,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-ios-hig-design",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-refactoring-ui",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-traction-eos",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 136
-    },
-    {
-      "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
-      "lastDay": 4,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/004-jeremy-google-cloud-agent-sdk",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/agent-context-manager",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/api-security-scanner",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/calendar-to-workflow",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/clickhouse-pack",
-      "lastDay": 3,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-genkit-pro",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/navigating-github",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/palantir-pack",
-      "lastDay": 4,
-      "lastWeek": 9,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/performance-budget-validator",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/promptbook",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/search-to-slack",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/security-audit-reporter",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/severity1-marketplace",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/staking-rewards-optimizer",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 135
-    },
-    {
-      "name": "@intentsolutionsio/api-versioning-manager",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/auto-scaling-configurator",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/box-cloud-filesystem",
-      "lastDay": 2,
-      "lastWeek": 7,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/brand-strategy-framework",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/database-query-profiler",
-      "lastDay": 2,
-      "lastWeek": 6,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/elevenlabs-pack",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/framecraft",
-      "lastDay": 2,
-      "lastWeek": 12,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-as-code-generator",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/research-to-deploy",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/security-headers-analyzer",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/security-agent",
-      "lastDay": 0,
-      "lastWeek": 15,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/snowflake-pack",
-      "lastDay": 2,
-      "lastWeek": 6,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/sql-query-optimizer",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/test-environment-manager",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 134
-    },
-    {
-      "name": "@intentsolutionsio/ansible-playbook-creator",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/api-gateway-builder",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/api-throttling-manager",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/documenso-pack",
-      "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/helm-chart-generator",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-metrics-collector",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/notion-pack",
-      "lastDay": 1,
-      "lastWeek": 18,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/sentiment-analysis-tool",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/sprint",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-scorecard-marketing",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 133
-    },
-    {
-      "name": "@intentsolutionsio/assemblyai-pack",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/b12-claude-plugin",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/clustering-algorithm-runner",
-      "lastDay": 2,
-      "lastWeek": 12,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/creator-studio-pack",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/disaster-recovery-planner",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/fairdb-operations-kit",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/pm-ai-partner",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/salesforce-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/websocket-server-builder",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 132
-    },
-    {
-      "name": "@intentsolutionsio/002-jeremy-yaml-master-agent",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/access-control-auditor",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/fathom-pack",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/input-validation-scanner",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/mattyp-changelog",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/monitoring-stack-deployer",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/navan-pack",
-      "lastDay": 2,
-      "lastWeek": 16,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/mutation-test-runner",
-      "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/soc2-audit-helper",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/together-pack",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-influence-psychology",
-      "lastDay": 1,
-      "lastWeek": 7,
-      "lastMonth": 131
-    },
-    {
-      "name": "@intentsolutionsio/appfolio-pack",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/classification-model-builder",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/database-index-advisor",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/onenote-pack",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/overnight-dev",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/query-performance-analyzer",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/ssl-certificate-manager",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-crossing-the-chasm",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 130
-    },
-    {
-      "name": "@intentsolutionsio/anthropic-pack",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/apify-pack",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/apple-notes-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/bottleneck-detector",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/capacity-planning-analyzer",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/clari-pack",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/coreweave-pack",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/experiment-tracking-setup",
-      "lastDay": 2,
-      "lastWeek": 12,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/load-balancer-configurator",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/mistral-pack",
-      "lastDay": 5,
-      "lastWeek": 14,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/mobile-app-tester",
-      "lastDay": 4,
-      "lastWeek": 7,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/salesloft-pack",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/roi-calculator",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/sow-generator",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/terraform-module-builder",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/twinmind-pack",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/zapier-zap-builder",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 129
-    },
-    {
-      "name": "@intentsolutionsio/003-jeremy-vertex-ai-media-master",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/ai-ethics-validator",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/ai-commit-gen",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/api-documentation-generator",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/cloud-cost-optimizer",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/figma-pack",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/hyperfocus",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/network-policy-manager",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/nosql-data-modeler",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/response-time-tracker",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/resource-usage-tracker",
-      "lastDay": 0,
-      "lastWeek": 9,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/security-pro-pack",
-      "lastDay": 1,
-      "lastWeek": 17,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/smoke-test-runner",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/snapshot-test-manager",
-      "lastDay": 1,
-      "lastWeek": 7,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-jobs-to-be-done",
-      "lastDay": 3,
-      "lastWeek": 6,
-      "lastMonth": 128
-    },
-    {
-      "name": "@intentsolutionsio/api-authentication-builder",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/backup-strategy-implementor",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/hello-world",
-      "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/hootsuite-pack",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-gcp-starter-examples",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/load-balancer-tester",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/miro-pack",
-      "lastDay": 2,
-      "lastWeek": 10,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/openevidence-pack",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 127
-    },
-    {
-      "name": "@intentsolutionsio/accessibility-test-scanner",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/algolia-pack",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/api-cache-manager",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/docker-compose-generator",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/freshie-inventory-manager",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/fullstack-starter-pack",
-      "lastDay": 2,
-      "lastWeek": 6,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/lucidchart-pack",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/regression-analysis-tool",
-      "lastDay": 2,
-      "lastWeek": 11,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/test-coverage-analyzer",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/webflow-pack",
-      "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/wispr-pack",
-      "lastDay": 1,
-      "lastWeek": 7,
-      "lastMonth": 126
-    },
-    {
-      "name": "@intentsolutionsio/api-event-emitter",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/api-load-tester",
-      "lastDay": 1,
-      "lastWeek": 3,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/api-schema-validator",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/discovery-questionnaire",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/formatter",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/grammarly-pack",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 125
+      "lastWeek": 87,
+      "lastMonth": 346,
+      "createdAt": 1766717017053,
+      "latestVersion": "2.0.0"
     },
     {
       "name": "@intentsolutionsio/guidewire-pack",
+      "status": "published",
+      "lastDay": 5,
+      "lastWeek": 199,
+      "lastMonth": 324,
+      "createdAt": 1776741959424,
+      "latestVersion": "2.0.1"
+    },
+    {
+      "name": "@intentsolutionsio/engineer-design-diagram",
+      "status": "published",
+      "lastDay": 10,
+      "lastWeek": 242,
+      "lastMonth": 242,
+      "createdAt": 1777867330963,
+      "latestVersion": "0.2.1"
+    },
+    {
+      "name": "@intentsolutionsio/market-price-tracker",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 125
+      "lastWeek": 23,
+      "lastMonth": 224,
+      "createdAt": 1776741684267,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/hipaa-compliance-checker",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/hyperparameter-tuner",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/real-user-monitoring",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/rest-api-generator",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/serpapi-pack",
-      "lastDay": 3,
-      "lastWeek": 8,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/tweetclaw",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-cro-methodology",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-hundred-million-offers",
-      "lastDay": 3,
-      "lastWeek": 6,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-storybrand-messaging",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 125
-    },
-    {
-      "name": "@intentsolutionsio/alerting-rule-creator",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 124
-    },
-    {
-      "name": "@intentsolutionsio/api-contract-generator",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 124
-    },
-    {
-      "name": "@intentsolutionsio/api-request-logger",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 124
-    },
-    {
-      "name": "@intentsolutionsio/claude-reflect",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 124
-    },
-    {
-      "name": "@intentsolutionsio/deep-learning-optimizer",
+      "name": "@intentsolutionsio/excel-analyst-pro",
+      "status": "published",
       "lastDay": 1,
       "lastWeek": 11,
-      "lastMonth": 124
+      "lastMonth": 189,
+      "createdAt": 1776741469824,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/environment-config-manager",
+      "name": "@intentsolutionsio/openbb-terminal",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 17,
+      "lastMonth": 182,
+      "createdAt": 1776741484922,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/options-flow-analyzer",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 124
+      "lastMonth": 181,
+      "createdAt": 1776741710149,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/grpc-service-generator",
+      "name": "@intentsolutionsio/crypto-portfolio-tracker",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 16,
+      "lastMonth": 175,
+      "createdAt": 1776741638231,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/nft-rarity-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 174,
+      "createdAt": 1776741699776,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/arbitrage-opportunity-finder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 24,
+      "lastMonth": 167,
+      "createdAt": 1776741475326,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/travel-assistant",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 41,
+      "lastMonth": 167,
+      "createdAt": 1776742103269,
+      "latestVersion": "1.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/skill-creator",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 13,
+      "lastMonth": 163,
+      "createdAt": 1776742235624,
+      "latestVersion": "5.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 14,
+      "lastMonth": 160,
+      "createdAt": 1776741607002,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wallet-portfolio-tracker",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 12,
+      "lastMonth": 160,
+      "createdAt": 1776741729951,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-tax-calculator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 159,
+      "createdAt": 1776741648453,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/compliance-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 157,
+      "createdAt": 1776741640114,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/flash-loan-simulator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 21,
+      "lastMonth": 157,
+      "createdAt": 1776741663488,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/market-movers-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 10,
+      "lastMonth": 157,
+      "createdAt": 1776741679506,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/blockchain-explorer-cli",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 156,
+      "createdAt": 1776741522342,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/defi-yield-optimizer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 11,
+      "lastMonth": 156,
+      "createdAt": 1776741653603,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/local-tts",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 156,
+      "createdAt": 1776741272966,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ml-model-trainer",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 124
+      "lastMonth": 155,
+      "createdAt": 1776741277876,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/linktree-pack",
+      "name": "@intentsolutionsio/wondelai-design-everyday-things",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 9,
-      "lastMonth": 124
+      "lastWeek": 5,
+      "lastMonth": 155,
+      "createdAt": 1776741832696,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/ollama-local-ai",
+      "name": "@intentsolutionsio/database-archival-system",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 152,
+      "createdAt": 1776741711937,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-test-automation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 151,
+      "createdAt": 1776741443439,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cohere-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 8,
+      "lastMonth": 151,
+      "createdAt": 1776741634697,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/contract-test-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 151,
+      "createdAt": 1776741660836,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-news-aggregator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 151,
+      "createdAt": 1776741633481,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-health-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 151,
+      "createdAt": 1776741754306,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-engine",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 151,
+      "createdAt": 1776741262867,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/persona-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 151,
+      "createdAt": 1776742142424,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-signal-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 150,
+      "createdAt": 1776741643301,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-backup-automator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 150,
+      "createdAt": 1776741722868,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/unit-test-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 150,
+      "createdAt": 1776742299588,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wallet-security-auditor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 150,
+      "createdAt": 1776741734689,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/zai-cli",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 150,
+      "createdAt": 1776741618257,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-audit-logger",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 149,
+      "createdAt": 1776741717321,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-diff-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 149,
+      "createdAt": 1776741744406,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-recovery-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 149,
+      "createdAt": 1776741774117,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/executive-assistant-skills",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 149,
+      "createdAt": 1776741474487,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/neural-network-builder",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 149,
+      "createdAt": 1776741301744,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-negotiation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 149,
+      "createdAt": 1776741541091,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-one-page-marketing",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 149,
+      "createdAt": 1776741550755,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/browser-compatibility-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 148,
+      "createdAt": 1776741552255,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/liquidity-pool-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 10,
+      "lastMonth": 148,
+      "createdAt": 1776741673967,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-test-suite",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 148,
+      "createdAt": 1776742151365,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/visual-regression-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 148,
+      "createdAt": 1776742304930,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-hooked-ux",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 148,
+      "createdAt": 1776741837303,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-obviously-awesome",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 7,
+      "lastMonth": 148,
+      "createdAt": 1776741545705,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-cache-layer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 147,
+      "createdAt": 1776741728051,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-deadlock-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 147,
+      "createdAt": 1776741739254,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/elevenlabs-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 14,
+      "lastMonth": 147,
+      "createdAt": 1776741858048,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/market-sentiment-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 147,
+      "createdAt": 1776741689689,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-deployment-helper",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 147,
+      "createdAt": 1776741282704,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/token-launch-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 147,
+      "createdAt": 1776741720118,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/whale-alert-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 147,
+      "createdAt": 1776741739600,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/boycott-filter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 146,
+      "createdAt": 1776741540431,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-derivatives-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 146,
+      "createdAt": 1776741628445,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-versioning-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 146,
+      "createdAt": 1776741296763,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/vibe-guide",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 146,
+      "createdAt": 1776742108359,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-made-to-stick",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 146,
+      "createdAt": 1776741536427,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cache-performance-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 145,
+      "createdAt": 1776741557657,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/container-registry-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 145,
+      "createdAt": 1776741650848,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/container-security-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 145,
+      "createdAt": 1776741655802,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/data-privacy-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 145,
+      "createdAt": 1776741695023,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-connection-pooler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 145,
+      "createdAt": 1776741733202,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-partition-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 145,
+      "createdAt": 1776741768869,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/devops-automation-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 145,
+      "createdAt": 1776741826196,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-drift-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 145,
+      "createdAt": 1776741903590,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-adk-orchestrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 145,
+      "createdAt": 1776741243728,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/trading-strategy-backtester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 145,
+      "createdAt": 1776741724954,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/application-profiler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 144,
+      "createdAt": 1776741470307,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-schema-designer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 144,
+      "createdAt": 1776741783990,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gh-dash",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 144,
+      "createdAt": 1776741878935,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/quicknode-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 144,
+      "createdAt": 1776742157146,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/recommendation-engine",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 144,
+      "createdAt": 1776741316128,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/regression-test-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 144,
+      "createdAt": 1776742167996,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-design-sprint",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 144,
+      "createdAt": 1776742113532,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-test-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 143,
+      "createdAt": 1776741798986,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gastown",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 143,
+      "createdAt": 1776741593740,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/navan-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 14,
+      "lastMonth": 143,
+      "createdAt": 1776742093357,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/veeva-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 143,
+      "createdAt": 1776742228935,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-top-design",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 143,
+      "createdAt": 1776741852345,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-ux-heuristics",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 143,
+      "createdAt": 1776741857246,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-error-handler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 142,
+      "createdAt": 1776741366917,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cpu-usage-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 142,
+      "createdAt": 1776741676912,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/data-validation-engine",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 142,
+      "createdAt": 1776741706039,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/distributed-tracing-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 142,
+      "createdAt": 1776741837206,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gas-fee-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 142,
+      "createdAt": 1776741668673,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 142,
+      "createdAt": 1776741267989,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-evaluation-suite",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 142,
+      "createdAt": 1776741287537,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/secret-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 142,
+      "createdAt": 1776742194667,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-drive-motivation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 142,
+      "createdAt": 1776741516001,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-predictable-revenue",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 142,
+      "createdAt": 1776741555484,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ci-cd-pipeline-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 141,
+      "createdAt": 1776741589894,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/csrf-protection-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 141,
+      "createdAt": 1776741689021,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/flyio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 141,
+      "createdAt": 1776741913078,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mempool-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 141,
+      "createdAt": 1776741694753,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-explainability-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 141,
+      "createdAt": 1776741292013,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/on-chain-analytics",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 141,
+      "createdAt": 1776741704727,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/orm-code-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 141,
+      "createdAt": 1776741812841,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-incident-responder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 141,
+      "createdAt": 1776742209945,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/stored-procedure-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 141,
+      "createdAt": 1776741828140,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-blue-ocean-strategy",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 141,
+      "createdAt": 1776741494266,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/workhuman-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 141,
+      "createdAt": 1776742244908,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/auto-scaling-configurator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 140,
+      "createdAt": 1776741500087,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/compliance-report-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 140,
+      "createdAt": 1776741645289,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cross-chain-bridge-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 140,
+      "createdAt": 1776741623465,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-documentation-gen",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 140,
+      "createdAt": 1776741749751,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-migration-manager",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 5,
+      "lastMonth": 140,
+      "createdAt": 1776741764014,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-transaction-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 140,
+      "createdAt": 1776741798655,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/databricks-pack",
+      "status": "published",
       "lastDay": 1,
       "lastWeek": 5,
-      "lastMonth": 124
+      "lastMonth": 140,
+      "createdAt": 1776741805135,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/general-legal-assistant",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 140,
+      "createdAt": 1776741480088,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/git-commit-smart",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 140,
+      "createdAt": 1776741883794,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/graphql-server-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 140,
+      "createdAt": 1776741440853,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/nlp-text-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 140,
+      "createdAt": 1776741306620,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/penetration-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 140,
+      "createdAt": 1776742145662,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-budget-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 140,
+      "createdAt": 1776742032418,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ramp-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 140,
+      "createdAt": 1776742161687,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/techsmith-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 140,
+      "createdAt": 1776742214034,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-orchestrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 140,
+      "createdAt": 1776742289194,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/webhook-handler-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 140,
+      "createdAt": 1776741455511,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/004-jeremy-google-cloud-agent-sdk",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 139,
+      "createdAt": 1776741356423,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-security-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 139,
+      "createdAt": 1776741426229,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/brightdata-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 139,
+      "createdAt": 1776741546698,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/data-seeder-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776741700157,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-sharding-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 139,
+      "createdAt": 1776741793860,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/dependency-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776741811210,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deployment-rollback-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776741820945,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/e2e-test-framework",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776741852958,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/finta-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 139,
+      "createdAt": 1776741901487,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-genkit-pro",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 139,
+      "createdAt": 1776741258201,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-genkit-terraform",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776741913788,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/podium-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 139,
+      "createdAt": 1776742147089,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-report-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 139,
+      "createdAt": 1776742294343,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/together-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 9,
+      "lastMonth": 139,
+      "createdAt": 1776742218658,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-lean-startup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 139,
+      "createdAt": 1776742118723,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-refactoring-ui",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 139,
+      "createdAt": 1776741847233,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-traction-eos",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 139,
+      "createdAt": 1776741570146,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-versioning-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 138,
+      "createdAt": 1776741436238,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/calendar-to-workflow",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741562644,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-replication-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 138,
+      "createdAt": 1776741779366,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/framecraft",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 138,
+      "createdAt": 1776741589225,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/geepers-agents",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 138,
+      "createdAt": 1776741598443,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-adk-terraform",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741908802,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-firestore",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741608443,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/navigating-github",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 138,
+      "createdAt": 1776742077901,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/palantir-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 138,
+      "createdAt": 1776742134577,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/promptbook",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741489578,
+      "latestVersion": "1.4.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-agent",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741995295,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/session-security-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 138,
+      "createdAt": 1776742224677,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/staking-rewards-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 138,
+      "createdAt": 1776741715194,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sugar",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741969622,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-ios-hig-design",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 138,
+      "createdAt": 1776741842617,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-web-typography",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 138,
+      "createdAt": 1776741861968,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/agent-context-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 137,
+      "createdAt": 1776741386025,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-gateway-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 137,
+      "createdAt": 1776741377006,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/box-cloud-filesystem",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 137,
+      "createdAt": 1776741532611,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/chaos-engineering-toolkit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 137,
+      "createdAt": 1776741584405,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clickhouse-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 137,
+      "createdAt": 1776741612865,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/code-cleanup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 137,
+      "createdAt": 1776741629140,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/encryption-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 137,
+      "createdAt": 1776741863344,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-adk-software-engineer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 137,
+      "createdAt": 1776741248596,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/remofirst-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 137,
+      "createdAt": 1776742166680,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/search-to-slack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 137,
+      "createdAt": 1776742188886,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-audit-reporter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 137,
+      "createdAt": 1776742200221,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-headers-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 137,
+      "createdAt": 1776742205129,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/severity1-marketplace",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 137,
+      "createdAt": 1776742230208,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/throughput-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 137,
+      "createdAt": 1776742070887,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 136,
+      "createdAt": 1776741339416,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-fuzzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 136,
+      "createdAt": 1776741436171,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-throttling-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 136,
+      "createdAt": 1776741431238,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/attio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 136,
+      "createdAt": 1776741485907,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/b12-claude-plugin",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 136,
+      "createdAt": 1776741506522,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/brand-strategy-framework",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 136,
+      "createdAt": 1776741465047,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clustering-algorithm-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 136,
+      "createdAt": 1776741199210,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-query-profiler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 136,
+      "createdAt": 1776741774708,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/documenso-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 136,
+      "createdAt": 1776741848088,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-as-code-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 136,
+      "createdAt": 1776741898519,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/research-to-deploy",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 136,
+      "createdAt": 1776742173583,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/sprint",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 136,
+      "createdAt": 1776741613368,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-environment-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 136,
+      "createdAt": 1776742283558,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ansible-playbook-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 135,
+      "createdAt": 1776741423878,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/anthropic-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 135,
+      "createdAt": 1776741429011,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-mock-server",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 135,
+      "createdAt": 1776741392061,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-rate-limiter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 135,
+      "createdAt": 1776741401315,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/data-visualization-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 135,
+      "createdAt": 1776741213237,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/dex-aggregator-router",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 135,
+      "createdAt": 1776741658472,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gitops-workflow-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 135,
+      "createdAt": 1776741888908,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/helm-chart-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 135,
+      "createdAt": 1776741893614,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-metrics-collector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 135,
+      "createdAt": 1776741997955,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mistral-pack",
+      "status": "published",
+      "lastDay": 4,
+      "lastWeek": 11,
+      "lastMonth": 135,
+      "createdAt": 1776742076187,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mutation-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 135,
+      "createdAt": 1776742087560,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/pm-ai-partner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 135,
+      "createdAt": 1776742092151,
+      "latestVersion": "1.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/salesforce-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 135,
+      "createdAt": 1776742177232,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sentiment-analysis-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 135,
+      "createdAt": 1776741326141,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/snowflake-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 135,
+      "createdAt": 1776742197705,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sql-query-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 135,
+      "createdAt": 1776741823153,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-scorecard-marketing",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 135,
+      "createdAt": 1776741560291,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/assemblyai-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 134,
+      "createdAt": 1776741480612,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clickup-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 134,
+      "createdAt": 1776741618071,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/creator-studio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 134,
+      "createdAt": 1776741682547,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-index-advisor",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 134,
+      "createdAt": 1776741759111,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/disaster-recovery-planner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 134,
+      "createdAt": 1776741831646,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fairdb-operations-kit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 134,
+      "createdAt": 1776741874121,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fairdb-ops-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 134,
+      "createdAt": 1776741584199,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/notion-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 134,
+      "createdAt": 1776742100763,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/prettier-markdown-hook",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 134,
+      "createdAt": 1776742098264,
+      "latestVersion": "1.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/websocket-server-builder",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 134,
+      "createdAt": 1776741460296,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-influence-psychology",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 134,
+      "createdAt": 1776741526090,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/002-jeremy-yaml-master-agent",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 133,
+      "createdAt": 1776741345442,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/access-control-auditor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 133,
+      "createdAt": 1776741367109,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apm-dashboard-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 133,
+      "createdAt": 1776741454214,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-never-forgets",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 133,
+      "createdAt": 1776741575118,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fathom-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 133,
+      "createdAt": 1776741885508,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-firebase",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 133,
+      "createdAt": 1776741603360,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/metrics-aggregator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 133,
+      "createdAt": 1776742022471,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/miro-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 8,
+      "lastMonth": 133,
+      "createdAt": 1776742071464,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/roi-calculator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 133,
+      "createdAt": 1776741156223,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-misconfiguration-finder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 133,
+      "createdAt": 1776742215068,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/shipwright",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 124
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 10,
+      "lastMonth": 133,
+      "createdAt": 1776741161170,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/test-doubles-generator",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 124
+      "name": "@intentsolutionsio/soc2-audit-helper",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 133,
+      "createdAt": 1776742251865,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/vulnerability-scanner",
-      "lastDay": 1,
+      "name": "@intentsolutionsio/test-data-generator",
+      "status": "published",
+      "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 124
+      "lastMonth": 133,
+      "createdAt": 1776742273457,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-contagious",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 133,
+      "createdAt": 1776741499334,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-crossing-the-chasm",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 133,
+      "createdAt": 1776741510287,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apple-notes-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776741465204,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/authentication-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776741492512,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/bottleneck-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776741527951,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/capacity-planning-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 132,
+      "createdAt": 1776741573970,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/classification-model-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776741194497,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/coreweave-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776741666254,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/error-rate-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 132,
+      "createdAt": 1776741874361,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hyperfocus",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 132,
+      "createdAt": 1776741992310,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/input-validation-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 132,
+      "createdAt": 1776742003316,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/log-analysis-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776742012942,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mattyp-changelog",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 132,
+      "createdAt": 1776741943473,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/monitoring-stack-deployer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 132,
+      "createdAt": 1776741949314,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/network-policy-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 132,
+      "createdAt": 1776741954784,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/onenote-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 132,
+      "createdAt": 1776742112289,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/resource-usage-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776742052108,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/service-mesh-configurator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 132,
+      "createdAt": 1776741964665,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/time-series-forecaster",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 132,
+      "createdAt": 1776741331102,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/twinmind-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 132,
+      "createdAt": 1776742223810,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-jobs-to-be-done",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 132,
+      "createdAt": 1776741531206,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-commit-gen",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 131,
+      "createdAt": 1776741391024,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-monitoring-dashboard",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741396718,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apify-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741449323,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/appfolio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741459687,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clari-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741595043,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/contributing-clanker",
+      "status": "published",
+      "lastDay": 5,
+      "lastWeek": 131,
+      "lastMonth": 131,
+      "createdAt": 1777867323247,
+      "latestVersion": "0.1.1"
+    },
+    {
+      "name": "@intentsolutionsio/dataset-splitter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741218574,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/load-balancer-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 131,
+      "createdAt": 1776742042186,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mobile-app-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 131,
+      "createdAt": 1776742081444,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/overnight-dev",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 131,
+      "createdAt": 1776742087226,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/query-performance-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 131,
+      "createdAt": 1776741818576,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/response-time-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 131,
+      "createdAt": 1776742056723,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/salesloft-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776742182221,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-pro-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 131,
+      "createdAt": 1776742001005,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sow-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 131,
+      "createdAt": 1776741166392,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ssl-certificate-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 131,
+      "createdAt": 1776742260826,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/stackblitz-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 131,
+      "createdAt": 1776742208455,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/terraform-module-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 131,
+      "createdAt": 1776741974510,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/zapier-zap-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 131,
+      "createdAt": 1776741170876,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/003-jeremy-vertex-ai-media-master",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 130,
+      "createdAt": 1776741351076,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-ethics-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 130,
+      "createdAt": 1776741175662,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/anomaly-detection-system",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 130,
+      "createdAt": 1776741185020,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-load-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 130,
+      "createdAt": 1776741382190,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-migration-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 130,
+      "createdAt": 1776741387229,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cloud-cost-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 130,
+      "createdAt": 1776741623637,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/experiment-tracking-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 130,
+      "createdAt": 1776741228741,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/feature-engineering-toolkit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 130,
+      "createdAt": 1776741233516,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/freshie-inventory-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 130,
+      "createdAt": 1776741803557,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/load-balancer-configurator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 130,
+      "createdAt": 1776741932915,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/smoke-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 130,
+      "createdAt": 1776742241282,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/alchemy-pack",
-      "lastDay": 0,
-      "lastWeek": 12,
-      "lastMonth": 123
-    },
-    {
-      "name": "@intentsolutionsio/api-sdk-generator",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 123
+      "lastMonth": 129,
+      "createdAt": 1776741401853,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/cors-policy-validator",
-      "lastDay": 2,
-      "lastWeek": 6,
-      "lastMonth": 123
+      "name": "@intentsolutionsio/algolia-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 129,
+      "createdAt": 1776741412656,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/file-to-code",
+      "name": "@intentsolutionsio/api-documentation-generator",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 2,
-      "lastMonth": 123
+      "lastMonth": 129,
+      "createdAt": 1776741361862,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/intercom-pack",
-      "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 123
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-terraform",
+      "name": "@intentsolutionsio/api-event-emitter",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 13,
-      "lastMonth": 123
-    },
-    {
-      "name": "@intentsolutionsio/runway-pack",
-      "lastDay": 3,
       "lastWeek": 6,
-      "lastMonth": 123
+      "lastMonth": 129,
+      "createdAt": 1776741371900,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/validate-plugin",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 123
-    },
-    {
-      "name": "@intentsolutionsio/abridge-pack",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/ai-sdk-agents",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/ai-ml-engineering-pack",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/api-response-validator",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/deployment-pipeline-orchestrator",
+      "name": "@intentsolutionsio/api-schema-validator",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 122
+      "lastMonth": 129,
+      "createdAt": 1776741416639,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/framer-pack",
-      "lastDay": 1,
-      "lastWeek": 14,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-github-actions-gcp",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/owasp-compliance-checker",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/performance-regression-detector",
-      "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/sla-sli-tracker",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 122
-    },
-    {
-      "name": "@intentsolutionsio/neurodivergent-visual-org",
+      "name": "@intentsolutionsio/bamboohr-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 121
+      "lastMonth": 129,
+      "createdAt": 1776741517049,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/secrets-manager-integrator",
+      "name": "@intentsolutionsio/database-security-scanner",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 121
+      "lastWeek": 2,
+      "lastMonth": 129,
+      "createdAt": 1776741788589,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/adobe-pack",
+      "name": "@intentsolutionsio/docker-compose-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 129,
+      "createdAt": 1776741842527,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/figma-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 120
+      "lastMonth": 129,
+      "createdAt": 1776741890993,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/canva-pack",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 120
-    },
-    {
-      "name": "@intentsolutionsio/data-preprocessing-pipeline",
+      "name": "@intentsolutionsio/hootsuite-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 120
+      "lastMonth": 129,
+      "createdAt": 1776741981134,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/flexport-pack",
+      "name": "@intentsolutionsio/jeremy-gcp-starter-examples",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 129,
+      "createdAt": 1776741253353,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/nosql-data-modeler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 129,
+      "createdAt": 1776741808087,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/procore-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 129,
+      "createdAt": 1776742152600,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/snapshot-test-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 129,
+      "createdAt": 1776742246361,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wispr-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 120
-    },
-    {
-      "name": "@intentsolutionsio/pi-pathfinder",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 120
-    },
-    {
-      "name": "@intentsolutionsio/shopify-pack",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 120
-    },
-    {
-      "name": "@intentsolutionsio/speak-pack",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 120
-    },
-    {
-      "name": "@intentsolutionsio/xss-vulnerability-scanner",
-      "lastDay": 0,
-      "lastWeek": 11,
-      "lastMonth": 120
+      "lastMonth": 129,
+      "createdAt": 1776742239940,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/youtube-strategy",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 10,
+      "lastMonth": 129,
+      "createdAt": 1776742123654,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-authentication-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 128,
+      "createdAt": 1776741340599,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-cache-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 128,
+      "createdAt": 1776741350600,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/backup-strategy-implementor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 128,
+      "createdAt": 1776741511388,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/castai-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 128,
+      "createdAt": 1776741579323,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/discovery-questionnaire",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 128,
+      "createdAt": 1776741141456,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fondo-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 128,
+      "createdAt": 1776741918288,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fullstack-starter-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 128,
+      "createdAt": 1776741935465,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hello-world",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 128,
+      "createdAt": 1776741964579,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hyperparameter-tuner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 128,
+      "createdAt": 1776741238112,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/lucidchart-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 128,
+      "createdAt": 1776742054478,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/make-scenario-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 128,
+      "createdAt": 1776741146439,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/openevidence-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 128,
+      "createdAt": 1776742117677,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/vulnerability-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 128,
+      "createdAt": 1776742266333,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-cro-methodology",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 128,
+      "createdAt": 1776741505352,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-storybrand-messaging",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 128,
+      "createdAt": 1776741565251,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/accessibility-test-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 127,
+      "createdAt": 1776741372890,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-ml-engineering-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 127,
+      "createdAt": 1776741396518,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-reflect",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 127,
+      "createdAt": 1776741579743,
+      "latestVersion": "1.5.0"
+    },
+    {
+      "name": "@intentsolutionsio/formatter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 127,
+      "createdAt": 1776741923633,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/grammarly-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 127,
+      "createdAt": 1776741953217,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-terraform",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 127,
+      "createdAt": 1776741923149,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/kubernetes-deployment-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 127,
+      "createdAt": 1776741927823,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/oraclecloud-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 127,
+      "createdAt": 1776742123023,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/regression-analysis-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 127,
+      "createdAt": 1776741320893,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/serpapi-pack",
+      "status": "published",
       "lastDay": 1,
       "lastWeek": 5,
-      "lastMonth": 120
+      "lastMonth": 127,
+      "createdAt": 1776742187383,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-coverage-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 127,
+      "createdAt": 1776742268158,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-doubles-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 127,
+      "createdAt": 1776742278508,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/tonone",
+      "status": "published",
+      "lastDay": 5,
+      "lastWeek": 127,
+      "lastMonth": 127,
+      "createdAt": 1777867315353,
+      "latestVersion": "0.9.7"
+    },
+    {
+      "name": "@intentsolutionsio/tweetclaw",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 127,
+      "createdAt": 1776741979702,
+      "latestVersion": "1.5.3"
+    },
+    {
+      "name": "@intentsolutionsio/webflow-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 127,
+      "createdAt": 1776742234620,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-hundred-million-offers",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 127,
+      "createdAt": 1776741521101,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/alerting-rule-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776741407319,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-contract-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 126,
+      "createdAt": 1776741356168,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-request-logger",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776741406484,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-sdk-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 126,
+      "createdAt": 1776741421642,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claudebase",
+      "status": "published",
+      "lastDay": 8,
+      "lastWeek": 126,
+      "lastMonth": 126,
+      "createdAt": 1777867338728,
+      "latestVersion": "0.2.0"
+    },
+    {
+      "name": "@intentsolutionsio/deep-learning-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 126,
+      "createdAt": 1776741223557,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/file-to-code",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 126,
+      "createdAt": 1776741896252,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/grpc-service-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776741445475,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hipaa-compliance-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776741975805,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/linktree-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776742036794,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ollama-local-ai",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 126,
+      "createdAt": 1776741311329,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-regression-detector",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 126,
+      "createdAt": 1776742042415,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/real-user-monitoring",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 126,
+      "createdAt": 1776742047249,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/rest-api-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 126,
+      "createdAt": 1776741450487,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/shopify-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 7,
+      "lastMonth": 126,
+      "createdAt": 1776742192751,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-sdk-agents",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 125,
+      "createdAt": 1776741180231,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/canva-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 125,
+      "createdAt": 1776741567722,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cors-policy-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 125,
+      "createdAt": 1776741671309,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/environment-config-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 125,
+      "createdAt": 1776741869031,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/evernote-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 125,
+      "createdAt": 1776741879235,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/intercom-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 125,
+      "createdAt": 1776742014863,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/owasp-compliance-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 125,
+      "createdAt": 1776742128831,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/validate-plugin",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 125,
+      "createdAt": 1776742277333,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/abridge-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 124,
+      "createdAt": 1776741362002,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-batch-processor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 124,
+      "createdAt": 1776741345543,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-response-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 124,
+      "createdAt": 1776741411642,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/framer-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 124,
+      "createdAt": 1776741929510,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-github-actions-gcp",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 124,
+      "createdAt": 1776741918359,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/neurodivergent-visual-org",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 124,
+      "createdAt": 1776742082401,
+      "latestVersion": "3.1.1"
+    },
+    {
+      "name": "@intentsolutionsio/runway-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 124,
+      "createdAt": 1776742172008,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/adobe-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 123,
+      "createdAt": 1776741380220,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deployment-pipeline-orchestrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 123,
+      "createdAt": 1776741816157,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/flexport-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 123,
+      "createdAt": 1776741907785,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/pi-pathfinder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 123,
+      "createdAt": 1776741990618,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/secrets-manager-integrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 123,
+      "createdAt": 1776741959827,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sla-sli-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 123,
+      "createdAt": 1776742061398,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/automl-pipeline-builder",
-      "lastDay": 1,
+      "status": "published",
+      "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 119
+      "lastMonth": 122,
+      "createdAt": 1776741189916,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/claude-memory-kit",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 119
+      "name": "@intentsolutionsio/data-preprocessing-pipeline",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 122,
+      "createdAt": 1776741208684,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/speak-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 122,
+      "createdAt": 1776742203153,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/gdpr-compliance-scanner",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 119
-    },
-    {
-      "name": "@intentsolutionsio/log-aggregation-setup",
-      "lastDay": 1,
-      "lastWeek": 7,
-      "lastMonth": 119
-    },
-    {
-      "name": "@intentsolutionsio/transfer-learning-adapter",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 119
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 121,
+      "createdAt": 1776741941194,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/jeremy-plugin-tool",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 118
+      "lastWeek": 3,
+      "lastMonth": 121,
+      "createdAt": 1776741985544,
+      "latestVersion": "2.0.0"
     },
     {
-      "name": "@intentsolutionsio/load-test-runner",
+      "name": "@intentsolutionsio/transfer-learning-adapter",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 118
+      "lastWeek": 3,
+      "lastMonth": 121,
+      "createdAt": 1776741335844,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/xss-vulnerability-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 121,
+      "createdAt": 1776742271063,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-memory-kit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 120,
+      "createdAt": 1776741600302,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/log-aggregation-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 120,
+      "createdAt": 1776741938134,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/maintainx-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 8,
-      "lastMonth": 118
+      "lastWeek": 2,
+      "lastMonth": 120,
+      "createdAt": 1776742059330,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/computer-vision-processor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 119,
+      "createdAt": 1776741204141,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/integration-test-runner",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 117
-    },
-    {
-      "name": "@intentsolutionsio/langfuse-pack",
-      "lastDay": 3,
-      "lastWeek": 7,
-      "lastMonth": 116
-    },
-    {
-      "name": "@intentsolutionsio/memory-leak-detector",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 116
+      "lastMonth": 119,
+      "createdAt": 1776742009284,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/load-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 119,
+      "createdAt": 1776742007859,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/performance-optimization-advisor",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 113
-    },
-    {
-      "name": "@intentsolutionsio/lokalise-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 112
+      "lastWeek": 7,
+      "lastMonth": 119,
+      "createdAt": 1776742038071,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/hex-pack",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 110
+      "name": "@intentsolutionsio/langfuse-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 118,
+      "createdAt": 1776742031108,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/memory-leak-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 117,
+      "createdAt": 1776742017667,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/klaviyo-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 110
+      "lastMonth": 114,
+      "createdAt": 1776742024634,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/lokalise-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 113,
+      "createdAt": 1776742048902,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hex-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 112,
+      "createdAt": 1776741970594,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/synthetic-monitoring-setup",
+      "status": "published",
       "lastDay": 1,
-      "lastWeek": 19,
-      "lastMonth": 79
-    },
-    {
-      "name": "@intentsolutionsio/obsidian-pack",
-      "lastDay": 1,
-      "lastWeek": 15,
-      "lastMonth": 75
-    },
-    {
-      "name": "@intentsolutionsio/glean-pack",
-      "lastDay": 6,
-      "lastWeek": 16,
-      "lastMonth": 74
+      "lastWeek": 4,
+      "lastMonth": 82,
+      "createdAt": 1776742066032,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/network-latency-analyzer",
+      "status": "published",
       "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 74
+      "lastWeek": 4,
+      "lastMonth": 77,
+      "createdAt": 1776742027404,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/obsidian-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 77,
+      "createdAt": 1776742106568,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/glean-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 8,
+      "lastMonth": 76,
+      "createdAt": 1776741947525,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/n8n-workflow-designer",
+      "status": "published",
       "lastDay": 1,
-      "lastWeek": 20,
-      "lastMonth": 73
-    },
-    {
-      "name": "@intentsolutionsio/langchain-pack",
-      "lastDay": 3,
-      "lastWeek": 28,
-      "lastMonth": 70
-    },
-    {
-      "name": "@intentsolutionsio/hubspot-pack",
-      "lastDay": 0,
-      "lastWeek": 15,
-      "lastMonth": 68
-    },
-    {
-      "name": "@intentsolutionsio/anima-pack",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 67
+      "lastWeek": 3,
+      "lastMonth": 75,
+      "createdAt": 1776741151393,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/pci-dss-validator",
+      "status": "published",
       "lastDay": 1,
+      "lastWeek": 10,
+      "lastMonth": 74,
+      "createdAt": 1776742139757,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hubspot-pack",
+      "status": "published",
+      "lastDay": 4,
       "lastWeek": 5,
-      "lastMonth": 65
+      "lastMonth": 73,
+      "createdAt": 1776741987099,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/windsurf-pack",
-      "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 60
+      "name": "@intentsolutionsio/langchain-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 18,
+      "lastMonth": 73,
+      "createdAt": 1767929563572,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/vastai-pack",
+      "name": "@intentsolutionsio/anima-pack",
+      "status": "published",
       "lastDay": 1,
-      "lastWeek": 13,
-      "lastMonth": 57
+      "lastWeek": 4,
+      "lastMonth": 70,
+      "createdAt": 1776741418062,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mindtickle-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 69,
+      "createdAt": 1776742066066,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-ai",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 62,
+      "lastMonth": 62,
+      "createdAt": 1777603633821,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-google-adk",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 60,
+      "lastMonth": 60,
+      "createdAt": 1777603623651,
+      "latestVersion": "2.0.0"
     },
     {
       "name": "@intentsolutionsio/openrouter-pack",
-      "lastDay": 3,
-      "lastWeek": 16,
-      "lastMonth": 56
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 10,
+      "lastMonth": 55,
+      "createdAt": 1767929515334,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/klingai-pack",
+      "status": "published",
+      "lastDay": 5,
+      "lastWeek": 32,
+      "lastMonth": 53,
+      "createdAt": 1767929518106,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/vastai-pack",
+      "status": "published",
       "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 47,
+      "createdAt": 1767929537310,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/windsurf-pack",
+      "status": "published",
+      "lastDay": 4,
       "lastWeek": 6,
-      "lastMonth": 30
-    },
-    {
-      "name": "@intentsolutionsio/granola-pack",
-      "lastDay": 2,
-      "lastWeek": 9,
-      "lastMonth": 22
-    },
-    {
-      "name": "@intentsolutionsio/sentry-pack",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 21
-    },
-    {
-      "name": "@intentsolutionsio/supabase-pack",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 19
-    },
-    {
-      "name": "@intentsolutionsio/firecrawl-pack",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 18
-    },
-    {
-      "name": "@intentsolutionsio/linear-pack",
-      "lastDay": 0,
-      "lastWeek": 8,
-      "lastMonth": 18
+      "lastMonth": 46,
+      "createdAt": 1767929526171,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/coderabbit-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 16
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1767929546848,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/cursor-pack",
+      "name": "@intentsolutionsio/granola-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 14
+      "lastMonth": 20,
+      "createdAt": 1767929567573,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/retellai-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1767929520308,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/firecrawl-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1767929528093,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/perplexity-pack",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 14
+      "status": "published",
+      "lastDay": 4,
+      "lastWeek": 7,
+      "lastMonth": 19,
+      "createdAt": 1767929523683,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/exa-pack",
+      "name": "@intentsolutionsio/linear-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 13
+      "lastWeek": 0,
+      "lastMonth": 18,
+      "createdAt": 1767929574015,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/replit-pack",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 13
-    },
-    {
-      "name": "@intentsolutionsio/apollo-pack",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 12
-    },
-    {
-      "name": "@intentsolutionsio/gamma-pack",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 12
-    },
-    {
-      "name": "@intentsolutionsio/ideogram-pack",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 12
-    },
-    {
-      "name": "@intentsolutionsio/vercel-pack",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 12
-    },
-    {
-      "name": "@intentsolutionsio/clerk-pack",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 11
-    },
-    {
-      "name": "@intentsolutionsio/deepgram-pack",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 11
-    },
-    {
-      "name": "@intentsolutionsio/fireflies-pack",
+      "name": "@intentsolutionsio/sentry-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 11
+      "lastMonth": 18,
+      "createdAt": 1767121182722,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/lindy-pack",
+      "name": "@intentsolutionsio/supabase-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 11
-    },
-    {
-      "name": "@intentsolutionsio/posthog-pack",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 11
+      "lastWeek": 1,
+      "lastMonth": 18,
+      "createdAt": 1767067636870,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "claude-plugin-validator",
-      "lastDay": 0,
+      "status": "published",
+      "lastDay": 1,
       "lastWeek": 6,
-      "lastMonth": 11
+      "lastMonth": 17,
+      "createdAt": 1763263826323,
+      "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/groq-pack",
+      "name": "@intentsolutionsio/ideogram-pack",
+      "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 10
+      "lastMonth": 16,
+      "createdAt": 1767929551266,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/customerio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 13,
+      "createdAt": 1767929561184,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/exa-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 13,
+      "createdAt": 1767929534960,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/lindy-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 13,
+      "createdAt": 1767929565624,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/replit-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 13,
+      "createdAt": 1767929532725,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apollo-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 12,
+      "createdAt": 1767929554160,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cursor-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 12,
+      "createdAt": 1767929512616,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gamma-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 12,
+      "createdAt": 1767929569776,
+      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/juicebox-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 2,
+      "lastMonth": 12,
+      "createdAt": 1767929559015,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/vercel-pack",
+      "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 10
+      "lastWeek": 1,
+      "lastMonth": 12,
+      "createdAt": 1767044418798,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clerk-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 11,
+      "createdAt": 1767929571928,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deepgram-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 11,
+      "createdAt": 1767929556761,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fireflies-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 11,
+      "createdAt": 1767929544753,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clay-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 10,
+      "createdAt": 1767929530301,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/groq-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 10,
+      "createdAt": 1767929539979,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/instantly-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 10,
+      "createdAt": 1767929542132,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/posthog-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 0,
+      "lastMonth": 10,
+      "createdAt": 1767929549075,
+      "latestVersion": "1.0.0"
     }
-  ]
+  ],
+  "telemetry": {
+    "candidates": 438,
+    "probed": 438,
+    "published": 418,
+    "unpublished": 17,
+    "foreign": 3,
+    "rateLimited": 0,
+    "errors": 0
+  }
 }

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1152,7 +1152,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             {npmPublished > 0 && (
                 <div class="hero-sponsor-marquee hero-stats-marquee">
                     <span class="hero-sponsor-label">
-                        live npm downloads · {fmtNum(npmPublished)} packages
+                        {fmtNum(npmMonth)} downloads / 30d · {fmtNum(npmPublished)} packages on npm
                     </span>
                     <div class="hero-sponsor-track">
                         {npmTop.map((p) => (

--- a/scripts/fetch-npm-stats.mjs
+++ b/scripts/fetch-npm-stats.mjs
@@ -78,7 +78,9 @@ async function fetchRegistryMetadata(name) {
   const enc = encodeURIComponent(name);
   const url = `https://registry.npmjs.org/${enc}`;
   let lastError = null;
-  for (let i = 0; i < 4; i++) {
+  // 6 retries with exponential backoff up to ~64 s, so we ride through
+  // brief 429 waves instead of giving up at 15 s.
+  for (let i = 0; i < 6; i++) {
     let res;
     try {
       res = await fetch(url);
@@ -89,18 +91,15 @@ async function fetchRegistryMetadata(name) {
     }
     if (res.status === 404) return { kind: 'not-found' };
     if (res.status === 429) {
-      // Backoff. If we exhaust retries we'll fall through to rate-limited.
-      await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, i)));
+      await new Promise((r) => setTimeout(r, 2000 * Math.pow(2, i)));
       continue;
     }
     if (res.status >= 500) {
-      // Server hiccups; retry too, but keep the status for diagnostics.
       lastError = new Error(`HTTP ${res.status}`);
       await new Promise((r) => setTimeout(r, 500 * (i + 1)));
       continue;
     }
     if (!res.ok) {
-      // 401/403 etc. — treat as not-ours; surface but don't kill the run.
       return { kind: 'forbidden', status: res.status };
     }
     try {
@@ -122,7 +121,8 @@ async function fetchDownloadsPoint(name, window) {
   const enc = encodeURIComponent(name);
   const url = `https://api.npmjs.org/downloads/point/${window}/${enc}`;
   let lastError = null;
-  for (let i = 0; i < 4; i++) {
+  // 6 retries with exponential backoff up to ~64 s.
+  for (let i = 0; i < 6; i++) {
     let res;
     try {
       res = await fetch(url);
@@ -133,7 +133,7 @@ async function fetchDownloadsPoint(name, window) {
     }
     if (res.status === 404) return { kind: 'not-found' };
     if (res.status === 429) {
-      await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, i)));
+      await new Promise((r) => setTimeout(r, 2000 * Math.pow(2, i)));
       continue;
     }
     if (res.status >= 500) {
@@ -233,7 +233,7 @@ async function statsFor(name) {
   };
 }
 
-async function collectStats(pkgNames, concurrency = 4) {
+async function collectStats(pkgNames, { concurrency = 1, throttleMs = 250 } = {}) {
   const counts = {
     candidates: pkgNames.length,
     probed: 0,
@@ -259,6 +259,7 @@ async function collectStats(pkgNames, concurrency = 4) {
         counts.probed += 1;
         counts.errors += 1;
         errorDetails.push({ name, detail: err.message });
+        if (throttleMs) await new Promise((r) => setTimeout(r, throttleMs));
         continue;
       }
       counts.probed += 1;
@@ -282,6 +283,10 @@ async function collectStats(pkgNames, concurrency = 4) {
           errorDetails.push({ name, detail: result.detail });
           break;
       }
+      // Inter-request throttle so we stay under npm's per-IP cap. With
+      // concurrency=1 + 250ms = 4 req/sec, well below the observed
+      // rate-limit threshold (~280 req/min in CI).
+      if (throttleMs) await new Promise((r) => setTimeout(r, throttleMs));
     }
   }
 


### PR DESCRIPTION
## What was wrong

The marquee stat was stuck at **41,975 since 2026-05-02** because the daily npm-stats cron was failing on registry rate limits — 158 of 437 packages 429'd every run, and the script (correctly) refused to publish unreliable totals.

PR #688 stripped the stale "last 30d" segment as a holding pattern; this brings it back with a real number.

## Real numbers as of today

| | Old (stuck since May 2) | New (today) |
|---|---:|---:|
| Published packages | 340 | **418** |
| Last 30 days | 41,975 | **53,237** |
| Last 7 days | 3,937 | **2,757** |
| Last 24 hours | 366 | **128** |

## What changes

- `scripts/fetch-npm-stats.mjs`:
  - Drop concurrency 4 → 1 (sequential)
  - Add 250 ms inter-request throttle (4 req/s, well under npm's per-IP cap)
  - Retries 4 → 6, base delay 1 s → 2 s (max backoff ~64 s) — rides through brief 429 waves instead of giving up at 15 s
  - Local run completed clean: 0 rate-limited, 0 errored
- `marketplace/src/pages/index.astro` — marquee restored: `53,237 downloads / 30d · 418 packages on npm`
- `marketplace/src/data/npm-stats.json` + README NPM-STATS block — refreshed to today
- The cron workflow itself doesn't change — it shells the same script, so its next scheduled run will succeed

## Test plan

- [ ] Build clean (verified: 3470 pages, ~33 s)
- [ ] Live homepage marquee reads the new format with real numbers
- [ ] Next scheduled cron run (00:15 UTC) succeeds

jeremylongshore.com made me do it
  -claude
intentsolutions.io