### PR TITLE
fix(validator): discover root-level SKILL.md (Anthropic-spec layout) — item B / bead claude-guna

### DIFF
--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -1387,6 +1387,8 @@ def find_skill_files(root: Path) -> List[Path]:
     # Search in plugins directory
     plugins_dir = root / "plugins"
     if plugins_dir.exists():
+        seen: set = set()
+        # Layout 1: plugins/<cat>/<plugin>/skills/<name>/SKILL.md (legacy)
         for p in plugins_dir.rglob("skills/*/SKILL.md"):
             if p.is_file():
                 parts = p.relative_to(root).parts
@@ -1394,7 +1396,28 @@ def find_skill_files(root: Path) -> List[Path]:
                     continue
                 if any(part.startswith("skills-backup-") for part in parts):
                     continue
+                abs_p = p.resolve()
+                if abs_p in seen:
+                    continue
+                seen.add(abs_p)
                 results.append(p)
+        # Layout 2: plugins/<cat>/<plugin>/SKILL.md (Anthropic-spec / Wondelai-style)
+        # SKILL.md sits at plugin root alongside .claude-plugin/plugin.json — no skills/<name>/ subdir.
+        for plugin_json in plugins_dir.rglob(".claude-plugin/plugin.json"):
+            plugin_root = plugin_json.parent.parent
+            skill_md = plugin_root / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            parts = skill_md.relative_to(root).parts
+            if any(part in excluded_dirs for part in parts):
+                continue
+            if any(part.startswith("skills-backup-") for part in parts):
+                continue
+            abs_p = skill_md.resolve()
+            if abs_p in seen:
+                continue
+            seen.add(abs_p)
+            results.append(skill_md)
 
     # Search in standalone skills directory
     skills_dir = root / "skills"
@@ -3460,12 +3483,27 @@ def validate_plugin(plugin_dir: Path, tier: str = TIER_STANDARD) -> Dict[str, An
         warnings.append("[plugin.json] No .claude-plugin/plugin.json found")
 
     # 2. Validate skills
+    # Two supported layouts:
+    #   (a) plugin_dir/skills/<name>/SKILL.md   (legacy nested)
+    #   (b) plugin_dir/SKILL.md                 (Anthropic-spec / Wondelai-style — SKILL.md at plugin root)
     skill_results = []
+    seen_skills: set = set()
     skills_dir = plugin_dir / 'skills'
     if skills_dir.exists():
         for skill_md in skills_dir.rglob('SKILL.md'):
+            abs_p = skill_md.resolve()
+            if abs_p in seen_skills:
+                continue
+            seen_skills.add(abs_p)
             result = validate_skill(skill_md, tier)
             skill_results.append((skill_md, result))
+    root_skill_md = plugin_dir / 'SKILL.md'
+    if root_skill_md.is_file():
+        abs_p = root_skill_md.resolve()
+        if abs_p not in seen_skills:
+            seen_skills.add(abs_p)
+            result = validate_skill(root_skill_md, tier)
+            skill_results.append((root_skill_md, result))
 
     # 3. Validate agents
     agent_results = []

--- a/tests/fixtures/root-level-skill-plugin/.claude-plugin/plugin.json
+++ b/tests/fixtures/root-level-skill-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "root-level-skill-fixture",
+  "version": "1.0.0",
+  "description": "Fixture: plugin with SKILL.md at root (Anthropic-spec layout) — exercises root-level discovery in find_skill_files.",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  }
+}

--- a/tests/fixtures/root-level-skill-plugin/SKILL.md
+++ b/tests/fixtures/root-level-skill-plugin/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: root-level-skill-fixture
+description: |
+  Minimal fixture skill for regression coverage of root-level SKILL.md discovery.
+  Use when validating that find_skill_files picks up Anthropic-spec layout.
+  Trigger with "root level skill fixture".
+allowed-tools: Read
+version: 1.0.0
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags: [test-fixture]
+---
+
+## Overview
+
+Fixture skill used by `tests/test_root_level_skill_discovery.py`. It exists solely
+to verify that the validator's batch walker (`find_skill_files`) picks up
+plugins that follow the Anthropic-spec layout — SKILL.md at plugin root with no
+`skills/<name>/` subdirectory.
+
+## Prerequisites
+
+None — this is a static fixture.
+
+## Instructions
+
+Do not invoke this skill. It is a test fixture only.
+
+## Output
+
+N/A.
+
+## Error Handling
+
+N/A.
+
+## Examples
+
+N/A.
+
+## Resources
+
+- `scripts/validate-skills-schema.py` — the function under test.

