### PR TITLE
feat(marketplace): Start-Here curated starter pack on homepage (Phase 4C)

### DIFF
--- a/marketplace/src/data/starter-pack.json
+++ b/marketplace/src/data/starter-pack.json
@@ -1,0 +1,52 @@
+{
+  "title": "Start here",
+  "subtitle": "Five Grade-A plugins that cover most first-day work in Claude Code. Install whichever match your stack.",
+  "plugins": [
+    {
+      "slug": "ai-commit-gen",
+      "name": "ai-commit-gen",
+      "tagline": "Conventional commit messages from any diff",
+      "category": "productivity",
+      "why": "Replaces the universal 'what should I write?' moment after staging changes. Read your diff, write the commit, ship.",
+      "install": "/plugin install ai-commit-gen@claude-code-plugins-plus"
+    },
+    {
+      "slug": "conversational-api-debugger",
+      "name": "conversational-api-debugger",
+      "tagline": "Root-cause REST API failures from OpenAPI + HAR",
+      "category": "mcp",
+      "why": "The fastest path from 'this endpoint is broken' to a fix. Combines API spec + actual HTTP traffic into a debugging conversation.",
+      "install": "/plugin install conversational-api-debugger@claude-code-plugins-plus"
+    },
+    {
+      "slug": "ci-cd-pipeline-builder",
+      "name": "ci-cd-pipeline-builder",
+      "tagline": "GitHub Actions, GitLab CI, Jenkins, et al. — generated",
+      "category": "devops",
+      "why": "Cuts the 'I have to look up YAML syntax' tax on every new pipeline. Tell it what you want, get a working workflow.",
+      "install": "/plugin install ci-cd-pipeline-builder@claude-code-plugins-plus"
+    },
+    {
+      "slug": "design-to-code",
+      "name": "design-to-code",
+      "tagline": "Figma + screenshots into React/Svelte/Vue components",
+      "category": "mcp",
+      "why": "Designer hands off a Figma file or a screenshot; you get production-ready components instead of pixel-pushing.",
+      "install": "/plugin install design-to-code@claude-code-plugins-plus"
+    },
+    {
+      "slug": "excel-analyst-pro",
+      "name": "excel-analyst-pro",
+      "tagline": "Auto-invoked financial modeling toolkit",
+      "category": "business-tools",
+      "why": "Bridges Claude Code into the spreadsheets your finance team lives in. Models, projections, sensitivity analysis without the formula chase.",
+      "install": "/plugin install excel-analyst-pro@claude-code-plugins-plus"
+    }
+  ],
+  "meta": {
+    "curated_by": "Jeremy Longshore",
+    "last_updated": "2026-05-07",
+    "selection_criteria": "Diverse coverage of common first-day-in-Claude-Code use cases (productivity, debugging, ops, frontend, business). All five score Grade A on the IS rubric.",
+    "rotation_cadence": "Quarterly — re-evaluated against marketplace install velocity once Phase 5B telemetry lands."
+  }
+}

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -8,6 +8,7 @@ import KillerSkills from '../components/KillerSkills.astro';
 import JeremysStash from '../components/JeremysStash.astro';
 import PartnerBar from '../components/PartnerBar.astro';
 import searchIndex from '../data/unified-search-index.json';
+import starterPack from '../data/starter-pack.json';
 
 // Dynamic stats from search index (updated at build time)
 const totalSkills = searchIndex.stats.totalSkills;
