### PR TITLE
feat: add 10 pluginpool plugins (productivity suite, all validate)

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -163,11 +163,7 @@
       "description": "Audit access control implementations",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -211,11 +207,7 @@
       "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
       "version": "1.0.0",
       "category": "productivity",
-      "keywords": [
-        "agents",
-        "context",
-        "automation"
-      ],
+      "keywords": ["agents", "context", "automation"],
       "author": {
         "name": "Jeremy Longshore"
       },
@@ -257,13 +249,7 @@
       "description": "AI ethics and fairness validation",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "ethics",
-        "fairness",
-        "bias",
-        "responsible-ai",
-        "ml"
-      ],
+      "keywords": ["ethics", "fairness", "bias", "responsible-ai", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -281,12 +267,7 @@
       "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
       "version": "1.0.0",
       "category": "mcp",
-      "keywords": [
-        "ai",
-        "experiments",
-        "logging",
-        "mcp"
-      ],
+      "keywords": ["ai", "experiments", "logging", "mcp"],
       "author": {
         "name": "Claude Code Plugins"
       },
@@ -372,12 +353,7 @@
       "description": "Create intelligent alerting rules for performance monitoring",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "alerting",
-        "monitoring",
-        "sre",
-        "observability"
-      ],
+      "keywords": ["alerting", "monitoring", "sre", "observability"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -395,13 +371,7 @@
       "description": "Detect anomalies and outliers in data",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "anomaly",
-        "outliers",
-        "detection",
-        "isolation",
-        "ml"
-      ],
+      "keywords": ["anomaly", "outliers", "detection", "isolation", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -419,13 +389,7 @@
       "description": "Create Ansible playbooks for configuration management",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "ansible",
-        "automation",
-        "configuration",
-        "playbooks",
-        "devops"
-      ],
+      "keywords": ["ansible", "automation", "configuration", "playbooks", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -443,12 +407,7 @@
       "description": "Build authentication systems with JWT, OAuth2, and API keys",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "authentication",
-        "jwt",
-        "oauth",
-        "security"
-      ],
+      "keywords": ["authentication", "jwt", "oauth", "security"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -466,12 +425,7 @@
       "description": "Implement batch API operations with bulk processing and job queues",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "batch",
-        "bulk",
-        "queue",
-        "job-processing"
-      ],
+      "keywords": ["batch", "bulk", "queue", "job-processing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -489,12 +443,7 @@
       "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "caching",
-        "redis",
-        "cdn",
-        "performance"
-      ],
+      "keywords": ["caching", "redis", "cdn", "performance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -512,12 +461,7 @@
       "description": "Generate API contracts for consumer-driven contract testing",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "contract",
-        "pact",
-        "testing",
-        "microservices"
-      ],
+      "keywords": ["contract", "pact", "testing", "microservices"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -535,13 +479,7 @@
       "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "api",
-        "documentation",
-        "openapi",
-        "swagger",
-        "docs"
-      ],
+      "keywords": ["api", "documentation", "openapi", "swagger", "docs"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -559,12 +497,7 @@
       "description": "Implement standardized error handling with proper HTTP status codes",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "error-handling",
-        "api",
-        "http-status",
-        "exceptions"
-      ],
+      "keywords": ["error-handling", "api", "http-status", "exceptions"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -582,13 +515,7 @@
       "description": "Implement event-driven APIs with message queues and event streaming",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "events",
-        "messaging",
-        "kafka",
-        "rabbitmq",
-        "event-driven"
-      ],
+      "keywords": ["events", "messaging", "kafka", "rabbitmq", "event-driven"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -606,14 +533,7 @@
       "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "fuzzing",
-        "api",
-        "security",
-        "edge-cases",
-        "input-validation"
-      ],
+      "keywords": ["testing", "fuzzing", "api", "security", "edge-cases", "input-validation"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -631,12 +551,7 @@
       "description": "Build API gateway with routing, authentication, and rate limiting",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "api-gateway",
-        "routing",
-        "proxy",
-        "microservices"
-      ],
+      "keywords": ["api-gateway", "routing", "proxy", "microservices"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -654,12 +569,7 @@
       "description": "Load test APIs with k6, Gatling, or Artillery",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "load-testing",
-        "performance",
-        "k6",
-        "stress-testing"
-      ],
+      "keywords": ["load-testing", "performance", "k6", "stress-testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -677,12 +587,7 @@
       "description": "Migrate APIs between versions with backward compatibility",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "migration",
-        "versioning",
-        "api",
-        "backward-compatibility"
-      ],
+      "keywords": ["migration", "versioning", "api", "backward-compatibility"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -700,12 +605,7 @@
       "description": "Create mock API servers from OpenAPI specs for testing",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "mock",
-        "testing",
-        "openapi",
-        "stub"
-      ],
+      "keywords": ["mock", "testing", "openapi", "stub"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -723,12 +623,7 @@
       "description": "Create monitoring dashboards for API health, metrics, and alerts",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "monitoring",
-        "metrics",
-        "observability",
-        "dashboard"
-      ],
+      "keywords": ["monitoring", "metrics", "observability", "dashboard"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -746,12 +641,7 @@
       "description": "Implement rate limiting with token bucket, sliding window, and Redis",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "rate-limiting",
-        "throttling",
-        "api",
-        "redis"
-      ],
+      "keywords": ["rate-limiting", "throttling", "api", "redis"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -769,12 +659,7 @@
       "description": "Log API requests with structured logging and correlation IDs",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "logging",
-        "observability",
-        "audit",
-        "correlation"
-      ],
+      "keywords": ["logging", "observability", "audit", "correlation"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -792,12 +677,7 @@
       "description": "Validate API responses against schemas and contracts",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "validation",
-        "schema",
-        "testing",
-        "api"
-      ],
+      "keywords": ["validation", "schema", "testing", "api"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -815,13 +695,7 @@
       "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "schema",
-        "validation",
-        "json-schema",
-        "joi",
-        "zod"
-      ],
+      "keywords": ["schema", "validation", "json-schema", "joi", "zod"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -839,12 +713,7 @@
       "description": "Generate client SDKs from OpenAPI specs for multiple languages",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "sdk",
-        "client",
-        "openapi",
-        "codegen"
-      ],
+      "keywords": ["sdk", "client", "openapi", "codegen"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -862,12 +731,7 @@
       "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "security",
-        "api",
-        "owasp",
-        "vulnerability"
-      ],
+      "keywords": ["security", "api", "owasp", "vulnerability"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -885,14 +749,7 @@
       "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "api",
-        "rest",
-        "graphql",
-        "automation",
-        "endpoints"
-      ],
+      "keywords": ["testing", "api", "rest", "graphql", "automation", "endpoints"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -910,12 +767,7 @@
       "description": "Manage API throttling with dynamic rate limits and quota management",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "throttling",
-        "rate-limiting",
-        "quota",
-        "traffic-management"
-      ],
+      "keywords": ["throttling", "rate-limiting", "quota", "traffic-management"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -933,12 +785,7 @@
       "description": "Manage API versions with migration strategies and backward compatibility",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "api",
-        "versioning",
-        "migration",
-        "backward-compatibility"
-      ],
+      "keywords": ["api", "versioning", "migration", "backward-compatibility"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -956,13 +803,7 @@
       "description": "Create Application Performance Monitoring dashboards",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "apm",
-        "monitoring",
-        "dashboard",
-        "grafana",
-        "datadog"
-      ],
+      "keywords": ["apm", "monitoring", "dashboard", "grafana", "datadog"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -980,12 +821,7 @@
       "description": "Profile application performance with CPU, memory, and execution time analysis",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "performance",
-        "profiling",
-        "monitoring",
-        "optimization"
-      ],
+      "keywords": ["performance", "profiling", "monitoring", "optimization"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1003,13 +839,7 @@
       "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "arbitrage",
-        "trading",
-        "defi",
-        "mev",
-        "profit"
-      ],
+      "keywords": ["arbitrage", "trading", "defi", "mev", "profit"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1028,11 +858,7 @@
       "description": "Validate authentication implementations",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1050,13 +876,7 @@
       "description": "Configure auto-scaling policies for applications and infrastructure",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "autoscaling",
-        "scaling",
-        "hpa",
-        "kubernetes",
-        "devops"
-      ],
+      "keywords": ["autoscaling", "scaling", "hpa", "kubernetes", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1074,13 +894,7 @@
       "description": "Build AutoML pipelines",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "automl",
-        "automated",
-        "pipeline",
-        "h2o",
-        "ml"
-      ],
+      "keywords": ["automl", "automated", "pipeline", "h2o", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1098,12 +912,7 @@
       "description": "Implement backup strategies for databases and applications",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "backup",
-        "disaster-recovery",
-        "restoration",
-        "devops"
-      ],
+      "keywords": ["backup", "disaster-recovery", "restoration", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1121,14 +930,7 @@
       "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "blockchain",
-        "explorer",
-        "etherscan",
-        "transactions",
-        "addresses",
-        "contracts"
-      ],
+      "keywords": ["blockchain", "explorer", "etherscan", "transactions", "addresses", "contracts"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1146,12 +948,7 @@
       "description": "Detect and resolve performance bottlenecks",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "bottleneck",
-        "performance",
-        "optimization",
-        "profiling"
-      ],
+      "keywords": ["bottleneck", "performance", "optimization", "profiling"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1194,12 +991,7 @@
       "description": "Optimize caching strategies for improved performance",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "cache",
-        "performance",
-        "optimization",
-        "redis"
-      ],
+      "keywords": ["cache", "performance", "optimization", "redis"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1217,12 +1009,7 @@
       "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
       "version": "0.1.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "calendar",
-        "automation",
-        "meetings",
-        "productivity"
-      ],
+      "keywords": ["calendar", "automation", "meetings", "productivity"],
       "author": {
         "name": "Claude Code Plugins Team"
       }
@@ -1233,12 +1020,7 @@
       "description": "Analyze and plan for capacity requirements",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "capacity-planning",
-        "scaling",
-        "forecasting",
-        "infrastructure"
-      ],
+      "keywords": ["capacity-planning", "scaling", "forecasting", "infrastructure"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1281,14 +1063,7 @@
       "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "ci-cd",
-        "github-actions",
-        "gitlab-ci",
-        "jenkins",
-        "devops",
-        "automation"
-      ],
+      "keywords": ["ci-cd", "github-actions", "gitlab-ci", "jenkins", "devops", "automation"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1307,13 +1082,7 @@
       "description": "Build classification models",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "classification",
-        "supervised",
-        "predictor",
-        "labels",
-        "ml"
-      ],
+      "keywords": ["classification", "supervised", "predictor", "labels", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1331,14 +1100,7 @@
       "description": "Optimize cloud costs and generate cost reports",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "cost",
-        "optimization",
-        "finops",
-        "cloud",
-        "aws",
-        "devops"
-      ],
+      "keywords": ["cost", "optimization", "finops", "cloud", "aws", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1356,13 +1118,7 @@
       "description": "Run clustering algorithms on datasets",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "clustering",
-        "kmeans",
-        "dbscan",
-        "hierarchical",
-        "ml"
-      ],
+      "keywords": ["clustering", "kmeans", "dbscan", "hierarchical", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1380,14 +1136,7 @@
       "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "compliance",
-        "security",
-        "audit",
-        "soc2",
-        "hipaa",
-        "devops"
-      ],
+      "keywords": ["compliance", "security", "audit", "soc2", "hipaa", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1405,11 +1154,7 @@
       "description": "Generate compliance reports",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1427,13 +1172,7 @@
       "description": "Computer vision image processing and analysis",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "cv",
-        "vision",
-        "images",
-        "detection",
-        "ml"
-      ],
+      "keywords": ["cv", "vision", "images", "detection", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1451,14 +1190,7 @@
       "description": "Manage container registries (ECR, GCR, Harbor)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "registry",
-        "containers",
-        "docker",
-        "ecr",
-        "gcr",
-        "devops"
-      ],
+      "keywords": ["registry", "containers", "docker", "ecr", "gcr", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1476,14 +1208,7 @@
       "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "security",
-        "containers",
-        "scanning",
-        "vulnerabilities",
-        "trivy",
-        "devops"
-      ],
+      "keywords": ["security", "containers", "scanning", "vulnerabilities", "trivy", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1527,16 +1252,7 @@
       "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
       "version": "1.0.0",
       "category": "mcp",
-      "keywords": [
-        "mcp",
-        "api",
-        "debugging",
-        "openapi",
-        "har",
-        "rest",
-        "curl",
-        "http"
-      ],
+      "keywords": ["mcp", "api", "debugging", "openapi", "har", "rest", "curl", "http"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1556,11 +1272,7 @@
       "description": "Validate CORS policies",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1578,12 +1290,7 @@
       "description": "Monitor and analyze CPU usage patterns in applications",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "cpu",
-        "monitoring",
-        "performance",
-        "optimization"
-      ],
+      "keywords": ["cpu", "monitoring", "performance", "optimization"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1697,13 +1404,7 @@
       "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "news",
-        "aggregator",
-        "sentiment",
-        "crypto",
-        "media"
-      ],
+      "keywords": ["news", "aggregator", "sentiment", "crypto", "media"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1721,15 +1422,7 @@
       "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "crypto",
-        "portfolio",
-        "trading",
-        "investment",
-        "bitcoin",
-        "ethereum",
-        "defi"
-      ],
+      "keywords": ["crypto", "portfolio", "trading", "investment", "bitcoin", "ethereum", "defi"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1748,13 +1441,7 @@
       "description": "Generate trading signals from technical indicators and market analysis",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "trading",
-        "signals",
-        "technical-analysis",
-        "indicators",
-        "crypto"
-      ],
+      "keywords": ["trading", "signals", "technical-analysis", "indicators", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1772,14 +1459,7 @@
       "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "crypto",
-        "tax",
-        "calculator",
-        "fifo",
-        "lifo",
-        "capital gains"
-      ],
+      "keywords": ["crypto", "tax", "calculator", "fifo", "lifo", "capital gains"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1797,11 +1477,7 @@
       "description": "Validate CSRF protection",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1819,13 +1495,7 @@
       "description": "Automated data preprocessing and cleaning pipelines",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "preprocessing",
-        "cleaning",
-        "etl",
-        "pipeline",
-        "data"
-      ],
+      "keywords": ["preprocessing", "cleaning", "etl", "pipeline", "data"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1843,11 +1513,7 @@
       "description": "Scan for data privacy issues",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1865,13 +1531,7 @@
       "description": "Generate realistic test data and database seed scripts for development and testing environments",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "seeding",
-        "test-data",
-        "fixtures",
-        "database",
-        "testing"
-      ],
+      "keywords": ["seeding", "test-data", "fixtures", "database", "testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1889,11 +1549,7 @@
       "description": "Database plugin for data-validation-engine",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "validation"
-      ],
+      "keywords": ["database", "backend", "validation"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1911,13 +1567,7 @@
       "description": "Create data visualizations and plots",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "visualization",
-        "plots",
-        "charts",
-        "graphs",
-        "analytics"
-      ],
+      "keywords": ["visualization", "plots", "charts", "graphs", "analytics"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1935,11 +1585,7 @@
       "description": "Database plugin for database-archival-system",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "archival"
-      ],
+      "keywords": ["database", "backend", "archival"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1957,11 +1603,7 @@
       "description": "Database plugin for database-audit-logger",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "audit"
-      ],
+      "keywords": ["database", "backend", "audit"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1979,13 +1621,7 @@
       "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backup",
-        "automation",
-        "disaster-recovery",
-        "devops"
-      ],
+      "keywords": ["database", "backup", "automation", "disaster-recovery", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2003,11 +1639,7 @@
       "description": "Database plugin for database-cache-layer",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "cache"
-      ],
+      "keywords": ["database", "backend", "cache"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2025,13 +1657,7 @@
       "description": "Implement and optimize database connection pooling for improved performance and resource management",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "connection-pool",
-        "database",
-        "performance",
-        "backend",
-        "optimization"
-      ],
+      "keywords": ["connection-pool", "database", "performance", "backend", "optimization"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2049,11 +1675,7 @@
       "description": "Database plugin for database-deadlock-detector",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "deadlock"
-      ],
+      "keywords": ["database", "backend", "deadlock"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2071,11 +1693,7 @@
       "description": "Database plugin for database-diff-tool",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "diff"
-      ],
+      "keywords": ["database", "backend", "diff"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2093,11 +1711,7 @@
       "description": "Database plugin for database-documentation-gen",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "documentation"
-      ],
+      "keywords": ["database", "backend", "documentation"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2115,11 +1729,7 @@
       "description": "Database plugin for database-health-monitor",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "health"
-      ],
+      "keywords": ["database", "backend", "health"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2137,12 +1747,7 @@
       "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "indexes",
-        "optimization",
-        "performance"
-      ],
+      "keywords": ["database", "indexes", "optimization", "performance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2160,13 +1765,7 @@
       "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "migration",
-        "schema",
-        "version-control",
-        "backend"
-      ],
+      "keywords": ["database", "migration", "schema", "version-control", "backend"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2184,11 +1783,7 @@
       "description": "Database plugin for database-partition-manager",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "partition"
-      ],
+      "keywords": ["database", "backend", "partition"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2206,13 +1801,7 @@
       "description": "Profile and optimize database queries for performance",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "database",
-        "query",
-        "profiling",
-        "optimization",
-        "sql"
-      ],
+      "keywords": ["database", "query", "profiling", "optimization", "sql"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2224,11 +1813,7 @@
       "description": "Database plugin for database-recovery-manager",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "recovery"
-      ],
+      "keywords": ["database", "backend", "recovery"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2246,13 +1831,7 @@
       "description": "Manage database replication, failover, and high availability configurations",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "replication",
-        "high-availability",
-        "failover",
-        "database",
-        "devops"
-      ],
+      "keywords": ["replication", "high-availability", "failover", "database", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2270,13 +1849,7 @@
       "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "schema",
-        "design",
-        "erd",
-        "normalization"
-      ],
+      "keywords": ["database", "schema", "design", "erd", "normalization"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2294,11 +1867,7 @@
       "description": "Database plugin for database-security-scanner",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "security"
-      ],
+      "keywords": ["database", "backend", "security"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2316,11 +1885,7 @@
       "description": "Database plugin for database-sharding-manager",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "sharding"
-      ],
+      "keywords": ["database", "backend", "sharding"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2364,11 +1929,7 @@
       "description": "Database plugin for database-transaction-monitor",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "transaction"
-      ],
+      "keywords": ["database", "backend", "transaction"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2386,13 +1947,7 @@
       "description": "Split datasets for training, validation, and testing",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "split",
-        "train-test",
-        "validation",
-        "stratify",
-        "ml"
-      ],
+      "keywords": ["split", "train-test", "validation", "stratify", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2410,13 +1965,7 @@
       "description": "Deep learning optimization techniques",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "optimization",
-        "adam",
-        "sgd",
-        "learning-rate",
-        "deep-learning"
-      ],
+      "keywords": ["optimization", "adam", "sgd", "learning-rate", "deep-learning"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2434,15 +1983,7 @@
       "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "defi",
-        "yield",
-        "farming",
-        "liquidity",
-        "apy",
-        "optimization",
-        "crypto"
-      ],
+      "keywords": ["defi", "yield", "farming", "liquidity", "apy", "optimization", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2460,14 +2001,7 @@
       "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "dependencies",
-        "npm",
-        "pip",
-        "composer",
-        "vulnerabilities"
-      ],
+      "keywords": ["security", "dependencies", "npm", "pip", "composer", "vulnerabilities"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2485,13 +2019,7 @@
       "description": "Orchestrate complex multi-stage deployment pipelines",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "pipeline",
-        "orchestration",
-        "deployment",
-        "cicd",
-        "devops"
-      ],
+      "keywords": ["pipeline", "orchestration", "deployment", "cicd", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2509,13 +2037,7 @@
       "description": "Manage and execute deployment rollbacks with safety checks",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "rollback",
-        "deployment",
-        "kubernetes",
-        "recovery",
-        "devops"
-      ],
+      "keywords": ["rollback", "deployment", "kubernetes", "recovery", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2591,14 +2113,7 @@
       "description": "Find optimal DEX routes for token swaps across multiple exchanges",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "dex",
-        "swap",
-        "trading",
-        "defi",
-        "aggregator",
-        "routing"
-      ],
+      "keywords": ["dex", "swap", "trading", "defi", "aggregator", "routing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2616,12 +2131,7 @@
       "description": "Plan and implement disaster recovery procedures",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "disaster-recovery",
-        "dr",
-        "business-continuity",
-        "devops"
-      ],
+      "keywords": ["disaster-recovery", "dr", "business-continuity", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2639,14 +2149,7 @@
       "description": "Generate custom discovery questionnaires for AI agency prospects",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "discovery",
-        "questionnaire",
-        "client",
-        "sales",
-        "agency",
-        "ai-agency"
-      ],
+      "keywords": ["discovery", "questionnaire", "client", "sales", "agency", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub"
       }
@@ -2657,12 +2160,7 @@
       "description": "Set up distributed tracing for microservices",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "tracing",
-        "observability",
-        "microservices",
-        "opentelemetry"
-      ],
+      "keywords": ["tracing", "observability", "microservices", "opentelemetry"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2680,13 +2178,7 @@
       "description": "Generate Docker Compose configurations for multi-container applications with best practices",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "docker",
-        "docker-compose",
-        "containers",
-        "orchestration",
-        "devops"
-      ],
+      "keywords": ["docker", "docker-compose", "containers", "orchestration", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2733,26 +2225,12 @@
       "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
       "version": "1.0.0",
       "category": "mcp",
-      "keywords": [
-        "mcp",
-        "memory",
-        "cascade",
-        "storage",
-        "encryption",
-        "search",
-        "fts",
-        "agent"
-      ],
+      "keywords": ["mcp", "memory", "cascade", "storage", "encryption", "search", "fts", "agent"],
       "author": {
         "name": "Intent Solutions IO",
         "email": "jeremy@intentsolutions.io"
       },
-      "mcpTools": [
-        "store_memory",
-        "recall_memory",
-        "search_memory",
-        "delete_memory"
-      ]
+      "mcpTools": ["store_memory", "recall_memory", "search_memory", "delete_memory"]
     },
     {
       "name": "e2e-test-framework",
@@ -2760,14 +2238,7 @@
       "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "e2e",
-        "playwright",
-        "cypress",
-        "selenium",
-        "browser-testing"
-      ],
+      "keywords": ["testing", "e2e", "playwright", "cypress", "selenium", "browser-testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2785,11 +2256,7 @@
       "description": "Encrypt and decrypt data with various algorithms",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2834,13 +2301,7 @@
       "description": "Manage environment configurations and secrets across deployments",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "config",
-        "environment",
-        "secrets",
-        "configuration",
-        "devops"
-      ],
+      "keywords": ["config", "environment", "secrets", "configuration", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2858,12 +2319,7 @@
       "description": "Monitor and analyze application error rates",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "errors",
-        "monitoring",
-        "reliability",
-        "sre"
-      ],
+      "keywords": ["errors", "monitoring", "reliability", "sre"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2949,13 +2405,7 @@
       "description": "Set up ML experiment tracking",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "experiments",
-        "mlflow",
-        "wandb",
-        "tracking",
-        "mlops"
-      ],
+      "keywords": ["experiments", "mlflow", "wandb", "tracking", "mlops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3008,11 +2458,7 @@
       "description": "Database operations management for FairDB PostgreSQL clusters",
       "version": "1.0.0",
       "category": "community",
-      "keywords": [
-        "database",
-        "postgresql",
-        "operations"
-      ],
+      "keywords": ["database", "postgresql", "operations"],
       "author": {
         "name": "Community"
       }
@@ -3023,13 +2469,7 @@
       "description": "Feature creation, selection, and transformation tools",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "features",
-        "engineering",
-        "selection",
-        "transformation",
-        "ml"
-      ],
+      "keywords": ["features", "engineering", "selection", "transformation", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3047,11 +2487,7 @@
       "description": "Converts file references into executable code implementations",
       "version": "0.1.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "files",
-        "automation",
-        "code-generation"
-      ],
+      "keywords": ["files", "automation", "code-generation"],
       "author": {
         "name": "Claude Code Plugins Team"
       }
