### PR TITLE
fix(ci): prescreen false-PASS + reject whole-file catalog reformat

### DIFF
--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -96,18 +96,41 @@ jobs:
         run: |
           set -euo pipefail
           # Use the GitHub API to list changed files — safer than running git
-          # against fork content.
+          # against fork content. NOTE: do NOT combine `--paginate` with `--jq`
+          # in one call — observed to return empty stdout on the runner even
+          # when the underlying API returns files (caused the 2026-05-16
+          # false-PASS bug on #726/#728). Fetch raw JSON pages, parse with a
+          # separate `jq` invocation. No `|| true` either — we want a real
+          # failure to surface rather than silently emit "no plugin paths".
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files" \
-            --jq '.[].filename' > /tmp/pr-files.txt || true
+            > /tmp/pr-files.json
+          jq -r '.[].filename' /tmp/pr-files.json > /tmp/pr-files.txt
+          echo "All changed files (count=$(wc -l < /tmp/pr-files.txt | tr -d ' ')):" >&2
+          head -50 /tmp/pr-files.txt >&2
           # Plugin dirs: plugins/<category>/<name>/...
-          grep '^plugins/' /tmp/pr-files.txt 2>/dev/null \
+          # `grep || true` is intentional here — empty match is a legit case
+          # (infra-only PR). awk + sort -u handle the rest.
+          { grep '^plugins/' /tmp/pr-files.txt || true; } \
             | awk -F/ '{print $1"/"$2"/"$3}' \
-            | sort -u > /tmp/changed-plugins.txt || true
+            | sort -u > /tmp/changed-plugins.txt
           echo "Changed plugin dirs:" >&2
-          cat /tmp/changed-plugins.txt >&2 || true
+          cat /tmp/changed-plugins.txt >&2
+          PLUGIN_LINES=$({ grep -c '^plugins/' /tmp/pr-files.txt || true; })
+          CHANGED_DIRS=$(wc -l < /tmp/changed-plugins.txt | tr -d ' ')
+          # Sanity guard: if the diff clearly touched plugin files but our
+          # dir-extraction came back empty, that's an internal bug, not a
+          # clean PR. Surface it so the verdict isn't a silent false PASS.
+          # Write our sanity-check signal to a separate file — the next step
+          # truncates /tmp/hard-blocks.txt at start, so we'd lose anything
+          # written here. The Classify step concatenates both files.
+          : > /tmp/diff-step-signals.txt
+          if [ "$PLUGIN_LINES" -gt 0 ] && [ "$CHANGED_DIRS" = "0" ]; then
+            echo "prescreen-internal-error: diff contained $PLUGIN_LINES plugin file(s) but extraction produced 0 dirs" >> /tmp/diff-step-signals.txt
+            echo "::error::pr-prescreen internal: plugin lines present but no dirs extracted (see /tmp/pr-files.txt)"
+          fi
           {
-            echo "count=$(wc -l < /tmp/changed-plugins.txt | tr -d ' ')"
+            echo "count=$CHANGED_DIRS"
           } >> "$GITHUB_OUTPUT"
 
       - name: Run validator against PR tree (full --json sweep)
@@ -191,7 +214,11 @@ jobs:
         run: |
           set -euo pipefail
           # Pass hard-block signals via the env var the classifier reads.
-          PR_PRESCREEN_HARD_BLOCKS="$(cat /tmp/hard-blocks.txt)" \
+          # Combine signals from the structural-detection step + the
+          # diff-step sanity check (each writes to its own file so neither
+          # step can clobber the other).
+          ALL_SIGNALS="$(cat /tmp/hard-blocks.txt /tmp/diff-step-signals.txt 2>/dev/null || true)"
+          PR_PRESCREEN_HARD_BLOCKS="$ALL_SIGNALS" \
             python3 base/scripts/pr-prescreen/classify.py /tmp/filtered-results.json \
             > /tmp/verdict.json
           VERDICT=$(jq -r '.verdict' /tmp/verdict.json)

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -71,6 +71,18 @@ jobs:
       - name: Validate catalog invariants (FS path = category)
         run: python3 scripts/validate-catalog-invariants.py
 
