### PR TITLE
feat(homepage): replace Level Up card with contact form (routes to forms-api → Slack)

### DIFF
--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -777,9 +777,52 @@ const currentPath = Astro.url.pathname;
           }
         });
 
+        const wireContact = (form) => form.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const btn = form.querySelector('button[type="submit"]');
+          const nameInput = form.querySelector('input[name="name"]');
+          const emailInput = form.querySelector('input[type="email"]');
+          const messageInput = form.querySelector('textarea[name="message"]');
+          const honey = form.querySelector('input[name="website"]');
+          const name = (nameInput?.value || '').trim();
+          const email = (emailInput?.value || '').trim();
+          const message = (messageInput?.value || '').trim();
+          if (name.length < 2) { flash(btn, 'Name required', false); return; }
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { flash(btn, 'Invalid email', false); return; }
+          if (message.length < 10) { flash(btn, 'Tell me more', false); return; }
+          flash(btn, 'Sending…', true, 0);
+          try {
+            const r = await fetch('/api/forms/contact', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                name,
+                email,
+                message,
+                source: form.dataset.contactForm || 'unknown',
+                website: honey?.value || ''
+              })
+            });
+            if (r.ok) {
+              flash(btn, "Got it — back within 24h!", true, 0);
+              if (nameInput) nameInput.value = '';
+              if (emailInput) emailInput.value = '';
+              if (messageInput) messageInput.value = '';
+            } else if (r.status === 429) {
+              flash(btn, 'Slow down', false);
+            } else {
+              const j = await r.json().catch(() => ({}));
+              flash(btn, j.error || 'Something went wrong', false);
+            }
+          } catch {
+            flash(btn, 'Network error', false);
+          }
+        });
+
         const init = () => {
           document.querySelectorAll('[data-signup-form]').forEach(wireSignup);
           document.querySelectorAll('[data-nomination-form]').forEach(wireNomination);
+          document.querySelectorAll('[data-contact-form]').forEach(wireContact);
         };
         if (document.readyState === 'loading') {
           document.addEventListener('DOMContentLoaded', init);

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -920,6 +920,148 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         }
 
         /* ========================================
+           LEVEL UP — contact form for Claude Code training
+           Replaces the old single-card Upwork section.
+           ======================================== */
+        .level-up-section {
+            padding: 4rem 2rem;
+            background: var(--surface);
+            border-top: 1px solid var(--border, var(--rule));
+            border-bottom: 1px solid var(--border, var(--rule));
+        }
+
+        .level-up-container {
+            max-width: 720px;
+            margin: 0 auto;
+        }
+
+        .level-up-header {
+            text-align: left;
+            margin-bottom: 2rem;
+        }
+
+        .level-up-title {
+            color: var(--text, var(--ink));
+            font-size: clamp(1.75rem, 3vw, 2.25rem);
+            font-weight: 700;
+            margin: 0 0 0.75rem;
+            letter-spacing: -0.02em;
+        }
+
+        .level-up-subtitle {
+            color: var(--text-2, var(--ink-2));
+            font-size: 1.05rem;
+            line-height: 1.55;
+            margin: 0;
+        }
+
+        .level-up-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            position: relative;
+        }
+
+        .level-up-row {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 1rem;
+        }
+
+        @media (min-width: 640px) {
+            .level-up-row {
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+
+        .level-up-field {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        .level-up-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--ink-3, var(--text-3));
+        }
+
+        .level-up-field input,
+        .level-up-field textarea {
+            background: var(--panel, var(--surface-2));
+            border: 1.5px solid var(--rule, var(--border));
+            border-radius: 8px;
+            padding: 0.75rem 0.9rem;
+            font-family: inherit;
+            font-size: 1rem;
+            color: var(--ink, var(--text));
+            outline: none;
+            transition: border-color 0.15s ease;
+            width: 100%;
+        }
+
+        .level-up-field textarea {
+            resize: vertical;
+            min-height: 110px;
+            font-family: 'Inter', system-ui, sans-serif;
+        }
+
+        .level-up-field input:focus,
+        .level-up-field textarea:focus {
+            border-color: var(--signal-edge, var(--accent));
+        }
+
+        .level-up-submit-row {
+            display: flex;
+            align-items: center;
+            gap: 1.25rem;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+        }
+
+        .level-up-submit {
+            background: var(--signal, var(--accent));
+            color: var(--bg, #0a0a0c);
+            border: none;
+            border-radius: 8px;
+            padding: 0.75rem 1.5rem;
+            font-family: inherit;
+            font-size: 0.95rem;
+            font-weight: 700;
+            cursor: pointer;
+            transition: opacity 0.15s ease;
+        }
+
+        .level-up-submit:hover {
+            opacity: 0.88;
+        }
+
+        .level-up-submit:disabled {
+            cursor: default;
+            opacity: 0.6;
+        }
+
+        .level-up-or {
+            color: var(--ink-3, var(--text-3));
+            font-size: 0.85rem;
+            margin: 0;
+        }
+
+        .level-up-or a {
+            color: var(--ink-link, var(--brand-blue));
+            text-decoration: underline;
+            text-underline-offset: 2px;
+        }
+
+        @media (max-width: 768px) {
+            .level-up-section {
+                padding: 3rem 1.5rem;
+            }
+        }
+
+        /* ========================================
            EMAIL SIGNUP SECTION
            ======================================== */
         .signup-section {
@@ -1696,27 +1838,45 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
     </section>
 
     <!-- Learn with Jeremy -->
-    <section class="products-section" id="training" style="padding: 3rem 2rem;">
-        <div style="text-align: center;">
-            <h2 class="section-title" style="margin-left: auto; margin-right: auto;">Level Up Your Claude Code Skills</h2>
-        </div>
-
-        <div class="products-grid" style="max-width: 600px;">
-            <div class="product-card service-card">
-                <h3>Claude Code Training</h3>
-                <div class="product-price">
-                    <span class="amount">Custom</span>
-                    <span class="label">per session</span>
-                </div>
-                <ul class="product-features">
-                    <li>Live screen-share with Jeremy</li>
-                    <li>Hands-on plugin dev training</li>
-                    <li>Custom workflow optimization</li>
-                    <li>Production deployment practices</li>
-                    <li>Ongoing support &amp; code reviews</li>
-                </ul>
-                <a href="https://www.upwork.com/services/product/lifestyle-to-learn-claude-code-cli-white-glove-training-to-build-with-ai-2016039265158461099?ref=project_share&tier=1" class="product-cta service-cta" target="_blank" rel="noopener noreferrer">Book Training Session</a>
+    <!-- Level Up — contact form for direct Claude Code training. Posts to
+         /api/forms/contact on the VPS forms-api (forwarded to the same Slack
+         destination as intentsolutions.io contact + partner forms). Upwork
+         link kept as secondary CTA below the form for self-serve booking. -->
+    <section class="level-up-section" id="training">
+        <div class="level-up-container">
+            <div class="level-up-header">
+                <h2 class="level-up-title">Level Up Your Claude Code Skills</h2>
+                <p class="level-up-subtitle">
+                    Live screen-share training with Jeremy. Plugin dev, workflow optimization, production deployment, ongoing code reviews. Tell me what you're working on — I'll get back within 24 hours.
+                </p>
             </div>
+
+            <form data-contact-form="level-up" class="level-up-form">
+                <div class="level-up-row">
+                    <label class="level-up-field">
+                        <span class="level-up-label">Name</span>
+                        <input type="text" name="name" required maxlength="120" autocomplete="name" />
+                    </label>
+                    <label class="level-up-field">
+                        <span class="level-up-label">Email</span>
+                        <input type="email" name="email" required maxlength="120" autocomplete="email" placeholder="you@company.com" />
+                    </label>
+                </div>
+                <label class="level-up-field">
+                    <span class="level-up-label">What are you working on?</span>
+                    <textarea name="message" required maxlength="2000" rows="4" placeholder="Stack, current pain points, what you'd want out of a session."></textarea>
+                </label>
+
+                <!-- honeypot — non-empty value silently 200s on the server -->
+                <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0;height:0;width:0;" />
+
+                <div class="level-up-submit-row">
+                    <button type="submit" class="level-up-submit">Send</button>
+                    <p class="level-up-or">
+                        Or <a href="https://www.upwork.com/services/product/lifestyle-to-learn-claude-code-cli-white-glove-training-to-build-with-ai-2016039265158461099?ref=project_share&amp;tier=1" target="_blank" rel="noopener noreferrer">book directly on Upwork</a>.
+                    </p>
+                </div>
+            </form>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary

The old "Level Up Your Claude Code Skills" section was a single Upwork-link card in a `max-width: 600px` container — looked orphaned and didn't capture leads. Replaces it with an inline contact form that posts to the existing VPS forms-api (same Slack-webhook destination as intentsolutions.io contact + partner forms).

## What changed

**`marketplace/src/pages/index.astro`**
- Section: lone `product-card` → contact form with name / email / message + honeypot
- Section ID still `#training` (anchor links preserved)
- Posts to `/api/forms/contact` with `source: "level-up"`
- Upwork link kept as secondary CTA underneath the submit button — small text "Or book directly on Upwork →"
- New scoped CSS block (`.level-up-section`, `.level-up-form`, etc.) — 720px max-width container, properly centered, focus-visible borders using design tokens (`--signal-edge`, `--ink-link`)

**`marketplace/src/layouts/BaseLayout.astro`**
- Added `wireContact` handler in the existing form-wire IIFE — mirrors `wireSignup` / `wireNomination` patterns exactly (validation, honeypot, rate-limit handling, button flash states)
- Validates: name ≥2 chars, email regex, message ≥10 chars
- On success: clears all 3 fields, shows "Got it — back within 24h!"
- Hooks via `data-contact-form` attribute (mirrors `data-signup-form` / `data-nomination-form`)

## Why reuse `/api/forms/contact` instead of new endpoint

`/srv/forms-api/server.mjs` on VPS already exposes `/api/forms/contact` taking `{name, email, message, source}` — used today by intentsolutions.io contact form. Same shape, same Slack webhook destination, same rate-limit bucket (lead-form: 3/60min per IP). Zero backend changes. The `source: "level-up"` payload differentiates the message in Slack.

If you want a dedicated `#intent-notifier` channel separate from the current operation-hired destination, that's a separate VPS-side change: add `SLACK_WEBHOOK_INTENT_NOTIFIER` to `/etc/intentsolutions/notify.sops.env`, update `server.mjs` to route by `source` field. Not in this PR — this PR just adds the form using the existing wiring.

## Test plan

- [x] `npm run build` clean (3869 pages, 40s)
- [x] Form HTML present in `dist/index.html` (verified `data-contact-form="level-up"`, the section title, the Upwork secondary link)
- [x] `wireContact` handler bundled (`/api/forms/contact` POST URL + `data-contact-form` selector both in JS bundle)
- [x] `validate-internal-links` → 527/527 valid (no regression)
- [ ] Manual smoke after merge: submit a test from prod homepage, confirm it lands in Slack with `source: "level-up"`

## Form security recap (inherited from forms-api)

- Honeypot `<input name="website">` — non-empty value → silent 200, no Slack post
- Per-IP rate-limit on VPS: 3 posts / 60 min on `/contact` (lead-form bucket)
- 2000-char message cap (client) + 8 KiB body cap (server)
- POST-only, JSON body required, validates email regex + non-empty name/message

## Sequencing

Independent of the previous merged PR #755 (Heat check). Doesn't touch the heat-check section or its data.