### PR TITLE
Add agentpay — payment layer for AI agents

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1064,7 +1064,34 @@ sources:
       - '.git/**'
       - '*.log'
 
-# Sync configuration
+  # ============================================================
+  # agentpay — Payment layer for AI agents
+  # https://github.com/M1mino/agentpay
+  # ============================================================
+
+  - name: agentpay
+    description: 'Payment layer for AI agents. Register agents, topup CREDIT balance by sending USDC on Base, pay other agents with signed EIP-191 transactions (0.5% fee), and withdraw CREDIT back to USDC (3% fee). Features: per-agent nonces for replay protection, rate limiting, audit endpoint for transparency.'
+    repo: M1mino/agentpay
+    source_path: ""
+    target_path: plugins/crypto/agentpay
+    author:
+      name: Anfisa
+      github: M1mino
+    license: MIT
+    category: crypto
+    verified: false
+    include:
+      - 'SKILL.md'
+      - 'README.md'
+    exclude:
+      - '*.py'
+      - '*.txt'
+      - 'venv/**'
+      - '.git/**'
+      - 'deploy/**'
+      - 'tests/**'
+
+# External Plugin Sync Configuration
 config:
   # Branch to sync from (default: main)
   default_branch: main


### PR DESCRIPTION
## Summary

Add **AgentPay** — payment layer for AI agents. External plugin synced from [M1mino/agentpay](https://github.com/M1mino/agentpay).

## What it does

- Register AI agents with a Base address
- Topup CREDIT balance by sending USDC on Base
- Pay other agents with signed EIP-191 transactions (0.5% fee)
- Withdraw CREDIT back to USDC (3% fee)
- Per-agent nonces for replay protection
- Audit endpoint for transparency

## Checklist

- [x] Valid YAML frontmatter in SKILL.md (8 marketplace fields)
- [x] 7 required body sections (Overview, Prerequisites, Instructions, Output, Error Handling, Examples, Resources)
- [x] 2-3 concrete examples with input/output
- [x] 4+ errors documented with solutions
- [x] MIT license
- [x] Entry added to sources.yaml

## Category
`crypto` — AgentPay handles USDC deposits, CREDIT transfers, and on-chain withdrawals on Base.

---

Let me know if anything needs to change! — Anfisa