### PR TITLE
feat(partners): kobiton sponsor badge + per-partner logoHeight sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Skills](https://img.shields.io/badge/skills-2%2C810-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Nixtla](https://img.shields.io/badge/Sponsor-nixtla.io-ff6b35)](https://nixtla.io)
+[![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
 425 plugins, 2,810 skills, 200 agents, 16 community contributors — validated and ready to install.

--- a/marketplace/src/components/PartnerBar.astro
+++ b/marketplace/src/components/PartnerBar.astro
@@ -23,7 +23,10 @@ const { partners } = partnersData;
         target="_blank"
         rel="noopener noreferrer"
         aria-label={`${p.name} (opens in new tab)`}
-        style={p.accentColor ? `--partner-accent: ${p.accentColor};` : undefined}
+        style={[
+          p.accentColor && `--partner-accent: ${p.accentColor}`,
+          p.logoHeight && `--partner-logo-height: ${p.logoHeight}px`,
+        ].filter(Boolean).join('; ') || undefined}
       >
         {p.logoLight || p.logoDark ? (
           <span class="partner-logo-wrap" aria-hidden="false">
@@ -133,7 +136,11 @@ const { partners } = partnersData;
   }
 
   .partner-logo {
-    height: 28px;
+    /* Per-partner override via --partner-logo-height (set inline on the
+       parent .partner-link). Falls back to 28px. Wider wordmarks
+       (e.g. 5+:1 aspect) should set logoHeight ~18-20 in partners.json
+       so they don't dominate the bar at the uniform default. */
+    height: var(--partner-logo-height, 28px);
     width: auto;
     max-width: 160px;
     object-fit: contain;

--- a/marketplace/src/data/partners.json
+++ b/marketplace/src/data/partners.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./partners.schema.json",
-  "_doc": "Partners shown on the homepage hero partner bar. Source of truth — edited by hand. Order matters (left-to-right). `logoLight` is the variant designed for LIGHT theme backgrounds (dark/colored fill); `logoDark` is for DARK theme backgrounds (white/light fill). `accentColor` is the partner's official brand color, used as a hairline accent on the card.",
+  "_doc": "Partners shown on the homepage hero partner bar. Source of truth — edited by hand. Order matters (left-to-right). `logoLight` is the variant designed for LIGHT theme backgrounds (dark/colored fill); `logoDark` is for DARK theme backgrounds (white/light fill). `accentColor` is the partner's official brand color, used as a hairline accent on the card. `logoHeight` (optional, px) overrides the default 28px logo height for partners whose wordmark aspect ratio dominates the bar — set lower (e.g. 18-20) for very-wide wordmarks so visual weight stays balanced across partners.",
   "partners": [
     {
       "slug": "kobiton",
@@ -20,7 +20,8 @@
       "tagline": "Time series forecasting & anomaly detection",
       "logoLight": "/images/partners/nixtla-light.svg",
       "logoDark": "/images/partners/nixtla-dark.svg",
-      "accentColor": "#000000"
+      "accentColor": "#000000",
+      "logoHeight": 20
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two small fixes flagged after the hero restructure landed in PR #751:

1. **Kobiton needs a README badge** matching the existing Nixtla one
2. **Nixtla logo renders much bigger than Kobiton** on the partner band

## 1. Sponsor: Kobiton badge

| Before | After |
|---|---|
| Only Nixtla badge in the README header | Matching Kobiton badge with Kobiton's official brand blue (`#0487D9`) |

```diff
 [![Sponsor: Nixtla](https://img.shields.io/badge/Sponsor-nixtla.io-ff6b35)](https://nixtla.io)
+[![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
```

## 2. Per-partner `logoHeight` sizing

**Root cause:** aspect-ratio mismatch between brand wordmarks.

| Logo | Native | Rendered at uniform `.partner-logo { height: 28px }` |
|---|---|---|
| Kobiton | 149×45 (3.3:1) | ~93px × 28px |
| Nixtla | 115×20 (5.75:1) | **160px** × 28px (capped at `max-width: 160px`, `object-fit: contain` fills box) |

Nixtla's wordmark is much wider-than-tall by design, so equal-height rendering made it dominate the band visually.

**Fix:** optional `logoHeight` field on each partner in `partners.json`. The component projects it as a CSS custom property `--partner-logo-height` on `.partner-link`. `.partner-logo` reads it with a `28px` fallback. Nixtla now ships `logoHeight: 20`.

Scales cleanly — future partners with extreme aspect ratios get their own override without touching CSS.

```diff
 // marketplace/src/data/partners.json
 {
   "slug": "nixtla",
   ...
-  "accentColor": "#000000"
+  "accentColor": "#000000",
+  "logoHeight": 20
 }
```

```diff
 /* marketplace/src/components/PartnerBar.astro */
 .partner-logo {
-  height: 28px;
+  height: var(--partner-logo-height, 28px);
   width: auto;
   max-width: 160px;
   object-fit: contain;
   display: block;
 }
```

## Test plan

- [x] `cd marketplace && npm run build` — 3859 pages, no errors
- [x] Kobiton `<a class="partner-link">` style: `--partner-accent: #0487D9` only (no logoHeight override, gets 28px default)
- [x] Nixtla `<a class="partner-link">` style: `--partner-accent: #000000; --partner-logo-height: 20px`
- [x] CSS bundle contains `--partner-logo-height` custom property fallback
- [x] README adds Kobiton badge between Nixtla and Buy-me-a-monster badges

## Out of scope

- Renaming "Sponsor" → "Partner" globally (you can revisit when other partner tiers shift)
- Schema file `partners.schema.json` (referenced in `$schema` but doesn't exist on disk — pre-existing; separate cleanup)