### PR TITLE
chore(ci): add eslint + prettier as blocking gates (PR A)

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -879,3 +879,46 @@ jobs:
         # uncovered package.json has a `typecheck` script added.
         run: |
           python3 scripts/audit-typescript-coverage.py --report-only --root plugins
+
+  eslint-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install root dev dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+
+      # BLOCKING — codebase passed baseline at PR #764 (2026-05-22).
+      # No report-only crutch: external PRs that introduce eslint errors fail here.
+      - name: Run eslint
+        run: pnpm lint:root
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install root dev dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+
+      # BLOCKING — 5 files autofixed on PR #764 baseline (2026-05-22).
+      # No report-only crutch: external PRs with formatting drift fail here.
+      # Run `pnpm format` locally to fix before pushing.
+      - name: Check prettier formatting
+        run: pnpm format:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,10 @@ full `.forge/` audit trail. JRig itself got real TypeScript code
   page renders `plugin.jrig?.verified` as a green "JRig-Verified · N/7
   layers" pill; (2) Freshie schema migration adds `jrig_passed`,
   `jrig_tier_blocked`, `jrig_baseline_delta` columns to `skill_compliance`
-  + new `forge_proofs` table for per-plugin verification evidence;
-  (3) new build step `enrich-jrig-data.mjs` reads `forge_proofs` via
-  sqlite3 CLI, writes `marketplace/src/data/jrig-data.json` for the
-  detail-page overlay. Build pipeline now 7 steps (added `jrig:enrich`).
+  - new `forge_proofs` table for per-plugin verification evidence;
+    (3) new build step `enrich-jrig-data.mjs` reads `forge_proofs` via
+    sqlite3 CLI, writes `marketplace/src/data/jrig-data.json` for the
+    detail-page overlay. Build pipeline now 7 steps (added `jrig:enrich`).
 - **Per-plugin `/plugins/<name>/verification` route** (#702) — 316-line
   Astro page that the JRig-Verified badge clicks through to. Two
   states: VERIFIED (shows passing-layer fraction, baseline delta, 7-layer
@@ -106,7 +106,7 @@ full `.forge/` audit trail. JRig itself got real TypeScript code
   `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md` brought into
   alignment with the validator's actual schema 3.3.1 behavior: 8-field
   enterprise required set (`name, description, allowed-tools, version,
-  author, license, compatibility, tags`) is the IS marketplace tier
+author, license, compatibility, tags`) is the IS marketplace tier
   requirement; missing any of these = ERROR (not warning). The 3.0.0–
   3.2.0 demotion-to-polish direction was reverted in 3.3.0; the doc never
   absorbed that revert until this PR. `allowed-tools` documented to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,10 @@ j-rig eval <skill-dir> --models haiku,sonnet,opus --db freshie/inventory.sqlite
 
 ## Two Catalog System — Critical
 
-| File | Purpose | Edit? |
-|---|---|---|
-| `.claude-plugin/marketplace.extended.json` | Source of truth | **Yes** |
-| `.claude-plugin/marketplace.json` | CLI-compatible, auto-generated | **Never** |
+| File                                       | Purpose                        | Edit?     |
+| ------------------------------------------ | ------------------------------ | --------- |
+| `.claude-plugin/marketplace.extended.json` | Source of truth                | **Yes**   |
+| `.claude-plugin/marketplace.json`          | CLI-compatible, auto-generated | **Never** |
 
 `pnpm run sync-marketplace` regenerates all three derived artifacts: `marketplace.json`, any missing `plugins/**/package.json` files, and the `README.md` AUTO-TOC block. The pre-commit hook runs this automatically when `marketplace.extended.json` is staged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to the Claude Code Plugins marketpla
 > **→ [`000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)** — the **Global Master Standard for Claude Skills** (v3.6.0, schema 3.6.0).
 >
 > It documents:
+>
 > - The **8 marketplace-tier required frontmatter fields** (vs Anthropic's 2-field minimum)
 > - The **7 required body sections** (`## Overview`, `## Prerequisites`, `## Instructions`, `## Output`, `## Error Handling`, `## Examples`, `## Resources`)
 > - The **100-point rubric** the validator scores against

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "format:check": "prettier --check 'scripts/**/*.{js,mjs,cjs,ts}' '*.{js,mjs,cjs,ts,json,md,yml,yaml}' 'packages/cli/src/**/*.{ts,json}'",
+    "format": "prettier --write 'scripts/**/*.{js,mjs,cjs,ts}' '*.{js,mjs,cjs,ts,json,md,yml,yaml}' 'packages/cli/src/**/*.{ts,json}'",
     "prepare": "husky"
   },
   "keywords": [

--- a/scripts/check-performance.mjs
+++ b/scripts/check-performance.mjs
@@ -161,20 +161,31 @@ async function analyzeBundleSize() {
 
 // Mobile budget: max gzipped HTML size for /explore and /skills pages (no lazy-fetched data)
 const MOBILE_BUDGETS = {
-  exploreHtml: 250 * 1024,  // 250 KB gzipped
-  skillsHtml: 250 * 1024,   // 250 KB gzipped
+  exploreHtml: 250 * 1024, // 250 KB gzipped
+  skillsHtml: 250 * 1024, // 250 KB gzipped
 };
 
 async function checkMobileBudgets() {
   log('\n=== Mobile Performance Budget Validation ===\n', 'bold');
   log('Mobile budgets measure only the gzipped HTML for /explore and /skills.', 'blue');
-  log('Lazy-fetched data files (/data/*.json) are excluded — they load after first paint.\n', 'blue');
+  log(
+    'Lazy-fetched data files (/data/*.json) are excluded — they load after first paint.\n',
+    'blue',
+  );
 
   const violations = [];
 
   const targets = [
-    { label: '/explore', file: path.join(DIST_DIR, 'explore', 'index.html'), budget: MOBILE_BUDGETS.exploreHtml },
-    { label: '/skills', file: path.join(DIST_DIR, 'skills', 'index.html'), budget: MOBILE_BUDGETS.skillsHtml },
+    {
+      label: '/explore',
+      file: path.join(DIST_DIR, 'explore', 'index.html'),
+      budget: MOBILE_BUDGETS.exploreHtml,
+    },
+    {
+      label: '/skills',
+      file: path.join(DIST_DIR, 'skills', 'index.html'),
+      budget: MOBILE_BUDGETS.skillsHtml,
+    },
   ];
 
   for (const target of targets) {
@@ -186,11 +197,22 @@ async function checkMobileBudgets() {
     const raw = fs.statSync(target.file).size;
     if (gz <= target.budget) {
       const remaining = target.budget - gz;
-      log(`  ✓ ${target.label}: ${formatBytes(gz)} gzipped (under budget by ${formatBytes(remaining)})`, 'green');
+      log(
+        `  ✓ ${target.label}: ${formatBytes(gz)} gzipped (under budget by ${formatBytes(remaining)})`,
+        'green',
+      );
     } else {
       const overage = gz - target.budget;
-      log(`  ✗ ${target.label}: ${formatBytes(gz)} gzipped — over ${formatBytes(target.budget)} budget by ${formatBytes(overage)}`, 'red');
-      violations.push({ check: `Mobile HTML ${target.label}`, budget: formatBytes(target.budget), actual: formatBytes(gz), overage: formatBytes(overage) });
+      log(
+        `  ✗ ${target.label}: ${formatBytes(gz)} gzipped — over ${formatBytes(target.budget)} budget by ${formatBytes(overage)}`,
+        'red',
+      );
+      violations.push({
+        check: `Mobile HTML ${target.label}`,
+        budget: formatBytes(target.budget),
+        actual: formatBytes(gz),
+        overage: formatBytes(overage),
+      });
     }
   }
 

--- a/scripts/sync-marketplace.cjs
+++ b/scripts/sync-marketplace.cjs
@@ -24,10 +24,10 @@ const DISALLOWED_KEYS = new Set([
   // Marketplace-website-only display fields. Added 2026-05-07 (Phase 4 of the
   // "Use the Printing Press to Learn" plan). The website renders these from
   // marketplace.extended.json; the CLI marketplace.json never sees them.
-  'tagline',           // 6–10 word NOI-framed outcome subtitle
-  'jrig',              // { verified, layers_passed, total_layers, baseline_delta }
-  'generated',         // boolean — set by /skill-creator --forge in plugin.json AND mirrored to marketplace.extended.json
-  'author_type',       // 'human' | 'forge' — provenance flag, ditto
+  'tagline', // 6–10 word NOI-framed outcome subtitle
+  'jrig', // { verified, layers_passed, total_layers, baseline_delta }
+  'generated', // boolean — set by /skill-creator --forge in plugin.json AND mirrored to marketplace.extended.json
+  'author_type', // 'human' | 'forge' — provenance flag, ditto
 ]);
 
 if (!fs.existsSync(extendedPath)) {


### PR DESCRIPTION
## Summary

PR A of the cleanup sequence. Two new required CI jobs added to `validate-plugins.yml` — both **blocking** from day 1, no report-only crutch. External PRs that fail either gate cannot merge until they fix the issue.

## Why blocking immediately

Baseline scan against `main` passes clean:
- **eslint**: 0 errors
- **prettier**: 5 files autofixed in this PR (CHANGELOG.md, CLAUDE.md, CONTRIBUTING.md, scripts/check-performance.mjs, scripts/sync-marketplace.cjs)

Zero-risk additions. Internal + external code held to the same bar.

## Changes

- 5 files prettier-autofixed
- `package.json` — added `format` script (prettier --write) for local fix convenience. `format:check` (the CI gate) was already present.
- `.github/workflows/validate-plugins.yml` — two new jobs: `eslint-check` + `format-check`. Both BLOCKING, no `|| true`.

## After merge: branch protection update

The two new jobs need to be added to the required-checks list on `main`:

```bash
gh api -X PUT repos/jeremylongshore/claude-code-plugins-plus-skills/branches/main/protection/required_status_checks \
  -F 'strict=false' \
  -f 'contexts[]=validate' \
  -f 'contexts[]=marketplace-validation' \
  -f 'contexts[]=eslint-check' \
  -f 'contexts[]=format-check'
```

(Run separately after merge — branch protection edits don't fit in the PR diff.)

## Cleanup sequence ahead

- **PR A (this)** — eslint + prettier blocking
- **PR B (next)** — ruff cleanup on 730 baseline violations + blocking
- **PR C (after)** — markdownlint setup + cleanup + blocking
- Then: flip shellcheck / codeblock-syntax / ts-coverage / widened-test-loop from report-only to blocking (post-cleanup of underlying violations)

## Test plan

- [x] `pnpm format:check` passes locally
- [x] `pnpm lint:root` passes locally
- [x] YAML syntax validated on the workflow
- [ ] CI green on `validate`, `marketplace-validation`, and the two new jobs

- Jeremy Longshore
intentsolutions.io