### PR TITLE
chore(security): refresh SECURITY.md + enable private vuln reporting (M5)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Do not open a public issue for security vulnerabilities.**
 
-Use [GitHub Private Security Advisories](https://github.com/jeremylongshore/claude-code-plugins/security/advisories/new) to report vulnerabilities privately. Alternatively, email **jeremy@intentsolutions.io**.
+Use [GitHub Private Security Advisories](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/security/advisories/new) to report vulnerabilities privately. Alternatively, email **jeremy@intentsolutions.io**.
 
 We will acknowledge receipt within 24 hours and provide a remediation timeline within 72 hours.
 
@@ -12,7 +12,7 @@ We will acknowledge receipt within 24 hours and provide a remediation timeline w
 
 This policy covers:
 
-- All plugins and skills in the `plugins/` directory (339 plugins, 1896 skills)
+- All plugins and skills in the `plugins/` directory (427 plugins, 2747 skills)
 - The `ccpi` CLI tool (`@intentsolutionsio/ccpi` on npm)
 - Cowork zip distribution packages
 - CI/CD pipelines and GitHub Actions workflows


### PR DESCRIPTION
## Summary

Item **M5** from session-1 council sequencing — closes the minimum-disclosure gap.

- Refresh stale catalog counts in SECURITY.md Scope: 339 plugins / 1896 skills → **427 / 2747** (current).
- Fix legacy install slug in Advisories URL — was pointing at \`jeremylongshore/claude-code-plugins\` (the 301 source), now points at the canonical \`jeremylongshore/claude-code-plugins-plus-skills\`. Means the SECURITY.md link works and lands on the correct advisories page.
- Enable GitHub Private Vulnerability Reporting on the canonical repo via \`gh api ... --method PUT\`.

## Why this matters

CISO seat flagged \"no working private disclosure channel\" as a binding constraint in the 2026-05-17 council. Without this, a researcher who tried to disclose privately would have hit a 404 on the URL we asked them to use.

## Verification

\`\`\`
$ gh api repos/jeremylongshore/claude-code-plugins-plus-skills/private-vulnerability-reporting
{\"enabled\":true}
\`\`\`

Security tab now shows the \"Report a vulnerability\" button.

## References

- Audit: \`000-docs/266-RA-AUDT-repo-quality-audit-2026-05-17.md\`
- Decision record: \`000-docs/267-AT-DECR-repo-sequencing-council-2026-05-17.md\`
- Session-1 plan: B + C + M5 bundle

## Test plan

- [x] gh api confirms private vuln reporting enabled
- [x] Advisories URL uses canonical slug
- [x] Counts match current catalog (427/2747)
- [ ] CI green

- Jeremy Longshore
intentsolutions.io