@@ -3089,11 +2525,7 @@
       "description": "Code formatting plugin using hooks to auto-format on save",
       "version": "1.0.0",
       "category": "examples",
-      "keywords": [
-        "formatting",
-        "hooks",
-        "automation"
-      ],
+      "keywords": ["formatting", "hooks", "automation"],
       "verification": {
         "score": 95,
         "grade": "A",
@@ -3156,14 +2588,7 @@
       "description": "Optimize transaction gas fees with timing and routing recommendations",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "gas",
-        "fees",
-        "ethereum",
-        "optimization",
-        "transaction",
-        "l2"
-      ],
+      "keywords": ["gas", "fees", "ethereum", "optimization", "transaction", "l2"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3181,11 +2606,7 @@
       "description": "Scan for GDPR compliance issues",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3229,14 +2650,7 @@
       "description": "Build GitOps workflows with ArgoCD and Flux",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "gitops",
-        "argocd",
-        "flux",
-        "cd",
-        "kubernetes",
-        "devops"
-      ],
+      "keywords": ["gitops", "argocd", "flux", "cd", "kubernetes", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3254,14 +2668,7 @@
       "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "graphql",
-        "api",
-        "server",
-        "apollo",
-        "schema",
-        "resolvers"
-      ],
+      "keywords": ["graphql", "api", "server", "apollo", "schema", "resolvers"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3280,12 +2687,7 @@
       "description": "Generate gRPC services with Protocol Buffers and streaming support",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "grpc",
-        "protobuf",
-        "microservices",
-        "streaming"
-      ],
+      "keywords": ["grpc", "protobuf", "microservices", "streaming"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3303,11 +2705,7 @@
       "description": "Simple example plugin demonstrating basic slash commands",
       "version": "1.0.0",
       "category": "examples",
-      "keywords": [
-        "example",
-        "tutorial",
-        "beginner"
-      ],
+      "keywords": ["example", "tutorial", "beginner"],
       "author": {
         "name": "Jeremy Longshore"
       }
@@ -3318,13 +2716,7 @@
       "description": "Generate Helm charts for Kubernetes applications",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "helm",
-        "kubernetes",
-        "packaging",
-        "charts",
-        "devops"
-      ],
+      "keywords": ["helm", "kubernetes", "packaging", "charts", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3342,11 +2734,7 @@
       "description": "Check HIPAA compliance",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3364,13 +2752,7 @@
       "description": "Optimize hyperparameters using grid/random/bayesian search",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "hyperparameters",
-        "optimization",
-        "tuning",
-        "search",
-        "ml"
-      ],
+      "keywords": ["hyperparameters", "optimization", "tuning", "search", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3388,14 +2770,7 @@
       "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "iac",
-        "terraform",
-        "cloudformation",
-        "pulumi",
-        "infrastructure",
-        "devops"
-      ],
+      "keywords": ["iac", "terraform", "cloudformation", "pulumi", "infrastructure", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3414,13 +2789,7 @@
       "description": "Detect infrastructure drift from desired state",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "drift",
-        "terraform",
-        "infrastructure",
-        "monitoring",
-        "devops"
-      ],
+      "keywords": ["drift", "terraform", "infrastructure", "monitoring", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3438,12 +2807,7 @@
       "description": "Collect comprehensive infrastructure performance metrics",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "infrastructure",
-        "metrics",
-        "monitoring",
-        "observability"
-      ],
+      "keywords": ["infrastructure", "metrics", "monitoring", "observability"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3461,11 +2825,7 @@
       "description": "Scan input validation practices",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3483,13 +2843,7 @@
       "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "integration-tests",
-        "test-runner",
-        "e2e",
-        "api-testing"
-      ],
+      "keywords": ["testing", "integration-tests", "test-runner", "e2e", "api-testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3507,13 +2861,7 @@
       "description": "Create Kubernetes deployments, services, and configurations with best practices",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "kubernetes",
-        "k8s",
-        "deployment",
-        "orchestration",
-        "containers"
-      ],
+      "keywords": ["kubernetes", "k8s", "deployment", "orchestration", "containers"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3532,14 +2880,7 @@
       "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "liquidity",
-        "pool",
-        "defi",
-        "impermanent",
-        "loss",
-        "apy"
-      ],
+      "keywords": ["liquidity", "pool", "defi", "impermanent", "loss", "apy"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3557,14 +2898,7 @@
       "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "load-balancer",
-        "alb",
-        "nginx",
-        "haproxy",
-        "networking",
-        "devops"
-      ],
+      "keywords": ["load-balancer", "alb", "nginx", "haproxy", "networking", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3606,12 +2940,7 @@
       "description": "Create and execute load tests for performance validation",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "load-testing",
-        "performance",
-        "stress-test",
-        "k6"
-      ],
+      "keywords": ["load-testing", "performance", "stress-test", "k6"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3629,14 +2958,7 @@
       "description": "Set up log aggregation (ELK, Loki, Splunk)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "logging",
-        "elk",
-        "loki",
-        "splunk",
-        "observability",
-        "devops"
-      ],
+      "keywords": ["logging", "elk", "loki", "splunk", "observability", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3654,12 +2976,7 @@
       "description": "Analyze logs for performance insights and issues",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "logs",
-        "analysis",
-        "performance",
-        "debugging"
-      ],
+      "keywords": ["logs", "analysis", "performance", "debugging"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3677,14 +2994,7 @@
       "description": "Create Make.com (Integromat) scenarios with AI assistance",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "make",
-        "integromat",
-        "automation",
-        "scenarios",
-        "workflow",
-        "ai-agency"
-      ],
+      "keywords": ["make", "integromat", "automation", "scenarios", "workflow", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub"
       }
@@ -3695,15 +3005,7 @@
       "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "market",
-        "scanner",
-        "movers",
-        "gainers",
-        "losers",
-        "volume",
-        "trading"
-      ],
+      "keywords": ["market", "scanner", "movers", "gainers", "losers", "volume", "trading"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3721,15 +3023,7 @@
       "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "market",
-        "price",
-        "tracking",
-        "trading",
-        "crypto",
-        "stocks",
-        "forex"
-      ],
+      "keywords": ["market", "price", "tracking", "trading", "crypto", "stocks", "forex"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3747,14 +3041,7 @@
       "description": "Analyze market sentiment from social media, news, and on-chain data",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "sentiment",
-        "analysis",
-        "social",
-        "news",
-        "market",
-        "crypto"
-      ],
+      "keywords": ["sentiment", "analysis", "social", "news", "market", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3773,12 +3060,7 @@
       "description": "Detect memory leaks and analyze memory usage patterns",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "memory",
-        "leak",
-        "detection",
-        "performance"
-      ],
+      "keywords": ["memory", "leak", "detection", "performance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3823,12 +3105,7 @@
       "description": "Aggregate and centralize performance metrics",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "metrics",
-        "aggregation",
-        "prometheus",
-        "monitoring"
-      ],
+      "keywords": ["metrics", "aggregation", "prometheus", "monitoring"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3846,13 +3123,7 @@
       "description": "Train and optimize machine learning models with automated workflows",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "ml",
-        "machine-learning",
-        "training",
-        "models",
-        "ai"
-      ],
+      "keywords": ["ml", "machine-learning", "training", "models", "ai"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3897,13 +3168,7 @@
       "description": "Deploy ML models to production",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "deployment",
-        "serving",
-        "production",
-        "api",
-        "mlops"
-      ],
+      "keywords": ["deployment", "serving", "production", "api", "mlops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3921,13 +3186,7 @@
       "description": "Comprehensive model evaluation with multiple metrics",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "evaluation",
-        "metrics",
-        "testing",
-        "validation",
-        "ml"
-      ],
+      "keywords": ["evaluation", "metrics", "testing", "validation", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3945,13 +3204,7 @@
       "description": "Model interpretability and explainability",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "explainability",
-        "shap",
-        "lime",
-        "interpretability",
-        "ml"
-      ],
+      "keywords": ["explainability", "shap", "lime", "interpretability", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3969,13 +3222,7 @@
       "description": "Track and manage model versions",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "versioning",
-        "mlflow",
-        "tracking",
-        "registry",
-        "mlops"
-      ],
+      "keywords": ["versioning", "mlflow", "tracking", "registry", "mlops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -3993,13 +3240,7 @@
       "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "monitoring",
-        "prometheus",
-        "grafana",
-        "observability",
-        "devops"
-      ],
+      "keywords": ["monitoring", "prometheus", "grafana", "observability", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4017,13 +3258,7 @@
       "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "mutation-testing",
-        "test-quality",
-        "stryker",
-        "pitest"
-      ],
+      "keywords": ["testing", "mutation-testing", "test-quality", "stryker", "pitest"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4041,14 +3276,7 @@
       "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "n8n",
-        "workflow",
-        "automation",
-        "self-hosted",
-        "open-source",
-        "ai-agency"
-      ],
+      "keywords": ["n8n", "workflow", "automation", "self-hosted", "open-source", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "url": "https://github.com/jeremylongshore/claude-code-plugins"
@@ -4061,12 +3289,7 @@
       "description": "Analyze network latency and optimize request patterns",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "network",
-        "latency",
-        "performance",
-        "api"
-      ],
+      "keywords": ["network", "latency", "performance", "api"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4084,13 +3307,7 @@
       "description": "Manage Kubernetes network policies and firewall rules",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "network-policy",
-        "security",
-        "kubernetes",
-        "firewall",
-        "devops"
-      ],
+      "keywords": ["network-policy", "security", "kubernetes", "firewall", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4108,13 +3325,7 @@
       "description": "Build and configure neural network architectures",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "neural-networks",
-        "deep-learning",
-        "architecture",
-        "pytorch",
-        "ml"
-      ],
+      "keywords": ["neural-networks", "deep-learning", "architecture", "pytorch", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4132,14 +3343,7 @@
       "description": "Analyze NFT rarity scores and valuations across collections",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "nft",
-        "rarity",
-        "valuation",
-        "traits",
-        "opensea",
-        "crypto"
-      ],
+      "keywords": ["nft", "rarity", "valuation", "traits", "opensea", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4157,13 +3361,7 @@
       "description": "Natural language processing and text analysis",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "nlp",
-        "text",
-        "analysis",
-        "tokenization",
-        "ml"
-      ],
+      "keywords": ["nlp", "text", "analysis", "tokenization", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4214,11 +3412,7 @@
       "description": "Database plugin for nosql-data-modeler",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "data"
-      ],
+      "keywords": ["database", "backend", "data"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4236,13 +3430,7 @@
       "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "on-chain",
-        "analytics",
-        "whale",
-        "metrics",
-        "blockchain"
-      ],
+      "keywords": ["on-chain", "analytics", "whale", "metrics", "blockchain"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4295,14 +3483,7 @@
       "description": "Track institutional options flow, unusual activity, and smart money movements",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "options",
-        "flow",
-        "institutional",
-        "trading",
-        "derivatives",
-        "smart money"
-      ],
+      "keywords": ["options", "flow", "institutional", "trading", "derivatives", "smart money"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4320,13 +3501,7 @@
       "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "orm",
-        "models",
-        "code-generation",
-        "database",
-        "backend"
-      ],
+      "keywords": ["orm", "models", "code-generation", "database", "backend"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4374,11 +3549,7 @@
       "description": "Check OWASP Top 10 compliance",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4396,11 +3567,7 @@
       "description": "Validate PCI DSS compliance",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4418,13 +3585,7 @@
       "description": "Automated penetration testing for web applications with OWASP Top 10 coverage",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "penetration-testing",
-        "pentesting",
-        "owasp",
-        "exploitation"
-      ],
+      "keywords": ["security", "penetration-testing", "pentesting", "owasp", "exploitation"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4442,12 +3603,7 @@
       "description": "Validate application against performance budgets",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "performance-budget",
-        "validation",
-        "ci-cd",
-        "testing"
-      ],
+      "keywords": ["performance-budget", "validation", "ci-cd", "testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4465,12 +3621,7 @@
       "description": "Get comprehensive performance optimization recommendations",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "optimization",
-        "performance",
-        "best-practices",
-        "advisor"
-      ],
+      "keywords": ["optimization", "performance", "best-practices", "advisor"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4488,12 +3639,7 @@
       "description": "Detect performance regressions in CI/CD pipeline",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "regression",
-        "performance",
-        "ci-cd",
-        "testing"
-      ],
+      "keywords": ["regression", "performance", "ci-cd", "testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4511,13 +3657,7 @@
       "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "performance",
-        "load-testing",
-        "benchmarking",
-        "stress-testing"
-      ],
+      "keywords": ["testing", "performance", "load-testing", "benchmarking", "stress-testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4652,13 +3792,7 @@
       "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "performance",
-        "query",
-        "optimization",
-        "explain",
-        "database"
-      ],
+      "keywords": ["performance", "query", "optimization", "explain", "database"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4676,12 +3810,7 @@
       "description": "Implement Real User Monitoring for actual performance data",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "rum",
-        "monitoring",
-        "performance",
-        "user-experience"
-      ],
+      "keywords": ["rum", "monitoring", "performance", "user-experience"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4699,13 +3828,7 @@
       "description": "Build recommendation systems and engines",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "recommendations",
-        "collaborative",
-        "content-based",
-        "ranking",
-        "ml"
-      ],
+      "keywords": ["recommendations", "collaborative", "content-based", "ranking", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4723,13 +3846,7 @@
       "description": "Regression analysis and modeling",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "regression",
-        "prediction",
-        "linear",
-        "polynomial",
-        "ml"
-      ],
+      "keywords": ["regression", "prediction", "linear", "polynomial", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4747,13 +3864,7 @@
       "description": "Track and run regression tests to ensure new changes don't break existing functionality",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "regression-testing",
-        "test-tracking",
-        "ci-cd",
-        "quality-assurance"
-      ],
+      "keywords": ["testing", "regression-testing", "test-tracking", "ci-cd", "quality-assurance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4771,11 +3882,7 @@
       "description": "Transforms research findings into deployed solutions automatically",
       "version": "0.1.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "research",
-        "automation",
-        "deployment"
-      ],
+      "keywords": ["research", "automation", "deployment"],
       "author": {
         "name": "Claude Code Plugins Team"
       }
@@ -4786,12 +3893,7 @@
       "description": "Track and optimize resource usage across the stack",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "resources",
-        "monitoring",
-        "optimization",
-        "metrics"
-      ],
+      "keywords": ["resources", "monitoring", "optimization", "metrics"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4809,12 +3911,7 @@
       "description": "Track and optimize application response times",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "response-time",
-        "latency",
-        "performance",
-        "monitoring"
-      ],
+      "keywords": ["response-time", "latency", "performance", "monitoring"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4832,14 +3929,7 @@
       "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "api",
-        "rest",
-        "generator",
-        "openapi",
-        "swagger",
-        "backend"
-      ],
+      "keywords": ["api", "rest", "generator", "openapi", "swagger", "backend"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4858,14 +3948,7 @@
       "description": "Calculate and present ROI for AI automation projects",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "roi",
-        "return on investment",
-        "calculator",
-        "sales",
-        "value",
-        "ai-agency"
-      ],
+      "keywords": ["roi", "return on investment", "calculator", "sales", "value", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub"
       }
@@ -4876,12 +3959,7 @@
       "description": "Automatically posts search results to Slack channels",
       "version": "0.1.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "search",
-        "slack",
-        "automation",
-        "integration"
-      ],
+      "keywords": ["search", "slack", "automation", "integration"],
       "author": {
         "name": "Claude Code Plugins Team"
       }
@@ -4892,13 +3970,7 @@
       "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "secrets",
