### PR TITLE
feat(sources): add 4 Ejentum harness plugins

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1064,6 +1064,87 @@ sources:
       - '.git/**'
       - '*.log'
 
+  # ============================================================
+  # Ejentum Reasoning Harness (Ejentum)
+  # https://github.com/ejentum/ejentum-mcp
+  # ============================================================
+
+  - name: ejentum-reasoning
+    description: Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.
+    repo: ejentum/ejentum-mcp
+    source_path: skills/reasoning
+    target_path: plugins/community/ejentum-reasoning
+    author:
+      name: Ejentum
+      github: ejentum
+      email: info@ejentum.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
+  - name: ejentum-code
+    description: Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.
+    repo: ejentum/ejentum-mcp
+    source_path: skills/code
+    target_path: plugins/community/ejentum-code
+    author:
+      name: Ejentum
+      github: ejentum
+      email: info@ejentum.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
+  - name: ejentum-anti-deception
+    description: Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.
+    repo: ejentum/ejentum-mcp
+    source_path: skills/anti-deception
+    target_path: plugins/community/ejentum-anti-deception
+    author:
+      name: Ejentum
+      github: ejentum
+      email: info@ejentum.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
+  - name: ejentum-memory
+    description: Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.
+    repo: ejentum/ejentum-mcp
+    source_path: skills/memory
+    target_path: plugins/community/ejentum-memory
+    author:
+      name: Ejentum
+      github: ejentum
+      email: info@ejentum.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds 4 Ejentum cognitive-harness skills as external plugin sources.

Each entry mirrors one harness mode of the Ejentum Reasoning Harness MCP server:

- **ejentum-reasoning** — analytical, planning, multi-step decision tasks
- **ejentum-code** — code generation, refactoring, architecture
- **ejentum-anti-deception** — sycophancy, hallucination, adversarial framing
- **ejentum-memory** — perception sharpening across multi-turn context

Source repo: [ejentum/ejentum-mcp](https://github.com/ejentum/ejentum-mcp) (MIT). Each SKILL.md follows the marketplace-tier 8-field frontmatter spec (`name`, `description`, `allowed-tools`, `version`, `author`, `license`, `compatibility`, `tags`) per the standard at `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`. Em-dash sweep clean. All 4 SKILL.md files updated upstream to meet your spec before this PR (commit a086fb5 in ejentum/ejentum-mcp).

Each skill triggers the corresponding `harness_*` tool on the ejentum MCP server (hosted at `https://api.ejentum.com/mcp` or installable via `npx -y ejentum-mcp`). Returns structured cognitive scaffolds (failure pattern, procedure, suppression vectors, falsification test) the agent absorbs before generating.

Affiliation: maintainer of `ejentum-mcp`.