### PR TITLE
feat(marketplace): rebuild plugin card mobile-first

### DIFF
--- a/marketplace/src/components/Hero.astro
+++ b/marketplace/src/components/Hero.astro
@@ -202,7 +202,7 @@ const { totalPlugins, totalCategories } = Astro.props;
     background: transparent;
     border: none;
     padding: 0;
-    color: var(--primary-light);
+    color: var(--ink);
     font-size: 0.875rem;
   }
 

--- a/marketplace/src/components/PluginCard.astro
+++ b/marketplace/src/components/PluginCard.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * PluginCard — single source of truth for plugin/skill cards across the marketplace.
+ *
+ * Used declaratively (this component) on index, community, plugins, plugins/[name].
+ * The class `.pcard` is exposed via global CSS so that pages which build cards
+ * client-side (explore, skills index) can render the same shape with the same
+ * styling. Import this component at the top of any such page even if you only
+ * use it for the side-effect of registering the global stylesheet.
+ *
+ * Mobile-first: on < 768px cards stack as a list separated by hairlines (no
+ * boxes). On >= 768px cards become bordered tiles; the parent owns the grid.
+ */
+interface Props {
+  name: string;
+  description: string;
+  installCommand?: string;
+  author?: string;
+  skillCount?: number;
+  href: string;
+}
+const { name, description, installCommand, author, skillCount, href } = Astro.props;
+const showMeta = Boolean(author) || Boolean(skillCount);
+---
+<a class="pcard" href={href}>
+  <h3>{name}</h3>
+  <p>{description}</p>
+  {installCommand && <code>{installCommand}</code>}
+  {showMeta && (
+    <small>
+      {author && <span>{author}</span>}
+      {author && skillCount ? ' · ' : null}
+      {skillCount && <span>{skillCount} skills</span>}
+    </small>
+  )}
+</a>
+
+<style is:global>
+  .pcard {
+    display: block;
+    padding: var(--space-5);
+    border-bottom: 1px solid var(--rule);
+    color: inherit;
+    text-decoration: none;
+    transition: var(--card-transition);
+  }
+  .pcard:hover { background: var(--panel-2); }
+  .pcard:focus-visible {
+    outline: 2px solid var(--signal);
+    outline-offset: -2px;
+  }
+
+  .pcard h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--ink);
+    margin: 0 0 var(--space-2);
+    overflow-wrap: anywhere;
+  }
+
+  .pcard p {
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: 400;
+    line-height: 1.5;
+    color: var(--ink-2);
+    margin: 0 0 var(--space-3);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .pcard code {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 400;
+    line-height: 1.4;
+    color: var(--ink);
+    background: var(--panel-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: 6px;
+    word-break: break-all;
+    margin: 0 0 var(--space-3);
+  }
+
+  .pcard small {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    line-height: 1.4;
+    color: var(--ink-3);
+  }
+
+  /* Tablet+: bordered tile in a grid (parent owns grid layout). */
+  @media (min-width: 768px) {
+    .pcard {
+      border: 1px solid var(--rule);
+      border-radius: 8px;
+    }
+  }
+</style>

--- a/marketplace/src/pages/community.astro
+++ b/marketplace/src/pages/community.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import PluginCard from '../components/PluginCard.astro';
 import searchIndex from '../data/unified-search-index.json';
 import spotlightData from '../data/spotlights.json';
 const hallOfFame = spotlightData.hallOfFame || [];
@@ -257,56 +258,15 @@ function getContributionSummary(plugins: any[]): string {
     /* ── Community Plugin Grid ── */
     .plugins-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-card, 300px), 1fr));
-      gap: var(--grid-gap, 1.5rem);
+      grid-template-columns: 1fr;
       margin-bottom: 4rem;
     }
 
-    .plugin-card {
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: var(--card-standard-radius, 12px);
-      padding: var(--card-standard-padding, 1.5rem);
-      text-decoration: none;
-      color: inherit;
-      display: block;
-      transition: var(--card-transition, border-color 0.2s ease);
-    }
-
-    .plugin-card:hover {
-      border-color: var(--gold);
-      transform: var(--card-hover-lift, translateY(-2px));
-      
-    }
-
-    .plugin-card-name {
-      font-size: var(--text-card-title, 1.1rem);
-      font-weight: 600;
-      color: var(--text);
-      margin-bottom: 0.5rem;
-    }
-
-    .plugin-card-desc {
-      font-size: var(--text-card-desc, 0.875rem);
-      color: var(--text-2);
-      line-height: var(--text-line-height, 1.5);
-      margin-bottom: 0.75rem;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    .plugin-card-meta {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      font-size: var(--text-card-meta, 0.8rem);
-      color: var(--text-3);
-    }
-
-    .plugin-card-category {
-      text-transform: capitalize;
+    @media (min-width: 768px) {
+      .plugins-grid {
+        grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-card, 300px), 1fr));
+        gap: var(--grid-gap, 1rem);
+      }
     }
 
     /* ── CTA Section ── */
