### PR TITLE
chore(ci): ts-coverage flip to blocking + codeblock TS cleanup (PR F)

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -873,12 +873,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      # REPORT-ONLY-UNTIL: 2026-06-21 (typescript-coverage-audit — bead claude-6f4o)
+      # BLOCKING — codebase passed baseline at PR #769 (2026-05-23).
+      # All 142 .ts files in plugins/ covered by a typecheck script in
+      # their enclosing package.json. Audit script excludes **/assets/**
+      # (illustrative skill-doc examples) and **/.vitepress/** (docs-site
+      # config, not part of the npm package).
       - name: Audit TypeScript files for typecheck coverage
-        # REPORT-ONLY for initial rollout — flip to blocking once each
-        # uncovered package.json has a `typecheck` script added.
         run: |
-          python3 scripts/audit-typescript-coverage.py --report-only --root plugins
+          python3 scripts/audit-typescript-coverage.py --root plugins
 
   eslint-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -27,6 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        # fetch-depth=2 + persist-credentials=true required for the
+        # "Catalog format guard" step below — it runs `git fetch origin
+        # <base_ref>` to compare against the PR's merge base. Without
+        # credentials persisted, that fetch errors with "could not read
+        # Username for github.com". Default actions/checkout@v6 behavior
+        # depth=1 doesn't include any history to compare against either.
+        with:
+          fetch-depth: 2
+          persist-credentials: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/plugins/mcp/ai-experiment-logger/package.json
+++ b/plugins/mcp/ai-experiment-logger/package.json
@@ -12,7 +12,8 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "web": "node dist/web/server.js",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "echo \"No tests yet\" && exit 0",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "mcp",

--- a/plugins/mcp/conversational-api-debugger/package.json
+++ b/plugins/mcp/conversational-api-debugger/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "mcp",

--- a/plugins/mcp/design-to-code/package.json
+++ b/plugins/mcp/design-to-code/package.json
@@ -6,10 +6,21 @@
   "main": "./dist/servers/design-converter.js",
   "scripts": {
     "build": "tsc",
-    "test": "vitest --passWithNoTests"
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit"
   },
-  "keywords": ["mcp", "figma", "design", "code-generation", "components", "a11y"],
-  "author": { "name": "Intent Solutions", "url": "https://intentsolutions.io" },
+  "keywords": [
+    "mcp",
+    "figma",
+    "design",
+    "code-generation",
+    "components",
+    "a11y"
+  ],
+  "author": {
+    "name": "Intent Solutions",
+    "url": "https://intentsolutions.io"
+  },
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/plugins/mcp/domain-memory-agent/package.json
+++ b/plugins/mcp/domain-memory-agent/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "mcp",

--- a/plugins/mcp/pr-to-spec/site/package.json
+++ b/plugins/mcp/pr-to-spec/site/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "astro": "^5.16.9",

--- a/plugins/mcp/workflow-orchestrator/package.json
+++ b/plugins/mcp/workflow-orchestrator/package.json
@@ -6,10 +6,21 @@
   "main": "./dist/servers/workflow-engine.js",
   "scripts": {
     "build": "tsc",
-    "test": "vitest --passWithNoTests"
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit"
   },
-  "keywords": ["mcp", "workflow", "orchestration", "dag", "automation", "tasks"],
-  "author": { "name": "Intent Solutions", "url": "https://intentsolutions.io" },
+  "keywords": [
+    "mcp",
+    "workflow",
+    "orchestration",
+    "dag",
+    "automation",
+    "tasks"
+  ],
+  "author": {
+    "name": "Intent Solutions",
+    "url": "https://intentsolutions.io"
+  },
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/plugins/mcp/x-bug-triage/mcp/triage-server/package.json
+++ b/plugins/mcp/x-bug-triage/mcp/triage-server/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "bun run server.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/scripts/audit-typescript-coverage.py
+++ b/scripts/audit-typescript-coverage.py
@@ -62,7 +62,19 @@ def main() -> int:
 
     repo_root = root.parent
 
-    ts_files = sorted(p for p in root.rglob("*.ts") if "node_modules" not in p.parts and not p.name.endswith(".d.ts"))
+    # Exclude:
+    #   - node_modules (third-party deps)
+    #   - .d.ts (type declarations only, no executable code to typecheck)
+    #   - **/assets/** (illustrative example .ts files inside skill docs —
+    #     not standalone typecheckable units; they reference external
+    #     packages and runtime context not declared in their parent pkg)
+    #   - **/.vitepress/** (docs-site config, not part of the npm package)
+    excluded_parts = {"node_modules", "assets", ".vitepress"}
+    ts_files = sorted(
+        p for p in root.rglob("*.ts")
+        if not (excluded_parts & set(p.parts))
+        and not p.name.endswith(".d.ts")
+    )
 
     if not ts_files:
         print("No .ts files under plugins/ (excluding node_modules + .d.ts).")

--- a/scripts/audit-typescript-coverage.py
+++ b/scripts/audit-typescript-coverage.py
@@ -71,9 +71,7 @@ def main() -> int:
     #   - **/.vitepress/** (docs-site config, not part of the npm package)
     excluded_parts = {"node_modules", "assets", ".vitepress"}
     ts_files = sorted(
-        p for p in root.rglob("*.ts")
-        if not (excluded_parts & set(p.parts))
-        and not p.name.endswith(".d.ts")
+        p for p in root.rglob("*.ts") if not (excluded_parts & set(p.parts)) and not p.name.endswith(".d.ts")
     )
 
     if not ts_files:

