### PR TITLE
feat(sources): add hyperflow plugin

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -803,16 +803,11 @@ sources:
       - '.claude-plugin/**'
       - 'skills/**'
       - 'hooks/**'
+      - 'package.json'
       - 'README.md'
       - 'LICENSE'
     exclude:
-      - 'node_modules/**'
-      - '.git/**'
-      - '*.log'
-      - 'docs/**'
-      - 'templates/**'
-      - '.github/**'
-      - 'scripts/**'
+      - '**/*.log'
 
   # ============================================================
   # CLI Power Skills (Yuriy Kotik)

--- a/sources.yaml
+++ b/sources.yaml
@@ -780,6 +780,41 @@ sources:
       - '.github/**'
 
   # ============================================================
+  # Hyperflow (Mohammed Abdelhady)
+  # https://github.com/Mohammed-Abdelhady/hyperflow
+  # Advanced multi-agent orchestration with persistent cross-session
+  # memory, per-step multi-level review, persona stitching, and
+  # adaptive flow profiles (8 skills + hooks)
+  # ============================================================
+
+  - name: hyperflow
+    description: Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles
+    repo: Mohammed-Abdelhady/hyperflow
+    source_path: .
+    target_path: plugins/ai-agency/hyperflow
+    author:
+      name: Mohammed Abdelhady
+      github: Mohammed-Abdelhady
+      email: abdelhadycongar@gmail.com
+    license: MIT
+    category: ai-agency
+    verified: false
+    include:
+      - '.claude-plugin/**'
+      - 'skills/**'
+      - 'hooks/**'
+      - 'README.md'
+      - 'LICENSE'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+      - 'docs/**'
+      - 'templates/**'
+      - '.github/**'
+      - 'scripts/**'
+
+  # ============================================================
   # CLI Power Skills (Yuriy Kotik)
   # https://github.com/ykotik/cli-power-skills
   # ============================================================


### PR DESCRIPTION
## Summary

Adds [`hyperflow`](https://github.com/Mohammed-Abdelhady/hyperflow) — an MIT-licensed Claude Code plugin providing advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles. Ships 8 skills (`scaffold`, `spec`, `scope`, `dispatch`, `trace`, `audit`, `deploy`, `cache`) plus session hooks, currently at version 2.5.0.

Follows the external-source pattern (`source_path: .` with explicit include globs), placed under `ai-agency` alongside `tonone` as the closest category fit for multi-agent orchestration.

## Test plan

- [ ] `sources.yaml` parses as valid YAML
- [ ] `repo` resolves to a public repo with `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- [ ] `include` globs (`.claude-plugin/**`, `skills/**`, `hooks/**`, `README.md`, `LICENSE`) match the actual layout of `Mohammed-Abdelhady/hyperflow`
- [ ] `target_path: plugins/ai-agency/hyperflow` is consistent with existing catalog layout