### PR TITLE
fix(sync): pull missing .ts deps + restore .mcp.json for mirror (closes #645 issues 1-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ logs/
 .env.local
 .env.*.local
 .mcp.json
+# Re-include MCP server configs for plugins that ship them — required for
+# Claude Code to know how to spawn the server. Without this, mirrored
+# plugins under plugins/mcp/* end up missing .mcp.json in the install
+# artifact and the MCP handshake fails (see #645).
+!plugins/mcp/*/.mcp.json
+!plugins/**/.mcp.json
 
 # Build outputs
 dist/

--- a/plugins/mcp/pr-to-spec/.mcp.json
+++ b/plugins/mcp/pr-to-spec/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "pr-spec-analyzer": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/servers/pr-spec-analyzer.js"],
+      "env": {}
+    }
+  }
+}

--- a/plugins/mcp/slack-channel/.mcp.json
+++ b/plugins/mcp/slack-channel/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "slack": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/node_modules/.bin/tsx",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.ts"]
+    }
+  }
+}

--- a/plugins/mcp/slack-channel/.source.json
+++ b/plugins/mcp/slack-channel/.source.json
@@ -4,12 +4,12 @@
     "path": ".",
     "branch": "main"
   },
-  "last_sync": "2026-05-12T23:15:20.342Z",
+  "last_sync": "2026-05-17T04:38:10.622Z",
   "author": {
     "name": "Jeremy Longshore",
     "github": "jeremylongshore",
     "email": "jeremy@intentsolutions.io"
   },
   "license": "MIT",
-  "files_synced": 1
+  "files_synced": 16
 }

--- a/plugins/mcp/slack-channel/README.md
+++ b/plugins/mcp/slack-channel/README.md
@@ -1,4 +1,4 @@
-# claude-code-slack-channel v0.8.0
+# claude-code-slack-channel v0.9.1
 
 Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal. Per-thread session isolation, hash-chained tamper-evident audit journal with optional per-channel Slack projection, policy-gated tools, five-layer prompt-injection defense.
 
@@ -6,7 +6,7 @@ Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channe
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.8.0)
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.9.1)
 
 > **Research Preview** — Channels require Claude Code v2.1.80+ and `claude.ai` login.
 

