### PR TITLE
docs(aar): allow AA-AACR session reviews in 000-docs/ + file the 2026-05-20→21 session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,12 @@ coverage/
 # doc-type for adversarial-technical decision records per Doc Filing Standard v4.3.
 # Pattern matches any *-AT-DECR-*.md at the root 000-docs/ level.
 !000-docs/*-AT-DECR-*.md
+# Session AARs — After-Action Comprehensive Reviews per Doc Filing Standard v4.3.
+# Session logs of multi-task work sessions (what was done, what's deferred, what
+# was explicitly NOT done). No inherent secrets risk; transparency is the point.
+# IMPORTANT: scrub tokens/webhooks before commit. If a session involved a leaked
+# secret in chat, redact it in the AAR (use `<REDACTED>` placeholder + flag for rotation).
+!000-docs/*-AA-AACR-*.md
 website/
 
 # Internal planning and research documents (do not commit to public repo)

--- a/000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md
+++ b/000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md
@@ -1,0 +1,214 @@
+# Session AAR — 2026-05-20 to 2026-05-21
+
+**Document type:** After-Action Comprehensive Review (AA-AACR)
+**Repo focus:** `jeremylongshore/claude-code-plugins-plus-skills` (primary), `intentsolutions-vps-runbook` (one PR)
+**Acting:** Jeremy Longshore + Claude (Opus 4.7, 1M context)
+**Status:** session closed; follow-ups deferred or filed
+
+---
+
+## Executive summary
+
+**11 PRs merged + 1 npm publish + 1 council DR filed + 1 SKILL.md mandate update + 5 cleanup beads filed (4 deferred to 2026-06-21) across two days.**
+
+Started as a homepage redesign + Kobiton catalog page task (the original user plan). Grew to encompass: CI tier system, partner-bar polish, redirect-domain logging on VPS, multi-site analytics report, LaTeX template bug fix, GA4 skill pack, homepage section rename, contact form wiring, beads hygiene + DoltHub backup, script-quality gates with deadline enforcer, npm CLI publish, ISEDC council session recovery, and a permanent fix to the `/exec-decision-council` skill's storage contract.
+
+---
+
+## Stream 1 — Homepage + Kobiton catalog (the original ask)
+
+| PR   | What                                                                                                                                                                                                                                                                 |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #750 | `feat(catalog): kobiton/automate — internal landing page via external sync` — synced kobiton/automate via `sources.yaml` (Skyvern pattern), license-gate verified MIT, spotlight pluginSlug flipped to internal `/plugins/kobiton-automate`                          |
+| #751 | `feat(hero): two-column layout, exit partner bar from hero, scoped yellow fixes` — Option B per designer spec: CSS grid 58fr/42fr ≥1024px, stat block 2×2 in right column, PartnerBar exits hero as full-bleed band, light-theme yellow legibility (`--signal-deep`) |
+
+Beads closed: `claude-q2kh` (kobiton catalog), `claude-8y1e` (hero), `claude-4yni` (superseded partner-bar dupe).
+
+---
+
+## Stream 2 — CI tier system + flaky test fix
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| #752 | `fix(ci): tier heavy E2E tests + fix false-positive broken-image check` — extracted `playwright-tests` + `production-e2e` into new `.github/workflows/e2e-tests.yml` with narrow `paths:` (only UI changes fire heavy tests). PartnerBar `loading="lazy"` → `eager` for above-the-fold logos (fixes `naturalWidth=0` false positive on hidden display:none variants). Test also patched defensively to skip hidden imgs. |
+
+Validate-plugins runtime: ~13m → ~3m for catalog-only PRs.
+
+---
+
+## Stream 3 — Partner badge + per-partner sizing
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                                      |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #753 | `feat(partners): kobiton readme badge + per-partner logoHeight sizing` — added "Sponsor: Kobiton" shields.io badge in README (matching Nixtla's pattern, Kobiton brand blue `#0487D9`). Added optional `logoHeight` field to `partners.json` projected as `--partner-logo-height` CSS var; Nixtla set to `20` to balance against Kobiton's 3.3:1 aspect ratio dominating. |
+
+---
+
+## Stream 4 — Caddy redirect-domain logging (cross-repo)
+
+| Repo                          | PR  | What                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------------------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `intentsolutions-vps-runbook` | #22 | `docs(caddy): wire access logging for redirect domains` — added `log` directive to the Caddyfile redirect block on the VPS so `claudecodeplugins.io` / `claudecodeskills.io` / `claudecoworkskills.io` hits land in `/var/log/caddy/redirects-access.log`. Live-applied + verified. Gotcha doc: pre-create the log file `caddy:caddy 600` ownership before reload, or systemctl gets stuck in `reloading` state. |
+
+---
+
+## Stream 5 — Multi-site analytics report (no PR — operational)
+
+- Pulled Umami stats for all 5 IS sites (tonsofskills.com, jeremylongshore.com, startaitools.com, intentsolutions.io, diagnosticpro.io) via direct REST (MCP 404 diagnosed: `umami-mcp-server@2.0.0` double-appends `/api`).
+- tonsofskills.com lifetime: 7,856 unique visitors / 8,819 sessions / 57,806 pageviews. **54% from Singapore — likely cloud-scraper bots; real human ≈4,000.**
+- Generated MD → PDF (initially plain pandoc due to skill bug, then v2 via fixed template).
+- Emailed to `jeremy@intentsolutions.io` × 2 (v1 + v2 partner-grade after the skill fix).
+
+---
+
+## Stream 6 — whiteglove-pdf template bug fix
+
+| Bead               | What                                                                                                                                                                                                                                                                                                                                      |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPS-so3` (CLOSED) | `\AtBeginEnvironment{longtable}` injection caused `Missing \endgroup inserted` on multi-table docs (lost a 7-page analytics PDF render). Fixed by swapping to `\BeforeBeginEnvironment` / `\AfterEndEnvironment` (run outside the env group). 11-page partner-grade PDF re-rendered successfully with 27 auto-numbered "Table N." labels. |
+
+Lives at `~/.claude/skills/whiteglove-pdf/templates/default.tex` — not in any git repo per Jeremy's "local skills not git-tracked" convention.
+
+---
+
+## Stream 7 — ga4-pack (5-skill SaaS pack)
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                           |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #754 | `feat(catalog): ga4-pack — 5-skill starter pack for Google Analytics 4` — closed `claude-ek79.5` scaffold decision: SaaS skill pack, NOT MCP wrapper. Five skills: `ga4-auth-setup`, `ga4-data-api-query`, `ga4-realtime-api`, `ga4-common-reports`, `ga4-bigquery-export`. Validator: 70/B (silver). Intentional cap at 5 — operationally narrow API surface. |
+
+---
+
+## Stream 8 — Heat check homepage section (the "Start here" kill)
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #755 | `feat(homepage): replace 'Start here' starter pack with 'Heat check' editorial picks` + included: wrapped `web-analytics` as a real marketplace plugin (was local-skill-only; the heat-check `/plugins/web-analytics` link was 404ing), removed the Pre-Built AI Agents Gumroad section. **Heat check 6 picks:** code-cleanup, web-analytics, kobiton-automate, excel-analyst-pro, slack-channel (external link to upstream `jeremylongshore/claude-code-slack-channel`), gastown-viewer-intent (external link to `intent-solutions-io/gastown-viewer-intent`). New schema field: `external_url` for entries that aren't marketplace plugins. Rotation cadence: "On vibes (and install velocity once Phase 5B telemetry lands)." |
+
+Heat check section title + framing chosen for personality + voice (not "Start here" / category-coverage).
+
+---
+
+## Stream 9 — Level Up contact form
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #756 | `feat(homepage): replace Level Up Upwork-only card with contact form (routes to forms-api → Slack)` — replaced lone Upwork link card with name/email/message inline contact form. Posts to existing `/api/forms/contact` on VPS forms-api (same Slack webhook destination as intentsolutions.io contact + partner forms). Source field: `"level-up"`. Honeypot field, server-side rate-limit, client-side validation. Upwork CTA kept as secondary inline link beneath the form. |
+
+---
+
+## Stream 10 — Beads hygiene + DoltHub backup
+
+- **Master plan find:** `claude-xx4k` epic (DR-267 repo sequencing council) — 30 sub-beads, comprehensive. Session 1 done; Sessions 2-5 ready.
+- **Dupes closed (background-task double-fires):** `claude-yi11`, `claude-va63`, `claude-m4ce`
+- **Engineer Design Diagram epic closed:** `claude-2rb6` + all 11 children — skill already built at `~/.claude/skills/engineer-design-diagram/` v0.2.0 (bead tree was just out of sync)
+- **DoltHub backup wired for OPS beads** (`~/.beads`): joined the shared bucket `jeremylongshore/beads-claude-code-plugins` (5 other beads instances already use it). 15m auto-sync interval on writes. Initial 2.2 MB sync completed in 3.8s.
+- **OPS-y6h closed:** VPS dev env Phase D done (the beads dolt remote was the missing piece)
+- **OPS-0ko closed:** gastownhall/beads SKILL.md upstream PR — positioning play executed in full; upstream maintainer triage isn't our deliverable
+
+---
+
+## Stream 11 — Script-quality gates + deadline enforcer
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #757 | `feat(ci): close script-quality blind spots` (later: `+ deadline enforcer + flip Gate 1 to report-only`) — **4 gates added:** (1) widened JS/TS test loop from `plugins/mcp/*` to `plugins/*/*` — caught a previously-invisible test failure on first run (`web-to-github-issue/tests/parser.test.js:651`). (2) `shellcheck-skills` job. (3) `skill-codeblock-syntax` lint of fenced python/bash/js/ts blocks across 3043 SKILL.md. (4) `typescript-coverage-audit` flagging .ts files in plugins/ without enclosing `typecheck` script. **All 4 in report-only with `REPORT-ONLY-UNTIL: 2026-06-21` markers.** **Plus `scripts/check-ci-deadlines.py`** that fails the build when any marker lapses — the forcing function so report-only doesn't rot. |
+
+**4 cleanup beads deferred to 2026-06-21:**
+
+| Bead               | Gate                                                                            |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `claude-d1gm` (P2) | Widened test loop — fix existing failures, flip to blocking                     |
+| `claude-lrhq` (P2) | Shellcheck — fix `security_scan.sh` (Python misnamed as .sh) + ~316 other files |
+| `claude-hy8p` (P3) | SKILL.md codeblock syntax errors                                                |
+| `claude-6f4o` (P3) | TypeScript coverage — add typecheck scripts to 9 packages                       |
+
+---
+
+## Stream 12 — ccpi v2.0.3 npm publish
+
+- Local was 2.0.3, npm latest was 2.0.0 (3 patch bumps had accumulated without publishing).
+- Token-leaked-to-chat caveat noted: `npm_<REDACTED-ROTATE-THIS-TOKEN>` — **needs rotation**.
+- Published via ephemeral `/tmp/ccpi-publish.npmrc` + `NPM_TOKEN` env var; .npmrc deleted, env unset afterwards.
+- npm latest is now 2.0.3.
+
+---
+
+## Stream 13 — Issue #710 ISEDC council recovery + skill mandate
+
+The longest sub-thread. Sequence of discovery:
+
+1. User asked "who is citing me?" — pointed at `gh issue #710` (Luna Prompts / skillnote interop pitch)
+2. Found a 2026-05-16 ISEDC council had been convened on it — 7-seat adversarial, 27-page PDF emailed, but the source MDs were lost to `/tmp` cleanup
+3. Discovered `sickn33/antigravity-awesome-skills#596` (38k★) explicitly cites **"Jeremy Longshore-style discovery affordance"** by name as the pattern they implemented — independent corroboration of standards-author signal
+4. Reconstructed the council DR partially from Gmail email body + bead notes (verbatim per-seat positions still in the PDF, recoverable via pdftotext if Gmail attachment is saved locally)
+5. Built `~/.claude/skills/exec-decision-council/sessions/` durability system:
+   - `metadata.json` + `session.jsonl` (rich structured records — 10 record kinds, multi-paragraph nested fields) + `decision-record.md` (derived) + `inputs/` + `outputs/`
+   - SKILL.md v1.0 → v1.1.0: new Step 9 (open sessions dir BEFORE convening), Step 10 (append-as-you-go JSONL), Step 11 (generate MD from JSONL), **Step 12 — MANDATORY `/doc-filing` final step**
+   - 3 new anti-patterns documented (no `/tmp/` working dir, no MD without JSONL, no skipping `/doc-filing`)
+
+| PR   | What                                                                                                                                                                                                                                                                                                                                                     |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #759 | `docs(council): file ISEDC #710 spec-mint decision record + fix .gitignore` — filed `000-docs/677-AT-DECR-isedc-710-spec-mint-2026-05-16.md` (partial recovery) + fixed `.gitignore` bug where `**/000-docs/` matched root (defeating `!000-docs/...` re-includes). Future `/doc-filing` invocations now land tracked AT-DECR docs without `git add -f`. |
+
+**Final acting-head-of-board call on #710 (2026-05-21):** Path 3 EXTENDED indefinitely. No reply posted. Reread confirmed latentloop07 did not ask a hard question; both `?` lines are soft "want to pin/mint?" framings, and the same comment commits them to ship the adapter regardless. Self-driving counterparty. **Reopen triggers narrowed:** adapter PR lands / explicit hard question / competing aggregator asserts spec-author claim. **Natural attrition: 2026-07-01.**
+
+Bead `claude-t11v` status: deferred indefinitely with the new triggers; `claude-djcb` linked.
+
+---
+
+## Anthropic-partner-silence respected throughout
+
+Per memory `anthropic-partner-silence-2026-05-19`: NO public-facing brand advertising of the Anthropic partnership in any of today's work. All technical product surfaces (schemas, MCP, marketplace interop) were free game — engaged publicly there.
+
+---
+
+## Cumulative artifacts produced this session
+
+| Type                    | Count                                | Notes                                                                                                                                    |
+| ----------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| PRs merged              | **10** (this repo) + **1** (runbook) | #750, #751, #752, #753, #754, #755, #756, #757, #759 + runbook #22                                                                       |
+| npm publishes           | **1**                                | `@intentsolutionsio/ccpi@2.0.3`                                                                                                          |
+| Council DRs filed       | **1**                                | `000-docs/677-AT-DECR-...` (partial recovery)                                                                                            |
+| SKILL.md updates        | **1**                                | `~/.claude/skills/exec-decision-council/SKILL.md` v1.0 → v1.1.0                                                                          |
+| New helper scripts      | **3**                                | `scripts/check-ci-deadlines.py`, `scripts/lint-skill-codeblocks.py`, `scripts/audit-typescript-coverage.py`                              |
+| Beads closed            | **~10**                              | claude-q2kh, claude-8y1e, claude-4yni, claude-yi11, claude-va63, claude-m4ce, claude-2rb6 (+ 11 children), OPS-y6h, OPS-0ko, OPS-so3     |
+| Beads filed/deferred    | **5**                                | claude-d1gm, claude-lrhq, claude-hy8p, claude-6f4o (cleanup deadlines 2026-06-21), claude-t11v (already existed; defer triggers updated) |
+| New marketplace plugins | **2**                                | `ga4-pack` (5 skills), `web-analytics` (1 skill, 9 agents — wrap of local skill)                                                         |
+
+---
+
+## Outstanding items (carried forward)
+
+- **NPM token rotation:** `npm_<REDACTED-ROTATE-THIS-TOKEN>` was pasted in chat. Rotate at `npmjs.com/settings/intentsolutions-io/tokens` whenever convenient.
+- **4 cleanup beads** auto-resurface 2026-06-21 (Gate 1-4 flip to blocking). Deadline enforcer fails the build if not actioned by then.
+- **Issue #710 / `claude-t11v`** — deferred indefinitely with named reopen triggers; natural-attrition 2026-07-01.
+- **Verbatim recovery of #710 council DR** — save the Gmail attachment `isedc-710-decision-record.pdf` to `~/.claude/skills/exec-decision-council/sessions/2026-05-16-issue-710-spec-mint/inputs/`, then `pdftotext` to populate the ~35 missing `seat-position` records in `session.jsonl`. The 27-page PDF is the canonical full deliberation.
+- **Repo sequencing master plan `claude-xx4k`** — Sessions 2-5 still open (Enterprise Evidence Pack, Standards + community surface, Supply chain hardening, Validator integrity + comp positioning). Not in scope for this session.
+- **Yellow-on-light sweep `claude-zold`** — out-of-scope follow-up from PR #751.
+- **Skill-creator update bead `claude-7yz...` (or similar)** — flagged by user, scope TBD.
+
+---
+
+## What this session did NOT do
+
+- Did NOT reply to GitHub issue #710 (intentional — let-it-sit)
+- Did NOT commit to schema 3.7.0 timeline for latentloop07's asks
+- Did NOT accept the spec-mint co-mint framing
+- Did NOT list skillnote in ccpi
+- Did NOT advertise the Anthropic partnership publicly (silence memory respected)
+- Did NOT flip any of the 4 new CI gates to blocking (all start report-only with deadline)
+- Did NOT touch jeremylongshore.com (per "stays on Netlify/Firebase" memory)
+- Did NOT run a new ISEDC council session (recovered the prior one + built the durability mechanism so future ones don't lose data the same way)
+
+---
+
+## Filing provenance
+
+This document filed via `/doc-filing` skill (Document Filing Standard v4.3) on 2026-05-21.
+
+**Source:** chat transcript of the 2026-05-20 → 2026-05-21 session.
+**Storage:** `000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md` (local; NOT git-tracked unless `.gitignore` allowlist extended to include `*-AA-AACR-*.md` — currently only `000-*` / `6767*` / spec snapshots / `*-AT-DECR-*` are re-included).
+**Backup:** Daily Borg via `borg-backup.timer` at 02:00 covers `~/000-projects/` including this `000-docs/`.
+
+If long-term audit visibility for session AARs in git is wanted, extend `.gitignore` line 92 (the AT-DECR allowlist) with a sibling rule for AA-AACR. Not done in this PR to keep scope tight; flag for a follow-up if the durability isn't enough.


### PR DESCRIPTION
## Summary

1. **Extends `.gitignore` allowlist** with `!000-docs/*-AA-AACR-*.md` so After-Action Comprehensive Reviews (session AARs per Doc Filing Standard v4.3) land in git when filed via `/doc-filing`. Symmetric to the `*-AT-DECR-*.md` rule added in PR #759.
2. **Files the comprehensive AAR for this session** (2026-05-20 → 2026-05-21) at `000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md`.

## Why no inherent secrets risk

Session AARs are operational logs: what PRs merged, what beads closed, what's deferred, what was explicitly NOT done. The transparency IS the point. But the allowlist comment in `.gitignore` calls out the obvious failure mode:

> *"IMPORTANT: scrub tokens/webhooks before commit. If a session involved a leaked secret in chat, redact it in the AAR (use `<REDACTED>` placeholder + flag for rotation)."*

Applied that to 678 before commit — one npm token had been pasted in chat earlier in the session. Replaced with `npm_<REDACTED-ROTATE-THIS-TOKEN>` placeholder. The session note about needing to rotate is preserved; the actual token value is gone.

## What the AAR captures

| Section | Highlights |
|---|---|
| Exec summary | 11 PRs merged + 1 npm publish + 1 council DR filed + 1 SKILL.md mandate update + 5 cleanup beads filed |
| 14 work streams | Homepage / Kobiton, CI tier, partner-bar, Caddy logging, analytics report, whiteglove-pdf bug, ga4-pack, Heat check, Level Up form, beads + DoltHub, script-quality gates, ccpi publish, ISEDC recovery, citation discovery |
| Outstanding items | npm token rotation, 4 cleanup beads' deadlines (2026-06-21), issue #710 deferred-indefinitely state, repo sequencing master plan still open |
| "Did NOT do" | No #710 reply, no spec-mint accepted, no Anthropic-partner brand advertising — explicit negative-space for future readers |

## Historical AARs (NOT included in this PR)

9 existing AA-AACR files now allowlist-eligible but **left untracked**:

```
000-docs/182-AA-AACR-lumera-agent-memory-implementation.md
000-docs/208-AA-AACR-beads-aar-2025-12.md
000-docs/236-AA-AACR-phase-1-ci-green.md
000-docs/237-AA-AACR-phase-2-foundation-clean.md
000-docs/242-AA-AACR-cli-v2-aar-2025.md
000-docs/243-AA-AACR-phase-4-aar.md
000-docs/244-AA-AACR-phase-5-aar.md
000-docs/246-AA-AACR-phase-6-aar.md
000-docs/251-AA-AACR-metrics-canonicalization-aar.md
```

These predate the redaction-discipline + sit in `?? untracked` after the allowlist change. Each needs manual secrets-review before `git add`. Recommended follow-up: a separate PR that audits + commits these one-by-one (or batches the clean ones).

## Verification

```
$ git check-ignore -v 000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md
.gitignore:98: !000-docs/*-AA-AACR-*.md   000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md
(exit 1 — NOT ignored ✓)

$ grep -E "npm_[A-Za-z0-9]{20,}|hooks\.slack\.com/services/[A-Z]" \
    000-docs/678-AA-AACR-session-2026-05-20-to-2026-05-21.md
(no matches — secrets-shaped strings absent ✓)
```

## Related caveat — already-merged PR #759 (`677-AT-DECR-...`)

The earlier AT-DECR doc (`677-AT-DECR-isedc-710-spec-mint-2026-05-16.md`, merged in #759) contains the council bg-check finding that named two individuals + a moonlighting context. These were the council's *adversarial-review findings*, not gossip — Jeremy reviewed the content before merge and authorized publication via the council skill's "for future readers" mandate. Noting here for the audit trail; no action needed unless Jeremy wants a follow-up to soften the wording in a future commit.