### PR TITLE
fix(validator): align agent field validation with current Anthropic sub-agents spec

### DIFF
--- a/marketplace/src/content/blog-posts/agents-md-cross-tool-plugin-brief.md
+++ b/marketplace/src/content/blog-posts/agents-md-cross-tool-plugin-brief.md
@@ -1,0 +1,178 @@
+---
+title: "AGENTS.md as a Cross-Tool Plugin Brief: A Case Study from kobiton/automate"
+description: "A 5-device parity sweep against kobiton/automate showed iOS screenshot capture ~17% faster than Android — but the more interesting finding is what an AGENTS.md file would close. A worked example of cross-tool plugin briefs done right."
+date: "2026-05-11"
+tags: ["claude-code", "mcp", "agents-md", "plugins", "mobile-testing", "kobiton", "parity", "devops", "appium"]
+featured: false
+---
+# AGENTS.md as a Cross-Tool Plugin Brief: A Case Study from kobiton/automate
+
+**TL;DR** — I ran a 5-device parity sweep against Kobiton's real-device cloud through the `kobiton/automate` Claude Code plugin. iOS screenshot capture came in ~17% faster than Android in this run. The interesting part isn't the gap — it's that the plugin doesn't document the gap, or the post-`deleteSession` cooldown, or which Appium log endpoints actually work. That's what an `AGENTS.md` file is for, and PR #10 on the repo is starting to add one. This is a worked example of what should go in it.
+
+---
+
+I spent last week poking at [`kobiton/automate`](https://github.com/kobiton/automate), the Claude Code plugin that fronts Kobiton's real-device cloud. Five devices, two pools, both major mobile platforms, one small WebDriverIO harness. The numbers showed something plugin authors rarely publish: iOS screenshot capture was about 17% faster than Android across the sample.
+
+That gap isn't a bug. It's platform variance. But it's the kind of variance you want surfaced before your CI bill quietly compounds it — and surfacing things like this is exactly what a cross-tool agent brief like `AGENTS.md` is for.
+
+## The plugin
+
+`kobiton/automate` is a thin Claude Code plugin pointing at a remote MCP server (`https://api.kobiton.com/mcp`). The repo holds manifests, one skill, schemas, and docs. Appium still runs the driver loop once a session opens. That's the right boundary. The plugin doesn't pretend to be Appium; it just helps the agent get into a working session and back out cleanly.
+
+The public repo currently exposes 12 MCP tools:
+
+| Area | Tools |
+|---|---|
+| Devices | `listDevices`, `getDeviceStatus`, `reserveDevice`, `terminateReservation` |
+| Sessions | `listSessions`, `getSession`, `getSessionArtifacts`, `terminateSession` |
+| Apps | `listApps`, `uploadAppToStore`, `confirmAppUpload`, `getApp` |
+
+Last week the team opened [PR #10](https://github.com/kobiton/automate/pull/10), which adds GitHub Copilot CLI support and an `AGENTS.md` file. Five files changed, 75 lines added. As of writing it's open and marked in testing. Most of the diff is portability work — declaring skill and MCP paths, swapping Claude-specific phrasing for neutral language, and adding the agent-facing instructions file itself.
+
+That PR is what made me want to write this up. It's a real example of a plugin moving from "works in Claude Code" to "any reasonable coding agent can read this and behave."
+
+## The parity sweep
+
+The harness is small. Open an Appium session, take five screenshots, record boot wall-clock and per-screenshot p50, terminate cleanly. Five devices:
+
+| Device pool | OS | Model | Boot ms | Screenshot p50 |
+|---|---|---|---:|---:|
+| PRIVATE | Android 13 | Galaxy A52s 5G | 4,206 | 353 |
+| CLOUD   | Android 9  | moto g(7) play | 5,451 | 297 |
+| PRIVATE | iOS 17.5.1 | iPhone XR | 5,091 | 242 |
+| CLOUD   | iOS 18.6   | iPhone 14 Plus | 4,490 | 306 |
+| CLOUD   | iOS 18.6.2 | iPad 9th Gen | 5,259 | 256 |
+
+In this run:
+
+- Boot times spread ~30%.
+- Screenshot p50 spread ~46%.
+- Android averaged ~325ms per screenshot.
+- iOS averaged ~268ms — about 17% faster.
+
+Five devices is not a fleet study, so don't read this as "iOS wins." What's worth noticing is that platform mattered more than pixel count. The fastest screenshot in the run came off an iPhone XR at 828×1792; the slowest came off a Galaxy A52s 5G at 1080×2400. Resolution alone didn't predict the spread.
+
+That gap matters in CI. A 57ms screenshot delta sounds trivial until you compound it. At 100 tests × 50 runs/day × 3 screenshots per test, you've spent ~855 seconds a day, or ~7 hours a month, on the slower path. Push that to five screenshots per test and you're at ~12 hours/month. Not a redesign-the-suite number. But it's real queue time — enough that a routing decision ("send the screenshot-heavy suite to iOS first") starts paying for itself.
+
+## Two findings an AGENTS.md would close
+
+Two things came up that an agent-facing brief would have closed before I started.
+
+### Endpoint compatibility
+
+`driver.getLogs('logcat')` didn't return usable data through the endpoint my client tried. Appium's docs distinguish between `/session/:sessionId/log` and `/session/:sessionId/se/log`, and which one works depends on the driver and server. A plugin like this should just say up front which log endpoints it supports, which it rejects, and what the agent should do when log retrieval fails.
+
+Without that, a test ported in from a vanilla Appium setup can silently lose its logs. The test still passes. The evidence is just gone. Worst kind of failure — the kind that smiles and waves while stealing your evidence.
+
+### Lifecycle invisibility
+
+After `deleteSession`, devices entered a brief cooldown. During the window `getDeviceStatus` reported them as `ACTIVATED` with `is_online=true` — but they couldn't actually accept a new session yet. A naive scheduler sees "ready," queues the next job, and waits.
+
+The fix is a documented lifecycle. Names like `ready` / `reserved` / `active` / `cleanup-required` / `cooldown-required` / `offline` / `unknown`. The wording matters less than having one. If `is_online=true` doesn't mean session-ready, the plugin needs to say that out loud.
+
+Both gaps are documentation, not code.
+
+## Where Claude Code conventions meet AGENTS.md
+
+If you've authored a Claude Code plugin you already know about `CLAUDE.md` (Claude-specific repo guidance) and `SKILL.md` (skill frontmatter and workflow). Neither replaces `AGENTS.md`.
+
+`AGENTS.md` is the tool-agnostic instruction file. A briefing packet any coding agent can read: setup, conventions, testing rules, operational caveats. `SKILL.md` belongs to a different model entirely — the open AgentSkills.io spec defines its structure for reusable skills. Related, not interchangeable.
+
+The four files compose:
+
+| File | Purpose |
+|---|---|
+| `README.md` | For humans — overview and install |
+| `CLAUDE.md` | Claude Code-specific guidance |
+| `SKILL.md` | Skill trigger and workflow |
+| `AGENTS.md` | Cross-tool operational guidance for any agent |
+
+A strong `AGENTS.md` for an MCP-backed testing plugin should cover capabilities (what it does), costs and latency (p50/p95, screenshot timing, upload constraints, platform variance), lifecycle states (what "ready" actually means), compatibility boundaries (which Appium endpoints work, when to fall back to artifact APIs), and orchestrator requirements (what CI systems and agent runtimes need to know).
+
+When a plugin documents that, a cost-conscious agent can make decisions instead of guessing. "This suite goes to the faster capture path." "This device needs cooldown." "This log endpoint isn't available, use artifacts." Without the spec you're guessing. With it, you're routing.
+
+## What kobiton/automate got right
+
+The plugin is a clean implementation of the thin-plugin / remote-MCP pattern that the AI agent ecosystem is converging on. MCP server config points to Kobiton's hosted endpoint. OAuth 2.1 is the default; API keys exist for headless CI. App uploads go through pre-signed storage URLs rather than routing binaries through the assistant. Tool schemas live as reference YAML. The `run-automation-suite` skill stays focused on guided Appium execution and doesn't try to become a test framework.
+
+That's the right scope. A Claude Code plugin shouldn't pretend to be Appium. It should help the agent pick a target, prepare inputs, run the test, collect evidence, and report out.
+
+PR #10 adds the cross-tool layer on top of that. It isn't a complete operational spec yet, but it's pointed in the right direction.
+
+## What's still open
+
+The gaps the parity sweep exposed are exactly what I'd document next:
+
+- Supported and unsupported Appium log endpoints.
+- Platform-specific log retrieval guidance.
+- Device lifecycle states between "online" and "session-ready."
+- Cooldown behavior after `deleteSession`.
+- Retry/backoff rules for schedulers.
+- Error shapes for partial success, timeout cleanup, and artifact failures.
+- Latency expectations for screenshot capture and session boot.
+
+The file doesn't have to be exhaustive on day one. It has to be honest — the operational facts an agent would otherwise learn the expensive way.
+
+## Method note
+
+The matrix wasn't a vibe check. Before any device touched the harness, I had three Claude sub-agents review the script in parallel — `code-reviewer`, `test-automator`, `security-auditor`. They caught:
+
+- Orphaned cleanup on timeout.
+- Partial success counted as full success in the fallback chain.
+- A timing bug where a 30-second log capture window could skid by ~1.5 seconds per device under load.
+
+Any one of those would have polluted the measurement. The cadence is reusable: specify the experiment, multi-review it, fix the harness, run the sweep, publish with caveats. Skipping the review step is how a 10-minute validation turns into a two-hour bug archaeology dig.
+
+## A test you can run this week
+
+If you author or consume a real-device testing plugin, run something like this against your own pool:
+
+```python
+for device in pool:
+    t0 = now()
+    session = create_session(device)
+    wait_for_ready()
+    boot_ms = now() - t0
+
+    shots = []
+    for _ in range(5):
+        s = now()
+        take_screenshot()
+        shots.append(now() - s)
+
+    delete_session(device)
+    results[device] = {"boot": boot_ms, "shots": shots}
+
+print_percentiles(results)
+```
+
+Five devices, five screenshots, one table. That's the baseline you can re-run whenever your pool changes — and the evidence you need to decide whether screenshot-heavy, log-heavy, or cold-start-sensitive tests should route differently.
+
+If your platform vendor's docs don't tell you which Appium endpoints work, what session cleanup actually does, or what "online" means — that's not a docs gap. That's operational risk wearing a friendly UI.
+
+## The takeaway
+
+Cross-tool plugin standards aren't abstract architecture. They're the difference between
+
+> "We picked Android arbitrarily and paid for the variance silently."
+
+and
+
+> "We routed the screenshot-heavy suite based on measured platform behavior."
+
+`kobiton/automate` is moving in the right direction. Clean remote-MCP shape, focused skill design, sensible auth boundaries — and now PR #10 starts the cross-tool instruction surface.
+
+If you author a plugin: `README.md` for humans, `CLAUDE.md` for Claude-specific bits, `SKILL.md` for skill workflow, `AGENTS.md` for everything any agent runtime needs to know. They compose; none of them replaces another.
+
+If you consume plugins from a real-device cloud — or any AI-orchestratable platform — ask your vendor whether they publish an `AGENTS.md` or equivalent. Then ask what's in it.
+
+If the answer is "what's that?", you found the gap.
+
+---
+
+**Postscript (2026-05-07).** While this post was being finalized, the `kobiton/automate` team merged Copilot CLI support ([PR #10](https://github.com/kobiton/automate/pull/10)) and opened a Phase 1 Gemini CLI extension PR ([PR #28](https://github.com/kobiton/automate/pull/28)). Both reuse the same `AGENTS.md`, the same MCP server endpoint via OAuth dynamic discovery (RFC 9728), and the same `skills/<name>/SKILL.md` convention — three CLIs against one source of truth, zero server-side code change.
+
+The Gemini PR description is the working reference for anyone trying this pattern: `AGENTS.md` carries the cross-tool load (no separate `GEMINI.md` needed), dynamic-discovery OAuth lets the install flow piggyback off plumbing already deployed, and skills auto-discover from the canonical path so they don't need explicit manifest references. If you're authoring a plugin in 2026 and want to ship it across Claude Code, Copilot CLI, and Gemini CLI with one source tree, read those two PRs.
+
+OpenAI Codex CLI is the natural fourth runtime in this space and fits the same pattern — `AGENTS.md` is read natively, MCP servers are declared in `~/.codex/config.toml` under `[mcp_servers.<name>]`, and the OAuth dynamic-discovery flow is identical. The only delta is the config format (TOML rather than JSON), which means a Codex extension to a multi-CLI plugin is typically just a documentation snippet — no new manifest, no new build step. Four agentic CLIs, one cross-tool surface, one MCP server. That's the convergence the AGENTS.md convention was hinting at all along.
+

--- a/marketplace/src/content/blog-posts/coherence-day-drift-detection-strategic-spine.md
+++ b/marketplace/src/content/blog-posts/coherence-day-drift-detection-strategic-spine.md
@@ -1,0 +1,90 @@
+---
+title: "Coherence as a Deliverable: How a Multi-Surface Engagement Stays Sane"
+description: "Why scattered Plane issues, beads, docs, and partner portals silently diverge — and four structural patterns that catch drift before it compounds."
+date: "2026-05-08"
+tags: ["claude-code", "architecture", "ai-agents", "release-engineering"]
+featured: false
+---
+A sprawling multi-surface engagement (Kobiton partner pilot, 4 months, three deliverable rounds) exposed a silent failure mode: drift doesn't announce itself. A title rename on Plane goes unnoticed when the canonical source doc still has the old framing. A partner-portal deliverable gets updated before the source file does, leaving future sessions reading stale context from what should be source-of-truth.
+
+On 2026-05-08, one session caught two separate drift instances and shipped four structural patterns to make drift cheaper to find next time. None of the drifts were bugs. Both were coherence gaps — places where a single idea lived in multiple surfaces (Plane, beads, local docs, partner portal) with different currency.
+
+The fix wasn't "use one surface." It was: **detect drift early, make the boundaries between surfaces explicit, give pre-committed thinking a home, and grow scope through buckets instead of through accretion.**
+
+## Drift Caught in Two Directions
+
+A May 4 session had renamed a Plane content issue from "Text-first AI triage on session logs (refined per F30)" to "AI-vision testing." The local draft file (`000-docs/020-DR-BLOG-...md`), the partner portal copy (`m2-blog-3.md`), and the CLAUDE.md history were all on the canonical thesis: text-first triage. Plane was the only surface out of sync.
+
+Caught by reading CLAUDE.md cold. A session with no prior context opened the resume-from-cold doc and noticed the contradiction. The fix: revert Plane back to canonical, log the vision-testing angle as a separate evergreen idea in a new file (`034-RR-OPEN`), mark it explicitly as deferred.
+
+The reverse-drift happened the same day. An R2 fork-staging update went to the partner portal first (because the client reads that surface), but the source doc (`021-AA-AACR-r2-...md`) was now stale. Sync brought source up to portal. Header table updated with new snapshot tag, new "Staged audit slate" metadata row. Reverse-drift is the silent kind: the deliverable surface looks current, the source looks wrong, and a future session reading source will replay outdated thinking.
+
+Two drifts in one day on the same engagement. The pattern: without explicit boundaries and a promotions log, every surface drifts toward stale.
+
+## A Current-Focus Block at the Top of CLAUDE.md
+
+Added to `kobiton/CLAUDE.md`: a "Current focus" block at the very top. Three rows. Each row names a live workstream (M2 blog cadence, M3+R3 final review, hooks-as-deterministic thesis), owns it to a bead, and defines what "done" looks like.
+
+Below that: an explicit "what NOT to start" list. New evergreen blogs, project-shipping blogs, site infra, channel work — all queued but explicitly deferred until M2/M3/R3 close.
+
+Why not a checklist or a TODO list? Because a TODO is committed work. A Current-focus block is a *priority map* for cold-starting future sessions. A TODO says "do this." The block says "this is load-bearing now; everything else queues below the line." Future sessions landing cold should know what's live without reading a month of history.
+
+```markdown
+## Current focus (2026-05-08) — read this first
+
+| Workstream | Owner | "Done" looks like |
+|---|---|---|
+| M2 Blog series delivery | kobiton-z3y | Blog 1 published May 11, Blog 2 May 18, Blog 3 May 25 |
+| M3 Featured Placement + R3 close | kobiton-9z0.7, kobiton-bmj | R3 deliverable filed and reviewed by May 25 |
+| Hooks-as-deterministic layer thesis | kobiton-5cj | Prototype → multi-reviewer pre-flight → R3 above-spec landing |
+
+**What NOT to start until M2/M3/R3 close:** new evergreen blog drafts, new project-shipping blogs, site-refresh work, channel infra.
+```
+
+## A Strategic Spine for the 19-Issue Backlog
+
+Same day, a separate consolidation: 19+ scattered Plane content issues organized into a 6-post evergreen series in publication order, with adjacent clusters (B/C/D/E) listed so unfiled ideas have homes too. This is the antidote to backlog rot. Without a spine, every new idea fights every other idea for next session's attention. With a spine, ideas cluster, and new sessions land oriented — they read the spine, see what's live in cluster A, and know that clusters B-E are queued but real.
+
+## RR-OPEN: The Pre-Committed Layer
+
+A new file: `034-RR-OPEN-things-to-think-about.md`. Single surface for engagement-adjacent open questions, loose threads, refinement ideas, and deferred decisions that aren't yet committed work. Not a TODO. Not a backlog. A *pre-committed thinking* surface.
+
+Six categories. Initial seed: 10 bullets. Crucially, it includes a "Promotions log" — when a bullet matures and graduates (to Plane CONTENT, beads, KOB issues, email, or CLAUDE.md), the commit message records where it went:
+
+```markdown
+### Promotions log
+
+- 2026-05-08 — "Per-harness spec audit scope (decide before May 14)"
+  RESOLVED as out-of-scope. Spec audit stays narrowly scoped to
+  code.claude.com/docs/en/mcp per existing contract. The "10-12
+  harness reach" framing migrates to OPS-28, not engagement scope.
+```
+
+Why not just a TODO list or a scattered Slack thread? Because ideas that live nowhere searchable get re-invented. RR-OPEN is a single backlog-rot antidote: ideas can live here, mature visibly, and graduate with an audit trail of where they went.
+
+## Scope Discipline Through Bucket Boundaries
+
+R3 scope expanded from one bucket to three in a single session. Normally that's a red flag. The discipline that kept it coherent: each bucket got its own bead with explicit deliverable boundaries.
+
+- Standard re-validation (existing bead, no boundary change)
+- Spec-conformance audit (new bead, separate surface, distinct findings)
+- Hooks bundle (conditional on multi-reviewer pre-flight before May 23)
+
+The empirical findings catalog (F11-F35) and the spec-conformance candidates (F36-F43) live in separate subsections. Scope can grow without losing shape if the boundaries between buckets are explicit and defensible.
+
+## Pre-Flight Catches the Signal-Type Misses
+
+A technical comment for a partner GitHub PR went through multi-reviewer pre-flight before posting. The catch: three signal-type mislabelings in a single comment. The same three mislabelings had propagated back into Plane CONTENT issues that referenced the same source material.
+
+Mistakes don't live in single surfaces. A mislabeling on a public comment is also on the issues that referenced the same source. Catching it pre-flight means one fix in three places. Catching it after publish means a correction comment, three issue edits, and a stale public comment that future readers will trust.
+
+## Also Shipped
+
+R2 follow-up email sent (closing the credibility gap from a May 5 commitment). One beads epic created, one stale bead closed. Three companion commits to `partner-portals/` for the reverse-drift fix.
+
+## Related Posts
+
+- [Enforcement travels with the code: audit-harness v0.1.0](/posts/audit-harness-v010-enforcement-travels-with-code/)
+- [Building an AI-friendly codebase: real-time CLAUDE.md creation](/posts/building-ai-friendly-codebase-documentation-real-time-claude-md-creation-journey/)
+- [Wild deep dive #2: CLAUDE.md as a resume-from-cold tool](/posts/wild-deep-dive-2-claude-md/)
+

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -270,7 +270,13 @@ AGENT_FIELDS = {
     'memory': {'type': 'string', 'source': 'anthropic', 'valid': ['user', 'project', 'local']},
     'background': {'type': 'boolean', 'source': 'anthropic'},
     'isolation': {'type': 'string', 'source': 'anthropic', 'valid': ['worktree']},
-    'permissionMode': {'type': 'string', 'source': 'anthropic', 'valid': ['default', 'acceptEdits', 'dontAsk', 'bypassPermissions', 'plan']},
+    'permissionMode': {'type': 'string', 'source': 'anthropic', 'valid': ['default', 'acceptEdits', 'auto', 'dontAsk', 'bypassPermissions', 'plan']},
+    # Spec fields confirmed against code.claude.com/docs/en/sub-agents (snapshot at
+    # ~/.claude/skills/agent-creator/references/anthropic-sub-agents-spec.md, captured
+    # 2026-05-08). Both `color` and `initialPrompt` are documented Anthropic optional
+    # fields; previously misclassified as DEPRECATED_AGENT_FIELDS / unknown.
+    'color': {'type': 'string', 'source': 'anthropic', 'valid': ['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'pink', 'cyan']},
+    'initialPrompt': {'type': 'string', 'source': 'anthropic'},
 }
 
 # Fields NOT supported in plugin agents (silently ignored by runtime)
@@ -279,12 +285,15 @@ AGENT_PLUGIN_RESTRICTED = {'hooks', 'mcpServers', 'permissionMode'}
 # Fields that are NOT in Anthropic spec — ERROR if found
 INVALID_AGENT_FIELDS = {}  # Cleared — all non-standard fields demoted to deprecated for migration
 
-# Non-standard fields used across existing agents — WARN now, batch-fix, then promote to ERROR
+# Non-standard fields used across existing agents — WARN now, batch-fix, then promote to ERROR.
+# `color` was removed from this list 2026-05-08: it IS a documented Anthropic-spec field per
+# code.claude.com/docs/en/sub-agents (Display color for the subagent in the task list and
+# transcript. Accepts red/blue/green/yellow/purple/orange/pink/cyan). It now lives in
+# AGENT_FIELDS with the valid-color enum.
 DEPRECATED_AGENT_FIELDS = {
     'capabilities': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
     'expertise_level': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
     'activation_priority': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
-    'color': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
     'activation_triggers': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
     'type': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',
     'category': 'Non-standard field. Not in Anthropic spec. Will be removed in future validation.',


### PR DESCRIPTION
## Summary

Discovered while testing the new Tier 2 validator (#698) on ali5ter's external plugin PR #680: the IS agent validator was flagging two fields that **are** documented Anthropic spec fields, leading to wrong review feedback on legitimate agent submissions. This PR corrects the field validation against the current canonical Anthropic sub-agents docs.

## What was wrong

The IS validator's `AGENT_FIELDS` was missing fields that Anthropic documents at `code.claude.com/docs/en/sub-agents`:

1. **`color`** was in `DEPRECATED_AGENT_FIELDS` with message "Non-standard field. Not in Anthropic spec." — but Anthropic explicitly documents it: *"Display color for the subagent in the task list and transcript. Accepts red, blue, green, yellow, purple, orange, pink, or cyan."*
2. **`initialPrompt`** was missing entirely — agents using it got `[agent] Unknown field` warnings. Anthropic documents it: *"Auto-submitted as the first user turn when this agent runs as the main session agent."*
3. **`permissionMode`** valid-values set was missing `auto` (Anthropic's auto-classifier mode).

## What this PR does

| Field | Before | After |
|---|---|---|
| `color` | DEPRECATED → warn "Non-standard" | AGENT_FIELDS with enum: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
| `initialPrompt` | Missing → warn "Unknown field" | AGENT_FIELDS as optional string |
| `permissionMode` valid set | `default, acceptEdits, dontAsk, bypassPermissions, plan` | adds `auto` |

## Verification — ali5ter's two agents from PR #680

**`advisor.md`** (over-50s-health-advisor):

```
Before: WARN [agent] Deprecated field 'color': Non-standard field. Not in Anthropic spec.
        ERROR [agent] 'disallowedTools' must be an array, got: str

After:  ERROR [agent] 'color' value 'teal' not valid. Must be one of: red, blue, green, yellow, purple, orange, pink, cyan
        ERROR [agent] 'disallowedTools' must be an array, got: str
```

The diagnosis is now accurate: `teal` is not a valid color value (correct), but `color` itself is a valid field. The off-list-value error surfaces the actual fix.

**`coach.md`** (pair-programmer):

```
Before: WARN [agent] Deprecated field 'color': Non-standard field. Not in Anthropic spec.
        WARN [agent] Unknown field: 'initialPrompt'
        WARN [agent] 'description' should be 200 characters or less

After:  WARN [agent] 'description' should be 200 characters or less
```

Two false-positive warnings eliminated. `color: orange` is silently valid (in enum). `initialPrompt: ...` is silently valid. Only the real description-length warning remains.

## Out of scope (separate work, already shipped)

- `/agent-creator` SKILL.md (local user-skill, no PR target) bumped 1.0.0 → 1.1.0 with corrected frontmatter template + new `references/anthropic-sub-agents-spec.md` (61KB verbatim snapshot from `code.claude.com/docs/en/sub-agents`) + `references/anthropic-example-subagents.md` (the 4 canonical Anthropic example agents). The skill previously listed `tools` (allowlist) as wrong, `model` as required, and `capabilities`/`expertise_level`/`activation_priority` as standard optional — all wrong per current spec.

## Snapshot refresh cadence

The Anthropic sub-agents spec snapshot lives at `~/.claude/skills/agent-creator/references/anthropic-sub-agents-spec.md` (captured 2026-05-08). Refresh quarterly via PR — diff against live URL, propagate changes into `AGENT_FIELDS` in the same PR, test suite catches drift.

## Test plan

- [ ] CI green
- [x] Re-run validator on ali5ter advisor.md → 1 false-positive eliminated, real `color: teal` value error surfaced correctly
- [x] Re-run validator on ali5ter coach.md → 2 false-positive warnings eliminated, real description-length warning remains
- [ ] Full marketplace tier scan: confirm no NEW false-positive errors on existing agents that legitimately use `color`/`initialPrompt`

## Risk

The set of agents using `color` or `initialPrompt` was previously emitting warnings (now silent — good). The set of agents using `color: <invalid-value>` (e.g., `teal`) will now ERROR at marketplace tier instead of WARN — that's a stricter gate. Mitigation: enum is exactly Anthropic's published list; affected agents need to pick a valid color anyway. If this surfaces unexpected breakage on the catalog scan, color can be downgraded to warn-only via a one-line change.

## Plan reference

Caught while testing PR #698's Tier 2 validator on real external-contributor agents (ali5ter PR #680). Surfaces the wider lesson that the IS validator + `/agent-creator` need to live in lock-step with the Anthropic spec snapshot — drift between them produces wrong review feedback.

- Jeremy Longshore
intentsolutions.io