### PR TITLE
chore(validator): bump SCHEMA_VERSION constant 3.3.2 → 3.6.0

### DIFF
--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -82,7 +82,7 @@ except ImportError:
 #                       doesn't affect /-menu visibility); added ${CLAUDE_EFFORT} to
 #                       YAML_VALUE_ALLOWED_VARS.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = '3.3.2'
+SCHEMA_VERSION = '3.6.0'
 
 # Validation tiers
 TIER_STANDARD = 'standard'


### PR DESCRIPTION
## Summary

One-line drift fix. The validator's banner constant was missed during the three schema minors that landed earlier today.

| File | Pre-PR | This PR |
|---|---|---|
| `scripts/validate-skills-schema.py:85` (`SCHEMA_VERSION`) | `3.3.2` | `3.6.0` |
| `000-docs/SCHEMA_CHANGELOG.md` | already at `3.6.0` | unchanged |
| `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md` | already at `3.6.0` | unchanged |

## Why this is autonomous (no pre-approval needed)

Per [#612](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/612) NON-NEGOTIABLE #5: *"Bug fixes that bring the validator into spec compliance are always OK to apply autonomously."* Version-string sync between the validator banner and the canonical schema log is the same class of fix — it's housekeeping, not architectural.

No rule changes. No required-fields set changes. No error-vs-warning semantics changes.

## Verification

```
$ python3 scripts/validate-skills-schema.py --verbose
🔍 CLAUDE CODE PLUGIN VALIDATOR v7.0 / schema 3.6.0 (standard tier)
```

## Refs

- #612 (governance + non-negotiables — this PR addresses the validator-banner drift noted during the 2026-05-14 audit)
- #714 (3.4.0 progressive disclosure, merged today)
- #715 (3.5.0 conditional visibility, merged today)
- #716 (3.6.0 self-declared config, merged today)