--- a/plugins/mcp/slack-channel/journal.ts
+++ b/plugins/mcp/slack-channel/journal.ts
@@ -1,0 +1,1145 @@
+/**
+ * journal.ts — Tamper-evident audit journal for the Slack↔Claude-Code bridge.
+ *
+ * This file is the Epic 30-A entry point. Scope of this bead (ccsc-5pi.1)
+ * is narrow: the `JournalEvent` schema and its inferred type. The writer,
+ * redaction module, canonical-JSON serializer, and verification command
+ * land in sibling beads (ccsc-5pi.2 – ccsc-5pi.16). See
+ * 000-docs/audit-journal-architecture.md for the full contract.
+ *
+ * Shape of a journal event (audit-journal-architecture.md §19-59):
+ *
+ *   {
+ *     v:        1,                          // schema version; chain refuses mixed versions
+ *     ts:       '2026-04-19T12:34:56.789Z', // ISO-8601 UTC with ms precision
+ *     seq:      42,                         // monotonic per chain
+ *     kind:     'gate.inbound.drop',        // discriminated union of 22 event kinds
+ *     toolName?: 'reply',
+ *     input?:   { chat_id: 'C01', text: '...' },     // post-redaction
+ *     outcome?: 'allow' | 'deny' | 'require' | 'drop' | 'n/a',
+ *     reason?:  'peer bot not in allowFrom',
+ *     ruleId?:  'no-exfil-to-untrusted-channel',
+ *     sessionKey?: { channel: 'C01', thread: '1711000000.000100' },
+ *     actor?:   'session_owner' | 'claude_process' | ...,
+ *     correlationId?: 'req-abc123',
+ *     prevHash: 'e3b0c44...',                // sha256 hex, 64 chars
+ *     hash:     'b94d27b...',                // sha256 hex, 64 chars
+ *   }
+ *
+ * Why `strict()` on the schema: the chain property depends on every writer
+ * and every verifier hashing the **same bytes**. Accepting unknown fields
+ * would let callers sneak unredacted content through the writer's redactor
+ * (which only walks the documented fields). Strict mode surfaces those
+ * mistakes at build time or on the first `parse()` call.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { createHash, randomBytes } from 'node:crypto'
+import { type FileHandle, open as fsOpen, readFile } from 'node:fs/promises'
+import { z } from 'zod'
+import type { SessionKey } from './lib'
+
+// ---------------------------------------------------------------------------
+// Event kinds — discriminated union tag
+// ---------------------------------------------------------------------------
+
+/** Every security-relevant event the journal records. Pinned by
+ *  000-docs/audit-journal-architecture.md §40-59; adding a new kind is an
+ *  intentional schema change and should be justified in a design-doc PR
+ *  before the code PR.
+ *
+ *  Grouping (for the reader, not enforced):
+ *    - `gate.*`        inbound/outbound gate decisions (lib.ts)
+ *    - `policy.*`      evaluator decisions + approval flow (policy.ts)
+ *    - `exfil.block`   `assertSendable()` refusal
+ *    - `session.*`     supervisor lifecycle transitions (supervisor.ts)
+ *    - `pairing.*`     DM-pairing state machine (access.json)
+ *    - `system.*`      boot, shutdown, rotation
+ */
+export const EventKind = z.enum([
+  'gate.inbound.deliver',
+  'gate.inbound.drop',
+  'gate.outbound.allow',
+  'gate.outbound.deny',
+  'policy.allow',
+  'policy.deny',
+  'policy.require',
+  'policy.approved',
+  'exfil.block',
+  'session.activate',
+  'session.quiesce',
+  'session.deactivate',
+  'session.quarantine',
+  'pairing.issued',
+  'pairing.accepted',
+  'pairing.expired',
+  'system.boot',
+  'system.shutdown',
+  'system.reload',
+  // Bot-manifest protocol (Epic 31-A). Emitted on every read_peer_manifests
+  // call so manifest activity is forensically visible even when cached;
+  // see 000-docs/bot-manifest-protocol.md §163-166.
+  'manifest.read',
+  'manifest.read.cached',
+  // Publisher side (Epic 31-B, ccsc-0qk.1/0qk.3). Emitted after a successful
+  // publish_manifest call, carrying the replaced-count so operators can see
+  // how many prior manifests were unpinned during the replace sweep.
+  'manifest.publish',
+])
+
+/** TypeScript string union of the 22 event kinds. */
+export type EventKind = z.infer<typeof EventKind>
+
+// ---------------------------------------------------------------------------
+// Supporting enums
+// ---------------------------------------------------------------------------
+
+/** Outcome of a gated action. `n/a` is the legitimate value for events
+ *  that are observational rather than decision-emitting (e.g.
+ *  `system.boot`, `session.activate`). Keep this set tight so the
+ *  verification tool can normalize cleanly. */
+export const Outcome = z.enum(['allow', 'deny', 'require', 'drop', 'n/a'])
+export type Outcome = z.infer<typeof Outcome>
+
+/** Who initiated or owns the action being recorded. Mirrors the
+ *  four-principal model in ARCHITECTURE.md; `system` is the catch-all
+ *  for supervisor / reaper / boot-path entries that have no human or
+ *  agent actor. */
+export const Actor = z.enum([
+  'session_owner',
+  'claude_process',
+  'human_approver',
+  'peer_agent',
+  'system',
+])
+export type Actor = z.infer<typeof Actor>
+
+// ---------------------------------------------------------------------------
+// Primitive shapes
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex string: exactly 64 lowercase hex chars. Enforced at
+ *  parse time so a malformed `prevHash` / `hash` is caught before it
+ *  reaches the verifier. The writer produces them via `toString('hex')`
+ *  on a Node crypto digest, which is guaranteed lowercase. */
+const Sha256Hex = z.string().regex(/^[0-9a-f]{64}$/, {
+  message: 'sha256 hex must be 64 lowercase hex chars',
+})
+
+/** Subset match of `SessionKey` from lib.ts. Duplicated here rather
+ *  than reusing the lib schema because the journal must be hashable
+ *  independent of whether lib.ts is loaded; keeping the structure
+ *  literal keeps the JCS canonical form frozen to this file.
+ *
+ *  The `satisfies` assertion guarantees the shape stays in lock-step
+ *  with the `SessionKey` type — a lib-side rename breaks the build
+ *  here, forcing a schema bump.
+ *
+ *  `.strict()` for the same reason the top-level `JournalEvent` is
+ *  strict: two writers that disagree on what fields live inside
+ *  `sessionKey` would hash to different canonical forms and break the
+ *  chain. Reject unknown fields at parse time. */
+const SessionKeyShape = z
+  .object({
+    channel: z.string(),
+    thread: z.string(),
+  })
+  .strict() satisfies z.ZodType<SessionKey>
+
+// ---------------------------------------------------------------------------
+// JournalEvent — the on-disk record shape
+// ---------------------------------------------------------------------------
+
+/** One line in `audit.log` after canonical serialization. Every field
+ *  is either required (carried by every event) or optional with a clear
+ *  meaning when absent.
+ *
+ *  Why `strict()`: unknown fields on a journal event mean either (a) a
+ *  caller is trying to sneak unredacted data through the writer, or
+ *  (b) two components disagree on the schema. Both need to be loud,
+ *  not swallowed. The cost is that schema growth requires a coordinated
+ *  bump of `v` — which is exactly the right friction for a forensic
+ *  record.
+ *
+ *  Canonicalisation note: when the writer (ccsc-5pi.2) hashes an event
+ *  it strips `hash` and JCS-serializes the rest. The schema therefore
+ *  accepts `hash` as required — partial events without `hash` are a
+ *  writer-internal intermediate, not a valid on-disk record.
+ */
+export const JournalEvent = z
+  .object({
+    /** Schema version. Bumped on any shape change; verify-journal (ccsc-
+     *  5pi.9) refuses a chain that mixes versions so a v1 → v2 rollover
+     *  cannot silently desync. */
+    v: z.literal(1),
+
+    /** ISO-8601 UTC timestamp with millisecond precision, e.g.
+     *  `2026-04-19T12:34:56.789Z`. The writer sets this from `nowIso()`
+     *  at append time; callers must not pre-populate. `z.string().datetime()`
+     *  enforces the ISO form and mandates a trailing `Z` / offset. */
+    ts: z.string().datetime({ offset: true, precision: 3 }),
+
+    /** Monotonic sequence number. Starts at 1 on the first event after
+     *  boot and never resets within a chain. A gap between consecutive
+     *  events is a tamper signal during verification — see audit-
+     *  journal-architecture.md §61-73. */
+    seq: z.number().int().nonnegative(),
+
+    /** Discriminated tag identifying what happened. See `EventKind`
+     *  above for the enumerated set. */
+    kind: EventKind,
+
+    /** MCP tool name when the event involves a tool call. Absent for
+     *  session / pairing / system events. */
+    toolName: z.string().min(1).optional(),
+
+    /** Redacted tool-call arguments. Every secret-shaped value has been
+     *  replaced with `[REDACTED:<kind>]` before this field is hashed or
+     *  written. Nested structures are walked recursively by the redactor
+     *  (ccsc-5pi.4). */
+    input: z.record(z.string(), z.unknown()).optional(),
+
+    /** Outcome classifier for decision events. `n/a` is valid and
+     *  required for observational events; absence is valid too (same
+     *  semantic). */
+    outcome: Outcome.optional(),
+
+    /** Short, human-readable explanation. Redacted before hashing.
+     *  Carries no PII or secret material by contract — if you find a
+     *  counter-example, file a bead against the caller, not the schema. */
+    reason: z.string().optional(),
+
+    /** Identifier of the matched policy rule for `policy.*` events. */
+    ruleId: z.string().min(1).optional(),
+
+    /** Owning session when the event is session-scoped. Absent for
+     *  `system.*` and some `pairing.*` events that predate session
+     *  creation. */
+    sessionKey: SessionKeyShape.optional(),
+
+    /** Who triggered or owns the event. See `Actor` above. */
+    actor: Actor.optional(),
+
+    /** Dapper-style correlation id linking related events — a single
+     *  tool call's policy-require → pairing-issued → pairing-accepted →
+     *  policy-approved → gate-outbound-allow all share one
+     *  `correlationId`. Absent for events that have no cross-cutting
+     *  trace (boot, reload). */
+    correlationId: z.string().min(1).optional(),
+
+    /** SHA-256 hex of the preceding event. The very first event in a
+     *  chain uses `sha256(TRUSTED_ANCHOR)`; see audit-journal-
+     *  architecture.md §76-85 for the anchor contract. */
+    prevHash: Sha256Hex,
+
+    /** SHA-256 hex of `prevHash || canonicalJson(event sans hash)`.
+     *  Computed by the writer (ccsc-5pi.2) and verified bit-for-bit by
+     *  the verify-journal command (ccsc-5pi.9). */
+    hash: Sha256Hex,
+  })
+  .strict()
+
+/** Inferred TypeScript shape of `JournalEvent`. Prefer this over the
+ *  Zod type when writing application code — the Zod object is the
+ *  parser, the TS type is the data. */
+export type JournalEvent = z.infer<typeof JournalEvent>
+
+/** Narrower type for the writer's pre-hash intermediate form: all the
+ *  fields that go into the hash, without `hash` itself. The writer
+ *  computes `sha256(prevHash || jcs(PartialEvent))` and then attaches
+ *  `hash` to produce a full `JournalEvent`. Not exported as a Zod
+ *  schema — it is a writer-internal shape, not a valid on-disk record. */
+export type PartialJournalEvent = Omit<JournalEvent, 'hash'>
+
+// ---------------------------------------------------------------------------
+// JournalWriter — SHA-256 hash-chained append-only writer (ccsc-5pi.2)
+// ---------------------------------------------------------------------------
+
+/** Everything a caller supplies for a new event. The writer fills in the
+ *  framing fields (`v`, `ts`, `seq`, `prevHash`, `hash`) so callers cannot
+ *  drift the hash-determining fields by accident.
+ *
+ *  Note the Omit excludes `v` even though it is a literal — the writer
+ *  always sets it to 1. When the schema version bumps, callers do not
+ *  need to update. */
+export type WriteInput = Omit<JournalEvent, 'v' | 'ts' | 'seq' | 'prevHash' | 'hash'>
+
+/** Construction options for `JournalWriter.open()`.
+ *
+ *  Defaults give you a production-shaped writer. Tests override `now` and
+ *  `initialPrevHash` to keep hash assertions deterministic.
+ */
+export interface WriterOptions {
+  /** Absolute path to the audit log file. Created with mode `0o600` if
+   *  it doesn't exist. */
+  path: string
+
+  /** Genesis `prevHash` for an empty file. Default is a fresh random
+   *  32-byte sha256, matching the "TRUSTED_ANCHOR" concept in
+   *  audit-journal-architecture.md §76-85. Callers that want the anchor
+   *  recorded in the first event's body pre-compute it and pass it here.
+   *  Ignored when the file is non-empty — existing chains dictate their
+   *  own lastHash. */
+  initialPrevHash?: string
+
+  /** Clock source for `ts`. Injected in tests so assertions can fix the
+   *  timestamp. Default: real wall clock. */
+  now?: () => Date
+}
+
+/** Module-level registry of open audit-log paths. Enforces the
+ *  "single JournalWriter per process" invariant (audit-journal-
+ *  architecture.md §148-151, invariant §312-326 #1). A second `open()`
+ *  on the same path while the first writer is still live rejects rather
+ *  than allowing two writers to interleave their hash chains silently. */
+const ACTIVE_PATHS = new Set<string>()
+
+/** Chunk size for the reverse-chunk tail read in `readLastLine`. 64 KiB is
+ *  large enough that realistic audit lines (~300-2000 bytes) fit in a
+ *  single chunk, small enough that the buffer cost stays negligible even
+ *  if recovery runs on a tiny-memory machine. Lines larger than the chunk
+ *  are handled correctly by the loop — it just reads another chunk. */
+const READ_LAST_LINE_CHUNK_SIZE = 64 * 1024
+
+/** Read the last non-empty newline-delimited line from an open file
+ *  handle without loading the whole file into memory. Returns null if
+ *  the file is empty (or contains only trailing newlines). Used by
+ *  `JournalWriter.open` to recover chain state in O(last-line-size)
+ *  memory instead of O(file-size) — the original full-`readFileSync`
+ *  path stopped scaling past the low-MB range per ccsc-otd.
+ *
+ *  Reads with explicit `position` so it doesn't disturb the append
+ *  pointer of an `a+`-opened handle (writes still land at EOF via
+ *  O_APPEND).
+ */
+async function readLastLine(fh: FileHandle): Promise<string | null> {
+  const { size } = await fh.stat()
+  if (size === 0) return null
+
+  // Walk backwards from EOF in chunks, accumulating into `tail`. Stop
+  // when we find a newline that precedes non-empty content (i.e., the
+  // newline before the last line) or when we reach the start of file.
+  let tail = Buffer.alloc(0)
+  let pos = size
+  while (pos > 0) {
+    const readSize = Math.min(READ_LAST_LINE_CHUNK_SIZE, pos)
+    pos -= readSize
+    const buf = Buffer.alloc(readSize)
+    const { bytesRead } = await fh.read(buf, 0, readSize, pos)
+    if (bytesRead === 0) break // unexpected but defensive
+    tail = Buffer.concat([buf.subarray(0, bytesRead), tail])
+
+    // Trim trailing newlines (one or more) before scanning for the
+    // boundary newline so an empty last line (file ends with "\n\n")
+    // is treated as "no content on that line".
+    let end = tail.length
+    while (end > 0 && tail[end - 1] === 0x0a /* '\n' */) end--
+    if (end === 0) {
+      // Chunk(s) so far are all newlines. Keep reading earlier bytes.
+      continue
+    }
+    // Look for the nearest newline strictly before `end`. If found,
+    // the last line is the slice after it (up to `end`).
+    const nl = tail.subarray(0, end).lastIndexOf(0x0a)
+    if (nl !== -1) {
+      return tail.subarray(nl + 1, end).toString('utf8')
+    }
+    // No newline yet and we've reached start-of-file — whole file is
+    // one line. Return it (minus any trailing newlines).
+    if (pos === 0) return tail.subarray(0, end).toString('utf8')
+    // Else: line is longer than what we've read; loop and pull another
+    // chunk.
+  }
+  // Got here only if the whole file was newlines.
+  return null
+}
+
+/** Tamper-evident append-only writer. See audit-journal-architecture.md
+ *  §76-161 for the full contract. One writer per process per path.
+ *
+ *  Lifecycle:
+ *    1. `JournalWriter.open({ path })` — opens the file in append mode,
+ *       reads any existing content to recover `lastHash` + `seq`, and
+ *       registers the path.
+ *    2. `.writeEvent(input)` — serializes through an internal queue so
+ *       concurrent callers cannot interleave increments. Computes
+ *       `hash = sha256(lastHash || jcs(event sans hash))`, appends a
+ *       newline-delimited JSON line, and returns the full event.
+ *    3. `.close()` — flushes, closes the file descriptor, frees the
+ *       path registration.
+ *
+ *  Fail-loud posture: any write failure puts the writer into a broken
+ *  state and subsequent `writeEvent` calls reject. Recovery is an
+ *  operator concern — inspect and restart. Silent recovery would
+ *  violate the forensic-record invariant.
+ */
+export class JournalWriter {
+  private fh: FileHandle | null
+  private lastHash: string
+  private nextSeq: number
+  private readonly now: () => Date
+  private readonly path: string
+
+  /** Serialization queue. Every `writeEvent` chains onto this promise so
+   *  that increment → hash → append runs as a single critical section
+   *  per call, regardless of how many callers await concurrently. */
+  private queue: Promise<unknown> = Promise.resolve()
+
+  /** Non-null when the writer has encountered a fatal write error. All
+   *  subsequent `writeEvent` calls reject with this error. */
+  private broken: Error | null = null
+
+  private constructor(
+    fh: FileHandle,
+    lastHash: string,
+    nextSeq: number,
+    now: () => Date,
+    path: string,
+  ) {
+    this.fh = fh
+    this.lastHash = lastHash
+    this.nextSeq = nextSeq
+    this.now = now
+    this.path = path
+  }
+
+  /** Open (or create) an audit log at `opts.path` and return a ready-
+   *  to-write JournalWriter.
+   *
+   *  Recovers chain state from the existing file: reads the last
+   *  newline-delimited JSON line, parses it through the `JournalEvent`
+   *  schema, and uses its `hash` and `seq + 1` as the seeds for new
+   *  writes. If the file is empty or absent, seeds from
+   *  `opts.initialPrevHash` (or a fresh random sha256 if unset) and
+   *  seq 1.
+   *
+   *  Throws if:
+   *    - Another `JournalWriter` is already open on the same path in
+   *      this process (single-writer invariant).
+   *    - The existing file's last line is not valid `JournalEvent`
+   *      JSON — fail loudly rather than silently start a new chain
+   *      that the verifier would reject anyway.
+   */
+  static async open(opts: WriterOptions): Promise<JournalWriter> {
+    if (ACTIVE_PATHS.has(opts.path)) {
+      throw new Error(
+        `JournalWriter.open: path already has an active writer in this process: ${opts.path}`,
+      )
+    }
+
+    // Mode 0o600 on creation; 'a+' flag sets O_RDWR|O_APPEND|O_CREAT.
+    // One FileHandle for both the tail read (to recover chain state) and
+    // every subsequent append — closes the stat-then-open TOCTOU window
+    // that a separate read-then-open pair exposes (per CodeQL
+    // js/file-system-race). O_APPEND still guarantees writes land
+    // atomically at EOF per audit-journal-architecture.md §155-160;
+    // reads use explicit `position` and don't move the append pointer.
+    //
+    // FileHandle (fs.open) rather than fs.createWriteStream because
+    // we need explicit `fh.sync()` after every write for durability;
+    // streams buffer and make that awkward. One event = one write =
+    // one fsync for this bead (ccsc-5pi.7). A higher-volume operator
+    // can relax to batch fsync in a future bead.
+    const fh = await fsOpen(opts.path, 'a+', 0o600)
+
+    let lastHash: string
+    let nextSeq: number
+    try {
+      const lastLine = await readLastLine(fh)
+      if (lastLine === null) {
+        // File is empty (fresh or operator-created with `touch`) —
+        // start a new chain. Not an error.
+        lastHash = opts.initialPrevHash ?? sha256Hex(randomBytes(32))
+        nextSeq = 1
+      } else {
+        let parsed: JournalEvent
+        try {
+          parsed = JournalEvent.parse(JSON.parse(lastLine))
+        } catch (err) {
+          throw new Error(
+            `JournalWriter.open: last line of ${opts.path} is not a valid JournalEvent — refusing to start a new chain that would be unverifiable. Underlying error: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+        }
+        lastHash = parsed.hash
+        nextSeq = parsed.seq + 1
+      }
+    } catch (err) {
+      // Don't leak the file descriptor if anything in the recovery path
+      // throws. ACTIVE_PATHS hasn't been registered yet so we just close.
+      // If close itself fails, surface it to stderr (it may indicate a
+      // deeper fs problem) but still throw the original recovery error —
+      // that's the one the operator needs to fix.
+      try {
+        await fh.close()
+      } catch (closeErr) {
+        console.error(
+          `[journal] fh.close failed during open() recovery cleanup for ${opts.path}: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+        )
+      }
+      throw err
+    }
+
+    ACTIVE_PATHS.add(opts.path)
+    return new JournalWriter(fh, lastHash, nextSeq, opts.now ?? ((): Date => new Date()), opts.path)
+  }
+
+  /** Append a new event. Returns the fully-framed `JournalEvent` that
+   *  was persisted, including the writer-assigned `v`, `ts`, `seq`,
+   *  `prevHash`, and `hash`.
+   *
+   *  Concurrent calls are serialized: if caller A and caller B both
+   *  `writeEvent()` without awaiting, the promises resolve in call
+   *  order and each sees a contiguous seq/hash chain.
+   */
+  async writeEvent(input: WriteInput): Promise<JournalEvent> {
+    if (this.broken) {
+      return Promise.reject(
+        new Error(`JournalWriter is broken after a prior write failure: ${this.broken.message}`),
+      )
+    }
+    if (this.fh === null) {
+      return Promise.reject(new Error('JournalWriter.writeEvent: writer is closed'))
+    }
+    // Chain onto the existing queue so increments are serialized. Using
+    // .then (not await) captures the write call's position in line
+    // immediately; callers observe monotonic order regardless of
+    // microtask scheduling.
+    const p = this.queue.then(() => this._doWrite(input))
+    // Swallow rejections on the queue itself so one failed write does
+    // not poison the queue chain. The caller still sees the rejection
+    // from `p`. The writer's `broken` field guards future calls.
+    this.queue = p.then(
+      () => undefined,
+      () => undefined,
+    )
+    return p
+  }
+
+  private async _doWrite(input: WriteInput): Promise<JournalEvent> {
+    // S2: guard broken state at the top of _doWrite so calls that were
+    // already enqueued before the break are also rejected. The enqueue-time
+    // check in writeEvent() catches fresh calls; this check catches calls
+    // that raced in before broken was set and are now draining the queue.
+    if (this.broken) {
+      throw new Error(`JournalWriter is broken after a prior write failure: ${this.broken.message}`)
+    }
+    if (this.fh === null) {
+      throw new Error('JournalWriter._doWrite: writer closed mid-queue')
+    }
+
+    // S3: validate caller-supplied fields BEFORE redaction/truncation and
+    // BEFORE hash computation. A ZodError on bad input must propagate
+    // without advancing seq/lastHash and without touching this.broken —
+    // bad input is a caller bug, not a writer failure; the writer remains
+    // usable for the next call. Ordering invariant: validate → redact →
+    // truncate → build partial → hash → post-hash sanity parse → write.
+    //
+    // We validate only the caller-supplied fields (WriteInput) here.
+    // The writer-assigned framing fields (v, ts, seq, prevHash, hash) are
+    // not yet available, so we cannot parse the full JournalEvent shape.
+    // The post-hash JournalEvent.parse below remains as a cheap sanity
+    // check that the writer assembled the full event correctly.
+    const WriteInputShape = JournalEvent.omit({
+      v: true,
+      ts: true,
+      seq: true,
+      prevHash: true,
+      hash: true,
+    })
+    WriteInputShape.parse(input)
+
+    // Redact token-shaped values BEFORE hashing so the on-disk bytes,
+    // the hash chain, and the journal the operator inspects all agree.
+    // Surgical per audit-journal-architecture.md §183-184: only `input`
+    // and `reason` are redacted; other top-level fields are
+    // `ruleId`/`correlationId`/`toolName`-style identifiers that never
+    // carry secrets by contract. An operator who mistakenly stuffs a
+    // token into one of those is a caller bug, not a redactor gap.
+    const redactedInput = redactEventFields(input)
+
+    // Truncate AFTER redaction so a half-truncated token never appears
+    // on disk (audit-journal-architecture.md §206). Hard-cap per field
+    // at TRUNCATION_LIMIT_DEFAULT; an over-limit string becomes a
+    // marker + gets a sibling `<field>.len` entry so forensics can see
+    // the original size without reading the raw payload.
+    const truncatedInput = truncateEventFields(redactedInput)
+
+    const partial: PartialJournalEvent = {
+      v: 1,
+      ts: this.now().toISOString(),
+      seq: this.nextSeq,
+      prevHash: this.lastHash,
+      ...truncatedInput,
+    }
+    const hash = sha256Hex(this.lastHash + canonicalJson(partial))
+    const event: JournalEvent = { ...partial, hash }
+
+    // Post-hash sanity check: the full assembled event must pass the strict
+    // JournalEvent schema. This is a belt-and-suspenders check after the
+    // pre-hash WriteInput validation above — it catches writer-side bugs
+    // (e.g. a framing field assembled incorrectly) rather than caller bugs.
+    JournalEvent.parse(event)
+
+    const line = `${JSON.stringify(event)}\n`
+    try {
+      await this.fh.write(line)
+      // fsync after every successful write (ccsc-5pi.7). Durability
+      // discipline for an audit journal: a crash between `write()`
+      // buffering the line and the kernel flushing it would leave
+      // the chain apparently intact in memory but missing tail
+      // events on disk. For a per-developer journal the per-write
+      // fsync cost is imperceptible; for a higher-volume operator a
+      // sibling bead can relax this to batch fsync.
+      await this.fh.sync()
+    } catch (err) {
+      this.broken = err instanceof Error ? err : new Error(String(err))
+      throw this.broken
+    }
+
+    // Advance chain state only after the write succeeds. A crash mid-
+    // write leaves `lastHash` and `nextSeq` at the pre-write values,
+    // so a restart-then-write resumes at the same point rather than
+    // gapping the seq or duplicating the hash.
+    this.nextSeq += 1
+    this.lastHash = hash
+
+    return event
+  }
+
+  /** The current chain-head hash. Exposed so callers that need the
+   *  "latest known good" pointer (e.g. the tail-anchor publisher in
+   *  Epic 30-B) can read it without parsing the last line of disk. */
+  get headHash(): string {
+    return this.lastHash
+  }
+
+  /** The seq the next successful write will carry. Useful for tests
+   *  and for operator diagnostics. */
+  get nextSequenceNumber(): number {
+    return this.nextSeq
+  }
+
+  /** Release the file descriptor. No separate flush is required:
+   *  every successful `writeEvent()` has already `fh.sync()`'d the
+   *  line to stable storage per ccsc-5pi.7, so there is no
+   *  buffered-but-unsynced tail to lose. Idempotent — calling
+   *  `close()` on an already-closed writer is a no-op. After close,
+   *  `writeEvent()` rejects. */
+  async close(): Promise<void> {
+    if (this.fh === null) return
+    try {
+      await this.fh.close()
+    } finally {
+      this.fh = null
+      ACTIVE_PATHS.delete(this.path)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON (RFC 8785 subset for integer-only event shapes)
+// ---------------------------------------------------------------------------
+
+/** Canonicalise `value` for hashing. Two independent encoders must
+ *  produce identical byte output so the verifier can recompute the
+ *  chain bit-for-bit.
+ *
+ *  RFC 8785 compliance notes:
+ *    - Strings: `JSON.stringify` matches the RFC 8785 escape rules for
+ *      all inputs that avoid non-BMP Unicode. Our event schema never
+ *      has strings chosen from outside the BMP (hashes are hex; ts is
+ *      ISO-8601; Slack IDs are ASCII; policy reason strings are
+ *      operator-authored ASCII).
+ *    - Numbers: the RFC mandates shortest IEEE-754 double form. Our
+ *      schema permits only integers (`seq`); other number forms throw.
+ *    - Objects: keys sorted by UTF-16 code-unit order (the RFC form),
+ *      which `Array.prototype.sort` delivers for the ASCII key names
+ *      the schema uses.
+ *    - Arrays: order-preserving.
+ *    - No whitespace.
+ *
+ *  Throws on `undefined`, functions, symbols, bigints — none are valid
+ *  `JournalEvent` content; the throw turns a schema-validation miss
+ *  into a loud failure at hash time.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error(`canonicalJson: only finite integer numbers supported (got ${String(value)})`)
+    }
+    return String(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value).sort()
+    const pairs = keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(value[k])}`)
+    return `{${pairs.join(',')}}`
+  }
+  throw new Error(`canonicalJson: unsupported value type: ${typeof value}`)
+}
+
+// ---------------------------------------------------------------------------
+// sha256 helper
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 over `input` and return 64-char lowercase hex. Used
+ *  by the writer for the hash chain and re-used by the verifier
+ *  (ccsc-5pi.9). Kept close to the type + writer so all hash producers
+ *  in this module share one implementation. */
+export function sha256Hex(input: string | Uint8Array): string {
+  return createHash('sha256').update(input).digest('hex')
+}
+
+/** Generate a fresh per-chain `TRUSTED_ANCHOR` per audit-journal-
+ *  architecture.md §76-85. The returned string is a 64-char lowercase
+ *  hex digest of 32 random bytes — matches `Sha256Hex` so it can be
+ *  passed directly as `initialPrevHash` to `JournalWriter.open()`
+ *  AND recorded in the first `system.boot` event's body.
+ *
+ *  Callers must do both: pass it to the writer (so the first event's
+ *  `prevHash` pins it) and include it in the event body (so a reader
+ *  can recover the anchor from the file alone). The chain then
+ *  commits to the anchor in two places, meaning an attacker who
+ *  edits the anchor in either location breaks the first event's hash
+ *  verification. */
+export function createBootAnchor(): string {
+  return sha256Hex(randomBytes(32))
+}
+
+/** Narrow `value` to a plain object shape. Rejects arrays, null, and
+ *  primitives. Used by `canonicalJson`, `redact`, and `truncate` so
+ *  the `value as Record<string, unknown>` casts that previously
+ *  followed `typeof value === 'object' && value !== null` become
+ *  compiler-checked narrowings instead of trust-me-bro assertions.
+ *  Not exported — these helpers are the only callers. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// ---------------------------------------------------------------------------
+// Redaction — token-shaped secret scrubbing (ccsc-5pi.4)
+// ---------------------------------------------------------------------------
+
+/** Known secret patterns. Each entry's `re` is a global regex; `kind`
+ *  becomes the `[REDACTED:<kind>]` placeholder. Patterns taken directly
+ *  from 000-docs/audit-journal-architecture.md §168-181 — changes to
+ *  this list require a design-doc update, not a code-side tweak.
+ *
+ *  Defense-in-depth, not compliance: the redactor catches the
+ *  well-known token shapes that leak most often through error messages
+ *  and logs. Bespoke secrets (project-internal tokens, operator-chosen
+ *  passwords pasted as message text) still require operator-side
+ *  hygiene. The journal is `0o600` for a reason. */
+const TOKEN_PATTERNS: ReadonlyArray<{ kind: string; re: RegExp }> = [
+  { kind: 'anthropic', re: /sk-[a-zA-Z0-9-]{20,}/g },
+  { kind: 'slack_bot', re: /xoxb-[0-9]+-[0-9]+-[a-zA-Z0-9]+/g },
+  { kind: 'slack_app', re: /xapp-[0-9]+-[A-Z0-9]+-[0-9]+-[a-f0-9]+/g },
+  { kind: 'github', re: /\bghp_[A-Za-z0-9]{36}\b/g },
+  { kind: 'aws_access', re: /\bAKIA[0-9A-Z]{16}\b/g },
+  { kind: 'jwt', re: /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g },
+]
+
+/** Return the pattern list for tests and the verifier. Read-only; the
+ *  patterns are frozen to match the design doc. */
+export function tokenPatterns(): ReadonlyArray<{ kind: string; re: RegExp }> {
+  return TOKEN_PATTERNS
+}
+
+/** Replace every occurrence of a known secret pattern in `s` with
+ *  `[REDACTED:<kind>]`. Pure over the input string. */
+function redactString(s: string): string {
+  let out = s
+  for (const { kind, re } of TOKEN_PATTERNS) {
+    out = out.replace(re, `[REDACTED:${kind}]`)
+  }
+  return out
+}
+
+/** Deep-walk `value`, redacting every string encountered and
+ *  recursively walking arrays and plain objects. Non-string primitives
+ *  (numbers, booleans, null) pass through unchanged; unsupported
+ *  container types (Maps, Sets, class instances) pass through by
+ *  reference — callers that need to redact those must pre-flatten them
+ *  into plain JSON shapes.
+ *
+ *  Pure: never mutates its argument. Always returns a new object /
+ *  array when the container has any redactable content. Returns the
+ *  same reference when nothing changed (microoptimisation — saves
+ *  allocations in the common case where events carry no tokens). */
+export function redact(value: unknown): unknown {
+  if (typeof value === 'string') {
+    const out = redactString(value)
+    return out === value ? value : out
+  }
+  if (Array.isArray(value)) {
+    let changed = false
+    const out: unknown[] = new Array(value.length)
+    for (let i = 0; i < value.length; i++) {
+      const next = redact(value[i])
+      if (next !== value[i]) changed = true
+      out[i] = next
+    }
+    return changed ? out : value
+  }
+  if (isRecord(value)) {
+    // Plain object fast-path. We do not try to detect class instances
+    // here because the journal event shape is JSON — class instances
+    // round-tripping through JSON.stringify would have lost their
+    // prototype anyway.
+    let changed = false
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      const next = redact(v)
+      if (next !== v) changed = true
+      out[k] = next
+    }
+    return changed ? out : value
+  }
+  return value
+}
+
+/** Writer-integration helper. Redacts only the two fields the design
+ *  doc lists (`input`, `reason`) and leaves everything else untouched.
+ *  Returns a new object when redaction changed anything; same
+ *  reference otherwise. Exported for the writer's own use; not part of
+ *  the public caller API.
+ *
+ *  Why restrict the scope? `toolName`, `ruleId`, `correlationId` and
+ *  friends are short identifiers that the caller authored. Redacting
+ *  them would mask real operator mistakes behind `[REDACTED:...]` and
+ *  make forensic review harder. If a caller does stuff a token into
+ *  one of those fields the journal will surface it loud — exactly the
+ *  forensic signal an operator wants. */
+export function redactEventFields(input: WriteInput): WriteInput {
+  const hasReason = typeof input.reason === 'string'
+  const hasInput = input.input !== undefined
+
+  if (!hasReason && !hasInput) return input
+
+  const out: WriteInput = { ...input }
+  if (hasReason) {
+    out.reason = redactString(input.reason as string)
+  }
+  if (hasInput) {
+    out.input = redact(input.input) as Record<string, unknown>
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Truncation — bound journal record size (ccsc-5pi.5)
+// ---------------------------------------------------------------------------
+
+/** Per-field character cap for journal records. Strings longer than
+ *  this get replaced with the truncation marker form:
+ *
+ *    `<first TRUNCATION_LIMIT_DEFAULT chars>[... truncated N chars]`
+ *
+ *  2048 chars is the doc-specified default (audit-journal-architecture.md
+ *  §200-210). Large enough to capture structured JSON error bodies and
+ *  typical tool-call args; small enough to keep the journal bounded
+ *  even under a burst of oversized payloads. */
+export const TRUNCATION_LIMIT_DEFAULT = 2048
+
+/** Truncate a single string to `max` characters, returning it unchanged
+ *  if already short enough. The marker preserves the original length
+ *  inline so a reader can tell the payload was oversized without
+ *  needing the sibling-field bookkeeping. */
+function truncateString(s: string, max: number): string {
+  if (s.length <= max) return s
+  const omitted = s.length - max
+  return `${s.slice(0, max)}[... truncated ${omitted} chars]`
+}
+
+/** Deep-walk `value`, bounding every string to `max` characters. For
+ *  object keys whose value was truncated, a sibling `<key>.len` entry
+ *  is added at the same object level recording the original character
+ *  count. The sibling key pattern matches audit-journal-architecture.md
+ *  §208-210. Arrays are walked but do not get sibling length entries
+ *  (arrays don't have named keys — the truncation marker itself
+ *  carries the size signal in that case).
+ *
+ *  Pure: returns the same reference when nothing was truncated.
+ *
+ *  Edge cases:
+ *    - If a sibling `<key>.len` key already exists on the object, it
+ *      is overwritten. Collisions with real data are not expected —
+ *      callers don't put dotted keys in event payloads — and silent
+ *      overwrite is preferable to a throw in the hot path.
+ *    - Non-string primitives (numbers, booleans, null) pass through.
+ *    - Unsupported container types (Maps, Sets, class instances) pass
+ *      through by reference. Pre-flatten those at the caller. */
+export function truncate(value: unknown, max: number = TRUNCATION_LIMIT_DEFAULT): unknown {
+  if (typeof value === 'string') {
+    const t = truncateString(value, max)
+    return t === value ? value : t
+  }
+  if (Array.isArray(value)) {
+    let changed = false
+    const out: unknown[] = new Array(value.length)
+    for (let i = 0; i < value.length; i++) {
+      const next = truncate(value[i], max)
+      if (next !== value[i]) changed = true
+      out[i] = next
+    }
+    return changed ? out : value
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
+    let changed = false
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of entries) {
+      if (typeof v === 'string' && v.length > max) {
+        out[k] = truncateString(v, max)
+        out[`${k}.len`] = v.length
+        changed = true
+      } else {
+        const next = truncate(v, max)
+        if (next !== v) changed = true
+        out[k] = next
+      }
+    }
+    return changed ? out : value
+  }
+  return value
+}
+
+/** Writer-integration helper. Mirrors `redactEventFields`: truncates
+ *  only `input` and `reason`, leaves everything else untouched. Called
+ *  by the writer after redaction so the hash is computed over the
+ *  bounded form.
+ *
+ *  Why scope it? `reason` and `input` are the realistic oversized-
+ *  payload surfaces; other fields are short identifiers. Truncating
+ *  `toolName` or `ruleId` would be more confusing than helpful. A
+ *  pathological caller who stuffs 100 KiB into `correlationId` will
+ *  surface that loudly rather than being quietly truncated — which
+ *  matches the redaction policy on the same fields. */
+export function truncateEventFields(
+  input: WriteInput,
+  max: number = TRUNCATION_LIMIT_DEFAULT,
+): WriteInput {
+  const hasReason = typeof input.reason === 'string'
+  const hasInput = input.input !== undefined
+
+  if (!hasReason && !hasInput) return input
+
+  const out: WriteInput = { ...input }
+  if (hasReason) {
+    const original = input.reason as string
+    // `reason` is a top-level string field governed by the strict
+    // JournalEvent schema; we cannot add a sibling `reason.len` key
+    // there (the schema would reject it). For this field the marker
+    // itself carries the original-length signal inline.
+    out.reason = truncateString(original, max)
+  }
+  if (hasInput) {
+    out.input = truncate(input.input, max) as Record<string, unknown>
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Verifier — Schneier-Kelsey chain integrity check (ccsc-5pi.10)
+// ---------------------------------------------------------------------------
+
+/** Shape of a verification failure. All fields aside from `reason`
+ *  are best-effort — a parse error on the first line, for example,
+ *  has no `seq` or `ts` to surface. The operator reads `reason` for
+ *  the human explanation and uses `lineNumber` to locate the
+ *  offending entry. */
+export interface VerifyBreak {
+  /** 1-indexed line number where the break was detected. The first
+   *  real JSON line is line 1. */
+  lineNumber: number
+  /** Parsed `seq` of the offending event if it passed schema
+   *  validation, else null. */
+  seq: number | null
+  /** Parsed `ts` of the offending event if it passed schema
+   *  validation, else null. */
+  ts: string | null
+  /** One-line human summary: `"hash mismatch"`, `"version skew"`,
+   *  `"seq gap"`, `"prevHash mismatch"`, `"parse error: ..."`, etc. */
+  reason: string
+  /** Expected hash (or prevHash) when applicable. */
+  expected?: string
+  /** Actual hash (or prevHash) when applicable. */
+  actual?: string
+}
+
+/** Result of a full-file verification pass. `eventsVerified` counts
+ *  events that matched expectations strictly before a break — useful
+ *  for a truncation-tolerance story in follow-up tooling. */
+export type VerifyResult =
+  | { ok: true; eventsVerified: number }
+  | { ok: false; eventsVerified: number; break: VerifyBreak }
+
+// Compile-time shape-drift guard. `lib.ts` duplicates the shape of
+// `VerifyResult` as `VerifyResultShape` (type-only, no runtime import)
+// to stay decoupled from journal.ts. These bidirectional checks break
+// the build the moment either side drifts.
+import type { VerifyResultShape } from './lib.ts'
+
+type _VerifyForward = VerifyResult extends VerifyResultShape ? true : never
+type _VerifyBackward = VerifyResultShape extends VerifyResult ? true : never
+const _verifyShapeForward: _VerifyForward = true
+const _verifyShapeBackward: _VerifyBackward = true
+void _verifyShapeForward
+void _verifyShapeBackward
+
+/** Verify a journal file end-to-end per audit-journal-architecture.md
+ *  §237-261. Reads the file line-by-line, schema-validates each
+ *  record, and recomputes `sha256(prevHash || canonicalJson(event
+ *  sans hash))` for every event. Any mismatch is reported as a
+ *  `VerifyBreak`.
+ *
+ *  Invariants checked (in line order):
+ *    - Schema v1 and the full strict `JournalEvent` shape.
+ *    - `hash` matches the recomputed value bit-for-bit.
+ *    - `prevHash` matches the previous accepted event's `hash`
+ *      (first event's `prevHash` is trusted as the genesis value —
+ *      that's the `TRUSTED_ANCHOR` contract from §76-85; validating
+ *      the anchor is a caller concern for now).
+ *    - `seq` is strictly monotonic by +1 with no gaps.
+ *
+ *  The function never modifies the file (read-only contract).
+ *  Returns on the first break; a second broken event after a fixed
+ *  first break is outside the verify-and-report-one-location
+ *  semantic the doc describes. */
+export async function verifyJournal(path: string): Promise<VerifyResult> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (err) {
+    return {
+      ok: false,
+      eventsVerified: 0,
+      break: {
+        lineNumber: 0,
+        seq: null,
+        ts: null,
+        reason: `read failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+
+  const lines = raw.split('\n')
+  let prevAcceptedHash: string | null = null
+  let prevAcceptedSeq: number | null = null
+  let eventsVerified = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    // Tolerate a trailing empty line (from the writer's final
+    // newline). Empty lines mid-file would indicate structural
+    // damage; those are flagged.
+    if (line.length === 0) {
+      if (i === lines.length - 1) continue
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber: i + 1,
+          seq: prevAcceptedSeq,
+          ts: null,
+          reason: 'empty line in middle of journal (structural damage)',
+        },
+      }
+    }
+
+    const lineNumber = i + 1
+
+    let event: JournalEvent
+    try {
+      event = JournalEvent.parse(JSON.parse(line))
+    } catch (err) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: null,
+          ts: null,
+          reason: `parse/schema error: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      }
+    }
+
+    if (event.v !== 1) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: `version skew: expected 1, got ${String(event.v)}`,
+        },
+      }
+    }
+
+    if (prevAcceptedHash !== null && event.prevHash !== prevAcceptedHash) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: 'prevHash mismatch — chain break',
+          expected: prevAcceptedHash,
+          actual: event.prevHash,
+        },
+      }
+    }
+
+    if (prevAcceptedSeq !== null && event.seq !== prevAcceptedSeq + 1) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: `seq gap — expected ${prevAcceptedSeq + 1}, got ${event.seq}`,
+          expected: String(prevAcceptedSeq + 1),
+          actual: String(event.seq),
+        },
+      }
+    }
+
+    // Recompute the hash. This is the primary tamper check: any edit
+    // to the event body (kind, input, reason, anything) will change
+    // the canonical serialization and so the computed hash.
+    const { hash: stored, ...rest } = event
+    const recomputed = sha256Hex(event.prevHash + canonicalJson(rest))
+    if (recomputed !== stored) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: 'hash mismatch — event body or prevHash was tampered',
+          expected: recomputed,
+          actual: stored,
+        },
+      }
+    }
+
+    prevAcceptedHash = event.hash
+    prevAcceptedSeq = event.seq
+    eventsVerified += 1
+  }
+
+  return { ok: true, eventsVerified }
+}

