### PR TITLE
feat(spotlight): kobiton/automate — Killer Skill of the Week

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Or use Claude's built-in command:
 
 <!-- KILLER-SKILL:START — do not edit; run `node scripts/render-spotlight.mjs` -->
 
-> **Killer Skill of the Week** — [skyvern](https://github.com/Skyvern-AI/skyvern) by [Skyvern-AI](https://github.com/Skyvern-AI)
+> **Killer Skill of the Week** — [automate](https://github.com/kobiton/automate) by [Kobiton Inc.](https://github.com/kobiton)
 >
-> **AI agents that drive your browser. 21,000 stars of Selenium-killer.**
+> **Real mobile devices on demand — no emulators, no flaky CI**
 >
-> Skyvern automates browser-based workflows with vision-language models — point it at a page, describe the goal, and the agent navigates, fills forms, handles 2FA, and extracts data. Where Selenium and Playwright break the moment a page redesigns, Skyvern adapts because it sees the page like a human would. The CLI skill exposes Skyvern's task runner inside Claude Code: navigate, fill forms, extract data, handle logins, and stream back structured results. Pulled into the marketplace via daily external sync from Skyvern-AI/skyvern (AGPL-3.0). Sourced into the catalog by community contributor @mark1ian.
+> Kobiton's automate plugin gives Claude Code, Cursor, Codex, and Gemini CLI direct access to the Kobiton real-device cloud via remote MCP. 12 tools across three surfaces — Devices (list / reserve / status / terminate), Sessions (list / get / artifacts / terminate), and Apps (upload / confirm / list / get) — plus 3 specialist agents for device picking, Appium capability reconciliation, and session triage. One install, real iOS + Android hardware, no emulator drift.
 >
-> _"Automate browser-based workflows using LLMs and computer vision."_ — Skyvern-AI
+> _"Mobile testing that runs where the bugs actually live — on the device, not the simulator."_ — Kobiton Inc.
 >
-> Grade: A | Week of May 2, 2026 (W18) | [View on GitHub](https://github.com/Skyvern-AI/skyvern)
+> Grade: A | Week of May 20, 2026 (W21) | [View on GitHub](https://github.com/kobiton/automate)
 >
-> Previous picks: [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
+> Previous picks: [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
 
 <!-- KILLER-SKILL:END -->
 

--- a/marketplace/src/data/spotlights.json
+++ b/marketplace/src/data/spotlights.json
@@ -1,19 +1,32 @@
 {
-  "week": "2026-W18",
+  "week": "2026-W21",
   "title": "Killer Skill of the Week",
   "spotlight": {
-    "pluginSlug": "skyvern",
-    "headline": "AI agents that drive your browser. 21,000 stars of Selenium-killer.",
-    "whyKiller": "Skyvern automates browser-based workflows with vision-language models — point it at a page, describe the goal, and the agent navigates, fills forms, handles 2FA, and extracts data. Where Selenium and Playwright break the moment a page redesigns, Skyvern adapts because it sees the page like a human would. The CLI skill exposes Skyvern's task runner inside Claude Code: navigate, fill forms, extract data, handle logins, and stream back structured results. Pulled into the marketplace via daily external sync from Skyvern-AI/skyvern (AGPL-3.0). Sourced into the catalog by community contributor @mark1ian.",
-    "author": "Skyvern-AI",
-    "authorGithub": "Skyvern-AI",
+    "pluginSlug": "automate",
+    "headline": "Real mobile devices on demand — no emulators, no flaky CI",
+    "whyKiller": "Kobiton's automate plugin gives Claude Code, Cursor, Codex, and Gemini CLI direct access to the Kobiton real-device cloud via remote MCP. 12 tools across three surfaces — Devices (list / reserve / status / terminate), Sessions (list / get / artifacts / terminate), and Apps (upload / confirm / list / get) — plus 3 specialist agents for device picking, Appium capability reconciliation, and session triage. One install, real iOS + Android hardware, no emulator drift.",
+    "author": "Kobiton Inc.",
+    "authorGithub": "kobiton",
     "grade": "A",
     "skillCount": 1,
-    "category": "productivity",
-    "link": "https://github.com/Skyvern-AI/skyvern",
-    "quote": "Automate browser-based workflows using LLMs and computer vision."
+    "category": "testing",
+    "link": "https://github.com/kobiton/automate",
+    "quote": "Mobile testing that runs where the bugs actually live — on the device, not the simulator."
   },
   "hallOfFame": [
+    {
+      "week": "2026-W18",
+      "pluginSlug": "skyvern",
+      "headline": "AI agents that drive your browser. 21,000 stars of Selenium-killer.",
+      "whyKiller": "Skyvern automates browser-based workflows with vision-language models — point it at a page, describe the goal, and the agent navigates, fills forms, handles 2FA, and extracts data. Where Selenium and Playwright break the moment a page redesigns, Skyvern adapts because it sees the page like a human would. The CLI skill exposes Skyvern's task runner inside Claude Code: navigate, fill forms, extract data, handle logins, and stream back structured results. Pulled into the marketplace via daily external sync from Skyvern-AI/skyvern (AGPL-3.0). Sourced into the catalog by community contributor @mark1ian.",
+      "author": "Skyvern-AI",
+      "authorGithub": "Skyvern-AI",
+      "grade": "A",
+      "skillCount": 1,
+      "category": "productivity",
+      "link": "https://github.com/Skyvern-AI/skyvern",
+      "quote": "Automate browser-based workflows using LLMs and computer vision."
+    },
     {
       "week": "2026-W17",
       "pluginSlug": "code-cleanup",
@@ -100,8 +113,8 @@
     }
   ],
   "meta": {
-    "version": "2.2.0",
-    "lastUpdated": "2026-05-02",
+    "version": "2.3.0",
+    "lastUpdated": "2026-05-20",
     "curatedBy": "Jeremy Longshore"
   }
 }


### PR DESCRIPTION
## What this is

Promotes Kobiton's automate plugin as the current Killer Skill of the Week.

## What changes

- `marketplace/src/data/spotlights.json`: rotate Skyvern (2026-W18) → Hall of Fame; set `automate` as current spotlight (2026-W21)
- `README.md`: Killer-Skill block auto-regenerated to match

External-link path — spotlight card + README block link directly to Kobiton's repo. No marketplace catalog sync, no source vendoring. (Internal browse page at `tonsofskills.com/plugins/automate` would require `sources.yaml` vendoring — flagged as a possible follow-up if Kobiton wants the internal landing surface later.)

## Reference

Public case study covering the plugin's MCP tool surface, AGENTS.md cross-tool brief, and platform variance characteristics:
https://kobiton.com/blog/agents-md-cross-tool-plugin-brief-case-study-kobiton-automate/

Plugin repo: https://github.com/kobiton/automate

## Verification

- \`node scripts/render-spotlight.mjs --check\` → exit 0 (README in sync)
- README block renders: "Killer Skill of the Week — automate by Kobiton Inc.", 12-tool whyKiller paragraph, quote, "View on GitHub" CTA, hall-of-fame list with Skyvern leading.