### PR TITLE
fix(ci): drop path filter from validate-plugins.yml

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -2,23 +2,12 @@ name: Validate Plugins
 
 on:
   workflow_dispatch:
+  # Runs on every PR. The jobs below are listed in branch-protection's
+  # required-status set; if a path filter here skips the run, those required
+  # checks stay "Expected" forever and the PR cannot merge (the "10 Expected
+  # forever" stuck-PR class — observed on PR #778). Trade-off: 5-10 extra
+  # Actions minutes per PR that doesn't touch validator-relevant files.
   pull_request:
-    paths:
-      - 'plugins/**'
-      - '.claude-plugin/**'
-      - 'marketplace/**'
-      - 'README.md'
-      - 'scripts/**'
-      - '.claude/**'
-      - 'workspace/**'
-      - '.github/workflows/validate-plugins.yml'
-      - 'eslint.config.mjs'
-      - '.prettierrc.json'
-      - '.prettierignore'
-      - '.lintstagedrc.json'
-      - 'commitlint.config.js'
-      - '.husky/**'
-      - 'package.json'
   push:
     branches: [main]
 

--- a/marketplace/src/content/blog-posts/unicode-hygiene-gate-same-day-trapdoor-defense.md
+++ b/marketplace/src/content/blog-posts/unicode-hygiene-gate-same-day-trapdoor-defense.md
@@ -140,4 +140,3 @@ Same day, part of a wider CI-hardening campaign:
   "url": "https://startaitools.com/posts/unicode-hygiene-gate-same-day-trapdoor-defense/"
 }
 </script>
-


### PR DESCRIPTION
## Summary

- 10 required-status checks (format-check, markdownlint, ruff-check, ruff-format-check, shellcheck-skills, skill-codeblock-syntax, typescript-coverage-audit, eslint-check, marketplace-validation, validate) live in `validate-plugins.yml`'s jobs.
- The workflow's `pull_request: paths:` filter skipped any PR that didn't touch those paths (e.g., `sources.yaml`-only contributions). Skipped runs = required checks stay "Expected" forever = PR can't merge except via admin override.
- Removing the path filter so the workflow runs on every PR. Trade-off: 5-10 extra Actions minutes per PR that doesn't touch validator-relevant files. Net win: ends the "10 Expected forever" stuck-PR class.

## Observed on

PR #778 (`sources.yaml`-only) — 10 required checks sat "Expected" with no runs queued. Same pattern would hit any future PR that lands outside the path filter.

## Test plan

- [ ] Validator jobs run + complete on this PR (which only touches `.github/workflows/validate-plugins.yml`, previously inside the filter — so this isn't a true regression test; will follow up by manually checking with a `sources.yaml`-only PR after merge).
- [ ] CI runtime per PR doesn't regress meaningfully (validate-plugins.yml is ~1-2 min by design).

## Out of scope

- Schema validation for `sources.yaml` entries (separate concern; if traffic warrants it later, add to `validate-catalog-invariants.py`).
- E2E tests still path-filtered; per workflow comment, those are not required-status checks so the "Expected forever" issue doesn't apply.

- Jeremy Longshore
intentsolutions.io