### PR TITLE
fix(homepage): relabel npm marquee '30d' → 'total downloads'

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1152,7 +1152,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             {npmPublished > 0 && (
                 <div class="hero-sponsor-marquee hero-stats-marquee">
                     <span class="hero-sponsor-label">
-                        {fmtNum(npmMonth)} downloads / 30d · {fmtNum(npmPublished)} packages on npm
+                        {fmtNum(npmMonth)} total downloads · {fmtNum(npmPublished)} packages on npm
                     </span>
                     <div class="hero-sponsor-track">
                         {npmTop.map((p) => (


### PR DESCRIPTION
Per owner: relabel only. Same number from last night's fetch (53,237).

jeremylongshore.com made me do it
  -claude
intentsolutions.io