@@ -628,14 +588,13 @@ function getContributionSummary(plugins: any[]): string {
     <h2 class="section-heading">Community Plugins</h2>
     <div class="plugins-grid">
       {communityPlugins.map(plugin => (
-        <a href={`/plugins/${plugin.name}/`} class="plugin-card">
-          <div class="plugin-card-name">{plugin.displayName || plugin.name}</div>
-          <p class="plugin-card-desc">{plugin.description}</p>
-          <div class="plugin-card-meta">
-            <span class="plugin-card-category">{plugin.category?.replace(/-/g, ' ')}</span>
-            <span>{plugin.author?.name || 'Community'}</span>
-          </div>
-        </a>
+        <PluginCard
+          name={plugin.displayName || plugin.name}
+          description={plugin.description}
+          installCommand={`/plugin install ${plugin.name}@claude-code-plugins-plus`}
+          author={plugin.author?.name || 'Community'}
+          href={`/plugins/${plugin.name}/`}
+        />
       ))}
     </div>
 

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -1,8 +1,14 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import CompareBar from '../components/CompareBar.astro';
+import PluginCard from '../components/PluginCard.astro';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+
+// PluginCard is imported for the side-effect of registering the global
+// `.pcard` stylesheet — the cards on this page are rendered client-side from
+// the unified-search-index, so we apply the class via JS-built HTML below.
+void PluginCard;
 
 // Read only the stats from the search index at build time — the full items array
 // (~2.5 MB JSON) is NOT inlined into HTML. It is fetched lazily at runtime from
@@ -189,272 +195,27 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       padding: 3rem 4rem;
     }
 
+    /* Results grid — layout only; card styling lives in PluginCard. */
     .results-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 1.5rem;
+      grid-template-columns: 1fr;
     }
 