@@ -771,6 +772,149 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         }
 
         /* ========================================
+           STARTER PACK SECTION (Phase 4C)
+           ======================================== */
+        .starter-pack-section {
+            padding: 4rem 2rem;
+            background: var(--surface);
+            border-top: 1px solid var(--border, var(--rule));
+            border-bottom: 1px solid var(--border, var(--rule));
+        }
+
+        .starter-pack-container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .starter-pack-header {
+            text-align: left;
+            margin-bottom: 2.5rem;
+            max-width: 720px;
+        }
+
+        .starter-pack-title {
+            color: var(--text, var(--ink));
+            font-size: clamp(1.75rem, 3vw, 2.25rem);
+            font-weight: 700;
+            margin: 0 0 0.5rem;
+            letter-spacing: -0.02em;
+        }
+
+        .starter-pack-subtitle {
+            color: var(--text-2, var(--ink-2));
+            font-size: 1.05rem;
+            line-height: 1.55;
+            margin: 0;
+        }
+
+        .starter-pack-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 1.25rem;
+            margin-bottom: 2rem;
+        }
+
+        .starter-card {
+            background: var(--surface-2, var(--panel));
+            border: 1px solid var(--border, var(--rule));
+            border-radius: 12px;
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            transition: border-color var(--duration-fast) var(--ease-out);
+        }
+
+        .starter-card:hover {
+            border-color: var(--accent, var(--signal));
+        }
+
+        .starter-card-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .starter-card-name {
+            color: var(--text, var(--ink));
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 1.1rem;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .starter-card-name:hover {
+            color: var(--accent, var(--signal));
+        }
+
+        .starter-card-category {
+            color: var(--text-3, var(--ink-2));
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-weight: 600;
+        }
+
+        .starter-card-tagline {
+            color: var(--text, var(--ink));
+            font-size: 1rem;
+            font-weight: 500;
+            font-style: italic;
+            margin: 0;
+            line-height: 1.4;
+        }
+
+        .starter-card-why {
+            color: var(--text-2, var(--ink-2));
+            font-size: 0.92rem;
+            line-height: 1.55;
+            margin: 0;
+        }
+
+        .starter-card-install {
+            margin-top: auto;
+            padding-top: 0.75rem;
+            border-top: 1px dashed var(--border, var(--rule));
+        }
+
+        .starter-card-install code {
+            color: var(--accent, var(--signal));
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.82rem;
+            user-select: all;
+            display: block;
+            word-break: break-all;
+            line-height: 1.4;
+        }
+
+        .starter-pack-meta {
+            color: var(--text-3, var(--ink-2));
+            font-size: 0.85rem;
+            margin: 0;
+        }
+
+        .starter-pack-explore-link {
+            color: var(--accent, var(--signal));
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .starter-pack-explore-link:hover {
+            text-decoration: underline;
+        }
+
+        @media (max-width: 768px) {
+            .starter-pack-section {
+                padding: 3rem 1.5rem;
+            }
+            .starter-pack-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* ========================================
            EMAIL SIGNUP SECTION
            ======================================== */
         .signup-section {
@@ -1273,6 +1417,35 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                         style="padding: 0.5rem 1rem; background: var(--primary); color: #0a0a0c; border: none; border-radius: 8px; font-weight: 600; font-size: 0.85rem; cursor: pointer; white-space: nowrap;">Submit</button>
                 </form>
             </div>
+        </div>
+    </section>
+
+    <!-- Start here — curated 5-plugin onboarding pack (Phase 4C) -->
+    <section class="starter-pack-section">
+        <div class="starter-pack-container">
+            <div class="starter-pack-header">
+                <h2 class="starter-pack-title">{starterPack.title}</h2>
+                <p class="starter-pack-subtitle">{starterPack.subtitle}</p>
+            </div>
+            <div class="starter-pack-grid">
+                {starterPack.plugins.map((plugin) => (
+                    <article class="starter-card">
+                        <header class="starter-card-header">
+                            <a href={`/plugins/${plugin.slug}`} class="starter-card-name">{plugin.name}</a>
+                            <span class="starter-card-category">{plugin.category}</span>
+                        </header>
+                        <p class="starter-card-tagline">{plugin.tagline}</p>
+                        <p class="starter-card-why">{plugin.why}</p>
+                        <div class="starter-card-install">
+                            <code>{plugin.install}</code>
+                        </div>
+                    </article>
+                ))}
+            </div>
+            <p class="starter-pack-meta">
+                Curated by {starterPack.meta.curated_by} · last updated {starterPack.meta.last_updated} ·
+                <a href="/explore" class="starter-pack-explore-link">explore all {totalPlugins} plugins →</a>
+            </p>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary

Adds a **"Start here"** section between the Hero and Jeremy's Stash on the homepage. Five curated Grade-A plugins covering distinct first-day-in-Claude-Code personas, with NOI-framed taglines, "why this is in the pack" paragraphs, and copy-friendly install commands.

Phase 4C of the "Use the Printing Press to Learn" plan. Solves the friction the Printing Press starter pack handles — tonsofskills.com had the breadth (343 plugins) but no first-5-minutes surface.

## The 5 picks

| Plugin | Persona | NOI tagline |
|---|---|---|
| \`ai-commit-gen\` | productivity | Conventional commit messages from any diff |
| \`conversational-api-debugger\` | debugging | Root-cause REST API failures from OpenAPI + HAR |
| \`ci-cd-pipeline-builder\` | ops | GitHub Actions, GitLab CI, Jenkins, et al. — generated |
| \`design-to-code\` | frontend | Figma + screenshots into React/Svelte/Vue components |
| \`excel-analyst-pro\` | business | Auto-invoked financial modeling toolkit |

## Selection criteria

- All five score Grade A on the IS rubric
- Each covers a **distinct first-day persona** (productivity / debugging / ops / frontend / business)
- Each has a stable \`/plugin install\` command (matches \`/plugins/<slug>\` URLs)

## Curation cadence

Editorial today (per \`feedback_killer_skill_is_editorial.md\` — same convention as Killer Skill of the Week). Quarterly rotation; re-evaluation against marketplace install velocity once Phase 5B telemetry lands.

## Files

| File | Type | Purpose |
|---|---|---|
| \`marketplace/src/data/starter-pack.json\` | new | Curation data (5 plugin entries + meta block) |
| \`marketplace/src/pages/index.astro\` | modified | Section markup + ~150 lines of scoped CSS |

## Test plan

- [ ] CI green
- [ ] Section renders between Hero and Jeremy's Stash
- [ ] Each card has name (links to plugin detail), category badge, tagline, why paragraph, install command
- [ ] Mobile (< 768px): grid collapses to single column
- [ ] Light/dark mode both readable
- [ ] Plugin slugs in JSON resolve to existing detail pages

## Risk

Pure additive — no existing homepage section is modified or removed. The 5 plugins picked already exist in the catalog (verified locally). If a plugin is removed in the future, its starter card 404s on the link click but the homepage still renders. Future enhancement bead: validate starter-pack.json plugins against the catalog at build time.

- Jeremy Longshore
intentsolutions.io