### PR TITLE
feat(cowork): idempotent build pipeline + drift gate + auto-cowork contract

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -680,6 +680,13 @@ jobs:
       - name: Validate Cowork Downloads
         run: node marketplace/scripts/validate-cowork-downloads.mjs
 
+      - name: Validate Cowork Manifest Drift
+        # Catalog ↔ manifest ↔ disk alignment gate. Complements
+        # validate-cowork-downloads.mjs (manifest → disk presence) by also
+        # walking disk → manifest (orphan detection) and catalog → manifest.
+        # See CLAUDE.md § "Auto-cowork contract" for the invariant.
+        run: node scripts/validate-cowork-manifest.mjs
+
       - name: Validate Cowork Security
         run: node scripts/validate-cowork-security.mjs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,22 @@ CI fails if any derived file is out of sync. Never hand-edit auto-generated file
 
 Performance budgets (CI-enforced): 40 MB total gzipped, 1 MB largest file, < 30s build, 2,800–4,000 routes.
 
+## Auto-cowork contract
+
+**Author flow.** Add a plugin to `.claude-plugin/marketplace.extended.json` and run `pnpm run sync-marketplace`. That is the entire authoring step. The pre-commit hook regenerates `marketplace.json`, plugin `package.json`s, and the README AUTO-TOC. There is no separate "update the cowork page" step.
+
+**Pipeline (deterministic from the catalog).** `cd marketplace && npm run build` runs `scripts/build.mjs`, which on every invocation:
+
+1. `cowork:zips` (`scripts/build-cowork-zips.mjs`) — wipes `marketplace/public/downloads/{plugins,bundles}` and rebuilds them from `marketplace.extended.json`. Produces individual plugin zips, category bundle zips, the mega-zip, `downloads/manifest.json`, and the Astro-consumed `marketplace/src/data/cowork-manifest.json`. Skips `category: mcp` entries (MCP plugins do not appear in cowork).
+2. `cowork:validate` (`scripts/validate-cowork-manifest.mjs`) — drift gate. Fails the build if catalog ↔ manifest ↔ disk fall out of alignment (orphan zips, missing entries, or stale manifest rows). Runs again in CI as a discrete step in `.github/workflows/validate-plugins.yml` so the failure signal is clearly named.
+3. `astro build` — copies `marketplace/public/` → `marketplace/dist/`. The `/cowork/` page reads `cowork-manifest.json` at build time and renders the download grid.
+
+**Deploy propagates the wipe.** The VPS force-command script `/usr/local/sbin/deploy-tonsofskills` ends with `rsync -a --delete /srv/tonsofskills/build/marketplace/dist/ /srv/tonsofskills/dist/`, so orphan files removed by the cowork build are also pruned from the served `dist/`. Documented in `intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md` § "Atomic deploy convention".
+
+**Don't commit downloads/.** `marketplace/public/downloads/` is gitignored (see `.gitignore:146`). CI checks out fresh and rebuilds from scratch — local state cannot leak to prod. Never commit or hand-edit anything under that directory.
+
+**Don't wire cowork build into `sync-marketplace`.** `sync-marketplace` is the fast (<2s) per-commit hook; `cowork:zips` is the slow (~30s) per-build step. They run on different cadences by design.
+
 ## Plugin Structure
 
 **AI instruction plugins** (`plugins/[category]/[name]/`): `.claude-plugin/plugin.json` + `README.md` + optional `commands/*.md`, `agents/*.md`, `skills/[name]/SKILL.md`.

--- a/marketplace/scripts/build.mjs
+++ b/marketplace/scripts/build.mjs
@@ -29,6 +29,7 @@ run('catalog:sync', 'node', ['scripts/sync-catalog.mjs']);
 run('jrig:enrich', 'node', ['scripts/enrich-jrig-data.mjs']);
 run('search:generate', 'node', ['scripts/generate-unified-search.mjs']);
 run('cowork:zips', 'node', [resolve(repoRoot, 'scripts/build-cowork-zips.mjs')]);
