### PR TITLE
chore(gitignore): exclude internal-only AT-DECR records from re-include allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,13 @@ coverage/
 # doc-type for adversarial-technical decision records per Doc Filing Standard v4.3.
 # Pattern matches any *-AT-DECR-*.md at the root 000-docs/ level.
 !000-docs/*-AT-DECR-*.md
+# Internal-only AT-DECRs — records explicitly held out of the public re-include
+# allowlist because their content is internal-only per a separate filing posture.
+# The session JSONL under ~/.claude/skills/exec-decision-council/sessions/ is the
+# durable source of truth for these records; the 000-docs copy is convenience-only
+# and stays local. Add new internal records by their filing number as filed.
+000-docs/680-AT-DECR-*.md
+000-docs/683-AT-DECR-*.md
 # Session AARs — After-Action Comprehensive Reviews per Doc Filing Standard v4.3.
 # Session logs of multi-task work sessions (what was done, what's deferred, what
 # was explicitly NOT done). No inherent secrets risk; transparency is the point.


### PR DESCRIPTION
## Summary

Tightens the .gitignore re-include allowlist for AT-DECR records under `000-docs/`. The wildcard `!000-docs/*-AT-DECR-*.md` rule correctly re-includes internal-process records (architecture, sequencing, schema decisions) that should be tracked, but silently re-includes records intentionally held out per a separate filing posture.

Adds explicit number-prefixed re-exclusions after the wildcard. Future internal records get added to the same block by filing number as filed.

## Test plan

- [x] `git check-ignore -v` confirms both target files match the explicit exclusion rules (last-match-wins)
- [x] `git status --short 000-docs/` empty after the change (no leak vector)
- [x] Other AT-DECR records still re-included correctly (wildcard intact)

- Jeremy Longshore
intentsolutions.io