### PR TITLE
chore(ci): add repo-specific codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,127 @@
+# Codecov configuration for jeremylongshore/claude-code-plugins-plus-skills
+#
+# Repo-specific — tuned to this repo's real surface (catalog-heavy, validator-driven,
+# multi-package monorepo). Not a generic starter.
+#
+# Posture:
+# - project target: auto (no regression vs current baseline) + 2% slack
+# - patch target: 40% (anchored to what the current test surface actually delivers;
+#   raise as pytest coverage of validate-skills-schema.py and packages/cli grows)
+# - if_ci_failed: success (Codecov outage must not red-X the CI)
+# - only_pulls: true (don't gate the bot-driven push streams to main)
+# - components: 7 real packages/dirs only — no phantoms
+
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: '30...100'
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: success
+        only_pulls: true
+    patch:
+      default:
+        target: 40%
+        threshold: 10%
+        if_ci_failed: success
+        only_pulls: true
+
+comment:
+  layout: 'condensed_header, diff, flags, components, files'
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+ignore:
+  # Documentation — never measured
+  - '**/*.md'
+  - '**/*.mdx'
+  - '000-docs/**'
+  - 'docs/**'
+
+  # Catalog data — generated or hand-edited JSON, not executable
+  - 'plugins/**/plugin.json'
+  - '.claude-plugin/**'
+  - 'marketplace/src/data/**'
+  - 'marketplace/public/data/**'
+  - 'marketplace/dist/**'
+  - 'marketplace/public/downloads/**'
+
+  # Forge audit trails (build-time only)
+  - '**/.forge/**'
+
+  # Freshie inventory CMDB artifacts
+  - 'freshie/inventory.sqlite'
+  - 'freshie/exports/**'
+  - 'freshie/archives/**'
+
+  # Test fixtures + e2e suites (measurers, not measured)
+  - 'tests/fixtures/**'
+  - 'tests/e2e/**'
+  - '**/__fixtures__/**'
+  - '**/__snapshots__/**'
+
+  # Standard build / generated / vendored
+  - '**/dist/**'
+  - '**/build/**'
+  - '**/coverage/**'
+  - '**/*.generated.*'
+  - '**/generated/**'
+  - '**/node_modules/**'
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+component_management:
+  individual_components:
+    - component_id: cli
+      name: cli
+      paths:
+        - 'packages/cli/**'
+
+    - component_id: plugin-validator
+      name: plugin-validator
+      paths:
+        - 'packages/plugin-validator/**'
+
+    - component_id: analytics
+      name: analytics
+      paths:
+        - 'packages/analytics-daemon/**'
+        - 'packages/analytics-dashboard/**'
+
+    - component_id: marketplace-site
+      name: marketplace-site
+      paths:
+        - 'marketplace/src/**'
+        - 'marketplace/scripts/**'
+
+    - component_id: validators
+      name: validators
+      paths:
+        - 'scripts/validate-*.py'
+        - 'scripts/validate-*.mjs'
+        - 'scripts/check-*.py'
+        - 'scripts/check-*.mjs'
+
+    - component_id: build-pipeline
+      name: build-pipeline
+      paths:
+        - 'scripts/sync-marketplace.cjs'
+        - 'scripts/build-*.mjs'
+        - 'scripts/generate-*.mjs'
+        - 'marketplace/scripts/build.mjs'
+
+    - component_id: freshie
+      name: freshie
+      paths:
+        - 'freshie/scripts/**'


### PR DESCRIPTION
## Summary

Adds a `codecov.yml` at repo root tuned to this repo's actual surface — catalog-heavy, validator-driven, multi-package monorepo with significant amounts of generated JSON that must not pollute coverage signal.

Replaces Codecov's implicit defaults that were applying to the existing pytest upload step in `.github/workflows/validate-plugins.yml:546`.

## Why these specific numbers

| Setting | Value | Why |
|---|---|---|
| `project.target` | `auto` + 2% slack | No regression vs current baseline. Aspirational floors would fail every PR until pytest tests for `validate-skills-schema.py` exist. |
| `patch.target` | `40%` | Anchored to what the current test surface actually delivers. The 5,056-line `validate-skills-schema.py` has zero pytest tests; any PR touching it would score 0% patch. Raise as tests are added. |
| `if_ci_failed` | `success` | Codecov service outages must not red-X our CI. |
| `only_pulls` | `true` | Neutralizes the `automation/npm-stats` and `auto-bump-on-pr` bot push streams to main. |

## Components — 7 real, no phantoms

Every component path verified against the actual `packages/`, `marketplace/`, `scripts/`, `freshie/` directories on disk:

- `cli` → `packages/cli/**`
- `plugin-validator` → `packages/plugin-validator/**`
- `analytics` → `packages/analytics-daemon/**`, `packages/analytics-dashboard/**`
- `marketplace-site` → `marketplace/src/**`, `marketplace/scripts/**`
- `validators` → `scripts/validate-*.py`, `scripts/validate-*.mjs`, `scripts/check-*.{py,mjs}`
- `build-pipeline` → `scripts/sync-marketplace.cjs`, `scripts/build-*.mjs`, `scripts/generate-*.mjs`, `marketplace/scripts/build.mjs`
- `freshie` → `freshie/scripts/**`

## Ignore list — repo-specific noise sources

- Catalog JSON: `.claude-plugin/**`, `plugins/**/plugin.json`, `marketplace/src/data/**`, `marketplace/public/data/**`
- Generated artifacts: `marketplace/dist/**`, `marketplace/public/downloads/**`, `**/.forge/**`
- Freshie CMDB: `freshie/inventory.sqlite`, `freshie/exports/**`, `freshie/archives/**`
- Standard build/test noise: `**/dist/**`, `**/build/**`, `**/__snapshots__/**`, `tests/fixtures/**`, `tests/e2e/**`, `**/*.md`, `**/*.mdx`

## Test plan

- [x] YAML parses (in-editor)
- [ ] First PR after merge — verify Codecov posts a comment without phantom-component zeros
- [ ] Verify patch gate fires cleanly on a real code-touching PR
- [ ] Verify catalog-only PRs (new SKILL.md, new plugin) get a "no coverable changes" pass

## Out of scope (deliberately)

- Promoting `codecov/patch` to a required status check (premature — let the gate run informationally first)
- `.gemini/` config deletion + `CONTRIBUTING.md` Gemini-review-flow rewrite (separate PR, separate scope)
- CodeRabbit / Greptile / Qodo integration (under evaluation, not landing in this PR)

- Jeremy Longshore
intentsolutions.io