### PR TITLE
feat(sak): 6767-h section-heading parser + prose-anchor validity checker

### DIFF
--- a/scripts/check-prose-anchors.py
+++ b/scripts/check-prose-anchors.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verify every 6767-h section citation in JSON Schema $comment fields exists.
+
+Usage:
+    python scripts/check-prose-anchors.py --doc PATH --schemas PATH [PATH ...]
+    python scripts/check-prose-anchors.py --index PATH --schemas PATH [PATH ...]
+    stdin: pipe parse-prose-anchors.py output | python scripts/check-prose-anchors.py --schemas ...
+
+Citation pattern: "6767-h § <id>" where <id> is digits/dots or uppercase letter.
+Exit 0 = valid, exit 1 = broken anchors found, exit 2 = I/O error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_CITE_RE = re.compile(r"6767-h\s+§\s*(\d[\d.]*|[A-Z])\b")
+
+def _citations(text: str) -> list[str]:
+    return [m.group(1).strip() for m in _CITE_RE.finditer(text)]
+
+def _walk(obj: Any, path: str = "") -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            p = f"{path}/{k}" if path else k
+            if k == "$comment" and isinstance(v, str):
+                out.append((p, v))
+            else:
+                out.extend(_walk(v, p))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            out.extend(_walk(item, f"{path}[{i}]"))
+    return out
+
+def _load_index(path: Path) -> dict[str, dict]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return {s["id"]: s for s in raw.get("sections", [])}
+
+def _index_from_doc(doc_path: Path) -> dict[str, dict]:
+    spec = importlib.util.spec_from_file_location(
+        "parse_prose_anchors", Path(__file__).parent / "parse-prose-anchors.py"
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Cannot load parse-prose-anchors.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return {s["id"]: s for s in mod.parse_sections(doc_path.read_text(encoding="utf-8"))}
+
+def _check_schema(path: Path, index: dict[str, dict]) -> list[dict]:
+    try:
+        schema = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return [{"schema": str(path), "json_path": "<file>", "comment": "",
+                 "cited_id": "<parse-error>", "error": str(exc)}]
+    findings: list[dict] = []
+    for jpath, text in _walk(schema):
+        for cid in _citations(text):
+            if cid not in index:
+                findings.append({"schema": str(path), "json_path": jpath, "comment": text,
+                                  "cited_id": cid, "error": f"Section '{cid}' not found in 6767-h index"})
+    return findings
+
+def _expand(patterns: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for pat in patterns:
+        for p in glob.glob(pat, recursive=True) or [pat]:
+            rp = Path(p).resolve()
+            if rp not in seen:
+                seen.add(rp)
+                paths.append(Path(p))
+    return paths
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Check JSON Schema $comment fields for broken 6767-h citations.")
+    grp = ap.add_mutually_exclusive_group()
+    grp.add_argument("--index", type=Path, default=None)
+    grp.add_argument("--doc", type=Path, default=None)
+    ap.add_argument("--schemas", nargs="+", required=True, metavar="PATH")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+    try:
+        if args.doc is not None:
+            if not args.doc.is_file():
+                print(f"ERROR: --doc not found: {args.doc}", file=sys.stderr)
+                return 2
+            index = _index_from_doc(args.doc.resolve())
+        elif args.index is not None:
+            if not args.index.is_file():
+                print(f"ERROR: --index not found: {args.index}", file=sys.stderr)
+                return 2
+            index = _load_index(args.index)
+        else:
+            try:
+                index = {s["id"]: s for s in json.load(sys.stdin).get("sections", [])}
+            except (json.JSONDecodeError, KeyError) as exc:
+                print(f"ERROR reading index from stdin: {exc}", file=sys.stderr)
+                return 2
+    except Exception as exc:
+        print(f"ERROR building index: {exc}", file=sys.stderr)
+        return 2
+    schema_paths = _expand(args.schemas)
+    if not schema_paths:
+        print("ERROR: no schema files found.", file=sys.stderr)
+        return 2
+    all_findings: list[dict] = []
+    cite_count = 0
+    for sp in schema_paths:
+        all_findings.extend(_check_schema(sp, index))
+        try:
+            for _, text in _walk(json.loads(sp.read_text(encoding="utf-8"))):
+                cite_count += len(_citations(text))
+        except Exception:
+            pass
+    report = {
+        "index_section_count": len(index),
+        "schemas_checked": len(schema_paths),
+        "citations_found": cite_count,
+        "broken_anchors": all_findings,
+        "valid": len(all_findings) == 0,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2))
+    elif all_findings:
+        print(f"FAIL: {len(all_findings)} broken anchor(s) across {len(schema_paths)} schema(s):", file=sys.stderr)
+        for f in all_findings:
+            print(f"  {f['schema']} @ {f['json_path']}: cited '{f['cited_id']}' — {f['error']}", file=sys.stderr)
+    else:
+        print(f"OK: {cite_count} citation(s) in {len(schema_paths)} schema(s) all valid ({len(index)} sections in index).")
+    return 0 if report["valid"] else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-prose-anchors.py
+++ b/scripts/check-prose-anchors.py
@@ -23,8 +23,10 @@ from typing import Any
 
 _CITE_RE = re.compile(r"6767-h\s+§\s*(\d[\d.]*|[A-Z])\b")
 
+
 def _citations(text: str) -> list[str]:
     return [m.group(1).strip() for m in _CITE_RE.finditer(text)]
+
 
 def _walk(obj: Any, path: str = "") -> list[tuple[str, str]]:
     out: list[tuple[str, str]] = []
@@ -40,9 +42,11 @@ def _walk(obj: Any, path: str = "") -> list[tuple[str, str]]:
             out.extend(_walk(item, f"{path}[{i}]"))
     return out
 
+
 def _load_index(path: Path) -> dict[str, dict]:
     raw = json.loads(path.read_text(encoding="utf-8"))
     return {s["id"]: s for s in raw.get("sections", [])}
+
 
 def _index_from_doc(doc_path: Path) -> dict[str, dict]:
     spec = importlib.util.spec_from_file_location(
@@ -54,19 +58,29 @@ def _index_from_doc(doc_path: Path) -> dict[str, dict]:
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
     return {s["id"]: s for s in mod.parse_sections(doc_path.read_text(encoding="utf-8"))}
 
+
 def _check_schema(path: Path, index: dict[str, dict]) -> list[dict]:
     try:
         schema = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
-        return [{"schema": str(path), "json_path": "<file>", "comment": "",
-                 "cited_id": "<parse-error>", "error": str(exc)}]
+        return [
+            {"schema": str(path), "json_path": "<file>", "comment": "", "cited_id": "<parse-error>", "error": str(exc)}
+        ]
     findings: list[dict] = []
     for jpath, text in _walk(schema):
         for cid in _citations(text):
             if cid not in index:
-                findings.append({"schema": str(path), "json_path": jpath, "comment": text,
-                                  "cited_id": cid, "error": f"Section '{cid}' not found in 6767-h index"})
+                findings.append(
+                    {
+                        "schema": str(path),
+                        "json_path": jpath,
+                        "comment": text,
+                        "cited_id": cid,
+                        "error": f"Section '{cid}' not found in 6767-h index",
+                    }
+                )
     return findings
+
 
 def _expand(patterns: list[str]) -> list[Path]:
     paths: list[Path] = []
@@ -78,6 +92,7 @@ def _expand(patterns: list[str]) -> list[Path]:
                 seen.add(rp)
                 paths.append(Path(p))
     return paths
+
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Check JSON Schema $comment fields for broken 6767-h citations.")
@@ -134,8 +149,11 @@ def main(argv: list[str] | None = None) -> int:
         for f in all_findings:
             print(f"  {f['schema']} @ {f['json_path']}: cited '{f['cited_id']}' — {f['error']}", file=sys.stderr)
     else:
-        print(f"OK: {cite_count} citation(s) in {len(schema_paths)} schema(s) all valid ({len(index)} sections in index).")
+        print(
+            f"OK: {cite_count} citation(s) in {len(schema_paths)} schema(s) all valid ({len(index)} sections in index)."
+        )
     return 0 if report["valid"] else 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/parse-prose-anchors.py
+++ b/scripts/parse-prose-anchors.py
@@ -102,7 +102,9 @@ def _repo_rel(path: Path) -> str:
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, cwd=str(path.parent),
+            capture_output=True,
+            text=True,
+            cwd=str(path.parent),
         )
         if r.returncode == 0:
             return str(path.resolve().relative_to(Path(r.stdout.strip())))
@@ -112,10 +114,7 @@ def _repo_rel(path: Path) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    default = (
-        Path(__file__).parent.parent / "000-docs"
-        / "6767-h-SPEC-DR-STND-claude-code-extensions-master.md"
-    )
+    default = Path(__file__).parent.parent / "000-docs" / "6767-h-SPEC-DR-STND-claude-code-extensions-master.md"
     ap = argparse.ArgumentParser(description="Parse 6767-h spec into a section index.")
     ap.add_argument("--doc", type=Path, default=default)
     ap.add_argument("--out", type=Path, default=None)

--- a/scripts/parse-prose-anchors.py
+++ b/scripts/parse-prose-anchors.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Parse a 6767-h prose spec markdown file and emit a JSON section index.
+
+Usage:
+    python scripts/parse-prose-anchors.py [--doc PATH] [--out PATH]
+
+Section ID rules:
+  1. Heading text beginning with a numeric prefix like "1)", "4.2.1.", etc.
+     uses that prefix as the section ID.
+  2. Heading text beginning with "Appendix A:" uses the letter as the ID.
+  3. All other headings are auto-numbered.  Headings that appear before the
+     first explicit numeric heading at their level get a "0.x" preamble ID
+     to avoid colliding with the explicit numbering that follows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_NUMERIC_PREFIX = re.compile(r"^(\d+(?:\.\d+)*)[\)\.\s]+(.*)")
+_APPENDIX_PREFIX = re.compile(r"^Appendix\s+([A-Z])[\.\:\-\s]+(.*)", re.IGNORECASE)
+_HEADING_LINE = re.compile(r"^(#{1,6})\s+(.*)")
+_INLINE_MD = re.compile(r"[`*_]{1,3}([^`*_]*)[`*_]{1,3}")
+
+
+def _clean(text: str) -> str:
+    return _INLINE_MD.sub(r"\1", text).strip()
+
+
+def _dotted(counters: list[int], depth: int) -> str:
+    return ".".join(str(c) for c in counters[:depth])
+
+
+def parse_sections(text: str) -> list[dict]:
+    counters: list[int] = [0] * 6
+    explicit_seen: list[bool] = [False] * 6
+    preamble_cnt: list[int] = [0] * 6
+    sections: list[dict] = []
+    in_fence = False
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        s = raw.strip()
+        if s.startswith("```") or s.startswith("~~~"):
+            in_fence = not in_fence
+        if in_fence:
+            continue
+
+        hm = _HEADING_LINE.match(raw)
+        if not hm:
+            continue
+
+        level = len(hm.group(1))
+        title = _clean(hm.group(2).strip())
+
+        nm = _NUMERIC_PREFIX.match(title)
+        am = _APPENDIX_PREFIX.match(title)
+
+        if nm:
+            raw_id, rest = nm.group(1), nm.group(2).strip()
+            parts = [int(x) for x in raw_id.split(".")]
+            for i, v in enumerate(parts):
+                if i < 6:
+                    counters[i] = v
+                    explicit_seen[i] = True
+            for i in range(len(parts), 6):
+                counters[i] = 0
+            section_id = raw_id
+            display = rest or title
+        elif am:
+            section_id = am.group(1).upper()
+            display = am.group(2).strip() or title
+        else:
+            if not explicit_seen[level - 1]:
+                preamble_cnt[level - 1] += 1
+                parent = _dotted(counters, level - 1)
+                n = preamble_cnt[level - 1]
+                section_id = f"{parent}.0.{n}" if parent else f"0.{n}"
+            else:
+                counters[level - 1] += 1
+                for i in range(level, 6):
+                    counters[i] = 0
+                section_id = _dotted(counters, level)
+            display = title
+
+        sections.append({"id": section_id, "title": display, "level": level, "line": lineno})
+
+    return sections
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _repo_rel(path: Path) -> str:
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, cwd=str(path.parent),
+        )
+        if r.returncode == 0:
+            return str(path.resolve().relative_to(Path(r.stdout.strip())))
+    except Exception:
+        pass
+    return str(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    default = (
+        Path(__file__).parent.parent / "000-docs"
+        / "6767-h-SPEC-DR-STND-claude-code-extensions-master.md"
+    )
+    ap = argparse.ArgumentParser(description="Parse 6767-h spec into a section index.")
+    ap.add_argument("--doc", type=Path, default=default)
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    doc = args.doc.resolve()
+    if not doc.is_file():
+        print(f"ERROR: not found: {doc}", file=sys.stderr)
+        return 1
+
+    sections = parse_sections(doc.read_text(encoding="utf-8"))
+    output = {
+        "doc_path": _repo_rel(doc),
+        "doc_sha256": _sha256(doc),
+        "parsed_at": datetime.now(timezone.utc).isoformat(),
+        "sections": sections,
+    }
+    serialized = json.dumps(output, indent=2)
+
+    if args.out:
+        args.out.write_text(serialized, encoding="utf-8")
+        print(f"Wrote {len(sections)} sections to {args.out}", file=sys.stderr)
+    else:
+        print(serialized)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/prose-anchors/expected-output.json
+++ b/tests/fixtures/prose-anchors/expected-output.json
@@ -1,0 +1,33 @@
+{
+  "_description": "Expected check-prose-anchors.py output (--json mode) for the two fixture schemas. Run against the live 6767-h index produced by parse-prose-anchors.py. The 'parsed_at' and 'doc_sha256' fields in the parser output are not captured here — only the check results are normalized.",
+  "valid_schema": {
+    "input": "tests/fixtures/prose-anchors/valid-schema.json",
+    "expected_exit_code": 0,
+    "expected_output": {
+      "index_section_count": 21,
+      "schemas_checked": 1,
+      "citations_found": 3,
+      "broken_anchors": [],
+      "valid": true
+    }
+  },
+  "invalid_schema": {
+    "input": "tests/fixtures/prose-anchors/invalid-schema.json",
+    "expected_exit_code": 1,
+    "expected_output": {
+      "index_section_count": 21,
+      "schemas_checked": 1,
+      "citations_found": 3,
+      "broken_anchors": [
+        {
+          "schema": "tests/fixtures/prose-anchors/invalid-schema.json",
+          "json_path": "properties/version/$comment",
+          "comment": "SemVer string. This section does not exist — see 6767-h § 99.99.99 for the imaginary reference.",
+          "cited_id": "99.99.99",
+          "error": "Section '99.99.99' not found in 6767-h index"
+        }
+      ],
+      "valid": false
+    }
+  }
+}

--- a/tests/fixtures/prose-anchors/invalid-schema.json
+++ b/tests/fixtures/prose-anchors/invalid-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Authoring schema for a skill frontmatter block. see 6767-h § 3.1 for the full frontmatter specification.",
+  "title": "SkillFrontmatter",
+  "type": "object",
+  "required": ["name", "description", "allowed-tools", "version", "author", "license"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "$comment": "Kebab-case skill identifier. see 6767-h § 3.1 for naming constraints.",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "version": {
+      "type": "string",
+      "$comment": "SemVer string. This section does not exist — see 6767-h § 99.99.99 for the imaginary reference.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    }
+  }
+}

--- a/tests/fixtures/prose-anchors/valid-schema.json
+++ b/tests/fixtures/prose-anchors/valid-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Authoring schema for a skill frontmatter block. see 6767-h § 3.1 for the full frontmatter specification.",
+  "title": "SkillFrontmatter",
+  "type": "object",
+  "required": ["name", "description", "allowed-tools", "version", "author", "license"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "$comment": "Kebab-case skill identifier. see 6767-h § 3.1 for naming constraints.",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "version": {
+      "type": "string",
+      "$comment": "SemVer string. Website gates require all published skills to carry a version. see 6767-h § 4.3 for the zero-warnings policy.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes bead `bd_000-projects-mfus` (SAK § 14 prose-schema-coherence prep).

Adds two stdlib-only Python scripts and 3 test fixtures supporting the future `prose-schema-coherence.yml` CI gate (per SAK plan 031 § 14.5):

- **`scripts/parse-prose-anchors.py`** (148 LOC) — parses `000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md`, emits a JSON section index with `id` / `title` / `level` / `line` per heading. 21 sections detected on current 6767-h.
- **`scripts/check-prose-anchors.py`** (141 LOC) — given the section index + JSON Schema files, walks every `$comment` looking for pattern `6767-h § <section>`. Exits 0 if all anchors valid; exits 1 listing broken anchors otherwise.
- **`tests/fixtures/prose-anchors/`** — `valid-schema.json` (cites real § 3.1 + § 4.3), `invalid-schema.json` (cites bogus § 99.99.99), `expected-output.json` (golden outputs).

## Fixture test results
- `valid-schema.json` → exit 0, 0 broken anchors
- `invalid-schema.json` → exit 1, 1 broken anchor reported at `properties/version/\$comment`

## Why now
SAK Phase 1 (kernel authoring/v1 schemas) will carry `$comment` strings citing 6767-h section numbers. Without this gate, schemas can silently cite renamed/removed sections. The parser ships now so the CI workflow can wire it up in SAK Phase 0 → Phase 1 transition.

## Bead / Refs
- Bead: \`bd_000-projects-mfus\`
- Plan: intent-eval-lab/000-docs/031-PP-PLAN-skill-refiner-sak-amendment-v6-2026-05-28.md § 14.5

## Test plan
- [ ] CI Validate Plugins passes
- [ ] Maintainer runs \`python3 scripts/parse-prose-anchors.py\` and confirms section count > 0
- [ ] Maintainer runs \`python3 scripts/check-prose-anchors.py tests/fixtures/prose-anchors/\` end-to-end

- Jeremy Longshore
intentsolutions.io