### PR TITLE
catalog: add aomi entry to marketplace.{json,extended.json}

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -11054,7 +11054,7 @@
     {
       "name": "zero-tech-debt",
       "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only \u2014 surfaces refactor candidates and walks a 7-step workflow before any deletion.",
       "version": "1.0.0",
       "category": "skill-enhancers",
       "keywords": [
@@ -11409,6 +11409,36 @@
       },
       "license": "MIT",
       "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Natural-language crypto/DeFi agent bundle \u2014 aomi-transact drives wallet-signed transactions across 40+ EVM protocols (Uniswap, Aave, GMX, Polymarket, Hyperliquid, Binance), aomi-build scaffolds new Aomi SDK crates from OpenAPI specs.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "email": "hello@aomi.dev"
+      },
+      "featured": false,
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-05-17T00:00:00.000Z"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     "version": "1.6.0",
     "homepage": "https://github.com/jeremylongshore/claude-code-plugins",
     "pluginRoot": "./plugins",
-    "totalPlugins": 422,
+    "totalPlugins": 429,
     "skillsEnabled": 268,
     "lastUpdated": "2026-04-20"
   },
@@ -2099,7 +2099,7 @@
     {
       "name": "engineer-design-diagram",
       "source": "./plugins/devops/engineer-design-diagram",
-      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI \u2014 package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
       "version": "0.2.0",
       "category": "devops",
       "keywords": [
@@ -2333,7 +2333,7 @@
     {
       "name": "freshie-inventory-manager",
       "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "description": "Interactive command center for the freshie ecosystem inventory database \u2014 conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
       "version": "1.0.0",
       "category": "database",
       "keywords": [
@@ -3442,7 +3442,7 @@
     {
       "name": "code-cleanup",
       "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions \u2014 dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
       "version": "1.0.0",
       "category": "testing",
       "keywords": [
@@ -3486,7 +3486,7 @@
     {
       "name": "promptbook",
       "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating \u2014 no data transmitted without explicit opt-in. Background submission after session end.",
       "version": "1.4.0",
       "category": "business-tools",
       "keywords": [
@@ -4708,7 +4708,7 @@
     {
       "name": "jeremy-google-adk",
       "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents \u2014 ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
       "version": "2.0.0",
       "category": "ai-ml",
       "keywords": [
@@ -5648,7 +5648,7 @@
     {
       "name": "langchain-pack",
       "source": "./plugins/saas-packs/langchain-pack",
-      "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated — use langchain-py-pack or langchain-ts-pack.",
+      "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated \u2014 use langchain-py-pack or langchain-ts-pack.",
       "version": "1.0.0",
       "category": "saas-packs",
       "keywords": [
@@ -6185,7 +6185,7 @@
     {
       "name": "b12-claude-plugin",
       "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "description": "B12 Website Generator \u2014 an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
       "version": "1.0.0",
       "category": "community",
       "keywords": [
@@ -7990,7 +7990,7 @@
     {
       "name": "zero-tech-debt",
       "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only \u2014 surfaces refactor candidates and walks a 7-step workflow before any deletion.",
       "version": "1.0.0",
       "category": "skill-enhancers",
       "keywords": [
@@ -8057,7 +8057,7 @@
     {
       "name": "pr-to-spec",
       "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "description": "The flight envelope for agentic coding \u2014 convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
       "version": "0.8.0",
       "category": "mcp",
       "repository": "https://github.com/jeremylongshore/pr-to-prompt",
@@ -8077,7 +8077,7 @@
     {
       "name": "slack-channel",
       "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
+      "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
       "version": "0.1.0",
       "category": "mcp",
       "keywords": [
@@ -8099,7 +8099,7 @@
     {
       "name": "x-bug-triage-plugin",
       "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "description": "Closed-loop bug triage: X complaints \u2192 clusters \u2192 repo evidence \u2192 owner routing \u2192 Slack review \u2192 filed issues",
       "version": "0.3.0",
       "category": "mcp",
       "author": {
@@ -8164,7 +8164,7 @@
     {
       "name": "shipwright",
       "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
       "version": "1.0.0",
       "category": "ai-agency",
       "author": {
@@ -8212,7 +8212,7 @@
     {
       "name": "plane",
       "source": "./plugins/productivity/plane",
-      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+      "description": "Plane is a team behavior observatory \u2014 synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
       "version": "0.1.0",
       "category": "productivity",
       "keywords": [
@@ -8232,7 +8232,7 @@
     {
       "name": "local-tts",
       "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "description": "Offline text-to-speech via VoxCPM2 \u2014 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
       "version": "1.0.0",
       "category": "ai-ml",
       "keywords": [
@@ -8276,6 +8276,30 @@
       },
       "license": "MIT",
       "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Natural-language crypto/DeFi agent bundle \u2014 aomi-transact drives wallet-signed transactions across 40+ EVM protocols (Uniswap, Aave, GMX, Polymarket, Hyperliquid, Binance), aomi-build scaffolds new Aomi SDK crates from OpenAPI specs.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "email": "hello@aomi.dev"
+      },
+      "featured": false
     }
   ]
 }


### PR DESCRIPTION
Closes the prescreen blocker on #727: *"Missing catalog entry for plugins/crypto/aomi in marketplace.extended.json"*.

## What landed

- `marketplace.extended.json` — new aomi entry with verification block (Grade A / 94 from the marketplace-tier validator on `plugins/crypto/aomi/skills/transact/SKILL.md` after today's frontmatter fixes on aomi-labs/skills:main)
- `marketplace.json` — mirror entry, `totalPlugins` bumped to 429
- `scripts/validate-catalog-invariants.py` passes

## Context

The aomi bundle was materialized into `plugins/crypto/aomi/` via `sources.yaml` in #679 (merged 2026-05-12), but the catalog entries weren't added at the time. PR #727 lifted aomi-transact's SKILL.md from grade C → grade A; this PR completes the registration so the prescreen no longer hard-blocks.

The materialized SKILL.md updates from today (frontmatter fixes, ## Resources section, scoped Bash, semver versions) are flowing in via the daily sources.yaml sync from aomi-labs/skills:main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)