### PR TITLE
feat(ci): pr-prescreen.yml + classify.py + Slack wiring (deterministic-only)

### DIFF
--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -1,0 +1,288 @@
+name: 'PR Pre-screen'
+
+# SAFE-FOR-FORKS design — pull_request_target runs in the BASE branch context
+# so secrets are available even on forked PRs. Two rules keep this safe:
+#
+#   1. Checkout uses the PR HEAD SHA with persist-credentials: false. Using
+#      the SHA (not the ref) prevents TOCTOU on force-pushes.
+#   2. We never execute PR-controlled code — only read the diff + run the
+#      repo's pinned validator (from main, not from the PR) against PR
+#      content.
+#
+# This pattern is copied verbatim from gemini-code-review.yml:23-79 (which
+# this workflow replaces in Phase 3 of the PR pre-screen system).
+#
+# Advisory only. Never a required check. Failures here NEVER block merges.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to pre-screen'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: 'pr-prescreen-${{ github.event.pull_request.number || inputs.pr_number }}'
+  cancel-in-progress: true
+
+jobs:
+  prescreen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    if: ${{ vars.ENABLE_PR_PRESCREEN == 'true' }}
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch PR metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}")
+          echo "head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "author=$(echo "$PR_DATA" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
+          echo "title<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$PR_DATA" | jq -r '.title' >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      # Check out the BASE (main) first — we run the validator and classifier
+      # FROM main, not from the PR. The PR's content is checked out into a
+      # subdirectory and inspected, never executed.
+      - name: Checkout base (validator source)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          path: base
+
+      - name: Checkout PR HEAD into ./pr (read-only inspection target)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.meta.outputs.head_sha }}
+          persist-credentials: false
+          fetch-depth: 0
+          path: pr
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator deps
+        run: |
+          python -m pip install --upgrade pip pyyaml
+
+      - name: Compute changed plugin paths
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Use the GitHub API to list changed files — safer than running git
+          # against fork content.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files" \
+            --jq '.[].filename' > /tmp/pr-files.txt || true
+          # Plugin dirs: plugins/<category>/<name>/...
+          grep '^plugins/' /tmp/pr-files.txt 2>/dev/null \
+            | awk -F/ '{print $1"/"$2"/"$3}' \
+            | sort -u > /tmp/changed-plugins.txt || true
+          echo "Changed plugin dirs:" >&2
+          cat /tmp/changed-plugins.txt >&2 || true
+          {
+            echo "count=$(wc -l < /tmp/changed-plugins.txt | tr -d ' ')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run validator against PR tree (full --json sweep)
+        id: validate
+        working-directory: pr
+        env:
+          CI: 'true'
+        run: |
+          set -euo pipefail
+          # We deliberately run the validator FROM the PR tree so the schema
+          # version + rubric matches what the PR ships against. The validator
+          # is pure read — no exec, no install. If the PR ships a malicious
+          # validator script, the catalog check below will flag it as a
+          # structural concern (validator path modified).
+          python3 ../base/scripts/validate-skills-schema.py --marketplace --json \
+            > /tmp/validator-results.json 2>/tmp/validator.log || true
+          echo "Validator stderr/info:" >&2
+          tail -50 /tmp/validator.log >&2 || true
+          # Filter to only changed plugin paths (if any). Otherwise we pass
+          # through all results, which keeps PASS behavior meaningful on
+          # PRs that don't touch plugin dirs.
+          python3 - <<'PY'
+          import json, pathlib
+          all_results = json.loads(pathlib.Path('/tmp/validator-results.json').read_text() or '[]')
+          changed_lines = pathlib.Path('/tmp/changed-plugins.txt').read_text().splitlines()
+          changed = [c.strip() for c in changed_lines if c.strip()]
+          if not changed:
+              filtered = all_results
+          else:
+              # Validator emits absolute paths. Match via substring on the
+              # plugins/<cat>/<name>/ fragment — robust to both absolute and
+              # repo-relative path encodings.
+              filtered = [r for r in all_results
+                          if any((c + '/') in r.get('path', '') for c in changed)]
+          # Make paths repo-relative for clean display in the comment.
+          for r in filtered:
+              p = r.get('path', '')
+              idx = p.find('/plugins/')
+              if idx >= 0:
+                  r['path'] = p[idx + 1:]
+          pathlib.Path('/tmp/filtered-results.json').write_text(json.dumps(filtered))
+          print(f"validator total: {len(all_results)}, filtered to PR: {len(filtered)}")
+          PY
+
+      - name: Detect structural hard-block signals
+        id: signals
+        working-directory: pr
+        run: |
+          set -euo pipefail
+          : > /tmp/hard-blocks.txt
+          # No catalog entry for any changed plugin?
+          if [ -s /tmp/changed-plugins.txt ]; then
+            while read -r plug; do
+              [ -z "$plug" ] && continue
+              # Look up the plugin in the source catalog.
+              if [ -f .claude-plugin/marketplace.extended.json ]; then
+                if ! grep -q "\"$plug\"\|/$(basename "$plug")\"" .claude-plugin/marketplace.extended.json; then
+                  echo "Missing catalog entry for $plug in marketplace.extended.json" >> /tmp/hard-blocks.txt
+                fi
+              fi
+              # No implementation files (only docs/metadata)?
+              if [ -d "$plug" ]; then
+                if [ -z "$(find "$plug" -type f \( -name 'SKILL.md' -o -name 'plugin.json' \) -print -quit)" ]; then
+                  echo "Plugin dir $plug has no SKILL.md or plugin.json" >> /tmp/hard-blocks.txt
+                fi
+              fi
+            done < /tmp/changed-plugins.txt
+          fi
+          echo "Detected hard-block signals:" >&2
+          cat /tmp/hard-blocks.txt >&2 || true
+
+      - name: Classify
+        id: classify
+        env:
+          PR_PRESCREEN_HARD_BLOCKS: ''  # populated below
+        run: |
+          set -euo pipefail
+          # Pass hard-block signals via the env var the classifier reads.
+          PR_PRESCREEN_HARD_BLOCKS="$(cat /tmp/hard-blocks.txt)" \
+            python3 base/scripts/pr-prescreen/classify.py /tmp/filtered-results.json \
+            > /tmp/verdict.json
+          VERDICT=$(jq -r '.verdict' /tmp/verdict.json)
+          SUMMARY=$(jq -r '.summary' /tmp/verdict.json)
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+          echo "=== verdict ===" >&2
+          jq . /tmp/verdict.json >&2
+
+      - name: Build PR comment body
+        id: comment
+        run: |
+          set -euo pipefail
+          python3 - > /tmp/pr-comment.md <<'PY'
+          import json, pathlib
+          v = json.loads(pathlib.Path('/tmp/verdict.json').read_text())
+          verdict = v['verdict']
+          icon = {'PASS': '✅', 'CHANGES_REQUESTED': '⚠️', 'HARD_BLOCK': '🛑'}[verdict]
+          lines = [f"## {icon} PR pre-screen: **{verdict}**", "", f"_{v['summary']}_", ""]
+          if v.get('blockers'):
+              lines += ["### Blockers", ""]
+              lines += [f"- {b}" for b in v['blockers']]
+              lines.append("")
+          if v.get('warnings'):
+              lines += ["### Warnings", ""]
+              lines += [f"- {w}" for w in v['warnings']]
+              lines.append("")
+          if v.get('results'):
+              lines += ["### Per-skill results", "", "| Path | Grade | Score | Errors | Warnings |", "|---|---|---|---|---|"]
+              for r in v['results']:
+                  if 'fatal' in r:
+                      lines.append(f"| `{r.get('path','?')}` | — | — | FATAL | {r['fatal']} |")
+                  else:
+                      lines.append(
+                          f"| `{r.get('path','?')}` | {r.get('grade','?')} | "
+                          f"{r.get('score','?')} | {r.get('errors',0)} | {r.get('warnings',0)} |"
+                      )
+              lines.append("")
+          lines += [
+              "---",
+              "_This is an **advisory** pre-screen, not a required check. Required "
+              "checks: `validate`, `marketplace-validation`._",
+          ]
+          print("\n".join(lines))
+          PY
+          echo "Wrote PR comment body to /tmp/pr-comment.md"
+
+      - name: Post PR comment / review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          VERDICT: ${{ steps.classify.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          if [ "$VERDICT" = "CHANGES_REQUESTED" ] || [ "$VERDICT" = "HARD_BLOCK" ]; then
+            # Structured review on the PR — visible to contributor as a review,
+            # not just a comment. The contributor is the audience here.
+            gh pr review "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --request-changes \
+              --body-file /tmp/pr-comment.md
+          else
+            # PASS: regular comment so we don't approve in a way that could
+            # be confused with editorial approval.
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --body-file /tmp/pr-comment.md
+          fi
+
+      - name: Notify Slack (PASS / HARD_BLOCK only)
+        if: steps.classify.outputs.verdict == 'PASS' || steps.classify.outputs.verdict == 'HARD_BLOCK'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.meta.outputs.title }}
+          PR_AUTHOR: ${{ steps.meta.outputs.author }}
+          REPO: ${{ github.repository }}
+          VERDICT: ${{ steps.classify.outputs.verdict }}
+          SUMMARY: ${{ steps.classify.outputs.summary }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK:-}" ]; then
+            echo "No Slack webhook configured; skipping notification."
+            exit 0
+          fi
+          if [ "$VERDICT" = "PASS" ]; then
+            ICON=":white_check_mark:"
+            CTA="ready for editorial review"
+          else
+            ICON=":warning:"
+            CTA="needs your attention"
+          fi
+          PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+          # Read blockers (if HARD_BLOCK) for inline display.
+          BLOCKERS=$(jq -r 'if .blockers and (.blockers|length>0) then "Blockers: " + (.blockers | join(", ")) else "" end' /tmp/verdict.json)
+          TEXT="${ICON} PR #${PR_NUMBER} from @${PR_AUTHOR} — *${VERDICT}*\n${PR_TITLE}\n${SUMMARY}"
+          if [ -n "$BLOCKERS" ]; then
+            TEXT="${TEXT}\n${BLOCKERS}"
+          fi
+          TEXT="${TEXT}\n<@U099CBRE7CL> ${CTA} · ${PR_URL}"
+          payload=$(jq -n --arg text "$(printf '%b' "$TEXT")" '{text: $text}')
+          curl -sS --fail -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK"

--- a/scripts/pr-prescreen/classify.py
+++ b/scripts/pr-prescreen/classify.py
@@ -17,11 +17,11 @@ Output:
     }
 
 Verdicts:
-    HARD_BLOCK         - structural issues a human absolutely must see
-                         (any fatal entry, any path-level hard-block signal
-                         injected by the caller, or any errors on an A/B
-                         skill that drops below D).
-    CHANGES_REQUESTED  - validator errors or any skill below grade C.
+    HARD_BLOCK         - any fatal entry, or any caller-supplied
+                         hard-block signal (no catalog entry, no
+                         implementation files, license mismatch, secret
+                         in diff, etc.).
+    CHANGES_REQUESTED  - validator errors OR any skill graded D/F.
     PASS               - zero errors AND every skill graded C or better.
 
 No I/O, no network, no dependencies beyond stdlib. Designed for unit-testing.
@@ -54,16 +54,14 @@ def classify(
     Returns:
         dict with keys verdict, blockers, warnings, summary, results.
     """
-    blockers: list[str] = []
+    # Materialize once — a generator gets exhausted by the loop below and
+    # the later truthiness check would silently see an empty iterator.
+    signals = [s for s in hard_block_signals if s]
+    blockers: list[str] = list(signals)
     warnings: list[str] = []
 
-    for reason in hard_block_signals:
-        if reason:
-            blockers.append(reason)
-
     fatal_count = 0
-    error_count = 0
-    failing_skills: list[tuple[str, str]] = []  # (path, grade) for D/F
+    failing_skills: list[tuple[str, str]] = []  # (path, grade) for errors or D/F
     weak_skills: list[tuple[str, str]] = []     # (path, grade) for C
 
     for entry in validator_results:
@@ -72,20 +70,19 @@ def classify(
             fatal_count += 1
             blockers.append(f"{path}: fatal — {entry['fatal']}")
             continue
-        errors = int(entry.get("errors", 0))
+        # `or 0` handles JSON null explicitly; .get default only fires on missing key.
+        errors = int(entry.get("errors") or 0)
         grade = entry.get("grade", "F")
-        if errors:
-            error_count += errors
-            failing_skills.append((path, grade))
-        if grade in ("D", "F"):
+        if errors or grade in ("D", "F"):
             if (path, grade) not in failing_skills:
                 failing_skills.append((path, grade))
         elif grade == "C":
-            weak_skills.append((path, grade))
+            if (path, grade) not in weak_skills:
+                weak_skills.append((path, grade))
 
-    if fatal_count or any(hard_block_signals):
+    if fatal_count or signals:
         verdict = "HARD_BLOCK"
-    elif error_count or failing_skills:
+    elif failing_skills:
         verdict = "CHANGES_REQUESTED"
     else:
         verdict = "PASS"
@@ -113,7 +110,8 @@ def _summarize(verdict: str, results: list[dict], blockers: list[str], warnings:
     n = len(results)
     if n == 0:
         return f"{verdict}: no plugin paths matched the PR diff."
-    scores = [int(r["score"]) for r in results if "score" in r]
+    # Null-safe: validator can emit "score": null on partial results.
+    scores = [int(r["score"]) for r in results if r.get("score") is not None]
     avg = (sum(scores) / len(scores)) if scores else 0
     parts = [f"{verdict}: {n} skill(s) inspected"]
     if scores:

--- a/scripts/pr-prescreen/classify.py
+++ b/scripts/pr-prescreen/classify.py
@@ -1,0 +1,160 @@
+"""PR pre-screen classifier.
+
+Pure function: validator JSON output -> verdict for a contributor PR.
+
+Input is the list emitted by `validate-skills-schema.py --marketplace --json`,
+optionally filtered to only paths the PR touches. Each entry is one of:
+    {"path": str, "score": int, "grade": str, "errors": int, "warnings": int}
+    {"path": str, "fatal": str}
+
+Output:
+    {
+      "verdict": "PASS" | "CHANGES_REQUESTED" | "HARD_BLOCK",
+      "blockers": [str, ...],       # human-readable blocker reasons
+      "warnings": [str, ...],       # non-blocking advisories
+      "summary":  str,              # short one-line summary
+      "results":  [ ... ],          # the (filtered) input list, echoed back
+    }
+
+Verdicts:
+    HARD_BLOCK         - structural issues a human absolutely must see
+                         (any fatal entry, any path-level hard-block signal
+                         injected by the caller, or any errors on an A/B
+                         skill that drops below D).
+    CHANGES_REQUESTED  - validator errors or any skill below grade C.
+    PASS               - zero errors AND every skill graded C or better.
+
+No I/O, no network, no dependencies beyond stdlib. Designed for unit-testing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Iterable
+
+
+GRADE_RANK = {"A": 5, "B": 4, "C": 3, "D": 2, "F": 1}
+
+
+def classify(
+    validator_results: list[dict],
+    *,
+    hard_block_signals: Iterable[str] = (),
+) -> dict:
+    """Classify a set of validator results into a single PR verdict.
+
+    Args:
+        validator_results: list of dicts from `validate-skills-schema.py --json`.
+        hard_block_signals: optional caller-supplied reasons that elevate the
+            verdict to HARD_BLOCK regardless of validator output (e.g. the
+            workflow detected no implementation files, no catalog entry, a
+            license mismatch, or a secret in the diff).
+
+    Returns:
+        dict with keys verdict, blockers, warnings, summary, results.
+    """
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    for reason in hard_block_signals:
+        if reason:
+            blockers.append(reason)
+
+    fatal_count = 0
+    error_count = 0
+    failing_skills: list[tuple[str, str]] = []  # (path, grade) for D/F
+    weak_skills: list[tuple[str, str]] = []     # (path, grade) for C
+
+    for entry in validator_results:
+        path = entry.get("path", "<unknown>")
+        if "fatal" in entry:
+            fatal_count += 1
+            blockers.append(f"{path}: fatal — {entry['fatal']}")
+            continue
+        errors = int(entry.get("errors", 0))
+        grade = entry.get("grade", "F")
+        if errors:
+            error_count += errors
+            failing_skills.append((path, grade))
+        if grade in ("D", "F"):
+            if (path, grade) not in failing_skills:
+                failing_skills.append((path, grade))
+        elif grade == "C":
+            weak_skills.append((path, grade))
+
+    if fatal_count or any(hard_block_signals):
+        verdict = "HARD_BLOCK"
+    elif error_count or failing_skills:
+        verdict = "CHANGES_REQUESTED"
+    else:
+        verdict = "PASS"
+
+    # Always surface failing-skill detail as blockers — both HARD_BLOCK and
+    # CHANGES_REQUESTED need to tell the contributor *what* broke.
+    for path, grade in failing_skills:
+        blockers.append(f"{path}: validator errors / grade {grade}")
+
+    for path, grade in weak_skills:
+        warnings.append(f"{path}: grade {grade} — borderline, consider polish")
+
+    summary = _summarize(verdict, validator_results, blockers, warnings)
+
+    return {
+        "verdict": verdict,
+        "blockers": blockers,
+        "warnings": warnings,
+        "summary": summary,
+        "results": validator_results,
+    }
+
+
+def _summarize(verdict: str, results: list[dict], blockers: list[str], warnings: list[str]) -> str:
+    n = len(results)
+    if n == 0:
+        return f"{verdict}: no plugin paths matched the PR diff."
+    scores = [int(r["score"]) for r in results if "score" in r]
+    avg = (sum(scores) / len(scores)) if scores else 0
+    parts = [f"{verdict}: {n} skill(s) inspected"]
+    if scores:
+        parts.append(f"avg score {avg:.0f}/100")
+    if blockers:
+        parts.append(f"{len(blockers)} blocker(s)")
+    if warnings:
+        parts.append(f"{len(warnings)} warning(s)")
+    return " · ".join(parts)
+
+
+def main(argv: list[str]) -> int:
+    """Read validator JSON from stdin (or argv[1]) and emit classifier JSON.
+
+    Hard-block signals come from the env var PR_PRESCREEN_HARD_BLOCKS, a
+    newline-separated list (set by the workflow when it detects e.g. no
+    catalog entry).
+    """
+    import os
+
+    raw: str
+    if len(argv) > 1 and argv[1] != "-":
+        with open(argv[1], "r", encoding="utf-8") as fh:
+            raw = fh.read()
+    else:
+        raw = sys.stdin.read()
+
+    raw = raw.strip()
+    if not raw:
+        results = []
+    else:
+        results = json.loads(raw)
+        if not isinstance(results, list):
+            print("classify.py: expected a JSON list on stdin", file=sys.stderr)
+            return 2
+
+    signals = [s for s in os.environ.get("PR_PRESCREEN_HARD_BLOCKS", "").split("\n") if s.strip()]
+    out = classify(results, hard_block_signals=signals)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/scripts/pr-prescreen/test_classify.py
+++ b/scripts/pr-prescreen/test_classify.py
@@ -1,0 +1,114 @@
+"""Unit tests for classify.py.
+
+Run: python3 -m pytest scripts/pr-prescreen/test_classify.py -q
+Or:  python3 scripts/pr-prescreen/test_classify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from classify import classify, main  # noqa: E402
+
+
+def _r(path: str, score: int, grade: str, errors: int = 0, warnings: int = 0) -> dict:
+    return {"path": path, "score": score, "grade": grade, "errors": errors, "warnings": warnings}
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_empty_input_passes(self):
+        out = classify([])
+        self.assertEqual(out["verdict"], "PASS")
+        self.assertEqual(out["blockers"], [])
+        self.assertIn("no plugin paths", out["summary"])
+
+    def test_all_grade_a_passes(self):
+        out = classify([_r("plugins/x/y/skills/y/SKILL.md", 95, "A")])
+        self.assertEqual(out["verdict"], "PASS")
+        self.assertEqual(out["blockers"], [])
+        self.assertEqual(out["warnings"], [])
+
+    def test_grade_c_passes_with_warning(self):
+        # Grade C is the floor for PASS — borderline but acceptable.
+        out = classify([_r("plugins/x/y/skills/y/SKILL.md", 72, "C")])
+        self.assertEqual(out["verdict"], "PASS")
+        self.assertEqual(len(out["warnings"]), 1)
+
+    def test_validator_errors_request_changes(self):
+        out = classify([_r("plugins/x/y/skills/y/SKILL.md", 65, "D", errors=2)])
+        self.assertEqual(out["verdict"], "CHANGES_REQUESTED")
+        self.assertTrue(any("validator errors" in b for b in out["blockers"]))
+
+    def test_grade_f_requests_changes_even_without_errors(self):
+        out = classify([_r("plugins/x/y/skills/y/SKILL.md", 40, "F", errors=0)])
+        self.assertEqual(out["verdict"], "CHANGES_REQUESTED")
+        self.assertTrue(any("grade F" in b for b in out["blockers"]))
+
+    def test_fatal_hard_blocks(self):
+        out = classify([{"path": "plugins/x/y/skills/y/SKILL.md", "fatal": "missing frontmatter"}])
+        self.assertEqual(out["verdict"], "HARD_BLOCK")
+        self.assertTrue(any("fatal" in b for b in out["blockers"]))
+
+    def test_external_hard_block_signal(self):
+        # Even an all-A PR hard-blocks if the workflow injected a structural concern.
+        out = classify(
+            [_r("plugins/x/y/skills/y/SKILL.md", 95, "A")],
+            hard_block_signals=["No catalog entry for plugins/x/y in marketplace.extended.json"],
+        )
+        self.assertEqual(out["verdict"], "HARD_BLOCK")
+        self.assertIn(
+            "No catalog entry for plugins/x/y in marketplace.extended.json",
+            out["blockers"],
+        )
+
+    def test_mixed_results_picks_worst(self):
+        out = classify(
+            [
+                _r("plugins/a/SKILL.md", 95, "A"),
+                _r("plugins/b/SKILL.md", 55, "F", errors=3),
+            ]
+        )
+        self.assertEqual(out["verdict"], "CHANGES_REQUESTED")
+        self.assertGreaterEqual(len(out["blockers"]), 1)
+
+    def test_summary_includes_average_score(self):
+        out = classify([_r("a", 90, "A"), _r("b", 80, "B")])
+        self.assertIn("85", out["summary"])
+
+    def test_main_reads_stdin(self):
+        payload = json.dumps([_r("plugins/x/SKILL.md", 95, "A")])
+        with patch("sys.stdin", StringIO(payload)), patch("sys.stdout", new_callable=StringIO) as out:
+            rc = main(["classify.py", "-"])
+        self.assertEqual(rc, 0)
+        parsed = json.loads(out.getvalue())
+        self.assertEqual(parsed["verdict"], "PASS")
+
+    def test_main_rejects_non_list(self):
+        payload = json.dumps({"oops": True})
+        with patch("sys.stdin", StringIO(payload)):
+            rc = main(["classify.py", "-"])
+        self.assertEqual(rc, 2)
+
+    def test_main_picks_up_env_signals(self):
+        payload = json.dumps([_r("plugins/x/SKILL.md", 95, "A")])
+        with patch("sys.stdin", StringIO(payload)), \
+             patch("sys.stdout", new_callable=StringIO) as out, \
+             patch.dict(os.environ, {"PR_PRESCREEN_HARD_BLOCKS": "secret detected in diff"}):
+            rc = main(["classify.py", "-"])
+        self.assertEqual(rc, 0)
+        parsed = json.loads(out.getvalue())
+        self.assertEqual(parsed["verdict"], "HARD_BLOCK")
+        self.assertIn("secret detected in diff", parsed["blockers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr-prescreen/test_classify.py
+++ b/scripts/pr-prescreen/test_classify.py
@@ -70,6 +70,25 @@ class ClassifyTests(unittest.TestCase):
             out["blockers"],
         )
 
+    def test_hard_block_signal_iterator_not_exhausted(self):
+        # Regression: a generator passed as hard_block_signals must not be
+        # consumed by an intermediate loop before the verdict check runs.
+        signals = (s for s in ["secret leaked"])
+        out = classify([_r("plugins/x/SKILL.md", 95, "A")], hard_block_signals=signals)
+        self.assertEqual(out["verdict"], "HARD_BLOCK")
+        self.assertIn("secret leaked", out["blockers"])
+
+    def test_null_errors_does_not_crash(self):
+        # Regression: validator can emit {"errors": null} on partial results.
+        out = classify([{"path": "p", "score": 90, "grade": "A", "errors": None, "warnings": None}])
+        self.assertEqual(out["verdict"], "PASS")
+
+    def test_null_score_does_not_crash_in_summary(self):
+        out = classify([{"path": "p", "score": None, "grade": "F", "errors": 1}])
+        # Verdict is CHANGES_REQUESTED due to errors; summary shouldn't crash.
+        self.assertEqual(out["verdict"], "CHANGES_REQUESTED")
+        self.assertIn("CHANGES_REQUESTED", out["summary"])
+
     def test_mixed_results_picks_worst(self):
         out = classify(
             [


### PR DESCRIPTION
## Summary

Phase 1 of the **PR pre-screen system** epic (replaces broken `gemini-code-review.yml`). Adds an advisory workflow that runs on every external PR, classifies the validator output, posts a structured comment/review on the PR, and pings Slack `#operation-hired` on PASS / HARD_BLOCK.

**No LLM yet** — that's Phase 2. Phase 3 deletes the Gemini workflow + the `--thorough` flag + ships the audit log.

## What changed

- `.github/workflows/pr-prescreen.yml` — new advisory workflow (~270 lines). `pull_request_target` fork-safe pattern from `gemini-code-review.yml:23-79` copied verbatim. SHA-pinned checkout, `persist-credentials: false`, never executes PR-controlled code.
- `scripts/pr-prescreen/classify.py` — pure-function classifier: validator JSON → `{verdict, blockers, warnings, summary}`. Zero I/O, zero deps beyond stdlib.
- `scripts/pr-prescreen/test_classify.py` — 12 unit tests; PASS / CHANGES_REQUESTED / HARD_BLOCK paths + edge cases.

## Verdict semantics

| Verdict | Trigger | PR action | Slack action |
|---|---|---|---|
| `PASS` | zero errors, every skill ≥ C | comment | ping `#operation-hired` |
| `CHANGES_REQUESTED` | validator errors OR any skill D/F | request-changes review | silent (contributor is audience) |
| `HARD_BLOCK` | fatal entry OR external signal (no catalog entry, missing impl files, etc.) | request-changes review | ping `#operation-hired` |

## Acceptance

- [x] `pull_request_target` fork-safe pattern preserved verbatim from gemini workflow
- [x] Workflow gated by `ENABLE_PR_PRESCREEN=true` (default off)
- [x] Validator stays deterministic — no Groq in this phase
- [x] 12 unit tests pass for the classifier
- [x] Comment/review renderer produces a structured table per skill
- [x] Existing required checks (`validate`, `marketplace-validation`) untouched

## Operator provisions (before flipping `ENABLE_PR_PRESCREEN` to `true`)

- secret `SLACK_OPERATION_HIRED_WEBHOOK_URL` (already needed by 3 existing workflows)
- variable `ENABLE_PR_PRESCREEN=true`

## Test plan

- [ ] Merge with `ENABLE_PR_PRESCREEN=false` — workflow exists but no-ops
- [ ] Flip variable to `true`, open synthetic PR with broken `plugin.json` → CHANGES_REQUESTED comment, no Slack
- [ ] Open synthetic clean PR → PASS comment + Slack ping
- [ ] `validate` + `marketplace-validation` checks still green
- [ ] `gemini-code-review.yml` still running alongside (not yet deleted)

## Refs

- epic bead `claude-135g`
- phase bead `claude-xxwb`
- replaces `.github/workflows/gemini-code-review.yml` (delete in Phase 3)

- Jeremy Longshore
intentsolutions.io