-        "api-keys",
-        "credentials",
-        "passwords"
-      ],
+      "keywords": ["security", "secrets", "api-keys", "credentials", "passwords"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4942,14 +4014,7 @@
       "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "secrets",
-        "vault",
-        "aws",
-        "security",
-        "credentials",
-        "devops"
-      ],
+      "keywords": ["secrets", "vault", "aws", "security", "credentials", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -4967,11 +4032,7 @@
       "description": "Security review subagent for code analysis",
       "version": "1.0.0",
       "category": "examples",
-      "keywords": [
-        "security",
-        "agent",
-        "code-review"
-      ],
+      "keywords": ["security", "agent", "code-review"],
       "verification": {
         "score": 94,
         "grade": "A",
@@ -4985,11 +4046,7 @@
       "description": "Generate comprehensive security audit reports",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5007,11 +4064,7 @@
       "description": "Analyze HTTP security headers",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5029,11 +4082,7 @@
       "description": "Assist with security incident response",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5051,11 +4100,7 @@
       "description": "Find security misconfigurations",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5104,13 +4149,7 @@
       "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "security",
-        "vulnerabilities",
-        "owasp",
-        "penetration-testing"
-      ],
+      "keywords": ["testing", "security", "vulnerabilities", "owasp", "penetration-testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5128,13 +4167,7 @@
       "description": "Sentiment analysis on text data",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "sentiment",
-        "opinion",
-        "emotion",
-        "polarity",
-        "nlp"
-      ],
+      "keywords": ["sentiment", "opinion", "emotion", "polarity", "nlp"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5152,13 +4185,7 @@
       "description": "Configure service mesh (Istio, Linkerd) for microservices",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "service-mesh",
-        "istio",
-        "linkerd",
-        "microservices",
-        "devops"
-      ],
+      "keywords": ["service-mesh", "istio", "linkerd", "microservices", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5176,11 +4203,7 @@
       "description": "Check session security implementation",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5228,13 +4251,7 @@
       "description": "Track SLAs, SLIs, and SLOs for service reliability",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "sla",
-        "sli",
-        "slo",
-        "sre",
-        "reliability"
-      ],
+      "keywords": ["sla", "sli", "slo", "sre", "reliability"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5252,13 +4269,7 @@
       "description": "Quick smoke test suites to verify critical functionality after deployments",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "smoke-tests",
-        "deployment",
-        "sanity-check",
-        "critical-path"
-      ],
+      "keywords": ["testing", "smoke-tests", "deployment", "sanity-check", "critical-path"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -5276,14 +4287,7 @@
       "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "snapshot",
-        "jest",
-        "vitest",
-        "diff-analysis",
-        "test-management"
-      ],
+      "keywords": ["testing", "snapshot", "jest", "vitest", "diff-analysis", "test-management"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -5301,11 +4305,7 @@
       "description": "Assist with SOC2 audit preparation",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5323,14 +4323,7 @@
       "description": "Generate professional Statements of Work for AI projects",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "sow",
-        "statement of work",
-        "contract",
-        "proposal",
-        "agency",
-        "ai-agency"
-      ],
+      "keywords": ["sow", "statement of work", "contract", "proposal", "agency", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub"
       }
@@ -5341,11 +4334,7 @@
       "description": "Detect SQL injection vulnerabilities",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5363,13 +4352,7 @@
       "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "sql",
-        "optimization",
-        "performance",
-        "database",
-        "query"
-      ],
+      "keywords": ["sql", "optimization", "performance", "database", "query"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5387,11 +4370,7 @@
       "description": "Manage and monitor SSL/TLS certificates",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5409,14 +4388,7 @@
       "description": "Optimize staking rewards across multiple protocols and chains",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "crypto",
-        "staking",
-        "defi",
-        "yield",
-        "optimization",
-        "rewards"
-      ],
+      "keywords": ["crypto", "staking", "defi", "yield", "optimization", "rewards"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5434,11 +4406,7 @@
       "description": "Database plugin for stored-procedure-generator",
       "version": "1.0.0",
       "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "procedure"
-      ],
+      "keywords": ["database", "backend", "procedure"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5526,12 +4494,7 @@
       "description": "Set up synthetic monitoring for proactive performance tracking",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "synthetic-monitoring",
-        "uptime",
-        "performance",
-        "testing"
-      ],
+      "keywords": ["synthetic-monitoring", "uptime", "performance", "testing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5549,13 +4512,7 @@
       "description": "Build reusable Terraform modules",
       "version": "1.0.0",
       "category": "devops",
-      "keywords": [
-        "terraform",
-        "iac",
-        "modules",
-        "infrastructure",
-        "devops"
-      ],
+      "keywords": ["terraform", "iac", "modules", "infrastructure", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5573,13 +4530,7 @@
       "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "coverage",
-        "code-coverage",
-        "metrics",
-        "analysis"
-      ],
+      "keywords": ["testing", "coverage", "code-coverage", "metrics", "analysis"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5597,13 +4548,7 @@
       "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "test-data",
-        "fake-data",
-        "fixtures",
-        "factory"
-      ],
+      "keywords": ["testing", "test-data", "fake-data", "fixtures", "factory"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5621,16 +4566,7 @@
       "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "mocks",
-        "stubs",
-        "spies",
-        "fakes",
-        "test-doubles",
-        "jest",
-        "sinon"
-      ],
+      "keywords": ["testing", "mocks", "stubs", "spies", "fakes", "test-doubles", "jest", "sinon"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -5673,14 +4609,7 @@
       "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "orchestration",
-        "workflow",
-        "parallel",
-        "test-selection",
-        "ci-cd"
-      ],
+      "keywords": ["testing", "orchestration", "workflow", "parallel", "test-selection", "ci-cd"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -5698,14 +4627,7 @@
       "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "reporting",
-        "coverage",
-        "metrics",
-        "dashboard",
-        "ci-cd"
-      ],
+      "keywords": ["testing", "reporting", "coverage", "metrics", "dashboard", "ci-cd"],
       "author": {
         "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
@@ -5723,12 +4645,7 @@
       "description": "Analyze and optimize system throughput",
       "version": "1.0.0",
       "category": "performance",
-      "keywords": [
-        "throughput",
-        "performance",
-        "capacity",
-        "optimization"
-      ],
+      "keywords": ["throughput", "performance", "capacity", "optimization"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5746,13 +4663,7 @@
       "description": "Time series forecasting and analysis",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "time-series",
-        "forecasting",
-        "arima",
-        "prophet",
-        "ml"
-      ],
+      "keywords": ["time-series", "forecasting", "arima", "prophet", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5797,14 +4708,7 @@
       "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "trading",
-        "backtesting",
-        "strategy",
-        "historical",
-        "performance",
-        "risk"
-      ],
+      "keywords": ["trading", "backtesting", "strategy", "historical", "performance", "risk"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5822,13 +4726,7 @@
       "description": "Transfer learning adaptation",
       "version": "1.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "transfer-learning",
-        "fine-tuning",
-        "pretrained",
-        "adapters",
-        "ml"
-      ],
+      "keywords": ["transfer-learning", "fine-tuning", "pretrained", "adapters", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5879,15 +4777,7 @@
       "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
       "version": "1.0.0",
       "category": "testing",
-      "keywords": [
-        "testing",
-        "unit-tests",
-        "test-generation",
-        "jest",
-        "pytest",
-        "mocha",
-        "junit"
-      ],
+      "keywords": ["testing", "unit-tests", "test-generation", "jest", "pytest", "mocha", "junit"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5931,13 +4821,7 @@
       "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "vulnerability",
-        "scanning",
-        "cve",
-        "sast"
-      ],
+      "keywords": ["security", "vulnerability", "scanning", "cve", "sast"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -5955,14 +4839,7 @@
       "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "wallet",
-        "portfolio",
-        "tracking",
-        "blockchain",
-        "defi",
-        "crypto"
-      ],
+      "keywords": ["wallet", "portfolio", "tracking", "blockchain", "defi", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -6003,12 +4880,7 @@
       "description": "Create secure webhook endpoints with signature verification and retry logic",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "webhook",
-        "events",
-        "signature",
-        "security"
-      ],
+      "keywords": ["webhook", "events", "signature", "security"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -6026,12 +4898,7 @@
       "description": "Build WebSocket servers for real-time bidirectional communication",
       "version": "1.0.0",
       "category": "api-development",
-      "keywords": [
-        "websocket",
-        "real-time",
-        "socket.io",
-        "ws"
-      ],
+      "keywords": ["websocket", "real-time", "socket.io", "ws"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -6049,13 +4916,7 @@
       "description": "Monitor large crypto transactions and whale wallet movements in real-time",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "whale",
-        "alert",
-        "monitor",
-        "large",
-        "transactions"
-      ],
+      "keywords": ["whale", "alert", "monitor", "large", "transactions"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -6102,11 +4963,7 @@
       "description": "Scan for XSS vulnerabilities",
       "version": "1.0.0",
       "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
+      "keywords": ["security", "compliance", "auditing"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -6124,14 +4981,7 @@
       "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
       "version": "1.0.0",
       "category": "ai-agency",
-      "keywords": [
-        "zapier",
-        "zap",
-        "automation",
-        "integration",
-        "workflow",
-        "ai-agency"
-      ],
+      "keywords": ["zapier", "zap", "automation", "integration", "workflow", "ai-agency"],
       "author": {
         "name": "Claude Code Plugin Hub"
       }
@@ -6142,15 +4992,7 @@
       "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
       "version": "2.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "firebase",
-        "genkit",
-        "ai-flows",
-        "rag",
-        "monitoring",
-        "gemini",
-        "vertex-ai"
-      ],
+      "keywords": ["firebase", "genkit", "ai-flows", "rag", "monitoring", "gemini", "vertex-ai"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6202,13 +5044,7 @@
       "description": "Production readiness validator for Vertex AI deployments and configurations",
       "version": "2.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "validation",
-        "production-readiness",
-        "security",
-        "compliance"
-      ],
+      "keywords": ["vertex-ai", "validation", "production-readiness", "security", "compliance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6278,13 +5114,7 @@
       "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
       "version": "2.0.0",
       "category": "devops",
-      "keywords": [
-        "terraform",
-        "genkit",
-        "firebase",
-        "cloud-run",
-        "infrastructure"
-      ],
+      "keywords": ["terraform", "genkit", "firebase", "cloud-run", "infrastructure"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6305,14 +5135,7 @@
       "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
       "version": "2.0.0",
       "category": "devops",
-      "keywords": [
-        "terraform",
-        "adk",
-        "agent-engine",
-        "vertex-ai",
-        "infrastructure",
-        "vpc-sc"
-      ],
+      "keywords": ["terraform", "adk", "agent-engine", "vertex-ai", "infrastructure", "vpc-sc"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6333,13 +5156,7 @@
       "description": "Terraform configurations for Vertex AI platform and Agent Engine",
       "version": "2.0.0",
       "category": "devops",
-      "keywords": [
-        "terraform",
-        "vertex-ai",
-        "gemini",
-        "model-garden",
-        "infrastructure"
-      ],
+      "keywords": ["terraform", "vertex-ai", "gemini", "model-garden", "infrastructure"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6512,13 +5329,7 @@
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
       "version": "5.0.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "skill-creation",
-        "validation",
-        "meta-tooling",
-        "grading",
-        "anthropic-spec"
-      ],
+      "keywords": ["skill-creation", "validation", "meta-tooling", "grading", "anthropic-spec"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6538,14 +5349,7 @@
       "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
       "version": "0.1.0",
       "category": "community",
-      "keywords": [
-        "memory",
-        "context",
-        "persistent",
-        "preferences",
-        "sessions",
-        "recall"
-      ],
+      "keywords": ["memory", "context", "persistent", "preferences", "sessions", "recall"],
       "author": {
         "name": "yldrmahmet",
         "url": "https://github.com/yldrmahmet"
@@ -6658,11 +5462,7 @@
         "hooks": 1,
         "total": 11
       },
-      "tags": [
-        "beginner-friendly",
-        "explanations",
-        "noise-filtering"
-      ],
+      "tags": ["beginner-friendly", "explanations", "noise-filtering"],
       "strict": true
     },
     {
@@ -6671,12 +5471,7 @@
       "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
       "version": "2.0.0",
       "category": "ai-ml",
-      "keywords": [
-        "adk",
-        "software-engineer",
-        "agent-development",
-        "vertex-ai"
-      ],
+      "keywords": ["adk", "software-engineer", "agent-development", "vertex-ai"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6758,13 +5553,7 @@
       "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
       "version": "1.0.0",
       "category": "crypto",
-      "keywords": [
-        "crypto",
-        "wallet",
-        "security",
-        "audit",
-        "web3"
-      ],
+      "keywords": ["crypto", "wallet", "security", "audit", "web3"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -6785,14 +5574,7 @@
       "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
       "version": "0.1.0",
       "category": "devops",
-      "keywords": [
-        "changelog",
-        "release-notes",
-        "weekly-update",
-        "git",
-        "github",
-        "automation"
-      ],
+      "keywords": ["changelog", "release-notes", "weekly-update", "git", "github", "automation"],
       "author": {
         "name": "Mattyp",
         "email": "mattyp@tonsofskills.com",
@@ -9295,12 +8077,7 @@
       "description": "Claude Code skill pack for Abridge (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "abridge",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["abridge", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9322,12 +8099,7 @@
       "description": "Claude Code skill pack for Adobe (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "adobe",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["adobe", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9349,12 +8121,7 @@
       "description": "Claude Code skill pack for Alchemy (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "alchemy",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["alchemy", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9376,12 +8143,7 @@
       "description": "Claude Code skill pack for Algolia (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "algolia",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["algolia", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9403,12 +8165,7 @@
       "description": "Claude Code skill pack for Anima (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "anima",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["anima", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9430,12 +8187,7 @@
       "description": "Claude Code skill pack for Anthropic (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "anthropic",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["anthropic", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9457,12 +8209,7 @@
       "description": "Claude Code skill pack for Apify (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "apify",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["apify", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9484,12 +8231,7 @@
       "description": "Claude Code skill pack for AppFolio (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "appfolio",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["appfolio", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9511,13 +8253,7 @@
       "description": "Claude Code skill pack for Apple Notes (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "apple-notes",
-        "apple notes",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["apple-notes", "apple notes", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9539,12 +8275,7 @@
       "description": "Claude Code skill pack for AssemblyAI (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "assemblyai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["assemblyai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9566,12 +8297,7 @@
       "description": "Claude Code skill pack for Attio (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "attio",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["attio", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9593,12 +8319,7 @@
       "description": "Claude Code skill pack for BambooHR (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "bamboohr",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["bamboohr", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9620,13 +8341,7 @@
       "description": "Claude Code skill pack for Bright Data (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "brightdata",
-        "bright data",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["brightdata", "bright data", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9648,12 +8363,7 @@
       "description": "Claude Code skill pack for Canva (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "canva",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["canva", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9675,13 +8385,7 @@
       "description": "Claude Code skill pack for Cast AI (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "castai",
-        "cast ai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["castai", "cast ai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9703,12 +8407,7 @@
       "description": "Claude Code skill pack for Clari (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "clari",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clari", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9730,12 +8429,7 @@
       "description": "Claude Code skill pack for ClickHouse (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "clickhouse",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clickhouse", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9757,12 +8451,7 @@
       "description": "Claude Code skill pack for ClickUp (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "clickup",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clickup", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9784,12 +8473,7 @@
       "description": "Claude Code skill pack for Cohere (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "cohere",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["cohere", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9811,12 +8495,7 @@
       "description": "Claude Code skill pack for CoreWeave (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "coreweave",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["coreweave", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9838,12 +8517,7 @@
       "description": "Claude Code skill pack for ElevenLabs (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "elevenlabs",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["elevenlabs", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9865,12 +8539,7 @@
       "description": "Claude Code skill pack for Fathom (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "fathom",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["fathom", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9892,12 +8561,7 @@
       "description": "Claude Code skill pack for Figma (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "figma",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["figma", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9919,12 +8583,7 @@
       "description": "Claude Code skill pack for Finta (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "finta",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["finta", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9946,12 +8605,7 @@
       "description": "Claude Code skill pack for Flexport (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "flexport",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["flexport", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9973,13 +8627,7 @@
       "description": "Claude Code skill pack for Fly.io (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "flyio",
-        "fly.io",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["flyio", "fly.io", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10001,12 +8649,7 @@
       "description": "Claude Code skill pack for Fondo (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "fondo",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["fondo", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10028,12 +8671,7 @@
       "description": "Claude Code skill pack for Framer (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "framer",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["framer", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10055,12 +8693,7 @@
       "description": "Claude Code skill pack for Glean (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "glean",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["glean", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10082,12 +8715,7 @@
       "description": "Claude Code skill pack for Grammarly (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "grammarly",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["grammarly", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10109,12 +8737,7 @@
       "description": "Claude Code skill pack for Hex (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "hex",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hex", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10136,12 +8759,7 @@
       "description": "Claude Code skill pack for Hootsuite (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "hootsuite",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hootsuite", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10163,12 +8781,7 @@
       "description": "Claude Code skill pack for HubSpot (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "hubspot",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hubspot", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10190,12 +8803,7 @@
       "description": "Claude Code skill pack for Intercom (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "intercom",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["intercom", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10217,12 +8825,7 @@
       "description": "Claude Code skill pack for Klaviyo (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "klaviyo",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["klaviyo", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10244,12 +8847,7 @@
       "description": "Claude Code skill pack for Linktree (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "linktree",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["linktree", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10271,12 +8869,7 @@
       "description": "Claude Code skill pack for Lucidchart (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "lucidchart",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["lucidchart", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10298,12 +8891,7 @@
       "description": "Claude Code skill pack for Mindtickle (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "mindtickle",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["mindtickle", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10325,12 +8913,7 @@
       "description": "Claude Code skill pack for Miro (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "miro",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["miro", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10352,12 +8935,7 @@
       "description": "Claude Code skill pack for Navan (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "navan",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["navan", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10379,12 +8957,7 @@
       "description": "Claude Code skill pack for Notion (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "notion",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["notion", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10406,12 +8979,7 @@
       "description": "Claude Code skill pack for OneNote (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "onenote",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["onenote", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10433,13 +9001,7 @@
       "description": "Claude Code skill pack for Oracle Cloud (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "oraclecloud",
-        "oracle cloud",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["oraclecloud", "oracle cloud", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10461,12 +9023,7 @@
       "description": "Claude Code skill pack for Palantir (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "palantir",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["palantir", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10488,12 +9045,7 @@
       "description": "Claude Code skill pack for Persona (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "persona",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["persona", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10547,12 +9099,7 @@
       "description": "Claude Code skill pack for Procore (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "procore",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["procore", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10574,12 +9121,7 @@
       "description": "Claude Code skill pack for QuickNode (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "quicknode",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["quicknode", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10601,12 +9143,7 @@
       "description": "Claude Code skill pack for Ramp (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "ramp",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["ramp", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10628,12 +9165,7 @@
       "description": "Claude Code skill pack for RemoFirst (12 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "remofirst",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["remofirst", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10655,12 +9187,7 @@
       "description": "Claude Code skill pack for Runway (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "runway",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["runway", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10682,12 +9209,7 @@
       "description": "Claude Code skill pack for Salesforce (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "salesforce",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["salesforce", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10709,12 +9231,7 @@
       "description": "Claude Code skill pack for Salesloft (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "salesloft",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["salesloft", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10736,12 +9253,7 @@
       "description": "Claude Code skill pack for SerpApi (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "serpapi",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["serpapi", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10763,14 +9275,7 @@
       "description": "Claude Code skill pack for Shopify (38 skills covering e-commerce development, storefront APIs, and app integration)",
       "version": "2.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "shopify",
-        "saas",
-        "sdk",
-        "integration",
-        "e-commerce",
-        "storefront-api"
-      ],
+      "keywords": ["shopify", "saas", "sdk", "integration", "e-commerce", "storefront-api"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10792,12 +9297,7 @@
       "description": "Claude Code skill pack for Snowflake (30 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "snowflake",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["snowflake", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10819,12 +9319,7 @@
       "description": "Claude Code skill pack for StackBlitz (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "stackblitz",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["stackblitz", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10846,12 +9341,7 @@
       "description": "Claude Code skill pack for TechSmith (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "techsmith",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["techsmith", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10873,13 +9363,7 @@
       "description": "Claude Code skill pack for Together AI (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "together",
-        "together ai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["together", "together ai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10901,12 +9385,7 @@
       "description": "Claude Code skill pack for Veeva (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "veeva",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["veeva", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10928,12 +9407,7 @@
       "description": "Claude Code skill pack for Webflow (24 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "webflow",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["webflow", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10955,12 +9429,7 @@
       "description": "Claude Code skill pack for Wispr (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "wispr",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["wispr", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10982,12 +9451,7 @@
       "description": "Claude Code skill pack for Workhuman (18 skills)",
       "version": "1.0.0",
       "category": "saas-packs",
-      "keywords": [
-        "workhuman",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["workhuman", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -11009,14 +9473,7 @@
       "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
       "version": "1.0.0",
       "category": "productivity",
-      "keywords": [
-        "product-management",
-        "pm",
-        "ai-partner",
-        "skills",
-        "commands",
-        "hooks"
-      ],
+      "keywords": ["product-management", "pm", "ai-partner", "skills", "commands", "hooks"],
       "author": {
         "name": "Ahmed Khaled",
         "email": "ahmd.khaled.a.mohamed@gmail.com"
@@ -11034,12 +9491,7 @@
       "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
       "version": "1.0.0",
       "category": "skill-enhancers",
-      "keywords": [
-        "validation",
-        "plugin-development",
-        "quality-assurance",
-        "linting"
-      ],
+      "keywords": ["validation", "plugin-development", "quality-assurance", "linting"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -11131,13 +9583,7 @@
       "featured": true,
       "external_sync": true,
       "mcpTools": 6,
-      "keywords": [
-        "mcp",
-        "pr-analysis",
-        "intent-drift",
-        "code-review",
-        "agent-protocol"
-      ]
+      "keywords": ["mcp", "pr-analysis", "intent-drift", "code-review", "agent-protocol"]
     },
     {
       "name": "slack-channel",
@@ -11145,14 +9591,7 @@
       "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
       "version": "0.1.0",
       "category": "mcp",
-      "keywords": [
-        "slack",
-        "channel",
-        "mcp",
-        "socket-mode",
-        "chatops",
-        "claude-code"
-      ],
+      "keywords": ["slack", "channel", "mcp", "socket-mode", "chatops", "claude-code"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
@@ -11178,13 +9617,7 @@
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
-      "keywords": [
-        "bug-triage",
-        "x-twitter",
-        "slack",
-        "devops",
-        "mcp"
-      ],
+      "keywords": ["bug-triage", "x-twitter", "slack", "devops", "mcp"],
       "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
       "homepage": "https://tonsofskills.com",
       "license": "MIT",
@@ -11203,14 +9636,7 @@
       "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
       "version": "1.0.0",
       "category": "community",
-      "keywords": [
-        "demo-video",
-        "video-generation",
-        "playwright",
-        "ffmpeg",
-        "edge-tts",
-        "mcp"
-      ],
+      "keywords": ["demo-video", "video-generation", "playwright", "ffmpeg", "edge-tts", "mcp"],
       "author": {
         "name": "vaddisrinivas",
         "url": "https://github.com/vaddisrinivas"
@@ -11384,6 +9810,126 @@
       },
       "license": "MIT",
       "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "commit-narrator",
+      "source": "./plugins/devops/commit-narrator",
+      "description": "Generate semantic commit messages from staged diffs, including the why behind changes. Deterministic Python helper (stdlib only) wrapped as a slash command.",
+      "version": "0.1.0",
+      "category": "devops",
+      "keywords": ["git", "commit", "conventional-commits", "devops"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "pr-storyteller",
+      "source": "./plugins/devops/pr-storyteller",
+      "description": "Generate PR title, body, and test plan from commits and diff vs base branch.",
+      "version": "0.1.0",
+      "category": "devops",
+      "keywords": ["git", "pr", "pull-request", "devops"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "test-gap",
+      "source": "./plugins/testing/test-gap",
+      "description": "Identify lines in your diff lacking test coverage from Cobertura, lcov, or coverage.json formats.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": ["testing", "coverage"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "deps-doctor",
+      "source": "./plugins/security/deps-doctor",
+      "description": "Multi-ecosystem dependency audit covering npm, pip, cargo, and go in one unified report.",
+      "version": "0.1.0",
+      "category": "security",
+      "keywords": ["security", "dependencies", "audit"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "env-lint",
+      "source": "./plugins/testing/env-lint",
+      "description": "Compare .env vs .env.example key parity without ever printing values.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": ["env", "config", "testing"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "secret-guard",
+      "source": "./plugins/security/secret-guard",
+      "description": "Pre-commit secret scanner using pattern and entropy detection with redacted output.",
+      "version": "0.1.0",
+      "category": "security",
+      "keywords": ["security", "secrets", "pre-commit"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "standup-gen",
+      "source": "./plugins/productivity/standup-gen",
+      "description": "Generate daily standup notes from git activity across one or many repositories.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": ["productivity", "git", "standup"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "todo-harvest",
+      "source": "./plugins/testing/todo-harvest",
+      "description": "Scan codebase for TODO, FIXME, and HACK comments with git blame author and age.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": ["testing", "todo", "code-quality"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "flaky-detector",
+      "source": "./plugins/testing/flaky-detector",
+      "description": "Run a test command N times and report per-test flakiness percentage.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": ["testing", "flaky", "reliability"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "changelog-forge",
+      "source": "./plugins/productivity/changelog-forge",
+      "description": "Convert conventional commits into a CHANGELOG section with semver bump suggestion.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": ["productivity", "changelog", "semver"],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8257,6 +8257,167 @@
       },
       "license": "MIT",
       "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "commit-narrator",
+      "source": "./plugins/devops/commit-narrator",
+      "description": "Generate semantic commit messages from staged diffs, including the why behind changes. Deterministic Python helper (stdlib only) wrapped as a slash command.",
+      "version": "0.1.0",
+      "category": "devops",
+      "keywords": [
+        "git",
+        "commit",
+        "conventional-commits",
+        "devops"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "pr-storyteller",
+      "source": "./plugins/devops/pr-storyteller",
+      "description": "Generate PR title, body, and test plan from commits and diff vs base branch.",
+      "version": "0.1.0",
+      "category": "devops",
+      "keywords": [
+        "git",
+        "pr",
+        "pull-request",
+        "devops"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "test-gap",
+      "source": "./plugins/testing/test-gap",
+      "description": "Identify lines in your diff lacking test coverage from Cobertura, lcov, or coverage.json formats.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "coverage"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "deps-doctor",
+      "source": "./plugins/security/deps-doctor",
+      "description": "Multi-ecosystem dependency audit covering npm, pip, cargo, and go in one unified report.",
+      "version": "0.1.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "dependencies",
+        "audit"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "env-lint",
+      "source": "./plugins/testing/env-lint",
+      "description": "Compare .env vs .env.example key parity without ever printing values.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": [
+        "env",
+        "config",
+        "testing"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "secret-guard",
+      "source": "./plugins/security/secret-guard",
+      "description": "Pre-commit secret scanner using pattern and entropy detection with redacted output.",
+      "version": "0.1.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "secrets",
+        "pre-commit"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "standup-gen",
+      "source": "./plugins/productivity/standup-gen",
+      "description": "Generate daily standup notes from git activity across one or many repositories.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "productivity",
+        "git",
+        "standup"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "todo-harvest",
+      "source": "./plugins/testing/todo-harvest",
+      "description": "Scan codebase for TODO, FIXME, and HACK comments with git blame author and age.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "todo",
+        "code-quality"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "flaky-detector",
+      "source": "./plugins/testing/flaky-detector",
+      "description": "Run a test command N times and report per-test flakiness percentage.",
+      "version": "0.1.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "flaky",
+        "reliability"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
+    },
+    {
+      "name": "changelog-forge",
+      "source": "./plugins/productivity/changelog-forge",
+      "description": "Convert conventional commits into a CHANGELOG section with semver bump suggestion.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "productivity",
+        "changelog",
+        "semver"
+      ],
+      "author": {
+        "name": "Mehmet Turac",
+        "url": "https://github.com/mturac"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | ₿   | [Crypto & Web3](#crypto--web3)                     |      26 |
 | 💾  | [Database](#database)                              |      26 |
 | 🎨  | [Design](#design)                                  |       7 |
-| 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      36 |
+| 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      38 |
 | 📚  | [Examples & Templates](#examples--templates)       |       5 |
 | 🧩  | [MCP Servers](#mcp-servers)                        |      10 |
 | 📦  | [Packages](#packages)                              |       5 |
 | ⚡  | [Performance](#performance)                        |      25 |
-| ✅  | [Productivity](#productivity)                      |      19 |
+| ✅  | [Productivity](#productivity)                      |      21 |
 | 🎁  | [SaaS Skill Packs](#saas-skill-packs)              |     106 |
-| 🔐  | [Security](#security)                              |      26 |
+| 🔐  | [Security](#security)                              |      28 |
 | ✨  | [Skill Enhancers](#skill-enhancers)                |       8 |
-| 🧪  | [Testing](#testing)                                |      26 |
+| 🧪  | [Testing](#testing)                                |      30 |
 
 ### AI & Machine Learning
 
@@ -364,7 +364,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### DevOps & Infrastructure
 
-🔧 **36 plugins** · category slug: `devops`
+🔧 **38 plugins** · category slug: `devops`
 
 | Plugin                             | Description                                                                                                                                 |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -373,6 +373,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `backup-strategy-implementor`      | Implement backup strategies for databases and applications                                                                                  |
 | `ci-cd-pipeline-builder`           | Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more                                                                      |
 | `cloud-cost-optimizer`             | Optimize cloud costs and generate cost reports                                                                                              |
+| `commit-narrator`                  | Generate semantic commit messages from staged diffs, including the why behind changes. Deterministic Python helper (stdlib only) wrapped…   |
 | `compliance-checker`               | Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)                                                                                      |
 | `container-registry-manager`       | Manage container registries (ECR, GCR, Harbor)                                                                                              |
 | `container-security-scanner`       | Scan containers for vulnerabilities using Trivy, Snyk, and other security tools                                                             |
@@ -399,6 +400,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `mattyp-changelog`                 | Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release…    |
 | `monitoring-stack-deployer`        | Deploy monitoring stacks (Prometheus, Grafana, Datadog)                                                                                     |
 | `network-policy-manager`           | Manage Kubernetes network policies and firewall rules                                                                                       |
+| `pr-storyteller`                   | Generate PR title, body, and test plan from commits and diff vs base branch.                                                                |
 | `secrets-manager-integrator`       | Integrate with secrets managers (Vault, AWS Secrets Manager, etc)                                                                           |
 | `service-mesh-configurator`        | Configure service mesh (Istio, Linkerd) for microservices                                                                                   |
 | `sugar`                            | Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow…    |
@@ -490,7 +492,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### Productivity
 
-✅ **19 plugins** · category slug: `productivity`
+✅ **21 plugins** · category slug: `productivity`
 
 | Plugin                                     | Description                                                                                                                                 |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -501,6 +503,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `agent-context-manager`                    | Automatically detects and loads AGENTS.md files to provide agent-specific instructions                                                      |
 | `ai-commit-gen`                            | AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly                             |
 | `box-cloud-filesystem`                     | Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage…  |
+| `changelog-forge`                          | Convert conventional commits into a CHANGELOG section with semver bump suggestion.                                                          |
 | `hyperfocus`                               | ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual…      |
 | `navigating-github`                        | First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on…  |
 | `neurodivergent-visual-org`                | Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes |
@@ -508,6 +511,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `plane`                                    | Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle…  |
 | `pm-ai-partner`                            | 12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers                                                   |
 | `prettier-markdown-hook`                   | Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions          |
+| `standup-gen`                              | Generate daily standup notes from git activity across one or many repositories.                                                             |
 | `travel-assistant`                         | Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete…  |
 | `vibe-guide`                               | Non-technical progress summaries for Claude Code work (hides diffs/log noise).                                                              |
 | `wondelai-design-sprint`                   | Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured…           |
@@ -633,7 +637,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### Security
 
-🔐 **26 plugins** · category slug: `security`
+🔐 **28 plugins** · category slug: `security`
 
 | Plugin                             | Description                                                                                                                              |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
@@ -644,6 +648,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `csrf-protection-validator`        | Validate CSRF protection                                                                                                                 |
 | `data-privacy-scanner`             | Scan for data privacy issues                                                                                                             |
 | `dependency-checker`               | Check dependencies for known vulnerabilities, outdated packages, and license compliance                                                  |
+| `deps-doctor`                      | Multi-ecosystem dependency audit covering npm, pip, cargo, and go in one unified report.                                                 |
 | `encryption-tool`                  | Encrypt and decrypt data with various algorithms                                                                                         |
 | `gdpr-compliance-scanner`          | Scan for GDPR compliance issues                                                                                                          |
 | `hipaa-compliance-checker`         | Check HIPAA compliance                                                                                                                   |
@@ -651,6 +656,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `owasp-compliance-checker`         | Check OWASP Top 10 compliance                                                                                                            |
 | `pci-dss-validator`                | Validate PCI DSS compliance                                                                                                              |
 | `penetration-tester`               | Automated penetration testing for web applications with OWASP Top 10 coverage                                                            |
+| `secret-guard`                     | Pre-commit secret scanner using pattern and entropy detection with redacted output.                                                      |
 | `secret-scanner`                   | Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials                                                        |
 | `security-audit-reporter`          | Generate comprehensive security audit reports                                                                                            |
 | `security-headers-analyzer`        | Analyze HTTP security headers                                                                                                            |
@@ -685,7 +691,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### Testing
 
-🧪 **26 plugins** · category slug: `testing`
+🧪 **30 plugins** · category slug: `testing`
 
 | Plugin                         | Description                                                                                                                               |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -698,6 +704,8 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `contract-test-validator`      | API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification                                             |
 | `database-test-manager`        | Database testing utilities with test data setup, transaction rollback, and schema validation                                              |
 | `e2e-test-framework`           | End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing                                               |
+| `env-lint`                     | Compare .env vs .env.example key parity without ever printing values.                                                                     |
+| `flaky-detector`               | Run a test command N times and report per-test flakiness percentage.                                                                      |
 | `integration-test-runner`      | Run and manage integration test suites with environment setup, database seeding, and cleanup                                              |
 | `load-balancer-tester`         | Test load balancing strategies with traffic distribution validation and failover testing                                                  |
 | `mobile-app-tester`            | Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps                                                       |
@@ -711,8 +719,10 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `test-data-generator`          | Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing                              |
 | `test-doubles-generator`       | Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks                                            |
 | `test-environment-manager`     | Manage test environments with Docker Compose, Testcontainers, and environment isolation                                                   |
+| `test-gap`                     | Identify lines in your diff lacking test coverage from Cobertura, lcov, or coverage.json formats.                                         |
 | `test-orchestrator`            | Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection                                        |
 | `test-report-generator`        | Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats                                               |
+| `todo-harvest`                 | Scan codebase for TODO, FIXME, and HACK comments with git blame author and age.                                                           |
 | `unit-test-generator`          | Automatically generate comprehensive unit tests from source code with multiple testing framework support                                  |
 | `visual-regression-tester`     | Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes                                                       |
 

--- a/plugins/devops/commit-narrator/.claude-plugin/plugin.json
+++ b/plugins/devops/commit-narrator/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "commit-narrator",
+  "version": "0.1.0",
+  "description": "Generate conventional commit messages from staged diffs.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-commit-narrator",
+  "license": "MIT",
+  "keywords": [
+    "git",
+    "commit",
+    "conventional",
+    "devops",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-commit-narrator"
+}

--- a/plugins/devops/commit-narrator/LICENSE
+++ b/plugins/devops/commit-narrator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/devops/commit-narrator/README.md
+++ b/plugins/devops/commit-narrator/README.md
@@ -1,0 +1,94 @@
+![hero](./assets/hero.svg)
+
+# commit-narrator
+
+**Write commit messages that say *why*, not just *what*.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 6 passing](https://img.shields.io/badge/tests-6%20passing-success.svg)](./tests)
+
+> **TL;DR:** `git add -p && /commit-narrator` → a conventional-commit message with a real rationale, not "fix stuff".
+
+## Why this exists
+
+Most "AI commit message" tools paraphrase the diff back at you. That's noise. A good commit message answers *why* the change was made, grounded in what the diff actually proves. This plugin runs a deterministic Python helper to classify the change and assemble the skeleton, and then leaves Claude to fill in the rationale from the diff itself — no LLM guesses about your repo's intent.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-commit-narrator ~/.claude/plugins/commit-narrator
+```
+
+Restart Claude Code; the slash command `/commit-narrator` appears.
+
+## Quick start
+
+```sh
+git add -p
+/commit-narrator
+```
+
+Or invoke the helper directly:
+
+```sh
+git diff --staged | python3 scripts/narrate.py --diff -
+python3 scripts/narrate.py --format json
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--diff PATH` / `-` | `git diff --cached` | Read diff from path or stdin |
+| `--format` | `text` | `text` or `json` |
+
+## Example output
+
+```text
+feat(api): add login throttle
+
+Changed files:
+- src/api/auth.py
+- tests/test_auth.py
+
+Throttle prevents brute-force enumeration on the /login endpoint by
+rate-limiting on (ip, email) — the abuse pattern surfaced in the
+2026-Q2 incident review.
+```
+
+## How it works
+
+1. Reads the staged diff (or a path you give it).
+2. Classifies the change type — `feat / fix / refactor / docs / test / chore / perf` — using path patterns and patch-hunk heuristics.
+3. Derives a scope from the most-touched top-level directory.
+4. Emits a conventional-commit subject plus a body listing changed files and a placeholder `WHY` line.
+5. Claude reads the helper's output and the diff, then replaces the placeholder with rationale that the diff actually supports.
+
+## Limitations
+
+- Heuristics are intentionally conservative. You'll get `chore` for messy mixed diffs — that's a signal to split the commit, not a bug.
+- The helper itself never calls a network service; only the slash command's Claude pass adds language.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/devops/commit-narrator/commands/commit-narrator.md
+++ b/plugins/devops/commit-narrator/commands/commit-narrator.md
@@ -1,0 +1,17 @@
+---
+name: commit-narrator
+description: Generate a conventional commit message from the staged diff
+allowed-tools: Bash
+---
+
+Role: act as the commit-message author responsible only for producing one conventional commit message for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+git diff --staged --binary | python3 scripts/narrate.py --diff -
+```
+
+The helper accepts an empty diff and returns no text. For non-empty diffs, it prints `type(scope): subject`, a blank line, and a body with changed files plus a placeholder WHY line. Valid types are `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, and `perf`.
+
+Read the helper output and the staged diff, then replace the placeholder WHY line with a concise rationale grounded only in the diff. Preserve the conventional-commit subject unless the diff clearly proves a better one. Print only the final commit message.

--- a/plugins/devops/commit-narrator/package.json
+++ b/plugins/devops/commit-narrator/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@intentsolutionsio/commit-narrator",
+  "version": "0.1.0",
+  "description": "Generate conventional commit messages from staged diffs.",
+  "keywords": [
+    "git",
+    "commit",
+    "conventional",
+    "devops",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/devops/commit-narrator"
+  },
+  "homepage": "https://tonsofskills.com/plugins/commit-narrator",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install commit-narrator\\\\n  or /plugin install commit-narrator@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/devops/commit-narrator/scripts/narrate.py
+++ b/plugins/devops/commit-narrator/scripts/narrate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate a conventional commit message from a git diff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+TYPES = ("feat", "fix", "refactor", "docs", "test", "chore", "perf")
+
+
+def run_git_diff() -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--staged", "--binary"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def read_diff(source: str | None) -> str:
+    if source == "-":
+        return sys.stdin.read()
+    return run_git_diff()
+
+
+_DIFF_GIT_LINE = re.compile(
+    r'^diff --git (?:"a/(?P<aq>(?:[^"\\]|\\.)*)"|a/(?P<ap>\S+)) (?:"b/(?P<bq>(?:[^"\\]|\\.)*)"|b/(?P<bp>.+))$'
+)
+
+
+def changed_files(diff: str) -> list[str]:
+    """Collect unique paths from a unified diff. Two sources, in order:
+    - `+++ b/<path>` (tab-separated from any trailing timestamp) — preferred, robust to spaces.
+    - `diff --git a/X b/Y` header — supports both unquoted and "quoted/with spaces" forms.
+    """
+    files: list[str] = []
+    seen: set[str] = set()
+
+    def _add(path: str) -> None:
+        if path and path != "/dev/null" and path not in seen:
+            seen.add(path)
+            files.append(path)
+
+    saw_plusplus = False
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            saw_plusplus = True
+            _add(line[len("+++ b/"):].split("\t", 1)[0].rstrip())
+        elif line.startswith("Binary files "):
+            match = re.search(r" b/(.+?) differ$", line)
+            if match:
+                _add(match.group(1))
+
+    if saw_plusplus:
+        return files
+
+    # Fallback for compact diffs that omit the +++/--- headers
+    for line in diff.splitlines():
+        m = _DIFF_GIT_LINE.match(line)
+        if m:
+            _add(m.group("bq") or m.group("bp") or "")
+    return files
+
+
+def classify(files: list[str], diff: str) -> str:
+    lower_files = [path.lower() for path in files]
+    lower_diff = diff.lower()
+    if any("/test" in f or f.startswith("test") or f.endswith("_test.py") or "spec." in f for f in lower_files):
+        return "test"
+    if any(f.startswith(("docs/", "doc/")) or Path(f).name.lower() in {"readme.md", "license"} for f in lower_files):
+        return "docs"
+    if any(word in lower_diff for word in ("performance", "optimize", "optimise", "benchmark", "cache hit")):
+        return "perf"
+    if any(word in lower_diff for word in ("bug", "fix", "error", "exception", "regression", "crash")):
+        return "fix"
+    if any(word in lower_diff for word in ("refactor", "rename", "extract", "cleanup")):
+        return "refactor"
+    if any(line.startswith("new file mode") for line in diff.splitlines()) or any(
+        f.startswith(("src/", "app/", "commands/", "scripts/")) for f in lower_files
+    ):
+        return "feat"
+    return "chore"
+
+
+def infer_scope(files: list[str]) -> str:
+    if not files:
+        return ""
+    first = files[0]
+    parts = first.split("/")
+    if len(parts) > 1:
+        return re.sub(r"[^a-z0-9-]+", "-", parts[0].lower()).strip("-") or "repo"
+    stem = Path(first).stem.lower()
+    return re.sub(r"[^a-z0-9-]+", "-", stem).strip("-") or "repo"
+
+
+def subject_for(change_type: str, scope: str, files: list[str]) -> str:
+    target = scope or "repository"
+    if change_type == "docs":
+        return f"update {target} documentation"
+    if change_type == "test":
+        return f"add {target} coverage"
+    if change_type == "fix":
+        return f"fix {target} behavior"
+    if change_type == "refactor":
+        return f"refactor {target} structure"
+    if change_type == "perf":
+        return f"improve {target} performance"
+    if change_type == "feat":
+        action = "add" if any("new file mode" in line for line in "\n".join(files).splitlines()) else "update"
+        return f"{action} {target} support"
+    return f"update {target} maintenance"
+
+
+def narrate(diff: str) -> dict[str, object]:
+    files = changed_files(diff)
+    if not diff.strip() or not files:
+        return {"type": "", "scope": "", "subject": "", "body": "", "files": []}
+    change_type = classify(files, diff)
+    scope = infer_scope(files)
+    subject = subject_for(change_type, scope, files)
+    listed = "\n".join(f"- {path}" for path in files[:5])
+    body = f"Changed files:\n{listed}\n\nWHY: Explain why this change is needed based on the diff."
+    return {"type": change_type, "scope": scope, "subject": subject, "body": body, "files": files}
+
+
+def render_text(result: dict[str, object]) -> str:
+    if not result["type"]:
+        return ""
+    return f"{result['type']}({result['scope']}): {result['subject']}\n\n{result['body']}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff", default=None, help="Diff source. Use '-' to read from stdin; omit to read staged git diff.")
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    args = parser.parse_args(argv)
+
+    result = narrate(read_diff(args.diff))
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        text = render_text(result)
+        if text:
+            print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/devops/pr-storyteller/.claude-plugin/plugin.json
+++ b/plugins/devops/pr-storyteller/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "pr-storyteller",
+  "version": "0.1.0",
+  "description": "Generate PR story data from commits and diffs.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-pr-storyteller",
+  "license": "MIT",
+  "keywords": [
+    "git",
+    "pr",
+    "pull-request",
+    "devops",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-pr-storyteller"
+}

--- a/plugins/devops/pr-storyteller/LICENSE
+++ b/plugins/devops/pr-storyteller/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/devops/pr-storyteller/README.md
+++ b/plugins/devops/pr-storyteller/README.md
@@ -1,0 +1,111 @@
+![hero](./assets/hero.svg)
+
+# pr-storyteller
+
+**Stop writing PR descriptions from a blank cursor. Generate a real one in seconds.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 6 passing](https://img.shields.io/badge/tests-6%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/pr-storyteller` → PR title + summary + test plan, drafted from your actual commits and diff.
+
+## Why this exists
+
+PR descriptions decay the moment they leave the author's keyboard. The reviewer skims, the author forgets to update later, and three months in nobody knows *why* the PR landed. `pr-storyteller` gives you a draft grounded in the commit history and the diff against your base branch — Claude then writes the prose, you tweak, you ship.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-pr-storyteller ~/.claude/plugins/pr-storyteller
+```
+
+Restart Claude Code; the slash command `/pr-storyteller` appears.
+
+## Quick start
+
+```sh
+/pr-storyteller
+```
+
+Or invoke the helper directly:
+
+```sh
+python3 scripts/story.py
+python3 scripts/story.py --base develop
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--base` | `main` (falls back to `master`) | Base branch to diff against |
+
+## Example output (JSON)
+
+```json
+{
+  "commits": [
+    {"hash": "abc1234", "subject": "feat(auth): rotate refresh tokens"},
+    {"hash": "def5678", "subject": "test(auth): cover stale-token replay"}
+  ],
+  "files_changed": [
+    {"path": "src/auth/refresh.py", "additions": 84, "deletions": 12},
+    {"path": "tests/test_refresh.py", "additions": 41, "deletions": 0}
+  ],
+  "suggested_title": "feat(auth): rotate refresh tokens"
+}
+```
+
+Claude turns that into:
+
+```markdown
+### Summary
+- Rotate the refresh-token secret on every successful refresh
+- Reject stale refresh tokens that have already been redeemed
+
+### Changes
+- `src/auth/refresh.py` — token rotation + replay rejection
+- `tests/test_refresh.py` — coverage for the replay path
+
+### Test plan
+- [ ] Successful login → both access and refresh tokens issued
+- [ ] Reuse a refresh token → 401 + token family invalidated
+- [ ] Clock skew tolerance still passes
+```
+
+## How it works
+
+1. Reads `git log <base>..HEAD` for commits (hash + subject).
+2. Reads `git diff --stat <base>..HEAD` for changed files + additions/deletions.
+3. Suggests a title from the latest commit subject.
+4. Claude composes a real PR body from that scaffold.
+
+## Limitations
+
+- Doesn't fetch from the remote — make sure your local `<base>` is current.
+- Handles empty diffs and non-git directories gracefully (returns empty JSON).
+- Binary files surface via `git diff --numstat` and are reported with `-` for additions/deletions.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/devops/pr-storyteller/commands/pr-storyteller.md
+++ b/plugins/devops/pr-storyteller/commands/pr-storyteller.md
@@ -1,0 +1,21 @@
+---
+name: pr-storyteller
+description: Generate a PR title, body, and test plan from commits and diff
+allowed-tools: Bash
+---
+
+Role: act as the PR description author responsible only for producing a PR title and markdown body for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+python3 scripts/story.py --base main
+```
+
+If the result has no commits and no changed files, rerun with:
+
+```bash
+python3 scripts/story.py --base master
+```
+
+The helper returns JSON with `commits`, `files_changed`, and `suggested_title`. Use only that JSON plus local diff evidence. Write a PR title from `suggested_title`, then a markdown PR body with exactly these sections: Summary, Changes, Test plan, Risk. Print only the PR title and markdown body.

--- a/plugins/devops/pr-storyteller/package.json
+++ b/plugins/devops/pr-storyteller/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@intentsolutionsio/pr-storyteller",
+  "version": "0.1.0",
+  "description": "Generate PR story data from commits and diffs.",
+  "keywords": [
+    "git",
+    "pr",
+    "pull-request",
+    "devops",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/devops/pr-storyteller"
+  },
+  "homepage": "https://tonsofskills.com/plugins/pr-storyteller",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install pr-storyteller\\\\n  or /plugin install pr-storyteller@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/devops/pr-storyteller/scripts/story.py
+++ b/plugins/devops/pr-storyteller/scripts/story.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Collect PR story data from local git history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+
+def git(args: list[str]) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return 1, ""
+    return proc.returncode, proc.stdout
+
+
+def is_repo() -> bool:
+    code, out = git(["rev-parse", "--is-inside-work-tree"])
+    return code == 0 and out.strip() == "true"
+
+
+def ref_exists(ref: str) -> bool:
+    code, _ = git(["rev-parse", "--verify", "--quiet", ref])
+    return code == 0
+
+
+def choose_base(base: str) -> str | None:
+    if ref_exists(base):
+        return base
+    if base == "main" and ref_exists("master"):
+        return "master"
+    return None
+
+
+def commits_since(base: str | None) -> list[dict[str, str]]:
+    if base:
+        code, out = git(["log", "--pretty=format:%h%x00%s", f"{base}..HEAD"])
+    else:
+        code, out = git(["log", "--pretty=format:%h%x00%s", "-n", "20"])
+    if code != 0:
+        return []
+    commits = []
+    for line in out.splitlines():
+        if "\0" in line:
+            short, subject = line.split("\0", 1)
+            commits.append({"hash": short, "subject": subject})
+    return commits
+
+
+def changed_files(base: str | None) -> list[dict[str, int | str]]:
+    args = ["diff", "--numstat", f"{base}...HEAD"] if base else ["diff", "--numstat", "HEAD"]
+    code, out = git(args)
+    if code != 0:
+        code, out = git(["diff", "--numstat"])
+    if code != 0:
+        return []
+    files = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        additions = 0 if parts[0] == "-" else int(parts[0])
+        deletions = 0 if parts[1] == "-" else int(parts[1])
+        files.append({"path": parts[2], "additions": additions, "deletions": deletions})
+    return files
+
+
+def story(base: str) -> dict[str, object]:
+    if not is_repo():
+        return {"commits": [], "files_changed": [], "suggested_title": ""}
+    selected = choose_base(base)
+    commits = commits_since(selected)
+    files = changed_files(selected)
+    title = commits[0]["subject"] if commits else "Update changes"
+    return {"commits": commits, "files_changed": files, "suggested_title": title}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="main", help="Base branch or ref. Defaults to main.")
+    args = parser.parse_args(argv)
+    print(json.dumps(story(args.base), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/productivity/changelog-forge/.claude-plugin/plugin.json
+++ b/plugins/productivity/changelog-forge/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "changelog-forge",
+  "version": "0.1.0",
+  "description": "Group conventional commits since last tag into a CHANGELOG section with semver bump suggestion.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-changelog-forge",
+  "license": "MIT",
+  "keywords": [
+    "productivity",
+    "changelog",
+    "semver",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-changelog-forge"
+}

--- a/plugins/productivity/changelog-forge/LICENSE
+++ b/plugins/productivity/changelog-forge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/productivity/changelog-forge/README.md
+++ b/plugins/productivity/changelog-forge/README.md
@@ -1,0 +1,122 @@
+![hero](./assets/hero.svg)
+
+# changelog-forge
+
+**Turn your conventional commits into a real CHANGELOG entry. Plus a semver bump suggestion.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 13 passing](https://img.shields.io/badge/tests-13%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/changelog-forge` → grouped CHANGELOG section + suggested `major | minor | patch`, derived from your commit history since the last tag.
+
+## Why this exists
+
+CHANGELOGs that are written *during* a release are always wrong. The person writing them has forgotten half the work, and the half they remember they describe inaccurately. `changelog-forge` reads the commits since the last tag, groups them by conventional-commit type, surfaces every `BREAKING CHANGE`, and suggests the right semver bump — so the changelog tracks ground truth.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-changelog-forge ~/.claude/plugins/changelog-forge
+```
+
+Restart Claude Code; the slash command `/changelog-forge` appears.
+
+## Quick start
+
+```sh
+/changelog-forge
+```
+
+Or directly:
+
+```sh
+python3 scripts/forge.py --format md
+python3 scripts/forge.py --from v1.2.0 --to HEAD --format json
+python3 scripts/forge.py --write                  # prepend (idempotently) to CHANGELOG.md
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--cwd` | cwd | Repo path |
+| `--from` | last tag | Base ref/tag |
+| `--to` | `HEAD` | End ref |
+| `--format` | `md` | `md` or `json` |
+| `--write` | off | Prepend (idempotently) to `CHANGELOG.md`; correctly inserts AFTER any leading `# Changelog` title |
+| `--changelog` | `CHANGELOG.md` | Target file |
+
+## Conventional-commit reference
+
+Headers parsed as `<type>(<scope>)!: <subject>`. Recognised types:
+
+`feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`.
+
+Anything else falls into an `other` bucket.
+
+Breaking changes are detected when:
+
+- the header has `!` before `:` (e.g. `feat!: drop /v0`), or
+- the body contains `BREAKING CHANGE: …`.
+
+## Semver bump heuristic
+
+| Trigger | Bump |
+|---|---|
+| any breaking | `major` |
+| any `feat` | `minor` |
+| any `fix` / `perf` | `patch` |
+| everything else | `patch` (effectively a no-op) |
+
+When a base tag is present (e.g. `v0.4.2`), the JSON output also returns `suggested_version`.
+
+## Example output (markdown)
+
+```
+## [Unreleased] - 2026-05-16
+
+### Features
+- **api**: paginate search endpoint (a1b2c3d)
+
+### Bug Fixes
+- handle null user in cookie middleware (e4f5g6h)
+
+### Performance
+- cache token-bucket counters (12ab34c)
+
+_Suggested bump: **minor**_
+_Suggested version: **0.5.0**_
+```
+
+## Idempotency
+
+Running `--write` twice with the same input produces the same file — both the diff and the SHA are stable. There's a dedicated test (`test_write_changelog_idempotent`) that runs the writer twice and asserts byte-for-byte equality.
+
+## Limitations
+
+- Flat conventional-commit grammar — multi-paragraph footers (`Refs:` blocks etc.) aren't merged.
+- `--write` only manages the `## [Unreleased]` block. Promoting it to a versioned section at release time is a manual step.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/productivity/changelog-forge/commands/changelog-forge.md
+++ b/plugins/productivity/changelog-forge/commands/changelog-forge.md
@@ -1,0 +1,17 @@
+---
+name: changelog-forge
+description: Group conventional commits since last tag into a CHANGELOG entry
+allowed-tools: Bash
+---
+
+Role: act as a release scribe. Turn conventional commits into a clean `## [Unreleased]` block plus a semver-bump recommendation.
+
+Run the helper:
+
+```bash
+python3 scripts/forge.py --format md
+```
+
+Useful flags: `--from v1.2.0`, `--to HEAD`, `--write` (prepend to `CHANGELOG.md`, idempotent), `--format json`.
+
+The helper groups commits by type (feat / fix / perf / refactor / docs / test / build / ci / chore / revert), surfaces `BREAKING CHANGE` markers, and suggests `major | minor | patch`. Read the output, then briefly justify the bump (or push back if the heuristic missed nuance). Only run `--write` when the user explicitly asks for it.

--- a/plugins/productivity/changelog-forge/package.json
+++ b/plugins/productivity/changelog-forge/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/changelog-forge",
+  "version": "0.1.0",
+  "description": "Group conventional commits since last tag into a CHANGELOG section with semver bump suggestion.",
+  "keywords": [
+    "productivity",
+    "changelog",
+    "semver",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/productivity/changelog-forge"
+  },
+  "homepage": "https://tonsofskills.com/plugins/changelog-forge",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install changelog-forge\\\\n  or /plugin install changelog-forge@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/productivity/changelog-forge/scripts/forge.py
+++ b/plugins/productivity/changelog-forge/scripts/forge.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Group conventional commits since last tag into a CHANGELOG section."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+CONVENTIONAL_TYPES = (
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "docs",
+    "test",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+)
+
+_HEADER = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!?):\s*(?P<subject>.+)$"
+)
+
+# Use RS (0x1e) record separator and US (0x1f) field separator
+_FMT = "%H%x1f%s%x1f%b%x1e"
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _last_tag(cwd: str) -> str | None:
+    out = _run(["git", "describe", "--tags", "--abbrev=0"], cwd).strip()
+    return out or None
+
+
+def _git_log(cwd: str, frm: str | None, to: str) -> str:
+    rng = f"{frm}..{to}" if frm else to
+    return _run(["git", "log", rng, f"--pretty=format:{_FMT}"], cwd)
+
+
+def _split_log(raw: str) -> list[tuple[str, str, str]]:
+    items: list[tuple[str, str, str]] = []
+    for record in raw.split("\x1e"):
+        record = record.strip("\n\r")
+        if not record:
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 3:
+            parts += [""] * (3 - len(parts))
+        h, subj, body = parts[0].strip(), parts[1], parts[2]
+        if h:
+            items.append((h, subj, body))
+    return items
+
+
+def parse_commit(hash_: str, subject: str, body: str) -> dict:
+    m = _HEADER.match(subject)
+    if not m:
+        return {"hash": hash_, "type": "other", "scope": None, "breaking": False,
+                "subject": subject, "body": body}
+    typ = m.group("type")
+    scope = m.group("scope")
+    breaking = bool(m.group("bang")) or ("BREAKING CHANGE" in body)
+    return {
+        "hash": hash_,
+        "type": typ if typ in CONVENTIONAL_TYPES else "other",
+        "scope": scope,
+        "breaking": breaking,
+        "subject": m.group("subject").strip(),
+        "body": body,
+    }
+
+
+def group_commits(commits: Iterable[dict]) -> dict[str, list[dict]]:
+    sections: dict[str, list[dict]] = {t: [] for t in CONVENTIONAL_TYPES}
+    sections["other"] = []
+    for c in commits:
+        sections.setdefault(c["type"], []).append(c)
+    return sections
+
+
+def suggested_bump(commits: list[dict]) -> str:
+    if any(c["breaking"] for c in commits):
+        return "major"
+    if any(c["type"] == "feat" for c in commits):
+        return "minor"
+    if any(c["type"] in ("fix", "perf") for c in commits):
+        return "patch"
+    return "patch"
+
+
+def bump_version(version: str, bump: str) -> str:
+    v = version.lstrip("v")
+    parts = v.split(".")
+    while len(parts) < 3:
+        parts.append("0")
+    try:
+        major, minor, patch = (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return v
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+_PRETTY_TITLES = {
+    "feat": "Features",
+    "fix": "Bug Fixes",
+    "perf": "Performance",
+    "refactor": "Refactor",
+    "docs": "Docs",
+    "test": "Tests",
+    "build": "Build",
+    "ci": "CI",
+    "chore": "Chores",
+    "revert": "Reverts",
+    "other": "Other",
+}
+
+_ORDER = ("feat", "fix", "perf", "refactor", "docs", "test", "build", "ci", "chore", "revert", "other")
+
+
+def render_markdown(report: dict, today: dt.date | None = None) -> str:
+    today = today or dt.date.today()
+    out = [f"## [Unreleased] - {today.isoformat()}", ""]
+    for typ in _ORDER:
+        entries = report["sections"].get(typ, [])
+        if not entries:
+            continue
+        out.append(f"### {_PRETTY_TITLES[typ]}")
+        for c in entries:
+            scope = f"**{c['scope']}**: " if c["scope"] else ""
+            bang = " ⚠ BREAKING" if c["breaking"] else ""
+            out.append(f"- {scope}{c['subject']}{bang} ({c['hash'][:7]})")
+        out.append("")
+    out.append(f"_Suggested bump: **{report['suggested_bump']}**_")
+    if report.get("suggested_version"):
+        out.append(f"_Suggested version: **{report['suggested_version']}**_")
+    out.append("")
+    return "\n".join(out)
+
+
+_UNRELEASED_BLOCK = re.compile(
+    r"(?ms)^## \[Unreleased\][^\n]*\n.*?(?=^## \[|\Z)"
+)
+
+
+def write_changelog(path: str, section_md: str) -> None:
+    section = section_md.rstrip() + "\n\n"
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            existing = f.read()
+        if _UNRELEASED_BLOCK.search(existing):
+            new = _UNRELEASED_BLOCK.sub(section, existing, count=1)
+        else:
+            # Insert the new section AFTER any leading `# Title` block, not before it.
+            stripped = existing.lstrip("\n")
+            if stripped.startswith("# "):
+                head_end = stripped.find("\n\n")
+                if head_end == -1:
+                    head_end = len(stripped)
+                head = stripped[: head_end + 2] if head_end < len(stripped) else stripped + "\n\n"
+                tail = stripped[head_end + 2 :] if head_end < len(stripped) else ""
+                new = head + section + tail
+            else:
+                new = section + existing
+    else:
+        new = "# Changelog\n\n" + section
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new)
+
+
+def build_report(cwd: str, frm: str | None, to: str) -> dict:
+    raw = _git_log(cwd, frm, to)
+    parsed = [parse_commit(*c) for c in _split_log(raw)]
+    sections = group_commits(parsed)
+    bump = suggested_bump(parsed)
+    suggested_version = None
+    base_tag = frm or _last_tag(cwd)
+    if base_tag:
+        suggested_version = bump_version(base_tag, bump)
+    return {
+        "from": frm or base_tag,
+        "to": to,
+        "commits": parsed,
+        "sections": sections,
+        "breaking_changes": [
+            {"commit": c["hash"], "note": c["subject"]} for c in parsed if c["breaking"]
+        ],
+        "suggested_bump": bump,
+        "suggested_version": suggested_version,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Generate a CHANGELOG section from conventional commits.")
+    p.add_argument("--cwd", default=os.getcwd())
+    p.add_argument("--from", dest="frm", default=None, help="Base ref or tag (default: last tag).")
+    p.add_argument("--to", default="HEAD")
+    p.add_argument("--format", choices=["json", "md"], default="md")
+    p.add_argument("--write", action="store_true", help="Prepend (idempotently) to CHANGELOG.md.")
+    p.add_argument("--changelog", default="CHANGELOG.md")
+    args = p.parse_args(argv)
+
+    frm = args.frm or _last_tag(args.cwd)
+    report = build_report(args.cwd, frm, args.to)
+    md = render_markdown(report)
+
+    if args.write:
+        write_changelog(os.path.join(args.cwd, args.changelog), md)
+
+    if args.format == "md":
+        sys.stdout.write(md)
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/productivity/standup-gen/.claude-plugin/plugin.json
+++ b/plugins/productivity/standup-gen/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "standup-gen",
+  "version": "0.1.0",
+  "description": "Generate daily standup notes from git activity across one or many repos.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-standup-gen",
+  "license": "MIT",
+  "keywords": [
+    "productivity",
+    "git",
+    "standup",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-standup-gen"
+}

--- a/plugins/productivity/standup-gen/LICENSE
+++ b/plugins/productivity/standup-gen/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/productivity/standup-gen/README.md
+++ b/plugins/productivity/standup-gen/README.md
@@ -1,0 +1,103 @@
+![hero](./assets/hero.svg)
+
+# standup-gen
+
+**Skip the "what did I do yesterday?" tax. Generate the answer from git.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 8 passing](https://img.shields.io/badge/tests-8%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/standup-gen` → markdown `Yesterday / Today / Blockers` block, pre-filled from your commits across every repo you care about.
+
+## Why this exists
+
+Standup writes itself if you only let it. Most engineers spend 5–10 minutes every morning scrolling commits to remember what they shipped — across two or three repos, across a long weekend, across timezones. `standup-gen` queries each repo's `git log` since the last business day, attributes commits to you (or the team), and hands you a clean draft. Claude fills in *Today (planned)* and *Blockers* if context allows.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-standup-gen ~/.claude/plugins/standup-gen
+```
+
+Restart Claude Code; the slash command `/standup-gen` appears.
+
+## Quick start
+
+```sh
+/standup-gen
+```
+
+Or directly:
+
+```sh
+python3 scripts/standup.py --format md
+python3 scripts/standup.py --repos /work/api,/work/web --format md
+python3 scripts/standup.py --since 2026-05-13 --author all --format json
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--repos` | cwd | Comma-separated repo paths |
+| `--since` | last business day | ISO date or `yesterday` |
+| `--until` | today (00:00, exclusive) | ISO date upper-bound, or `none` to drop the bound |
+| `--author` | `git config user.email` | Email filter, or `all` |
+| `--format` | `json` | `json` or `md` |
+
+The default `--until=today` is intentional — without it, "yesterday" silently leaks today's commits into the standup.
+
+## Example output
+
+```markdown
+# Standup — 2026-05-16
+
+## Yesterday
+### api
+- 2026-05-15 `4c3d39e` feat: add login throttle
+- 2026-05-15 `8d424a0` test: cover replay path
+### web
+- 2026-05-15 `93a8826` fix: navbar overlap on small screens
+
+## Today (planned)
+- TODO
+
+## Blockers
+- TODO
+```
+
+## How it works
+
+1. For each repo, runs `git log --since=<date> --until=<date>` with your email as `--author`.
+2. Groups commits by date and renders the markdown skeleton.
+3. Claude can then propose `Today (planned)` items from in-flight files, and flag obvious blockers from commit messages (`WIP:`, `revert`, etc.).
+
+## Limitations
+
+- Only counts authored commits — co-authored trailers aren't matched.
+- "Yesterday" is calendar-day, not work-session-day. Burnouts who commit at 3am may want `--since=yesterday`.
+- Multi-repo only — no GitHub PR/issue activity (yet).
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/productivity/standup-gen/commands/standup-gen.md
+++ b/plugins/productivity/standup-gen/commands/standup-gen.md
@@ -1,0 +1,17 @@
+---
+name: standup-gen
+description: Generate daily standup notes from git activity
+allowed-tools: Bash
+---
+
+Role: act as a standup-note author. Produce Yesterday / Today / Blockers sections grounded only in the user's git activity.
+
+Run the helper:
+
+```bash
+python3 scripts/standup.py --format md
+```
+
+Useful flags: `--since 2026-05-15`, `--since yesterday`, `--repos /path/repoA,/path/repoB`, `--author all`, `--format json`.
+
+The helper fills "Yesterday" from commit subjects and leaves "Today (planned)" and "Blockers" as placeholders. Read the commit list, then propose 1–3 candidate "Today" items derived from in-flight files (e.g. files with WIP or follow-up commits). Mark blockers only if the diffs or commit messages clearly evidence one. Print the final markdown.

--- a/plugins/productivity/standup-gen/package.json
+++ b/plugins/productivity/standup-gen/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/standup-gen",
+  "version": "0.1.0",
+  "description": "Generate daily standup notes from git activity across one or many repos.",
+  "keywords": [
+    "productivity",
+    "git",
+    "standup",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/productivity/standup-gen"
+  },
+  "homepage": "https://tonsofskills.com/plugins/standup-gen",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install standup-gen\\\\n  or /plugin install standup-gen@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/productivity/standup-gen/scripts/standup.py
+++ b/plugins/productivity/standup-gen/scripts/standup.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate daily standup notes from `git log` across one or many repos."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _git_user_email(cwd: str) -> str:
+    return _run(["git", "config", "user.email"], cwd).strip()
+
+
+def _last_business_day(today: dt.date) -> dt.date:
+    if today.weekday() == 0:  # Monday → Friday
+        return today - dt.timedelta(days=3)
+    if today.weekday() == 6:  # Sunday → Friday
+        return today - dt.timedelta(days=2)
+    return today - dt.timedelta(days=1)
+
+
+def _parse_since(value: str | None, today: dt.date | None = None) -> str:
+    today = today or dt.date.today()
+    if not value or value == "yesterday":
+        return _last_business_day(today).isoformat()
+    return value
+
+
+def _collect_commits(
+    repo: str,
+    since_iso: str,
+    author: str | None,
+    until_iso: str | None = None,
+) -> list[dict]:
+    if not os.path.isdir(os.path.join(repo, ".git")):
+        return []
+    args = [
+        "git",
+        "log",
+        f"--since={since_iso} 00:00:00",
+        "--pretty=format:%H%x09%ad%x09%s",
+        "--date=short",
+    ]
+    if until_iso:
+        args.append(f"--until={until_iso} 00:00:00")
+    if author and author != "all":
+        args.append(f"--author={author}")
+    out = _run(args, repo)
+    commits: list[dict] = []
+    for line in out.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        commits.append({"hash": parts[0], "date": parts[1], "subject": parts[2]})
+    return commits
+
+
+def _render_markdown(report: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"# Standup — {dt.date.today().isoformat()}")
+    lines.append("")
+    lines.append("## Yesterday")
+    any_commit = False
+    for r in report["repos"]:
+        commits = r["commits"]
+        if not commits:
+            continue
+        any_commit = True
+        rname = os.path.basename(r["path"].rstrip("/")) or r["path"]
+        lines.append(f"### {rname}")
+        for c in commits:
+            lines.append(f"- {c['date']} `{c['hash'][:7]}` {c['subject']}")
+    if not any_commit:
+        lines.append("- _no commits in range_")
+    lines.append("")
+    lines.append("## Today (planned)")
+    lines.append("- TODO")
+    lines.append("")
+    lines.append("## Blockers")
+    lines.append("- TODO")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_report(
+    repos: Iterable[str],
+    since_iso: str,
+    author: str | None,
+    until_iso: str | None = None,
+) -> dict:
+    repo_reports: list[dict] = []
+    for r in repos:
+        repo_reports.append({
+            "path": r,
+            "commits": _collect_commits(r, since_iso, author, until_iso),
+        })
+    return {
+        "since": since_iso,
+        "until": until_iso,
+        "author": author or "self",
+        "repos": repo_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Generate standup notes from git activity.")
+    p.add_argument("--repos", default=None, help="Comma-separated repo paths (default: cwd).")
+    p.add_argument("--since", default=None, help="ISO date or 'yesterday' (default: last business day).")
+    p.add_argument("--until", default=None,
+                   help="ISO date upper-bound (default: today, exclusive). Use 'none' to drop the bound.")
+    p.add_argument("--author", default=None, help="Email to filter by, or 'all' (default: self).")
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    cwd = os.getcwd()
+    if args.repos:
+        repos = [os.path.abspath(r.strip()) for r in args.repos.split(",") if r.strip()]
+    else:
+        repos = [cwd]
+
+    since_iso = _parse_since(args.since)
+    if args.until is None:
+        # default upper bound: today at 00:00, so "yesterday" never bleeds into today
+        until_iso: str | None = dt.date.today().isoformat()
+    elif args.until.lower() == "none":
+        until_iso = None
+    else:
+        until_iso = args.until
+
+    author = args.author or _git_user_email(repos[0]) or None
+    if args.author == "all":
+        author = "all"
+
+    report = _build_report(repos, since_iso, author, until_iso)
+    if args.format == "md":
+        sys.stdout.write(_render_markdown(report))
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/security/deps-doctor/.claude-plugin/plugin.json
+++ b/plugins/security/deps-doctor/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "deps-doctor",
+  "version": "0.1.0",
+  "description": "/deps-doctor runs dependency health audits across supported ecosystems.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-deps-doctor",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "dependencies",
+    "audit",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-deps-doctor"
+}

--- a/plugins/security/deps-doctor/LICENSE
+++ b/plugins/security/deps-doctor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/security/deps-doctor/README.md
+++ b/plugins/security/deps-doctor/README.md
@@ -1,0 +1,107 @@
+![hero](./assets/hero.svg)
+
+# deps-doctor
+
+**One slash command. Four ecosystems. Knows when an audit tool is missing — and doesn't pretend otherwise.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 7 passing](https://img.shields.io/badge/tests-7%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/deps-doctor` → unified vuln/outdated/license report across npm, pip, cargo, and go in one pass.
+
+## Why this exists
+
+Polyglot repos make dependency hygiene awkward — you end up with three different reports in three different terminals, and you forget which one was for staging. `deps-doctor` detects which ecosystems are present, shells out to the audit tools you actually have installed, and emits one consistent report. Missing tool? It says "skipped: tool not installed" — never silently green.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-deps-doctor ~/.claude/plugins/deps-doctor
+```
+
+Restart Claude Code; the slash command `/deps-doctor` appears.
+
+## Quick start
+
+```sh
+/deps-doctor
+```
+
+Or directly:
+
+```sh
+python3 scripts/doctor.py --format md
+python3 scripts/doctor.py --severity high --ecosystem npm,pip
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | `json` | `json` or `md` |
+| `--severity` | _all_ | Minimum severity: `low | moderate | high | critical` |
+| `--ecosystem` | _all detected_ | Comma-separated subset, e.g. `npm,pip` |
+
+## Supported ecosystems
+
+| Ecosystem | Audit tool | Detected by |
+|---|---|---|
+| npm | `npm audit --json` | `package.json` |
+| pip | `pip-audit --format=json` | `requirements.txt` / `pyproject.toml` |
+| cargo | `cargo audit --json` | `Cargo.toml` |
+| go | `govulncheck -json ./...` | `go.mod` |
+
+Missing tools are reported as `"status": "skipped: tool not installed"`, never as a clean pass.
+
+## Example output (markdown)
+
+```
+## deps-doctor report
+
+### npm — 2 critical, 1 high
+- **CVE-2024-XXXX** in `axios@0.21.1` → fixed in `0.21.4` (critical)
+- **CVE-2024-YYYY** in `lodash@4.17.20` → fixed in `4.17.21` (high)
+
+### pip — clean
+
+### cargo — _skipped: cargo audit not installed_
+
+### go — clean
+```
+
+## How it works
+
+1. Scans the project root for marker files (`package.json`, `Cargo.toml`, …).
+2. Runs each ecosystem's audit tool via `subprocess` — no shell, no injection surface.
+3. Normalizes the JSON shapes from each tool into one schema.
+4. Aggregates by severity and renders.
+
+## Limitations
+
+- Network-only audits (registry lookups) inherit the speed of the underlying tool.
+- License auditing is a placeholder field (`license_warnings: []`) — populate via a future plugin.
+- Audit-tool installation is up to you; this plugin is glue, not an installer.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/security/deps-doctor/commands/deps-doctor.md
+++ b/plugins/security/deps-doctor/commands/deps-doctor.md
@@ -1,0 +1,17 @@
+---
+name: deps-doctor
+description: Run dependency health audits across supported ecosystems
+allowed-tools: Bash
+---
+
+Run `python3 scripts/doctor.py "$@"` from the deps-doctor plugin root.
+
+Purpose: detect supported dependency ecosystems, run available local audit tools, and summarize advisories without failing when tools are missing.
+
+Inputs: optional `--format`, `--severity`, and `--ecosystem` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network directly, and do not hide skipped tools.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/plugins/security/deps-doctor/package.json
+++ b/plugins/security/deps-doctor/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/deps-doctor",
+  "version": "0.1.0",
+  "description": "/deps-doctor runs dependency health audits across supported ecosystems.",
+  "keywords": [
+    "security",
+    "dependencies",
+    "audit",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/security/deps-doctor"
+  },
+  "homepage": "https://tonsofskills.com/plugins/deps-doctor",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install deps-doctor\\\\n  or /plugin install deps-doctor@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/security/deps-doctor/scripts/doctor.py
+++ b/plugins/security/deps-doctor/scripts/doctor.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Run dependency health audits across supported ecosystems."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = {"low": 0, "moderate": 1, "medium": 1, "high": 2, "critical": 3}
+COMMANDS = {
+    "npm": ["npm", "audit", "--json"],
+    "pip": ["pip-audit", "--format=json"],
+    "cargo": ["cargo", "audit", "--json"],
+    "go": ["govulncheck", "-json", "./..."],
+}
+
+
+def detect_ecosystems(root: Path = Path(".")) -> list[str]:
+    ecosystems: list[str] = []
+    if (root / "package.json").exists():
+        ecosystems.append("npm")
+    if (root / "requirements.txt").exists() or (root / "pyproject.toml").exists():
+        ecosystems.append("pip")
+    if (root / "Cargo.toml").exists():
+        ecosystems.append("cargo")
+    if (root / "go.mod").exists():
+        ecosystems.append("go")
+    return ecosystems
+
+
+def run_audit(name: str) -> tuple[str | None, str | None]:
+    command = COMMANDS[name]
+    if shutil.which(command[0]) is None:
+        return None, "skipped: tool not installed"
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.stdout:
+        return result.stdout, None
+    if result.returncode != 0:
+        return None, result.stderr.strip() or f"{name} audit failed"
+    return "{}", None
+
+
+def normalize_severity(value: Any) -> str:
+    text = str(value or "unknown").lower()
+    return "moderate" if text == "medium" else text
+
+
+def fixed_in(value: Any) -> list[str]:
+    if value in (None, False):
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, dict):
+        version = value.get("version")
+        if version:
+            return [str(version)]
+    return []
+
+
+def npm_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for package, vuln in payload.get("vulnerabilities", {}).items():
+        via = vuln.get("via", [])
+        source = next((item for item in via if isinstance(item, dict)), {})
+        advisories.append({
+            "id": str(source.get("source") or source.get("url") or vuln.get("name") or package),
+            "severity": normalize_severity(vuln.get("severity") or source.get("severity")),
+            "package": package,
+            "version": ",".join(vuln.get("nodes", [])) or "",
+            "fixed_in": fixed_in(vuln.get("fixAvailable")),
+        })
+    for advisory in payload.get("advisories", {}).values():
+        advisories.append({
+            "id": str(advisory.get("id") or advisory.get("url") or advisory.get("module_name")),
+            "severity": normalize_severity(advisory.get("severity")),
+            "package": advisory.get("module_name", ""),
+            "version": advisory.get("vulnerable_versions", ""),
+            "fixed_in": fixed_in(advisory.get("patched_versions")),
+        })
+    return advisories
+
+
+def pip_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for dep in payload.get("dependencies", []):
+        for vuln in dep.get("vulns", []):
+            advisories.append({
+                "id": str(vuln.get("id") or vuln.get("aliases", [""])[0]),
+                "severity": normalize_severity(vuln.get("severity")),
+                "package": dep.get("name", ""),
+                "version": dep.get("version", ""),
+                "fixed_in": fixed_in(vuln.get("fix_versions")),
+            })
+    return advisories
+
+
+def cargo_advisories(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for item in payload.get("vulnerabilities", {}).get("list", []):
+        advisory = item.get("advisory", {})
+        package = item.get("package", {})
+        versions = item.get("versions", {})
+        advisories.append({
+            "id": str(advisory.get("id", "")),
+            "severity": normalize_severity(advisory.get("severity")),
+            "package": package.get("name", ""),
+            "version": package.get("version", ""),
+            "fixed_in": fixed_in(versions.get("patched")),
+        })
+    return advisories
+
+
+def go_advisories(output: str) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        finding = event.get("finding") or event.get("vulnerability") or {}
+        osv = finding.get("osv") or finding
+        if not osv:
+            continue
+        advisories.append({
+            "id": str(osv.get("id", "")),
+            "severity": normalize_severity(osv.get("database_specific", {}).get("severity")),
+            "package": finding.get("package", ""),
+            "version": "",
+            "fixed_in": fixed_in(osv.get("affected", [])),
+        })
+    return advisories
+
+
+def parse_advisories(name: str, output: str) -> list[dict[str, Any]]:
+    # govulncheck emits NDJSON (one JSON object per line); pass raw text through
+    # so the go parser can handle line-by-line. Other tools emit a single JSON document.
+    if name == "go":
+        return go_advisories(output)
+    try:
+        payload = json.loads(output or "{}")
+    except json.JSONDecodeError:
+        return []
+    if name == "npm":
+        return npm_advisories(payload)
+    if name == "pip":
+        return pip_advisories(payload)
+    if name == "cargo":
+        return cargo_advisories(payload)
+    return []
+
+
+def severity_allowed(advisory: dict[str, Any], minimum: str) -> bool:
+    return SEVERITY_ORDER.get(advisory.get("severity", "unknown"), -1) >= SEVERITY_ORDER[minimum]
+
+
+def audit(ecosystems: list[str], minimum: str = "low") -> dict[str, list[dict[str, Any]]]:
+    results: list[dict[str, Any]] = []
+    for name in ecosystems:
+        output, skipped = run_audit(name)
+        advisories = [] if output is None else [item for item in parse_advisories(name, output) if severity_allowed(item, minimum)]
+        results.append({
+            "name": name,
+            "advisories": advisories,
+            "outdated_count": 0,
+            "license_warnings": [],
+            **({"skipped": skipped} if skipped else {}),
+        })
+    return {"ecosystems": results}
+
+
+def markdown(result: dict[str, list[dict[str, Any]]]) -> str:
+    grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {key: [] for key in ("critical", "high", "moderate", "low", "unknown")}
+    skipped: list[str] = []
+    for eco in result["ecosystems"]:
+        if eco.get("skipped"):
+            skipped.append(f"- {eco['name']}: {eco['skipped']}")
+        for advisory in eco["advisories"]:
+            grouped.setdefault(advisory.get("severity", "unknown"), []).append((eco["name"], advisory))
+
+    lines = ["# Dependency Doctor"]
+    for severity in ("critical", "high", "moderate", "low", "unknown"):
+        items = grouped.get(severity, [])
+        if not items:
+            continue
+        lines.extend([f"## {severity.title()}", "| Ecosystem | ID | Package | Version | Fixed In |", "| --- | --- | --- | --- | --- |"])
+        for ecosystem, advisory in items:
+            lines.append(
+                f"| {ecosystem} | {advisory['id']} | {advisory['package']} | "
+                f"{advisory['version']} | {','.join(advisory['fixed_in']) or '-'} |"
+            )
+    if skipped:
+        lines.append("## Skipped")
+        lines.extend(skipped)
+    if len(lines) == 1:
+        lines.append("No advisories found.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run dependency health audits across ecosystems.")
+    parser.add_argument("--format", choices=("json", "md"), default="json")
+    parser.add_argument("--severity", choices=("low", "moderate", "high", "critical"), default="low")
+    parser.add_argument("--ecosystem", help="Comma-separated ecosystem filter, e.g. npm,pip.")
+    args = parser.parse_args(argv)
+
+    detected = detect_ecosystems()
+    if args.ecosystem:
+        allowed = {item.strip() for item in args.ecosystem.split(",") if item.strip()}
+        detected = [item for item in detected if item in allowed]
+    result = audit(detected, args.severity)
+    print(markdown(result) if args.format == "md" else json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/secret-guard/.claude-plugin/plugin.json
+++ b/plugins/security/secret-guard/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "secret-guard",
+  "version": "0.1.0",
+  "description": "Scan staged diffs or files for leaked secrets with redacted output.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-secret-guard",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "secrets",
+    "pre-commit",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-secret-guard"
+}

--- a/plugins/security/secret-guard/LICENSE
+++ b/plugins/security/secret-guard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/security/secret-guard/README.md
+++ b/plugins/security/secret-guard/README.md
@@ -1,0 +1,112 @@
+![hero](./assets/hero.svg)
+
+# secret-guard
+
+**Block leaked API keys before they hit `origin`. Pattern + entropy. Redacted output.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 10 passing](https://img.shields.io/badge/tests-10%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/secret-guard` → scans your staged diff for AWS / GitHub / Slack / Stripe / Google API keys, JWTs, private keys, and high-entropy base64 strings. Blocks the commit before the secret leaves your machine.
+
+## Why this exists
+
+Most "secret scanners" run in CI — *after* the leak is already in git history. By then, rotating the key is the only fix, because git history is forever. `secret-guard` runs in your pre-commit hook (or via Claude Code on demand) and catches the leak *before* the commit object exists. And the output is redacted by design: you can paste a finding in chat, in a PR, in Slack, without leaking the very thing you're trying to protect.
+
+## Install (Claude Code + pre-commit)
+
+```sh
+git clone https://github.com/mturac/pluginpool-secret-guard ~/.claude/plugins/secret-guard
+```
+
+To wire as a pre-commit hook:
+
+```sh
+cp ~/.claude/plugins/secret-guard/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+## Quick start
+
+```sh
+/secret-guard                                            # scan staged diff
+python3 scripts/guard.py                                 # same, directly
+python3 scripts/guard.py --files src/config.py .env      # scan specific files
+python3 scripts/guard.py --allowlist .secretignore       # suppress known false positives
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--files F…` | _staged diff_ | Scan specific files instead of the staged diff |
+| `--allowlist PATH` | _none_ | Regexes (one per line) that suppress matching findings |
+| `--format` | `json` | `json` or `md` |
+
+## Detected patterns
+
+| Rule | Match |
+|---|---|
+| AWS Access Key ID | `AKIA[0-9A-Z]{16}` |
+| GitHub PAT | `gh[pousr]_[A-Za-z0-9]{36,}` |
+| Slack token | `xox[abpr]-[A-Za-z0-9-]{10,}` |
+| Stripe key | `sk_(live|test)_[A-Za-z0-9]{24,}` |
+| Google API key | `AIza[0-9A-Za-z_-]{35}` |
+| JWT | `eyJ…\.eyJ…\.…` |
+| Private key | `-----BEGIN … PRIVATE KEY-----` |
+| Generic high-entropy | base64-ish ≥32 chars, Shannon entropy ≥ 4.5 |
+
+## Example output (markdown)
+
+```
+# secret-guard report
+
+| file | line | rule | snippet |
+|---|---|---|---|
+| src/config.py | 12 | aws-access-key | AKIA… |
+| .env | 4 | stripe-key | sk_l… |
+```
+
+Note: snippets are always `rule + first 4 chars + …` — never the full secret.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean — no secrets found |
+| `1` | At least one finding (commit is blocked when used as a hook) |
+
+## Safety guarantees
+
+- `test_redaction_contains_only_rule_and_first_four` asserts the raw secret never appears in JSON or markdown output.
+- `test_files_mode_does_not_crash_on_non_utf8` ensures non-UTF-8 / binary files are skipped, not crashed on.
+
+## Limitations
+
+- Pattern lists drift; submit PRs for new providers.
+- Entropy heuristic produces some false positives on minified bundles — use `--allowlist` to suppress.
+- Doesn't scan repo history; pair with `git-secrets` or `trufflehog` for that.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/security/secret-guard/commands/secret-guard.md
+++ b/plugins/security/secret-guard/commands/secret-guard.md
@@ -1,0 +1,25 @@
+---
+name: secret-guard
+description: Scan staged diff (or specified files) for leaked secrets with redacted output
+allowed-tools: Bash
+---
+
+Role: act as a pre-merge security gate. Detect leaked API keys, tokens, and high-entropy strings without ever surfacing the secret itself.
+
+Run the helper:
+
+```sh
+python3 scripts/guard.py --format md
+```
+
+Useful flags: `--files app.py config.txt` (scan explicit files instead of staged diff), `--allowlist .secret-allowlist` (suppress known false positives).
+
+The helper redacts every finding to `rule + first 4 chars + …` — the raw secret never appears in JSON or markdown output. This invariant is enforced by `tests/test_guard.py::test_redaction_contains_only_rule_and_first_four`.
+
+For pre-commit integration:
+
+```sh
+cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+Exit codes: `0` clean, `1` finding present. Read the report and recommend: rotate, allowlist, or fix.

--- a/plugins/security/secret-guard/package.json
+++ b/plugins/security/secret-guard/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/secret-guard",
+  "version": "0.1.0",
+  "description": "Scan staged diffs or files for leaked secrets with redacted output.",
+  "keywords": [
+    "security",
+    "secrets",
+    "pre-commit",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/security/secret-guard"
+  },
+  "homepage": "https://tonsofskills.com/plugins/secret-guard",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install secret-guard\\\\n  or /plugin install secret-guard@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/security/secret-guard/scripts/guard.py
+++ b/plugins/security/secret-guard/scripts/guard.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Scan staged diffs or files for secrets with redacted output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable, Iterator, List, Pattern, Sequence, Tuple
+
+
+NAMED_PATTERNS: Sequence[Tuple[str, Pattern[str]]] = (
+    ("AWS Access Key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("GitHub PAT", re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}")),
+    ("Slack token", re.compile(r"xox[abpr]-[A-Za-z0-9-]{10,}")),
+    ("Stripe", re.compile(r"sk_(live|test)_[A-Za-z0-9]{24,}")),
+    ("Google API", re.compile(r"AIza[0-9A-Za-z_-]{35}")),
+    ("JWT", re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")),
+    ("Private key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+)
+ENTROPY_RE = re.compile(r"[A-Za-z0-9+/=_-]{32,}")
+
+
+def shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    total = len(value)
+    return -sum((value.count(char) / total) * math.log2(value.count(char) / total) for char in set(value))
+
+
+def load_allowlist(path: str | None) -> List[Pattern[str]]:
+    if not path:
+        return []
+    rules = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                rules.append(re.compile(line))
+    return rules
+
+
+def is_allowed(rules: Sequence[Pattern[str]], line: str, secret: str) -> bool:
+    return any(rule.search(line) or rule.search(secret) for rule in rules)
+
+
+def redact(rule: str, secret: str) -> str:
+    return f"{rule}: {secret[:4]}\u2026"
+
+
+def scan_line(file_name: str, line_no: int, line: str, allowlist: Sequence[Pattern[str]]) -> List[dict]:
+    findings = []
+    for rule, pattern in NAMED_PATTERNS:
+        for match in pattern.finditer(line):
+            secret = match.group(0)
+            if not is_allowed(allowlist, line, secret):
+                findings.append({"file": file_name, "line": line_no, "pattern": rule, "snippet_redacted": redact(rule, secret)})
+    if findings:
+        return findings
+    for match in ENTROPY_RE.finditer(line):
+        secret = match.group(0)
+        if shannon_entropy(secret) >= 4.5 and not is_allowed(allowlist, line, secret):
+            findings.append(
+                {"file": file_name, "line": line_no, "pattern": "Generic high-entropy", "snippet_redacted": redact("Generic high-entropy", secret)}
+            )
+    return findings
+
+
+def staged_added_lines() -> Iterator[Tuple[str, int, str]]:
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--no-ext-diff"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        raise RuntimeError(proc.stderr.strip() or "git diff failed")
+
+    current_file = None
+    next_line = 0
+    for raw in proc.stdout.splitlines():
+        if raw.startswith("+++ b/"):
+            current_file = raw[6:]
+            continue
+        if raw.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", raw)
+            next_line = int(match.group(1)) if match else 0
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            if current_file is not None:
+                yield current_file, next_line, raw[1:]
+            next_line += 1
+
+
+def _looks_binary(path: str) -> bool:
+    try:
+        with open(path, "rb") as handle:
+            chunk = handle.read(1024)
+        return b"\x00" in chunk
+    except OSError:
+        return True
+
+
+def file_lines(paths: Sequence[str]) -> Iterator[Tuple[str, int, str]]:
+    for path in paths:
+        if _looks_binary(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                for index, line in enumerate(handle, 1):
+                    yield path, index, line.rstrip("\n")
+        except OSError:
+            continue
+
+
+def scan_sources(sources: Iterable[Tuple[str, int, str]], allowlist: Sequence[Pattern[str]]) -> List[dict]:
+    findings = []
+    for file_name, line_no, line in sources:
+        findings.extend(scan_line(file_name, line_no, line, allowlist))
+    return findings
+
+
+def to_markdown(findings: Sequence[dict]) -> str:
+    lines = ["# secret-guard report", ""]
+    if not findings:
+        lines.append("No findings.")
+        return "\n".join(lines) + "\n"
+    lines.append("| File | Line | Pattern | Snippet |")
+    lines.append("| --- | ---: | --- | --- |")
+    for item in findings:
+        lines.append(f"| {item['file']} | {item['line']} | {item['pattern']} | {item['snippet_redacted']} |")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Scan staged diffs or files for leaked secrets.")
+    parser.add_argument("--files", nargs="+", help="Scan specific files instead of staged diff")
+    parser.add_argument("--format", choices=("json", "md"), default="json", help="Output format")
+    parser.add_argument("--allowlist", help="Regex allowlist file, one pattern per line")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    allowlist = load_allowlist(args.allowlist)
+    sources = file_lines(args.files) if args.files else staged_added_lines()
+    findings = scan_sources(sources, allowlist)
+    if args.format == "md":
+        sys.stdout.write(to_markdown(findings))
+    else:
+        sys.stdout.write(json.dumps(findings, indent=2, sort_keys=True) + "\n")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/testing/env-lint/.claude-plugin/plugin.json
+++ b/plugins/testing/env-lint/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "env-lint",
+  "version": "0.1.0",
+  "description": "Validate .env files against .env.example without printing values.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-env-lint",
+  "license": "MIT",
+  "keywords": [
+    "env",
+    "config",
+    "testing",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-env-lint"
+}

--- a/plugins/testing/env-lint/LICENSE
+++ b/plugins/testing/env-lint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/testing/env-lint/README.md
+++ b/plugins/testing/env-lint/README.md
@@ -1,0 +1,103 @@
+![hero](./assets/hero.svg)
+
+# env-lint
+
+**Catch missing/extra env-var keys before they bite you in prod. Never prints values.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 7 passing](https://img.shields.io/badge/tests-7%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/env-lint` → "you're missing `STRIPE_WEBHOOK_SECRET` in `.env.local` (referenced in `.env.example`)" — without ever logging the secret value.
+
+## Why this exists
+
+Every team has the same outage: someone adds a new env var to `.env.example`, forgets to mention it in the PR, and a teammate's local server quietly 500s on a code path that needs it. Or worse, prod is missing a key. `env-lint` diffs your live env file against `.env.example` and tells you which keys are missing or extra — and *only* the keys, never the values. Safe to paste in chat, safe to log to CI.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-env-lint ~/.claude/plugins/env-lint
+```
+
+Restart Claude Code; the slash command `/env-lint` appears.
+
+## Quick start
+
+```sh
+/env-lint
+```
+
+Or directly:
+
+```sh
+python3 scripts/envlint.py --format md
+python3 scripts/envlint.py --example .env.example --env .env.production
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--example` | auto-detect | Path to template (`.env.example`) |
+| `--env` | auto-detect | Path to actual env file |
+| `--format` | `json` | `json` or `md` |
+
+When run without `--example/--env`, it scans the cwd for known pairs: `(.env, .env.example)`, `(.env.local, .env.example)`, `(.env.production, .env.example)`.
+
+## Example output
+
+```
+# env-lint report
+
+## .env.example ↔ .env.local
+- **missing in env**: STRIPE_WEBHOOK_SECRET, SENTRY_DSN
+- **extra in env**: LEGACY_API_KEY
+- **empty values for**: REDIS_URL
+```
+
+## Safety guarantee
+
+A test in the suite (`test_never_emits_values_in_json_or_markdown`) writes a fake value `SUPERSECRETVALUE123` into a temp `.env` and asserts that string never appears in either the JSON output or the markdown report. The CI badge above represents that invariant.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All required keys present (extras are warnings, not errors) |
+| `1` | At least one required key is missing |
+
+## How it works
+
+1. Parses each `.env` file as `KEY=VALUE` (comments and blank lines skipped).
+2. Computes the key-set difference both ways.
+3. Reports missing keys (template has them, env doesn't), extra keys (env has them, template doesn't), and empty values.
+
+## Limitations
+
+- Doesn't expand `${VAR}` references — it only checks key presence.
+- Quoted values are detected as "present" even if the quoted content is empty (`KEY=""` is *empty*, not missing).
+- Custom env-file naming conventions need explicit `--example/--env`.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/testing/env-lint/commands/env-lint.md
+++ b/plugins/testing/env-lint/commands/env-lint.md
@@ -1,0 +1,19 @@
+---
+name: env-lint
+description: Validate .env files against .env.example without printing values
+allowed-tools: Bash
+---
+
+Role: act as an env-var auditor. Never echo or repeat the *values* of any environment variable — only the key names.
+
+Run the helper:
+
+```sh
+python3 scripts/envlint.py --format md
+```
+
+Useful flags: `--example .env.example --env .env.local`, `--format json`.
+
+The helper auto-detects common pairs (`.env` vs `.env.example`, `.env.local` vs `.env.example`, `.env.production` vs `.env.example`) or accepts an explicit pair. It reports missing keys, extra keys, and keys with empty values. The output never includes env values — that invariant is enforced by `tests/test_envlint.py::test_never_emits_values_in_json_or_markdown`.
+
+Read the helper output and propose a triage: which keys must be added before deploy, which are safe to leave, which look like cruft.

--- a/plugins/testing/env-lint/package.json
+++ b/plugins/testing/env-lint/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/env-lint",
+  "version": "0.1.0",
+  "description": "Validate .env files against .env.example without printing values.",
+  "keywords": [
+    "env",
+    "config",
+    "testing",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/testing/env-lint"
+  },
+  "homepage": "https://tonsofskills.com/plugins/env-lint",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install env-lint\\\\n  or /plugin install env-lint@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/testing/env-lint/scripts/envlint.py
+++ b/plugins/testing/env-lint/scripts/envlint.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate .env files against .env.example without emitting values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+KEY_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+DEFAULT_PAIRS = (
+    (".env.example", ".env"),
+    (".env.example", ".env.local"),
+    (".env.example", ".env.production"),
+)
+
+
+def parse_env(path: str) -> Tuple[List[str], Dict[str, bool]]:
+    keys: List[str] = []
+    empty: Dict[str, bool] = {}
+    seen = set()
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            match = KEY_RE.match(line)
+            if not match:
+                continue
+            key = match.group(1)
+            if key not in seen:
+                keys.append(key)
+                seen.add(key)
+            value = line.split("=", 1)[1].strip()
+            empty[key] = value in {"", '""', "''"}
+    return keys, empty
+
+
+def existing_pairs() -> List[Tuple[str, str]]:
+    return [(example, env) for example, env in DEFAULT_PAIRS if os.path.exists(example) and os.path.exists(env)]
+
+
+def compare_pair(example: str, env: str) -> dict:
+    example_keys, _ = parse_env(example)
+    env_keys, env_empty = parse_env(env)
+    example_set = set(example_keys)
+    env_set = set(env_keys)
+    return {
+        "example": example,
+        "env": env,
+        "missing_in_env": [key for key in example_keys if key not in env_set],
+        "extra_in_env": [key for key in env_keys if key not in example_set],
+        "empty_values": [key for key in env_keys if env_empty.get(key, False)],
+    }
+
+
+def to_markdown(results: Sequence[dict]) -> str:
+    lines = ["# env-lint report", ""]
+    if not results:
+        lines.append("No existing .env pairs found.")
+        return "\n".join(lines) + "\n"
+    for item in results:
+        lines.extend(
+            [
+                f"## {item['env']} vs {item['example']}",
+                "",
+                f"- Missing in env: {', '.join(item['missing_in_env']) or 'none'}",
+                f"- Extra in env: {', '.join(item['extra_in_env']) or 'none'}",
+                f"- Empty values: {', '.join(item['empty_values']) or 'none'}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate .env files against .env.example without printing values.")
+    parser.add_argument("--example", help="Example env file path")
+    parser.add_argument("--env", help="Environment file path")
+    parser.add_argument("--format", choices=("json", "md"), default="json", help="Output format")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if bool(args.example) != bool(args.env):
+        raise SystemExit("--example and --env must be provided together")
+
+    pairs = [(args.example, args.env)] if args.example else existing_pairs()
+    results = [compare_pair(example, env) for example, env in pairs]
+    payload = {"pairs": results}
+    if args.format == "md":
+        sys.stdout.write(to_markdown(results))
+    else:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 1 if any(pair["missing_in_env"] for pair in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/testing/flaky-detector/.claude-plugin/plugin.json
+++ b/plugins/testing/flaky-detector/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "flaky-detector",
+  "version": "0.1.0",
+  "description": "Run a test command N times and report per-test flakiness percentages.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-flaky-detector",
+  "license": "MIT",
+  "keywords": [
+    "testing",
+    "flaky",
+    "reliability",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-flaky-detector"
+}

--- a/plugins/testing/flaky-detector/LICENSE
+++ b/plugins/testing/flaky-detector/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/testing/flaky-detector/README.md
+++ b/plugins/testing/flaky-detector/README.md
@@ -1,0 +1,106 @@
+![hero](./assets/hero.svg)
+
+# flaky-detector
+
+**Run your test command N times. Find out which tests don't always agree with themselves.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 11 passing](https://img.shields.io/badge/tests-11%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/flaky-detector --cmd "pytest -v" --runs 10` → per-test flakiness %, sorted worst-first, ready to triage.
+
+## Why this exists
+
+A test that fails 1-in-20 wastes more team time than a test that never fails. CI flakes erode trust; everyone learns to "just re-run it". This tool runs your suite N times, parses pass/fail per test, and tells you exactly which tests are flaky and at what rate — so you can decide: rerun, isolate, mark `@pytest.mark.flaky`, or fix the underlying race.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-flaky-detector ~/.claude/plugins/flaky-detector
+```
+
+Restart Claude Code; the slash command `/flaky-detector` appears.
+
+## Quick start
+
+```sh
+python3 scripts/flaky.py --cmd "pytest -v" --runs 10 --format md
+python3 scripts/flaky.py --cmd "go test ./..." --runs 20 --parallel 4 --out report.json
+python3 scripts/flaky.py --cmd "jest --ci" --parser jest --runs 5
+```
+
+> Tip: prefer `pytest -v` over `pytest -q` so every result lands on its own line.
+> If you use `-q`, flaky-detector still picks up the tail `FAILED path::test` summary
+> lines and exits non-zero with a warning rather than reporting a false green.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--cmd` | required | The test command (single line, no shell wrapping) |
+| `--runs` | `10` | How many times to invoke the command |
+| `--parallel` | `1` | Concurrent runs (only safe for parallel-clean suites) |
+| `--parser` | `auto` | `pytest`, `jest`, `gotest`, `tap`, or `auto` |
+| `--out` | _none_ | Write JSON report to this path |
+| `--format` | `json` | `json` or `md` |
+
+## Supported parsers
+
+| Parser | Matches |
+|---|---|
+| `pytest` | `tests/foo.py::test_bar PASSED|FAILED|ERROR|SKIPPED` plus the `-q` tail summary |
+| `jest` / `vitest` | `✓ name`, `✗ name`, `PASS file`, `FAIL file` |
+| `gotest` | `--- PASS:`, `--- FAIL:`, `--- SKIP:` |
+| `tap` | `ok N - name`, `not ok N - name` |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | No flakies, no always-failing |
+| `1` | At least one test is flaky (`0 < flakiness_pct < 100`) |
+| `2` | At least one test is always-failing |
+| `3` | Zero tests parsed but the runner reported activity — re-run with `-v` |
+
+## Example output (markdown)
+
+```
+# Flaky-detector report (10 runs)
+
+- flaky: **2**  |  always-failing: **0**  |  always-passing: 47
+
+| test | pass | fail | flakiness % |
+|---|---|---|---|
+| tests/test_payment.py::test_idempotency | 6 | 4 | 40.0 |
+| tests/test_search.py::test_index_warmup | 8 | 2 | 20.0 |
+```
+
+## Limitations
+
+- `--parallel > 1` only works for parallel-safe suites; otherwise concurrent runs share state and lie.
+- Streaming stdout from very long suites is buffered — be patient on the first run.
+- The parser is tuned for default reporters. Custom plugins (pytest-rich, etc.) may need a tweak.
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/testing/flaky-detector/commands/flaky-detector.md
+++ b/plugins/testing/flaky-detector/commands/flaky-detector.md
@@ -1,0 +1,17 @@
+---
+name: flaky-detector
+description: Detect flaky tests by running a test command N times
+allowed-tools: Bash
+---
+
+Role: act as a flake hunter. Identify tests that don't always agree with themselves.
+
+Run the helper:
+
+```bash
+python3 scripts/flaky.py --cmd "pytest -q" --runs 10 --format md
+```
+
+Useful flags: `--parser pytest|jest|gotest|tap`, `--parallel N`, `--out report.json`.
+
+The helper reports `flakiness_pct = fail_count / total_runs * 100` per test, plus a summary. Exit codes: `0` clean, `1` flaky tests found, `2` always-failing tests found. Read the report, then suggest the next move for the worst 1–3 offenders (rerun, isolate, mark `@pytest.mark.flaky`, or root-cause). Don't speculate beyond what the output supports.

--- a/plugins/testing/flaky-detector/package.json
+++ b/plugins/testing/flaky-detector/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/flaky-detector",
+  "version": "0.1.0",
+  "description": "Run a test command N times and report per-test flakiness percentages.",
+  "keywords": [
+    "testing",
+    "flaky",
+    "reliability",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/testing/flaky-detector"
+  },
+  "homepage": "https://tonsofskills.com/plugins/flaky-detector",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install flaky-detector\\\\n  or /plugin install flaky-detector@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/testing/flaky-detector/scripts/flaky.py
+++ b/plugins/testing/flaky-detector/scripts/flaky.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Run a test command N times and report per-test flakiness."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import shlex
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Callable
+
+
+# ---------- parsers ----------
+
+_PYTEST_LINE = re.compile(
+    r"^(?P<path>\S+::\S+(?:::\S+)?)\s+(?P<status>PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)"
+)
+# Short-form `pytest -q` only prints `FAILED path::test - reason` / `ERROR path::test` in the
+# tail summary, plus a final tally line. We pick those up to avoid a false-green report when
+# the user runs the default short reporter.
+_PYTEST_TAIL = re.compile(r"^(?P<status>FAILED|ERROR|PASSED)\s+(?P<path>\S+::\S+(?:::\S+)?)")
+_PYTEST_TALLY = re.compile(r"=+\s*(?:(\d+) failed[, ]*)?(?:(\d+) passed[, ]*)?")
+
+
+def parse_pytest(stdout: str) -> dict[str, str]:
+    """Parse pytest -v and pytest -q output. Returns {test_id: 'pass'|'fail'|'skip'}."""
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _PYTEST_LINE.search(line)
+        if m:
+            status = m.group("status")
+            test_id = m.group("path")
+            if status in ("PASSED", "XPASS"):
+                results[test_id] = "pass"
+            elif status in ("FAILED", "ERROR", "XFAIL"):
+                results[test_id] = "fail"
+            elif status == "SKIPPED":
+                results[test_id] = "skip"
+            continue
+        m2 = _PYTEST_TAIL.match(line)
+        if m2:
+            status, tid = m2.group("status"), m2.group("path")
+            if status == "PASSED":
+                results.setdefault(tid, "pass")
+            else:
+                results[tid] = "fail"
+    return results
+
+
+def _pytest_tally(stdout: str) -> tuple[int, int]:
+    """Return (failed, passed) from the pytest tail tally line, or (0, 0) if absent."""
+    failed = passed = 0
+    for line in reversed(stdout.splitlines()):
+        m = _PYTEST_TALLY.search(line)
+        if m and (m.group(1) or m.group(2)):
+            failed = int(m.group(1) or 0)
+            passed = int(m.group(2) or 0)
+            break
+    return failed, passed
+
+
+_JEST_LINE = re.compile(r"^\s*(✓|✗|×|PASS|FAIL)\s+(.+?)(?:\s+\(\d+\s*m?s\))?\s*$")
+
+
+def parse_jest(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _JEST_LINE.match(line)
+        if not m:
+            continue
+        token, name = m.group(1), m.group(2).strip()
+        if token in ("✓", "PASS"):
+            results[name] = "pass"
+        elif token in ("✗", "×", "FAIL"):
+            results[name] = "fail"
+    return results
+
+
+_GOTEST_LINE = re.compile(r"^---\s+(PASS|FAIL|SKIP):\s+(\S+)")
+
+
+def parse_gotest(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _GOTEST_LINE.match(line)
+        if m:
+            status, name = m.group(1), m.group(2)
+            results[name] = {"PASS": "pass", "FAIL": "fail", "SKIP": "skip"}[status]
+    return results
+
+
+_TAP_LINE = re.compile(r"^(ok|not ok)\s+\d+\s*-?\s*(.*?)\s*$")
+
+
+def parse_tap(stdout: str) -> dict[str, str]:
+    results: dict[str, str] = {}
+    for line in stdout.splitlines():
+        m = _TAP_LINE.match(line)
+        if m:
+            ok, name = m.group(1), m.group(2)
+            name = name or f"<test-{len(results) + 1}>"
+            results[name] = "pass" if ok == "ok" else "fail"
+    return results
+
+
+PARSERS: dict[str, Callable[[str], dict[str, str]]] = {
+    "pytest": parse_pytest,
+    "jest": parse_jest,
+    "gotest": parse_gotest,
+    "tap": parse_tap,
+}
+
+
+def auto_parser(cmd: str) -> str:
+    c = cmd.lower()
+    if "jest" in c or "vitest" in c:
+        return "jest"
+    if "go test" in c:
+        return "gotest"
+    if "tap" in c:
+        return "tap"
+    return "pytest"
+
+
+# ---------- runner ----------
+
+def _run_once(cmd: str) -> str:
+    res = subprocess.run(shlex.split(cmd), capture_output=True, text=True, check=False)
+    return (res.stdout or "") + "\n" + (res.stderr or "")
+
+
+def run_many(cmd: str, runs: int, parallel: int) -> list[str]:
+    if parallel <= 1 or runs == 1:
+        return [_run_once(cmd) for _ in range(runs)]
+    outputs: list[str] = [""] * runs
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as ex:
+        futures = {ex.submit(_run_once, cmd): i for i in range(runs)}
+        for fut in concurrent.futures.as_completed(futures):
+            i = futures[fut]
+            outputs[i] = fut.result()
+    return outputs
+
+
+# ---------- aggregator ----------
+
+def aggregate(per_run: list[dict[str, str]]) -> dict:
+    total = len(per_run)
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: {"pass": 0, "fail": 0, "skip": 0})
+    for run in per_run:
+        for tid, status in run.items():
+            counts[tid][status] += 1
+
+    tests = []
+    for tid, c in counts.items():
+        runs_seen = c["pass"] + c["fail"]
+        pct = (c["fail"] / runs_seen * 100.0) if runs_seen else 0.0
+        tests.append(
+            {
+                "id": tid,
+                "pass_count": c["pass"],
+                "fail_count": c["fail"],
+                "skip_count": c["skip"],
+                "flakiness_pct": round(pct, 2),
+            }
+        )
+
+    flaky = [t for t in tests if 0 < t["flakiness_pct"] < 100]
+    always_failing = [t for t in tests if t["pass_count"] == 0 and t["fail_count"] > 0]
+    always_passing = [t for t in tests if t["fail_count"] == 0 and t["pass_count"] > 0]
+
+    tests.sort(key=lambda t: (-t["flakiness_pct"], t["id"]))
+    return {
+        "tests": tests,
+        "summary": {
+            "total_runs": total,
+            "flaky_tests": len(flaky),
+            "always_failing": len(always_failing),
+            "always_passing": len(always_passing),
+        },
+    }
+
+
+def render_markdown(report: dict) -> str:
+    s = report["summary"]
+    lines = [
+        f"# Flaky-detector report ({s['total_runs']} runs)",
+        "",
+        f"- flaky: **{s['flaky_tests']}**  |  always-failing: **{s['always_failing']}**  |  always-passing: {s['always_passing']}",
+        "",
+        "| test | pass | fail | flakiness % |",
+        "|---|---|---|---|",
+    ]
+    for t in report["tests"]:
+        if t["fail_count"] == 0:
+            continue
+        lines.append(f"| {t['id']} | {t['pass_count']} | {t['fail_count']} | {t['flakiness_pct']} |")
+    return "\n".join(lines) + "\n"
+
+
+# ---------- main ----------
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Detect flaky tests by running a command N times.")
+    p.add_argument("--cmd", required=True)
+    p.add_argument("--runs", type=int, default=10)
+    p.add_argument("--parallel", type=int, default=1)
+    p.add_argument("--parser", choices=list(PARSERS.keys()) + ["auto"], default="auto")
+    p.add_argument("--out", default=None)
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    parser_name = auto_parser(args.cmd) if args.parser == "auto" else args.parser
+    parse = PARSERS[parser_name]
+
+    outputs = run_many(args.cmd, args.runs, args.parallel)
+    per_run = [parse(o) for o in outputs]
+    report = aggregate(per_run)
+    report["parser"] = parser_name
+
+    # Guard against silent false-green: if zero tests parsed yet the tally suggests
+    # tests actually ran, surface a warning + non-zero exit.
+    warnings: list[str] = []
+    if parser_name == "pytest" and not any(per_run) and outputs:
+        for o in outputs:
+            failed, passed = _pytest_tally(o)
+            if failed + passed > 0:
+                warnings.append(
+                    f"pytest reported {failed} failed / {passed} passed but no per-test "
+                    "lines parsed — re-run with `-v` so flaky-detector can attribute results."
+                )
+                break
+    report["warnings"] = warnings
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.format == "md":
+        sys.stdout.write(render_markdown(report))
+    else:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+    if report["summary"]["always_failing"] > 0:
+        return 2
+    if report["summary"]["flaky_tests"] > 0:
+        return 1
+    if warnings:
+        sys.stderr.write("\n".join(warnings) + "\n")
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/testing/test-gap/.claude-plugin/plugin.json
+++ b/plugins/testing/test-gap/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "test-gap",
+  "version": "0.1.0",
+  "description": "/test-gap surfaces lines added or changed in the current git diff that are not covered by tests.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-test-gap",
+  "license": "MIT",
+  "keywords": [
+    "testing",
+    "coverage",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-test-gap"
+}

--- a/plugins/testing/test-gap/LICENSE
+++ b/plugins/testing/test-gap/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/testing/test-gap/README.md
+++ b/plugins/testing/test-gap/README.md
@@ -1,0 +1,99 @@
+![hero](./assets/hero.svg)
+
+# test-gap
+
+**Surface the lines you just changed that have zero test coverage — before the PR review does.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 7 passing](https://img.shields.io/badge/tests-7%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/test-gap` → markdown table of files where your diff added lines that nothing tests yet.
+
+## Why this exists
+
+Repo-wide coverage percentages are useless on a PR — what matters is whether the *lines you just touched* are covered. CI rarely tells you that, and "100% line coverage" isn't the target anyway. `test-gap` intersects your branch's diff with an existing coverage report and shows you the gap, sorted worst-first.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-test-gap ~/.claude/plugins/test-gap
+```
+
+Restart Claude Code; the slash command `/test-gap` appears.
+
+## Quick start
+
+```sh
+# After running your test suite with coverage:
+python3 -m pytest --cov --cov-report=xml         # produces coverage.xml
+/test-gap                                         # in Claude Code
+```
+
+Or directly:
+
+```sh
+python3 scripts/gap.py --format md
+python3 scripts/gap.py --base develop --report build/lcov.info
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--base` | `main` (falls back to `master`) | Diff against this branch |
+| `--report` | auto-detect | Path to `coverage.xml`, `lcov.info`, or `coverage.json` |
+| `--format` | `json` | `json` or `md` |
+
+## Supported coverage formats
+
+| Format | Where it comes from |
+|---|---|
+| Cobertura `coverage.xml` | `pytest-cov`, `pytest --cov-report=xml`, `coverage xml` |
+| `lcov.info` | `jest --coverage`, `c8`, Istanbul |
+| `coverage.json` | `coverage json` |
+
+## Example output (markdown)
+
+```
+| file | changed lines | uncovered | uncovered lines |
+|---|---|---|---|
+| src/auth/refresh.py | 42 | 11 | 81-83, 102, 117-122 |
+| src/util/parse.py | 15 | 7 | 22-28 |
+```
+
+## How it works
+
+1. Reads `git diff --unified=0 <base>..HEAD` and collects the added line numbers per file.
+2. Parses the coverage report into a `{file: {covered_lines}}` map.
+3. Intersects: any added line not in the covered set is reported as a gap.
+4. Sorts the table by uncovered-count descending so the worst offenders surface first.
+
+## Limitations
+
+- Coverage is taken at face value — it doesn't know about branch coverage or test quality.
+- Cobertura paths must match diff paths; configure your runner to emit project-relative paths.
+- Empty diffs and no-test repos are handled gracefully (no output).
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/testing/test-gap/commands/test-gap.md
+++ b/plugins/testing/test-gap/commands/test-gap.md
@@ -1,0 +1,17 @@
+---
+name: test-gap
+description: Surface changed git diff lines that are not covered by tests
+allowed-tools: Bash
+---
+
+Run `python3 scripts/gap.py "$@"` from the test-gap plugin root.
+
+Purpose: compare the current git diff against the selected base branch, parse the selected or auto-detected coverage report, and report changed lines that are not covered by tests.
+
+Inputs: optional `--base`, `--report`, and `--format` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network, and do not hide failures.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/plugins/testing/test-gap/package.json
+++ b/plugins/testing/test-gap/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@intentsolutionsio/test-gap",
+  "version": "0.1.0",
+  "description": "/test-gap surfaces lines added or changed in the current git diff that are not covered by tests.",
+  "keywords": [
+    "testing",
+    "coverage",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/testing/test-gap"
+  },
+  "homepage": "https://tonsofskills.com/plugins/test-gap",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install test-gap\\\\n  or /plugin install test-gap@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/testing/test-gap/scripts/gap.py
+++ b/plugins/testing/test-gap/scripts/gap.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Find changed git diff lines that coverage reports mark as uncovered."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CoverageFile:
+    covered: set[int]
+    uncovered: set[int]
+    pct: float
+
+
+HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def default_base() -> str:
+    for branch in ("main", "master"):
+        result = run(["git", "rev-parse", "--verify", branch])
+        if result.returncode == 0:
+            return branch
+    return "main"
+
+
+def git_diff(base: str) -> str:
+    result = run(["git", "diff", "--unified=0", f"{base}..HEAD"])
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def parse_diff(diff_text: str) -> dict[str, list[int]]:
+    changed: dict[str, set[int]] = {}
+    current_file: str | None = None
+    current_line: int | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:].strip()
+            current_file = None if path == "/dev/null" else path.removeprefix("b/")
+            if current_file:
+                changed.setdefault(current_file, set())
+            continue
+
+        match = HUNK_RE.match(line)
+        if match:
+            current_line = int(match.group(1))
+            continue
+
+        if current_file is None or current_line is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            changed[current_file].add(current_line)
+            current_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        elif line.startswith(" "):
+            current_line += 1
+
+    return {path: sorted(lines) for path, lines in changed.items()}
+
+
+def pct(covered: set[int], uncovered: set[int]) -> float:
+    total = len(covered | uncovered)
+    return round((len(covered) / total) * 100, 2) if total else 100.0
+
+
+def parse_lcov(path: Path) -> dict[str, CoverageFile]:
+    files: dict[str, CoverageFile] = {}
+    current: str | None = None
+    covered: set[int] = set()
+    uncovered: set[int] = set()
+
+    def flush() -> None:
+        if current is not None:
+            files[normalize(current)] = CoverageFile(set(covered), set(uncovered), pct(covered, uncovered))
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if raw.startswith("SF:"):
+            flush()
+            current = raw[3:]
+            covered.clear()
+            uncovered.clear()
+        elif raw.startswith("DA:") and current is not None:
+            line_no, hits, *_ = raw[3:].split(",")
+            target = covered if int(float(hits)) > 0 else uncovered
+            target.add(int(line_no))
+        elif raw == "end_of_record":
+            flush()
+            current = None
+            covered.clear()
+            uncovered.clear()
+    flush()
+    return files
+
+
+def parse_cobertura(path: Path) -> dict[str, CoverageFile]:
+    root = ET.parse(path).getroot()
+    files: dict[str, CoverageFile] = {}
+    for class_node in root.findall(".//class"):
+        filename = class_node.get("filename")
+        if not filename:
+            continue
+        covered: set[int] = set()
+        uncovered: set[int] = set()
+        for line in class_node.findall(".//line"):
+            number = line.get("number")
+            hits = line.get("hits", "0")
+            if number is None:
+                continue
+            target = covered if int(float(hits)) > 0 else uncovered
+            target.add(int(number))
+        files[normalize(filename)] = CoverageFile(covered, uncovered, pct(covered, uncovered))
+    return files
+
+
+def parse_coverage_json(path: Path) -> dict[str, CoverageFile]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    files: dict[str, CoverageFile] = {}
+    for filename, data in payload.get("files", {}).items():
+        covered = set(map(int, data.get("executed_lines", [])))
+        uncovered = set(map(int, data.get("missing_lines", [])))
+        summary = data.get("summary", {})
+        percent = summary.get("percent_covered")
+        files[normalize(filename)] = CoverageFile(covered, uncovered, round(float(percent), 2) if percent is not None else pct(covered, uncovered))
+    return files
+
+
+def normalize(path: str) -> str:
+    return os.path.normpath(path).replace("\\", "/")
+
+
+def detect_report(explicit: str | None) -> Path | None:
+    if explicit:
+        candidate = Path(explicit)
+        return candidate if candidate.exists() else None
+    for name in ("coverage.xml", "lcov.info", "coverage.json"):
+        candidate = Path(name)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def parse_report(path: Path | None) -> dict[str, CoverageFile]:
+    if path is None:
+        return {}
+    if path.name == "lcov.info":
+        return parse_lcov(path)
+    if path.suffix == ".xml":
+        return parse_cobertura(path)
+    if path.suffix == ".json":
+        return parse_coverage_json(path)
+    raise SystemExit(f"Unsupported coverage report: {path}")
+
+
+_UNKNOWN_PCT = -1.0  # sentinel: no coverage info for this file
+
+
+def coverage_for(path: str, coverage: dict[str, CoverageFile]) -> CoverageFile:
+    norm = normalize(path)
+    if norm in coverage:
+        return coverage[norm]
+    for candidate, data in coverage.items():
+        if candidate.endswith("/" + norm) or norm.endswith("/" + candidate):
+            return data
+    return CoverageFile(set(), set(), _UNKNOWN_PCT)
+
+
+def build_result(changed: dict[str, list[int]], coverage: dict[str, CoverageFile]) -> dict[str, list[dict[str, object]]]:
+    have_coverage = bool(coverage)
+    files: list[dict[str, object]] = []
+    for path in sorted(changed):
+        data = coverage_for(path, coverage)
+        if data.pct == _UNKNOWN_PCT:
+            uncovered = list(changed[path])  # unknown → treat every changed line as a gap
+            cov_pct: object = None
+        else:
+            uncovered = [line for line in changed[path] if line in data.uncovered]
+            cov_pct = data.pct
+        files.append({
+            "path": path,
+            "changed_lines": changed[path],
+            "uncovered_lines": uncovered,
+            "coverage_pct": cov_pct,
+        })
+    return {"files": files, "coverage_loaded": have_coverage}
+
+
+def markdown(result: dict[str, list[dict[str, object]]]) -> str:
+    files = sorted(result["files"], key=lambda item: len(item["uncovered_lines"]), reverse=True)
+    if not files:
+        return "No changed lines found."
+    rows = ["| File | Changed | Uncovered | Coverage |", "| --- | ---: | ---: | ---: |"]
+    for item in files:
+        cov = item["coverage_pct"]
+        cov_cell = "unknown" if cov is None else f"{cov:.2f}%"
+        rows.append(
+            f"| {item['path']} | {len(item['changed_lines'])} | "
+            f"{','.join(map(str, item['uncovered_lines'])) or '-'} | {cov_cell} |"
+        )
+    if not result.get("coverage_loaded", True):
+        rows.append("")
+        rows.append("> **No coverage report found** — every changed line is reported as a gap. "
+                    "Run your test suite with coverage (e.g. `pytest --cov --cov-report=xml`) first.")
+    return "\n".join(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Report changed diff lines not covered by tests.")
+    parser.add_argument("--base", help="Base branch for git diff; defaults to main, then master.")
+    parser.add_argument("--report", help="Coverage report path.")
+    parser.add_argument("--format", choices=("json", "md"), default="json")
+    args = parser.parse_args(argv)
+
+    base = args.base or default_base()
+    if args.report and not Path(args.report).exists():
+        sys.stderr.write(f"error: coverage report not found at {args.report}\n")
+        return 2
+    changed = parse_diff(git_diff(base))
+    result = build_result(changed, parse_report(detect_report(args.report)))
+    if not result.get("coverage_loaded") and changed:
+        sys.stderr.write(
+            "warning: no coverage report detected (looked for coverage.xml, lcov.info, "
+            "coverage.json) — treating every changed line as a gap.\n"
+        )
+    print(markdown(result) if args.format == "md" else json.dumps(result, indent=2, sort_keys=True))
+    return 1 if changed and not result.get("coverage_loaded") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/testing/todo-harvest/.claude-plugin/plugin.json
+++ b/plugins/testing/todo-harvest/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "todo-harvest",
+  "version": "0.1.0",
+  "description": "Find TODO/FIXME/HACK comments with git-blame author and age.",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "repository": "https://github.com/mturac/pluginpool-todo-harvest",
+  "license": "MIT",
+  "keywords": [
+    "testing",
+    "todo",
+    "code-quality",
+    "agent-skills"
+  ],
+  "homepage": "https://github.com/mturac/pluginpool-todo-harvest"
+}

--- a/plugins/testing/todo-harvest/LICENSE
+++ b/plugins/testing/todo-harvest/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pluginpool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/testing/todo-harvest/README.md
+++ b/plugins/testing/todo-harvest/README.md
@@ -1,0 +1,93 @@
+![hero](./assets/hero.svg)
+
+# todo-harvest
+
+**Find the oldest, most-forgotten TODOs and put their authors on blast (constructively).**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/)
+[![Claude Code Plugin](https://img.shields.io/badge/claude--code-plugin-7c3aed.svg)](https://docs.claude.com/en/docs/claude-code/overview)
+[![Tests: 9 passing](https://img.shields.io/badge/tests-9%20passing-success.svg)](./tests)
+
+> **TL;DR:** `/todo-harvest` → markdown table of every `TODO/FIXME/HACK` with `git blame` author + age in days, sorted oldest-first.
+
+## Why this exists
+
+`TODO` comments are how engineers say "future me will deal with this." Future me never does. Worse, future-me-the-new-hire doesn't even know who wrote them or whether they still apply. `todo-harvest` runs `git blame` for each match so you can triage: 800-day-old TODOs from a dev who left the company three years ago are deletable; 12-day-old ones from this sprint are real work.
+
+## Install (Claude Code)
+
+```sh
+git clone https://github.com/mturac/pluginpool-todo-harvest ~/.claude/plugins/todo-harvest
+```
+
+Restart Claude Code; the slash command `/todo-harvest` appears.
+
+## Quick start
+
+```sh
+/todo-harvest
+```
+
+Or directly:
+
+```sh
+python3 scripts/harvest.py --format md
+python3 scripts/harvest.py --min-age 180 --format md     # only stuff older than 6 months
+python3 scripts/harvest.py --markers TODO,FIXME --format json
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--repo` | cwd | Repo path |
+| `--markers` | `TODO,FIXME,HACK,XXX,NOTE` | Comma-separated marker words |
+| `--min-age` | `0` | Only show markers ≥ N days old |
+| `--format` | `json` | `json` or `md` |
+
+## Example output (markdown)
+
+```
+| age (d) | marker | file:line | author | note |
+|---|---|---|---|---|
+| 1247 | HACK | src/legacy/login.py:42 | Alice (left in 2022) | special-case the demo-account UA |
+| 412 | FIXME | src/db.py:81 | Bob | this `n+1` lookup needs a join |
+| 88 | TODO | src/auth.py:17 | Cara | wire to the new OAuth2 path |
+```
+
+## How it works
+
+1. Uses `git ls-files` so untracked + `.gitignore`d files are skipped.
+2. Detects worktrees correctly (`.git` can be a file pointer, not a directory).
+3. Skips binary files (null byte in first 1 KB).
+4. Matches markers as whole words: `TODO`, `TODO:`, `# TODO …`.
+5. Runs `git blame --porcelain -L N,N -- <file>` per match for the original author + author-time.
+
+## Limitations
+
+- One `git blame` call per match means it's slow on huge repos — use `--min-age` or `--markers` to narrow.
+- "Age" is the age of the *current* line. Renames and reformats reset the clock.
+- Unicode-safe (decodes with `errors="replace"`).
+
+## Examples
+
+Step-by-step walkthroughs with real input fixtures and the helper's actual output live in [`examples/`](./examples/README.md). Three or four scenarios per plugin — from the happy path to the edge cases the test suite guards.
+
+## Part of the pluginpool family
+
+Ten focused Claude Code plugins for everyday productivity:
+[commit-narrator](https://github.com/mturac/pluginpool-commit-narrator) ·
+[pr-storyteller](https://github.com/mturac/pluginpool-pr-storyteller) ·
+[test-gap](https://github.com/mturac/pluginpool-test-gap) ·
+[deps-doctor](https://github.com/mturac/pluginpool-deps-doctor) ·
+[env-lint](https://github.com/mturac/pluginpool-env-lint) ·
+[secret-guard](https://github.com/mturac/pluginpool-secret-guard) ·
+[standup-gen](https://github.com/mturac/pluginpool-standup-gen) ·
+[todo-harvest](https://github.com/mturac/pluginpool-todo-harvest) ·
+[flaky-detector](https://github.com/mturac/pluginpool-flaky-detector) ·
+[changelog-forge](https://github.com/mturac/pluginpool-changelog-forge)
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE). Contributions welcome.

--- a/plugins/testing/todo-harvest/commands/todo-harvest.md
+++ b/plugins/testing/todo-harvest/commands/todo-harvest.md
@@ -1,0 +1,17 @@
+---
+name: todo-harvest
+description: List TODO/FIXME/HACK comments with author + age in days
+allowed-tools: Bash
+---
+
+Role: act as a debt-triage assistant. Surface the oldest, highest-cost TODOs first.
+
+Run the helper:
+
+```bash
+python3 scripts/harvest.py --format md
+```
+
+Useful flags: `--markers TODO,FIXME,HACK`, `--min-age 90`, `--format json`.
+
+The helper uses `git ls-files` (respecting .gitignore) and runs `git blame` per match for author + age. Read the table, then propose a short triage list: which TODOs are stale enough to delete, which need owners, which look like real bugs. Be specific — quote the file and line.

--- a/plugins/testing/todo-harvest/package.json
+++ b/plugins/testing/todo-harvest/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@intentsolutionsio/todo-harvest",
+  "version": "0.1.0",
+  "description": "Find TODO/FIXME/HACK comments with git-blame author and age.",
+  "keywords": [
+    "testing",
+    "todo",
+    "code-quality",
+    "agent-skills",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/testing/todo-harvest"
+  },
+  "homepage": "https://tonsofskills.com/plugins/todo-harvest",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Mehmet Turac",
+    "url": "https://github.com/mturac"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install todo-harvest\\\\n  or /plugin install todo-harvest@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/testing/todo-harvest/scripts/harvest.py
+++ b/plugins/testing/todo-harvest/scripts/harvest.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Harvest TODO/FIXME/HACK markers from a git repo with author + age."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+DEFAULT_MARKERS = ("TODO", "FIXME", "HACK", "XXX", "NOTE")
+
+
+def _run(args: list[str], cwd: str) -> str:
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+    return res.stdout
+
+
+def _is_binary(path: str) -> bool:
+    try:
+        with open(path, "rb") as f:
+            chunk = f.read(1024)
+        return b"\x00" in chunk
+    except OSError:
+        return True
+
+
+def _list_files(repo: str) -> list[str]:
+    out = _run(["git", "ls-files"], repo)
+    return [line for line in out.splitlines() if line]
+
+
+def _marker_pattern(markers: Iterable[str]) -> re.Pattern:
+    escaped = [re.escape(m) for m in markers]
+    return re.compile(r"\b(" + "|".join(escaped) + r")\b[:\s](.*)$")
+
+
+def _blame(repo: str, path: str, line: int) -> dict:
+    out = _run(
+        ["git", "blame", "--porcelain", "-L", f"{line},{line}", "--", path],
+        repo,
+    )
+    author = ""
+    epoch = 0
+    commit = ""
+    for ln in out.splitlines():
+        if not commit and re.match(r"^[0-9a-f]{7,40} ", ln):
+            commit = ln.split(" ", 1)[0]
+        if ln.startswith("author "):
+            author = ln[len("author "):].strip()
+        elif ln.startswith("author-time "):
+            try:
+                epoch = int(ln[len("author-time "):].strip())
+            except ValueError:
+                epoch = 0
+    return {"author": author, "commit": commit, "author_time": epoch}
+
+
+def _age_days(epoch: int, now: dt.datetime | None = None) -> int:
+    if epoch <= 0:
+        return -1
+    now = now or dt.datetime.now(tz=dt.timezone.utc)
+    delta = now - dt.datetime.fromtimestamp(epoch, tz=dt.timezone.utc)
+    return max(0, delta.days)
+
+
+def _is_git_repo(repo: str) -> bool:
+    """A directory is a git repo if `.git` is a dir (normal) OR a file (worktree).
+    Fall back to `git rev-parse --is-inside-work-tree` for edge cases like
+    GIT_DIR overrides or bare checkouts."""
+    git_path = os.path.join(repo, ".git")
+    if os.path.exists(git_path):  # file (worktree pointer) or directory
+        return True
+    res = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "--is-inside-work-tree"],
+        capture_output=True, text=True, check=False,
+    )
+    return res.returncode == 0 and res.stdout.strip() == "true"
+
+
+def harvest(repo: str, markers: tuple[str, ...] = DEFAULT_MARKERS, min_age: int = 0) -> list[dict]:
+    if not _is_git_repo(repo):
+        return []
+    pat = _marker_pattern(markers)
+    hits: list[dict] = []
+    for rel in _list_files(repo):
+        abs_path = os.path.join(repo, rel)
+        if not os.path.isfile(abs_path) or _is_binary(abs_path):
+            continue
+        try:
+            with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+                for n, line in enumerate(f, 1):
+                    m = pat.search(line)
+                    if not m:
+                        continue
+                    marker, text = m.group(1), m.group(2).strip()
+                    blame = _blame(repo, rel, n)
+                    age = _age_days(blame["author_time"])
+                    if age >= 0 and age < min_age:
+                        continue
+                    hits.append(
+                        {
+                            "path": rel,
+                            "line": n,
+                            "marker": marker,
+                            "text": text,
+                            "author": blame["author"],
+                            "age_days": age,
+                            "commit": blame["commit"],
+                        }
+                    )
+        except OSError:
+            continue
+    hits.sort(key=lambda h: (-h["age_days"], h["path"], h["line"]))
+    return hits
+
+
+def _render_markdown(hits: list[dict]) -> str:
+    if not hits:
+        return "_No matching markers._\n"
+    out = ["| age (d) | marker | file:line | author | note |", "|---|---|---|---|---|"]
+    for h in hits:
+        note = h["text"].replace("|", "\\|")
+        out.append(
+            f"| {h['age_days']} | {h['marker']} | {h['path']}:{h['line']} | {h['author']} | {note} |"
+        )
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Harvest TODO/FIXME/HACK markers with git blame.")
+    p.add_argument("--repo", default=os.getcwd())
+    p.add_argument("--markers", default=",".join(DEFAULT_MARKERS),
+                   help="Comma-separated marker words.")
+    p.add_argument("--min-age", type=int, default=0)
+    p.add_argument("--format", choices=["json", "md"], default="json")
+    args = p.parse_args(argv)
+
+    markers = tuple(m.strip() for m in args.markers.split(",") if m.strip())
+    hits = harvest(args.repo, markers, args.min_age)
+    if args.format == "md":
+        sys.stdout.write(_render_markdown(hits))
+    else:
+        json.dump(hits, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds all 10 plugins from [mturac/pluginpool](https://github.com/mturac/pluginpool) — focused developer productivity helpers wrapped as Claude Code slash commands, organized across 4 categories.

## Plugins added

| Plugin | Category | What it does | Tests |
|---|---|---|---:|
| commit-narrator | devops | Semantic commit message from `git diff --cached` | 8 |
| pr-storyteller | devops | PR title + body + test plan from commits | 6 |
| test-gap | testing | Lines in diff lacking test coverage | 9 |
| env-lint | testing | `.env` vs `.env.example` key parity | 7 |
| todo-harvest | testing | TODO/FIXME/HACK scan with git blame | 9 |
| flaky-detector | testing | Per-test flakiness % from N runs | 11 |
| deps-doctor | security | Multi-ecosystem dependency audit | 8 |
| secret-guard | security | Pre-commit secret scanner | 10 |
| standup-gen | productivity | Standup notes from git activity | 8 |
| changelog-forge | productivity | Conventional commits → CHANGELOG | 13 |

**89 hermetic tests across the suite, all green. Python standard library only at runtime — no `pip install` needed.** MIT.

## Validator results

All 10 plugins pass marketplace-tier validation with **zero errors** (just one INFO suggesting commands→skills migration, which is non-blocking):

```
$ for p in <all 10>; do python3 scripts/validate-skills-schema.py --marketplace plugins/$p/; done
# Each: "INFO: [plugin] commands/ directory has 1 files — consider migrating to skills/"
# Each: "Skills: 0, Agents: 0" (commands-based plugins)
# No ERRORs across any plugin
```

## PR contents

Each plugin folder contains:
- `.claude-plugin/plugin.json` — full schema with author as object, name, version, description, repository, license, keywords, homepage
- `commands/<name>.md` — slash command with `name` + `description` + `allowed-tools` frontmatter
- `scripts/<helper>.py` — Python stdlib-only helper that does the actual work
- `README.md` — plugin documentation
- `LICENSE` — MIT (with attribution to upstream)

Plus:
- `.claude-plugin/marketplace.extended.json` — 10 new entries with category, keywords, source path, author
- `.claude-plugin/marketplace.json` — regenerated via `node scripts/sync-marketplace.cjs`

## Upstream

Each plugin also lives as its own standalone repo: [mturac/pluginpool-<name>](https://github.com/mturac?tab=repositories&q=pluginpool). The umbrella index is at https://github.com/mturac/pluginpool.

Allow edits from maintainers: enabled. Happy to revise categories, add `skills/` wrappers per plugin (so `Skills: 0` becomes `Skills: 10`), or split into separate PRs per plugin if you'd prefer.