### PR TITLE
feat: add agency-os plugin (AI agency + Notion board)

### DIFF
--- a/plugins/ai-agency/agency-os/.claude-plugin/plugin.json
+++ b/plugins/ai-agency/agency-os/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "agency-os",
+  "version": "0.1.6",
+  "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
+  "author": {
+    "name": "AutomateLab",
+    "url": "https://github.com/ratamaha-git"
+  },
+  "repository": "https://github.com/ratamaha-git/agency-os",
+  "homepage": "https://github.com/ratamaha-git/agency-os",
+  "license": "MIT",
+  "keywords": [
+    "notion",
+    "task-management",
+    "ai-agency",
+    "autonomous-agent",
+    "workflow",
+    "project-management",
+    "mcp",
+    "claude-code"
+  ]
+}

--- a/plugins/ai-agency/agency-os/LICENSE
+++ b/plugins/ai-agency/agency-os/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AutomateLab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/ai-agency/agency-os/README.md
+++ b/plugins/ai-agency/agency-os/README.md
@@ -1,0 +1,39 @@
+# agency-os
+
+> Run your work like an AI agency, from a single Notion board.
+
+Turn Notion into the dashboard of your own AI agency. You discuss ideas with the agent, it clarifies scope and writes the plan into Notion, you approve, and agents ship the work in parallel - with result links back on the row.
+
+## What you get
+
+- **Agent-driven planning.** Talk through an idea in plain English. The agent asks questions, carves work into tasks and subtasks, sets dependencies, and writes the plan to Notion.
+- **One board for everything.** Ideas, tasks, decisions, and finished work in one place.
+- **Parallel execution.** Agents run Exec=Agent rows in parallel, respecting dependency order. Right model for the job - fast models for mechanical work, bigger ones for judgment tasks.
+- **Operator-gated.** Nothing dispatches autonomously. Every run is opt-in; the board is honest about what's queued and why.
+
+## Quick Start
+
+1. Duplicate the [public Notion template](https://www.notion.so/35dd01a02a8081dea01cd8d42617f0c8) into your workspace.
+2. Create a Notion integration at https://www.notion.so/my-integrations and share it with the duplicated page.
+3. Add `NOTION_KEY=secret_...` to your `.env`.
+4. Run `/agency-os scaffold` to wire the board.
+
+Full setup guide: https://github.com/ratamaha-git/agency-os/blob/main/docs/harnesses/claude-code.md
+
+## Skills
+
+- `/agency-os suggest` - Drop an idea into the Notion inbox
+- `/agency-os discuss` - Open a task for clarification with the agent
+- `/agency-os approve` - Promote to To-Do (cascades subtasks)
+- `/agency-os start` - Flip To-Do to In Progress and load the kickoff brief
+- `/agency-os run --go` - Batch-execute all Exec=Agent To-Do rows
+- `/agency-os done` - Close with a result link
+
+## Learn more
+
+- GitHub: https://github.com/ratamaha-git/agency-os
+- Launch post: https://automatelab.tech/p/b3e8d44b-dd98-4e16-a888-9b1be7e9829c/
+
+## License
+
+MIT - AutomateLab


### PR DESCRIPTION
## Plugin: agency-os

**Category:** ai-agency

**GitHub:** https://github.com/ratamaha-git/agency-os

**Description:** Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel - with dependency ordering and model routing.

### What it does

agency-os turns Notion into the dashboard of your own AI agency. You discuss ideas with the agent, it clarifies scope and writes the plan into Notion, you approve, and agents ship the work in parallel with result links back on the row.

- Agent-driven planning (suggest / discuss / approve flow)
- Parallel execution respecting dependency order
- Right model for the job - fast models for mechanical, bigger for judgment
- Operator-gated - nothing dispatches autonomously

### Files included

- `.claude-plugin/plugin.json` - metadata (name, version, description, author, keywords, repo links)
- `README.md` - quick start, skills reference, learn more
- `LICENSE` - MIT

### Install

```bash
ccpi install agency-os
```

Or: duplicate the [public Notion template](https://www.notion.so/35dd01a02a8081dea01cd8d42617f0c8) and run `/agency-os scaffold`.

### Launch post

https://automatelab.tech/p/b3e8d44b-dd98-4e16-a888-9b1be7e9829c/