### PR TITLE
feat(validate): JRig Tier 3A spec snapshots + gitignore exceptions (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ coverage/
 #   v3.x legacy:   6767-* prefix (kept tracked during transition; will deprecate)
 !000-docs/000-*.md
 !000-docs/6767*.md
+# Spec snapshots read by JRig Tier 3A (refreshed quarterly via PR, NOT live-fetch)
+!000-docs/anthropic-skills-spec-snapshot.md
+!000-docs/agentskills-spec-snapshot.md
 website/
 
 # Internal planning and research documents (do not commit to public repo)

--- a/000-docs/agentskills-spec-snapshot.md
+++ b/000-docs/agentskills-spec-snapshot.md
@@ -1,0 +1,83 @@
+# AgentSkills.io Open Spec — Versioned Snapshot
+
+**Snapshot ID**: 2026-05-07-initial
+**Source**: https://agentskills.io/specification
+**Captured**: 2026-05-07
+**Refresh cadence**: Quarterly (manual PR or scheduled cron)
+**Read by**: JRig Tier 3A spec-compliance check (called from `/validate-skillmd --thorough`)
+
+---
+
+## Why this file exists
+
+AgentSkills.io is the open standard Claude Code follows for `compatibility`, `metadata`, and `license`. We capture it as a versioned snapshot for the same reason as the Anthropic spec snapshot — Tier 3A validates against frozen references, not live URLs.
+
+---
+
+## Required fields (open spec)
+
+- `name`
+- `description`
+
+Same as Anthropic's spec floor.
+
+---
+
+## Optional fields (open spec)
+
+| Field | Notes |
+|---|---|
+| `allowed-tools` | Optional under the open spec; IS marketplace requires it |
+| `compatibility` | **Free-text string, max 500 chars.** Documents environment requirements (intended product, runtime, system packages, network access). NOT an enum. NOT a CSV platform list. The IS-invented `compatible-with` field was a closed allow-list and is deprecated. |
+| `license` | SPDX identifier or human-readable description |
+| `metadata` | Free-form key-value mapping for any additional context |
+
+---
+
+## `compatibility` field guidance (deeper)
+
+Examples per the open spec:
+
+```yaml
+compatibility: "Designed for Claude Code"
+compatibility: "Designed for Claude Code, also compatible with Codex and OpenClaw"
+compatibility: "Requires Python 3.10+ with uv installed"
+compatibility: "Requires git, docker, and jq on PATH"
+compatibility: "Node.js >= 18, npm >= 9"
+compatibility: "Designed for Claude Code; requires Bash 5+ and rg (ripgrep)"
+compatibility: "Requires network access to api.example.com (port 443)"
+```
+
+Anti-pattern: enumerating a closed list of platforms. The deprecated IS `compatible-with: claude-code, codex, openclaw` was an enum — replaced by free-text `compatibility`.
+
+---
+
+## `metadata` field guidance
+
+Open-ended object. Common keys observed in the wild:
+
+- `category` (e.g., `devops`, `security`, `analytics`)
+- `version` (when not at top-level — both forms valid per open spec)
+- `author` (when not at top-level — both forms valid)
+- `tags` (when not at top-level)
+- `homepage`, `repository` (URLs to project sources)
+
+The IS rubric prefers top-level `version` / `author` / `tags` (these are required at the IS marketplace tier). Skills that put them under `metadata` still pass, since the open spec accepts both.
+
+---
+
+## Refresh procedure
+
+1. Fetch `https://agentskills.io/specification` rendered content
+2. Diff against current snapshot — identify added / removed / changed fields
+3. Update sections above (required, optional, `compatibility` guidance, `metadata` guidance)
+4. Bump Snapshot ID to `YYYY-MM-DD-NN`
+5. Open PR with the diff
+6. PR review = human gate
+7. Merge → Tier 3A reads new snapshot on next `--thorough` run
+
+---
+
+## Status
+
+Initial seed snapshot, 2026-05-07. Captures the open-spec field facts the IS validator already enforces (`compatibility` free-text, `metadata` open object, `license` optional). First quarterly refresh will check live URL for any changes since this date.

--- a/000-docs/anthropic-skills-spec-snapshot.md
+++ b/000-docs/anthropic-skills-spec-snapshot.md
@@ -1,0 +1,94 @@
+# Anthropic Skills Spec — Versioned Snapshot
+
+**Snapshot ID**: 2026-05-07-initial
+**Source**: https://code.claude.com/docs/en/skills
+**Captured**: 2026-05-07
+**Refresh cadence**: Quarterly (manual PR or scheduled cron)
+**Read by**: JRig Tier 3A spec-compliance check (called from `/validate-skillmd --thorough`)
+
+---
+
+## Why this file exists
+
+Tier 3A of `/validate-skillmd` validates SKILL.md frontmatter against Anthropic's official spec. We **do not live-fetch** that spec at validation time — rate-limit risk plus CI flakiness make live-fetch a bad gate. Instead, we capture the spec as a versioned snapshot here, refresh it quarterly via a dedicated PR, and let validation read this frozen reference.
+
+The PR review on each refresh = the human gate that catches breaking spec changes BEFORE they hit thousands of skill validations.
+
+---
+
+## Required-field set (Anthropic spec floor)
+
+Anthropic's published spec requires only these two fields:
+
+- `name` — string, max 64 chars, lowercase + hyphens + numbers, no reserved words (`anthropic`, `claude`)
+- `description` — string, max 1024 chars, third-person voice, must be non-empty
+
+Every other field documented at `code.claude.com/docs/en/skills#frontmatter-reference` is optional under Anthropic's spec floor.
+
+> **NOTE**: The IS marketplace tier requires 8 fields, not 2. That's the IS rubric sitting on top of Anthropic's spec — it doesn't change Anthropic's published requirements. See `000-docs/SCHEMA_CHANGELOG.md` § NON-NEGOTIABLES.
+
+---
+
+## Optional-field allow-list (with type validation)
+
+| Field | Type | Notes |
+|---|---|---|
+| `allowed-tools` | comma-separated string OR space-separated string OR YAML list | All three forms accepted (per Anthropic doc verbatim). Paren-depth-aware tokenization for multi-word forms like `Bash(git add *)`. |
+| `model` | string | `inherit` / `opus` / `sonnet` / `haiku` shorthand; full IDs accepted but not recommended |
+| `effort` | enum | `low` / `medium` / `high` / `xhigh` / `max` |
+| `argument-hint` | string | Autocomplete hint for `/`-invocation |
+| `arguments` | string (space-separated) | Named positional args (`$arg1`, `$arg2`) |
+| `paths` | comma-separated globs | Limits auto-activation to matching paths |
+| `context` | enum | `fork` (run in subagent) |
+| `agent` | string | Subagent type when `context: fork`; defaults to `general-purpose` |
+| `user-invocable` | boolean | Default `true`; `false` hides from `/` menu |
+| `disable-model-invocation` | boolean | Default `false`; `true` blocks Claude auto-activation |
+| `hooks` | object | Skill-scoped lifecycle hooks |
+| `shell` | enum | `bash` (default) / `powershell` |
+| `when_to_use` | string | Combined cap with description = 1,536 chars |
+| `metadata` | object | Free-form key-value (per agentskills.io) |
+| `compatibility` | string (max 500 chars) | Free-text per agentskills.io |
+| `license` | string | SPDX or human-readable |
+
+---
+
+## Documented substitution variables
+
+These are replaced before Claude processes the skill body:
+
+- `$ARGUMENTS` / `$0` / `$1` … `$9` — user-provided arguments
+- `${CLAUDE_SESSION_ID}` — current session ID
+- `${CLAUDE_SKILL_DIR}` — absolute path to the current skill's directory
+- `${CLAUDE_PLUGIN_ROOT}` — absolute path to the plugin root (when skill is plugin-bundled)
+- `${CLAUDE_PLUGIN_DATA}` — persistent plugin state directory (survives updates; v2.1.78+)
+- `${CLAUDE_EFFORT}` — current effort level (added in schema 3.3.1)
+
+---
+
+## Dynamic Context Injection (DCI)
+
+```markdown
+!`shell-command`
+```
+
+- Output is injected verbatim into the skill body at activation time
+- Always include a fallback for missing tools: `` !`tool --version 2>/dev/null || echo 'not installed'` ``
+- Keep injections small — summaries, not full file dumps
+
+---
+
+## Refresh procedure
+
+1. Fetch `https://code.claude.com/docs/en/skills` and `https://code.claude.com/docs/en/skills#frontmatter-reference` rendered HTML
+2. Diff against current snapshot — identify added / removed / changed fields
+3. Update sections above (required-field set, optional allow-list, substitution vars, DCI rules)
+4. Bump Snapshot ID to `YYYY-MM-DD-NN`
+5. Open PR with the diff
+6. PR review checks: any required-field set change requires explicit IS architectural approval (see SCHEMA_CHANGELOG.md NON-NEGOTIABLES). Bug fixes that bring the IS validator into spec compliance can ship autonomously.
+7. Merge → Tier 3A reads the new snapshot on next `--thorough` run
+
+---
+
+## Status
+
+This is the **initial seed** snapshot, written 2026-05-07 against the Anthropic docs as understood at that date. A full structural refresh against the live published spec is the first task of the next quarterly cadence. The seed captures the same field facts the IS validator already enforces — it gives Tier 3A something concrete to compare against on day one.


### PR DESCRIPTION
## Summary

- Adds two versioned spec snapshots to \`000-docs/\` for JRig Tier 3A spec-compliance checks: \`anthropic-skills-spec-snapshot.md\` (Anthropic floor) and \`agentskills-spec-snapshot.md\` (open spec).
- Adds two gitignore re-include rules so the snapshots can sit in the otherwise-ignored \`000-docs/\` alongside existing canonical standards (\`000-*\` and \`6767-*\` prefixes).
- These are the frozen reference inputs that \`/validate-skillmd --thorough\` will read when JRig integration lands.

## Plan reference

Phase 2 (Enhance \`/validate-skillmd\` to Use JRig Directly) of the "Use the Printing Press to Learn" plan. Specifically the snapshot-strategy half — Tier 3A reads frozen spec snapshots, NOT live URLs (rate-limit + CI flakiness avoidance).

## Why snapshots, not live-fetch

The original plan called out live-fetching Anthropic + AgentSkills.io docs as a Tier 3A risk. Mitigation per the plan: capture as versioned snapshots in \`000-docs/\`, refresh quarterly via dedicated PR, let the PR review be the human gate that catches breaking spec changes before they reach validation.

This PR ships the seed snapshots so Tier 3A has something concrete to compare against on day one. First quarterly refresh will diff against live URLs; refresh PRs are the ongoing cadence.

## Files

| File | Size | Purpose |
|---|---|---|
| \`000-docs/anthropic-skills-spec-snapshot.md\` | 4.8 KB | Anthropic spec floor: required fields, optional-field allow-list with type validation, substitution variables, DCI rules, refresh procedure |
| \`000-docs/agentskills-spec-snapshot.md\` | 3.2 KB | AgentSkills.io open spec: required fields, \`compatibility\` free-text guidance, \`metadata\` open-object guidance, refresh procedure |
| \`.gitignore\` | +2 lines | Re-include rules: \`!000-docs/anthropic-skills-spec-snapshot.md\` + \`!000-docs/agentskills-spec-snapshot.md\` |

## Out of scope (deliberate)

- The corresponding \`/validate-skillmd\` SKILL.md update (Tier 0/1/2/3 framing, Tier 2 5-check gate, Tier 3 JRig wiring) lives in \`~/.claude/skills/validate-skillmd/SKILL.md\` and is local-only — no PR target for that today. Once JRig CLI lands as a repo dev-dep, the skill moves into a plugin and ships via marketplace.
- Live JRig CLI integration is a separate PR. JRig itself is at v0.14.0 and production-ready (per audit captured in memory \`reference_jrig_state_2026_05_07.md\`); wiring is unblocked but not part of this PR.

## Test plan

- [ ] CI green (\`validate\`, \`marketplace-validation\`)
- [ ] \`git ls-files 000-docs/ | grep snapshot\` shows both files tracked
- [ ] \`git check-ignore -v 000-docs/anthropic-skills-spec-snapshot.md\` returns nothing (i.e., NOT ignored after the gitignore update)

## Risk

Pure documentation addition + gitignore re-include. No code path touches the snapshots until \`/validate-skillmd --thorough\` is wired to JRig (separate future PR). Worst case: the snapshots drift further than three months from the live spec — the quarterly refresh PR cadence catches that.

- Jeremy Longshore
intentsolutions.io