### PR TITLE
Add Quill — dual-AI MCP thinking partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ Community contributors make this marketplace better. Newest first.
 - [Numman Ali's Skills](https://github.com/numman-ali/n-skills) — Externally-synced community skills
 - [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) — Open-source security scanner for agent skills, plugins, and MCP servers (39+ rules, AST taint tracking, A-F grading)
 - [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
+- [Quill](https://github.com/YG3-ai/quill) — MCP thinking partner that pairs two AIs in dialogue, one drafting while the other critiques. Four skills: consult, perspective, assumptions, and mosaic. Requires both a Claude Pro and a ChatGPT Plus subscription.
 
 ---
 


### PR DESCRIPTION
## What this adds

Adds [Quill](https://github.com/YG3-ai/quill) to the Ecosystem section — an external dual-AI thinking-partner plugin by YG3-ai.

## Why Ecosystem, not a full plugin submission

Quill is an external plugin with its own repo and MCP server (`pip install quill-mcp`). It follows the same pattern as CCHub and Prism Scanner already listed in the Ecosystem section: external links to tools that extend the Claude Code ecosystem without being registered in this marketplace's catalog.

## What Quill does

Runs a second AI alongside Claude Code so you get an independent vantage point on your work. Four MCP skills:

- `/quill:consult` — stuck or frustrated, something feels off. Reframes before more code is written.
- `/quill:perspective` — exploring, wants a second angle without being stuck.
- `/quill:assumptions` — surfaces what Claude decided silently: hidden constraints, skipped options, implicit trade-offs.
- `/quill:mosaic` — high-stakes decisions. Both AIs draft independently, then critique each other.

Research-tested: 4/4 wins on decisions-under-tension vs single AI. Free on existing Claude Pro + ChatGPT Plus subscriptions — no extra API key needed.

## Change summary

One line added to `README.md` in the Ecosystem section. No new files, no plugin files, no frontmatter.
