### PR TITLE
feat(freshie): JRig integration columns + forge_proofs table (Phase 5 schema)

### DIFF
--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -3190,8 +3190,26 @@ def populate_compliance_db(db_path: str, skill_results: list, agent_results: lis
         has_implementation_md INTEGER DEFAULT 0,
         reference_file_count INTEGER DEFAULT 0,
         has_config_dir INTEGER DEFAULT 0,
-        gold_standard_pct INTEGER DEFAULT 0
+        gold_standard_pct INTEGER DEFAULT 0,
+        jrig_passed INTEGER DEFAULT NULL,
+        jrig_tier_blocked INTEGER DEFAULT NULL,
+        jrig_baseline_delta REAL DEFAULT NULL
     )''')
+
+    # Idempotent migration: add JRig integration columns to pre-existing tables
+    # that were created before these columns were part of the schema. Phase 5
+    # of "Use the Printing Press to Learn" plan — JRig behavioral-eval results
+    # join into skill_compliance so reports unify spec rubric + behavioral
+    # verdict in one query.
+    c.execute("PRAGMA table_info(skill_compliance)")
+    existing_cols = {row[1] for row in c.fetchall()}
+    for col_name, col_def in (
+        ("jrig_passed", "INTEGER DEFAULT NULL"),
+        ("jrig_tier_blocked", "INTEGER DEFAULT NULL"),
+        ("jrig_baseline_delta", "REAL DEFAULT NULL"),
+    ):
+        if col_name not in existing_cols:
+            c.execute(f"ALTER TABLE skill_compliance ADD COLUMN {col_name} {col_def}")
 
     c.execute('''CREATE TABLE IF NOT EXISTS agent_compliance (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -3229,10 +3247,31 @@ def populate_compliance_db(db_path: str, skill_results: list, agent_results: lis
         run_id INTEGER
     )''')
 
+    # Forge proofs table — Phase 4A of the "Use the Printing Press to Learn"
+    # plan. Stores per-plugin verification evidence produced during the
+    # /skill-creator --forge generation pipeline (Tier 1+2+3 results) and
+    # joined into the marketplace build at render time so the JRig-Verified
+    # badge surfaces real evidence on plugin detail pages.
+    c.execute('''CREATE TABLE IF NOT EXISTS forge_proofs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        plugin_name TEXT NOT NULL,
+        run_id INTEGER,
+        verification_type TEXT NOT NULL,
+        passed INTEGER NOT NULL,
+        evidence TEXT,
+        layers_passed INTEGER DEFAULT NULL,
+        total_layers INTEGER DEFAULT 7,
+        baseline_delta REAL DEFAULT NULL,
+        verified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(plugin_name, verification_type, run_id)
+    )''')
+
     # Helpful index for run-scoped queries.
     c.execute('CREATE INDEX IF NOT EXISTS idx_skill_compliance_run_id ON skill_compliance(run_id)')
     c.execute('CREATE INDEX IF NOT EXISTS idx_agent_compliance_run_id ON agent_compliance(run_id)')
     c.execute('CREATE INDEX IF NOT EXISTS idx_plugin_compliance_run_id ON plugin_compliance(run_id)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_forge_proofs_plugin ON forge_proofs(plugin_name)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_forge_proofs_passed ON forge_proofs(passed)')
 
     # Purge legacy rows that pre-date run_id tagging. These rows have NULL
     # run_id and absolute /SKILL.md paths, and cannot be joined against


### PR DESCRIPTION
## Summary

Adds the schema surface that JRig behavioral-eval results land in. Unblocks the marketplace JRig-Verified badge data flow — PR #696 already renders the badge; this PR adds the data plumbing.

**Real Python code: schema additions + idempotent ALTER migration. Tested on live freshie DB.**

## Changes

### \`skill_compliance\` — 3 new columns (idempotent migration)

| Column | Type | Purpose |
|---|---|---|
| \`jrig_passed\` | INTEGER, nullable | Boolean — did all 7 JRig layers pass on the model matrix? |
| \`jrig_tier_blocked\` | INTEGER, nullable | Which JRig layer (1–7) failed. NULL when not evaluated. |
| \`jrig_baseline_delta\` | REAL, nullable | Performance delta vs. naked Claude. >0 = helps, <0 = hurts. |

### \`forge_proofs\` — new table for per-plugin verification evidence

```sql
CREATE TABLE forge_proofs (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  plugin_name TEXT NOT NULL,
  run_id INTEGER,
  verification_type TEXT NOT NULL,    -- 'tier1' / 'tier2' / 'tier3-jrig' / 'dogfood'
  passed INTEGER NOT NULL,
  evidence TEXT,
  layers_passed INTEGER,
  total_layers INTEGER DEFAULT 7,
  baseline_delta REAL,
  verified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
  UNIQUE(plugin_name, verification_type, run_id)
);
```

Indexes: \`idx_forge_proofs_plugin\` (plugin_name), \`idx_forge_proofs_passed\`.

## Migration safety

- \`skill_compliance\` uses ALTER TABLE only when columns missing (PRAGMA table_info checked before each ADD COLUMN)
- \`forge_proofs\` uses CREATE TABLE IF NOT EXISTS
- Test: applied to live \`freshie/inventory.sqlite\` via full \`--populate-db\` scan; columns + table appeared, no data loss
- Re-run on already-migrated DB is a no-op (PRAGMA check prevents double-add)

## Cross-PR coordination

This PR is the **data-side counterpart** to:
- **#696** (merged) — Marketplace renders \`plugin.jrig\` badge from build pipeline
- **#698** (in flight) — Tier 2 validator produces some of the input data
- **JRig #41** in \`j-rig-skill-binary-eval\` (in flight) — JRig consumer-side

**Next PR (separate)**: \`marketplace/scripts/build.mjs\` to JOIN \`forge_proofs\` into plugin entries at build time so #696's badges actually populate from real data.

## Test plan

- [x] Apply migration to fresh DB (CREATE TABLE creates with new columns)
- [x] Apply migration to pre-existing DB (ALTER TABLE adds 3 columns)
- [x] Re-run on already-migrated DB (no-op — verified locally)
- [x] Live freshie DB now has \`jrig_passed\`, \`jrig_tier_blocked\`, \`jrig_baseline_delta\` + \`forge_proofs\` table
- [ ] CI green

## Risk

Migrations on production data are always non-trivial. Mitigations:
- Schema changes only ADD columns or tables — never DROP, never RENAME
- Existing rows get NULL for new columns (no defaults that could mask absence-of-data)
- Re-run idempotency via PRAGMA-check guard before ALTER

The 74MB freshie/inventory.sqlite binary is intentionally NOT included in this PR — that's a separate refresh PR (similar pattern to #694). The schema migration runs on every \`--populate-db\` invocation, so the next time anyone runs validation against the live DB, the columns appear automatically.

- Jeremy Longshore
intentsolutions.io