+      # Reject PRs that reformat .claude-plugin/marketplace.extended.json beyond
+      # the line budget implied by added/modified entries. Prevents prettier or
+      # IDE format-on-save passes from rewriting the whole catalog and wrecking
+      # merge bases for every other in-flight PR. Pulls origin/main for the
+      # comparison; safe-skips on push to main (no useful base).
+      - name: Catalog format guard (no whole-file reformat)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          python3 scripts/check-catalog-format.py "origin/${{ github.base_ref }}"
+
       - name: Verify README TOC is in sync with catalog
         run: node scripts/generate-readme-toc.mjs --check
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -36,6 +36,11 @@ marketplace/src/data/unified-search-index.json
 marketplace/src/data/cowork-manifest.json
 marketplace/src/data/npm-stats.json
 
+# Source of truth — DO NOT reformat. Hand-edit only, formatting is load-bearing.
+# A CI guard (scripts/check-catalog-format.py) rejects PRs that collapse the
+# multi-line keyword arrays or otherwise reformat existing entries.
+.claude-plugin/marketplace.extended.json
+
 
 # Out-of-scope subtrees (own formatters / large surface area — handle in follow-up PRs)
 marketplace/

--- a/scripts/check-catalog-format.py
+++ b/scripts/check-catalog-format.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Reject PRs that reformat .claude-plugin/marketplace.extended.json beyond
+the line budget implied by structural changes.
+
+Background: contributors sometimes run prettier (or an IDE format-on-save) over
+the catalog file, which collapses every multi-line `keywords: [...]` array into
+a single line across the entire 11k-line file. The net diff then shows -1200
+lines for a PR that only adds one logical plugin entry. Reformatting wrecks
+merge bases for any other PR touching the same file, so we reject it at CI.
+
+Heuristic: count net new/removed/modified plugin entries (by `name`). Each
+added/removed entry has an expected line budget; modifications are smaller.
+If the file's actual net line delta exceeds budget by a fixed tolerance,
+flag as reformat.
+
+Usage:
+    python3 scripts/check-catalog-format.py [BASE_REF]
+
+BASE_REF defaults to "origin/main". Exits non-zero on suspected reformat.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+CATALOG = ".claude-plugin/marketplace.extended.json"
+# Per-entry line budgets — generous to allow real edits.
+LINES_PER_ADDED = 80
+LINES_PER_REMOVED = 80
+LINES_PER_MODIFIED = 20
+TOLERANCE = 300  # absolute line-count slack before we call it a reformat
+
+
+def main(argv: list[str]) -> int:
+    base_ref = argv[1] if len(argv) > 1 else "origin/main"
+
+    try:
+        base_json = subprocess.check_output(
+            ["git", "show", f"{base_ref}:{CATALOG}"],
+            stderr=subprocess.PIPE,
+        ).decode()
+    except subprocess.CalledProcessError as e:
+        print(f"check-catalog-format: could not read {base_ref}:{CATALOG} — {e.stderr.decode().strip()}", file=sys.stderr)
+        # No base = new repo; nothing to compare against.
+        return 0
+
+    head_path = pathlib.Path(CATALOG)
+    if not head_path.exists():
+        print(f"check-catalog-format: {CATALOG} not present in working tree", file=sys.stderr)
+        return 0
+    head_json = head_path.read_text()
+
+    if base_json == head_json:
+        print("check-catalog-format: catalog unchanged — OK")
+        return 0
+
+    try:
+        base = json.loads(base_json)
+        head = json.loads(head_json)
+    except json.JSONDecodeError as e:
+        print(f"::error file={CATALOG}::Catalog is not valid JSON: {e}")
+        return 1
+
+    base_entries = {p["name"]: p for p in base.get("plugins", []) if p.get("name")}
+    head_entries = {p["name"]: p for p in head.get("plugins", []) if p.get("name")}
+
+    added = set(head_entries) - set(base_entries)
+    removed = set(base_entries) - set(head_entries)
+    common = set(base_entries) & set(head_entries)
+    modified = {n for n in common if base_entries[n] != head_entries[n]}
+
+    base_lines = base_json.count("\n")
+    head_lines = head_json.count("\n")
+    net = head_lines - base_lines
+    budget = (
+        LINES_PER_ADDED * len(added)
+        - LINES_PER_REMOVED * len(removed)
+        + LINES_PER_MODIFIED * len(modified)
+    )
+
+    delta = abs(net - budget)
+    print(
+        f"check-catalog-format: net {net:+d} lines "
+        f"(budget {budget:+d}±{TOLERANCE}, delta {delta}) "
+        f"for {len(added)} added / {len(modified)} modified / {len(removed)} removed entries"
+    )
+
+    if delta > TOLERANCE:
+        msg = (
+            f"Catalog churn ({net:+d} lines net) far exceeds budget "
+            f"({budget:+d}±{TOLERANCE}) for {len(added)} added, {len(modified)} modified, "
+            f"{len(removed)} removed entries. Suggests a formatter pass ran over the file. "
+            "Please revert whitespace-only changes — the catalog's multi-line layout is load-bearing "
+            "(see .prettierignore). If your changes are intentional, open an issue first."
+        )
+        print(f"::error file={CATALOG}::{msg}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Two bugs surfaced today by the first external PRs through the new pre-screen pipeline (#726, #728):

### 1. Pre-screen classifier false-PASS

`pr-prescreen.yml` "Compute changed plugin paths" step combined `gh api --paginate` with `--jq` and silently produced empty stdout on the runner (works locally), then `|| true` swallowed the failure. Classifier got an empty results list and reported `PASS: no plugin paths matched the PR diff` on PRs that clearly added plugin dirs.

**Fix**:
- Separate `gh api --paginate` from `jq` (call jq on the JSON file in a second step)
- Drop the blanket `|| true` from the API call
- Add diagnostic head + cat of intermediate files (`/tmp/pr-files.txt`, `/tmp/changed-plugins.txt`) so the next failure isn't invisible
- Add a sanity guard: if the diff contained plugin files but extraction produced zero dirs, emit a `prescreen-internal-error` hard-block signal so the verdict can never be a silent false PASS again

### 2. Catalog whole-file reformat slipping through

Contributors ran prettier (or IDE format-on-save) over `.claude-plugin/marketplace.extended.json`, collapsing every multi-line `keywords: [...]` array into single-line form across the entire 11k-line file. Net on #726/#728: 1 plugin entry added, -1200 lines reformatted. Wrecks merge bases for every other in-flight PR.

**Fix**:
- Add `.claude-plugin/marketplace.extended.json` to `.prettierignore` (formatting is load-bearing — the multi-line layout is the source of truth)
- Add `scripts/check-catalog-format.py` — a line-budget guard wired into `validate-plugins.yml`. Compares the parsed JSON structurally vs base, computes expected line delta from added/modified/removed entries, and rejects PRs where actual delta exceeds budget by >300 lines

### Verified
- Guard against current main on this branch returns OK (catalog unchanged)
- Guard against pr-726 locally flagged at delta 1631 (net -1551 vs +80 budget for 1 new entry) — exit 1

## Test plan
- [ ] Merge → next PR touching plugins/ exercises both fixes
- [ ] CI passes on this PR (no plugin changes here, guard short-circuits to OK)
- [ ] Confirm the pre-screen workflow doesn't regress on infra-only PRs (post-skip is still triggered when `count == 0`)

## Refs
- #726, #728 — the PRs that triggered both findings
- Both will need the contributor to revert the formatter pass (or we rebase the entries ourselves) before re-merge

- Jeremy Longshore
intentsolutions.io