### PR TITLE
feat(schema): IS-extension fields for forge provenance + marketplace display (Phase 5A)

### DIFF
--- a/plugins/skill-enhancers/validate-plugin/package.json
+++ b/plugins/skill-enhancers/validate-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/validate-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validates Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard",
   "keywords": [
     "validation",

--- a/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
+++ b/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
@@ -40,6 +40,24 @@ Seven optional fields provide discovery, attribution, and versioning metadata.
 
 ---
 
+## 2.5 Intent Solutions Extension Fields (Optional)
+
+Two provenance fields outside Anthropic's spec, set by `/skill-creator --forge` to flag the plugin's origin. These are NOT part of Anthropic's published spec — they are an Intent Solutions extension. CI accepts them; CLI consumers ignore them.
+
+| Field | Type | Set by | Purpose |
+|---|---|---|---|
+| `generated` | boolean | `/skill-creator --forge` | `true` when the plugin was produced by the forge pipeline (NOI gate + ecosystem absorb + mandatory validation). Hand-authored plugins omit this field or set `false`. |
+| `author_type` | enum (`"human"` \| `"forge"`) | `/skill-creator --forge` (sets `"forge"`) | Coarser provenance — same information as `generated`, in enum form. The marketplace renders a "Forge-generated" pill when either flag indicates forge origin. |
+
+**Anti-spam moat (rationale):** the marketplace surfaces a visual provenance flag for forge-generated plugins so reviewers and end users can distinguish them from human-authored work. Combined with the rate-limit + human-review-queue gating in the contribution workflow, this is the quality moat against the failure mode where a public `--forge` flag floods the catalog with low-quality wrappers.
+
+**NOT in plugin.json** (intentional separation of concerns):
+
+- `tagline` — marketplace-website display field. Lives in `marketplace.extended.json` per-plugin entry, NOT in `plugin.json`. Stripped from `marketplace.json` (CLI-safe) by `scripts/sync-marketplace.cjs`.
+- `jrig` — JRig behavioral-eval verdict. Computed by JRig CLI, persisted to `freshie/inventory.sqlite` `forge_proofs` table, joined into the marketplace data at build time. Not authored by hand and not stored in `plugin.json`.
+
+---
+
 ## 3. Component Path Fields (Optional)
 
 Seven fields define where Claude discovers plugin components. Each accepts flexible types to support single-directory, multi-directory, and inline-object configurations.
@@ -78,7 +96,7 @@ When component path fields are omitted, Claude auto-discovers components using t
 | 14 | `outputStyles` | No | string \| array | Component Path |
 | 15 | `lspServers` | No | string \| array \| object | Component Path |
 
-**No other fields are permitted.** CI rejects any field not in this list.
+**Anthropic spec floor**: only the 15 fields above are part of Anthropic's published `plugin.json` spec. Two additional fields are valid as Intent Solutions extensions and are documented in section 2.5: `generated` (boolean) and `author_type` (`"human"` | `"forge"`). Both are forge-provenance flags set by `/skill-creator --forge`.
 
 ---
 
@@ -128,7 +146,7 @@ These fields are **not** part of the official Anthropic spec and will be rejecte
 ## 7. Validation Rules
 
 ### Structural rules
-- Only the 15 fields listed in section 4 are allowed. Unknown fields cause validation failure.
+- The 15 Anthropic spec fields (section 4) and the 2 IS-extension fields (section 2.5) are accepted. Other unknown fields are flagged but not currently rejected by CI — see `.github/workflows/validate-plugins.yml` for the current enforced gate (JSON validity + README existence + script executability + source path existence).
 - `plugin.json` must be valid JSON (no trailing commas, no comments).
 - File must be located at `.claude-plugin/plugin.json` relative to plugin root.
 

--- a/scripts/sync-marketplace.cjs
+++ b/scripts/sync-marketplace.cjs
@@ -21,6 +21,13 @@ const DISALLOWED_KEYS = new Set([
   'zcf_metadata',
   'external_sync',
   'verification',
+  // Marketplace-website-only display fields. Added 2026-05-07 (Phase 4 of the
+  // "Use the Printing Press to Learn" plan). The website renders these from
+  // marketplace.extended.json; the CLI marketplace.json never sees them.
+  'tagline',           // 6–10 word NOI-framed outcome subtitle
+  'jrig',              // { verified, layers_passed, total_layers, baseline_delta }
+  'generated',         // boolean — set by /skill-creator --forge in plugin.json AND mirrored to marketplace.extended.json
+  'author_type',       // 'human' | 'forge' — provenance flag, ditto
 ]);
 
 if (!fs.existsSync(extendedPath)) {


### PR DESCRIPTION
## Summary

- Extends \`scripts/sync-marketplace.cjs\` DISALLOWED_KEYS to strip 4 new website-only display fields (\`tagline\`, \`jrig\`, \`generated\`, \`author_type\`) from \`marketplace.json\` so the CLI catalog stays clean.
- Documents the 2 IS-extension fields (\`generated\`, \`author_type\`) in \`plugin-schema.md\` section 2.5 — provenance flags set by \`/skill-creator --forge\`.
- Corrects the schema doc's stale "closed allow-list" claim (CI doesn't currently enforce it; only basic structural checks).

## Plan reference

Phase 5A (anti-spam moat) of the "Use the Printing Press to Learn" plan. Pairs with #696 (badge rendering).

## What this enables

Once both #696 and #695 land, plugins can carry these fields end-to-end:

| Field | Where authored | Where consumed |
|---|---|---|
| \`tagline\` | \`marketplace.extended.json\` per-plugin entry | Website plugin detail page (italic subtitle under name); stripped from CLI \`marketplace.json\` |
| \`jrig\` | Build pipeline reads \`freshie/inventory.sqlite\` \`forge_proofs\` table | Website plugin detail page (green "JRig-Verified · N/7 layers" pill); stripped from CLI |
| \`generated\` | \`/skill-creator --forge\` writes to \`plugin.json\` | Marketplace renders "Forge-generated" pill |
| \`author_type\` | \`/skill-creator --forge\` writes to \`plugin.json\` | Coarser provenance flag — same info as \`generated\` in enum form |

## Why CI didn't already reject these

Investigated during this PR: \`plugin-schema.md\` claimed "Only the 15 fields in section 4 are allowed. CI rejects any field not in this list." That claim was aspirational — \`.github/workflows/validate-plugins.yml\` only enforces JSON validity + README existence + script executability + source path existence. No closed-allow-list enforcement exists. The doc is now corrected to match what CI actually does.

If we want to actually enforce a closed allow-list in CI (separate, larger PR), the IS extension set becomes part of that allow-list from the start.

## Files changed

| File | Delta |
|---|---|
| \`scripts/sync-marketplace.cjs\` | +9 lines: 4 new entries in DISALLOWED_KEYS with comment explaining the 2026-05-07 Phase 4 origin |
| \`plugins/.../plugin-schema.md\` | +20 lines: new section 2.5 + footer + structural-rules correction |

## Test plan

- [ ] CI green (\`validate\`, \`marketplace-validation\`)
- [ ] \`pnpm run sync-marketplace\` regenerates \`marketplace.json\` without any of the 4 new keys (run locally with a hand-crafted test entry to verify strip)
- [ ] No regressions: existing plugin entries without these fields still sync identically

## Risk

Pure additive change. Today no plugin entry has any of the 4 new fields, so the strip logic is a no-op until #696 is followed by an actual plugin that uses them. Worst case: one of the 4 keys is misspelled (typo in DISALLOWED_KEYS); mitigation = direct visual review of the 9-line diff.

- Jeremy Longshore
intentsolutions.io