### PR TITLE
chore(readme): resync AUTO-TOC block

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,31 +70,31 @@ ccpi update                     # Pull latest versions
 
 ### 📦 Live npm Downloads
 
-Across **418 published packages** in the 
+Across **418 published packages** in the
 [claude-code-plugins](https://www.npmjs.com/~jeremylongshore) namespace. Updated daily by GitHub Actions.
 
-| Window | All packages | Established (>30d) |
-|--------|-------------:|-------------------:|
-| Last 24 hours | 128 | 36 |
-| Last 7 days | 2,757 | 206 |
-| Last 30 days | 53,237 | 990 |
+| Window        | All packages | Established (>30d) |
+| ------------- | -----------: | -----------------: |
+| Last 24 hours |          128 |                 36 |
+| Last 7 days   |        2,757 |                206 |
+| Last 30 days  |       53,237 |                990 |
 
 <sub>"Established" excludes packages first published within the last 30 days, so a bulk-publish event doesn't dominate the headline.</sub>
 
 **Top 10 by last 30 days:**
 
-| # | Package | Last 30d |
-|---|---------|---------:|
-| 1 | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi) | 346 |
-| 2 | [`@intentsolutionsio/guidewire-pack`](https://www.npmjs.com/package/@intentsolutionsio/guidewire-pack) | 324 |
-| 3 | [`@intentsolutionsio/engineer-design-diagram`](https://www.npmjs.com/package/@intentsolutionsio/engineer-design-diagram) | 242 |
-| 4 | [`@intentsolutionsio/market-price-tracker`](https://www.npmjs.com/package/@intentsolutionsio/market-price-tracker) | 224 |
-| 5 | [`@intentsolutionsio/excel-analyst-pro`](https://www.npmjs.com/package/@intentsolutionsio/excel-analyst-pro) | 189 |
-| 6 | [`@intentsolutionsio/openbb-terminal`](https://www.npmjs.com/package/@intentsolutionsio/openbb-terminal) | 182 |
-| 7 | [`@intentsolutionsio/options-flow-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/options-flow-analyzer) | 181 |
-| 8 | [`@intentsolutionsio/crypto-portfolio-tracker`](https://www.npmjs.com/package/@intentsolutionsio/crypto-portfolio-tracker) | 175 |
-| 9 | [`@intentsolutionsio/nft-rarity-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/nft-rarity-analyzer) | 174 |
-| 10 | [`@intentsolutionsio/arbitrage-opportunity-finder`](https://www.npmjs.com/package/@intentsolutionsio/arbitrage-opportunity-finder) | 167 |
+| #   | Package                                                                                                                            | Last 30d |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------- | -------: |
+| 1   | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi)                                                 |      346 |
+| 2   | [`@intentsolutionsio/guidewire-pack`](https://www.npmjs.com/package/@intentsolutionsio/guidewire-pack)                             |      324 |
+| 3   | [`@intentsolutionsio/engineer-design-diagram`](https://www.npmjs.com/package/@intentsolutionsio/engineer-design-diagram)           |      242 |
+| 4   | [`@intentsolutionsio/market-price-tracker`](https://www.npmjs.com/package/@intentsolutionsio/market-price-tracker)                 |      224 |
+| 5   | [`@intentsolutionsio/excel-analyst-pro`](https://www.npmjs.com/package/@intentsolutionsio/excel-analyst-pro)                       |      189 |
+| 6   | [`@intentsolutionsio/openbb-terminal`](https://www.npmjs.com/package/@intentsolutionsio/openbb-terminal)                           |      182 |
+| 7   | [`@intentsolutionsio/options-flow-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/options-flow-analyzer)               |      181 |
+| 8   | [`@intentsolutionsio/crypto-portfolio-tracker`](https://www.npmjs.com/package/@intentsolutionsio/crypto-portfolio-tracker)         |      175 |
+| 9   | [`@intentsolutionsio/nft-rarity-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/nft-rarity-analyzer)                   |      174 |
+| 10  | [`@intentsolutionsio/arbitrage-opportunity-finder`](https://www.npmjs.com/package/@intentsolutionsio/arbitrage-opportunity-finder) |      167 |
 
 <sub>Last refreshed 2026-05-07T15:28:44.521Z.</sub>
 


### PR DESCRIPTION
TOC drifted from `marketplace.extended.json`. Caught by the `Verify README TOC is in sync with catalog` CI step on PR #689; resyncs via `pnpm run sync-marketplace`.

jeremylongshore.com made me do it
  -claude
intentsolutions.io