-    .result-card {
-      display: flex;
-      flex-direction: column;
-      padding: 1.75rem;
-      background: var(--surface-2);
-      border-radius: 12px;
-      border: none;
-      
-      transition: all 0.3s var(--transition-smooth);
-      position: relative;
-    }
-
-    .result-card:hover {
-      transform: translateY(-3px);
-      
-    }
-
-    .result-card-link {
-      display: block;
-      text-decoration: none;
-      color: inherit;
-      flex: 1;
-    }
-
-    .card-actions {
-      display: flex;
-      gap: 0.5rem;
-      justify-content: flex-end;
-      margin-top: auto;
-      padding-top: 1rem;
-    }
-
-    .install-copy-btn {
-      padding: 0.4rem 0.75rem;
-      background: var(--gold);
-      border: 1px solid var(--gold);
-      border-radius: 6px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: var(--surface);
-      cursor: pointer;
-      transition: all 0.2s;
-      font-family: 'Inter', system-ui, sans-serif;
-    }
-
-    .install-copy-btn:hover {
-      background: var(--brand-orange-dark);
-      border-color: var(--brand-orange-dark);
-    }
-
-    .install-copy-btn.copied {
-      background: #10b981;
-      border-color: #10b981;
-    }
-
-    .compare-toggle-btn {
-      padding: 0.4rem 0.75rem;
-      background: var(--surface-3);
-      border: 1px solid var(--brand-light-gray);
-      border-radius: 6px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: var(--brand-mid-gray);
-      cursor: pointer;
-      transition: all 0.2s;
-      font-family: 'Inter', system-ui, sans-serif;
-      position: static;
-    }
-
-    .compare-toggle-btn:hover {
-      border-color: var(--gold);
-      color: var(--gold);
-      background: rgba(234, 170, 0, 0.1);
-    }
-
-    .compare-toggle-btn.active {
-      background: var(--brand-orange);
-      border-color: var(--brand-orange);
-      color: #0a0a0c;
-    }
-
-    .compare-toggle-btn.active:hover {
-      background: var(--brand-orange-dark);
-    }
-
-    /* Inline badges */
-    .card-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.2rem;
-      padding: 0.15rem 0.45rem;
-      border-radius: 4px;
-      font-size: 0.65rem;
-      font-weight: 700;
-      font-family: 'JetBrains Mono', monospace;
-      text-transform: uppercase;
-      white-space: nowrap;
-      letter-spacing: 0.03em;
-    }
-
-    .card-badge.featured {
-      background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
-      color: #78350f;
-    }
-
-    .card-badge.new {
-      background: linear-gradient(135deg, #34d399 0%, #10b981 100%);
-      color: #064e3b;
-    }
-
-    .card-badge.has-skills {
-      background: rgba(234, 170, 0, 0.15);
-      color: var(--gold);
-    }
-
-    /* Bookmark button */
-    .bookmark-btn {
-      position: absolute;
-      top: 0.75rem;
-      left: 0.75rem;
-      width: 28px;
-      height: 28px;
-      background: var(--surface-3);
-      border: 1px solid var(--brand-light-gray);
-      border-radius: 6px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 0.9rem;
-      transition: all 0.2s;
-      opacity: 0;
-      z-index: 2;
-    }
-
-    .result-card:hover .bookmark-btn {
-      opacity: 1;
-    }
-
-    .bookmark-btn:hover {
-      border-color: #ef4444;
-      background: rgba(248, 81, 73, 0.15);
-    }
-
-    .bookmark-btn.active {
-      opacity: 1;
-      background: rgba(248, 81, 73, 0.15);
-      border-color: #ef4444;
-      color: #ef4444;
+    @media (min-width: 768px) {
+      .results-grid {
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1rem;
+      }
     }
 
     /* Keyboard navigation focus state */
-    .result-card.keyboard-focused {
-      outline: 3px solid var(--gold);
-      outline-offset: 2px;
-      
-    }
-
-    .result-type-badge {
-      position: absolute;
-      top: 1rem;
-      right: 1rem;
-      padding: 0.35rem 0.75rem;
-      font-size: 0.7rem;
-      font-weight: 700;
-      font-family: 'JetBrains Mono', monospace;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border-radius: 6px;
-    }
-
-    .result-type-badge.plugin {
-      background: rgba(106, 155, 204, 0.15);
-      color: var(--brand-blue);
-    }
-
-    .result-type-badge.skill {
-      background: rgba(234, 170, 0, 0.15);
-      color: var(--gold);
+    .pcard.keyboard-focused {
+      outline: 2px solid var(--signal);
+      outline-offset: -2px;
     }
 
     .author-toggle {
       margin-left: 0;
-    }
-
-    .result-name {
-      font-size: 1.15rem;
-      font-weight: 600;
-      color: var(--text);
-      margin-bottom: 0.75rem;
-      padding-right: 4.5rem;
-    }
-
-    .result-description {
-      font-size: 0.9rem;
-      color: var(--text-2);
-      line-height: 1.6;
-      margin-bottom: 1rem;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    .result-meta {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      font-size: 0.8rem;
-      color: var(--text-3);
-    }
-
-    .result-meta-row {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-    }
-
-    .parent-plugin {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.5rem 0.75rem;
-      background: var(--surface-3);
-      border-radius: 6px;
-      color: var(--gold);
-      font-weight: 600;
-      font-family: 'Inter', system-ui, sans-serif;
-    }
-
-    .result-category {
-      text-transform: capitalize;
-    }
-
-    .result-tools {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.4rem;
-      margin-top: 0.75rem;
-    }
-
-    .tool-tag {
-      padding: 0.25rem 0.6rem;
-      background: rgba(234, 170, 0, 0.1);
-      color: var(--gold);
-      font-size: 0.7rem;
-      font-weight: 600;
-      border-radius: 4px;
-      font-family: 'JetBrains Mono', monospace;
-    }
-
-    .keyword-tag {
-      padding: 0.25rem 0.6rem;
-      background: rgba(106, 155, 204, 0.1);
-      color: var(--brand-blue);
-      font-size: 0.7rem;
-      font-weight: 600;
-      border-radius: 4px;
-      font-family: 'Inter', system-ui, sans-serif;
     }
 
     .no-results {
@@ -492,12 +253,6 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
     }
 
     /* Mobile Responsive */
-    @media (max-width: 1024px) {
-      .results-grid {
-        grid-template-columns: repeat(2, 1fr);
-      }
-    }
-
     @media (max-width: 768px) {
       .explorer-hero {
         padding: 2.5rem 2rem 2rem;
@@ -541,34 +296,9 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         text-align: center;
       }
 
-      .results-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .result-card {
-        padding: 1.25rem;
-      }
-
-      .result-name {
-        padding-right: 3.5rem;
-      }
-
-      .result-meta-row {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.35rem;
-      }
-
       .hero-stats {
         flex-direction: column;
         gap: 1rem;
-      }
-
-      .card-badge,
-      .result-type-badge,
-      .tool-tag,
-      .keyword-tag {
-        font-size: 0.75rem;
       }
     }
 
@@ -595,28 +325,6 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       .hero-search-input {
         font-size: 0.95rem;
         padding: 0.75rem 1rem;
-      }
-
-      .result-card {
-        padding: 1rem;
-      }
-
-      .result-name {
-        font-size: 1rem;
-        padding-right: 3rem;
-      }
-
-      .result-description {
-        font-size: 0.85rem;
-      }
-
-      .result-type-badge {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.65rem;
-      }
-
-      .card-actions {
-        flex-wrap: wrap;
       }
 
       .hero-stats {
@@ -716,7 +424,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         Showing {_rawStats.totalItems} items
       </span>
 
-      <span class="keyboard-hint" title="Keyboard shortcuts: / search, j/k navigate, Enter open, c compare, f favorite">
+      <span class="keyboard-hint" title="Keyboard shortcuts: / search, j/k navigate, Enter open">
         <kbd>/</kbd> <kbd>j</kbd><kbd>k</kbd> <kbd>↵</kbd>
       </span>
     </div>
@@ -874,90 +582,36 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         : (item.parentPlugin ? `/cowork` : `/skills/${escHtml(item.slug)}/`);
       const installName = item.type === 'plugin' ? item.name : (item.parentPlugin?.name || item.name);
       const installCmd = `/plugin install ${escHtml(installName)}@claude-code-plugins-plus`;
-      const favs = window.BookmarkManager ? window.BookmarkManager.getAll() : [];
-      const isFav = favs.includes(item.id || item.name);
 
-      const tagsHtml = item.type === 'plugin' && item.keywords && item.keywords.length > 0
-        ? `<div class="result-tools">
-            ${item.keywords.slice(0, 3).map(kw => `<span class="keyword-tag">${escHtml(kw.replace(/-/g,' '))}</span>`).join('')}
-            ${item.keywords.length > 3 ? `<span class="keyword-tag">+${item.keywords.length - 3} more</span>` : ''}
-          </div>`
-        : item.type === 'skill' && item.allowedTools && item.allowedTools.length > 0
-          ? `<div class="result-tools">
-              ${item.allowedTools.slice(0, 3).map(t => `<span class="tool-tag">${escHtml(t)}</span>`).join('')}
-              ${item.allowedTools.length > 3 ? `<span class="tool-tag">+${item.allowedTools.length - 3} more</span>` : ''}
-            </div>`
-          : '';
-
-      const parentHtml = item.type === 'skill' && item.parentPlugin
-        ? `<div class="parent-plugin"><span>📦</span><span>Provided by ${escHtml(item.parentPlugin.name)}</span></div>`
+      const metaParts = [];
+      if (item.type === 'skill' && item.parentPlugin) {
+        metaParts.push(`<span>Provided by ${escHtml(item.parentPlugin.name)}</span>`);
+      }
+      if (item.skillCount > 0) {
+        metaParts.push(`<span>${item.skillCount} skills</span>`);
+      }
+      const metaHtml = metaParts.length
+        ? `<small>${metaParts.join(' · ')}</small>`
         : '';
 
-      return `<div class="result-card"
+      return `<div
           data-type="${escHtml(item.type)}"
           data-category="${escHtml(item.category)}"
           data-item-id="${id}"
           data-item-name="${displayName}"
           data-author-type="${escHtml(item.authorType || 'official')}">
-          <button class="bookmark-btn${isFav ? ' active' : ''}" data-bookmark-id="${id}" title="${isFav ? 'Remove from favorites' : 'Add to favorites'}">${isFav ? '♥' : '♡'}</button>
-          <a href="${href}" class="result-card-link">
-            <span class="result-type-badge ${escHtml(item.type)}">${escHtml(item.type)}</span>
-            <h3 class="result-name">${displayName}</h3>
-            <p class="result-description">${escHtml(item.description)}</p>
-            <div class="result-meta">
-              ${parentHtml}
-              <div class="result-meta-row">
-                <span class="result-category">${escHtml(item.category.replace(/-/g,' '))}</span>
-                ${item.skillCount > 0 ? `<span class="card-badge has-skills">${item.skillCount} skills</span>` : ''}
-              </div>
-            </div>
-            ${tagsHtml}
+          <a class="pcard" href="${href}">
+            <h3>${displayName}</h3>
+            <p>${escHtml(item.description)}</p>
+            <code>${installCmd}</code>
+            ${metaHtml}
           </a>
-          <div class="card-actions">
-            <button class="install-copy-btn" data-install-cmd="${installCmd}" title="Copy install command">Install</button>
-            <button class="compare-toggle-btn" data-compare-id="${id}" data-compare-name="${displayName}" data-compare-type="${escHtml(item.type)}" title="Add to comparison">+ Compare</button>
-          </div>
         </div>`;
     }
 
-    function attachCardListeners(container) {
-      // Install copy buttons
-      container.querySelectorAll('.install-copy-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.preventDefault(); e.stopPropagation();
-          const cmd = btn.dataset.installCmd;
-          navigator.clipboard.writeText(cmd).then(() => {
-            const orig = btn.textContent;
-            btn.textContent = 'Copied!';
-            btn.classList.add('copied');
-            setTimeout(() => { btn.textContent = orig; btn.classList.remove('copied'); }, 1500);
-            if (window.trackEvent) window.trackEvent('install_copied', { plugin_name: cmd, source: 'explore_card' });
-          });
-        });
-      });
-      // Compare buttons
-      container.querySelectorAll('.compare-toggle-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.preventDefault(); e.stopPropagation();
-          const { compareId: id, compareName: name, compareType: type } = btn.dataset;
-          if (window.CompareManager) {
-            if (window.CompareManager.has(id)) {
-              window.CompareManager.remove(id);
-              if (window.trackEvent) window.trackEvent('compare_action', { action: 'remove', plugin_name: name });
-            } else {
-              window.CompareManager.add({ id, name, type });
-              if (window.trackEvent) window.trackEvent('compare_action', { action: 'add', plugin_name: name });
-            }
-          }
-        });
-      });
-      // Bookmark buttons
-      container.querySelectorAll('.bookmark-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.preventDefault(); e.stopPropagation();
-          if (window.BookmarkManager) window.BookmarkManager.toggle(btn.dataset.bookmarkId);
-        });
-      });
+    function attachCardListeners(_container) {
+      // Cards are now plain links — bookmark/compare toggles moved off the
+      // cards (filter rail / detail page own them).
     }
 
     function renderResults(items) {
@@ -1109,18 +763,15 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       let focusedCardIndex = -1;
 
       function updateCardFocus(newIndex) {
-        const cards = document.querySelectorAll('.result-card:not([style*="display: none"])');
+        const cards = document.querySelectorAll('.pcard');
         if (cards.length === 0) return;
 
-        // Remove focus from previous card
         if (focusedCardIndex >= 0 && focusedCardIndex < cards.length) {
           cards[focusedCardIndex].classList.remove('keyboard-focused');
         }
 
-        // Clamp to valid range
         focusedCardIndex = Math.max(0, Math.min(newIndex, cards.length - 1));
 
-        // Add focus to new card
         const focusedCard = cards[focusedCardIndex];
         focusedCard.classList.add('keyboard-focused');
         focusedCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -1129,13 +780,11 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       document.addEventListener('keydown', (e) => {
         const inInput = ['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName);
 
-        // Focus search on / (unless already in input)
         if (e.key === '/' && !inInput) {
           e.preventDefault();
           document.getElementById('main-search').focus();
         }
 
-        // Clear search on Escape
         if (e.key === 'Escape') {
           if (document.activeElement.id === 'main-search') {
             document.getElementById('main-search').blur();
@@ -1145,15 +794,13 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
               applyFilters();
             }
           }
-          // Clear card focus on Escape
-          const focusedCard = document.querySelector('.result-card.keyboard-focused');
+          const focusedCard = document.querySelector('.pcard.keyboard-focused');
           if (focusedCard) {
             focusedCard.classList.remove('keyboard-focused');
             focusedCardIndex = -1;
           }
         }
 
-        // j/k navigation (only when not in input)
         if (!inInput) {
           if (e.key === 'j' || e.key === 'ArrowDown') {
             e.preventDefault();
@@ -1163,31 +810,11 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
             e.preventDefault();
             updateCardFocus(focusedCardIndex - 1);
           }
-          // Enter to open focused card
           if (e.key === 'Enter') {
-            const focusedCard = document.querySelector('.result-card.keyboard-focused');
+            const focusedCard = document.querySelector('.pcard.keyboard-focused');
             if (focusedCard) {
-              const link = focusedCard.querySelector('.result-card-link');
-              if (link) {
-                e.preventDefault();
-                window.location.href = link.href;
-              }
-            }
-          }
-          // c to add to compare
-          if (e.key === 'c') {
-            const focusedCard = document.querySelector('.result-card.keyboard-focused');
-            if (focusedCard) {
-              const compareBtn = focusedCard.querySelector('.compare-toggle-btn');
-              if (compareBtn) compareBtn.click();
-            }
-          }
-          // f to toggle favorite
-          if (e.key === 'f') {
-            const focusedCard = document.querySelector('.result-card.keyboard-focused');
-            if (focusedCard) {
-              const bookmarkBtn = focusedCard.querySelector('.bookmark-btn');
-              if (bookmarkBtn) bookmarkBtn.click();
+              e.preventDefault();
+              window.location.href = focusedCard.href;
             }
           }
         }

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -7,6 +7,7 @@ import CoworkGrid from '../components/CoworkGrid.astro';
 import KillerSkills from '../components/KillerSkills.astro';
 import JeremysStash from '../components/JeremysStash.astro';
 import PartnerBar from '../components/PartnerBar.astro';
+import PluginCard from '../components/PluginCard.astro';
 import searchIndex from '../data/unified-search-index.json';
 import starterPack from '../data/starter-pack.json';
 
@@ -809,84 +810,15 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
 
         .starter-pack-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-            gap: 1.25rem;
+            grid-template-columns: 1fr;
             margin-bottom: 2rem;
         }
 
-        .starter-card {
-            background: var(--surface-2, var(--panel));
-            border: 1px solid var(--border, var(--rule));
-            border-radius: 12px;
-            padding: 1.5rem;
-            display: flex;
-            flex-direction: column;
-            gap: 0.75rem;
-            transition: border-color var(--duration-fast) var(--ease-out);
-        }
-
-        .starter-card:hover {
-            border-color: var(--accent, var(--signal));
-        }
-
-        .starter-card-header {
-            display: flex;
-            align-items: baseline;
-            justify-content: space-between;
-            gap: 0.75rem;
-            flex-wrap: wrap;
-        }
-
-        .starter-card-name {
-            color: var(--text, var(--ink));
-            font-family: 'JetBrains Mono', 'Fira Code', monospace;
-            font-size: 1.1rem;
-            font-weight: 600;
-            text-decoration: none;
-        }
-
-        .starter-card-name:hover {
-            color: var(--accent, var(--signal));
-        }
-
-        .starter-card-category {
-            color: var(--text-3, var(--ink-2));
-            font-size: 0.75rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            font-weight: 600;
-        }
-
-        .starter-card-tagline {
-            color: var(--text, var(--ink));
-            font-size: 1rem;
-            font-weight: 500;
-            font-style: italic;
-            margin: 0;
-            line-height: 1.4;
-        }
-
-        .starter-card-why {
-            color: var(--text-2, var(--ink-2));
-            font-size: 0.92rem;
-            line-height: 1.55;
-            margin: 0;
-        }
-
-        .starter-card-install {
-            margin-top: auto;
-            padding-top: 0.75rem;
-            border-top: 1px dashed var(--border, var(--rule));
-        }
-
-        .starter-card-install code {
-            color: var(--accent, var(--signal));
-            font-family: 'JetBrains Mono', 'Fira Code', monospace;
-            font-size: 0.82rem;
-            user-select: all;
-            display: block;
-            word-break: break-all;
-            line-height: 1.4;
+        @media (min-width: 768px) {
+            .starter-pack-grid {
+                grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+                gap: 1.25rem;
+            }
         }
 
         .starter-pack-meta {
@@ -908,9 +840,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         @media (max-width: 768px) {
             .starter-pack-section {
                 padding: 3rem 1.5rem;
-            }
-            .starter-pack-grid {
-                grid-template-columns: 1fr;
             }
         }
 
@@ -1429,17 +1358,12 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             </div>
             <div class="starter-pack-grid">
                 {starterPack.plugins.map((plugin) => (
-                    <article class="starter-card">
-                        <header class="starter-card-header">
-                            <a href={`/plugins/${plugin.slug}`} class="starter-card-name">{plugin.name}</a>
-                            <span class="starter-card-category">{plugin.category}</span>
-                        </header>
-                        <p class="starter-card-tagline">{plugin.tagline}</p>
-                        <p class="starter-card-why">{plugin.why}</p>
-                        <div class="starter-card-install">
-                            <code>{plugin.install}</code>
-                        </div>
-                    </article>
+                    <PluginCard
+                        name={plugin.name}
+                        description={plugin.why || plugin.tagline}
+                        installCommand={plugin.install}
+                        href={`/plugins/${plugin.slug}`}
+                    />
                 ))}
             </div>
             <p class="starter-pack-meta">

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -5,6 +5,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import FaqAccordion from '../../components/FaqAccordion.astro';
 import DetailCta from '../../components/DetailCta.astro';
+import PluginCard from '../../components/PluginCard.astro';
 import skillsCatalog from '../../data/skills-catalog.json';
 import readmeSections from '../../data/readme-sections.json';
 import jrigData from '../../data/jrig-data.json';
@@ -295,10 +296,12 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
           <h2>Related Plugins</h2>
           <div class="related-plugins">
             {relatedPlugins.map((related: any) => (
-              <a href={`/plugins/${related.name}`} class="related-card">
-                <h3>{related.name}</h3>
-                <p>{related.description}</p>
-              </a>
+              <PluginCard
+                name={related.name}
+                description={related.description}
+                installCommand={`/plugin install ${related.name}@claude-code-plugins-plus`}
+                href={`/plugins/${related.name}`}
+              />
             ))}
           </div>
         </div>
@@ -993,46 +996,17 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
     font-weight: 600;
   }
 
-  /* Related plugins */
+  /* Related plugins — grid layout only; card styling lives in PluginCard. */
   .related-plugins {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 1rem;
+    grid-template-columns: 1fr;
   }
 
-  .related-card {
-    background: var(--surface-2, var(--brand-light));
-    border: 1px solid var(--border, var(--brand-light-gray));
-    border-radius: var(--radius-md);
-    padding: 1rem;
-    text-decoration: none;
-    color: var(--text, var(--brand-dark));
-    transition: all var(--duration-fast) var(--ease-out);
-  }
-
-  .related-card:hover {
-    border-color: var(--brand-orange);
-    transform: translateY(-2px);
-    
-  }
-
-  .related-card h3 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: var(--brand-orange);
-    font-family: 'Inter', system-ui, sans-serif;
-  }
-
-  .related-card p {
-    font-size: 0.85rem;
-    color: var(--text-2, var(--brand-mid-gray));
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    line-height: 1.5;
+  @media (min-width: 768px) {
+    .related-plugins {
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
   }
 
   /* Tags footer (moved keywords) */
@@ -1101,10 +1075,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
 
     .info-grid {
       grid-template-columns: 1fr 1fr;
-    }
-
-    .related-plugins {
-      grid-template-columns: 1fr;
     }
 
     .gist-header {

--- a/marketplace/src/pages/plugins/index.astro
+++ b/marketplace/src/pages/plugins/index.astro
@@ -2,6 +2,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import PluginCard from '../../components/PluginCard.astro';
 
 // Load plugin catalog
 const catalogPath = join(process.cwd(), '../.claude-plugin/marketplace.extended.json');
@@ -34,10 +35,12 @@ const pageDescription = `Explore all ${catalog.plugins.length} plugins for Claud
           <h2>{category.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</h2>
           <div class="plugins-grid">
             {plugins.map((plugin: any) => (
-              <a href={`/plugins/${plugin.name}/`} class="plugin-card">
-                <h3>{plugin.name}</h3>
-                <p>{plugin.description}</p>
-              </a>
+              <PluginCard
+                name={plugin.name}
+                description={plugin.description}
+                installCommand={`/plugin install ${plugin.name}@claude-code-plugins-plus`}
+                href={`/plugins/${plugin.name}/`}
+              />
             ))}
           </div>
         </div>
@@ -60,18 +63,18 @@ const pageDescription = `Explore all ${catalog.plugins.length} plugins for Claud
     .header h1 {
       font-size: 2.5rem;
       font-weight: 700;
-      color: var(--brand-dark);
+      color: var(--ink);
       margin-bottom: 1rem;
     }
 
     .subtitle {
       font-size: 1.1rem;
-      color: var(--brand-mid-gray);
+      color: var(--ink-2);
       margin-bottom: 1.5rem;
     }
 
     .explore-link a {
-      color: var(--brand-orange);
+      color: var(--ink-link);
       font-weight: 600;
       text-decoration: none;
     }
@@ -87,49 +90,22 @@ const pageDescription = `Explore all ${catalog.plugins.length} plugins for Claud
     .category-section h2 {
       font-size: 1.5rem;
       font-weight: 600;
-      color: var(--brand-dark);
+      color: var(--ink);
       margin-bottom: 1.5rem;
       padding-bottom: 0.5rem;
-      border-bottom: 2px solid var(--brand-orange);
+      border-bottom: 1px solid var(--rule);
     }
 
     .plugins-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-      gap: 1.5rem;
+      grid-template-columns: 1fr;
     }
 
-    .plugin-card {
-      display: block;
-      padding: 1.5rem;
-      background: var(--card);
-      border: 2px solid var(--brand-light-gray);
-      border-radius: 12px;
-      text-decoration: none;
-      transition: all 0.3s var(--transition-smooth);
-    }
-
-    .plugin-card:hover {
-      border-color: var(--brand-orange);
-      transform: translateY(-4px);
-      
-    }
-
-    .plugin-card h3 {
-      font-size: 1.1rem;
-      font-weight: 600;
-      color: var(--brand-dark);
-      margin-bottom: 0.5rem;
-    }
-
-    .plugin-card p {
-      font-size: 0.9rem;
-      color: var(--brand-mid-gray);
-      line-height: 1.6;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
+    @media (min-width: 768px) {
+      .plugins-grid {
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1rem;
+      }
     }
 
     @media (max-width: 768px) {
@@ -139,10 +115,6 @@ const pageDescription = `Explore all ${catalog.plugins.length} plugins for Claud
 
       .header h1 {
         font-size: 2rem;
-      }
-
-      .plugins-grid {
-        grid-template-columns: 1fr;
       }
     }
   </style>

--- a/marketplace/src/pages/skills/index.astro
+++ b/marketplace/src/pages/skills/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import PluginCard from '../../components/PluginCard.astro';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -132,91 +133,17 @@ const allTools = _rawCatalog.allowedToolsUsed;
       padding: 3rem 4rem;
     }
 
+    /* Skills grid — layout only; card styling lives in PluginCard. */
     .skills-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 1.5rem;
+      grid-template-columns: 1fr;
     }
 
-    .skill-card {
-      display: block;
-      padding: 1.5rem;
-      background: var(--card);
-      border-radius: var(--radius-lg);
-      border: 2px solid var(--border);
-      text-decoration: none;
-      transition: all var(--duration-normal) var(--ease-out);
-    }
-
-    .skill-card:hover {
-      border-color: var(--primary);
-      transform: translateY(-4px);
-      
-    }
-
-    .skill-name {
-      font-size: 1.1rem;
-      font-weight: 600;
-      color: var(--text);
-      margin-bottom: 0.5rem;
-    }
-
-    .skill-description {
-      font-size: 0.9rem;
-      color: var(--text-2);
-      line-height: 1.6;
-      margin-bottom: 1rem;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    .skill-tools {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-bottom: 0.75rem;
-    }
-
-    .tool-badge {
-      padding: 0.25rem 0.75rem;
-      background: rgb(250 255 105 / 0.1);
-      color: var(--primary-dark);
-      font-size: 0.75rem;
-      font-weight: 600;
-      border-radius: var(--radius-sm);
-      font-family: 'Inter', system-ui, sans-serif;
-    }
-
-    .tool-badge-more {
-      background: var(--border);
-      color: var(--text-2);
-    }
-
-    .skill-meta {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      font-size: 0.75rem;
-      color: var(--text-2);
-    }
-
-    .skill-category {
-      text-transform: capitalize;
-    }
-
-    .skill-plugin-info {
-      margin-top: 0.75rem;
-      padding-top: 0.75rem;
-      border-top: 1px solid var(--border);
-      font-size: 0.8125rem;
-      color: var(--text-2);
-    }
-
-    .skill-plugin-info strong {
-      color: var(--primary);
-      font-weight: 600;
+    @media (min-width: 768px) {
+      .skills-grid {
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1rem;
+      }
     }
 
     .no-results {
@@ -336,39 +263,15 @@ const allTools = _rawCatalog.allowedToolsUsed;
   <div class="skills-grid-section">
     <div id="skills-grid" class="skills-grid" aria-live="polite">
       {firstPageSkills.map((skill: any) => (
-        <a
-          href={`/skills/${skill.slug}/`}
-          class="skill-card"
-          data-slug={skill.slug}
-        >
-          <h3 class="skill-name">{skill.name}</h3>
-          <p class="skill-description">
-            {skill.description || 'No description available'}
-          </p>
-
-          <div class="skill-tools">
-            {skill.allowedTools.slice(0, 3).map((tool: string) => (
-              <span class="tool-badge">{tool}</span>
-            ))}
-            {skill.allowedTools.length > 3 && (
-              <span class="tool-badge tool-badge-more">
-                +{skill.allowedTools.length - 3} more
-              </span>
-            )}
-          </div>
-
-          <div class="skill-meta">
-            <span class="skill-category">{skill.parentPlugin.category.replace(/-/g, ' ')}</span>
-            <span>{skill.version}</span>
-          </div>
-
-          <div class="skill-plugin-info">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display: inline; vertical-align: middle; margin-right: 4px;">
-              <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
-            </svg>
-            Provided by <strong>{skill.parentPlugin.name}</strong>
-          </div>
-        </a>
+        <div data-slug={skill.slug}>
+          <PluginCard
+            name={skill.name}
+            description={skill.description || 'No description available'}
+            installCommand={`/plugin install ${skill.parentPlugin.name}@claude-code-plugins-plus`}
+            author={`Provided by ${skill.parentPlugin.name}`}
+            href={`/skills/${skill.slug}/`}
+          />
+        </div>
       ))}
       <!-- Remaining skills appended by JS after /data/skills-catalog.json fetch -->
       <div id="skills-loading-more" style="grid-column: 1 / -1; text-align: center; padding: 2rem; color: var(--text-2); font-size: 0.9rem;">
@@ -426,19 +329,14 @@ const allTools = _rawCatalog.allowedToolsUsed;
     }
 
     function skillCardHtml(skill) {
-      const tools = skill.allowedTools || [];
-      return `<a href="/skills/${escHtml(skill.slug)}/" class="skill-card" data-slug="${escHtml(skill.slug)}">
-        <h3 class="skill-name">${escHtml(skill.name)}</h3>
-        <p class="skill-description">${escHtml(skill.description || 'No description available')}</p>
-        <div class="skill-tools">
-          ${tools.slice(0, 3).map(t => `<span class="tool-badge">${escHtml(t)}</span>`).join('')}
-          ${tools.length > 3 ? `<span class="tool-badge tool-badge-more">+${tools.length - 3} more</span>` : ''}
-        </div>
-        <div class="skill-meta">
-          <span class="skill-category">${escHtml((skill.parentPlugin.category || '').replace(/-/g,' '))}</span>
-          <span>${escHtml(skill.version)}</span>
-        </div>
-      </a>`;
+      const parent = (skill.parentPlugin && skill.parentPlugin.name) || '';
+      const installCmd = parent ? `/plugin install ${parent}@claude-code-plugins-plus` : '';
+      return `<div data-slug="${escHtml(skill.slug)}"><a class="pcard" href="/skills/${escHtml(skill.slug)}/">
+        <h3>${escHtml(skill.name)}</h3>
+        <p>${escHtml(skill.description || 'No description available')}</p>
+        ${installCmd ? `<code>${escHtml(installCmd)}</code>` : ''}
+        ${parent ? `<small><span>Provided by ${escHtml(parent)}</span></small>` : ''}
+      </a></div>`;
     }
 
     function appendRemainingSkills(skills) {


### PR DESCRIPTION
## Summary

Replaces five drifted per-page card definitions (`.result-card`, `.plugin-card`, `.skill-card`, `.related-card`, `.starter-card`) with a single `PluginCard` component. Five elements only: `h3 / p / code / small`. No badges, tag chips, grade pills, copy buttons, or JRig markers.

Mobile cards stack as a hairline-separated list (no boxes). Tablet+ become bordered tiles in a grid (parent owns grid layout).

## Token-level fix

`Hero.astro:201` install-command color was `var(--primary-light)` — `rgba(250,255,105,0.25)` on light bg = 1.3:1 contrast, failing WCAG AA. Switched to `var(--ink)` for high contrast.

## Migrated

- `index.astro` — starter-pack section
- `explore.astro` — JS-rendered cards now produce `.pcard` HTML; deleted ~600 lines of `.result-card` + bookmark/compare/install/badge CSS
- `community.astro`
- `plugins/index.astro`
- `plugins/[name].astro` — related-plugins
- `skills/index.astro` — server- and client-rendered

## What disappeared

- Type badges, skill-count chip, compare toggle, bookmark button, install copy button on `.result-card`
- "CODE-QUALITY" tag pills
- Pale yellow on light bg
- Box-inside-box (cards with bordered tag-rows inside)
- Install-command horizontal scroll (now wraps via `word-break: break-all`)

## Out of scope

`KillerSkills.astro`, `CollectionsGrid.astro`, `JeremysStash.astro` (different shapes); JRig-Verified badge on cards (data feed exists; separate decision).

## Numbers

| Metric | Value |
|---|---|
| Pages migrated | 6 |
| New component | `PluginCard.astro` (104 lines) |
| Net code change | -776 / +230 = **-546 lines** |
| Build | 3914 pages, 23.92s |
| Route validator | 427/427 pass |
| Internal-link validator | 524/524 pass |

## Test plan

- [ ] CI (validate, marketplace-validation, playwright) green
- [ ] Visual: open `/`, `/explore`, `/skills`, `/community`, `/plugins`, `/plugins/<any>` at 375 / 1024 / 1440 px
- [ ] Toggle light theme — confirm install commands readable (WCAG AA)
- [ ] Tap any card on mobile — full-card link works
- [ ] Long plugin names wrap; no horizontal scroll on install commands
- [ ] Explore: `/`, `j`/`k`, Enter keyboard nav still works
- [ ] Light Lighthouse run on `/` — 0 contrast errors on cards

- Jeremy Longshore
intentsolutions.io