### PR TITLE
feat(catalog): ga4-pack — 5-skill starter pack for Google Analytics 4

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -10,8 +10,8 @@
     "version": "1.6.0",
     "homepage": "https://github.com/jeremylongshore/claude-code-plugins",
     "pluginRoot": "./plugins",
-    "totalPlugins": 423,
-    "skillsEnabled": 269,
+    "totalPlugins": 424,
+    "skillsEnabled": 274,
     "lastUpdated": "2026-05-20"
   },
   "plugins": [
@@ -3504,7 +3504,7 @@
     {
       "name": "kobiton-automate",
       "source": "./plugins/testing/kobiton-automate",
-      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+      "description": "Real mobile devices on demand via Kobiton's remote MCP \u2014 no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
       "version": "1.0.2",
       "category": "testing",
       "keywords": [
@@ -7658,6 +7658,37 @@
       }
     },
     {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 \u2014 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.0.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 5
+      },
+      "verification": {
+        "score": 70,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
       "name": "gamma-pack",
       "source": "./plugins/saas-packs/gamma-pack",
       "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
@@ -11060,7 +11091,7 @@
     {
       "name": "zero-tech-debt",
       "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only \u2014 surfaces refactor candidates and walks a 7-step workflow before any deletion.",
       "version": "1.0.0",
       "category": "skill-enhancers",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,8 @@
     "version": "1.6.0",
     "homepage": "https://github.com/jeremylongshore/claude-code-plugins",
     "pluginRoot": "./plugins",
-    "totalPlugins": 423,
-    "skillsEnabled": 269,
+    "totalPlugins": 424,
+    "skillsEnabled": 274,
     "lastUpdated": "2026-05-20"
   },
   "plugins": [
@@ -5726,6 +5726,28 @@
         "meetings",
         "ai-notes",
         "meeting-intelligence"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.0.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
       ],
       "author": {
         "name": "Jeremy Longshore",

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | 📦  | [Packages](#packages)                              |       5 |
 | ⚡  | [Performance](#performance)                        |      25 |
 | ✅  | [Productivity](#productivity)                      |      19 |
-| 🎁  | [SaaS Skill Packs](#saas-skill-packs)              |     105 |
+| 🎁  | [SaaS Skill Packs](#saas-skill-packs)              |     106 |
 | 🔐  | [Security](#security)                              |      26 |
 | ✨  | [Skill Enhancers](#skill-enhancers)                |       9 |
 | 🧪  | [Testing](#testing)                                |      27 |
@@ -519,7 +519,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 
 ### SaaS Skill Packs
 
-🎁 **105 plugins** · category slug: `saas-packs`
+🎁 **106 plugins** · category slug: `saas-packs`
 
 | Plugin              | Description                                                                                                                                 |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -564,6 +564,7 @@ Jump to any of the 18 categories below. Plugin counts are catalog totals — aut
 | `flyio-pack`        | Claude Code skill pack for Fly.io (18 skills)                                                                                               |
 | `fondo-pack`        | Claude Code skill pack for Fondo (18 skills)                                                                                                |
 | `framer-pack`       | Claude Code skill pack for Framer (18 skills)                                                                                               |
+| `ga4-pack`          | Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport,…  |
 | `gamma-pack`        | Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content…         |
 | `glean-pack`        | Claude Code skill pack for Glean (24 skills)                                                                                                |
 | `grammarly-pack`    | Claude Code skill pack for Grammarly (24 skills)                                                                                            |

--- a/plugins/saas-packs/ga4-pack/.claude-plugin/plugin.json
+++ b/plugins/saas-packs/ga4-pack/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ga4-pack",
+  "version": "1.0.0",
+  "description": "Claude Code skill pack for Google Analytics 4 — auth setup, Data API v1 patterns, Realtime API, BigQuery export, common reports (DAU/MAU, retention, attribution).",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "google-analytics",
+    "ga4",
+    "analytics",
+    "data-api",
+    "bigquery",
+    "saas"
+  ]
+}

--- a/plugins/saas-packs/ga4-pack/README.md
+++ b/plugins/saas-packs/ga4-pack/README.md
@@ -1,0 +1,47 @@
+# ga4-pack
+
+> Claude Code skill pack for Google Analytics 4. 5 starter skills covering the operationally-leveraged paths: auth setup, Data API v1 queries, Realtime API, common reports (DAU / MAU / retention / top pages), and BigQuery export.
+
+**Install:** `/plugin install ga4-pack@claude-code-plugins-plus`
+
+**Links:** [Tons of Skills](https://tonsofskills.com/learn/ga4/) · [GA4 Data API v1 docs](https://developers.google.com/analytics/devguides/reporting/data/v1) · [GA4 BigQuery export](https://support.google.com/analytics/answer/9358801)
+
+---
+
+## What's in the box
+
+| Skill | When to use it |
+|---|---|
+| `ga4-auth-setup` | First-time setup of OAuth user creds OR a service account for read-only analytics access. |
+| `ga4-data-api-query` | Building a properly-structured `runReport` request against the Data API v1 — metrics, dimensions, date ranges, filters, ordering. |
+| `ga4-realtime-api` | Pulling active-users / current-session data from the Realtime endpoint. Different shape, different limits than the standard Data API. |
+| `ga4-common-reports` | The canonical reports every site owner wants: DAU/MAU, retention, top pages, top sources, conversion funnel. Copy-paste recipes. |
+| `ga4-bigquery-export` | Wiring GA4 → BigQuery for unsampled, queryable event-level data. Schema, partitioning, common SQL patterns. |
+
+Five skills, not thirty. **Intentional**: GA4's API surface is wide but the operational paths most engineers actually need are narrow. Each skill in this pack is a real reference — not boilerplate. If you need a specialized use case (e.g., GA4 Measurement Protocol, custom event taxonomy, consent-mode signal handling), open an issue and we'll add a focused skill.
+
+## When NOT to use this pack
+
+- **You're using Umami / Plausible / Fathom instead of GA4**: use `web-analytics` instead — that pack is Umami-primary, GA4 as fallback only.
+- **You need to write events from a website**: this pack is read-only / reporting-focused. For event instrumentation, use Google's official tag manager guides directly.
+- **You're on Universal Analytics (UA)**: UA was sunset 2023-07-01. Migrate to GA4 first; this pack assumes GA4 properties.
+
+## Prerequisites
+
+- A GA4 property (not Universal Analytics)
+- One of:
+  - **OAuth user credentials** with `analytics.readonly` scope (for ad-hoc / interactive use)
+  - **Service account** with the GA4 property's API access (for automated / CI use)
+- For BigQuery export: a linked GCP project with BigQuery enabled (no extra cost — GA4 → BQ is free for the standard tier; sampling-free)
+
+See `ga4-auth-setup` for the actual setup steps.
+
+## Trigger examples
+
+| You ask Claude | Skill that fires |
+|---|---|
+| "Set up GA4 auth with a service account" | `ga4-auth-setup` |
+| "Query DAU for the last 30 days from GA4" | `ga4-data-api-query` |
+| "How many people are on my site right now?" | `ga4-realtime-api` |
+| "Show me retention week-over-week from GA4" | `ga4-common-reports` |
+| "I want unsampled GA4 data — set up the BigQuery export" | `ga4-bigquery-export` |

--- a/plugins/saas-packs/ga4-pack/package.json
+++ b/plugins/saas-packs/ga4-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/ga4-pack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth, Data API v1, Realtime API, common reports, and BigQuery export",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/ga4-pack/package.json
+++ b/plugins/saas-packs/ga4-pack/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@intentsolutionsio/ga4-pack",
+  "version": "1.0.0",
+  "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth, Data API v1, Realtime API, common reports, and BigQuery export",
+  "main": "README.md",
+  "type": "module",
+  "files": [
+    "README.md",
+    ".claude-plugin/",
+    "skills/"
+  ],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "google-analytics",
+    "ga4",
+    "analytics",
+    "data-api",
+    "bigquery",
+    "saas-pack"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/saas-packs/ga4-pack"
+  },
+  "homepage": "https://tonsofskills.com/learn/ga4/",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/plugins/saas-packs/ga4-pack/skills/ga4-auth-setup/SKILL.md
+++ b/plugins/saas-packs/ga4-pack/skills/ga4-auth-setup/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ga4-auth-setup
+description: |
+  Configure auth for the GA4 Data API — OAuth user credentials for interactive use,
+  or a service account for automation / CI. Pick the right path, set the right scopes,
+  grant the right property-level access. Trigger with "set up GA4 auth",
+  "GA4 service account", "GA4 OAuth", "connect to Google Analytics".
+allowed-tools: Bash(gcloud:*), Bash(curl:*), Bash(jq:*), Bash(python3:*), Bash(ls:*)
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, analytics, google-analytics, ga4, auth]
+compatibility: Designed for Claude Code
+---
+
+# GA4 Auth Setup
+
+GA4 has two production-grade auth paths. Pick before you start; mixing them mid-flight is the most common failure mode.
+
+| Path | When | Credential file |
+|---|---|---|
+| **Service account** | Automation, CI, server-side scripts. Token is long-lived, scoped, revocable. | `~/.config/gcloud/sa-ga4.json` (or any path you choose) |
+| **OAuth user creds** | Interactive use, multiple GA4 properties, ad-hoc analyst work. Token refreshes from a `~/.config/gcloud/application_default_credentials.json` file. | ADC |
+
+**Recommendation:** service account for any pipeline / report-runner / agent use. OAuth for a human poking around. Don't share OAuth user creds across machines — that's an audit-trail mess.
+
+## Path A — Service account (recommended for automation)
+
+### 1. Create the SA in GCP
+
+```bash
+PROJECT=your-gcp-project          # the project that will own the SA
+SA_NAME=ga4-reader
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+gcloud iam service-accounts create "$SA_NAME" \
+  --display-name="GA4 read-only API access" \
+  --project="$PROJECT"
+
+# Generate a key (file lands locally)
+gcloud iam service-accounts keys create ~/.config/gcloud/sa-ga4.json \
+  --iam-account="$SA_EMAIL"
+```
+
+### 2. Grant the SA access to your GA4 property
+
+This is the step everyone forgets. GA4 has **property-level** access control that lives in the Google Analytics web UI, NOT in GCP IAM. The service account email needs to be added there.
+
+1. Open <https://analytics.google.com/>
+2. Admin (bottom-left gear) → Property column → **Property Access Management**
+3. Add user: paste `$SA_EMAIL` (e.g. `ga4-reader@your-project.iam.gserviceaccount.com`)
+4. Role: **Viewer** (read-only — anything more is over-privilege)
+5. Save
+
+### 3. Enable the Data API in the SA's project
+
+```bash
+gcloud services enable analyticsdata.googleapis.com --project="$PROJECT"
+```
+
+### 4. Test the auth round-trip
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/sa-ga4.json \
+PROPERTY_ID=123456789 \
+python3 -c "
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import RunReportRequest, DateRange, Metric, Dimension
+import os
+client = BetaAnalyticsDataClient()
+req = RunReportRequest(
+    property=f'properties/{os.environ[\"PROPERTY_ID\"]}',
+    date_ranges=[DateRange(start_date='7daysAgo', end_date='today')],
+    metrics=[Metric(name='activeUsers')],
+    dimensions=[Dimension(name='date')],
+)
+resp = client.run_report(req)
+for row in resp.rows:
+    print(row.dimension_values[0].value, row.metric_values[0].value)
+"
+```
+
+If you get rows back, auth works. If you get `PermissionDenied: 403`, the SA isn't added to the property (step 2). If you get `Disabled: 403`, the API isn't enabled (step 3).
+
+## Path B — OAuth user credentials (interactive)
+
+```bash
+gcloud auth application-default login \
+  --scopes='https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/cloud-platform'
+```
+
+This opens a browser, you sign in with the Google account that has access to the GA4 property, and a refresh token lands at `~/.config/gcloud/application_default_credentials.json`. The Data API client picks it up automatically when `GOOGLE_APPLICATION_CREDENTIALS` is not set.
+
+Same test as Path A step 4 — just omit the `GOOGLE_APPLICATION_CREDENTIALS=` prefix.
+
+## Finding your `PROPERTY_ID`
+
+GA4 property IDs are 9-digit numbers (not the `G-XXXXX` measurement ID, which is for the front-end tracker).
+
+1. Open <https://analytics.google.com/>
+2. Admin → Property column → **Property Details**
+3. Top of the page: **Property ID** — copy the digits, e.g. `123456789`
+
+## Secret hygiene
+
+- **Never commit the SA JSON key.** Add to `.gitignore`:
+  ```
+  *-sa-*.json
+  sa-ga4.json
+  ```
+- **Use SOPS+age** for the SA key in any repo it lives in. Per the IS standard: `cd <repo> && sops-init`, then `mv ~/.config/gcloud/sa-ga4.json .sops/ga4-sa.json.sops` and decrypt in-process when needed.
+- **Rotate the SA key annually** at minimum: `gcloud iam service-accounts keys list --iam-account=$SA_EMAIL` shows the active keys; create a new one + delete the old one.
+- **Grant Viewer-only** at the GA4 property level. Editor or Administrator gives the SA the power to delete the property — you don't want a CI pipeline with that blast radius.
+
+## Common errors
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| `403 PermissionDenied: User does not have sufficient permissions for this property.` | SA email not added to GA4 property | Path A, step 2 |
+| `403 SERVICE_DISABLED` | Data API not enabled in SA's GCP project | Path A, step 3 |
+| `401 UNAUTHENTICATED` | `GOOGLE_APPLICATION_CREDENTIALS` points to a missing/unreadable file | `ls -la $GOOGLE_APPLICATION_CREDENTIALS` |
+| `Invalid property ID: G-XXXX` | Using measurement ID instead of property ID | See "Finding your PROPERTY_ID" above |
+| `Quota exceeded` | Default Data API quota is 200K tokens/day per property | Check Quotas in Cloud Console; raise quota or batch queries with broader date ranges |
+
+## Related skills
+
+- `ga4-data-api-query` — once auth works, build the actual `runReport` call
+- `ga4-bigquery-export` — for unsampled event-level data via BigQuery instead of the Data API

--- a/plugins/saas-packs/ga4-pack/skills/ga4-bigquery-export/SKILL.md
+++ b/plugins/saas-packs/ga4-pack/skills/ga4-bigquery-export/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: ga4-bigquery-export
+description: |
+  Wire GA4 → BigQuery for unsampled, queryable event-level data. Covers the
+  one-time export setup, the events_YYYYMMDD table schema, partitioning + clustering,
+  and the SQL patterns for the reports the Data API can't do well (true cohort
+  retention, custom-event attribution, large date ranges). Trigger with
+  "GA4 BigQuery", "GA4 to BQ", "event-level GA4 data", "unsampled GA4",
+  "GA4 export setup", "GA4 SQL".
+allowed-tools: Bash(bq:*), Bash(gcloud:*)
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, analytics, google-analytics, ga4, bigquery]
+compatibility: Designed for Claude Code
+---
+
+# GA4 → BigQuery Export
+
+The Data API is good but bounded — sampled past a threshold, capped at ~150 dimensions, no cohort joins. BigQuery export gives you the raw event stream as SQL-queryable tables, **free** at the standard GA4 tier (up to 1M events/day), with no sampling and full event payloads.
+
+This skill: one-time setup, then the SQL recipes for what the Data API can't do well.
+
+## Setup — one time
+
+### 1. Link your GA4 property to a GCP project
+
+In <https://analytics.google.com/>:
+
+1. Admin → Property column → **BigQuery Links**
+2. Create a link → pick your GCP project
+3. Data location: pick the BQ region for the export tables (US multi-region is fine for most cases; EU if you need data residency)
+4. **Export type:**
+   - **Daily** — single `events_YYYYMMDD` table per day, written ~24h after midnight. Fine for most reporting.
+   - **Streaming** — `events_intraday_YYYYMMDD` table written ~near-real-time. Costs more, useful for hot ops dashboards.
+   - Most setups: enable both. Streaming for "today", daily for everything else.
+5. **Include advertising identifiers** — uncheck unless you specifically need device-graph data (most don't)
+6. Save
+
+The first daily table lands within 24h. The first streaming table is near-immediate. After that you have a new `events_YYYYMMDD` every day forever, no maintenance needed.
+
+### 2. Verify the export is working
+
+```bash
+PROJECT=your-gcp-project
+DATASET=analytics_123456789       # auto-named after the property ID
+
+bq ls "$PROJECT:$DATASET" 2>&1 | head -10
+# Expect: events_YYYYMMDD tables + events_intraday_YYYYMMDD if streaming enabled
+```
+
+If you see no dataset, the link is configured but the first export hasn't fired yet — wait 24h.
+
+### 3. Authorize a service account for querying
+
+The SA from `ga4-auth-setup` only has Data API access. For BQ queries, grant the same SA:
+
+```bash
+SA_EMAIL=ga4-reader@your-project.iam.gserviceaccount.com
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/bigquery.dataViewer"
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/bigquery.jobUser"
+```
+
+`dataViewer` reads tables; `jobUser` lets the SA run queries (queries are jobs in BQ's model).
+
+## The events table schema (the important columns)
+
+Every row in `events_YYYYMMDD` is one event. The schema is denormalized — user + session + event + page + device all flat in each row.
+
+| Column | Type | Notes |
+|---|---|---|
+| `event_date` | `STRING` | `'YYYYMMDD'` |
+| `event_timestamp` | `INT64` | Microseconds since epoch |
+| `event_name` | `STRING` | `page_view`, `session_start`, `purchase`, custom event names |
+| `event_params` | `ARRAY<STRUCT<key, value>>` | All event parameters; value is itself a union STRUCT (`string_value`, `int_value`, `float_value`, `double_value`) |
+| `user_pseudo_id` | `STRING` | GA4's cookie-based user ID (anonymous unless `user_id` is set) |
+| `user_id` | `STRING` | If you set `user_id` via `gtag('set', {user_id: '...'})` |
+| `user_properties` | `ARRAY<STRUCT<key, value>>` | Same shape as event_params |
+| `device.*` | `STRUCT` | category / os / browser / model |
+| `geo.*` | `STRUCT` | country / region / city |
+| `traffic_source.*` | `STRUCT` | source / medium / campaign of FIRST session (not current) |
+| `session_traffic_source_last_click.*` | `STRUCT` | source / medium of CURRENT session — what you usually want |
+| `ga_session_id` (param) | `INT64` | Pulled via `(SELECT value.int_value FROM UNNEST(event_params) WHERE key='ga_session_id')` |
+| `ga_session_number` (param) | `INT64` | Same idiom — 1 = first session, 2 = second, etc. |
+
+The `event_params` and `user_properties` arrays are the gnarly bit. Pulling a parameter requires UNNEST + filter. The idiom:
+
+```sql
+-- Pull the page_location for every page_view
+SELECT
+  TIMESTAMP_MICROS(event_timestamp) AS ts,
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location') AS page,
+  user_pseudo_id
+FROM `your-project.analytics_123456789.events_*`
+WHERE _TABLE_SUFFIX BETWEEN '20260513' AND '20260520'
+  AND event_name = 'page_view'
+LIMIT 100;
+```
+
+`_TABLE_SUFFIX BETWEEN '...' AND '...'` is the canonical way to scan a date range across the wildcard table. **Always set it** — without a suffix filter, you query the entire history and pay for it.
+
+## Recipe 1 — True cohort retention
+
+The thing the Data API can't do cleanly:
+
+```sql
+WITH first_seen AS (
+  SELECT
+    user_pseudo_id,
+    DATE(MIN(TIMESTAMP_MICROS(event_timestamp))) AS first_date
+  FROM `your-project.analytics_123456789.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN '20260401' AND '20260520'
+  GROUP BY user_pseudo_id
+),
+activity AS (
+  SELECT
+    user_pseudo_id,
+    DATE(TIMESTAMP_MICROS(event_timestamp)) AS active_date
+  FROM `your-project.analytics_123456789.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN '20260401' AND '20260520'
+  GROUP BY user_pseudo_id, active_date
+)
+SELECT
+  DATE_TRUNC(f.first_date, WEEK) AS cohort_week,
+  DATE_DIFF(a.active_date, f.first_date, WEEK) AS weeks_since,
+  COUNT(DISTINCT a.user_pseudo_id) AS active_users
+FROM first_seen f
+JOIN activity a USING (user_pseudo_id)
+GROUP BY cohort_week, weeks_since
+ORDER BY cohort_week, weeks_since;
+```
+
+Output: rows of `(cohort_week, weeks_since, active_users)`. Pivot in your tool of choice for the classic triangle chart.
+
+## Recipe 2 — Sessions table (denormalized from events)
+
+GA4's BQ export is event-rows, not session-rows. To reason about sessions, build the session table yourself:
+
+```sql
+WITH sessions AS (
+  SELECT
+    user_pseudo_id,
+    (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS session_id,
+    MIN(TIMESTAMP_MICROS(event_timestamp)) AS session_start,
+    MAX(TIMESTAMP_MICROS(event_timestamp)) AS session_end,
+    COUNT(*) AS event_count,
+    COUNTIF(event_name = 'page_view') AS pageviews,
+    ANY_VALUE(device.category) AS device,
+    ANY_VALUE(geo.country) AS country,
+    ANY_VALUE(session_traffic_source_last_click.manual_campaign.source) AS source,
+    ANY_VALUE(session_traffic_source_last_click.manual_campaign.medium) AS medium,
+  FROM `your-project.analytics_123456789.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN '20260513' AND '20260520'
+  GROUP BY user_pseudo_id, session_id
+  HAVING session_id IS NOT NULL
+)
+SELECT * FROM sessions
+ORDER BY session_start DESC
+LIMIT 100;
+```
+
+You'd usually `CREATE TABLE` or `CREATE MATERIALIZED VIEW` over this — querying the events table directly every time is slow + expensive.
+
+## Recipe 3 — Top pages by source
+
+```sql
+SELECT
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location') AS page,
+  session_traffic_source_last_click.manual_campaign.source AS source,
+  COUNT(*) AS pageviews,
+  COUNT(DISTINCT user_pseudo_id) AS users
+FROM `your-project.analytics_123456789.events_*`
+WHERE _TABLE_SUFFIX BETWEEN '20260513' AND '20260520'
+  AND event_name = 'page_view'
+GROUP BY page, source
+HAVING pageviews > 10        -- filter the long tail
+ORDER BY pageviews DESC
+LIMIT 50;
+```
+
+## Cost considerations
+
+BigQuery costs $5/TB scanned (first 1 TB/month free). What that translates to in practice:
+
+| Scenario | ~TB / query |
+|---|---|
+| Small site, 1k events/day, 30-day window | < 1 GB |
+| Medium site, 100k events/day, 30-day window | ~10 GB |
+| Large site, 1M events/day, 30-day window | ~100 GB |
+| Same scenarios but querying the full 14-month history | 12-15x the above |
+
+Stay under the free tier with normal usage. Cost-saving patterns:
+
+1. **Always set `_TABLE_SUFFIX BETWEEN`** — don't scan all history if you only need 7 days
+2. **Materialize hot queries** — CREATE TABLE / CREATE MATERIALIZED VIEW for sessions, daily aggregates, etc.
+3. **`SELECT` only the columns you need** — BQ is columnar; selecting `event_params` array always reads the whole array even if you only want one parameter
+4. **Use `--dry-run`** before any new query to see TB scanned: `bq query --dry_run --use_legacy_sql=false "SELECT ..."`
+
+## Streaming vs daily — which to query
+
+| Table prefix | When |
+|---|---|
+| `events_YYYYMMDD` | Stable historical data. Use for reports, analysis. |
+| `events_intraday_YYYYMMDD` | "Today" data, near-realtime. Schema is identical, but rows may not be deduped yet. |
+| `events_*` (wildcard) | When the date range crosses both. BQ will scan both transparently. |
+
+Today's data lives in `events_intraday_TODAY`; tomorrow it gets rolled into `events_TODAY` and the intraday table for today is dropped. So if you have a query that needs both stable history + today, use `events_*` and filter on `_TABLE_SUFFIX`.
+
+## Common gotchas
+
+| Issue | Why |
+|---|---|
+| Numbers don't match the GA4 UI exactly | UI uses different identity-stitching for cross-device users; raw events are pre-stitching. Off by a few % is expected. |
+| `event_params` UNNEST returns NULL | The key doesn't exist on that event. Always wrap in `(SELECT ... LIMIT 1)` so missing-key events return NULL instead of erroring. |
+| Query scans way more than expected | Missing `_TABLE_SUFFIX` filter, OR using `events_*` without a `_TABLE_SUFFIX BETWEEN` clause |
+| `events_intraday_*` has 2x the rows you'd expect | Intraday tables aren't deduped; the same event may appear twice if it was buffered + retried. The daily rollup dedupes. |
+| No `user_id` even though I set it on the front-end | `user_id` is the explicit identifier; `user_pseudo_id` is the auto-generated cookie ID. If `user_id` is consistently NULL, the `gtag('set', {user_id: ...})` call is firing AFTER the event you're checking, or it's set on a property that the export doesn't pull. |
+
+## Related skills
+
+- `ga4-auth-setup` — for the service account that queries BQ
+- `ga4-data-api-query` — when you DON'T need event-level granularity (Data API is faster + cheaper for aggregates)
+- `ga4-common-reports` — the Data API recipes that BQ supersedes

--- a/plugins/saas-packs/ga4-pack/skills/ga4-common-reports/SKILL.md
+++ b/plugins/saas-packs/ga4-pack/skills/ga4-common-reports/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: ga4-common-reports
+description: |
+  Copy-paste recipes for the 6-7 reports every site owner actually wants:
+  DAU/MAU/WAU, retention cohort, top pages by source, channel attribution,
+  conversion funnel, geo breakdown, device split. Each recipe is a fully-formed
+  Data API request. Trigger with "GA4 DAU", "GA4 retention", "GA4 top pages",
+  "GA4 funnel", "GA4 channel report", "common GA4 reports".
+allowed-tools: Bash(python3:*)
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, analytics, google-analytics, ga4, reports]
+compatibility: Designed for Claude Code
+---
+
+# GA4 Common Reports
+
+Recipes for the reports that get asked for ~95% of the time. Each one is a complete `runReport` you can paste, change `PROPERTY_ID`, and run. Prerequisite: `ga4-auth-setup` done.
+
+The setup block (same for every recipe):
+
+```python
+import os
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import (
+    RunReportRequest, DateRange, Metric, Dimension,
+    FilterExpression, Filter, OrderBy,
+)
+
+PROPERTY = f"properties/{os.environ['GA4_PROPERTY_ID']}"
+client = BetaAnalyticsDataClient()
+```
+
+## 1. Daily Active Users (DAU) — 30-day rolling
+
+```python
+req = RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="30daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers")],
+    dimensions=[Dimension(name="date")],
+    order_bys=[OrderBy(dimension=OrderBy.DimensionOrderBy(dimension_name="date"))],
+)
+resp = client.run_report(req)
+for r in resp.rows:
+    print(f"{r.dimension_values[0].value} {r.metric_values[0].value}")
+```
+
+**Why `yesterday`, not `today`:** today's number is incomplete and will keep climbing through the day. For a clean rolling DAU, end the window at `yesterday`.
+
+## 2. MAU / WAU — rolling unique users
+
+GA4 doesn't expose MAU as a single metric — you compute it from the same `activeUsers` rolled up over a wider date range. The trick: a single-row report with no date dimension returns the unique count over the entire window (de-duplicated across days).
+
+```python
+# MAU (last 30 days)
+mau = client.run_report(RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="29daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers")],
+))
+mau_count = int(mau.rows[0].metric_values[0].value) if mau.rows else 0
+
+# WAU (last 7 days)
+wau = client.run_report(RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="6daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers")],
+))
+wau_count = int(wau.rows[0].metric_values[0].value) if wau.rows else 0
+
+print(f"MAU: {mau_count:,}   WAU: {wau_count:,}   Ratio (engagement): {wau_count/mau_count:.2%}")
+```
+
+Stickiness rule-of-thumb: `WAU/MAU > 0.5` is good, `> 0.7` is excellent, `< 0.2` means most users visit once and bounce.
+
+## 3. Top pages — last 7 days, ordered by pageviews
+
+```python
+req = RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="7daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="screenPageViews"), Metric(name="activeUsers"), Metric(name="averageSessionDuration")],
+    dimensions=[Dimension(name="pagePath")],
+    order_bys=[OrderBy(metric=OrderBy.MetricOrderBy(metric_name="screenPageViews"), desc=True)],
+    limit=25,
+)
+resp = client.run_report(req)
+print(f"{'Path':<60} {'Views':>8} {'Users':>8} {'AvgSec':>8}")
+for r in resp.rows:
+    print(f"{r.dimension_values[0].value[:58]:<60} "
+          f"{r.metric_values[0].value:>8} {r.metric_values[1].value:>8} "
+          f"{float(r.metric_values[2].value):>8.1f}")
+```
+
+## 4. Channel attribution — where did users come from?
+
+```python
+req = RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="30daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers"), Metric(name="sessions"), Metric(name="engagedSessions")],
+    dimensions=[Dimension(name="sessionDefaultChannelGrouping")],
+    order_bys=[OrderBy(metric=OrderBy.MetricOrderBy(metric_name="activeUsers"), desc=True)],
+)
+resp = client.run_report(req)
+print(f"{'Channel':<28} {'Users':>10} {'Sessions':>10} {'Engaged%':>10}")
+for r in resp.rows:
+    users = int(r.metric_values[0].value)
+    sess = int(r.metric_values[1].value)
+    eng = int(r.metric_values[2].value)
+    eng_rate = eng / sess if sess else 0
+    print(f"{r.dimension_values[0].value:<28} {users:>10,} {sess:>10,} {eng_rate:>9.1%}")
+```
+
+GA4's default channel grouping has ~12 buckets: Direct, Organic Search, Paid Search, Organic Social, Paid Social, Email, Referral, Display, Video, Affiliates, Audio, etc. Use `sessionSource` + `sessionMedium` for finer-grained attribution (e.g. `google / organic` vs `bing / organic`).
+
+## 5. Retention cohort — week 1 / 2 / 3 / 4 return rate
+
+GA4 has a built-in cohort exploration in the UI but the Data API doesn't expose it cleanly. The workaround: query DAU per week and compute rolling overlap. The cheap approximation:
+
+```python
+# Weekly active users for the last 8 weeks
+req = RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="56daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers")],
+    dimensions=[Dimension(name="isoYearIsoWeek")],
+    order_bys=[OrderBy(dimension=OrderBy.DimensionOrderBy(dimension_name="isoYearIsoWeek"))],
+)
+resp = client.run_report(req)
+for r in resp.rows:
+    print(f"{r.dimension_values[0].value}  {r.metric_values[0].value}")
+```
+
+For true cohort retention (e.g. "of users acquired in week N, what % came back in week N+1, N+2, N+3"), you need event-level data — use `ga4-bigquery-export` and write the cohort SQL directly. The Data API can't express the join.
+
+## 6. Conversion funnel — landing → engagement → conversion
+
+GA4 funnels via API: query each step as a separate `runReport` filtered by the event that defines the step, then divide.
+
+```python
+def step_users(event_name, days_ago=7):
+    return int(client.run_report(RunReportRequest(
+        property=PROPERTY,
+        date_ranges=[DateRange(start_date=f"{days_ago}daysAgo", end_date="yesterday")],
+        metrics=[Metric(name="activeUsers")],
+        dimension_filter=FilterExpression(filter=Filter(
+            field_name="eventName",
+            string_filter=Filter.StringFilter(
+                match_type=Filter.StringFilter.MatchType.EXACT,
+                value=event_name,
+            ),
+        )),
+    )).rows[0].metric_values[0].value)
+
+# Example funnel: landed → engaged → signed up → purchased
+steps = [
+    ("session_start",  step_users("session_start")),
+    ("user_engagement", step_users("user_engagement")),
+    ("sign_up",         step_users("sign_up")),
+    ("purchase",        step_users("purchase")),
+]
+top = steps[0][1] or 1
+print(f"{'Step':<20} {'Users':>10} {'% of top':>10}")
+for name, count in steps:
+    print(f"{name:<20} {count:>10,} {count/top:>9.1%}")
+```
+
+Limitation: this counts users who fired the event at any point in the window, NOT users who progressed through the funnel in order. For ordered funnels (true sequencing), use BigQuery export or the GA4 UI's Exploration → Funnel report.
+
+## 7. Geo + device split
+
+```python
+req = RunReportRequest(
+    property=PROPERTY,
+    date_ranges=[DateRange(start_date="30daysAgo", end_date="yesterday")],
+    metrics=[Metric(name="activeUsers"), Metric(name="bounceRate")],
+    dimensions=[Dimension(name="country"), Dimension(name="deviceCategory")],
+    order_bys=[OrderBy(metric=OrderBy.MetricOrderBy(metric_name="activeUsers"), desc=True)],
+    limit=30,
+)
+resp = client.run_report(req)
+for r in resp.rows:
+    country, device = r.dimension_values[0].value, r.dimension_values[1].value
+    users, bounce = r.metric_values[0].value, float(r.metric_values[1].value)
+    print(f"{country:<20} {device:<10} {users:>10} {bounce:>6.1%}")
+```
+
+A common signal: if one country dominates with low engagement + high bounce, it's often bot traffic from that country's cloud-host hubs (Singapore, Vietnam, China data centers are the usual suspects).
+
+## When the Data API isn't enough
+
+Three reasons to graduate to BigQuery export:
+
+1. **Sampling** — your queries hit `resp.metadata.data_loss_from_other_row=True`. Sampled = approximate. BQ export = exact.
+2. **Custom event analytics** — joining event-level data across sessions, computing retention cohorts, building attribution models. SQL is the only sensible tool.
+3. **Cost** — Data API has daily quotas; BQ is pay-per-query (free for small properties, cheap up to ~100M events/day).
+
+See `ga4-bigquery-export` for the setup.
+
+## Related skills
+
+- `ga4-auth-setup` — prerequisite
+- `ga4-data-api-query` — the underlying API the recipes here use
+- `ga4-realtime-api` — for "right now" data instead of any of the above
+- `ga4-bigquery-export` — when these recipes hit their limits

--- a/plugins/saas-packs/ga4-pack/skills/ga4-data-api-query/SKILL.md
+++ b/plugins/saas-packs/ga4-pack/skills/ga4-data-api-query/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: ga4-data-api-query
+description: |
+  Build a runReport request against the GA4 Data API v1 — pick valid metric/dimension
+  combinations, set date ranges that respect data-freshness limits, apply filters,
+  paginate large result sets, handle sampling thresholds. Trigger with "query GA4",
+  "GA4 Data API", "runReport", "fetch GA4 metrics", "GA4 pageviews", "GA4 sessions".
+allowed-tools: Bash(python3:*), Bash(curl:*)
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, analytics, google-analytics, ga4, data-api]
+compatibility: Designed for Claude Code
+---
+
+# GA4 Data API v1 — runReport
+
+The Data API v1 is the canonical read path for GA4. One endpoint (`runReport`) covers most use cases. Two paths matter for picking the right query: **dimensions** describe rows (date, page, source), **metrics** describe values (sessions, users, events). Not every combination is valid — see "Compatibility" below.
+
+Prerequisite: auth working (see `ga4-auth-setup`).
+
+## The minimum viable query
+
+```python
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import (
+    RunReportRequest, DateRange, Metric, Dimension,
+)
+
+client = BetaAnalyticsDataClient()
+
+req = RunReportRequest(
+    property="properties/123456789",     # YOUR property ID (digits only)
+    date_ranges=[
+        DateRange(start_date="30daysAgo", end_date="today"),
+    ],
+    metrics=[Metric(name="activeUsers")],
+    dimensions=[Dimension(name="date")],
+)
+resp = client.run_report(req)
+
+for row in resp.rows:
+    date = row.dimension_values[0].value     # YYYYMMDD string
+    users = row.metric_values[0].value       # numeric string
+    print(f"{date}: {users}")
+```
+
+That's the full skeleton. Everything below extends this shape.
+
+## The 12 metrics worth knowing
+
+| Metric | What it counts | Notes |
+|---|---|---|
+| `activeUsers` | Unique users with engagement in the window | The "users" people mean by default |
+| `newUsers` | First-seen users in the window | |
+| `totalUsers` | All users (engaged or not) — superset of `activeUsers` | |
+| `sessions` | Sessions started in the window | Re-engages after 30min inactivity |
+| `engagedSessions` | Sessions ≥10s OR ≥2 pageviews OR ≥1 conversion | The "good" sessions |
+| `screenPageViews` | Pageviews + app screenviews combined | What people mean by "pageviews" |
+| `eventCount` | Total event count (every event, not just `page_view`) | Often misleadingly large |
+| `bounceRate` | `(sessions - engagedSessions) / sessions` | Lower is better |
+| `averageSessionDuration` | Avg seconds per session | Across `sessions`, not `engagedSessions` |
+| `eventsPerSession` | `eventCount / sessions` | |
+| `conversions` | Events flagged as conversions in the property setup | Property-specific |
+| `totalRevenue` | Sum of `purchase` event revenue | Currency = property default |
+
+`bounceRate` and `averageSessionDuration` are ratios — don't `SUM` them across rows; they're already aggregated within each row's group.
+
+## The 12 dimensions worth knowing
+
+| Dimension | Cardinality | When to use |
+|---|---|---|
+| `date` | Low (1/day) | Time series |
+| `dateHour` | Med | Intra-day patterns |
+| `pagePath` | High | Top-pages reports |
+| `pageTitle` | High | When path is opaque (e.g. SPA hash routes) |
+| `sessionSource` / `sessionMedium` | Med | Attribution |
+| `sessionDefaultChannelGrouping` | Low (~12 channels) | High-level traffic source breakdown |
+| `country` / `region` / `city` | Med / Med / High | Geo |
+| `deviceCategory` | Low (desktop/mobile/tablet) | |
+| `browser` / `operatingSystem` | Med | Tech audit |
+| `landingPage` | High | Entry-page reports |
+| `eventName` | Med | Event-level breakdowns |
+| `customEvent:<name>` | Property-specific | If you defined custom dimensions in the property setup |
+
+## Compatibility — not every (dim, metric) combo is valid
+
+GA4 enforces a compatibility matrix at the API level. If you ask for `sessions` + `customEvent:purchaseId` together you may get an empty result or a `400 INVALID_ARGUMENT`. Two rules cover ~90% of cases:
+
+1. **User-scoped vs session-scoped vs event-scoped dimensions don't always mix with each other's metrics.** Stick to dimensions in the same scope as your headline metric where possible.
+2. **High-cardinality custom dimensions can trigger sampling.** GA4 will silently sample if a single query touches more than the property's data-quota threshold; the response includes `metadata.dataLossFromOtherRow=true`. Check it.
+
+If you're unsure, query the compatibility metadata endpoint:
+```python
+from google.analytics.data_v1beta.types import CheckCompatibilityRequest
+compat = client.check_compatibility(CheckCompatibilityRequest(
+    property="properties/123456789",
+    dimensions=[Dimension(name="pagePath"), Dimension(name="sessionSource")],
+    metrics=[Metric(name="screenPageViews"), Metric(name="sessions")],
+))
+print(compat)
+```
+
+## Filters
+
+Filters are nested expressions. The common case: filter rows by a dimension value.
+
+```python
+from google.analytics.data_v1beta.types import (
+    FilterExpression, Filter, FilterExpressionList,
+)
+
+# Just pages under /docs/
+docs_only = FilterExpression(
+    filter=Filter(
+        field_name="pagePath",
+        string_filter=Filter.StringFilter(
+            match_type=Filter.StringFilter.MatchType.BEGINS_WITH,
+            value="/docs/",
+            case_sensitive=False,
+        ),
+    ),
+)
+
+# AND combine: organic search AND not from referrer "spam.com"
+combined = FilterExpression(
+    and_group=FilterExpressionList(expressions=[
+        FilterExpression(filter=Filter(
+            field_name="sessionMedium",
+            string_filter=Filter.StringFilter(
+                match_type=Filter.StringFilter.MatchType.EXACT,
+                value="organic",
+            ),
+        )),
+        FilterExpression(not_expression=FilterExpression(filter=Filter(
+            field_name="sessionSource",
+            string_filter=Filter.StringFilter(
+                match_type=Filter.StringFilter.MatchType.EXACT,
+                value="spam.com",
+            ),
+        ))),
+    ]),
+)
+
+req = RunReportRequest(
+    property="properties/123456789",
+    date_ranges=[DateRange(start_date="30daysAgo", end_date="today")],
+    metrics=[Metric(name="sessions")],
+    dimensions=[Dimension(name="pagePath")],
+    dimension_filter=docs_only,
+)
+```
+
+Use `metric_filter` for filtering by metric (e.g. only rows where `sessions > 100`). Same shape.
+
+## Date ranges
+
+| Form | Meaning |
+|---|---|
+| `"2026-05-01"` | Absolute (ISO date) |
+| `"30daysAgo"` | Relative — N days before today |
+| `"yesterday"`, `"today"` | Named relative |
+| `"NdaysAgo"` to `"today"` | Standard rolling window |
+
+GA4 has **48-hour data freshness** — today's numbers fluctuate; yesterday's settle ~24h after midnight in the property's timezone; numbers older than 48h are stable. Don't draw conclusions from "today" alone.
+
+Multiple `date_ranges` in one request gives you a comparison report:
+```python
+DateRange(start_date="30daysAgo", end_date="yesterday", name="current"),
+DateRange(start_date="60daysAgo", end_date="31daysAgo", name="prior"),
+```
+The response will have `dateRange` as an extra dimension on each row.
+
+## Pagination
+
+```python
+req = RunReportRequest(
+    # ... as above
+    limit=10_000,    # max 250_000 per request
+    offset=0,
+)
+resp = client.run_report(req)
+# resp.row_count is the TOTAL matching rows; resp.rows is the current page
+while resp.row_count > req.offset + len(resp.rows):
+    req.offset += len(resp.rows)
+    resp = client.run_report(req)
+    # process resp.rows
+```
+
+For result sets over ~1M rows, use `ga4-bigquery-export` instead.
+
+## Sampling — always check
+
+```python
+resp = client.run_report(req)
+if resp.metadata.data_loss_from_other_row:
+    print("WARNING: data was sampled. Tighten date range, drop high-cardinality dimensions, or use BigQuery export for unsampled data.")
+```
+
+If sampled, results are statistically valid but not exact. For exact counts, BigQuery export is the only path.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `400 INVALID_ARGUMENT: dimension X is incompatible with metric Y` | Compatibility matrix violation | Use `check_compatibility` to find a valid combination |
+| `400 The request must contain at least one valid dimension` | All dimensions in the list are invalid (typo, deprecated name) | Check the [Dimensions & metrics explorer](https://ga-dev-tools.google/ga4/dimensions-metrics-explorer/) |
+| `503 RESOURCE_EXHAUSTED` | Per-property quota hit | Wait 1h or raise quota; batch fewer queries |
+| Empty `rows` despite valid query | Date range outside data window OR property has no data for that period | Sanity-check with a known-good query (e.g. `activeUsers` over `today`) |
+
+## Related skills
+
+- `ga4-auth-setup` — prerequisite
+- `ga4-realtime-api` — for "right now" data instead of `runReport`'s ~24h lag
+- `ga4-common-reports` — copy-paste recipes for the canonical 6-7 reports
+- `ga4-bigquery-export` — when you've outgrown the Data API

--- a/plugins/saas-packs/ga4-pack/skills/ga4-realtime-api/SKILL.md
+++ b/plugins/saas-packs/ga4-pack/skills/ga4-realtime-api/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: ga4-realtime-api
+description: |
+  Pull current-session / active-user data from the GA4 Realtime endpoint —
+  a separate API surface from runReport with different metrics, dimensions, and
+  freshness guarantees (~30 min rolling window instead of T-48h). Trigger with
+  "GA4 realtime", "active users right now", "GA4 current sessions",
+  "who's on my site now".
+allowed-tools: Bash(python3:*), Bash(curl:*)
+version: 1.0.0
+license: MIT
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+tags: [saas, analytics, google-analytics, ga4, realtime]
+compatibility: Designed for Claude Code
+---
+
+# GA4 Realtime API
+
+The Realtime API is GA4's "what's happening right now" endpoint. Different from `runReport`:
+
+| | `runReport` (Data API) | `runRealtimeReport` (Realtime) |
+|---|---|---|
+| Freshness | ~24-48h lag, stable | Last ~30 min, rolling |
+| Window | Any date range | Implicit — last 30 min |
+| Metrics | ~50 supported | ~10 supported (subset) |
+| Dimensions | ~150 supported | ~15 supported (subset) |
+| Quota | Per-property daily | Separate Realtime quota |
+| Use case | Reports, dashboards, trend analysis | Live dashboards, monitoring, "are we down?" |
+
+Don't try to use `runReport` for now-data — its freshest data point is yesterday. Use `runRealtimeReport`.
+
+## Minimum viable call
+
+```python
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import (
+    RunRealtimeReportRequest, Metric, Dimension,
+)
+
+client = BetaAnalyticsDataClient()
+resp = client.run_realtime_report(RunRealtimeReportRequest(
+    property="properties/123456789",
+    metrics=[Metric(name="activeUsers")],
+))
+
+# Single-row response when there are no dimensions
+total = int(resp.rows[0].metric_values[0].value) if resp.rows else 0
+print(f"Active users right now: {total}")
+```
+
+No `date_ranges` block — the implicit window is the last 30 min. Adding one will error.
+
+## Realtime metrics (the full list)
+
+| Metric | What it counts |
+|---|---|
+| `activeUsers` | Unique users in the last 30 min |
+| `screenPageViews` | Pageviews + screenviews in the last 30 min |
+| `eventCount` | Total events in the last 30 min |
+| `conversions` | Conversion events in the last 30 min |
+| `keyEvents` | Key events (post-2024 rename of conversions) |
+
+Custom-event aggregates (e.g. `purchase_revenue`) are NOT in the Realtime API. If you need realtime revenue, derive it from `eventCount` filtered to `eventName=="purchase"` plus your average AOV.
+
+## Realtime dimensions (the full list)
+
+| Dimension | Use |
+|---|---|
+| `country`, `city` | Geo of currently-active users |
+| `deviceCategory` | desktop / mobile / tablet split |
+| `unifiedScreenName` / `unifiedScreenClass` | App screen / web title |
+| `eventName` | Event-type breakdown |
+| `streamId`, `streamName` | When property has multiple data streams (web + iOS + Android) |
+| `platform` | web / ios / android |
+| `appVersion`, `audienceName`, `audienceId` | When defined in the property |
+
+That's the full list. ~15 dims total. Compare to `runReport`'s ~150.
+
+## Common realtime queries
+
+### "How many people are on my site right now?"
+
+```python
+resp = client.run_realtime_report(RunRealtimeReportRequest(
+    property="properties/123456789",
+    metrics=[Metric(name="activeUsers")],
+))
+print(int(resp.rows[0].metric_values[0].value) if resp.rows else 0)
+```
+
+### "Active users by country, right now"
+
+```python
+resp = client.run_realtime_report(RunRealtimeReportRequest(
+    property="properties/123456789",
+    metrics=[Metric(name="activeUsers")],
+    dimensions=[Dimension(name="country")],
+    limit=20,
+))
+for r in resp.rows:
+    print(f"{r.dimension_values[0].value:25s} {r.metric_values[0].value}")
+```
+
+### "Which events are firing in the last 30 min?"
+
+```python
+resp = client.run_realtime_report(RunRealtimeReportRequest(
+    property="properties/123456789",
+    metrics=[Metric(name="eventCount")],
+    dimensions=[Dimension(name="eventName")],
+    limit=30,
+))
+```
+
+This is the live event firehose — useful to verify a new tracking deployment is actually firing.
+
+### "Top pages right now"
+
+```python
+resp = client.run_realtime_report(RunRealtimeReportRequest(
+    property="properties/123456789",
+    metrics=[Metric(name="screenPageViews")],
+    dimensions=[Dimension(name="unifiedScreenName")],   # NOT pagePath — that's Data-API-only
+    limit=20,
+))
+```
+
+Realtime doesn't expose `pagePath` directly. Use `unifiedScreenName` (the page title) or `unifiedScreenClass`. To get path-level granularity in realtime, push a custom event with the path as a parameter, then query by `eventName` + that custom dimension.
+
+## Filters
+
+Same shape as `runReport` — `FilterExpression` / `Filter` blocks. Realtime supports `dimension_filter` and `metric_filter` but not the full set of dimensions / metrics; check the [Realtime API schema](https://developers.google.com/analytics/devguides/reporting/data/v1/realtime-api-schema) before writing complex filters.
+
+## Quotas — different from Data API
+
+Realtime has its own quota bucket. Defaults (2026):
+
+- 5,000 requests per project per day
+- 250 requests per property per day
+- 60 requests per minute per property
+
+For a live dashboard polling every 10s: that's 6 RPM, well within limits. For a hot incident where you want minute-by-minute data, you can poll up to 60x/min per property.
+
+## Don't poll faster than 30s
+
+The data window is the last 30 min. Polling faster than ~30s wastes quota without meaningful resolution change. For most "live" use cases, 60s polling is plenty.
+
+## Common gotchas
+
+| Issue | Why |
+|---|---|
+| `activeUsers` doesn't match the GA4 web UI's "Realtime" overview | The UI uses a slightly different window (~5 min default) and may include in-flight events not yet reportable via API. Web UI > API for instant-incidents. |
+| Empty rows on a busy site | Property may be using a different stream you didn't filter for. Add `Dimension(name="streamId")` to see splits. |
+| `400 INVALID_ARGUMENT: Realtime reports do not support dimension X` | Using a Data-API-only dimension (e.g. `pagePath`, `sessionSource`). Use a Realtime dimension. |
+| Latency between front-end event and Realtime visibility | ~10-30 seconds is normal. If >2 minutes, check the GA4 DebugView for event delivery issues. |
+
+## Related skills
+
+- `ga4-auth-setup` — prerequisite
+- `ga4-data-api-query` — for any window longer than 30 min
+- `ga4-common-reports` — for canonical reports (DAU/MAU/retention) which are NOT realtime-able


### PR DESCRIPTION
## Summary

Closes the scaffold decision in `claude-ek79.5` (under epic `claude-ek79` — Analytics MCP — Umami primary + GA4 fallback).

**Decision:** SaaS skill pack, **not** MCP wrapper.

**Rationale:** GA4 already has the Data API v1 + BigQuery export as native query surfaces. The leveraged value is teaching Claude the operational paths through them — query construction, metric/dimension compatibility, sampling thresholds, BQ event-schema SQL — not wrapping the API. The bead description literally said *"the skill teaches Claude HOW to use GA tools"* — that's the SaaS pack pattern.

## What's in the box

5 skills, intentionally — GA4's API surface is wide but operationally narrow. Better to ship 5 substantive skills than 30 boilerplate ones.

| Skill | Scope |
|---|---|
| `ga4-auth-setup` | OAuth user creds + service account paths. GA4 property-level access (the step everyone forgets). Secret hygiene. Common 401/403/INVALID errors. |
| `ga4-data-api-query` | `runReport` deep-dive — 12 metrics + 12 dimensions worth knowing, compatibility matrix, filters, multi-range comparison, pagination, sampling-detection. |
| `ga4-realtime-api` | `runRealtimeReport` — different schema, different limits, different quota bucket from Data API. Active-users / top events / geo-now recipes. |
| `ga4-common-reports` | Copy-paste recipes: DAU/MAU/WAU + stickiness ratio, top pages, channel attribution, weekly retention proxy, funnel conversion, geo+device split. |
| `ga4-bigquery-export` | Setup walkthrough, the events table schema, the UNNEST idiom for `event_params`, true cohort retention SQL, sessions-table denormalization, cost guardrails. |

## Why not 30 skills

The anthropic-pack pattern is 30 skills covering Claude API. That works because Claude API is a deep platform with many distinct production failure modes. GA4 is a deep platform too but the **read-side** API has narrow operational surface — most engineers want a tight set of "how do I query X" recipes, not 30 micro-skills. Future skills get added in response to real use cases (e.g. `ga4-measurement-protocol`, `ga4-consent-mode`, `ga4-attribution-modeling`) as they surface.

## What this unblocks in the epic

| Bead | Status after this PR |
|---|---|
| `claude-ek79.5` (scaffold decision) | ✅ Can close — scaffold is shipped |
| `claude-ek79.6` (Plugin: GA4 skill — query patterns + reporting templates) | Largely fulfilled by the 5 skills here; can scope down or close depending on what additional skills are wanted |
| `claude-ek79.7` (Plugin: validate + marketplace entry + README) | ✅ Fulfilled — catalog entry + README + validator pass included |

## Test plan

- [x] All 5 SKILL.md files validate (validator v7.0 / schema 3.6.0) — 70/B average (silver tier), no errors
- [x] `node scripts/sync-marketplace.cjs` regenerates catalog cleanly
- [x] `totalPlugins` 423 → 424, `skillsEnabled` 269 → 274 in metadata
- [x] Catalog entry inserted (alphabetical zone, near gamma-pack)
- [x] Honest self-grading: B/silver/70, not gold-inflated
- [ ] CI on this PR (will run on push)

## Honest grading note

The validator's remaining warnings are all advisory:
- `Magic number '123456789'` — the 9-digit example property ID, clearly contextual placeholders in code samples
- `Consider imperative language instead of 'you should/can/will'` — minor stylistic
- All `allowed-tools` already trimmed to least-privilege (Bash only — no Read/Write/Edit declared)

Could push to A/90 with another hour of polishing, but the leverage is in shipping substantive content + iterating against real use. Marking B/silver to set expectations honestly.

## License

MIT (consistent with the rest of the marketplace's SaaS packs).