### PR TITLE
docs(contributing): pin Plugin & Skill Spec across all contributor surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-submission.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yml
@@ -3,6 +3,22 @@ description: Submit a plugin
 title: "[Plugin] "
 labels: ["plugin-submission"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Read the spec before you submit
+
+        Every plugin and skill in this marketplace is graded against the
+        **[Global Master Standard for Claude Skills (v3.6.0)](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)**.
+
+        Marketplace-tier requirements at a glance:
+        - **8 frontmatter fields** per SKILL.md: `name`, `description`, `allowed-tools`, `version`, `author`, `license`, `compatibility`, `tags`
+        - **7 body sections**: `## Overview`, `## Prerequisites`, `## Instructions`, `## Output`, `## Error Handling`, `## Examples`, `## Resources`
+        - **100-point rubric**: the validator scores against it; submissions below the threshold are flagged before review
+        - **No `--thorough` shortcuts**: validator is deterministic; LLM judging lives at the workflow layer
+
+        Also worth reading: [CONTRIBUTING.md § Before You Submit](../blob/main/CONTRIBUTING.md#before-you-submit--read-this) and the [PR Pre-screen runbook](../blob/main/000-docs/265-DR-GUID-pr-prescreen-system.md).
+
   - type: input
     id: plugin-name
     attributes:
@@ -47,15 +63,19 @@ body:
   - type: checkboxes
     id: checklist
     attributes:
-      label: Checklist
+      label: Checklist (per spec v3.6.0)
       options:
-        - label: Has plugin.json
+        - label: I have read the [skill spec](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)
           required: true
-        - label: Has README.md
+        - label: Has `plugin.json` + `.claude-plugin/marketplace.json`
           required: true
-        - label: Has LICENSE
+        - label: Each SKILL.md has the **8 marketplace-required frontmatter fields**
           required: true
-        - label: Tested locally
+        - label: Each SKILL.md has the **7 required body sections**
           required: true
-        - label: No hardcoded secrets
+        - label: Has README.md and LICENSE at the plugin root
+          required: true
+        - label: Tested locally with `python3 scripts/validate-skills-schema.py --marketplace --verbose <plugin-dir>`
+          required: true
+        - label: No hardcoded secrets, no shell substitution in YAML descriptions, no `..` link escapes
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
 # Pull Request
 
-> 📘 **First time contributing?** Read [CONTRIBUTING.md § Before You Submit](../blob/main/CONTRIBUTING.md#before-you-submit--read-this).
-> It explains the Intent Solutions enterprise-standards philosophy — why the
-> bar is where it is, and how to pass the validators on your first push.
-> Reading it up front saves a round-trip with our auto-review bot.
+> 📘 **First time contributing?** Read both:
+> 1. [CONTRIBUTING.md § Before You Submit](../blob/main/CONTRIBUTING.md#before-you-submit--read-this) — the contract and the workflow
+> 2. **[Plugin & Skill Spec (v3.6.0)](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)** — the authoritative spec the validator scores against (8-field frontmatter, 7 body sections, 100-point rubric, all source-cited)
+>
+> The PR Pre-screen workflow will post a structured review with the exact
+> validator findings on every PR — reading both up front saves a round-trip.
 
 ## Type of Change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,23 @@
 
 Thank you for your interest in contributing to the Claude Code Plugins marketplace. With hundreds of plugins and thousands of agent skills, this is a community-driven project and contributions of all sizes are welcome.
 
+> ## 📋 Read the spec before you start
+>
+> Every plugin and skill in this marketplace is graded against a single
+> authoritative specification:
+>
+> **→ [`000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)** — the **Global Master Standard for Claude Skills** (v3.6.0, schema 3.6.0).
+>
+> It documents:
+> - The **8 marketplace-tier required frontmatter fields** (vs Anthropic's 2-field minimum)
+> - The **7 required body sections** (`## Overview`, `## Prerequisites`, `## Instructions`, `## Output`, `## Error Handling`, `## Examples`, `## Resources`)
+> - The **100-point rubric** the validator scores against
+> - Conditional fields (`requires_env`, `requires_tools`, `argument-hint`, etc.)
+> - The self-declared config surface (`required_environment_variables`, `metadata.intent-solutions.config`)
+> - Source citations for every field — Anthropic's [skills docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), [Claude Code skills](https://code.claude.com/docs/en/skills), [AgentSkills.io spec](https://agentskills.io/specification), and the [anthropics/skills reference implementation](https://github.com/anthropics/skills).
+>
+> If your submission deviates from the spec, the validator will flag it and the PR Pre-screen workflow will request changes before a human looks at it. Reading the spec up front saves a round-trip.
+
 ## Before You Submit — Read This
 
 Tons of Skills publishes Intent Solutions-grade plugins and skills. That means full-capability, enterprise-ready implementations — validators, tests, docs, license, the works.
@@ -19,11 +36,11 @@ At Intent Solutions we ship the full-fledged capability. We don't publish half-i
 - Your `SKILL.md` needs the full frontmatter schema (not just `name` + `description`). See [Adding Skills](#adding-skills) below.
 - Your plugin needs a `README.md`, a `LICENSE`, a valid `plugin.json` (allowed fields only), and an entry in `.claude-plugin/marketplace.extended.json`.
 - Your code and config can't trip the security scanner — no `rm -rf`, no `eval`, no base64 obfuscation, no hardcoded secrets, no URL shorteners, HTTPS only.
-- Your skill needs to score at or above the enterprise threshold on our 100-point rubric. Run the same validator CI runs:
+- Your skill needs to score at or above the marketplace threshold on our 100-point rubric (full rubric in the [spec doc](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)). Run the same validator CI runs:
   ```bash
-  python3 scripts/validate-skills-schema.py --enterprise --verbose plugins/<category>/<name>/
+  python3 scripts/validate-skills-schema.py --marketplace --verbose plugins/<category>/<name>/
   ```
-- If any of this fails in CI, **Gemini 2.5 Pro will post a specific, actionable review** on your PR explaining exactly what's wrong and how to fix it. A human maintainer will follow up if the bot was unclear.
+- If any of this fails in CI, the **PR Pre-screen workflow** ([runbook](000-docs/265-DR-GUID-pr-prescreen-system.md)) will post a structured review on your PR with the exact validator findings + a short Groq-generated summary. A human maintainer follows up after that.
 
 ### "But I just want to submit a small skill"
 


### PR DESCRIPTION
## Summary

The marketplace tier expectations live in [000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md) — the **authoritative Global Master Standard for Claude Skills (v3.6.0)** with 8 required frontmatter fields, 7 body sections, 100-point rubric, and source citations against Anthropic + AgentSkills.io + Claude Code docs.

Problem: it was buried in \`000-docs/\` and external contributors couldn't find it. Surfaced by the hyperflow submission on #722 — Mohammed shipped a thoughtful plugin but every SKILL.md was missing all 6 marketplace-required fields and all 7 body sections because the expectations weren't visible until the validator failed.

## What changed

Three contributor-facing surfaces now link the spec prominently:

| Surface | Change |
|---|---|
| \`CONTRIBUTING.md\` | New \"📋 Read the spec before you start\" callout above \"Before You Submit\". Distilled requirements + canonical source citations. |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | Top-of-template now points to BOTH CONTRIBUTING and the spec. Replaces stale \"auto-review bot\" phrasing (referred to the deleted Gemini workflow) with the PR Pre-screen runbook link. |
| \`.github/ISSUE_TEMPLATE/plugin-submission.yml\` | Adds a markdown description block with the spec callout; replaces 5 generic checkboxes with 7 spec-aware ones covering the real validator gates. |

Also corrected two stale pieces in CONTRIBUTING.md:
- \"Gemini 2.5 Pro will post a specific, actionable review\" → now references the PR Pre-screen workflow (Gemini workflow was retired in #721)
- \`--enterprise\` flag in the example → \`--marketplace\` (\`--enterprise\` alias is deprecated)

## Verification

- \`yaml\` parses cleanly on the issue template
- All links resolve to in-repo paths or upstream sources cited in the spec doc

## Refs

- Surfaced by #722 (hyperflow submission)
- Spec doc: [000-docs/6767-b-SPEC-DR-STND-...](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)
- Runbook: [000-docs/265-DR-GUID-pr-prescreen-system.md](../blob/main/000-docs/265-DR-GUID-pr-prescreen-system.md)

- Jeremy Longshore
intentsolutions.io