--- a/tests/test_root_level_skill_discovery.py
+++ b/tests/test_root_level_skill_discovery.py
@@ -1,0 +1,98 @@
+"""Regression tests for root-level SKILL.md discovery in the batch validator.
+
+Covers the bug where `find_skill_files` and `validate_plugin` only walked the
+legacy `plugins/<cat>/<name>/skills/<name>/SKILL.md` layout and missed the
+Anthropic-spec layout where SKILL.md sits at the plugin root.
+
+Bead: claude-guna. Audit: 000-docs/266. Decision: 000-docs/267.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import importlib.util
+
+VALIDATOR_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "validate-skills-schema.py"
+)
+spec = importlib.util.spec_from_file_location("validate_skills_schema", VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+
+FIXTURE_SRC = Path(__file__).parent / "fixtures" / "root-level-skill-plugin"
+
+
+def _stage_plugin(repo_root: Path, category: str, name: str) -> Path:
+    """Copy the fixture into a synthetic plugins/<category>/<name>/ dir."""
+    dest = repo_root / "plugins" / category / name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(FIXTURE_SRC, dest)
+    return dest
+
+
+def test_find_skill_files_picks_up_root_level_skill_md(tmp_path):
+    """Root-level SKILL.md (Anthropic-spec layout) must appear in batch walk."""
+    plugin_dir = _stage_plugin(tmp_path, "design", "fixture-root-level")
+    expected = plugin_dir / "SKILL.md"
+
+    results = validator.find_skill_files(tmp_path)
+
+    assert expected in results, (
+        f"find_skill_files missed root-level SKILL.md.\n"
+        f"  expected: {expected}\n"
+        f"  got: {results}"
+    )
+
+
+def test_find_skill_files_dedupes_when_both_layouts_present(tmp_path):
+    """If a plugin has both root SKILL.md and skills/<name>/SKILL.md, no duplicates."""
+    plugin_dir = _stage_plugin(tmp_path, "design", "fixture-both-layouts")
+    nested_skill = plugin_dir / "skills" / "nested" / "SKILL.md"
+    nested_skill.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(plugin_dir / "SKILL.md", nested_skill)
+
+    results = validator.find_skill_files(tmp_path)
+    resolved = [p.resolve() for p in results]
+
+    assert len(resolved) == len(set(resolved)), (
+        f"find_skill_files produced duplicates: {resolved}"
+    )
+    assert len(results) == 2, (
+        f"expected 2 distinct SKILL.md files (root + nested), got {len(results)}: {results}"
+    )
+
+
+def test_find_skill_files_still_picks_up_legacy_nested_layout(tmp_path):
+    """Regression: legacy skills/<name>/SKILL.md layout must keep working."""
+    plugin_dir = tmp_path / "plugins" / "design" / "fixture-nested-only"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".claude-plugin").mkdir()
+    shutil.copy(
+        FIXTURE_SRC / ".claude-plugin" / "plugin.json",
+        plugin_dir / ".claude-plugin" / "plugin.json",
+    )
+    nested = plugin_dir / "skills" / "thing" / "SKILL.md"
+    nested.parent.mkdir(parents=True)
+    shutil.copy(FIXTURE_SRC / "SKILL.md", nested)
+
+    results = validator.find_skill_files(tmp_path)
+
+    assert nested in results, f"legacy nested SKILL.md missed: {nested} not in {results}"
+
+
+def test_validate_plugin_counts_root_level_skill(tmp_path):
+    """validate_plugin must count root-level SKILL.md (Skills: 1, not 0)."""
+    plugin_dir = _stage_plugin(tmp_path, "design", "fixture-validate-plugin")
+
+    result = validator.validate_plugin(plugin_dir, tier=validator.TIER_MARKETPLACE)
+
+    assert result.get("skill_count") == 1, (
+        f"expected 1 skill from root-level SKILL.md, got {result.get('skill_count')}; "
+        f"full result keys: {list(result.keys())}"
+    )


### PR DESCRIPTION
## Summary

Item **B** from session-1 council sequencing — closes the validator's batch-mode discovery gap for Anthropic-spec plugin layouts.

The batch walker only handled the legacy \`plugins/<cat>/<name>/skills/<name>/SKILL.md\` layout. Plugins where SKILL.md sits at the plugin root alongside \`.claude-plugin/plugin.json\` (the Wondelai-style / Anthropic-spec layout) were silently skipped — \`Skills: 0\` on validation despite a valid skill on disk.

## What changed

**\`scripts/validate-skills-schema.py\`**
- \`find_skill_files\`: second walk anchored on \`.claude-plugin/plugin.json\`, picks up \`<plugin_root>/SKILL.md\`, dedups against the legacy walk by resolved absolute path.
- \`validate_plugin\`: also discovers root-level SKILL.md alongside the legacy \`skills/\` walk, same dedup.

**\`tests/test_root_level_skill_discovery.py\`** + fixture under \`tests/fixtures/root-level-skill-plugin/\` — 4 cases:
1. root-level layout discovered
2. dedup when both layouts coexist
3. legacy nested layout still discovered (no regression)
4. \`validate_plugin\` returns \`skill_count == 1\` for root-level layout

## Verification

\`\`\`
$ python3 scripts/validate-skills-schema.py --marketplace plugins/design/wondelai-design-everyday-things/
   Skills: 1, Agents: 0
   Average skill score: 64.0/100
\`\`\`

Full-repo delta: **3509 → 3535 skills (+26)**. Matches the count of Wondelai-style plugins on disk.

Spot-checked legacy nested plugins (productivity/plane, skill-enhancers/*) — all still report \`Skills: 1+\`. No regression.

## Expected side-effect

This surfaces ~26 previously-invisible plugins. Their grades now appear in batch validation output, which may bump the orphan count tracked in #660 item 2. Expected, not a regression.

## References

- Bead: \`claude-guna\`
- Audit: \`000-docs/266-RA-AUDT-repo-quality-audit-2026-05-17.md\`
- Decision record: \`000-docs/267-AT-DECR-repo-sequencing-council-2026-05-17.md\`
- Related earlier fix: PR #736 (parent-attribution in \`marketplace/scripts/discover-skills.mjs\`)

## Test plan

- [x] 4 pytest cases pass
- [x] Wondelai plugin now returns Skills: 1
- [x] Legacy-layout plugins unaffected (spot-checked 5)
- [x] Full-repo skill count increased by ~26
- [ ] CI green

- Jeremy Longshore
intentsolutions.io