+run('cowork:validate', 'node', [resolve(repoRoot, 'scripts/validate-cowork-manifest.mjs')]);
 
 // Copy large data files to public/data/ so they are served as static assets at runtime.
 // Source-of-truth remains in src/data/ for build scripts; public/data/ is the runtime copy.

--- a/scripts/build-cowork-zips.mjs
+++ b/scripts/build-cowork-zips.mjs
@@ -7,10 +7,20 @@
  * category bundles, a mega-zip, and a manifest.json with metadata.
  *
  * Output: marketplace/public/downloads/
- *   plugins/      - Individual plugin zips
- *   bundles/      - Category bundle zips
- *   claude-code-plugins-all.zip - Everything
- *   manifest.json - Sizes, counts, checksums
+ *   plugins/                      - Individual plugin zips
+ *   bundles/                      - Category bundle zips
+ *   claude-code-plugins-all.zip   - Mega-zip (every non-MCP plugin)
+ *   manifest.json                 - Sizes, counts, checksums
+ *
+ * Idempotency contract: this script wipes `plugins/` and `bundles/` before
+ * each run so the on-disk state after every invocation is exactly what the
+ * catalog declares — no more, no less. The drift gate
+ * `scripts/validate-cowork-manifest.mjs` enforces the same invariant in CI.
+ * See CLAUDE.md § "Auto-cowork contract".
+ *
+ * Skip rule: plugins with `category: mcp` (or path `./plugins/mcp/*`) are
+ * not zipped — MCP servers cannot be installed by Cowork users (they need
+ * a host process, not a static drop-in).
  */
 
 import {
@@ -20,6 +30,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
@@ -248,7 +259,11 @@ async function main() {
 
   console.log(`Found ${plugins.length} plugins in catalog\n`);
 
-  // Create output directories
+  // Wipe + recreate output subdirs so the script is idempotent.
+  // Without this, zips from removed/renamed catalog entries linger on disk
+  // and drift away from the manifest (which is regenerated from the catalog).
+  rmSync(join(OUTPUT_DIR, 'plugins'), { recursive: true, force: true });
+  rmSync(join(OUTPUT_DIR, 'bundles'), { recursive: true, force: true });
   mkdirSync(join(OUTPUT_DIR, 'plugins'), { recursive: true });
   mkdirSync(join(OUTPUT_DIR, 'bundles'), { recursive: true });
 

--- a/scripts/validate-cowork-manifest.mjs
+++ b/scripts/validate-cowork-manifest.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * validate-cowork-manifest.mjs
+ *
+ * CI GATE: catalog ↔ manifest ↔ disk alignment for the cowork pipeline.
+ *
+ * The intended invariant: every non-MCP plugin in marketplace.extended.json
+ * has exactly one zip on disk and exactly one manifest entry — and nothing
+ * else exists on disk. build-cowork-zips.mjs is responsible for producing
+ * that state (it wipes plugins/ + bundles/ before each run); this script
+ * is the regression gate that catches drift if either side breaks.
+ *
+ * Complements the two pre-existing cowork gates:
+ *   - marketplace/scripts/validate-cowork-downloads.mjs
+ *       Walks manifest → disk to assert every referenced zip is present.
+ *       Does NOT detect orphans (disk → manifest direction).
+ *   - scripts/validate-cowork-security.mjs
+ *       Samples 30 zip contents for sensitive files. Content-level check.
+ *
+ * This validator owns the topology-level check: catalog drives manifest,
+ * manifest drives disk, and disk must contain nothing the manifest does
+ * not declare. The catalog is the single source of truth.
+ *
+ * References:
+ *   - CLAUDE.md § "Auto-cowork contract" — the invariant + author workflow
+ *   - scripts/build-cowork-zips.mjs — the producer this gate guards
+ *   - .claude-plugin/marketplace.extended.json — source of truth (catalog)
+ *
+ * Exit codes:
+ *   0 - aligned
+ *   1 - drift detected (catalog/manifest/disk mismatch)
+ *
+ * Usage:
+ *   node scripts/validate-cowork-manifest.mjs
+ *
+ * CI wiring:
+ *   - marketplace/scripts/build.mjs runs this immediately after `cowork:zips`
+ *     so a local `npm run build` catches drift before it can land.
+ *   - .github/workflows/validate-plugins.yml runs it as a separate named
+ *     step after `Validate Cowork Downloads` for a clear CI failure signal.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const EXTENDED_JSON = join(ROOT, '.claude-plugin', 'marketplace.extended.json');
+const MANIFEST_JSON = join(ROOT, 'marketplace', 'src', 'data', 'cowork-manifest.json');
+const PLUGIN_ZIP_DIR = join(ROOT, 'marketplace', 'public', 'downloads', 'plugins');
+const BUNDLE_ZIP_DIR = join(ROOT, 'marketplace', 'public', 'downloads', 'bundles');
+
+const SKIP_CATEGORIES = new Set(['mcp']);
+
+function catalogCategory(plugin) {
+  const source = plugin.source || '';
+  const dirParts = source.replace(/^\.?\/?plugins\//, '').split('/');
+  return dirParts.length > 1 ? dirParts[0] : plugin.category || 'uncategorized';
+}
+
+function listZips(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith('.zip'));
+}
+
+const errors = [];
+
+if (!existsSync(EXTENDED_JSON)) {
+  console.error(`FATAL: catalog not found at ${EXTENDED_JSON}`);
+  process.exit(1);
+}
+if (!existsSync(MANIFEST_JSON)) {
+  console.error(
+    `FATAL: cowork manifest not found at ${MANIFEST_JSON} — run \`node scripts/build-cowork-zips.mjs\` first`,
+  );
+  process.exit(1);
+}
+
+const catalog = JSON.parse(readFileSync(EXTENDED_JSON, 'utf-8'));
+const manifest = JSON.parse(readFileSync(MANIFEST_JSON, 'utf-8'));
+
+const catalogPlugins = (catalog.plugins || []).filter(
+  (p) => !SKIP_CATEGORIES.has(catalogCategory(p)),
+);
+const catalogNames = new Set(catalogPlugins.map((p) => p.name));
+
+const manifestPlugins = manifest.plugins || [];
+const manifestNames = new Set(manifestPlugins.map((p) => p.name));
+
+const manifestBundles = manifest.bundles || [];
+const manifestBundleNames = new Set(manifestBundles.map((b) => b.fileName));
+
+// Check 1: catalog count == manifest count (non-MCP)
+if (catalogPlugins.length !== manifestPlugins.length) {
+  errors.push(
+    `Plugin count mismatch: catalog has ${catalogPlugins.length} non-MCP plugins, manifest has ${manifestPlugins.length}`,
+  );
+}
+
+// Check 2: every catalog (non-MCP) plugin appears in manifest
+for (const p of catalogPlugins) {
+  if (!manifestNames.has(p.name)) {
+    errors.push(`Catalog plugin "${p.name}" missing from manifest`);
+  }
+}
+
+// Check 3: every manifest entry's zip exists on disk
+for (const p of manifestPlugins) {
+  const zipPath = join(ROOT, 'marketplace', 'public', p.path.replace(/^\//, ''));
+  if (!existsSync(zipPath)) {
+    errors.push(`Manifest plugin "${p.name}" references missing zip: ${p.path}`);
+  }
+}
+
+// Check 4: every zip on disk has a matching manifest entry
+const diskPluginZips = listZips(PLUGIN_ZIP_DIR);
+const expectedPluginZips = new Set(manifestPlugins.map((p) => p.fileName));
+for (const zip of diskPluginZips) {
+  if (!expectedPluginZips.has(zip)) {
+    errors.push(`Orphan plugin zip on disk (no manifest entry): plugins/${zip}`);
+  }
+}
+
+// Check 5: every manifest plugin entry's name appears in catalog (no extra manifest entries)
+for (const p of manifestPlugins) {
+  if (!catalogNames.has(p.name)) {
+    errors.push(`Manifest plugin "${p.name}" not present in catalog (stale manifest entry)`);
+  }
+}
+
+// Check 6: every bundle zip on disk has a matching manifest bundle entry
+const diskBundleZips = listZips(BUNDLE_ZIP_DIR);
+for (const zip of diskBundleZips) {
+  if (!manifestBundleNames.has(zip)) {
+    errors.push(`Orphan bundle zip on disk (no manifest entry): bundles/${zip}`);
+  }
+}
+
+// Check 7: every manifest bundle has a zip on disk
+for (const b of manifestBundles) {
+  const zipPath = join(ROOT, 'marketplace', 'public', b.path.replace(/^\//, ''));
+  if (!existsSync(zipPath)) {
+    errors.push(`Manifest bundle "${b.fileName}" references missing zip: ${b.path}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Cowork manifest drift detected:\n');
+  for (const e of errors) {
+    console.error(`  - ${e}`);
+  }
+  console.error(
+    `\n${errors.length} drift error(s). Run \`node scripts/build-cowork-zips.mjs\` to regenerate.`,
+  );
+  process.exit(1);
+}
+
+console.log('Cowork manifest aligned:');
+console.log(`  ${catalogPlugins.length} non-MCP catalog plugins`);
+console.log(`  ${manifestPlugins.length} manifest plugin entries`);
+console.log(`  ${diskPluginZips.length} plugin zips on disk`);
+console.log(`  ${manifestBundles.length} manifest bundle entries`);
+console.log(`  ${diskBundleZips.length} bundle zips on disk`);


### PR DESCRIPTION
## Summary

- Wipe `marketplace/public/downloads/{plugins,bundles}` at start of `build-cowork-zips.mjs` — script becomes a deterministic function of `marketplace.extended.json`.
- New `scripts/validate-cowork-manifest.mjs` — catalog ↔ manifest ↔ disk drift gate, wired into the marketplace build + `.github/workflows/validate-plugins.yml`.
- `CLAUDE.md` "Auto-cowork contract" section documents the invariant + deliberate decisions.
- Verified `/usr/local/sbin/deploy-tonsofskills` already uses `rsync -a --delete` — prod inherits the wipe automatically. Finding recorded in `intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md` (separate PR).

Closes #779.

## Verification done locally

- [x] Idempotency twice: identical file set on consecutive runs (421 plugin zips, 18 bundle zips). Byte-level non-determinism in zip headers is pre-existing (timestamps), not from this change.
- [x] Stale-zip injection: `STALE-ORPHAN-TEST.zip` + `STALE-BUNDLE-TEST.zip` wiped on next run.
- [x] Original 6 orphans removed: `general-legal-assistant`, `langchain-pack`, `windsurf` plugin zips + `automation`, `code-quality`, `finance` bundle zips.
- [x] Drift gate fires non-zero on `INJECTED-DRIFT.zip` with descriptive error.
- [x] `validate-cowork-security.mjs` still green (5/5 checks pass).
- [x] `validate-unicode-hygiene.py` clean on new + modified files.

## Test plan (CI)

- [ ] `validate-plugins.yml` — full suite incl. new \"Validate Cowork Manifest Drift\" step
- [ ] Marketplace build (`cd marketplace && npm run build`) succeeds with new `cowork:validate` step
- [ ] No performance budget regressions
- [ ] Existing cowork gates remain green: Validate Cowork Downloads, Validate Cowork Security

## Beads ↔ GH ↔ Plane

- Epic `claude-s43v` ↔ #779 ↔ CCP-29
- Sub-beads:
  - `claude-2hlo` — idempotency fix (this PR)
  - `claude-q39n` — drift gate (this PR)
  - `claude-522d` — contract docs (this PR)
  - `claude-hg0y` — VPS verification (separate runbook PR — `intentsolutions-vps-runbook#25`)

## Why this matters

The catalog is already the single source of truth for the cowork page (`build-cowork-zips.mjs` iterates `catalog.plugins`, never walks the filesystem). The pipeline was correct in direction but additive on disk, which meant local environments accumulated orphans whenever a catalog entry was removed or renamed. This PR closes that gap with the smallest possible diff (5 files, +203/-5) and adds a CI gate so the contract can't silently regress.

- Jeremy Longshore
intentsolutions.io