--- a/plugins/mcp/slack-channel/manifest.ts
+++ b/plugins/mcp/slack-channel/manifest.ts
@@ -1,0 +1,573 @@
+/**
+ * manifest.ts — Peer-bot manifest schema (Epic 31-A).
+ *
+ * A manifest is a JSON payload that a peer agent posts in-channel to advertise
+ * what it is: name, vendor, version, tools it exposes, channels it opts into,
+ * and a contact address. Other bots and humans read manifests as *information*;
+ * they are advertisements, never grants (Miller 2006, Robust Composition).
+ *
+ * This file intentionally has no imports from `policy.ts` or `lib.ts`'s
+ * policy-adjacent surface. The symmetric constraint — `policy.ts` does not
+ * import from this module — is enforced by the 31-A.4 invariant test in
+ * `server.test.ts`. See `000-docs/bot-manifest-protocol.md` §91-109 for the
+ * binding invariant and §17-55 for the on-wire schema this file encodes.
+ *
+ * Scope of this file for ccsc-s53.1:
+ *   - The `ManifestV1` Zod schema with magic-header discriminator.
+ *   - Inferred TypeScript type.
+ *
+ * Sibling beads add: size cap (s53.3), the `read_peer_manifests` MCP tool
+ * (s53.2), and the 5-minute per-channel read cache (s53.5).
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// ManifestV1 — on-channel advertisement schema
+// ---------------------------------------------------------------------------
+
+/**
+ * SemVer 2.0.0 subset accepted for `version`: `MAJOR.MINOR.PATCH` with an
+ * optional pre-release suffix `-<alnum/dot/hyphen>`. Build metadata (`+…`)
+ * is deliberately excluded — manifests that want to signal a build should
+ * surface it via `description`, not the version field. Keeping the regex
+ * narrow means downstream consumers that want to sort manifests can do so
+ * without a full SemVer parser.
+ */
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/
+
+/**
+ * Slack public-channel ID shape. `C` + uppercase alphanumerics. DM IDs
+ * (`D…`) and private-group IDs (`G…`) are deliberately rejected — a
+ * manifest advertising participation in a DM or private group would leak
+ * non-public information about the bot's reach and is out of scope for
+ * the v1 protocol.
+ */
+const CHANNEL_ID_RE = /^C[A-Z0-9]+$/
+
+/**
+ * Zod schema for the v1 manifest payload.
+ *
+ * The literal `__claude_bot_manifest_v1__: true` property doubles as a
+ * version discriminator: future protocol revisions will mint a new key
+ * (e.g. `__claude_bot_manifest_v2__`) so consumers that understand only
+ * v1 can skip unknown versions without false-matching them. Matches the
+ * frozen contract in `000-docs/bot-manifest-protocol.md` §24-41.
+ *
+ * Validation failures (malformed JSON, missing fields, wrong types, size
+ * cap violations, or the magic header missing / not literally `true`) are
+ * silently dropped by the consumer — see the protocol doc §81 and bead
+ * ccsc-s53.13 ("Drop malformed, invalid, and oversized manifests
+ * silently"). This file only encodes the *shape*; the dropping happens in
+ * the read tool (ccsc-s53.2) and the size-cap layer (ccsc-s53.3).
+ */
+/**
+ * Optional A2A agent-card subset (Epic 31-B.6, bead ccsc-0qk.6).
+ *
+ * Shape-aligned with Google's Agent-to-Agent protocol
+ * (/.well-known/agent-card.json) so a future HTTP-transport publish
+ * path can reuse this field verbatim without a schema migration. The
+ * fields here are deliberately a subset — the top-level ManifestV1
+ * fields (name, vendor, version, description, tools) already carry
+ * the overlap documented in bot-manifest-protocol.md's "Alignment
+ * with Google A2A" section; agentCard carries the A2A-specific
+ * metadata that has no Slack-side equivalent.
+ *
+ * Consumer contract: this field is metadata. The Slack read path
+ * (extractManifests) accepts it but does nothing with it beyond
+ * Zod validation. A peer that signals HTTP capabilities here does
+ * not thereby get any additional trust — advertisements are not
+ * grants, same as every other manifest field (§91-109).
+ *
+ * Sizes are conservative so an agentCard-bearing manifest comfortably
+ * fits under the 8 KB publish cap.
+ */
+const AgentCard = z.object({
+  /** HTTPS endpoints where the agent is also reachable. Optional —
+   *  Slack-only bots omit. Capped at 10 entries; each entry is a
+   *  fully-qualified URL. */
+  endpoints: z.array(z.string().url()).max(10).optional(),
+
+  /** Input/output content types the agent accepts/produces. Maps to
+   *  A2A's defaultInputModes / defaultOutputModes. Values are MIME
+   *  types (e.g. 'application/json') or schema URIs. */
+  schemas: z
+    .object({
+      input: z.array(z.string().min(1).max(200)).max(20).optional(),
+      output: z.array(z.string().min(1).max(200)).max(20).optional(),
+    })
+    .optional(),
+
+  /** Authentication schemes the HTTPS surface expects. Public or
+   *  Slack-only bots omit. Example values: 'bearer', 'apiKey',
+   *  'oauth2'. */
+  authentication: z
+    .object({
+      schemes: z.array(z.string().min(1).max(40)).max(10),
+    })
+    .optional(),
+
+  /** Capability flags — A2A's defaults. Additional flags can land in a
+   *  v2 agentCard schema without breaking existing readers (Zod strips
+   *  unknown keys by default on z.object). */
+  capabilities: z
+    .object({
+      streaming: z.boolean().optional(),
+      pushNotifications: z.boolean().optional(),
+    })
+    .optional(),
+})
+
+export const ManifestV1 = z.object({
+  __claude_bot_manifest_v1__: z.literal(true),
+  name: z.string().min(1).max(80),
+  vendor: z.string().min(1).max(80),
+  version: z.string().regex(SEMVER_RE),
+  description: z.string().max(1000),
+  tools: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(80),
+        description: z.string().max(400),
+      }),
+    )
+    .max(50),
+  channels: z.array(z.string().regex(CHANNEL_ID_RE)).max(50).optional(),
+  contact: z.string().email().optional(),
+  publishedAt: z.string().datetime(),
+  /** Optional A2A agent-card subset. See `AgentCard` above for the
+   *  shape and rationale. A manifest without this field is a
+   *  Slack-only bot; a manifest with it advertises additional
+   *  HTTP-level surface area for future interop. */
+  agentCard: AgentCard.optional(),
+})
+
+/** Inferred type for a validated manifest payload. */
+export type ManifestV1 = z.infer<typeof ManifestV1>
+
+/**
+ * The magic header key. Exported so the read tool (ccsc-s53.2) and any
+ * pins.list discriminator can match on the same literal without repeating
+ * the string. Consumers MUST check that the key's value is exactly `true`
+ * before trusting the payload to be a v1 manifest — presence alone is not
+ * enough (a peer could post `{"__claude_bot_manifest_v1__": "yes"}` and
+ * that must not match).
+ */
+export const MANIFEST_V1_MAGIC_KEY = '__claude_bot_manifest_v1__' as const
+
+/**
+ * Hard cap on a single manifest's raw body, in bytes after UTF-8 encode
+ * (Epic 31-A.3). The doc (§47) phrases the cap as "≤ 40 KB"; we treat
+ * "KB" as 1024 bytes, the convention used everywhere else in this
+ * codebase for memory-safety constants. Anything over is silently
+ * dropped before `JSON.parse` is called — the point of the cap is to
+ * bound the cost of the parse step, which can blow up memory
+ * super-linearly on deeply-nested or hostile payloads. A peer that can
+ * make us allocate 100 MB to parse one pinned message is a cheap DoS
+ * otherwise.
+ */
+export const MAX_MANIFEST_BYTES = 40 * 1024
+
+/**
+ * Publish-side cap on the serialized manifest (Epic 31-B.2, bead
+ * ccsc-0qk.2). Deliberately stricter than `MAX_MANIFEST_BYTES` by a
+ * factor of 5 — Postel's Law: "be conservative in what you send,
+ * liberal in what you receive." A publisher writes what it controls;
+ * a reader tolerates what the peer happens to post. 8 KB is plenty
+ * for a well-formed v1 manifest (the schema caps description at 1000
+ * chars, up to 50 tools with ≤ 480 chars each, up to 50 channels) and
+ * surfaces operator mistakes (e.g. a pasted API payload that should
+ * have been a manifest) loudly at publish time.
+ */
+export const MAX_PUBLISH_MANIFEST_BYTES = 8 * 1024
+
+// ---------------------------------------------------------------------------
+// extractManifests — pure filter/parse/validate for a batch of message texts
+// ---------------------------------------------------------------------------
+
+/**
+ * Cheap pre-filter: does a message body syntactically mention the magic
+ * header key? Used to short-circuit the parse step for the overwhelming
+ * majority of messages that are not manifest payloads. A false positive
+ * here (message body that coincidentally contains the key string in
+ * prose) is caught by `JSON.parse` or Zod on the next step — this is
+ * purely a perf filter, never a trust signal.
+ */
+function looksLikeManifest(text: string): boolean {
+  return text.includes(MANIFEST_V1_MAGIC_KEY)
+}
+
+/** UTF-8 byte length of a string. Uses TextEncoder so the count matches
+ *  what Slack's servers and the doc mean by "40 KB after UTF-8 encode"
+ *  (§47) — `string.length` would count UTF-16 code units and under-
+ *  report for multi-byte code points. */
+const utf8Encoder = new TextEncoder()
+function utf8ByteLength(s: string): number {
+  return utf8Encoder.encode(s).length
+}
+
+/**
+ * Extract every valid v1 manifest from a batch of message texts (Epic
+ * 31-A.2, bead ccsc-s53.2). The flow is:
+ *
+ *   1. skip null / undefined / non-string bodies
+ *   2. cheap string-includes filter on the magic header key
+ *   3. `JSON.parse` — silent drop on any throw
+ *   4. `ManifestV1.safeParse` — silent drop on any Zod error
+ *
+ * "Silent drop" is the doc's chosen posture (§81, §255) for
+ * malformed/invalid manifests: a peer posting garbage must not break the
+ * consumer, and there is no caller-visible error channel because this is
+ * advertising, not an API. Operators get ground truth via the 30-A
+ * journal when the read tool logs the read event — per-message drop
+ * details are intentionally not surfaced.
+ *
+ * The 40 KB raw-body size cap (ccsc-s53.3, §47) is enforced here too —
+ * oversized bodies are dropped before `JSON.parse` is called so a
+ * hostile pinned message cannot force gigabyte-scale allocation.
+ *
+ * Returns validated manifests in the order they appeared in the input.
+ * Duplicate de-dup is NOT performed here — a channel that has the same
+ * peer's manifest pinned AND in the last 50 messages will surface both
+ * copies, and the caller (or Claude reading the tool output) decides
+ * what to do with the duplication. Keeping this function position-
+ * preserving and non-deduping makes it trivially testable.
+ */
+export function extractManifests(texts: ReadonlyArray<string | null | undefined>): ManifestV1[] {
+  return texts.flatMap((text) => {
+    if (typeof text !== 'string' || text.length === 0) return []
+    if (!looksLikeManifest(text)) return []
+    // 40 KB raw-body size cap (ccsc-s53.3). Checked *after* the
+    // pre-filter (so we only pay the byte-count walk on candidate
+    // payloads) but *before* `JSON.parse` (so the parser can't be
+    // weaponised to allocate gigabytes on a hostile pinned message).
+    // Oversized drops log a debug line because they are operator-
+    // actionable — a peer hitting the cap is either buggy or adversarial.
+    // Malformed-JSON and Zod-failure drops stay silent (see §81): common
+    // and not a signal.
+    const bytes = utf8ByteLength(text)
+    if (bytes > MAX_MANIFEST_BYTES) {
+      console.debug(`[manifest] silent drop: oversized body ${bytes}B > ${MAX_MANIFEST_BYTES}B cap`)
+      return []
+    }
+    try {
+      const parsed: unknown = JSON.parse(text)
+      const result = ManifestV1.safeParse(parsed)
+      return result.success ? [result.data] : []
+    } catch {
+      return []
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Per-channel read cache + rate limit (Epic 31-A.5, bead ccsc-s53.5)
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL for a cached per-channel manifest list. Doubles as the rate limit
+ * on reads: within the TTL window, the consumer returns the cached value
+ * and does not hit `pins.list` / `conversations.history` again. Design
+ * doc §84. Five minutes is long enough that a chatty operator does not
+ * spam Slack, short enough that a peer's manifest edit surfaces within
+ * roughly a coffee break.
+ */
+export const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface ManifestCacheEntry {
+  readonly cachedAt: number
+  readonly manifests: ReadonlyArray<ManifestV1>
+}
+
+export interface ManifestCache {
+  /** Return the cached manifests if the entry is fresh (age < TTL).
+   *  Returns `undefined` on miss — either no entry, or the entry has
+   *  expired. Expired entries are lazily evicted on access. Caller
+   *  decides what to do on miss (fetch + `set`, typically). */
+  get(channelId: string): ReadonlyArray<ManifestV1> | undefined
+  /** Store `manifests` for `channelId`, stamped at the cache's `now()`.
+   *  If the cache is at `maxEntries`, evicts the single oldest entry
+   *  (smallest `cachedAt`) before inserting — soft LRU. */
+  set(channelId: string, manifests: ReadonlyArray<ManifestV1>): void
+  /** Drop every entry. Exposed for test teardown and for future
+   *  operator commands (e.g. a `/manifest:flush` on schema change). */
+  clear(): void
+  /** Current entry count. Exposed for tests and operator inspection. */
+  size(): number
+}
+
+export interface ManifestCacheOptions {
+  /** Time source. Accept for testability; defaults to `Date.now`.
+   *  Must return wall-clock milliseconds since the Unix epoch. */
+  now?: () => number
+  /** Soft cap on distinct-channel entries. When insertion would exceed
+   *  this, the oldest entry is evicted. Default 256 — larger than the
+   *  channel count in any realistic workspace, small enough to bound
+   *  memory to roughly (maxEntries × 40 KB) worst case when every slot
+   *  holds a cap-size manifest list. */
+  maxEntries?: number
+  /** Entry TTL in ms. Defaults to `MANIFEST_CACHE_TTL_MS`. Exposed for
+   *  tests that need to exercise the expiry boundary without waiting
+   *  five minutes of wall-clock time. */
+  ttlMs?: number
+}
+
+/**
+ * Create a per-channel manifest cache. Opaque over an internal
+ * `Map<channelId, ManifestCacheEntry>` — the cache itself is a plain
+ * object with method members, not a class, so there is no `this`
+ * binding to worry about when the caller passes the methods around
+ * (e.g. into a lambda). Entries are dropped on process exit by design
+ * (protocol doc §166 "A restart clears it.") — persistence is out of
+ * scope.
+ */
+export function createManifestCache(opts: ManifestCacheOptions = {}): ManifestCache {
+  const now = opts.now ?? Date.now
+  const maxEntries = opts.maxEntries ?? 256
+  const ttlMs = opts.ttlMs ?? MANIFEST_CACHE_TTL_MS
+  const store = new Map<string, ManifestCacheEntry>()
+
+  return {
+    get(channelId) {
+      const entry = store.get(channelId)
+      if (!entry) return undefined
+      if (now() - entry.cachedAt >= ttlMs) {
+        // Lazy eviction of an expired entry. Avoids a keep-alive bug
+        // where an expired entry stays around forever because it's
+        // never touched again — each `get` of an expired entry also
+        // removes it.
+        store.delete(channelId)
+        return undefined
+      }
+      return entry.manifests
+    },
+    set(channelId, manifests) {
+      // Soft LRU-by-age: on an insertion that would breach the cap,
+      // drop the single entry with the smallest `cachedAt`. Scanning
+      // the map is O(n) but n ≤ maxEntries = 256, so the cost is
+      // bounded and negligible compared to the Slack round-trip that
+      // populated the value.
+      if (store.size >= maxEntries && !store.has(channelId)) {
+        let oldestKey: string | undefined
+        let oldestAt = Infinity
+        for (const [k, v] of store) {
+          if (v.cachedAt < oldestAt) {
+            oldestAt = v.cachedAt
+            oldestKey = k
+          }
+        }
+        if (oldestKey !== undefined) store.delete(oldestKey)
+      }
+      store.set(channelId, { cachedAt: now(), manifests })
+    },
+    clear() {
+      store.clear()
+    },
+    size() {
+      return store.size
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Publish-size gate (Epic 31-B.2, bead ccsc-0qk.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a validated manifest to its on-wire JSON form and assert
+ * the UTF-8 byte count is within the 8 KB publish cap. Throws on
+ * violation with a message that names both the actual byte count and
+ * the cap, so an operator debugging a rejected publish knows exactly
+ * which field to shrink.
+ *
+ * Returns the serialized string on success so the caller can post it
+ * directly. Keeping serialization and size-check in one function
+ * guarantees the bytes we measure are the bytes we post — a split
+ * signature (`assertPublishSize(manifest)` + separate
+ * `JSON.stringify` in the caller) would leave room for formatting
+ * differences to silently raise the effective cap.
+ *
+ * Stricter than the 40 KB read-side cap (Postel's Law — strict on
+ * output, liberal on input). See `MAX_PUBLISH_MANIFEST_BYTES` for the
+ * reasoning.
+ */
+// ---------------------------------------------------------------------------
+// findOurPriorManifestPins — pure filter for the replace sweep (ccsc-0qk.10)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape we need from a pins.list item to decide whether it's a prior
+ * manifest we posted. Kept deliberately minimal so the consumer can
+ * pass Slack's full item shape via structural typing without a runtime
+ * coercion — every field is optional so a file-kind pin (no `.message`)
+ * is handled gracefully.
+ */
+export interface PinItemLike {
+  readonly type?: string
+  readonly message?: {
+    readonly text?: string | null
+    readonly bot_id?: string
+    readonly user?: string
+    readonly ts?: string
+  }
+}
+
+/** Identity handles needed to recognise our own posts in a pins.list
+ *  response. Either field may be empty when bootstrap hasn't finished
+ *  populating them; the filter treats empty values as "don't match". */
+export interface BotIdentity {
+  readonly botId?: string
+  readonly botUserId?: string
+}
+
+/**
+ * Return the message timestamps of pins this bot posted that carry a
+ * v1 manifest body (Epic 31-B.10, bead ccsc-0qk.10). Extracted from
+ * the publish_manifest handler so the replace-sweep filter can be
+ * tested independently of any Slack mock.
+ *
+ * Filter semantics, each applied as a distinct reject step:
+ *
+ *   1. type !== 'message' — skip file and file_comment pins.
+ *   2. no message or no ts — not actionable.
+ *   3. bot_id / user does not match our identity — peer's pin, don't touch.
+ *   4. body does not contain the magic header — not a manifest,
+ *      leave it alone even if we posted it.
+ *
+ * Returns ts values in the input's iteration order. Deduplication is
+ * NOT performed — the caller (the publish handler) calls pins.remove
+ * once per ts, and Slack itself de-dupes repeat removes.
+ *
+ * If both `selfBotId` and `botUserId` on `identity` are empty strings
+ * (bootstrap hasn't populated them yet), the filter returns `[]` —
+ * fail-closed: better to skip the replace sweep than to mistakenly
+ * unpin a peer's manifest.
+ */
+export function findOurPriorManifestPins(
+  items: ReadonlyArray<PinItemLike>,
+  identity: BotIdentity,
+): string[] {
+  const selfBotId = identity.botId ?? ''
+  const botUserId = identity.botUserId ?? ''
+  if (!selfBotId && !botUserId) return []
+  return items.flatMap((item) => {
+    if (item.type !== 'message') return []
+    const msg = item.message
+    if (!msg?.ts) return []
+    const isOurs =
+      (!!selfBotId && msg.bot_id === selfBotId) || (!!botUserId && msg.user === botUserId)
+    if (!isOurs) return []
+    const text = msg.text ?? ''
+    if (!text.includes(MANIFEST_V1_MAGIC_KEY)) return []
+    return [msg.ts]
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Publish rate limiter (Epic 31-B.4, bead ccsc-0qk.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * One publish per channel per hour. Prevents pin-spam if an operator
+ * (or a misbehaving automation) triggers repeated publishes. Not
+ * persisted — a process restart clears the window, which is the
+ * accepted tradeoff for keeping this purely in-memory (doc §166 has
+ * the same "restart clears" posture for the read cache).
+ */
+export const PUBLISH_RATE_LIMIT_MS = 60 * 60 * 1000
+
+export interface PublishRateLimiter {
+  /**
+   * Check whether `channelId` is currently in a cooldown window and,
+   * if not, record `now()` as the most-recent publish timestamp. The
+   * record happens BEFORE the caller's actual publish — reserving the
+   * slot — so a concurrent or retried call sees the cooldown even if
+   * the first call's publish is mid-flight or later fails. A rate
+   * limiter that rolls back on downstream failure is trivially
+   * bypassable (retry until success), which is not what we want here.
+   *
+   * Throws on a hit with an ID-bearing, time-bearing message naming
+   * both the channel and the approximate minutes remaining until the
+   * next publish is allowed.
+   */
+  checkAndRecord(channelId: string): void
+  /** Drop every entry. For tests and future operator commands. */
+  clear(): void
+  /** Current entry count. For tests and operator inspection. */
+  size(): number
+}
+
+export interface PublishRateLimiterOptions {
+  /** Time source. Defaults to `Date.now`. */
+  now?: () => number
+  /** Window length in ms. Defaults to `PUBLISH_RATE_LIMIT_MS`. */
+  windowMs?: number
+  /** Soft cap on distinct-channel entries. Default 256 — same bound
+   *  as the read cache; larger than any realistic workspace channel
+   *  count, small enough to cap memory. */
+  maxEntries?: number
+}
+
+/**
+ * Create an in-memory per-channel publish rate limiter. Symmetric to
+ * `createManifestCache` on the read side: plain-object factory, no
+ * `this` binding concerns, injected time source for testability,
+ * soft-LRU eviction when the entry cap would be breached.
+ */
+export function createPublishRateLimiter(opts: PublishRateLimiterOptions = {}): PublishRateLimiter {
+  const now = opts.now ?? Date.now
+  const windowMs = opts.windowMs ?? PUBLISH_RATE_LIMIT_MS
+  const maxEntries = opts.maxEntries ?? 256
+  const store = new Map<string, number>()
+
+  return {
+    checkAndRecord(channelId) {
+      const currentMs = now()
+      const lastMs = store.get(channelId)
+      if (lastMs !== undefined && currentMs - lastMs < windowMs) {
+        const remainingMs = windowMs - (currentMs - lastMs)
+        const remainingMins = Math.max(1, Math.ceil(remainingMs / 60_000))
+        throw new Error(
+          `Publish rate limit: channel '${channelId}' was last published ` +
+            `${Math.floor((currentMs - lastMs) / 60_000)}m ago; 1-per-hour window. ` +
+            `Try again in ~${remainingMins}m.`,
+        )
+      }
+      // Soft-LRU eviction matches the read cache pattern — drop the
+      // entry with the smallest timestamp when we'd otherwise breach
+      // maxEntries on an insertion for a new channel.
+      if (store.size >= maxEntries && !store.has(channelId)) {
+        let oldestKey: string | undefined
+        let oldestAt = Infinity
+        for (const [k, v] of store) {
+          if (v < oldestAt) {
+            oldestAt = v
+            oldestKey = k
+          }
+        }
+        if (oldestKey !== undefined) store.delete(oldestKey)
+      }
+      store.set(channelId, currentMs)
+    },
+    clear() {
+      store.clear()
+    },
+    size() {
+      return store.size
+    },
+  }
+}
+
+export function assertPublishSizeAndSerialize(manifest: ManifestV1): string {
+  const body = JSON.stringify(manifest, null, 2)
+  const bytes = utf8ByteLength(body)
+  if (bytes > MAX_PUBLISH_MANIFEST_BYTES) {
+    throw new Error(
+      `Publish size: manifest serializes to ${bytes}B > ${MAX_PUBLISH_MANIFEST_BYTES}B cap. ` +
+        `Shrink description, tools[], or channels[] before republishing.`,
+    )
+  }
+  return body
+}

--- a/plugins/mcp/slack-channel/package.json
+++ b/plugins/mcp/slack-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-slack",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Slack channel for Claude Code — two-way chat via Socket Mode",
   "type": "module",
   "bin": "./server.ts",
@@ -12,11 +12,15 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@slack/socket-mode": "2.0.6",
-    "@slack/web-api": "7.15.0",
+    "@slack/web-api": "7.15.2",
     "tsx": "^4.21.0",
     "zod": "3.25.76"
+  },
+  "overrides": {
+    "axios": "^1.16.1",
+    "fast-uri": "^3.1.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/plugins/mcp/slack-channel/policy.ts
+++ b/plugins/mcp/slack-channel/policy.ts
@@ -1,0 +1,647 @@
+/**
+ * policy.ts — Declarative policy engine for claude-code-slack-channel.
+ *
+ * This module provides the Zod schema for PolicyRule. The evaluate()
+ * function, shadow-detection linter, monotonicity check, and path
+ * canonicalization land in sibling beads (29-A.3 – 29-A.7). See
+ * 000-docs/policy-evaluation-flow.md for the full design contract.
+ *
+ * Scope of this file for 29-A.1:
+ *   - PolicyRule discriminated union (auto_approve | deny | require_approval)
+ *   - MatchSpec with at-least-one-field refinement
+ *   - Inferred TypeScript types
+ *
+ * Deliberately narrow surface: no compound combinators, no expression DSL.
+ * Three effects only; more is a footgun for shadows.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { realpathSync } from 'node:fs'
+import { resolve, sep } from 'node:path'
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// MatchSpec — which tool calls a rule applies to.
+// ---------------------------------------------------------------------------
+
+/** Fields a rule's `match` can constrain. Each field is optional; the
+ *  refinement below rejects match specs that constrain zero fields (a
+ *  rule that matches everything is almost always a bug).
+ *
+ *  - `tool`       — exact MCP tool name, e.g. "upload_file".
+ *  - `pathPrefix` — canonicalized via realpath by evaluate() (29-A.4);
+ *                   the value stored here is the pre-resolve literal.
+ *  - `channel`    — Slack channel ID, e.g. "C0123456789".
+ *  - `thread_ts`  — Slack thread timestamp, e.g. "1712345678.001100".
+ *                   Scopes a rule to a single thread within a channel.
+ *                   Schema-only in v0.5.x: reserved for Epic 29-B's
+ *                   evaluate() wiring so operators can ship thread-
+ *                   scoped rules against a stable v1 schema without a
+ *                   migration edit once enforcement lands.
+ *  - `actor`      — who is calling the tool. Approvers arrive on a
+ *                   later turn so they are not a valid `actor` here.
+ *  - `argEquals`  — subset equality on validated MCP input args. Keys
+ *                   are compared against the top-level input object;
+ *                   every listed key must equal the listed value.
+ */
+export const MatchSpec = z
+  .object({
+    tool: z.string().min(1).optional(),
+    pathPrefix: z.string().min(1).optional(),
+    channel: z
+      .string()
+      .regex(/^[CD][A-Z0-9]+$/)
+      .optional(),
+    thread_ts: z
+      .string()
+      .regex(/^\d+\.\d+$/)
+      .optional(),
+    actor: z.enum(['session_owner', 'claude_process']).optional(),
+    argEquals: z.record(z.string(), z.unknown()).optional(),
+  })
+  .refine(
+    (m) =>
+      m.tool !== undefined ||
+      m.pathPrefix !== undefined ||
+      m.channel !== undefined ||
+      m.thread_ts !== undefined ||
+      m.actor !== undefined ||
+      (m.argEquals !== undefined && Object.keys(m.argEquals).length > 0),
+    { message: 'match must constrain at least one field' },
+  )
+
+export type MatchSpec = z.infer<typeof MatchSpec>
+
+// ---------------------------------------------------------------------------
+// PolicyRule — discriminated union over the three effects.
+// ---------------------------------------------------------------------------
+
+/** Common fields on every rule — identity and position in the policy set. */
+const RuleBase = {
+  /** Stable, human-readable identifier. Shows up in audit log + error
+   *  messages. Two rules with the same id is a load-time error. */
+  id: z.string().min(1).max(120),
+
+  /** Tie-breaker within effect when two rules would otherwise be
+   *  equivalent. Primary ordering is authored array position (first-
+   *  applicable, see 000-docs/policy-evaluation-flow.md §Combining).
+   *  Lower `priority` wins the tie. */
+  priority: z.number().int().default(100),
+
+  match: MatchSpec,
+} as const
+
+/** `auto_approve`: allow the call without operator intervention. */
+export const AutoApproveRule = z.object({
+  ...RuleBase,
+  effect: z.literal('auto_approve'),
+})
+
+/** `deny`: refuse the call. `reason` is surfaced to Claude so the model
+ *  knows why the tool call was rejected — short, non-sensitive prose. */
+export const DenyRule = z.object({
+  ...RuleBase,
+  effect: z.literal('deny'),
+  reason: z.string().min(1).max(200),
+})
+
+/** `require_approval`: hold the call until human approver(s) respond on
+ *  Slack. `ttlMs` is how long an approval remains valid after it
+ *  arrives; future calls that match the same rule + session within the
+ *  window are auto-approved. Default = 5 minutes.
+ *
+ *  `approvers` is the quorum threshold (NIST two-person integrity when
+ *  ≥2). Same Slack `user_id` cannot double-satisfy — the server tracks
+ *  approvedBy as a Set<user_id> and dedups on that. Display name is
+ *  never used (spoofable). Hard ceiling of 10 is anti-footgun: no real
+ *  workflow needs more than that, and an operator typo like `100`
+ *  should be loud, not a deadlock. */
+export const RequireApprovalRule = z.object({
+  ...RuleBase,
+  effect: z.literal('require_approval'),
+  ttlMs: z
+    .number()
+    .int()
+    .positive()
+    .max(24 * 60 * 60 * 1000) // 24h hard ceiling
+    .default(5 * 60 * 1000),
+  approvers: z.number().int().min(1).max(10).default(1),
+})
+
+/** Discriminated union over the three effects. evaluate() (29-A.3)
+ *  walks a list of these in authored order and returns on the first
+ *  rule whose `match` applies. */
+export const PolicyRule = z.discriminatedUnion('effect', [
+  AutoApproveRule,
+  DenyRule,
+  RequireApprovalRule,
+])
+
+export type PolicyRule = z.infer<typeof PolicyRule>
+export type AutoApproveRule = z.infer<typeof AutoApproveRule>
+export type DenyRule = z.infer<typeof DenyRule>
+export type RequireApprovalRule = z.infer<typeof RequireApprovalRule>
+
+/** Parse an unknown value as a PolicyRule. Throws on invalid input with
+ *  Zod's standard error shape. The loader (29-A.5) wraps this with the
+ *  shadow-detection linter; direct callers usually want that instead. */
+export function parsePolicyRule(raw: unknown): PolicyRule {
+  return PolicyRule.parse(raw)
+}
+
+/** Parse an unknown value as an array of PolicyRule. Zod-validates the
+ *  array shape and each rule. Does NOT enforce uniqueness of `id` —
+ *  call `assertUniqueRuleIds()` for that (kept separate so the loader
+ *  can report parse + uniqueness errors independently and so pure
+ *  parse callers aren't forced to accept the throw contract of the
+ *  uniqueness check). */
+export function parsePolicyRules(raw: unknown): PolicyRule[] {
+  return z.array(PolicyRule).parse(raw)
+}
+
+// ---------------------------------------------------------------------------
+// PolicyDecision — output of evaluate(). See 000-docs/policy-evaluation-flow.md §27-30.
+// ---------------------------------------------------------------------------
+
+/** The decision returned by `evaluate()`. Three kinds — a deliberately
+ *  narrow surface. `allow` is the happy path; `deny` refuses with a
+ *  reason surfaced to Claude; `require` pauses until a human approver
+ *  responds on Slack within `ttlMs`.
+ *
+ *  Not confused with `PolicyRule.effect` (the *input* shape): rule
+ *  effects are `auto_approve | deny | require_approval`; decisions are
+ *  `allow | deny | require`. An `auto_approve` rule produces an `allow`
+ *  decision; a `require_approval` rule produces a `require` decision
+ *  unless a fresh approval is already in flight (which turns it into
+ *  `allow`). See the flowchart in policy-evaluation-flow.md.
+ *
+ *  **No runtime validation.** Decisions are produced by `evaluate()`
+ *  from validated inputs, never parsed from untrusted data, so a Zod
+ *  schema here would be dead weight. The type alone is the contract.
+ */
+export type PolicyDecision =
+  | {
+      kind: 'allow'
+      /** ID of the matching rule. Absent when the default branch fires
+       *  (no rule matched + tool not in `requireAuthoredPolicy`). */
+      rule?: string
+    }
+  | {
+      kind: 'deny'
+      rule: string
+      /** Short, non-sensitive prose surfaced to Claude so the model
+       *  knows why the tool call was rejected. */
+      reason: string
+    }
+  | {
+      kind: 'require'
+      rule: string
+      /** For now always the human approver; named so future expansion
+       *  (peer-agent approvals, escalation paths) can extend the union. */
+      approver: 'human_approver'
+      /** How long an approval, once granted, is fresh for. Propagated
+       *  from the matching `RequireApprovalRule.ttlMs`. */
+      ttlMs: number
+      /** Quorum threshold — how many distinct Slack `user_id`s must
+       *  approve before the decision flips to allow. Propagated from
+       *  `RequireApprovalRule.approvers` (default 1). */
+      approvers: number
+    }
+
+// Compile-time shape-drift guard. `lib.ts` deliberately duplicates the
+// shape of `PolicyDecision` as `PolicyDecisionShape` (type-only, no
+// runtime import) to stay decoupled from policy.ts. These bidirectional
+// `satisfies` casts break the build the moment either side drifts —
+// without forcing a runtime import or a third shared module.
+import type { PolicyDecisionShape } from './lib.ts'
+
+type _PolicyDecisionForward = PolicyDecision extends PolicyDecisionShape ? true : never
+type _PolicyDecisionBackward = PolicyDecisionShape extends PolicyDecision ? true : never
+const _decisionShapeForward: _PolicyDecisionForward = true
+const _decisionShapeBackward: _PolicyDecisionBackward = true
+void _decisionShapeForward
+void _decisionShapeBackward
+
+// ---------------------------------------------------------------------------
+// Path canonicalization (CWE-22) — see policy-evaluation-flow.md §174-196.
+// ---------------------------------------------------------------------------
+
+/** Canonicalize a `match.pathPrefix` at load time.
+ *
+ *  The policy loader calls this once per rule and caches the result.
+ *  `realpathSync.native` resolves every symlink in the configured
+ *  prefix, so the comparison at evaluate time is a prefix-check on
+ *  two canonical paths — no TOCTOU, no smuggling.
+ *
+ *  Throws if the prefix does not exist on disk. That's intentional:
+ *  a rule pointing at a nonexistent path can never match anything, so
+ *  it's almost certainly a typo that the operator should fix at load
+ *  time, not a mystery-miss at evaluation time. Fail loud.
+ *
+ *  See policy-evaluation-flow.md §174-196 for the full design rationale
+ *  and CWE-22 mitigation story.
+ */
+export function canonicalizeRulePathPrefix(raw: string): string {
+  return realpathSync.native(resolve(raw))
+}
+
+/** Canonicalize a per-call request path.
+ *
+ *  Unlike the prefix (canonicalized once at load), the input path is
+ *  canonicalized on every tool call — fresh `realpath` each time so a
+ *  newly-created symlink between calls is caught on the next match.
+ *
+ *  Throws if the path does not exist. That's the desired fail-closed
+ *  posture: a tool call referencing a nonexistent path gets a policy
+ *  error (loud) rather than matching a rule against an unresolvable
+ *  lexical string (quiet).
+ */
+export function canonicalizeRequestPath(raw: string, cwd: string = process.cwd()): string {
+  return realpathSync.native(resolve(cwd, raw))
+}
+
+/** Prefix-matches a canonicalized request path against a canonicalized
+ *  rule prefix. Both args MUST already be realpath-resolved via the
+ *  helpers above — this function does no I/O, just a string compare.
+ *
+ *  The `+ sep` guard prevents `/etc/passwd` from matching prefix
+ *  `/etc/pass` while still allowing an exact-equality match (the common
+ *  case of a rule targeting a file, not a directory).
+ */
+export function pathMatchesPrefix(resolvedPath: string, resolvedPrefix: string): boolean {
+  return resolvedPath === resolvedPrefix || resolvedPath.startsWith(resolvedPrefix + sep)
+}
+
+// ---------------------------------------------------------------------------
+// 31-A.4 Invariant — manifest data NEVER passed to evaluate()
+//
+// Design: 000-docs/bot-manifest-protocol.md §91-109 ("The binding invariant").
+//
+// Peer-bot manifests are advertisements, not grants (Miller 2006). Policy
+// decisions MUST use only verified signals carried on ToolCall (tool,
+// sessionKey.channel, actor) — never content a peer advertised about itself.
+// A peer claiming "I am an approver" in its manifest does not make it one;
+// allowBotIds and access.json are the only sources of role truth.
+//
+// Enforcement here is structural + contractual:
+//
+//   1. policy.ts imports NO manifest-module path, direct or re-exported.
+//      Enforced by the "31-A.4 invariant" test in server.test.ts, which
+//      parses this file's import specifiers on every CI run. A violation
+//      is a merge block, not a warning.
+//
+//   2. When the (future, conditionally-shipped) manifest consumer lands in
+//      Epic 31-A, its output flows to Claude only as MCP tool-call text —
+//      the same trust surface as a chat message. It does NOT flow into
+//      ToolCall.input, PolicyRule[], or EvaluateOptions. Reviewers of any
+//      31-A PR must confirm this before merge.
+//
+//   3. access.json mutation from manifest reads is forbidden (see the
+//      manifest protocol doc §190-203). That rule is enforced in the
+//      manifest-consumer module itself, not here — policy.ts's job is
+//      to stay unreachable from manifest content, full stop.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// evaluate() — first-applicable combining (XACML) per policy-evaluation-flow.md
+// ---------------------------------------------------------------------------
+
+/** Surface of a tool call as the evaluator sees it.
+ *
+ *  Path-bearing tools put the caller-supplied path in `input.path`;
+ *  evaluate() canonicalizes it when a rule constrains `pathPrefix`.
+ *  `actor` is the direct caller — human approvers arrive as later turns,
+ *  never as the `actor` on the original call. */
+export interface ToolCall {
+  tool: string
+  input: Record<string, unknown>
+  sessionKey: { channel: string; thread: string }
+  actor: 'session_owner' | 'claude_process'
+}
+
+/** Key into the approvals map: `${ruleId}:${channel}:${thread}`. Scoped
+ *  to (rule, session) per policy-evaluation-flow.md §285-287 so a
+ *  different session in the same channel never inherits the approval. */
+export type ApprovalKey = string
+
+/** Build the approval-map key for a (rule, sessionKey) pair. */
+export function approvalKey(
+  ruleId: string,
+  sessionKey: { channel: string; thread: string },
+): ApprovalKey {
+  return `${ruleId}:${sessionKey.channel}:${sessionKey.thread}`
+}
+
+/** Set of tools for which an unmatched call defaults to deny-by-omission
+ *  (rather than the blanket allow for everything else). Mutation of
+ *  external state goes here; read-only tools do not — see
+ *  policy-evaluation-flow.md §107-117. */
+export const DEFAULT_REQUIRE_AUTHORED_POLICY: ReadonlySet<string> = new Set(['upload_file'])
+
+export interface EvaluateOptions {
+  /** (rule, session) → approval window. An entry with `ttlExpires > now`
+   *  flips a `require_approval` rule into an `allow` decision. Written
+   *  by the permission-reply handler, not by `evaluate()`. */
+  approvals?: ReadonlyMap<ApprovalKey, { ttlExpires: number }>
+  /** Tools that require an authored rule; unmatched calls return deny. */
+  requireAuthoredPolicy?: ReadonlySet<string>
+}
+
+/** Pure evaluator. Walks `rules` in authored order and returns on the
+ *  first match (XACML first-applicable, see policy-evaluation-flow.md
+ *  §89-93). Side-effect-free: journal emission, approval recording,
+ *  and Slack posts happen outside, after evaluate() returns.
+ *
+ *  Path matching canonicalizes both sides via `realpath` on every call
+ *  (see canonicalizeRequestPath + canonicalizeRulePathPrefix). If
+ *  either path does not exist, the `pathPrefix` constraint is treated
+ *  as "not matching" — fail-closed: a rule can't match a path that
+ *  doesn't resolve.
+ *
+ *  Returns the default decision when no rule matches:
+ *    - `deny` (rule = 'default') if `call.tool` is in requireAuthoredPolicy
+ *    - `allow` (rule undefined) otherwise
+ */
+export function evaluate(
+  call: ToolCall,
+  rules: readonly PolicyRule[],
+  now: number,
+  opts: EvaluateOptions = {},
+): PolicyDecision {
+  const approvals = opts.approvals ?? new Map<ApprovalKey, { ttlExpires: number }>()
+  const requireAuthored = opts.requireAuthoredPolicy ?? DEFAULT_REQUIRE_AUTHORED_POLICY
+
+  for (const rule of rules) {
+    if (!matchApplies(rule.match, call)) continue
+
+    switch (rule.effect) {
+      case 'auto_approve':
+        return { kind: 'allow', rule: rule.id }
+      case 'deny':
+        return { kind: 'deny', rule: rule.id, reason: rule.reason }
+      case 'require_approval': {
+        const approval = approvals.get(approvalKey(rule.id, call.sessionKey))
+        if (approval && approval.ttlExpires > now) {
+          return { kind: 'allow', rule: rule.id }
+        }
+        return {
+          kind: 'require',
+          rule: rule.id,
+          approver: 'human_approver',
+          ttlMs: rule.ttlMs,
+          approvers: rule.approvers,
+        }
+      }
+    }
+  }
+
+  // No rule matched — default branch.
+  if (requireAuthored.has(call.tool)) {
+    return {
+      kind: 'deny',
+      rule: 'default',
+      reason: `no policy authored for tool '${call.tool}'`,
+    }
+  }
+  return { kind: 'allow' }
+}
+
+/** Does `match` apply to `call`? Every undefined field is a wildcard. */
+function matchApplies(match: MatchSpec, call: ToolCall): boolean {
+  if (match.tool !== undefined && match.tool !== call.tool) return false
+  if (match.channel !== undefined && match.channel !== call.sessionKey.channel) return false
+  if (match.actor !== undefined && match.actor !== call.actor) return false
+
+  if (match.pathPrefix !== undefined) {
+    const raw = call.input.path
+    if (typeof raw !== 'string') return false
+    try {
+      const resolvedPrefix = canonicalizeRulePathPrefix(match.pathPrefix)
+      const resolvedInput = canonicalizeRequestPath(raw)
+      if (!pathMatchesPrefix(resolvedInput, resolvedPrefix)) return false
+    } catch {
+      // Either side failed to resolve: treat as non-match. Fail-closed.
+      return false
+    }
+  }
+
+  if (match.argEquals !== undefined) {
+    for (const [k, v] of Object.entries(match.argEquals)) {
+      if (!jsonEqual(call.input[k], v)) return false
+    }
+  }
+
+  return true
+}
+
+/** Structural equality via JSON round-trip. Good enough for validated
+ *  MCP input (plain JSON, no functions/cycles/dates); if perf becomes
+ *  an issue, swap in a real deep-eq. Returns false on non-serializable
+ *  inputs rather than throwing. */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// assertUniqueRuleIds() — load-time hard invariant per ACCESS.md §"Safety
+// checks the loader runs" and policy-evaluation-flow.md. Duplicate `id`s
+// are fatal because the evaluator walks in authored order and returns on
+// the first match, so a second rule with the same id is silently
+// unreachable — a subtle footgun the operator should see at boot, not in
+// a post-incident audit trail review.
+// ---------------------------------------------------------------------------
+
+/** Throws if two or more rules share an `id`. Error message enumerates
+ *  every duplicated id so an operator fixing a large policy sees the
+ *  full set at once. Called AFTER `parsePolicyRules()` because it
+ *  assumes the input is already schema-valid (so `rule.id` is a
+ *  non-empty string). Sibling to `detectShadowing()` and
+ *  `detectBroadAutoApprove()` — but unlike those, throws rather than
+ *  returning warnings, matching the documented "fatal at boot"
+ *  contract in ACCESS.md.
+ */
+export function assertUniqueRuleIds(rules: readonly PolicyRule[]): void {
+  const seen = new Set<string>()
+  const dupes = new Set<string>()
+  for (const rule of rules) {
+    if (seen.has(rule.id)) dupes.add(rule.id)
+    seen.add(rule.id)
+  }
+  if (dupes.size > 0) {
+    const sorted = [...dupes].sort()
+    throw new Error(
+      `duplicate rule id(s): ${sorted.join(', ')}. Every rule must have a unique id — the evaluator uses first-applicable, so a second rule with the same id is unreachable.`,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// detectShadowing() — load-time linter per policy-evaluation-flow.md §199-230
+// ---------------------------------------------------------------------------
+
+export interface ShadowWarning {
+  /** The rule that never gets reached. */
+  later: string
+  /** The earlier rule that swallows every call the later rule would match. */
+  earlier: string
+  message: string
+}
+
+/** Static subset-check over MatchSpec fields. A later rule is shadowed
+ *  when an earlier rule's match is less-specific-or-equal on every
+ *  field. Warn-not-block: the warnings go to stderr at load time so the
+ *  operator can reorder or narrow. Never fail-closed — an operator who
+ *  intentionally wrote an unreachable rule (e.g., as a placeholder
+ *  during a refactor) shouldn't be forced to delete it just to boot.
+ */
+export function detectShadowing(rules: readonly PolicyRule[]): ShadowWarning[] {
+  const warnings: ShadowWarning[] = []
+  for (let j = 1; j < rules.length; j++) {
+    const later = rules[j]!
+    for (let i = 0; i < j; i++) {
+      const earlier = rules[i]!
+      if (matchSubsetOrEqual(earlier.match, later.match)) {
+        warnings.push({
+          later: later.id,
+          earlier: earlier.id,
+          message: `rule '${later.id}' is shadowed by earlier rule '${earlier.id}' — every call the later rule would match is already caught by the earlier one`,
+        })
+        break // first shadow is sufficient; don't double-report
+      }
+    }
+  }
+  return warnings
+}
+
+/** Is `outer.match` less-specific-or-equal to `inner.match` on every
+ *  field? Used by both shadow detection and monotonicity — if yes,
+ *  `outer` matches a superset of what `inner` matches. */
+function matchSubsetOrEqual(outer: MatchSpec, inner: MatchSpec): boolean {
+  if (outer.tool !== undefined && outer.tool !== inner.tool) return false
+  if (outer.channel !== undefined && outer.channel !== inner.channel) return false
+  if (outer.actor !== undefined && outer.actor !== inner.actor) return false
+
+  if (outer.pathPrefix !== undefined) {
+    if (inner.pathPrefix === undefined) return false
+    // Lexical prefix check (both would be canonicalized in practice).
+    if (
+      inner.pathPrefix !== outer.pathPrefix &&
+      !inner.pathPrefix.startsWith(outer.pathPrefix + sep)
+    ) {
+      return false
+    }
+  }
+
+  if (outer.argEquals !== undefined) {
+    if (inner.argEquals === undefined) return false
+    for (const [k, v] of Object.entries(outer.argEquals)) {
+      if (!jsonEqual(inner.argEquals[k], v)) return false
+    }
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// checkMonotonicity() — hot-reload invariant per policy-evaluation-flow.md §234-244
+// ---------------------------------------------------------------------------
+
+export interface MonotonicityViolation {
+  /** The newly-added auto_approve rule that would weaken policy. */
+  newRule: string
+  /** The existing deny rule whose match the new rule supersets. */
+  existingDeny: string
+  message: string
+}
+
+/** Detects whether adopting `next` as the active policy set would
+ *  weaken policy compared to `prev`. A violation is:
+ *
+ *    A newly-added rule R with effect 'auto_approve' whose `match` is
+ *    a subset of an existing 'deny' rule's match — i.e., the deny
+ *    would have covered R's calls, so adding R silently opens a hole.
+ *
+ *  Caller's responsibility: if this returns a non-empty array, refuse
+ *  to adopt `next` and keep `prev` active. The server logs the
+ *  violation, surfaces a beads issue, and requires operator action
+ *  (doc §237-249). Removed rules don't trigger — removing a deny
+ *  obviously weakens policy, and the operator signed off by removing.
+ */
+export function checkMonotonicity(
+  prev: readonly PolicyRule[],
+  next: readonly PolicyRule[],
+): MonotonicityViolation[] {
+  const violations: MonotonicityViolation[] = []
+  const prevIds = new Set(prev.map((r) => r.id))
+  const prevDenies = prev.filter(
+    (r): r is Extract<PolicyRule, { effect: 'deny' }> => r.effect === 'deny',
+  )
+
+  for (const newRule of next) {
+    if (prevIds.has(newRule.id)) continue // unchanged or modified, not added
+    if (newRule.effect !== 'auto_approve') continue
+
+    for (const existingDeny of prevDenies) {
+      if (matchSubsetOrEqual(existingDeny.match, newRule.match)) {
+        violations.push({
+          newRule: newRule.id,
+          existingDeny: existingDeny.id,
+          message: `new auto_approve rule '${newRule.id}' weakens existing deny '${existingDeny.id}' — reload refused`,
+        })
+      }
+    }
+  }
+
+  return violations
+}
+
+// ---------------------------------------------------------------------------
+// detectBroadAutoApprove() — boot-time footgun warning for auto_approve
+// rules with overly broad match (no `tool` and no `pathPrefix`).
+// ---------------------------------------------------------------------------
+
+export interface BroadMatchWarning {
+  ruleId: string
+  message: string
+}
+
+/** Flag `auto_approve` rules whose `match` is too broad to be intentional.
+ *  The heuristic: a narrow auto_approve must scope itself with at least
+ *  one of `tool` or `pathPrefix`. Without either, the rule auto-approves
+ *  based on `channel` / `actor` / `thread_ts` / `argEquals` alone — which
+ *  means any tool, on any path, in that scope gets a green light.
+ *
+ *  That's almost always a misconfiguration: the operator meant to bound
+ *  the rule to a specific safe operation and forgot. Warn loud at boot
+ *  so the operator catches it before a silent over-grant lands in prod.
+ *  Warn-not-block (same posture as `detectShadowing`) — an operator who
+ *  intentionally wants "trust claude_process fully in this channel" can
+ *  still boot; they just see the warning in logs.
+ *
+ *  Not shadow-detection (which flags unreachable rules) and not
+ *  monotonicity (which flags weakening reloads). This is a separate
+ *  axis: "this rule IS reachable and would be monotone, but its shape
+ *  means it probably matches far more than you think."
+ */
+export function detectBroadAutoApprove(rules: readonly PolicyRule[]): BroadMatchWarning[] {
+  const warnings: BroadMatchWarning[] = []
+  for (const rule of rules) {
+    if (rule.effect !== 'auto_approve') continue
+    const hasNarrow = rule.match.tool !== undefined || rule.match.pathPrefix !== undefined
+    if (!hasNarrow) {
+      warnings.push({
+        ruleId: rule.id,
+        message:
+          `auto_approve rule '${rule.id}' has no 'tool' or 'pathPrefix' in its match — ` +
+          `this rule auto-approves ANY tool call within its scope, which is almost always ` +
+          `a misconfiguration. Narrow the rule or convert to require_approval.`,
+      })
+    }
+  }
+  return warnings
+}

--- a/plugins/mcp/slack-channel/server.ts
+++ b/plugins/mcp/slack-channel/server.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 /**
  * Slack Channel for Claude Code
  *
@@ -983,6 +983,7 @@ async function executeReply(args: Record<string, any>, ctx: ToolContext): Promis
       const uploadArgs: Record<string, any> = {
         channel_id: chatId,
         file: resolved,
+        filename: basename(resolved),
       }
       if (threadTs) uploadArgs.thread_ts = threadTs
       await ctx.web.filesUploadV2(uploadArgs as any)

--- a/plugins/mcp/slack-channel/supervisor.ts
+++ b/plugins/mcp/slack-channel/supervisor.ts
@@ -1,0 +1,980 @@
+/**
+ * supervisor.ts — Session supervisor interface for the MCP server.
+ *
+ * This file is the Epic 32-B entry point. It declares the shape of the
+ * SessionSupervisor actor — the single component allowed to create,
+ * transition, or destroy sessions — without providing a runtime. The
+ * activate / quiesce / deactivate implementations land in sibling beads
+ * (ccsc-xa3.2, ccsc-xa3.3, and the deactivate + reaper beads under
+ * ccsc-xa3.14). See 000-docs/session-state-machine.md §221-267 for the
+ * full behavioural contract this interface pins down, and Armstrong
+ * (2003) for the supervisor / lifecycle pattern it borrows from.
+ *
+ * Design notes:
+ *
+ *   - **Actor, not a library.** Every mutation of a live session flows
+ *     through a single SessionSupervisor owned by server.ts. lib.ts
+ *     primitives (sessionPath, saveSession, loadSession) are called only
+ *     from here. A session file written by any other path is a bug.
+ *
+ *   - **One mutex per session file.** Two Slack threads in the same
+ *     channel are independent; their handles carry independent mutexes.
+ *     The supervisor guarantees serialised `update()` calls per key, not
+ *     per channel.
+ *
+ *   - **Crash is not data loss.** The on-disk file is the source of
+ *     truth. In-memory handles are caches. If the process crashes mid-
+ *     flight, the next inbound event for that key re-enters Activating
+ *     and re-reads the file (see session-state-machine.md §239-247).
+ *
+ *   - **No policy, no gate, no journal.** The supervisor decides when a
+ *     session is loaded, held, flushed, or quarantined — it does not
+ *     decide who can speak (inbound gate), which tools run (Epic 29-B),
+ *     or what gets logged (Epic 30-A). Those subsystems observe session
+ *     state; they never mutate it.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { JournalWriter } from './journal'
+import type { Session, SessionKey } from './lib'
+import { loadSession, saveSession, sessionPath } from './lib'
+
+// ---------------------------------------------------------------------------
+// Lifecycle state
+// ---------------------------------------------------------------------------
+
+/** Observable lifecycle state for one session, mirroring the five-state
+ *  FSM in 000-docs/session-state-machine.md §109-155. Nonexistent is
+ *  implicit (no handle) so it is not an enumerated value here.
+ *
+ *  Transitions are strict and are the supervisor's responsibility — the
+ *  doc diagram is authoritative, this type is descriptive.
+ *
+ *    - `activating`   — load-or-create in progress; single-writer critical
+ *                       section. Callers of activate() observe this only
+ *                       through the returned Promise resolving.
+ *    - `active`       — handle is live, `session` reflects the on-disk
+ *                       file after the most recent `update()`.
+ *    - `quiescing`    — refusing new work; pending writes still flushing.
+ *                       `update()` rejects.
+ *    - `deactivating` — last flush resolved; handle about to be released.
+ *                       Terminal from the caller's perspective.
+ *    - `quarantined`  — save or load failure; supervisor filed a beads
+ *                       issue and will not auto-reload. Only a human
+ *                       (SO) clears this; see session-state-machine.md
+ *                       §132-137.
+ */
+export type SessionState = 'activating' | 'active' | 'quiescing' | 'deactivating' | 'quarantined'
+
+// ---------------------------------------------------------------------------
+// SessionHandle — in-memory wrapper around one Session file
+// ---------------------------------------------------------------------------
+
+/** Live handle to one session. Returned by `SessionSupervisor.activate()`.
+ *
+ *  Callers treat the handle as opaque: read `session` for the current
+ *  snapshot, call `update()` to persist a change. The handle enforces
+ *  serialised writes through an internal mutex keyed on this session's
+ *  path — two concurrent `update()` calls on the same handle run in
+ *  strict order (see session-state-machine.md §210 invariant 1).
+ *
+ *  A handle is valid only while `state === 'active'`. Once quiesce has
+ *  started, `update()` rejects; callers must re-activate to resume.
+ */
+export interface SessionHandle {
+  /** Identity. Immutable for the lifetime of the handle. */
+  readonly key: SessionKey
+
+  /** Lifecycle state of this handle as observed by the supervisor.
+   *  Consumers may read but must not assume state is stable between
+   *  awaits — the reaper or a shutdown signal can transition the
+   *  handle out from under them. Always re-check after an `await`. */
+  readonly state: SessionState
+
+  /** Most recent successfully persisted snapshot of this session. The
+   *  reference may point to frozen / read-only data; callers must not
+   *  mutate it in place. Produce the next version inside `update()`. */
+  readonly session: Session
+
+  /** Serialise an update through the per-session mutex, persist it via
+   *  the atomic writer (`saveSession()`), and refresh `this.session`.
+   *
+   *  Contract:
+   *    - `fn` receives the current session and returns the next one.
+   *      It must be pure — no I/O, no sleeps, no throwing except to
+   *      signal a validation failure that should abort the update.
+   *    - The supervisor persists the returned value with the atomic
+   *      writer. Partial state never lands on disk.
+   *    - On save failure the handle transitions to `quarantined` and
+   *      the returned promise rejects. In-memory `session` reverts to
+   *      the pre-update value; no consumer ever sees the failed draft.
+   *    - While `state !== 'active'` the promise rejects without
+   *      calling `fn`. */
+  update(fn: (prev: Session) => Session): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// SessionSupervisor — the actor contract
+// ---------------------------------------------------------------------------
+
+/** Supervisor for the per-thread session population. There is exactly one
+ *  `SessionSupervisor` per MCP server process; it owns the
+ *  `Map<SessionKey, SessionHandle>` named in session-state-machine.md
+ *  §229 and is the only code permitted to drive state transitions on
+ *  that map.
+ *
+ *  Armstrong-style shape: the supervisor is a long-lived actor that
+ *  delegates work to short-lived per-session children (the handles).
+ *  Crashes of a single session are isolated — quarantine a handle, keep
+ *  serving every other key. Crashes of the supervisor itself restart
+ *  the whole population from disk (see §239-247).
+ *
+ *  The supervisor is **not** responsible for deciding whether an inbound
+ *  event reaches Claude (that is the inbound `gate()` in lib.ts), for
+ *  deciding whether a tool call runs (policy evaluator, Epic 29), or
+ *  for persisting the audit log (journal sink, Epic 30). It is a pure
+ *  session-lifecycle authority.
+ */
+export interface SessionSupervisor {
+  /** Activate the session for `key`: load the file if it exists, create
+   *  an empty one if not, and return a live handle.
+   *
+   *  `initialOwnerId` is the Slack user ID to record as `ownerId` on a
+   *  newly-created session file. It is consulted **only** on the create
+   *  branch; if the session file already exists, the stored owner wins
+   *  and the argument is ignored. A caller that knows the session
+   *  already exists may omit it. A caller that cannot vouch for owner
+   *  (supervisor rehydration on boot, internal bookkeeping) may omit it
+   *  as well — activate() will then reject if the file is missing,
+   *  rather than synthesize an owner.
+   *
+   *  Contract:
+   *    - Idempotent per key. Two concurrent activate() calls for the
+   *      same key return the same handle (single-flight, per
+   *      session-state-machine.md §266).
+   *    - While loading/creating the handle observes `state =
+   *      'activating'`; the returned promise resolves only after the
+   *      handle reaches `active`.
+   *    - Load failure on an existing file transitions to `quarantined`
+   *      and rejects the promise; the supervisor files a beads issue
+   *      for the SO and never auto-retries.
+   *    - Path-validation failure (realpath escape, bad SessionKey
+   *      component) rejects before any on-disk work; no session is
+   *      recorded for the key.
+   *    - Does not enforce idle TTL. Reaper logic lives in the deactivate
+   *      path, not here. */
+  activate(key: SessionKey, initialOwnerId?: string): Promise<SessionHandle>
+
+  /** Refuse new work on `key` and wait for pending writes to flush.
+   *
+   *  Contract:
+   *    - After `quiesce()` begins, `update()` on the associated handle
+   *      rejects. New `activate()` calls for the same key wait for
+   *      quiesce to complete, then re-activate from disk.
+   *    - A new inbound event may cancel the quiesce and return the
+   *      handle to `active`, per session-state-machine.md §124 (the
+   *      `Quiescing → Active` transition). That decision is the
+   *      supervisor's; callers of `quiesce()` receive a promise that
+   *      resolves in either terminal case.
+   *    - Quiesce is idempotent: a second call during an in-flight
+   *      quiesce joins the same promise. */
+  quiesce(key: SessionKey): Promise<void>
+
+  /** Release the in-memory handle. The on-disk file is left alone.
+   *
+   *  Contract:
+   *    - Must be preceded by a completed `quiesce(key)`. Calling
+   *      `deactivate` on an `active` key is a programmer error and
+   *      rejects.
+   *    - After deactivation, the supervisor's live map no longer
+   *      contains `key`. Future inbound events for the same key
+   *      re-enter `activate()` and reload the file from disk.
+   *    - Quarantined handles are not deactivated through this path —
+   *      they persist until a human clears the quarantine flag. */
+  deactivate(key: SessionKey): Promise<void>
+
+  /** Graceful shutdown. Quiesces every live session in parallel, awaits
+   *  all flushes, then deactivates. Called from server.ts on SIGTERM /
+   *  SIGINT and on stdin EOF from the Claude Code host.
+   *
+   *  After `shutdown()` resolves the supervisor is unusable; a second
+   *  `activate()` call rejects. A new supervisor instance is required
+   *  to resume, and it will rebuild state from disk. */
+  shutdown(): Promise<void>
+
+  /** Clear the quarantine flag for `key`, allowing a future `activate()`
+   *  to succeed. This is the explicit operator-action path specified in
+   *  session-state-machine.md §129 ("only a human (SO) clears this").
+   *
+   *  Contract:
+   *    - If `key` is not quarantined this is a no-op; no error is thrown
+   *      because the operator may have already cleared it.
+   *    - After this call, a subsequent `activate()` will attempt to load
+   *      the session file from disk as normal. If the file is still
+   *      corrupted, the load will fail and the key will be quarantined
+   *      again.
+   *    - Does not perform any I/O; it only removes the in-memory
+   *      quarantine entry. The audit journal event for this action lands
+   *      in Epic 32-B. */
+  clearQuarantine(key: SessionKey): void
+
+  /** One pass of the idle reaper. Finds every `active` handle whose
+   *  `session.lastActiveAt` is older than `idleMs` and has no in-flight
+   *  work, then drives it through quiesce → deactivate.
+   *
+   *  Contract:
+   *    - Never reaps a handle with `inFlight.size > 0` (session-state-
+   *      machine.md §265 — the idle TTL check runs before quiesce and
+   *      does not pre-empt in-flight work).
+   *    - Never reaps a handle whose state is not `active`. Quiescing /
+   *      deactivating / quarantined handles are on their own edge of
+   *      the FSM; the reaper stays out of their way.
+   *    - Errors on a single session do not stop the tick. The reaper
+   *      logs the failure and moves on so one quarantined handle can't
+   *      starve the rest of the population.
+   *    - Pure relative to wall-clock — tests inject a `clock` to drive
+   *      the threshold deterministically.
+   *
+   *  Timer wiring lives in `server.ts`: this function is the reapable
+   *  unit so the server can decide tick frequency, or a test can call
+   *  it directly. */
+  reapIdle(): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Factory — createSessionSupervisor
+// ---------------------------------------------------------------------------
+
+/** Structured log line emitted by the supervisor. `event` is a stable
+ *  identifier (e.g. `session.activate`); `fields` carries the event's
+ *  payload. Consumers are expected to inject their own writer; the
+ *  default writes one newline-delimited JSON object per call to stdout
+ *  so the journal sink (Epic 30-A) can tail the stream. */
+export type SupervisorLog = (event: string, fields: Record<string, unknown>) => void
+
+/** Injection points for a SessionSupervisor. All are optional; defaults
+ *  give you a production-shaped supervisor that writes to stdout and
+ *  reads real wall-clock time. Tests supply their own `log` and `clock`
+ *  to keep assertions deterministic. */
+export interface SupervisorOptions {
+  /** State directory root, e.g. `~/.claude/channels/slack`. The same
+   *  root passed to `sessionPath()` and `loadSession()` in lib.ts. */
+  stateRoot: string
+  /** Optional structured log sink. Defaults to a stdout JSON-line
+   *  writer. */
+  log?: SupervisorLog
+  /** Optional wall-clock source, returning epoch-ms. Defaults to
+   *  `Date.now`. Injected for deterministic tests of `createdAt` and
+   *  `lastActiveAt`. */
+  clock?: () => number
+  /** Idle threshold for the reaper, in milliseconds. A session is
+   *  eligible for reaping when `clock() - session.lastActiveAt >
+   *  idleMs`. Default: 4 hours (14_400_000 ms). Matches the
+   *  `SLACK_SESSION_IDLE_MS` env var documented in
+   *  session-state-machine.md §119. */
+  idleMs?: number
+  /** Optional audit journal writer. When provided, the supervisor emits
+   *  `session.activate`, `session.quiesce`, and `session.deactivate` events
+   *  at the corresponding state transitions. Journal write failures are
+   *  logged and swallowed — they must never interrupt message delivery or
+   *  session lifecycle (audit-journal-architecture.md invariant: broken
+   *  journal MUST NOT take down the hot path). */
+  journal?: JournalWriter
+}
+
+/** Default idle threshold: 4 hours in ms. Documented in
+ *  session-state-machine.md §119. */
+export const DEFAULT_IDLE_MS = 4 * 60 * 60 * 1000
+
+/** Parse `SLACK_SESSION_IDLE_MS` from an env record and return a valid
+ *  idle threshold in ms. Falls back to `DEFAULT_IDLE_MS` when the var
+ *  is unset, empty, non-numeric, negative, or non-finite.
+ *
+ *  Pure *relative to the `env` argument*: parsing the record is
+ *  deterministic and side-effect-free. The default parameter value
+ *  reads `process.env` as an ergonomic fallback so the call site in
+ *  server.ts boot can write `resolveIdleMs()` without repeating the
+ *  env lookup. Tests pass an explicit record to keep the function
+ *  deterministic at the test boundary. */
+export function resolveIdleMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.SLACK_SESSION_IDLE_MS
+  if (raw === undefined || raw === '') return DEFAULT_IDLE_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_IDLE_MS
+  return Math.floor(parsed)
+}
+
+/** Default structured log writer: one newline-delimited JSON object per
+ *  call, written to stdout. Matches the format the journal sink will
+ *  tail. Keeping this internal means callers who want a different sink
+ *  just pass their own `log` — no global config. */
+function defaultLog(event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ event, ...fields })
+  // process.stdout.write is sync for TTYs, async for pipes; either way
+  // the supervisor does not await the flush. Structured logs are best-
+  // effort; loss of a line is not a correctness issue.
+  process.stdout.write(`${line}\n`)
+}
+
+/** Construct a SessionSupervisor bound to a state directory.
+ *
+ *  Build one of these at server boot per state root. The supervisor is
+ *  long-lived; every inbound event flows through the same instance.
+ *
+ *  This factory currently returns a supervisor whose `activate()` is
+ *  fully wired (ccsc-xa3.2) and whose `quiesce()`, `deactivate()`, and
+ *  `shutdown()` throw `not yet implemented`. Those land in sibling
+ *  beads (ccsc-xa3.3, ccsc-xa3.14). Handle `update()` is also staged
+ *  for a later bead and currently rejects — callers of `activate()`
+ *  can read state but not yet persist changes. See
+ *  000-docs/session-state-machine.md §221-267 for the full target
+ *  behaviour. */
+export function createSessionSupervisor(opts: SupervisorOptions): SessionSupervisor {
+  const log = opts.log ?? defaultLog
+  const clock = opts.clock ?? Date.now
+  const idleMs = opts.idleMs ?? DEFAULT_IDLE_MS
+  const { stateRoot, journal } = opts
+
+  /** Awaitable journal write for session lifecycle transitions. Never throws —
+   *  a broken journal MUST NOT take down the session lifecycle path. Errors are
+   *  forwarded to `log`. Returns a promise so callers in non-hot paths (quiesce,
+   *  deactivate) can await completion before they return — this ensures that
+   *  the journal file is durable before the supervisor's own state changes. */
+  async function journalWrite(input: Parameters<JournalWriter['writeEvent']>[0]): Promise<void> {
+    if (journal === undefined) return
+    try {
+      await journal.writeEvent(input)
+    } catch (err: unknown) {
+      log('journal.write_error', {
+        kind: input.kind,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  // Live handles, keyed by the stringified SessionKey. Use a composite
+  // string because `Map<object, ...>` keys by reference and two equal-
+  // valued SessionKey literals would not collide.
+  const live = new Map<string, ConcreteHandle>()
+
+  // Quarantined keys: maps keyId → the Error that caused the quarantine.
+  // Preserving the original failure reason allows activate() to surface
+  // the first-failure context when it rejects. Quarantined is a sticky
+  // terminal state per session-state-machine.md §129 — only an explicit
+  // clearQuarantine() call removes an entry. A key in this map MUST NOT
+  // also be in `live`; the two maps are disjoint by invariant.
+  const quarantined = new Map<string, Error>()
+
+  // Single-flight: concurrent activate() calls for the same key share
+  // one load/create promise. Cleared after the promise settles so a
+  // post-deactivate re-activation is not served a stale entry.
+  const activating = new Map<string, Promise<SessionHandle>>()
+
+  function keyId(k: SessionKey): string {
+    // `\0` is not a legal character in a Slack channel/ts string, so it
+    // is safe as a separator. Avoids the `"C1:T1" vs "C:1T1"` collision
+    // you would get with a single-colon join.
+    return `${k.channel}\0${k.thread}`
+  }
+
+  async function doActivate(
+    key: SessionKey,
+    initialOwnerId: string | undefined,
+  ): Promise<SessionHandle> {
+    // Path validation runs first — a malformed key never touches disk.
+    // Any throw here propagates; no handle is recorded.
+    const path = sessionPath(stateRoot, key)
+
+    let session: Session
+    try {
+      session = await loadSession(stateRoot, path)
+    } catch (err) {
+      if (!isNotFound(err)) {
+        // Real read failure: permissions, I/O, corrupt JSON, realpath
+        // escape. Per session-state-machine.md §259-267 this is a
+        // Quarantined transition — record in the quarantined map so
+        // subsequent activate() calls reject rather than re-attempting
+        // a load that is likely still broken. Bead-filing lands in
+        // ccsc-xa3.8; the map entry is the in-process forensic trail.
+        const errObj = err instanceof Error ? err : new Error(String(err))
+        const id = keyId(key)
+        quarantined.set(id, errObj)
+        log('session.activate_error', {
+          channel: key.channel,
+          thread: key.thread,
+          error: errorMessage(err),
+        })
+        throw err
+      }
+      // ENOENT branch: this key has never been activated. Require the
+      // caller to name the initial owner; otherwise refuse rather than
+      // synthesize identity. Aligned with session-state-machine.md §39
+      // ("the identity primitive does not accept user-authored values").
+      if (initialOwnerId === undefined) {
+        throw new Error(
+          `activate: session file missing and no initialOwnerId provided for ${JSON.stringify(
+            key,
+          )}`,
+        )
+      }
+      const now = clock()
+      session = {
+        v: 1,
+        key,
+        createdAt: now,
+        lastActiveAt: now,
+        ownerId: initialOwnerId,
+        data: {},
+      }
+      await saveSession(path, session)
+    }
+
+    const handle = new ConcreteHandle(key, session, path)
+    // Wire the quarantine callback so update()'s failure arm can record
+    // the error in the supervisor's quarantined map AND remove the handle
+    // from live. Without this the supervisor's two maps would be out of
+    // sync: live still carrying a quarantined handle that activate()
+    // would return instead of rejecting.
+    const id = keyId(key)
+    handle.onQuarantine = (err: Error) => {
+      quarantined.set(id, err)
+      live.delete(id)
+      log('session.update_error', {
+        channel: key.channel,
+        thread: key.thread,
+        error: errorMessage(err),
+      })
+    }
+    handle.markActive()
+    live.set(id, handle)
+
+    log('session.activate', {
+      channel: key.channel,
+      thread: key.thread,
+      ownerId: session.ownerId,
+    })
+    await journalWrite({
+      kind: 'session.activate',
+      outcome: 'n/a',
+      actor: 'system',
+      sessionKey: key,
+    })
+
+    return handle
+  }
+
+  return {
+    activate(key: SessionKey, initialOwnerId?: string): Promise<SessionHandle> {
+      const id = keyId(key)
+
+      // Quarantined keys are a sticky terminal state per session-state-
+      // machine.md §129. Reject immediately with the original failure
+      // reason so the caller surfaces the first-failure context rather
+      // than silently re-loading a potentially-corrupted file from disk.
+      // Only a human (SO) calling clearQuarantine() unblocks this key.
+      const priorErr = quarantined.get(id)
+      if (priorErr !== undefined) {
+        return Promise.reject(
+          new Error(`SessionSupervisor.activate: key is quarantined`, { cause: priorErr }),
+        )
+      }
+
+      // Cached handle wins: subsequent activate() on a live key returns
+      // the same handle without re-reading the file (session-state-
+      // machine.md §266 invariant).
+      const existing = live.get(id)
+      if (existing !== undefined) {
+        return Promise.resolve(existing)
+      }
+
+      // Single-flight: if a concurrent activation is already in
+      // progress, join it. The initialOwnerId from the second caller is
+      // discarded — the first caller won the race and their owner
+      // (if any) is the authoritative first owner.
+      const inflight = activating.get(id)
+      if (inflight !== undefined) {
+        return inflight
+      }
+
+      const promise = doActivate(key, initialOwnerId).finally(() => {
+        activating.delete(id)
+      })
+      activating.set(id, promise)
+      return promise
+    },
+
+    async quiesce(key: SessionKey): Promise<void> {
+      const id = keyId(key)
+      const handle = live.get(id)
+      if (handle === undefined) {
+        // Nothing to drain. Per session-state-machine.md §124 a
+        // quiesce() on a Nonexistent key is a no-op — there is no
+        // handle to transition and no work to flush. Do not emit a
+        // log line for the empty case; it adds no information and
+        // would confuse the journal sink's per-session correlation.
+        return
+      }
+
+      log('session.quiesce', {
+        channel: key.channel,
+        thread: key.thread,
+        inflight: handle.inFlight.size,
+      })
+
+      // beginQuiesce() transitions the state active → quiescing synchronously.
+      // The journal write follows so the state is already visible to concurrent
+      // callers when the event is persisted. Journal errors never abort the
+      // quiesce path — beginQuiesce already began.
+      const drainPromise = handle.beginQuiesce()
+      await journalWrite({
+        kind: 'session.quiesce',
+        outcome: 'n/a',
+        actor: 'system',
+        sessionKey: key,
+      })
+
+      return drainPromise
+    },
+
+    async deactivate(key: SessionKey): Promise<void> {
+      const id = keyId(key)
+      const handle = live.get(id)
+      if (handle === undefined) {
+        // No live handle — nothing to release. Matches quiesce()'s
+        // Nonexistent-key no-op per session-state-machine.md §124.
+        // Do not log an empty-case line; a deactivate on an already-
+        // dropped key is a recovery idempotency guarantee, not an
+        // event worth correlating.
+        return
+      }
+
+      // Quarantined handles are out of scope per the interface contract
+      // (§197-198): only a human clears the quarantine flag. Fail loudly
+      // rather than silently release a handle that the supervisor has
+      // marked as needing SO attention.
+      if (handle.state === 'quarantined') {
+        throw new Error(
+          `deactivate: handle for ${JSON.stringify(key)} is quarantined; human action required`,
+        )
+      }
+
+      // Deactivation is only legal after a completed quiesce. Refusing
+      // the active path is how the supervisor enforces the "work has
+      // drained before release" invariant — session-state-machine.md
+      // §210 invariant 2. An active-state deactivate would race with
+      // in-flight update()/tool calls and violate the at-most-one-
+      // writer rule.
+      if (handle.state !== 'quiescing') {
+        throw new Error(
+          `deactivate: handle for ${JSON.stringify(key)} is in state '${handle.state}'; must be quiesced first`,
+        )
+      }
+
+      handle.markDeactivating()
+
+      // Defensive final persist. `saveSession` is atomic (tmp + rename
+      // under `wx`). In the current supervisor shape `session` never
+      // drifts from disk between update() calls (update() is still
+      // unwired and the one field mutated by the supervisor itself is
+      // `_state`, which is not persisted). Still, writing here makes
+      // deactivate the single "this file is now stable on disk" fence
+      // so future beads that add in-memory fields (e.g. lastActiveAt
+      // refresh in the reaper) don't leak drift at shutdown.
+      try {
+        await saveSession(handle.path, handle.session)
+      } catch (err) {
+        // A write failure at the deactivation boundary is not something
+        // we can recover from on this handle — the on-disk copy may or
+        // may not be the last-known-good. Transition to quarantine so
+        // that the NEXT activate() rejects instead of silently re-
+        // loading a potentially-corrupted file. Recording the error in
+        // the quarantined map BEFORE removing from live ensures the
+        // signal is never lost between the two maps. Bead-filing for
+        // quarantine lands with the reaper work (ccsc-xa3.8); for now
+        // the quarantined map entry is the forensic trail.
+        handle.markQuarantined()
+        quarantined.set(id, err instanceof Error ? err : new Error(String(err)))
+        live.delete(id)
+        log('session.deactivate_error', {
+          channel: key.channel,
+          thread: key.thread,
+          error: errorMessage(err),
+        })
+        throw err
+      }
+
+      live.delete(id)
+
+      log('session.deactivate', {
+        channel: key.channel,
+        thread: key.thread,
+      })
+      await journalWrite({
+        kind: 'session.deactivate',
+        outcome: 'n/a',
+        actor: 'system',
+        sessionKey: key,
+      })
+    },
+
+    clearQuarantine(key: SessionKey): void {
+      const id = keyId(key)
+      // No-op if not quarantined — idempotent so repeat operator calls
+      // (e.g. a script that bulk-clears) do not error.
+      quarantined.delete(id)
+    },
+
+    shutdown(): Promise<void> {
+      // Under ccsc-xa3.14 (deactivate + reaper sub-epic).
+      return Promise.reject(
+        new Error('SessionSupervisor.shutdown: not yet implemented (ccsc-xa3.14)'),
+      )
+    },
+
+    async reapIdle(): Promise<void> {
+      const now = clock()
+      const threshold = now - idleMs
+
+      // Snapshot candidate keys first so we don't iterate the live map
+      // while mutating it through deactivate(). Capture only what the
+      // filter allows; the quiesce/deactivate pair per candidate runs
+      // on the snapshot list.
+      const candidates: SessionKey[] = []
+      for (const handle of live.values()) {
+        if (handle.state !== 'active') continue
+        if (handle.inFlight.size > 0) continue
+        if (handle.session.lastActiveAt > threshold) continue
+        candidates.push(handle.key)
+      }
+
+      if (candidates.length === 0) return
+
+      log('session.reap_tick', {
+        idleMs,
+        threshold,
+        candidates: candidates.length,
+      })
+
+      // Sequential rather than parallel: keeps log ordering predictable
+      // and keeps contention on the filesystem (one atomic rename at a
+      // time) down on reapers that drain dozens of sessions at once.
+      // For a developer install the population is small; the parallel
+      // win is not worth the log-interleaving loss.
+      for (const key of candidates) {
+        try {
+          await this.quiesce(key)
+          await this.deactivate(key)
+        } catch (err) {
+          // One quarantined or racing handle must not starve the rest
+          // of the tick. Log and continue.
+          log('session.reap_error', {
+            channel: key.channel,
+            thread: key.thread,
+            error: errorMessage(err),
+          })
+        }
+      }
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — ConcreteHandle
+// ---------------------------------------------------------------------------
+
+/** In-process implementation of SessionHandle.
+ *
+ *  Not exported: callers consume the `SessionHandle` interface. Keeping
+ *  the class private lets later beads (update(), deactivate()) grow its
+ *  internals without widening the public surface.
+ *
+ *  Current scope:
+ *    - ccsc-xa3.2 — identity, state, snapshot, in-flight map allocation,
+ *      markActive() transition.
+ *    - ccsc-xa3.3 — beginQuiesce()/beginWork()/endWork() drain mechanics
+ *      and the active → quiescing transition.
+ *    - update() body and Quiescing → Deactivating / cancellation edges
+ *      land in later beads. */
+class ConcreteHandle implements SessionHandle {
+  readonly key: SessionKey
+  session: Session
+
+  // Backing field for the public `state` accessor. Starts in
+  // 'activating' so a consumer who somehow observes the handle before
+  // markActive() runs sees the honest transient state rather than a
+  // false 'active'.
+  private _state: SessionState = 'activating'
+
+  /** Per-request AbortControllers for tool calls dispatched against
+   *  this session. Populated by `beginWork()` (called from server.ts's
+   *  tool-call path in ccsc-xa3.15); cleared by `endWork()` when the
+   *  call settles. Quiesce waits for this map to drain; shutdown will
+   *  abort every entry before deactivating (ccsc-xa3.14). */
+  readonly inFlight: Map<string, AbortController> = new Map()
+
+  /** Resolved path this session's file lives at. Kept on the handle so
+   *  later beads' `update()` and deactivate paths do not re-run
+   *  `sessionPath()` (which would re-mkdir the parent). */
+  readonly path: string
+
+  /** Mutex tail for serialised `update()` calls. Each call chains its
+   *  work onto this promise so concurrent updates run in strict call
+   *  order without interleaving. Initialized to a resolved promise so
+   *  the first update starts immediately. The chain carries
+   *  `Promise<void>` throughout; individual links catch their own errors
+   *  to prevent a rejected link from collapsing the whole chain. */
+  private writeQueue: Promise<void> = Promise.resolve()
+
+  /** In-flight drain promise allocated by `beginQuiesce()`. Null when
+   *  the handle is Active (nothing to drain). Callers of quiesce share
+   *  this promise so concurrent quiesce() requests do not allocate
+   *  multiple drains. */
+  private quiescePromise: Promise<void> | null = null
+
+  /** Resolver for `quiescePromise`. Called by `endWork()` when the
+   *  last in-flight entry drains, or directly by `beginQuiesce()` when
+   *  the map is already empty at quiesce time. */
+  private resolveQuiesce: (() => void) | null = null
+
+  /** Callback invoked when `update()` transitions the handle to
+   *  `quarantined`. The supervisor injects this so its `quarantined` map
+   *  stays consistent: a quarantine triggered inside the write queue
+   *  must be recorded in the same map that `activate()` checks, or a
+   *  subsequent activate() would silently reload a potentially-corrupt
+   *  file instead of rejecting. Set once by the supervisor after
+   *  construction; never null after `markActive()`. */
+  onQuarantine: ((err: Error) => void) | null = null
+
+  constructor(key: SessionKey, session: Session, path: string) {
+    this.key = key
+    this.session = session
+    this.path = path
+  }
+
+  get state(): SessionState {
+    return this._state
+  }
+
+  /** Transition from `activating` → `active`. Called by the supervisor
+   *  once the handle is fully wired and live in the map. Package-
+   *  private by convention; callers outside this file must not invoke
+   *  it. Later beads replace this with a proper state-transition method
+   *  that accepts the full FSM. */
+  markActive(): void {
+    this._state = 'active'
+  }
+
+  /** Transition from `quiescing` → `deactivating`. Only the supervisor
+   *  invokes this, and only after the drain promise has resolved.
+   *  Package-private by convention; external callers must go through
+   *  `SessionSupervisor.deactivate()`. */
+  markDeactivating(): void {
+    this._state = 'deactivating'
+  }
+
+  /** Transition to `quarantined`. Terminal from the supervisor's
+   *  perspective — only a human clears it. Called on save-path
+   *  failures that leave the on-disk state uncertain. */
+  markQuarantined(): void {
+    this._state = 'quarantined'
+  }
+
+  /** Begin a graceful drain. Transitions state `active` → `quiescing`
+   *  and returns a promise that resolves when the in-flight map reaches
+   *  zero entries. Contract:
+   *
+   *    - Idempotent when already quiescing: returns the existing drain
+   *      promise so two concurrent callers share one drain.
+   *    - Idempotent no-op when the in-flight map is already empty:
+   *      resolves on the next microtask to preserve the promise
+   *      ordering callers expect.
+   *    - Rejects if called from any state other than `active` or
+   *      `quiescing` — the FSM has no edge there.
+   *
+   *  Called by `SessionSupervisor.quiesce()`. Not a SessionHandle
+   *  interface method; consumers use the supervisor's quiesce() entry
+   *  point which emits the `session.quiesce` log line. */
+  beginQuiesce(): Promise<void> {
+    if (this._state === 'quiescing') {
+      // Join the already-running drain (session-state-machine.md §266
+      // documents quiesce() as idempotent — a second call receives the
+      // first's promise).
+      if (this.quiescePromise === null) {
+        // Defensive: state is quiescing but no promise was recorded.
+        // That's a programmer error (markActive / beginQuiesce sequence
+        // violated). Fail loudly rather than silently synthesize. The
+        // key is included so the journal sink can correlate the bug
+        // back to the offending session without grepping the running
+        // process.
+        return Promise.reject(
+          new Error(
+            `beginQuiesce: quiescing state without drain promise for ${JSON.stringify(this.key)}`,
+          ),
+        )
+      }
+      return this.quiescePromise
+    }
+
+    if (this._state !== 'active') {
+      return Promise.reject(new Error(`beginQuiesce: cannot quiesce from state '${this._state}'`))
+    }
+
+    this._state = 'quiescing'
+
+    this.quiescePromise = new Promise<void>((resolve) => {
+      this.resolveQuiesce = resolve
+    })
+
+    // If nothing is in flight at quiesce time, resolve on the next
+    // microtask. Queueing (rather than resolving inline) keeps the
+    // promise-returns-before-handler semantic consistent with the
+    // drain-via-endWork() path, so callers cannot accidentally depend
+    // on synchronous resolution.
+    if (this.inFlight.size === 0) {
+      queueMicrotask(() => {
+        this.resolveQuiesce?.()
+      })
+    }
+
+    return this.quiescePromise
+  }
+
+  /** Register an AbortController for an in-flight tool call and return
+   *  it to the caller. The caller's responsibility is to invoke
+   *  `endWork(requestId)` when the call settles. On shutdown (ccsc-
+   *  xa3.14) the supervisor will call `.abort()` on every entry still
+   *  in the map.
+   *
+   *  Not used in this bead — xa3.15 wires it into the tool-call path.
+   *  Published here so `beginQuiesce()` has a real drain contract to
+   *  honour and tests can exercise the drain path. */
+  beginWork(requestId: string): AbortController {
+    if (this.inFlight.has(requestId)) {
+      throw new Error(`beginWork: requestId already in flight: '${requestId}'`)
+    }
+    const ctrl = new AbortController()
+    this.inFlight.set(requestId, ctrl)
+    return ctrl
+  }
+
+  /** Mark a tool call complete. Removes the controller from the in-
+   *  flight map and, if the handle is quiescing and the map is now
+   *  empty, resolves the drain promise. Safe to call with an unknown
+   *  requestId — treated as a no-op so crash-recovery bookkeeping
+   *  that double-ends is not a fatal error. */
+  endWork(requestId: string): void {
+    const had = this.inFlight.delete(requestId)
+    if (!had) return
+
+    if (this._state === 'quiescing' && this.inFlight.size === 0) {
+      this.resolveQuiesce?.()
+    }
+  }
+
+  /** Serialise a state mutation through the per-session write mutex,
+   *  persist it atomically, and refresh `this.session` on success.
+   *
+   *  The write queue is a promise chain: each call appends a new link
+   *  and returns a promise that resolves only after the previous link
+   *  settles. Links catch their own errors so a failed update does not
+   *  prevent subsequent calls from running — the handle quarantines
+   *  itself and further calls will immediately reject at the state check.
+   *
+   *  Implementation mirrors the `deactivate()` save path: both use
+   *  `saveSession()` (tmp + chmod + rename from lib.ts) and both
+   *  transition to `quarantined` on save failure. */
+  update(fn: (prev: Session) => Session): Promise<void> {
+    // Capture state at enqueue time for the early-exit checks below.
+    // We re-check after acquiring the mutex because state can change
+    // while waiting in the queue (a concurrent quiesce, for example).
+    const enqueueTimeState = this._state
+
+    if (enqueueTimeState === 'quarantined') {
+      return Promise.reject(new Error(`SessionHandle.update: handle is quarantined`))
+    }
+    if (enqueueTimeState !== 'active') {
+      // Covers 'quiescing', 'deactivating', and 'activating'. Include the
+      // actual state so callers can distinguish the cases without inspecting
+      // `handle.state` separately.
+      return Promise.reject(
+        new Error(`SessionHandle.update: handle is not active (state: ${enqueueTimeState})`),
+      )
+    }
+
+    // Expose a stable Promise<void> to the caller that resolves/rejects
+    // based solely on this link's outcome.
+    let resolve!: () => void
+    let reject!: (err: unknown) => void
+    const callerPromise = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+
+    // Chain the work unit onto the write queue. The link must catch all
+    // errors to avoid collapsing the chain — the original rejection is
+    // forwarded to the caller via `callerPromise`.
+    this.writeQueue = this.writeQueue.then(async () => {
+      // Re-check state now that we hold the mutex. A concurrent quiesce
+      // or a previous update's quarantine may have changed things.
+      if (this._state === 'quarantined') {
+        reject(new Error(`SessionHandle.update: handle is quarantined`))
+        return
+      }
+      if (this._state !== 'active') {
+        reject(new Error(`SessionHandle.update: handle is not active (state: ${this._state})`))
+        return
+      }
+
+      const prev = this.session
+      const next = fn(prev)
+
+      try {
+        await saveSession(this.path, next)
+        this.session = next
+        resolve()
+      } catch (err) {
+        // Save failure: quarantine the handle so future update() and
+        // activate() calls fail fast. In-memory session reverts to
+        // `prev` (it was never reassigned). This mirrors the deactivate()
+        // failure arm exactly (session-state-machine.md §132-137).
+        this._state = 'quarantined'
+        const errObj = err instanceof Error ? err : new Error(String(err))
+        // Notify the supervisor so its quarantined map and live map stay
+        // in sync. Without this, a subsequent activate() would return the
+        // cached live handle (which is now quarantined) instead of
+        // rejecting — violating the sticky-quarantine invariant.
+        this.onQuarantine?.(errObj)
+        reject(
+          new Error(`SessionHandle.update: save failed; handle quarantined`, {
+            cause: errObj,
+          }),
+        )
+      }
+    })
+
+    return callerPromise
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — error helpers
+// ---------------------------------------------------------------------------
+
+/** True for errors thrown by `loadSession` when the session file does
+ *  not exist yet. `realpathSync.native` surfaces a NodeJS.ErrnoException
+ *  with `code === 'ENOENT'`; we check `code` defensively in case the
+ *  error was wrapped. */
+function isNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const e = err as { code?: unknown }
+  return e.code === 'ENOENT'
+}
+
+/** Best-effort error message extractor for structured logs. Uses
+ *  `Error.message` when available; falls back to the stringified value
+ *  so non-Error throws (string, number) still log something. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/plugins/mcp/x-bug-triage/.mcp.json
+++ b/plugins/mcp/x-bug-triage/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "triage": {
+      "command": "bun",
+      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}/mcp/triage-server", "--silent", "start"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,14 +393,14 @@ importers:
   plugins/mcp/slack-channel:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.27.1
-        version: 1.27.1(zod@3.25.76)
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@slack/socket-mode':
         specifier: 2.0.6
         version: 2.0.6
       '@slack/web-api':
-        specifier: 7.15.0
-        version: 7.15.0
+        specifier: 7.15.2
+        version: 7.15.2
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1987,6 +1987,16 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@octokit/auth-token@5.1.2':
     resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
     engines: {node: '>= 18'}
@@ -2339,12 +2349,12 @@ packages:
     resolution: {integrity: sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@slack/types@2.20.1':
-    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.15.0':
-    resolution: {integrity: sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==}
+  '@slack/web-api@7.15.2':
+    resolution: {integrity: sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@standard-schema/spec@1.0.0':
@@ -2935,6 +2945,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -3039,8 +3053,8 @@ packages:
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3839,6 +3853,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.0:
     resolution: {integrity: sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==}
 
@@ -4029,6 +4052,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -4953,6 +4980,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7223,6 +7254,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@octokit/auth-token@5.1.2': {}
 
   '@octokit/core@6.1.6':
@@ -7496,7 +7549,7 @@ snapshots:
   '@slack/socket-mode@2.0.6':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/web-api': 7.15.0
+      '@slack/web-api': 7.15.2
       '@types/node': 22.19.3
       '@types/ws': 8.18.1
       eventemitter3: 5.0.1
@@ -7504,17 +7557,18 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
-  '@slack/types@2.20.1': {}
+  '@slack/types@2.21.1': {}
 
-  '@slack/web-api@7.15.0':
+  '@slack/web-api@7.15.2':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/types': 2.20.1
+      '@slack/types': 2.21.1
       '@types/node': 22.19.3
       '@types/retry': 0.12.0
-      axios: 1.13.6
+      axios: 1.16.1
       eventemitter3: 5.0.1
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -7524,6 +7578,7 @@ snapshots:
       retry: 0.13.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -8299,9 +8354,19 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.12.6:
     dependencies:
@@ -8515,13 +8580,15 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.13.6:
+  axios@1.16.1:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -9411,6 +9478,8 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  follow-redirects@1.16.0: {}
+
   fontace@0.4.0:
     dependencies:
       fontkitten: 1.0.0
@@ -9662,6 +9731,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@8.0.1: {}
 
@@ -10626,6 +10702,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/sources.yaml
+++ b/sources.yaml
@@ -645,8 +645,10 @@ sources:
     include:
       - '.claude-plugin/**'
       - '.mcp.json'
-      - 'server.ts'
-      - 'lib.ts'
+      # '*.ts' (not explicit server.ts/lib.ts) — server.ts imports
+      # journal.ts, manifest.ts, policy.ts. Listing files explicitly drops
+      # the imports and produces a non-functional mirror (see #645).
+      - '*.ts'
       - 'package.json'
       - '.npmrc'
       - 'skills/**'
@@ -657,6 +659,8 @@ sources:
       - 'node_modules/**'
       - '.git/**'
       - '*.log'
+      - '*.test.ts'
+      - '*.spec.ts'
 
   - name: x-bug-triage
     description: Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues


### PR DESCRIPTION
## Summary

Fixes 2 of the 5 install gotchas reported by @shade-familiar in #645 against the slack-channel plugin. Both root-caused to the marketplace mirror sync silently dropping files the plugin needs at runtime.

### Issue 1 — missing .ts modules

`sources.yaml` listed `server.ts` and `lib.ts` explicitly. But `server.ts` imports `journal.ts`, `manifest.ts`, `policy.ts`, and `supervisor.ts` — none of which were in the include list. The mirror shipped a non-functional server. Users hit:

```
error: Cannot find module './journal.ts' from '.../slack-channel/0.1.0/server.ts'
```

**Fix**: changed pattern to `'*.ts'` (with `*.test.ts` / `*.spec.ts` excluded). Force-resynced; mirror now contains the four missing modules.

### Issue 2 — missing .mcp.json

Root `.gitignore` had a blanket `.mcp.json` rule (intended for developer local configs). It silently ate every plugin's `.mcp.json` that was added *after* the rule landed:
- `plugins/mcp/slack-channel/.mcp.json` (sync wrote it, git ignored it)
- `plugins/mcp/pr-to-spec/.mcp.json` (same)
- `plugins/mcp/x-bug-triage/.mcp.json` (same)

Without `.mcp.json` in the install artifact, Claude Code can't determine how to spawn the MCP server → handshake fails.

**Fix**: added a negation rule: `!plugins/**/.mcp.json`. Re-tracked the three affected plugins' `.mcp.json` files. The seven other `.mcp.json` files that were tracked before the .gitignore rule landed are unchanged.

### What's NOT fixed here

Issues 3–5 from #645 are upstream concerns:
- **#3** `start` script timeout — needs fix in `jeremylongshore/claude-code-slack-channel`'s package.json (remove the `bun install --frozen-lockfile` from `start`, or split into separate launch entry in `.mcp.json`)
- **#4** `--dangerously-load-development-channels` flag — docs nit in upstream README
- **#5** silent allowlist drops — observability improvement in upstream `policy.ts`

I'll file an upstream issue tracking those three.

## Test plan
- [x] Local force-sync of slack-channel pulled all 16 files (was 7)
- [x] `git ls-files plugins/mcp/*/.mcp.json` returns 10 entries (was 7) — slack-channel + pr-to-spec + x-bug-triage added
- [x] `git check-ignore plugins/mcp/slack-channel/.mcp.json` now reports `!plugins/**/.mcp.json` (was `.mcp.json`)
- [ ] Validate workflows green on this PR
- [ ] (Post-merge) @shade-familiar can re-test the install path

## Closes
Refs #645 (issues 1 + 2 of 5). Issues 3-5 stay open in #645 pending upstream fixes.

- Jeremy Longshore
intentsolutions.io