### PR TITLE
fix(ci): drop pull_request trigger from codeql (closes #652)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: "CodeQL Security Analysis"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # pull_request trigger removed 2026-05-16 — was firing false-positive alerts on PRs
+  # for code that's documented as known-safe (release/, scripts/). Coverage on main
+  # is preserved via the push trigger; PRs merging to main get scanned at merge time.
+  # Closes #652.
   # schedule disabled — burns Actions minutes
   # - cron: '0 6 * * 1'
 


### PR DESCRIPTION
## Summary
- Removes `pull_request` trigger from `.github/workflows/codeql.yml`
- CodeQL coverage on `main` preserved via `push` trigger
- PRs scanned at merge-to-main time instead of per-PR
- Closes #652 (13-day-old self-assigned issue for the same problem)

## Why now
Step 0 of the 2026-05-16 triage plan: kill external-noise sources on PRs so the internal validators (`validate` + `marketplace-validation` + `pr-prescreen`) carry the signal. CodeQL false-positives on `release/` + `scripts/` have been documented as safe and were crowding out signal from the new pr-prescreen workflow.

## Test plan
- [x] YAML syntax verified (edit-only change)
- [ ] Merge → next external PR (#726/#727/#728) opens with cleaner check status
- [ ] CodeQL still runs on next push to `main`

## Risk
Low. Single-trigger removal, reversible in one commit. `push` to `main` still scans everything.

- Jeremy Longshore
intentsolutions.io