--- a/scripts/lint-skill-codeblocks.py
+++ b/scripts/lint-skill-codeblocks.py
@@ -34,8 +34,14 @@ import sys
 import tempfile
 from pathlib import Path
 
-# Languages we know how to check; everything else is skipped.
-CHECKABLE = {"python", "py", "bash", "sh", "shell", "javascript", "js", "typescript", "ts"}
+# Languages we know how to syntax-check; everything else is skipped.
+#
+# TypeScript intentionally NOT in this set: SKILL.md TypeScript blocks are
+# illustrative snippets that reference external types, runtime context, or
+# API definitions not present in the block itself. Running `tsc --noEmit`
+# on isolated fragments produces thousands of false positives. Type-safety
+# of actual code is enforced by per-package `pnpm typecheck` jobs.
+CHECKABLE = {"python", "py", "bash", "sh", "shell", "javascript", "js"}
 FENCE_RE = re.compile(r"^```([a-zA-Z0-9_+\-]*)\s*$")
 NOQA = "# noqa: lint-codeblocks"
 


### PR DESCRIPTION
## Summary

Two cleanup wins in one PR:

1. **TypeScript-coverage**: REPORT-ONLY → BLOCKING (9 uncovered packages → 0)
2. **Codeblock-syntax linter**: dropped TypeScript from CHECKABLE (1,428 → 97 errors, 93% reduction)

## 1. typescript-coverage-audit → BLOCKING

Baseline: 9 packages with .ts files but no `typecheck` script. Now all 142 .ts files in plugins/ are covered.

**Cleanup:**

Added `"typecheck": "tsc --noEmit"` to 7 packages with existing `tsconfig.json`:

- `plugins/mcp/ai-experiment-logger`
- `plugins/mcp/conversational-api-debugger`
- `plugins/mcp/design-to-code`
- `plugins/mcp/domain-memory-agent`
- `plugins/mcp/pr-to-spec/site`
- `plugins/mcp/workflow-orchestrator`
- `plugins/mcp/x-bug-triage/mcp/triage-server`

Updated `scripts/audit-typescript-coverage.py` to exclude two legitimately non-checkable categories:

- `**/assets/**` — illustrative example .ts files inside skill docs. Reference external types + runtime context not declared in the parent package.
- `**/.vitepress/**` — docs-site config files (axiom), not part of npm package surface.

**CI change:** `--report-only` flag removed, REPORT-ONLY-UNTIL marker removed. Gate is now blocking.

## 2. skill-codeblock-syntax: TypeScript removed from CHECKABLE

The linter was producing **1,374 false positives** on TS blocks. Root cause: SKILL.md TypeScript blocks are illustrative fragments that reference external types and runtime context the linter can't resolve.

```python
# Before:
CHECKABLE = {"python", "py", "bash", "sh", "shell", "javascript", "js", "typescript", "ts"}

# After:
CHECKABLE = {"python", "py", "bash", "sh", "shell", "javascript", "js"}
```

Type-safety for actual TS code is enforced by the per-package `pnpm typecheck` job (now blocking via gate #1 above).

**Baseline reduction:** 1,428 errors → 97 (66 bash + 24 JS + 7 python).

The remaining 97 are concentrated in CLI example fragments and pseudocode. Tracked under existing bead `claude-hy8p`. Gate stays REPORT-ONLY-UNTIL 2026-06-21 while that cleanup proceeds.

## After merge: branch protection

Add `typescript-coverage-audit` to required checks:

```bash
gh api -X PATCH repos/jeremylongshore/claude-code-plugins-plus-skills/branches/main/protection/required_status_checks \
  -F 'strict=false' \
  -f 'contexts[]=validate' \
  -f 'contexts[]=marketplace-validation' \
  -f 'contexts[]=eslint-check' \
  -f 'contexts[]=format-check' \
  -f 'contexts[]=ruff-check' \
  -f 'contexts[]=ruff-format-check' \
  -f 'contexts[]=shellcheck-skills' \
  -f 'contexts[]=typescript-coverage-audit'
```

(Pending merge of PR #768 for shellcheck-skills.)

## Cleanup sequence

- PR A (#764, merged) — eslint + prettier blocking
- PR B (#765, merged) — ruff check + format blocking
- PR D (#766, merged) — repo-root cleanup
- PR C (#767, merged) — markdownlint config + bulk fix + report-only
- PR E (#768, open)   — shellcheck cleanup + blocking
- **PR F (this)**     — ts-coverage flip + codeblock TS cleanup

Closes bead `claude-6f4o`.

## Test plan

- [x] `python3 scripts/audit-typescript-coverage.py --root plugins` exits 0 (0 uncovered)
- [x] `python3 scripts/lint-skill-codeblocks.py --root plugins` reports 97 (down from 1,428)
- [x] YAML validated
- [ ] CI green on all 6 (soon 8) required gates

- Jeremy Longshore
intentsolutions.io