### PR TITLE
📦 npm download stats refresh (manual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,33 +71,33 @@ ccpi update                     # Pull latest versions
 
 ### 📦 Live npm Downloads
 
-Across **418 published packages** in the
+Across **425 published packages** in the 
 [claude-code-plugins](https://www.npmjs.com/~jeremylongshore) namespace. Updated daily by GitHub Actions.
 
-| Window        | All packages | Established (>30d) |
-| ------------- | -----------: | -----------------: |
-| Last 24 hours |          128 |                 36 |
-| Last 7 days   |        2,757 |                206 |
-| Last 30 days  |       53,237 |                990 |
+| Window | All packages | Established (>30d) |
+|--------|-------------:|-------------------:|
+| Last 24 hours | 195 | 183 |
+| Last 7 days | 2,477 | 2,379 |
+| Last 30 days | 14,130 | 11,983 |
 
 <sub>"Established" excludes packages first published within the last 30 days, so a bulk-publish event doesn't dominate the headline.</sub>
 
 **Top 10 by last 30 days:**
 
-| #   | Package                                                                                                                            | Last 30d |
-| --- | ---------------------------------------------------------------------------------------------------------------------------------- | -------: |
-| 1   | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi)                                                 |      346 |
-| 2   | [`@intentsolutionsio/guidewire-pack`](https://www.npmjs.com/package/@intentsolutionsio/guidewire-pack)                             |      324 |
-| 3   | [`@intentsolutionsio/engineer-design-diagram`](https://www.npmjs.com/package/@intentsolutionsio/engineer-design-diagram)           |      242 |
-| 4   | [`@intentsolutionsio/market-price-tracker`](https://www.npmjs.com/package/@intentsolutionsio/market-price-tracker)                 |      224 |
-| 5   | [`@intentsolutionsio/excel-analyst-pro`](https://www.npmjs.com/package/@intentsolutionsio/excel-analyst-pro)                       |      189 |
-| 6   | [`@intentsolutionsio/openbb-terminal`](https://www.npmjs.com/package/@intentsolutionsio/openbb-terminal)                           |      182 |
-| 7   | [`@intentsolutionsio/options-flow-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/options-flow-analyzer)               |      181 |
-| 8   | [`@intentsolutionsio/crypto-portfolio-tracker`](https://www.npmjs.com/package/@intentsolutionsio/crypto-portfolio-tracker)         |      175 |
-| 9   | [`@intentsolutionsio/nft-rarity-analyzer`](https://www.npmjs.com/package/@intentsolutionsio/nft-rarity-analyzer)                   |      174 |
-| 10  | [`@intentsolutionsio/arbitrage-opportunity-finder`](https://www.npmjs.com/package/@intentsolutionsio/arbitrage-opportunity-finder) |      167 |
+| # | Package | Last 30d |
+|---|---------|---------:|
+| 1 | [`@intentsolutionsio/ccpi`](https://www.npmjs.com/package/@intentsolutionsio/ccpi) | 519 |
+| 2 | [`@intentsolutionsio/engineer-design-diagram`](https://www.npmjs.com/package/@intentsolutionsio/engineer-design-diagram) | 290 |
+| 3 | [`@intentsolutionsio/guidewire-pack`](https://www.npmjs.com/package/@intentsolutionsio/guidewire-pack) | 263 |
+| 4 | [`@intentsolutionsio/hubspot-pack`](https://www.npmjs.com/package/@intentsolutionsio/hubspot-pack) | 201 |
+| 5 | [`@intentsolutionsio/zero-tech-debt`](https://www.npmjs.com/package/@intentsolutionsio/zero-tech-debt) | 177 |
+| 6 | [`@intentsolutionsio/validate-plugin`](https://www.npmjs.com/package/@intentsolutionsio/validate-plugin) | 170 |
+| 7 | [`@intentsolutionsio/cli-ux-tester`](https://www.npmjs.com/package/@intentsolutionsio/cli-ux-tester) | 164 |
+| 8 | [`@intentsolutionsio/tonone`](https://www.npmjs.com/package/@intentsolutionsio/tonone) | 160 |
+| 9 | [`@intentsolutionsio/claude-workflow-skills`](https://www.npmjs.com/package/@intentsolutionsio/claude-workflow-skills) | 159 |
+| 10 | [`@intentsolutionsio/contributing-clanker`](https://www.npmjs.com/package/@intentsolutionsio/contributing-clanker) | 157 |
 
-<sub>Last refreshed 2026-05-07T15:28:44.521Z.</sub>
+<sub>Last refreshed 2026-05-28T01:44:16.713Z.</sub>
 
 <!-- NPM-STATS:END -->
 

--- a/marketplace/src/data/npm-stats.json
+++ b/marketplace/src/data/npm-stats.json
@@ -1,634 +1,454 @@
 {
-  "generatedAt": "2026-05-07T15:28:44.521Z",
-  "publishedCount": 418,
-  "establishedCount": 32,
-  "candidateCount": 438,
-  "totalDay": 128,
-  "totalWeek": 2757,
-  "totalMonth": 53237,
-  "establishedDay": 36,
-  "establishedWeek": 206,
-  "establishedMonth": 990,
+  "generatedAt": "2026-05-28T01:44:16.713Z",
+  "publishedCount": 425,
+  "establishedCount": 411,
+  "candidateCount": 447,
+  "totalDay": 195,
+  "totalWeek": 2477,
+  "totalMonth": 14130,
+  "establishedDay": 183,
+  "establishedWeek": 2379,
+  "establishedMonth": 11983,
   "top": [
     {
       "name": "@intentsolutionsio/ccpi",
       "status": "published",
-      "lastDay": 14,
-      "lastWeek": 87,
-      "lastMonth": 346,
+      "lastDay": 18,
+      "lastWeek": 248,
+      "lastMonth": 519,
       "createdAt": 1766717017053,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/guidewire-pack",
-      "status": "published",
-      "lastDay": 5,
-      "lastWeek": 199,
-      "lastMonth": 324,
-      "createdAt": 1776741959424,
-      "latestVersion": "2.0.1"
+      "latestVersion": "2.0.3"
     },
     {
       "name": "@intentsolutionsio/engineer-design-diagram",
       "status": "published",
-      "lastDay": 10,
-      "lastWeek": 242,
-      "lastMonth": 242,
+      "lastDay": 0,
+      "lastWeek": 11,
+      "lastMonth": 290,
       "createdAt": 1777867330963,
       "latestVersion": "0.2.1"
     },
     {
-      "name": "@intentsolutionsio/market-price-tracker",
+      "name": "@intentsolutionsio/guidewire-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 17,
+      "lastMonth": 263,
+      "createdAt": 1776741959424,
+      "latestVersion": "2.0.1"
+    },
+    {
+      "name": "@intentsolutionsio/hubspot-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 201,
+      "createdAt": 1776741987099,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/zero-tech-debt",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 9,
+      "lastMonth": 177,
+      "createdAt": 1778992918428,
+      "latestVersion": "1.0.2"
+    },
+    {
+      "name": "@intentsolutionsio/validate-plugin",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 23,
-      "lastMonth": 224,
+      "lastWeek": 8,
+      "lastMonth": 170,
+      "createdAt": 1776742277333,
+      "latestVersion": "1.0.1"
+    },
+    {
+      "name": "@intentsolutionsio/cli-ux-tester",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 164,
+      "createdAt": 1778628454442,
+      "latestVersion": "3.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/tonone",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 160,
+      "createdAt": 1777867315353,
+      "latestVersion": "0.9.7"
+    },
+    {
+      "name": "@intentsolutionsio/claude-workflow-skills",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 159,
+      "createdAt": 1778628423991,
+      "latestVersion": "1.5.0"
+    },
+    {
+      "name": "@intentsolutionsio/contributing-clanker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 157,
+      "createdAt": 1777867323247,
+      "latestVersion": "0.1.1"
+    },
+    {
+      "name": "@intentsolutionsio/claudebase",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 155,
+      "createdAt": 1777867338728,
+      "latestVersion": "0.2.0"
+    },
+    {
+      "name": "@intentsolutionsio/aomi",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 151,
+      "createdAt": 1778628415956,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/plane",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 151,
+      "createdAt": 1778211005416,
+      "latestVersion": "0.1.1"
+    },
+    {
+      "name": "@intentsolutionsio/podium-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 6,
+      "lastMonth": 146,
+      "createdAt": 1776742147089,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/market-price-tracker",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 7,
+      "lastMonth": 144,
       "createdAt": 1776741684267,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/excel-analyst-pro",
+      "name": "@intentsolutionsio/over-50s-health",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 189,
+      "lastWeek": 8,
+      "lastMonth": 138,
+      "createdAt": 1778628439596,
+      "latestVersion": "3.2.0"
+    },
+    {
+      "name": "@intentsolutionsio/pair-programmer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 137,
+      "createdAt": 1778628446772,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/obsidian-project-documentation",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 8,
+      "lastMonth": 135,
+      "createdAt": 1778628431893,
+      "latestVersion": "3.2.1"
+    },
+    {
+      "name": "@intentsolutionsio/excel-analyst-pro",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 10,
+      "lastMonth": 117,
       "createdAt": 1776741469824,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/openbb-terminal",
       "status": "published",
-      "lastDay": 1,
-      "lastWeek": 17,
-      "lastMonth": 182,
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 115,
       "createdAt": 1776741484922,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/options-flow-analyzer",
+      "name": "@intentsolutionsio/openrouter-pack",
+      "status": "published",
+      "lastDay": 7,
+      "lastWeek": 54,
+      "lastMonth": 101,
+      "createdAt": 1767929515334,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-ai",
+      "status": "published",
+      "lastDay": 4,
+      "lastWeek": 7,
+      "lastMonth": 89,
+      "createdAt": 1777603633821,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/klingai-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 15,
+      "lastMonth": 87,
+      "createdAt": 1767929518106,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-google-adk",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 181,
-      "createdAt": 1776741710149,
-      "latestVersion": "1.0.0"
+      "lastMonth": 84,
+      "createdAt": 1777603623651,
+      "latestVersion": "2.0.0"
     },
     {
       "name": "@intentsolutionsio/crypto-portfolio-tracker",
       "status": "published",
-      "lastDay": 1,
-      "lastWeek": 16,
-      "lastMonth": 175,
-      "createdAt": 1776741638231,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/nft-rarity-analyzer",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 174,
-      "createdAt": 1776741699776,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/arbitrage-opportunity-finder",
-      "status": "published",
       "lastDay": 0,
-      "lastWeek": 24,
-      "lastMonth": 167,
-      "createdAt": 1776741475326,
+      "lastWeek": 7,
+      "lastMonth": 81,
+      "createdAt": 1776741638231,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/travel-assistant",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 41,
-      "lastMonth": 167,
+      "lastWeek": 3,
+      "lastMonth": 81,
       "createdAt": 1776742103269,
       "latestVersion": "1.1.0"
     },
     {
-      "name": "@intentsolutionsio/skill-creator",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 13,
-      "lastMonth": 163,
-      "createdAt": 1776742235624,
-      "latestVersion": "5.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/claude-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 160,
-      "createdAt": 1776741607002,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wallet-portfolio-tracker",
+      "name": "@intentsolutionsio/market-movers-scanner",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 12,
-      "lastMonth": 160,
-      "createdAt": 1776741729951,
+      "lastWeek": 6,
+      "lastMonth": 80,
+      "createdAt": 1776741679506,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/crypto-tax-calculator",
+      "name": "@intentsolutionsio/mattyp-changelog",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 159,
-      "createdAt": 1776741648453,
+      "lastDay": 4,
+      "lastWeek": 10,
+      "lastMonth": 76,
+      "createdAt": 1776741943473,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/openevidence-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 10,
+      "lastMonth": 76,
+      "createdAt": 1776742117677,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/compliance-checker",
+      "name": "@intentsolutionsio/cursor-pack",
+      "status": "published",
+      "lastDay": 9,
+      "lastWeek": 52,
+      "lastMonth": 74,
+      "createdAt": 1767929512616,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/firecrawl-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 42,
+      "lastMonth": 71,
+      "createdAt": 1767929528093,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ideogram-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 157,
-      "createdAt": 1776741640114,
+      "lastWeek": 16,
+      "lastMonth": 67,
+      "createdAt": 1767929551266,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/options-flow-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 65,
+      "createdAt": 1776741710149,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/miro-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 28,
+      "lastMonth": 64,
+      "createdAt": 1776742071464,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/flash-loan-simulator",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 21,
-      "lastMonth": 157,
+      "lastWeek": 8,
+      "lastMonth": 62,
       "createdAt": 1776741663488,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/market-movers-scanner",
+      "name": "@intentsolutionsio/wallet-portfolio-tracker",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 157,
-      "createdAt": 1776741679506,
+      "lastWeek": 6,
+      "lastMonth": 62,
+      "createdAt": 1776741729951,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/blockchain-explorer-cli",
+      "name": "@intentsolutionsio/replit-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 39,
+      "lastMonth": 61,
+      "createdAt": 1767929532725,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/arbitrage-opportunity-finder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 60,
+      "createdAt": 1776741475326,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-tax-calculator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 54,
+      "createdAt": 1776741648453,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/nft-rarity-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 54,
+      "createdAt": 1776741699776,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/linear-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 27,
+      "lastMonth": 51,
+      "createdAt": 1767929574015,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/flyio-pack",
+      "status": "published",
+      "lastDay": 7,
+      "lastWeek": 21,
+      "lastMonth": 50,
+      "createdAt": 1776741913078,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-vertex-engine",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 11,
+      "lastMonth": 49,
+      "createdAt": 1776741262867,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/vastai-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 15,
+      "lastMonth": 48,
+      "createdAt": 1767929537310,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/abridge-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 47,
+      "createdAt": 1776741362002,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/serpapi-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 47,
+      "createdAt": 1776742187383,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/langfuse-pack",
+      "status": "published",
+      "lastDay": 5,
+      "lastWeek": 18,
+      "lastMonth": 45,
+      "createdAt": 1776742031108,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/procore-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 156,
-      "createdAt": 1776741522342,
+      "lastMonth": 44,
+      "createdAt": 1776742152600,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/defi-yield-optimizer",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 11,
-      "lastMonth": 156,
-      "createdAt": 1776741653603,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/local-tts",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 156,
-      "createdAt": 1776741272966,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ml-model-trainer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 155,
-      "createdAt": 1776741277876,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-design-everyday-things",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 155,
-      "createdAt": 1776741832696,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-archival-system",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 152,
-      "createdAt": 1776741711937,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-test-automation",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 151,
-      "createdAt": 1776741443439,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cohere-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 8,
-      "lastMonth": 151,
-      "createdAt": 1776741634697,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/contract-test-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 151,
-      "createdAt": 1776741660836,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/crypto-news-aggregator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 151,
-      "createdAt": 1776741633481,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-health-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 151,
-      "createdAt": 1776741754306,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-engine",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 151,
-      "createdAt": 1776741262867,
-      "latestVersion": "2.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/persona-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 151,
-      "createdAt": 1776742142424,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/crypto-signal-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 150,
-      "createdAt": 1776741643301,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-backup-automator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 150,
-      "createdAt": 1776741722868,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/unit-test-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 150,
-      "createdAt": 1776742299588,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wallet-security-auditor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 150,
-      "createdAt": 1776741734689,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/zai-cli",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 150,
-      "createdAt": 1776741618257,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-audit-logger",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 149,
-      "createdAt": 1776741717321,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-diff-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 149,
-      "createdAt": 1776741744406,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-recovery-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 149,
-      "createdAt": 1776741774117,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/executive-assistant-skills",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 149,
-      "createdAt": 1776741474487,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/neural-network-builder",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 3,
-      "lastMonth": 149,
-      "createdAt": 1776741301744,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-negotiation",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 149,
-      "createdAt": 1776741541091,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-one-page-marketing",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 149,
-      "createdAt": 1776741550755,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/browser-compatibility-tester",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 148,
-      "createdAt": 1776741552255,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/liquidity-pool-analyzer",
-      "status": "published",
-      "lastDay": 0,
       "lastWeek": 10,
-      "lastMonth": 148,
-      "createdAt": 1776741673967,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/performance-test-suite",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 148,
-      "createdAt": 1776742151365,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/visual-regression-tester",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 148,
-      "createdAt": 1776742304930,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-hooked-ux",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 148,
-      "createdAt": 1776741837303,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-obviously-awesome",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 7,
-      "lastMonth": 148,
-      "createdAt": 1776741545705,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-cache-layer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 147,
-      "createdAt": 1776741728051,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-deadlock-detector",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 147,
-      "createdAt": 1776741739254,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/elevenlabs-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 14,
-      "lastMonth": 147,
-      "createdAt": 1776741858048,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/market-sentiment-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 147,
-      "createdAt": 1776741689689,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/model-deployment-helper",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 147,
-      "createdAt": 1776741282704,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/token-launch-tracker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 147,
-      "createdAt": 1776741720118,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/whale-alert-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 147,
-      "createdAt": 1776741739600,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/boycott-filter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 146,
-      "createdAt": 1776741540431,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/crypto-derivatives-tracker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 146,
-      "createdAt": 1776741628445,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/model-versioning-tracker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 146,
-      "createdAt": 1776741296763,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/vibe-guide",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 146,
-      "createdAt": 1776742108359,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-made-to-stick",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 146,
-      "createdAt": 1776741536427,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cache-performance-optimizer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 145,
-      "createdAt": 1776741557657,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/container-registry-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 145,
-      "createdAt": 1776741650848,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/container-security-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 145,
-      "createdAt": 1776741655802,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/data-privacy-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 145,
-      "createdAt": 1776741695023,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-connection-pooler",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 145,
-      "createdAt": 1776741733202,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-partition-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 145,
-      "createdAt": 1776741768869,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/devops-automation-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 145,
-      "createdAt": 1776741826196,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-drift-detector",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 145,
-      "createdAt": 1776741903590,
+      "lastMonth": 43,
+      "createdAt": 1776741653603,
       "latestVersion": "1.0.0"
     },
     {
@@ -636,179 +456,17 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 145,
+      "lastMonth": 43,
       "createdAt": 1776741243728,
       "latestVersion": "2.1.0"
     },
     {
-      "name": "@intentsolutionsio/trading-strategy-backtester",
+      "name": "@intentsolutionsio/retellai-pack",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 145,
-      "createdAt": 1776741724954,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/application-profiler",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 144,
-      "createdAt": 1776741470307,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-schema-designer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 144,
-      "createdAt": 1776741783990,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gh-dash",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 144,
-      "createdAt": 1776741878935,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/quicknode-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 144,
-      "createdAt": 1776742157146,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/recommendation-engine",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 144,
-      "createdAt": 1776741316128,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/regression-test-tracker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 144,
-      "createdAt": 1776742167996,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-design-sprint",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 144,
-      "createdAt": 1776742113532,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-test-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 143,
-      "createdAt": 1776741798986,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gastown",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 143,
-      "createdAt": 1776741593740,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/navan-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 14,
-      "lastMonth": 143,
-      "createdAt": 1776742093357,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/veeva-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 143,
-      "createdAt": 1776742228935,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-top-design",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 143,
-      "createdAt": 1776741852345,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-ux-heuristics",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 143,
-      "createdAt": 1776741857246,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-error-handler",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 142,
-      "createdAt": 1776741366917,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cpu-usage-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 142,
-      "createdAt": 1776741676912,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/data-validation-engine",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 142,
-      "createdAt": 1776741706039,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/distributed-tracing-setup",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 142,
-      "createdAt": 1776741837206,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gas-fee-optimizer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 142,
-      "createdAt": 1776741668673,
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 43,
+      "createdAt": 1767929520308,
       "latestVersion": "1.0.0"
     },
     {
@@ -816,368 +474,143 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 142,
+      "lastMonth": 41,
       "createdAt": 1776741267989,
       "latestVersion": "2.0.0"
     },
     {
-      "name": "@intentsolutionsio/model-evaluation-suite",
+      "name": "@intentsolutionsio/executive-assistant-skills",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 142,
-      "createdAt": 1776741287537,
+      "lastMonth": 40,
+      "createdAt": 1776741474487,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fondo-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 40,
+      "createdAt": 1776741918288,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/trading-strategy-backtester",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 40,
+      "createdAt": 1776741724954,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 9,
+      "lastMonth": 38,
+      "createdAt": 1776741607002,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/elevenlabs-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 38,
+      "createdAt": 1776741858048,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/secret-scanner",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 142,
+      "lastDay": 4,
+      "lastWeek": 9,
+      "lastMonth": 38,
       "createdAt": 1776742194667,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/wondelai-drive-motivation",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 142,
-      "createdAt": 1776741516001,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-predictable-revenue",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 142,
-      "createdAt": 1776741555484,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ci-cd-pipeline-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 141,
-      "createdAt": 1776741589894,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/csrf-protection-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 141,
-      "createdAt": 1776741689021,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/flyio-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 141,
-      "createdAt": 1776741913078,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/mempool-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 141,
-      "createdAt": 1776741694753,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/model-explainability-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 141,
-      "createdAt": 1776741292013,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/on-chain-analytics",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 141,
-      "createdAt": 1776741704727,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/orm-code-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 141,
-      "createdAt": 1776741812841,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/security-incident-responder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 141,
-      "createdAt": 1776742209945,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/stored-procedure-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 141,
-      "createdAt": 1776741828140,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-blue-ocean-strategy",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 141,
-      "createdAt": 1776741494266,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/workhuman-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 141,
-      "createdAt": 1776742244908,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/auto-scaling-configurator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 140,
-      "createdAt": 1776741500087,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/compliance-report-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 140,
-      "createdAt": 1776741645289,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cross-chain-bridge-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 140,
-      "createdAt": 1776741623465,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-documentation-gen",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 140,
-      "createdAt": 1776741749751,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-migration-manager",
-      "status": "published",
-      "lastDay": 3,
-      "lastWeek": 5,
-      "lastMonth": 140,
-      "createdAt": 1776741764014,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-transaction-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 140,
-      "createdAt": 1776741798655,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/databricks-pack",
+      "name": "@intentsolutionsio/shipwright",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 140,
-      "createdAt": 1776741805135,
+      "lastWeek": 6,
+      "lastMonth": 38,
+      "createdAt": 1776741161170,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/general-legal-assistant",
+      "name": "@intentsolutionsio/maintainx-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 8,
+      "lastMonth": 36,
+      "createdAt": 1776742059330,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-health-monitor",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 140,
-      "createdAt": 1776741480088,
+      "lastMonth": 35,
+      "createdAt": 1776741754306,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/git-commit-smart",
+      "name": "@intentsolutionsio/mistral-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 140,
-      "createdAt": 1776741883794,
+      "lastWeek": 5,
+      "lastMonth": 35,
+      "createdAt": 1776742076187,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/graphql-server-builder",
+      "name": "@intentsolutionsio/navan-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 140,
-      "createdAt": 1776741440853,
+      "lastWeek": 5,
+      "lastMonth": 35,
+      "createdAt": 1776742093357,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/nlp-text-analyzer",
+      "name": "@intentsolutionsio/skill-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 35,
+      "createdAt": 1776742235624,
+      "latestVersion": "5.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/youtube-strategy",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 11,
+      "lastMonth": 35,
+      "createdAt": 1776742123654,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cohere-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 34,
+      "createdAt": 1776741634697,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/compliance-checker",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 140,
-      "createdAt": 1776741306620,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/penetration-tester",
-      "status": "published",
-      "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 140,
-      "createdAt": 1776742145662,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/performance-budget-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 140,
-      "createdAt": 1776742032418,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ramp-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 140,
-      "createdAt": 1776742161687,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/techsmith-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 140,
-      "createdAt": 1776742214034,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/test-orchestrator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 140,
-      "createdAt": 1776742289194,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/webhook-handler-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 140,
-      "createdAt": 1776741455511,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/004-jeremy-google-cloud-agent-sdk",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 139,
-      "createdAt": 1776741356423,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-security-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 139,
-      "createdAt": 1776741426229,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/brightdata-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 139,
-      "createdAt": 1776741546698,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/data-seeder-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776741700157,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-sharding-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 139,
-      "createdAt": 1776741793860,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/dependency-checker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776741811210,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/deployment-rollback-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776741820945,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/e2e-test-framework",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776741852958,
+      "lastMonth": 34,
+      "createdAt": 1776741640114,
       "latestVersion": "1.0.0"
     },
     {
@@ -1185,997 +618,277 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 139,
+      "lastMonth": 34,
       "createdAt": 1776741901487,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/jeremy-genkit-pro",
+      "name": "@intentsolutionsio/jeremy-github-actions-gcp",
       "status": "published",
       "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 139,
-      "createdAt": 1776741258201,
+      "lastWeek": 8,
+      "lastMonth": 34,
+      "createdAt": 1776741918359,
       "latestVersion": "2.1.0"
     },
     {
-      "name": "@intentsolutionsio/jeremy-genkit-terraform",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776741913788,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/podium-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 139,
-      "createdAt": 1776742147089,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/test-report-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 139,
-      "createdAt": 1776742294343,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/together-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 9,
-      "lastMonth": 139,
-      "createdAt": 1776742218658,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-lean-startup",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 139,
-      "createdAt": 1776742118723,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-refactoring-ui",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 139,
-      "createdAt": 1776741847233,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-traction-eos",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 139,
-      "createdAt": 1776741570146,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-versioning-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 138,
-      "createdAt": 1776741436238,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/calendar-to-workflow",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741562644,
-      "latestVersion": "0.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-replication-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 138,
-      "createdAt": 1776741779366,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/framecraft",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 138,
-      "createdAt": 1776741589225,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/geepers-agents",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 138,
-      "createdAt": 1776741598443,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-adk-terraform",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741908802,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-firestore",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741608443,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/navigating-github",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 138,
-      "createdAt": 1776742077901,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/palantir-pack",
+      "name": "@intentsolutionsio/jeremy-vertex-terraform",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 7,
-      "lastMonth": 138,
-      "createdAt": 1776742134577,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/promptbook",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741489578,
-      "latestVersion": "1.4.0"
+      "lastMonth": 33,
+      "createdAt": 1776741923149,
+      "latestVersion": "2.0.0"
     },
     {
       "name": "@intentsolutionsio/security-agent",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
+      "lastWeek": 14,
+      "lastMonth": 33,
       "createdAt": 1776741995295,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/session-security-checker",
+      "name": "@intentsolutionsio/shopify-pack",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 138,
-      "createdAt": 1776742224677,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/staking-rewards-optimizer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 138,
-      "createdAt": 1776741715194,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/sugar",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741969622,
+      "lastDay": 4,
+      "lastWeek": 9,
+      "lastMonth": 33,
+      "createdAt": 1776742192751,
       "latestVersion": "2.0.0"
     },
     {
-      "name": "@intentsolutionsio/wondelai-ios-hig-design",
+      "name": "@intentsolutionsio/veeva-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 138,
-      "createdAt": 1776741842617,
+      "lastWeek": 8,
+      "lastMonth": 33,
+      "createdAt": 1776742228935,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/wondelai-web-typography",
+      "name": "claude-plugin-validator",
       "status": "published",
-      "lastDay": 0,
+      "lastDay": 1,
       "lastWeek": 6,
-      "lastMonth": 138,
-      "createdAt": 1776741861968,
+      "lastMonth": 33,
+      "createdAt": 1763263826323,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/agent-context-manager",
+      "name": "@intentsolutionsio/anthropic-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 8,
+      "lastMonth": 32,
+      "createdAt": 1776741429011,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/brightdata-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 32,
+      "createdAt": 1776741546698,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-ml-engineering-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 137,
-      "createdAt": 1776741386025,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-gateway-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 137,
-      "createdAt": 1776741377006,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/box-cloud-filesystem",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 137,
-      "createdAt": 1776741532611,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/chaos-engineering-toolkit",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 137,
-      "createdAt": 1776741584405,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/clickhouse-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 137,
-      "createdAt": 1776741612865,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/code-cleanup",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 137,
-      "createdAt": 1776741629140,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/encryption-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 137,
-      "createdAt": 1776741863344,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-adk-software-engineer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 137,
-      "createdAt": 1776741248596,
-      "latestVersion": "2.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/remofirst-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 137,
-      "createdAt": 1776742166680,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/search-to-slack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 137,
-      "createdAt": 1776742188886,
-      "latestVersion": "0.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/security-audit-reporter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 137,
-      "createdAt": 1776742200221,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/security-headers-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 137,
-      "createdAt": 1776742205129,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/severity1-marketplace",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 137,
-      "createdAt": 1776742230208,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/throughput-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 137,
-      "createdAt": 1776742070887,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 136,
-      "createdAt": 1776741339416,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-fuzzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 136,
-      "createdAt": 1776741436171,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-throttling-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 136,
-      "createdAt": 1776741431238,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/attio-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 136,
-      "createdAt": 1776741485907,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/b12-claude-plugin",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 136,
-      "createdAt": 1776741506522,
+      "lastMonth": 31,
+      "createdAt": 1776741396518,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/brand-strategy-framework",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 136,
+      "lastWeek": 7,
+      "lastMonth": 31,
       "createdAt": 1776741465047,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/clustering-algorithm-runner",
+      "name": "@intentsolutionsio/calendar-to-workflow",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 136,
-      "createdAt": 1776741199210,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-query-profiler",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 136,
-      "createdAt": 1776741774708,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/documenso-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 136,
-      "createdAt": 1776741848088,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-as-code-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 136,
-      "createdAt": 1776741898519,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/research-to-deploy",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 136,
-      "createdAt": 1776742173583,
+      "lastMonth": 31,
+      "createdAt": 1776741562644,
       "latestVersion": "0.1.0"
     },
     {
-      "name": "@intentsolutionsio/sprint",
+      "name": "@intentsolutionsio/computer-vision-processor",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 136,
-      "createdAt": 1776741613368,
+      "lastMonth": 31,
+      "createdAt": 1776741204141,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/test-environment-manager",
+      "name": "@intentsolutionsio/geepers-agents",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 136,
-      "createdAt": 1776742283558,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ansible-playbook-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 135,
-      "createdAt": 1776741423878,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/anthropic-pack",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 135,
-      "createdAt": 1776741429011,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-mock-server",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 135,
-      "createdAt": 1776741392061,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-rate-limiter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 135,
-      "createdAt": 1776741401315,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/data-visualization-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 135,
-      "createdAt": 1776741213237,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/dex-aggregator-router",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 135,
-      "createdAt": 1776741658472,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gitops-workflow-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 135,
-      "createdAt": 1776741888908,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/helm-chart-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 135,
-      "createdAt": 1776741893614,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/infrastructure-metrics-collector",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 135,
-      "createdAt": 1776741997955,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/mistral-pack",
-      "status": "published",
-      "lastDay": 4,
-      "lastWeek": 11,
-      "lastMonth": 135,
-      "createdAt": 1776742076187,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/mutation-test-runner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 135,
-      "createdAt": 1776742087560,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/pm-ai-partner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 135,
-      "createdAt": 1776742092151,
-      "latestVersion": "1.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/salesforce-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 135,
-      "createdAt": 1776742177232,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/sentiment-analysis-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 135,
-      "createdAt": 1776741326141,
+      "lastDay": 2,
+      "lastWeek": 8,
+      "lastMonth": 31,
+      "createdAt": 1776741598443,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/snowflake-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 135,
+      "lastWeek": 6,
+      "lastMonth": 31,
       "createdAt": 1776742197705,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/sql-query-optimizer",
+      "name": "@intentsolutionsio/transfer-learning-adapter",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 135,
-      "createdAt": 1776741823153,
+      "lastWeek": 6,
+      "lastMonth": 31,
+      "createdAt": 1776741335844,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/wondelai-scorecard-marketing",
+      "name": "@intentsolutionsio/jeremy-adk-software-engineer",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 30,
+      "createdAt": 1776741248596,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/pci-dss-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 30,
+      "createdAt": 1776742139757,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/perplexity-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 135,
-      "createdAt": 1776741560291,
+      "lastMonth": 30,
+      "createdAt": 1767929523683,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/assemblyai-pack",
+      "name": "@intentsolutionsio/wondelai-made-to-stick",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 134,
-      "createdAt": 1776741480612,
+      "lastWeek": 8,
+      "lastMonth": 30,
+      "createdAt": 1776741536427,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/anima-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 29,
+      "createdAt": 1776741418062,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clickhouse-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 29,
+      "createdAt": 1776741612865,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/clickup-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 134,
+      "lastWeek": 4,
+      "lastMonth": 29,
       "createdAt": 1776741618071,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/creator-studio-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 134,
-      "createdAt": 1776741682547,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-index-advisor",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 134,
-      "createdAt": 1776741759111,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/disaster-recovery-planner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 134,
-      "createdAt": 1776741831646,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fairdb-operations-kit",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 134,
-      "createdAt": 1776741874121,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fairdb-ops-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 134,
-      "createdAt": 1776741584199,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/notion-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 134,
-      "createdAt": 1776742100763,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/prettier-markdown-hook",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 134,
-      "createdAt": 1776742098264,
-      "latestVersion": "1.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/websocket-server-builder",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 134,
-      "createdAt": 1776741460296,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-influence-psychology",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 134,
-      "createdAt": 1776741526090,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/002-jeremy-yaml-master-agent",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 133,
-      "createdAt": 1776741345442,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/access-control-auditor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 133,
-      "createdAt": 1776741367109,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/apm-dashboard-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 133,
-      "createdAt": 1776741454214,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/claude-never-forgets",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 133,
-      "createdAt": 1776741575118,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fathom-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 133,
-      "createdAt": 1776741885508,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-firebase",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 133,
-      "createdAt": 1776741603360,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/metrics-aggregator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 133,
-      "createdAt": 1776742022471,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/miro-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 8,
-      "lastMonth": 133,
-      "createdAt": 1776742071464,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/roi-calculator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 133,
-      "createdAt": 1776741156223,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/security-misconfiguration-finder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 133,
-      "createdAt": 1776742215068,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/shipwright",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 10,
-      "lastMonth": 133,
-      "createdAt": 1776741161170,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/soc2-audit-helper",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 133,
-      "createdAt": 1776742251865,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/test-data-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 133,
-      "createdAt": 1776742273457,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-contagious",
+      "name": "@intentsolutionsio/contract-test-validator",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 133,
-      "createdAt": 1776741499334,
+      "lastMonth": 29,
+      "createdAt": 1776741660836,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/wondelai-crossing-the-chasm",
+      "name": "@intentsolutionsio/crypto-derivatives-tracker",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 133,
-      "createdAt": 1776741510287,
+      "lastDay": 1,
+      "lastWeek": 8,
+      "lastMonth": 29,
+      "createdAt": 1776741628445,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/apple-notes-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776741465204,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/authentication-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776741492512,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/bottleneck-detector",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776741527951,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/capacity-planning-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 132,
-      "createdAt": 1776741573970,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/classification-model-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776741194497,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/coreweave-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776741666254,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/error-rate-monitor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 132,
-      "createdAt": 1776741874361,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/hyperfocus",
+      "name": "@intentsolutionsio/general-legal-assistant",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 132,
-      "createdAt": 1776741992310,
-      "latestVersion": "0.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/input-validation-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 132,
-      "createdAt": 1776742003316,
+      "lastMonth": 29,
+      "createdAt": 1776741480088,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/log-analysis-tool",
+      "name": "@intentsolutionsio/granola-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776742012942,
+      "lastMonth": 29,
+      "createdAt": 1767929567573,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/mattyp-changelog",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 132,
-      "createdAt": 1776741943473,
-      "latestVersion": "0.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/monitoring-stack-deployer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 132,
-      "createdAt": 1776741949314,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/network-policy-manager",
+      "name": "@intentsolutionsio/local-tts",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 132,
-      "createdAt": 1776741954784,
+      "lastMonth": 29,
+      "createdAt": 1776741272966,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/onenote-pack",
+      "name": "@intentsolutionsio/ramp-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 132,
-      "createdAt": 1776742112289,
+      "lastMonth": 29,
+      "createdAt": 1776742161687,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/resource-usage-tracker",
+      "name": "@intentsolutionsio/security-pro-pack",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
-      "createdAt": 1776742052108,
+      "lastDay": 2,
+      "lastWeek": 7,
+      "lastMonth": 29,
+      "createdAt": 1776742001005,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/service-mesh-configurator",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 132,
+      "lastDay": 1,
+      "lastWeek": 7,
+      "lastMonth": 29,
       "createdAt": 1776741964665,
       "latestVersion": "1.0.0"
     },
@@ -2183,261 +896,855 @@
       "name": "@intentsolutionsio/time-series-forecaster",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 132,
+      "lastWeek": 4,
+      "lastMonth": 29,
       "createdAt": 1776741331102,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-crossing-the-chasm",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 29,
+      "createdAt": 1776741510287,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-hooked-ux",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 29,
+      "createdAt": 1776741837303,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-hundred-million-offers",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 8,
+      "lastMonth": 29,
+      "createdAt": 1776741521101,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-influence-psychology",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 29,
+      "createdAt": 1776741526090,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-schema-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 28,
+      "createdAt": 1776741416639,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/liquidity-pool-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 28,
+      "createdAt": 1776741673967,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-incident-responder",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 6,
+      "lastMonth": 28,
+      "createdAt": 1776742209945,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/twinmind-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 132,
+      "lastWeek": 3,
+      "lastMonth": 28,
       "createdAt": 1776742223810,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-design-everyday-things",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 28,
+      "createdAt": 1776741832696,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/wondelai-jobs-to-be-done",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 132,
+      "lastWeek": 3,
+      "lastMonth": 28,
       "createdAt": 1776741531206,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/ai-commit-gen",
+      "name": "@intentsolutionsio/wondelai-one-page-marketing",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 28,
+      "createdAt": 1776741550755,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-traction-eos",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 28,
+      "createdAt": 1776741570146,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fathom-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 27,
+      "createdAt": 1776741885508,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-firestore",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 27,
+      "createdAt": 1776741608443,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-gcp-starter-examples",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 131,
-      "createdAt": 1776741391024,
-      "latestVersion": "1.0.0"
+      "lastMonth": 27,
+      "createdAt": 1776741253353,
+      "latestVersion": "2.1.0"
     },
     {
-      "name": "@intentsolutionsio/api-monitoring-dashboard",
+      "name": "@intentsolutionsio/jeremy-genkit-pro",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741396718,
-      "latestVersion": "1.0.0"
+      "lastMonth": 27,
+      "createdAt": 1776741258201,
+      "latestVersion": "2.1.0"
     },
     {
-      "name": "@intentsolutionsio/apify-pack",
+      "name": "@intentsolutionsio/model-deployment-helper",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741449323,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/appfolio-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741459687,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/clari-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741595043,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/contributing-clanker",
-      "status": "published",
-      "lastDay": 5,
-      "lastWeek": 131,
-      "lastMonth": 131,
-      "createdAt": 1777867323247,
-      "latestVersion": "0.1.1"
-    },
-    {
-      "name": "@intentsolutionsio/dataset-splitter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741218574,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/load-balancer-tester",
-      "status": "published",
-      "lastDay": 0,
+      "lastDay": 2,
       "lastWeek": 5,
-      "lastMonth": 131,
-      "createdAt": 1776742042186,
+      "lastMonth": 27,
+      "createdAt": 1776741282704,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/mobile-app-tester",
+      "name": "@intentsolutionsio/n8n-workflow-designer",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 131,
-      "createdAt": 1776742081444,
+      "lastMonth": 27,
+      "createdAt": 1776741151393,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/overnight-dev",
+      "name": "@intentsolutionsio/performance-regression-detector",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 131,
-      "createdAt": 1776742087226,
+      "lastWeek": 6,
+      "lastMonth": 27,
+      "createdAt": 1776742042415,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/query-performance-analyzer",
+      "name": "@intentsolutionsio/roi-calculator",
       "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 131,
-      "createdAt": 1776741818576,
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 27,
+      "createdAt": 1776741156223,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/response-time-tracker",
+      "name": "@intentsolutionsio/sprint",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 131,
-      "createdAt": 1776742056723,
+      "lastMonth": 27,
+      "createdAt": 1776741613368,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/salesloft-pack",
+      "name": "@intentsolutionsio/synthetic-monitoring-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 27,
+      "createdAt": 1776742066032,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/together-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776742182221,
+      "lastMonth": 27,
+      "createdAt": 1776742218658,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/security-pro-pack",
+      "name": "@intentsolutionsio/wondelai-predictable-revenue",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 27,
+      "createdAt": 1776741555484,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-ux-heuristics",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 27,
+      "createdAt": 1776741857246,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-web-typography",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 131,
-      "createdAt": 1776742001005,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/sow-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 131,
-      "createdAt": 1776741166392,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ssl-certificate-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 131,
-      "createdAt": 1776742260826,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/stackblitz-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 131,
-      "createdAt": 1776742208455,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/terraform-module-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 131,
-      "createdAt": 1776741974510,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/zapier-zap-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 131,
-      "createdAt": 1776741170876,
+      "lastMonth": 27,
+      "createdAt": 1776741861968,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/003-jeremy-vertex-ai-media-master",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 130,
+      "lastWeek": 7,
+      "lastMonth": 26,
       "createdAt": 1776741351076,
       "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ai-ethics-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 130,
-      "createdAt": 1776741175662,
-      "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/anomaly-detection-system",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 130,
+      "lastWeek": 5,
+      "lastMonth": 26,
       "createdAt": 1776741185020,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/api-load-tester",
+      "name": "@intentsolutionsio/api-event-emitter",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 6,
-      "lastMonth": 130,
-      "createdAt": 1776741382190,
+      "lastMonth": 26,
+      "createdAt": 1776741371900,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/api-migration-tool",
+      "name": "@intentsolutionsio/api-fuzzer",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 130,
-      "createdAt": 1776741387229,
+      "lastWeek": 4,
+      "lastMonth": 26,
+      "createdAt": 1776741436171,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/cloud-cost-optimizer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 130,
-      "createdAt": 1776741623637,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/experiment-tracking-setup",
+      "name": "@intentsolutionsio/automl-pipeline-builder",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 130,
-      "createdAt": 1776741228741,
+      "lastMonth": 26,
+      "createdAt": 1776741189916,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/b12-claude-plugin",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776741506522,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-signal-generator",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 26,
+      "createdAt": 1776741643301,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/framecraft",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776741589225,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gas-fee-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776741668673,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-genkit-terraform",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 26,
+      "createdAt": 1776741913788,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/lucidchart-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776742054478,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/market-sentiment-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 26,
+      "createdAt": 1776741689689,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/palantir-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776742134577,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sow-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 26,
+      "createdAt": 1776741166392,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-doubles-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 26,
+      "createdAt": 1776742278508,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/windsurf-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 26,
+      "createdAt": 1767929526171,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-blue-ocean-strategy",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 26,
+      "createdAt": 1776741494266,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-storybrand-messaging",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 26,
+      "createdAt": 1776741565251,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 9,
+      "lastMonth": 25,
+      "createdAt": 1776741339416,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/004-jeremy-google-cloud-agent-sdk",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 25,
+      "createdAt": 1776741356423,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/appfolio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741459687,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/blockchain-explorer-cli",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741522342,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/boycott-filter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 25,
+      "createdAt": 1776741540431,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/canva-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741567722,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/container-registry-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741650848,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cors-policy-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 25,
+      "createdAt": 1776741671309,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-deadlock-detector",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741739254,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/dataset-splitter",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741218574,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/error-rate-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776741874361,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/overnight-dev",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 25,
+      "createdAt": 1776742087226,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/owasp-compliance-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 25,
+      "createdAt": 1776742128831,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/promptbook",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 25,
+      "createdAt": 1776741489578,
+      "latestVersion": "1.4.0"
+    },
+    {
+      "name": "@intentsolutionsio/secrets-manager-integrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 9,
+      "lastMonth": 25,
+      "createdAt": 1776741959827,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/token-launch-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 25,
+      "createdAt": 1776741720118,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-drive-motivation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 25,
+      "createdAt": 1776741516001,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-refactoring-ui",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 25,
+      "createdAt": 1776741847233,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/attio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 24,
+      "createdAt": 1776741485907,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cache-performance-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 24,
+      "createdAt": 1776741557657,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/castai-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 24,
+      "createdAt": 1776741579323,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/classification-model-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 24,
+      "createdAt": 1776741194497,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/code-cleanup",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 24,
+      "createdAt": 1776741629140,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cpu-usage-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776741676912,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-index-advisor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 8,
+      "lastMonth": 24,
+      "createdAt": 1776741759111,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deployment-rollback-manager",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776741820945,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gh-dash",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 24,
+      "createdAt": 1776741878935,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hyperfocus",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 24,
+      "createdAt": 1776741992310,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-as-code-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 24,
+      "createdAt": 1776741898519,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-adk-terraform",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 24,
+      "createdAt": 1776741908802,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-versioning-tracker",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776741296763,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/neurodivergent-visual-org",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776742082401,
+      "latestVersion": "3.1.1"
+    },
+    {
+      "name": "@intentsolutionsio/resource-usage-tracker",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 7,
+      "lastMonth": 24,
+      "createdAt": 1776742052108,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/techsmith-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776742214034,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/terraform-module-builder",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 24,
+      "createdAt": 1776741974510,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/webhook-handler-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 24,
+      "createdAt": 1776741455511,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-obviously-awesome",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 24,
+      "createdAt": 1776741545705,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-sdk-agents",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741180231,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-authentication-builder",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776741340599,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apm-dashboard-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776741454214,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apple-notes-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776741465204,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/assemblyai-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776741480612,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/box-cloud-filesystem",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741532611,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/chaos-engineering-toolkit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741584405,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clustering-algorithm-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776741199210,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/data-visualization-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741213237,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-archival-system",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776741711937,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/databricks-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741805135,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/discovery-questionnaire",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776741141456,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/environment-config-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 23,
+      "createdAt": 1776741869031,
       "latestVersion": "1.0.0"
     },
     {
@@ -2445,43 +1752,1456 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 130,
+      "lastMonth": 23,
       "createdAt": 1776741233516,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/freshie-inventory-manager",
+      "name": "@intentsolutionsio/gamma-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1767929569776,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/glean-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776741947525,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/graphql-server-builder",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 130,
-      "createdAt": 1776741803557,
+      "lastMonth": 23,
+      "createdAt": 1776741440853,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/groq-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 23,
+      "createdAt": 1767929539979,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-firebase",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741603360,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/lindy-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 6,
+      "lastMonth": 23,
+      "createdAt": 1767929565624,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/linktree-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776742036794,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/obsidian-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776742106568,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/pm-ai-partner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 23,
+      "createdAt": 1776742092151,
+      "latestVersion": "1.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/quicknode-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 23,
+      "createdAt": 1776742157146,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/research-to-deploy",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 23,
+      "createdAt": 1776742173583,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/response-time-tracker",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776742056723,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/session-security-checker",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 7,
+      "lastMonth": 23,
+      "createdAt": 1776742224677,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/snapshot-test-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776742246361,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sugar",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776741969622,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-contagious",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 23,
+      "createdAt": 1776741499334,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-scorecard-marketing",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 23,
+      "createdAt": 1776741560291,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/zai-cli",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 23,
+      "createdAt": 1776741618257,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-commit-gen",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776741391024,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ansible-playbook-creator",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 22,
+      "createdAt": 1776741423878,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-cache-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 22,
+      "createdAt": 1776741350600,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-contract-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776741356168,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-documentation-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741361862,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-gateway-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776741377006,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-load-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741382190,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-test-automation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741443439,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-versioning-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776741436238,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apollo-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1767929554160,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/browser-compatibility-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776741552255,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/crypto-news-aggregator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741633481,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-migration-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 22,
+      "createdAt": 1776741764014,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-transaction-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741798655,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/framer-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776741929510,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hootsuite-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776741981134,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/integration-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776742009284,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/intercom-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776742014863,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/kubernetes-deployment-creator",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 7,
+      "lastMonth": 22,
+      "createdAt": 1776741927823,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/load-balancer-configurator",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 130,
+      "lastWeek": 4,
+      "lastMonth": 22,
       "createdAt": 1776741932915,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mempool-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776741694753,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mobile-app-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776742081444,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-explainability-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741292013,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/network-policy-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776741954784,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/onenote-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 22,
+      "createdAt": 1776742112289,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/query-performance-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776741818576,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/runway-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776742172008,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/search-to-slack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 6,
+      "lastMonth": 22,
+      "createdAt": 1776742188886,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-audit-reporter",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 6,
+      "lastMonth": 22,
+      "createdAt": 1776742200221,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/severity1-marketplace",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776742230208,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-data-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776742273457,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-orchestrator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776742289194,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/throughput-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 22,
+      "createdAt": 1776742070887,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wallet-security-auditor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 22,
+      "createdAt": 1776741734689,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wispr-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776742239940,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-negotiation",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 22,
+      "createdAt": 1776741541091,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/zapier-zap-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 22,
+      "createdAt": 1776741170876,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/access-control-auditor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741367109,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ai-ethics-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741175662,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-rate-limiter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741401315,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-throttling-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741431238,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/authentication-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741492512,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/auto-scaling-configurator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741500087,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clari-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741595043,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/clay-pack",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 7,
+      "lastMonth": 21,
+      "createdAt": 1767929530301,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cloud-cost-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741623637,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/creator-studio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741682547,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/cross-chain-bridge-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741623465,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/csrf-protection-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 21,
+      "createdAt": 1776741689021,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-cache-layer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 21,
+      "createdAt": 1776741728051,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/dependency-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741811210,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/dex-aggregator-router",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741658472,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/distributed-tracing-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741837206,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/flexport-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741907785,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fullstack-starter-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741935465,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gdpr-compliance-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741941194,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-drift-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741903590,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/jeremy-plugin-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741985544,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/log-aggregation-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741938134,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/log-analysis-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776742012942,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/make-scenario-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741146439,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/metrics-aggregator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776742022471,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ml-model-trainer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741277876,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/model-evaluation-suite",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741287537,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/navigating-github",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776742077901,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/network-latency-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742027404,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/notion-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776742100763,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/oraclecloud-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776742123023,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/penetration-tester",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742145662,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-budget-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742032418,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-optimization-advisor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 21,
+      "createdAt": 1776742038071,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/persona-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742142424,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/pi-pathfinder",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776741990618,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/smoke-test-runner",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 130,
+      "lastWeek": 4,
+      "lastMonth": 21,
       "createdAt": 1776742241282,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/soc2-audit-helper",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742251865,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ssl-certificate-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742260826,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-report-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 21,
+      "createdAt": 1776742294343,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/tweetclaw",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741979702,
+      "latestVersion": "1.5.3"
+    },
+    {
+      "name": "@intentsolutionsio/vulnerability-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742266333,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/websocket-server-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741460296,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-cro-methodology",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 21,
+      "createdAt": 1776741505352,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-design-sprint",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776742113532,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-ios-hig-design",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741842617,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-top-design",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 21,
+      "createdAt": 1776741852345,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/xss-vulnerability-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 7,
+      "lastMonth": 21,
+      "createdAt": 1776742271063,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/adobe-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741380220,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/agent-context-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741386025,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/alerting-rule-creator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741407319,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-mock-server",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 20,
+      "createdAt": 1776741392061,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-request-logger",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741406484,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-security-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741426229,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/apify-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741449323,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/coderabbit-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 20,
+      "createdAt": 1767929546848,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/customerio-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1767929561184,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-sharding-manager",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741793860,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deployment-pipeline-orchestrator",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 7,
+      "lastMonth": 20,
+      "createdAt": 1776741816157,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/e2e-test-framework",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776741852958,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fairdb-ops-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741584199,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/figma-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776741890993,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/formatter",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 6,
+      "lastMonth": 20,
+      "createdAt": 1776741923633,
+      "latestVersion": "2.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/gastown",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741593740,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/infrastructure-metrics-collector",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 6,
+      "lastMonth": 20,
+      "createdAt": 1776741997955,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/load-balancer-tester",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776742042186,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/neural-network-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 20,
+      "createdAt": 1776741301744,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/nlp-text-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776741306620,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/on-chain-analytics",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776741704727,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/performance-test-suite",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776742151365,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/real-user-monitoring",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776742047249,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/salesloft-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776742182221,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-headers-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776742205129,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sentiment-analysis-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741326141,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/stored-procedure-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776741828140,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/unit-test-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 20,
+      "createdAt": 1776742299588,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/vibe-guide",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 20,
+      "createdAt": 1776742108359,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/webflow-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 6,
+      "lastMonth": 20,
+      "createdAt": 1776742234620,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/002-jeremy-yaml-master-agent",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741345442,
+      "latestVersion": "2.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-migration-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741387229,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-sdk-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741421642,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/bottleneck-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741527951,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/capacity-planning-analyzer",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776741573970,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ci-cd-pipeline-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741589894,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-memory-kit",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776741600302,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-never-forgets",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741575118,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/claude-reflect",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776741579743,
+      "latestVersion": "1.5.0"
+    },
+    {
+      "name": "@intentsolutionsio/coreweave-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1776741666254,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-audit-logger",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1776741717321,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-connection-pooler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1776741733202,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-security-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1776741788589,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deep-learning-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776741223557,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/devops-automation-pack",
+      "status": "published",
+      "lastDay": 3,
+      "lastWeek": 7,
+      "lastMonth": 19,
+      "createdAt": 1776741826196,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hipaa-compliance-checker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776741975805,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/memory-leak-detector",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 19,
+      "createdAt": 1776742017667,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/monitoring-stack-deployer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776741949314,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mutation-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776742087560,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/orm-code-generator",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 19,
+      "createdAt": 1776741812841,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/recommendation-engine",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 19,
+      "createdAt": 1776741316128,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/rest-api-generator",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 19,
+      "createdAt": 1776741450487,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/security-misconfiguration-finder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776742215068,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sentry-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1767121182722,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/staking-rewards-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 19,
+      "createdAt": 1776741715194,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/wondelai-lean-startup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 19,
+      "createdAt": 1776742118723,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/workhuman-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 19,
+      "createdAt": 1776742244908,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/alchemy-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 129,
+      "lastWeek": 4,
+      "lastMonth": 18,
       "createdAt": 1776741401853,
       "latestVersion": "1.0.0"
     },
@@ -2490,881 +3210,98 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 129,
+      "lastMonth": 18,
       "createdAt": 1776741412656,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/api-documentation-generator",
+      "name": "@intentsolutionsio/data-privacy-scanner",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 2,
-      "lastMonth": 129,
-      "createdAt": 1776741361862,
+      "lastMonth": 18,
+      "createdAt": 1776741695023,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/api-event-emitter",
+      "name": "@intentsolutionsio/data-seeder-generator",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 129,
-      "createdAt": 1776741371900,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776741700157,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/api-schema-validator",
+      "name": "@intentsolutionsio/data-validation-engine",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 4,
+      "lastMonth": 18,
+      "createdAt": 1776741706039,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/disaster-recovery-planner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776741831646,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/fairdb-operations-kit",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776741874121,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/file-to-code",
+      "status": "published",
+      "lastDay": 2,
+      "lastWeek": 5,
+      "lastMonth": 18,
+      "createdAt": 1776741896252,
+      "latestVersion": "0.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/fireflies-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 2,
+      "lastMonth": 18,
+      "createdAt": 1767929544753,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/freshie-inventory-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 18,
+      "createdAt": 1776741803557,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/git-commit-smart",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 5,
-      "lastMonth": 129,
-      "createdAt": 1776741416639,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/bamboohr-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 129,
-      "createdAt": 1776741517049,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/database-security-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 129,
-      "createdAt": 1776741788589,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/docker-compose-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 129,
-      "createdAt": 1776741842527,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/figma-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 129,
-      "createdAt": 1776741890993,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/hootsuite-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 129,
-      "createdAt": 1776741981134,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-gcp-starter-examples",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 129,
-      "createdAt": 1776741253353,
-      "latestVersion": "2.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/nosql-data-modeler",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 129,
-      "createdAt": 1776741808087,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/procore-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 129,
-      "createdAt": 1776742152600,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/snapshot-test-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 129,
-      "createdAt": 1776742246361,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wispr-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 129,
-      "createdAt": 1776742239940,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/youtube-strategy",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 129,
-      "createdAt": 1776742123654,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-authentication-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 128,
-      "createdAt": 1776741340599,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-cache-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 128,
-      "createdAt": 1776741350600,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/backup-strategy-implementor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 128,
-      "createdAt": 1776741511388,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/castai-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 128,
-      "createdAt": 1776741579323,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/discovery-questionnaire",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 128,
-      "createdAt": 1776741141456,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fondo-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 128,
-      "createdAt": 1776741918288,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fullstack-starter-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 128,
-      "createdAt": 1776741935465,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/hello-world",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 128,
-      "createdAt": 1776741964579,
+      "lastMonth": 18,
+      "createdAt": 1776741883794,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/hyperparameter-tuner",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 128,
+      "lastWeek": 5,
+      "lastMonth": 18,
       "createdAt": 1776741238112,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/lucidchart-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 128,
-      "createdAt": 1776742054478,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/make-scenario-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 128,
-      "createdAt": 1776741146439,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/openevidence-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 128,
-      "createdAt": 1776742117677,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/vulnerability-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 128,
-      "createdAt": 1776742266333,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-cro-methodology",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 128,
-      "createdAt": 1776741505352,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-storybrand-messaging",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 128,
-      "createdAt": 1776741565251,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/accessibility-test-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 127,
-      "createdAt": 1776741372890,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ai-ml-engineering-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 127,
-      "createdAt": 1776741396518,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/claude-reflect",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 127,
-      "createdAt": 1776741579743,
-      "latestVersion": "1.5.0"
-    },
-    {
-      "name": "@intentsolutionsio/formatter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 127,
-      "createdAt": 1776741923633,
-      "latestVersion": "2.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/grammarly-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 127,
-      "createdAt": 1776741953217,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-terraform",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 127,
-      "createdAt": 1776741923149,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/kubernetes-deployment-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 127,
-      "createdAt": 1776741927823,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/oraclecloud-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 127,
-      "createdAt": 1776742123023,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/regression-analysis-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 127,
-      "createdAt": 1776741320893,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/serpapi-pack",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 127,
-      "createdAt": 1776742187383,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/test-coverage-analyzer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 127,
-      "createdAt": 1776742268158,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/test-doubles-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 127,
-      "createdAt": 1776742278508,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/tonone",
-      "status": "published",
-      "lastDay": 5,
-      "lastWeek": 127,
-      "lastMonth": 127,
-      "createdAt": 1777867315353,
-      "latestVersion": "0.9.7"
-    },
-    {
-      "name": "@intentsolutionsio/tweetclaw",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 127,
-      "createdAt": 1776741979702,
-      "latestVersion": "1.5.3"
-    },
-    {
-      "name": "@intentsolutionsio/webflow-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 127,
-      "createdAt": 1776742234620,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/wondelai-hundred-million-offers",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 127,
-      "createdAt": 1776741521101,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/alerting-rule-creator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776741407319,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-contract-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 126,
-      "createdAt": 1776741356168,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-request-logger",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776741406484,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-sdk-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 126,
-      "createdAt": 1776741421642,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/claudebase",
-      "status": "published",
-      "lastDay": 8,
-      "lastWeek": 126,
-      "lastMonth": 126,
-      "createdAt": 1777867338728,
-      "latestVersion": "0.2.0"
-    },
-    {
-      "name": "@intentsolutionsio/deep-learning-optimizer",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 126,
-      "createdAt": 1776741223557,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/file-to-code",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 126,
-      "createdAt": 1776741896252,
-      "latestVersion": "0.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/grpc-service-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776741445475,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/hipaa-compliance-checker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776741975805,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/linktree-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776742036794,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ollama-local-ai",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 3,
-      "lastMonth": 126,
-      "createdAt": 1776741311329,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/performance-regression-detector",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 5,
-      "lastMonth": 126,
-      "createdAt": 1776742042415,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/real-user-monitoring",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 126,
-      "createdAt": 1776742047249,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/rest-api-generator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 126,
-      "createdAt": 1776741450487,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/shopify-pack",
-      "status": "published",
-      "lastDay": 3,
-      "lastWeek": 7,
-      "lastMonth": 126,
-      "createdAt": 1776742192751,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/ai-sdk-agents",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 125,
-      "createdAt": 1776741180231,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/canva-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 6,
-      "lastMonth": 125,
-      "createdAt": 1776741567722,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cors-policy-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 125,
-      "createdAt": 1776741671309,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/environment-config-manager",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 125,
-      "createdAt": 1776741869031,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/evernote-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 125,
-      "createdAt": 1776741879235,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/intercom-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 125,
-      "createdAt": 1776742014863,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/owasp-compliance-checker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 125,
-      "createdAt": 1776742128831,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/validate-plugin",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 125,
-      "createdAt": 1776742277333,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/abridge-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 124,
-      "createdAt": 1776741362002,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-batch-processor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 124,
-      "createdAt": 1776741345543,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/api-response-validator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 124,
-      "createdAt": 1776741411642,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/framer-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 124,
-      "createdAt": 1776741929510,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-github-actions-gcp",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 124,
-      "createdAt": 1776741918359,
-      "latestVersion": "2.1.0"
-    },
-    {
-      "name": "@intentsolutionsio/neurodivergent-visual-org",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 124,
-      "createdAt": 1776742082401,
-      "latestVersion": "3.1.1"
-    },
-    {
-      "name": "@intentsolutionsio/runway-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 124,
-      "createdAt": 1776742172008,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/adobe-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 123,
-      "createdAt": 1776741380220,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/deployment-pipeline-orchestrator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 123,
-      "createdAt": 1776741816157,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/flexport-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 123,
-      "createdAt": 1776741907785,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/pi-pathfinder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 123,
-      "createdAt": 1776741990618,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/secrets-manager-integrator",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 123,
-      "createdAt": 1776741959827,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/sla-sli-tracker",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 123,
-      "createdAt": 1776742061398,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/automl-pipeline-builder",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 122,
-      "createdAt": 1776741189916,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/data-preprocessing-pipeline",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 122,
-      "createdAt": 1776741208684,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/speak-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 122,
-      "createdAt": 1776742203153,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gdpr-compliance-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 121,
-      "createdAt": 1776741941194,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-plugin-tool",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 121,
-      "createdAt": 1776741985544,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/transfer-learning-adapter",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 121,
-      "createdAt": 1776741335844,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/xss-vulnerability-scanner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 121,
-      "createdAt": 1776742271063,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/claude-memory-kit",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 120,
-      "createdAt": 1776741600302,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/log-aggregation-setup",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 120,
-      "createdAt": 1776741938134,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/maintainx-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 2,
-      "lastMonth": 120,
-      "createdAt": 1776742059330,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/computer-vision-processor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 119,
-      "createdAt": 1776741204141,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/integration-test-runner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 119,
-      "createdAt": 1776742009284,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/load-test-runner",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 119,
-      "createdAt": 1776742007859,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/performance-optimization-advisor",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 119,
-      "createdAt": 1776742038071,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/langfuse-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 5,
-      "lastMonth": 118,
-      "createdAt": 1776742031108,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/memory-leak-detector",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 117,
-      "createdAt": 1776742017667,
       "latestVersion": "1.0.0"
     },
     {
@@ -3372,17 +3309,368 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 114,
+      "lastMonth": 18,
       "createdAt": 1776742024634,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/load-test-runner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 18,
+      "createdAt": 1776742007859,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/lokalise-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 113,
+      "lastWeek": 6,
+      "lastMonth": 18,
       "createdAt": 1776742048902,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/mindtickle-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 18,
+      "createdAt": 1776742066066,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/nosql-data-modeler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776741808087,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/prettier-markdown-hook",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 18,
+      "createdAt": 1776742098264,
+      "latestVersion": "1.1.0"
+    },
+    {
+      "name": "@intentsolutionsio/regression-test-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776742167996,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/remofirst-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 18,
+      "createdAt": 1776742166680,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sla-sli-tracker",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776742061398,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/speak-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776742203153,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/sql-query-optimizer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776741823153,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-coverage-analyzer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 18,
+      "createdAt": 1776742268158,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/test-environment-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 18,
+      "createdAt": 1776742283558,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/whale-alert-monitor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 18,
+      "createdAt": 1776741739600,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/accessibility-test-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 17,
+      "createdAt": 1776741372890,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-batch-processor",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741345543,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-error-handler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741366917,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-response-validator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741411642,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/bamboohr-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 17,
+      "createdAt": 1776741517049,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/compliance-report-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 17,
+      "createdAt": 1776741645289,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-query-profiler",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 17,
+      "createdAt": 1776741774708,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-replication-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 17,
+      "createdAt": 1776741779366,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-schema-designer",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 17,
+      "createdAt": 1776741783990,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-test-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 17,
+      "createdAt": 1776741798986,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/docker-compose-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741842527,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/experiment-tracking-setup",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741228741,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/grpc-service-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741445475,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/helm-chart-generator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741893614,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/input-validation-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 17,
+      "createdAt": 1776742003316,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/ollama-local-ai",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776741311329,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/salesforce-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 17,
+      "createdAt": 1776742177232,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/stackblitz-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 17,
+      "createdAt": 1776742208455,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/visual-regression-tester",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 17,
+      "createdAt": 1776742304930,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/api-monitoring-dashboard",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 16,
+      "createdAt": 1776741396718,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/container-security-scanner",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 16,
+      "createdAt": 1776741655802,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-backup-automator",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 16,
+      "createdAt": 1776741722868,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-diff-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 16,
+      "createdAt": 1776741744406,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-documentation-gen",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 16,
+      "createdAt": 1776741749751,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-partition-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 16,
+      "createdAt": 1776741768869,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/evernote-pack",
+      "status": "published",
+      "lastDay": 1,
+      "lastWeek": 4,
+      "lastMonth": 16,
+      "createdAt": 1776741879235,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/grammarly-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 16,
+      "createdAt": 1776741953217,
       "latestVersion": "1.0.0"
     },
     {
@@ -3390,215 +3678,26 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 112,
+      "lastMonth": 16,
       "createdAt": 1776741970594,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/synthetic-monitoring-setup",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 82,
-      "createdAt": 1776742066032,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/network-latency-analyzer",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 77,
-      "createdAt": 1776742027404,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/obsidian-pack",
+      "name": "@intentsolutionsio/juicebox-pack",
       "status": "published",
       "lastDay": 1,
       "lastWeek": 3,
-      "lastMonth": 77,
-      "createdAt": 1776742106568,
+      "lastMonth": 16,
+      "createdAt": 1767929559015,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/glean-pack",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 8,
-      "lastMonth": 76,
-      "createdAt": 1776741947525,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/n8n-workflow-designer",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 3,
-      "lastMonth": 75,
-      "createdAt": 1776741151393,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/pci-dss-validator",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 10,
-      "lastMonth": 74,
-      "createdAt": 1776742139757,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/hubspot-pack",
-      "status": "published",
-      "lastDay": 4,
-      "lastWeek": 5,
-      "lastMonth": 73,
-      "createdAt": 1776741987099,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/langchain-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 18,
-      "lastMonth": 73,
-      "createdAt": 1767929563572,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/anima-pack",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 4,
-      "lastMonth": 70,
-      "createdAt": 1776741418062,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/mindtickle-pack",
-      "status": "published",
-      "lastDay": 1,
-      "lastWeek": 3,
-      "lastMonth": 69,
-      "createdAt": 1776742066066,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-vertex-ai",
-      "status": "published",
-      "lastDay": 3,
-      "lastWeek": 62,
-      "lastMonth": 62,
-      "createdAt": 1777603633821,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/jeremy-google-adk",
-      "status": "published",
-      "lastDay": 3,
-      "lastWeek": 60,
-      "lastMonth": 60,
-      "createdAt": 1777603623651,
-      "latestVersion": "2.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/openrouter-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 10,
-      "lastMonth": 55,
-      "createdAt": 1767929515334,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/klingai-pack",
-      "status": "published",
-      "lastDay": 5,
-      "lastWeek": 32,
-      "lastMonth": 53,
-      "createdAt": 1767929518106,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/vastai-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 7,
-      "lastMonth": 47,
-      "createdAt": 1767929537310,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/windsurf-pack",
-      "status": "published",
-      "lastDay": 4,
-      "lastWeek": 6,
-      "lastMonth": 46,
-      "createdAt": 1767929526171,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/coderabbit-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 4,
-      "lastMonth": 20,
-      "createdAt": 1767929546848,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/granola-pack",
+      "name": "@intentsolutionsio/regression-analysis-tool",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 3,
-      "lastMonth": 20,
-      "createdAt": 1767929567573,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/retellai-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 5,
-      "lastMonth": 20,
-      "createdAt": 1767929520308,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/firecrawl-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 3,
-      "lastMonth": 19,
-      "createdAt": 1767929528093,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/perplexity-pack",
-      "status": "published",
-      "lastDay": 4,
-      "lastWeek": 7,
-      "lastMonth": 19,
-      "createdAt": 1767929523683,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/linear-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 18,
-      "createdAt": 1767929574015,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/sentry-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 3,
-      "lastMonth": 18,
-      "createdAt": 1767121182722,
+      "lastMonth": 16,
+      "createdAt": 1776741320893,
       "latestVersion": "1.0.0"
     },
     {
@@ -3606,98 +3705,125 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 1,
-      "lastMonth": 18,
+      "lastMonth": 16,
       "createdAt": 1767067636870,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "claude-plugin-validator",
+      "name": "@intentsolutionsio/application-profiler",
       "status": "published",
-      "lastDay": 1,
-      "lastWeek": 6,
-      "lastMonth": 17,
-      "createdAt": 1763263826323,
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 15,
+      "createdAt": 1776741470307,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/ideogram-pack",
+      "name": "@intentsolutionsio/backup-strategy-implementor",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 16,
-      "createdAt": 1767929551266,
+      "lastMonth": 15,
+      "createdAt": 1776741511388,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/customerio-pack",
+      "name": "@intentsolutionsio/data-preprocessing-pipeline",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 15,
+      "createdAt": 1776741208684,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/database-recovery-manager",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 15,
+      "createdAt": 1776741774117,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/deepgram-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 15,
+      "createdAt": 1767929556761,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/documenso-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 4,
-      "lastMonth": 13,
-      "createdAt": 1767929561184,
+      "lastMonth": 15,
+      "createdAt": 1776741848088,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/gitops-workflow-builder",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 4,
+      "lastMonth": 15,
+      "createdAt": 1776741888908,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/hello-world",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 3,
+      "lastMonth": 15,
+      "createdAt": 1776741964579,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/posthog-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 2,
+      "lastMonth": 15,
+      "createdAt": 1767929549075,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/encryption-tool",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 5,
+      "lastMonth": 14,
+      "createdAt": 1776741863344,
       "latestVersion": "1.0.0"
     },
     {
       "name": "@intentsolutionsio/exa-pack",
       "status": "published",
       "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 13,
+      "lastWeek": 2,
+      "lastMonth": 14,
       "createdAt": 1767929534960,
       "latestVersion": "1.0.0"
     },
     {
-      "name": "@intentsolutionsio/lindy-pack",
+      "name": "@intentsolutionsio/clerk-pack",
+      "status": "published",
+      "lastDay": 0,
+      "lastWeek": 1,
+      "lastMonth": 13,
+      "createdAt": 1767929571928,
+      "latestVersion": "1.0.0"
+    },
+    {
+      "name": "@intentsolutionsio/instantly-pack",
       "status": "published",
       "lastDay": 0,
       "lastWeek": 2,
       "lastMonth": 13,
-      "createdAt": 1767929565624,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/replit-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 13,
-      "createdAt": 1767929532725,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/apollo-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 12,
-      "createdAt": 1767929554160,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/cursor-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 12,
-      "createdAt": 1767929512616,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/gamma-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 12,
-      "createdAt": 1767929569776,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/juicebox-pack",
-      "status": "published",
-      "lastDay": 2,
-      "lastWeek": 2,
-      "lastMonth": 12,
-      "createdAt": 1767929559015,
+      "createdAt": 1767929542132,
       "latestVersion": "1.0.0"
     },
     {
@@ -3705,80 +3831,17 @@
       "status": "published",
       "lastDay": 0,
       "lastWeek": 1,
-      "lastMonth": 12,
+      "lastMonth": 13,
       "createdAt": 1767044418798,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/clerk-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 11,
-      "createdAt": 1767929571928,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/deepgram-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 11,
-      "createdAt": 1767929556761,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/fireflies-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 11,
-      "createdAt": 1767929544753,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/clay-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 10,
-      "createdAt": 1767929530301,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/groq-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 10,
-      "createdAt": 1767929539979,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/instantly-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 1,
-      "lastMonth": 10,
-      "createdAt": 1767929542132,
-      "latestVersion": "1.0.0"
-    },
-    {
-      "name": "@intentsolutionsio/posthog-pack",
-      "status": "published",
-      "lastDay": 0,
-      "lastWeek": 0,
-      "lastMonth": 10,
-      "createdAt": 1767929549075,
       "latestVersion": "1.0.0"
     }
   ],
   "telemetry": {
-    "candidates": 438,
-    "probed": 438,
-    "published": 418,
-    "unpublished": 17,
-    "foreign": 3,
+    "candidates": 447,
+    "probed": 447,
+    "published": 425,
+    "unpublished": 20,
+    "foreign": 2,
     "rateLimited": 0,
     "errors": 0
   }


### PR DESCRIPTION
Regenerates `marketplace/src/data/npm-stats.json` + README NPM-STATS block with current download counts (commit from the `update-npm-stats` run on GitHub's runner).

**Fresh totals (2026-05-27):** publishedCount 425, totalMonth **14,130** (was 53,237 on 2026-05-07 — that month was a spike), totalWeek 2,477.

Note: every prior daily cron failed because the workflow referenced a `stats` label that didn't exist — `gh pr create` exited 1 *after* pushing the branch. Created the label now, so future crons will open this PR cleanly.

- Jeremy Longshore
intentsolutions.io