### PR TITLE
chore(gitignore): publish databricks-pack 000-docs research catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,13 @@ coverage/
 # metrics, quality gates, beads <-> GH <-> Plane mirror, rollback procedure,
 # and lessons-learned.
 !000-docs/*-RL-REPT-*.md
+# Databricks pack research catalog — explicitly published as the public design
+# record backing the v2-rebuild community design review (GH issues #789-#795).
+# Both the issue bodies and any external reply links into this directory; the
+# files must be tracked for the cross-references to resolve. See repo
+# CLAUDE.md § "Auto-cowork contract" + Doc Filing Standard v4.3.
+!plugins/saas-packs/databricks-pack/000-docs/
+!plugins/saas-packs/databricks-pack/000-docs/**
 website/
 
 # Internal planning and research documents (do not commit to public repo)

--- a/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
@@ -1,0 +1,53 @@
+# 000-docs Index — databricks-pack
+
+**Filing standard:** Document Filing System v4.3
+**Last updated:** 2026-05-27 (added 010-013 — MCP landscape research + Epic 1 scope adjustment; Claude Code changelog impact moved to repo-root 000-docs as repo-wide AT-ADEC)
+**Total docs:** 13
+
+---
+
+## BL — Business & Legal
+
+| # | File | Description |
+|---|---|---|
+| 001 | `001-BL-LICN-license.txt` | MIT license |
+
+## RL — Research & Learning
+
+| # | File | Description |
+|---|---|---|
+| 002 | `002-RL-RSRC-databricks-compute-pain-research.md` | 12 pain entries: cluster lifecycle, Photon, DBR versioning, cost (citations from community.databricks.com, GH issues, KB, Medium) |
+| 003 | `003-RL-RSRC-databricks-delta-streaming-research.md` | 12 pain entries: Delta Lake, Liquid Clustering, Structured Streaming, DLT |
+| 004 | `004-RL-RSRC-databricks-uc-bundles-ops-research.md` | 10 pain entries: Unity Catalog migration, Asset Bundles, SCIM/SSO, secrets, networking |
+| 005 | `005-RL-RSRC-anthropic-skill-architecture-patterns.md` | 10 patterns from Anthropic first-party skills (security-guidance plugin, feature-dev, mcp-builder) |
+| 006 | `006-RL-RSRC-databricks-v2-rebuild-synthesis.md` | Synthesis: 34 pain entries → 5-skill + MCP architecture, CTO decisions, pilot recommendation |
+| 010 | `010-RL-RSRC-databricks-mcp-official-landscape.md` | Walk of Databricks managed MCP servers (Genie, Vector Search, SQL, UC Functions) + custom/external paths + control-plane gap analysis |
+| 011 | `011-RL-RSRC-databricks-mcp-community-landscape.md` | Community Databricks MCP inventory — confirms databrickslabs/mcp is deprecated, 5 community alts are 1-46 stars no-CI |
+| 012 | `012-RL-RSRC-claude-code-databricks-mcp-integration.md` | How Claude Code / Cowork register Databricks MCPs; cowork-zip excludes category:mcp by design; dual-surface distribution implications |
+
+## AT — Architecture & Technical
+
+| # | File | Description |
+|---|---|---|
+| 007 | `007-AT-ADEC-databricks-v2-cto-decision.md` | Decision record: pack handling (v2.0.0 + deprecation lane), 5-skill scope, pilot, timing, demo arc |
+| 013 | `013-AT-ADEC-epic1-mcp-scope-adjustment.md` | Epic 1 scope cut: drop T4/T5/T9 (subsumed by Databricks managed SQL MCP), expand T2 (3 auth flows), add T13 (App mode) + T14 (dual-surface helpers). Grounded in 010/011/012. |
+
+**Repo-wide impact (filed at root):** Claude Code platform changelog impact lives in `/home/jeremy/000-projects/claude-code-plugins/000-docs/681-AT-ADEC-claude-code-platform-changelog-impact-2026-05-27.md` — affects validators, schema versioning, skill-creator, MCP validators, hook docs, the existing 414+ plugins, AND this databricks-pack rebuild as one downstream consumer.
+
+## RA — Reports & Analysis
+
+| # | File | Description |
+|---|---|---|
+| 008 | `008-RA-REVW-pack-handling-pressure-test.md` | Adversarial review of pack-handling decision — MODIFY verdict (add deprecation lane + tombstones) |
+| 009 | `009-RA-REVW-pilot-timing-pressure-test.md` | Adversarial review of pilot/timing decision — MODIFY verdict (cut scope to 3 pains, MCP first, drop opus eval) |
+
+---
+
+## Quick reference — doc codes used
+
+| CC | Category | ABCD | Type |
+|---|---|---|---|
+| BL | Business & Legal | LICN | License |
+| RL | Research & Learning | RSRC | Research resource |
+| AT | Architecture & Technical | ADEC | Architecture decision |
+| RA | Reports & Analysis | REVW | Review / critique |

--- a/plugins/saas-packs/databricks-pack/000-docs/001-BL-LICN-license.txt
+++ b/plugins/saas-packs/databricks-pack/000-docs/001-BL-LICN-license.txt
@@ -1,0 +1,3 @@
+MIT License
+
+Copyright (c) 2025 Jeremy Longshore

--- a/plugins/saas-packs/databricks-pack/000-docs/002-RL-RSRC-databricks-compute-pain-research.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/002-RL-RSRC-databricks-compute-pain-research.md
@@ -1,0 +1,233 @@
+# Databricks Pain Catalog — Domain 1: Compute / Photon / DBR Versioning / Cost
+
+**Scope:** Recurring, painful, real-world Databricks issues across cluster lifecycle, Photon engine, DBR (Databricks Runtime) versioning, and compute cost surprises.
+**Research date:** 2026-05-27
+**Sources:** Databricks Community Forum, official docs (release notes, KB, troubleshooting), Microsoft Learn Q&A, Medium war stories, vendor analyses (Unravel, Flexera, Cloudzero), Databricks CLI GitHub.
+**Note on Reddit/Twitter:** Reddit content fetching is blocked from this environment; the catalog draws from the open community forum and Microsoft Q&A as the most direct equivalent (engineers complaining in public with reproducible context). Each entry below has a Databricks-employee response or a maintainer-acknowledged status — not speculation.
+
+---
+
+## D01 — Cluster startup randomly takes 20–35 min instead of 5
+
+**Domain:** compute
+**Trigger:** Engineer kicks off a job-compute cluster (1 driver + 1 worker, small DBR, ~2 libs) on Azure Databricks. It usually takes 5–6 min cold-start. Sometimes — several times a week, unpredictably — it takes 20–35 min instead, and the user pays Azure VM charges for the whole window.
+**Symptom:** Cluster sits in `PENDING` for 20–35 min before reaching `RUNNING`. No error surfaced in the UI — just "still starting." Azure managed-resource-group event log shows VM-creation/attachment delays. Workspace is typically VNet-injected.
+**Root cause:** Three independently variable cloud-provider stages stacked: (1) Azure VM allocation under quota/zone pressure, (2) NIC attachment + UDR/DNS resolution against the customer VNet, (3) Databricks bootstrap script + library install over that network. Any one of them can spike from seconds to ~20 min and Databricks reports the aggregate as "starting." DNS resolution through a custom DNS server is the single most common amplifier per Databricks-employee answers on related threads.
+**Blast radius:** single-job (per-cluster), but pattern repeats across every job in the workspace, so effective blast = workspace-wide for SLA-bound pipelines.
+**Current workaround (manual):** Stand up an instance pool with `min_idle > 0` to skip VM allocation; pin a smaller library set; pre-bake an init script into a base image instead of installing at startup; if the workspace is VNet-injected, audit the UDR table and DNS server. None of these eliminate the tail — they shrink the distribution.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/databricks-cluster-random-slow-start-times/td-p/78172 (Azure, single-user job compute, OP describes 20-35 min recurrences)
+- https://community.databricks.com/t5/data-engineering/job-compute-is-taking-longer-even-after-using-pool/td-p/114389 (April 2025; even with pools, ~5 min remains; Databricks-employee response)
+- https://docs.databricks.com/aws/en/compute/troubleshooting/cluster-error-codes (canonical list of bootstrap timeout / cloud-provider error codes)
+**Response architecture recommendation:** **MCP server + subagent + SKILL.md.** The MCP server wraps the Databricks Workspace API (`clusters.events`, `clusters.get`) so the agent can pull the full event timeline for a specific cluster ID rather than asking the human to copy-paste UI screenshots. A subagent fan-out can pull events for the last N slow starts in parallel and bucket the time spent in `PENDING` by Databricks event_type, surfacing whether the long tail lives in cloud-provider provisioning vs DNS vs library install. **No hook** — this is always user-initiated ("why was this cluster slow?"). Slash command `/cluster-coldstart-forensics <cluster_id>` is the entry point.
+
+---
+
+## D02 — Photon silently falls back to Spark on UDFs while you keep paying the Photon DBU premium
+
+**Domain:** photon
+**Trigger:** Team enables Photon on a SQL warehouse or job cluster to "speed things up." Queries contain Python UDFs, Pandas UDFs, RDD API calls, or other unsupported operations.
+**Symptom:** Bill goes up (Photon DBU multiplier is roughly 2x), runtime does NOT go down or improves only slightly. In the Spark UI SQL/DataFrame execution plan, yellow boxes (Photon) are mixed with blue boxes (Spark) — and the bottom-of-plan "Task Time in Photon" metric reads a low percentage (e.g. 8%, 15%) of total task time. Photon executes bottom-up from the table-scan operator and bails to Spark at the first unsupported op, but you are still billed Photon DBUs for the cluster's full uptime.
+**Root cause:** Photon is a per-cluster (not per-query) billing toggle. Once enabled on the runtime_engine, every minute the cluster is up is billed at the Photon rate regardless of which operators in any given query actually executed inside the Photon C++ engine. UDFs, RDD APIs, Dataset APIs, certain expressions, and unusual data formats trigger silent fallback to JVM Spark for the rest of the operator chain. There is no warning, no log line, no policy switch that says "this query did not benefit from Photon."
+**Blast radius:** workspace-wide cost impact across every job/SQL endpoint running Photon-enabled clusters. Real-world reports show a 4x cost increase against ~1.8x runtime improvement on individual queries.
+**Current workaround (manual):** (1) Open every long-running query's execution-details page, eyeball the "Task Time in Photon" %, and if low, either rewrite the UDF in built-in functions or move that workload to a non-Photon cluster. (2) Use cluster policies with `runtime_engine: {"type":"fixed","value":"STANDARD"}` to forbid Photon on workloads that have known UDF dependencies. (3) For SQL warehouses, the only switch is the per-warehouse Photon toggle — no per-query control.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/why-is-photon-increasing-dbu-used-per-hour/td-p/41481 (OP: "Why is Photon increasing DBU per hour?" — official answer confirms Photon DBU is higher; "cost reduction is achieved by (possible) faster runtimes")
+- https://community.databricks.com/t5/get-started-discussions/photon-and-udf-efficiency/td-p/38570 ("when creating a UDF, photon will not be used")
+- https://community.databricks.com/t5/data-engineering/how-do-i-know-how-much-of-a-query-job-used-photon/td-p/25385 (canonical answer: dig into Query Details > Execution Details > Task Time in Photon — there is no API for this)
+- https://community.databricks.com/t5/data-engineering/temporarily-disable-photon/td-p/31145 (real user: one operation ran 2x slower under Photon and was still billed Photon rate)
+**Response architecture recommendation:** **MCP server + scripts/ + slash command.** MCP server because we need authenticated calls to `sql.queries.history` and `clusters.get` to pull per-query Photon metrics for the past N days. A bundled `scripts/photon-fallback-audit.py` walks the query history for a warehouse, parses each query's execution plan JSON, computes (task_time_in_photon / total_task_time), buckets queries by Photon-effective vs Photon-tax, and projects monthly $$ wasted on the Photon premium for queries with <30% Photon coverage. Slash command `/photon-audit <warehouse_id> --days 30` is the entry point. **No subagent** — this is one sequential scan, not parallelizable work. **No hook** — auditing is intentional, not reactive.
+
+---
+
+## D03 — DBR 14→15 default working directory changed; jobs writing to local paths silently fail at 500 MB
+
+**Domain:** DBR-versioning
+**Trigger:** Team upgrades a pipeline from DBR 13.x or 14.x to DBR 15.x (typically 15.4 LTS for the LTS guarantee). Non-Scala code writes intermediate files to a relative path or `os.getcwd()` expecting the driver's ephemeral local disk.
+**Symptom:** Jobs that wrote multi-hundred-MB intermediate files start failing — sometimes silently, sometimes with workspace-file-system limit errors. Files appear in the workspace files area instead of `/tmp`-equivalent. Workspace file size limit is 500 MB, so anything over that fails. Behavior also surfaces as "files I expected to be ephemeral are showing up in the user's workspace tree" — a security/audit surprise.
+**Root cause:** Starting in DBR 14.0, all non-Scala code uses the workspace filesystem as the default CWD instead of the driver's ephemeral disk. This was a quiet behavior change to support "files alongside notebook" UX, but it inherits the workspace's 500 MB file limit and changes the path semantics of every `open("foo.csv", "w")` style call. Scala code is unaffected — which makes the failure modes split-brain across mixed-language pipelines.
+**Blast radius:** every Python/SQL/R pipeline that does intermediate file I/O. On any DBR ≥14.0 upgrade. Often discovered weeks after rollout when a particular dataset crosses 500 MB.
+**Current workaround (manual):** Audit every file-write in the codebase, hardcode `/local_disk0/tmp/...` or `/tmp/...` (driver ephemeral) for ephemeral writes, or move large intermediates to Unity Catalog volumes / S3 / ADLS. There is no global toggle to restore old behavior.
+**Citations:**
+
+- https://maze-runner.medium.com/databricks-runtime-15-4-lts-issues-fatal-flaws-crashing-your-workloads-a722bacf6a71 (Swiggy field report on the CWD breakage at scale)
+- https://docs.databricks.com/aws/en/release-notes/runtime/15.4lts (official notes — "non-Scala code uses workspace filesystem as CWD" + 500 MB workspace file limit)
+- https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/15.4lts (Azure docs mirror)
+**Response architecture recommendation:** **SKILL.md + references/ + scripts/.** No live API needed — this is a static code audit. `scripts/find-cwd-writes.py` grep/AST-scans the user's notebooks and Python files for `open(...)`, `pd.to_csv(...)`, `pickle.dump(...)`, etc. with relative paths and flags them with a recommended rewrite to `/local_disk0/tmp/` or a Unity Catalog volume. `references/dbr14-cwd-change.md` carries the deep encyclopedia of every CWD-affected code pattern with before/after snippets. **No MCP** — purely local file analysis. **No subagent** — sequential walk is fine for typical repo sizes. Could optionally fire as a **PreToolUse hook** on `Edit` of `requirements.txt` or `cluster.json` if those mention DBR 15.x, but the primary surface is `/dbr-upgrade-check`.
+
+---
+
+## D04 — DBR 15.x removes DBFS library storage; DBR 15.1+ removes JDK 11
+
+**Domain:** DBR-versioning
+**Trigger:** Team upgrades to DBR 15.1+ on a workspace that has historically installed libraries from `dbfs:/FileStore/jars/...` or relies on JDK 11 via init scripts.
+**Symptom:** Cluster startup fails with library-install errors; or Java workloads (custom JARs, certain ML libraries) throw `UnsupportedClassVersionError` / unexpected JNI failures. The DBR 9.1 → 15.4 upgrade thread on the community forum shows the user hitting `ModuleNotFoundError: No module named 'dbruntime'` — a downstream symptom of init-script execution failing because of the DBFS lib path removal.
+**Root cause:** Databricks made two simultaneous deprecations in the 15.x line: (1) DBFS-root library storage disabled by default starting DBR 15.1 (security hardening — libraries must live in workspace files, Unity Catalog volumes, or a package repository); (2) JDK 11 removed in DBR 15.1+, only JDK 17 supported. Both changes are documented but the cumulative effect on a multi-year-old pipeline upgrading directly from DBR 9.1 or 10.4 is dozens of breakages stacked on top of each other.
+**Blast radius:** every cluster spec referencing DBFS-jar libraries; every JAR built against JDK 11 internals or older Scala versions; every init script that touches Java paths.
+**Current workaround (manual):** (1) Re-host every library on UC Volumes or workspace files; (2) rebuild JARs against JDK 17 and Scala 2.13 (preview path for DBR 16/17 upgrade); (3) audit init scripts; (4) do NOT skip multiple LTS versions — incremental 9.1→10.4→11.3→12.2→13.3→14.3→15.4 is painful but each hop surfaces one breakage at a time vs all at once.
+**Citations:**
+
+- https://community.databricks.com/t5/get-started-discussions/facing-issues-while-upgrading-dbr-version-from-9-1-lts-to-15-4/td-p/114800 (Apr–May 2025; user hits `ModuleNotFoundError: No module named 'dbruntime'`; Databricks employee Louis Frolio gives the UC Volumes / workspace-files migration recipe)
+- https://docs.databricks.com/aws/en/release-notes/runtime/15.4lts (canonical breaking-changes list including DBFS lib deprecation and JDK 17)
+- https://docs.databricks.com/en/release-notes/runtime/15.1.html (15.1 = "JDK 11 removed; JDK 17 required" — pivotal version)
+**Response architecture recommendation:** **SKILL.md + references/ + scripts/ + MCP server.** `references/dbr-upgrade-paths.md` carries the canonical hop ladder + per-version breaking-change list (auto-derived from release-notes URLs). MCP server pulls the user's actual cluster specs via `clusters.list` and identifies clusters still pinned to EoS DBR + flags libraries living on DBFS roots. `scripts/scan-jar-jdk.sh` runs `javap -v` against the user's JAR artifacts to detect JDK 11-compiled bytecode. **No hook** — upgrades are deliberate. Slash command `/dbr-upgrade-plan` plus a long-running mode that emits an ordered migration plan.
+
+---
+
+## D05 — DBR 15.4 LTS enables `spark.sql.legacy.jdbc.useNullCalendar=true` by default and quietly changes TIMESTAMP semantics
+
+**Domain:** DBR-versioning
+**Trigger:** Team upgrades a JDBC-using pipeline (read from SQL Server / Oracle / Postgres into Spark) from DBR 14.3 LTS to 15.4 LTS. No code change.
+**Symptom:** TIMESTAMP values coming back from the JDBC source differ from what they were on DBR 14.3 — different timezone interpretation, different handling of dates before the Gregorian cutover, etc. Downstream reports show subtly wrong values for historical timestamps. Often surfaces as a data-quality alert two weeks after upgrade.
+**Root cause:** `spark.sql.legacy.jdbc.useNullCalendar` flipped from `false` to `true` as the new default in DBR 15.4 LTS. The flag changes the calendar Spark uses to parse JDBC date/timestamp values. The change is in the release notes under "behavioral changes" but is easy to miss in a 30-bullet release-notes page.
+**Blast radius:** every pipeline reading TIMESTAMP columns from JDBC sources. Especially impactful for historical data, finance, healthcare (where pre-1900 dates exist).
+**Current workaround (manual):** Explicitly set `spark.sql.legacy.jdbc.useNullCalendar=false` in cluster Spark config to restore pre-15.4 behavior, OR audit every JDBC TIMESTAMP read and validate against ground truth.
+**Citations:**
+
+- https://docs.databricks.com/aws/en/release-notes/runtime/15.4lts (canonical: "spark.sql.legacy.jdbc.useNullCalendar setting is now enabled by default")
+- https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/15.4lts (Azure mirror)
+**Response architecture recommendation:** **SKILL.md + references/.** This pain is dense in metadata but light in tooling — the right answer is to give the agent a comprehensive, up-to-date `references/dbr-15.4-behavioral-changes.md` listing every flag flip so when the user says "upgraded to 15.4 and getting weird data," the agent walks the list rather than reinventing the diff. **Optionally a scripts/test-timestamp-roundtrip.py** that emits a synthetic JDBC TIMESTAMP through both old and new calendar modes and confirms which one the user's downstream expects. **No MCP, no hook, no subagent** — this is a knowledge problem, not an integration problem.
+
+---
+
+## D06 — `CLOUD_PROVIDER_LAUNCH_FAILURE` / `NPIP_TUNNEL_SETUP_FAILURE` flood VNet-injected workspaces
+
+**Domain:** compute
+**Trigger:** Engineer launches a cluster in a VNet/VPC-injected workspace (private link, no public IP). Cluster fails to start.
+**Symptom:** `termination_reason_code: CLOUD_PROVIDER_LAUNCH_FAILURE` with error parameters mentioning `AuthorizationFailed`, `InvalidResourceReference`, full subnet, IP exhaustion, or quota; OR `NPIP_TUNNEL_SETUP_FAILURE` with `Timed out waiting for ngrok tunnel to be up`. Cluster terminates after the bootstrap timeout (~700s for bootstrap, ~200s for SCC/NPIP tunnel).
+**Root cause:** Multiple distinct underlying failures share these umbrella codes: (a) subnet IP exhaustion or quota limits on AWS/Azure/GCP; (b) custom DNS server in the customer VNet can't resolve `*.cloud.databricks.com`; (c) UDR/NSG/security-group blocks ports 443/6666 to the SCC relay; (d) a VNet referenced in the workspace config was deleted; (e) cloud-provider throttling during regional surges. Databricks surfaces the same `NPIP_TUNNEL_SETUP_FAILURE` code for all the network-related causes, leaving the engineer to brute-force which one applies.
+**Blast radius:** workspace-wide — if DNS or routing is broken, no cluster in the workspace starts. Often discovered as a Monday-morning outage when a Friday-night change rolled.
+**Current workaround (manual):** Differential triage: (1) `nslookup *.cloud.databricks.com` from a VM in the same subnet; (2) `nc -zv <scc-relay-host> 443 6666`; (3) check NSG/security-group inbound and outbound; (4) check subnet free-IP count against pool/cluster max-worker count; (5) check cloud-provider status page; (6) check whether anyone touched the VNet recently.
+**Citations:**
+
+- https://docs.databricks.com/aws/en/compute/troubleshooting/cluster-error-codes (canonical termination-reason-code dictionary)
+- https://community.databricks.com/t5/data-engineering/npip-tunnel-setup-failure/td-p/121068 (June 2025, AWS NPIP failure thread; Databricks employee response)
+- https://community.databricks.com/t5/data-engineering/cloud-provider-launch-failure/td-p/21845 (Azure CLOUD_PROVIDER_LAUNCH_FAILURE with VNet/subnet root cause)
+- https://learn.microsoft.com/en-us/answers/questions/2244769/databricks-cluster-start-up-fails-on-test-workspac (NPIP, DNS-related fix)
+**Response architecture recommendation:** **MCP server + subagent + scripts/.** MCP server because differential triage requires authenticated calls to `clusters.events`, `workspaces.get`, and ideally the cloud-provider's own status/quota APIs (AWS EC2 `DescribeAccountAttributes`, Azure `Microsoft.Network/virtualNetworks/subnets`). Subagents fan out the differential checks in parallel: one checks DNS, one checks subnet IPs, one checks NSG rules, one checks Databricks status page, one diffs the workspace config against last-known-good. `scripts/triage-cluster-launch-failure.sh` does the basic non-API checks (`nslookup`, `nc -zv`) the user can run from a peer VM. Slash command `/cluster-launch-triage <cluster_id>`. **Optionally a PostToolUse hook** on `databricks clusters create` that, if the create fails with one of these codes, auto-invokes the triage flow.
+
+---
+
+## D07 — All-purpose compute used for production pipelines = 2–4x DBU overspend
+
+**Domain:** cost
+**Trigger:** Team prototypes a pipeline in a notebook on an all-purpose cluster (interactive), then "ships to prod" by scheduling that notebook on the same all-purpose cluster instead of moving it to a Jobs cluster.
+**Symptom:** Monthly Databricks bill is 2–4x what the team's modeling predicted. No code change would reduce it. `system.billing.usage` shows the same SKU at all-purpose DBU rate (~$0.40/DBU-hr for i3.xlarge) instead of jobs-compute rate (~$0.15/DBU-hr).
+**Root cause:** All-purpose ("interactive") compute carries a 2–3x higher DBU rate than Jobs compute for the same instance type, by Databricks's pricing model. The premium pays for shared multi-user notebook UX features the production job doesn't use. Engineers default to all-purpose because it's the default tab in the UI and because "we already had a cluster." Often compounded by: (a) cluster left running 24/7 instead of terminating between job runs, (b) no auto-termination, (c) team didn't know a job-compute cluster exists.
+**Blast radius:** workspace-wide cost impact; the single highest-ROI cost optimization in most Databricks deployments per Unravel/Cloudzero/Flexera vendor analyses.
+**Current workaround (manual):** Convert scheduled notebook to a Job with a Jobs cluster spec; configure auto-termination; ideally adopt cluster policies that forbid scheduled work on all-purpose. Audit historical billing to estimate refund-equivalent savings.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/job-cluster-vs-all-purpose-cluster/td-p/16566 (canonical community thread on the distinction)
+- https://www.cloudzero.com/blog/databricks-pricing/ (2026 breakdown: ~$0.15 vs ~$0.40 DBU/hr for i3.xlarge across compute types)
+- https://www.unraveldata.com/resources/databricks-automatic-termination-challenges-finops-teams/ (real numbers: weekend idle = ~$800 on i3.8xlarge; 2-week holiday = $5K–$10K; 6-month idle = $12K)
+- https://www.unraveldata.com/resources/databricks-interactive-clusters-decision-framework/ ("production batch on all-purpose = paying 2-3x more")
+**Response architecture recommendation:** **MCP server + scripts/ + slash command.** MCP server reads `system.billing.usage` and `jobs.list` to identify scheduled jobs running on all-purpose clusters. `scripts/cost-leak-audit.py` projects 30-day savings from moving each to Jobs compute. Output is a ranked list with absolute $$ saved per migration. **Optional PostToolUse hook on `databricks jobs create`** that warns if the new job references an all-purpose cluster ID rather than declaring its own job_cluster_key. **Slash command** `/cost-audit-all-purpose-leaks`. **No subagent** — sequential scan is fast.
+
+---
+
+## D08 — Serverless features bill silently against accounts that never opted into serverless
+
+**Domain:** cost
+**Trigger:** Workspace admin has not enabled serverless for notebooks/workflows. They turn on Predictive Optimization, Lakehouse Monitoring, materialized views in SQL warehouses, Vector Search, or Lakeflow Connect.
+**Symptom:** Surprise line items appear in `system.billing.usage` with `billing_origin_product` values of `PREDICTIVE_OPTIMIZATION`, `LAKEHOUSE_MONITORING`, `VECTOR_SEARCH`, `FINE_GRAINED_ACCESS_CONTROL`, etc., billed at serverless DBU rates (~$0.70–$0.95/DBU vs ~$0.40–$0.55 for classic). Bill is meaningfully higher than budgeted, and the admin "doesn't see any serverless workloads running."
+**Root cause:** Multiple Databricks platform features execute on serverless compute in the background by design, regardless of whether the customer has explicitly enabled serverless for user workloads. The features are turned on through different UI surfaces (Catalog Explorer for Predictive Optimization, table-properties UI for monitoring, SQL `CREATE MATERIALIZED VIEW` statement, etc.) so the cause-effect chain between "I checked this box" and "this serverless line item appeared" is not visible at toggle time.
+**Blast radius:** account-wide cost impact, especially painful for orgs that explicitly chose classic compute for cost-control reasons and don't have serverless budget policies in place.
+**Current workaround (manual):** Query `system.billing.usage` filtered by `billing_origin_product IN ('PREDICTIVE_OPTIMIZATION','LAKEHOUSE_MONITORING','MATERIALIZED_VIEW','VECTOR_SEARCH','FINE_GRAINED_ACCESS_CONTROL','LAKEFLOW_CONNECT')` to identify silent serverless consumers. Disable the features that aren't paying for themselves. Set serverless budget policies BEFORE enabling any of these.
+**Citations:**
+
+- https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing (canonical list of `billing_origin_product` values that signal background serverless usage)
+- https://learn.microsoft.com/en-us/azure/databricks/admin/system-tables/serverless-billing (Azure mirror)
+- https://www.revefi.com/blog/databricks-serverless-budget-policies-2026 (vendor walkthrough: budget policies as the only preventive control)
+- https://adamtheautomator.com/azure-databricks-serverless-cost-optimization/ (community write-up: "Multiple Databricks features leverage serverless compute in the background without requiring your account to be enabled for serverless")
+**Response architecture recommendation:** **MCP server + scripts/ + scheduled subagent.** MCP server runs the canonical `system.billing.usage` query (Unity Catalog read) to detect background serverless consumers and their 30-day spend. `scripts/serverless-shadow-audit.py` ranks features by $$/month and recommends whether to keep, gate behind a budget policy, or disable. A periodic subagent (e.g. weekly cron via the `loop` skill or a CI scheduled action) re-runs the audit and alerts on new `billing_origin_product` values appearing — that's how you catch a new feature being silently enabled. **No hook** because the trigger event (a coworker enables Predictive Optimization in the UI) doesn't go through any tool we can intercept.
+
+---
+
+## D09 — Instance pool with `min_idle > 0` keeps paying cloud-provider for idle VMs even though DBU billing is zero
+
+**Domain:** cost
+**Trigger:** Team configures an instance pool with `min_idle_instances: 5` to get fast cluster startup, then walks away.
+**Symptom:** Databricks UI shows pool DBU consumption as $0 when no cluster is attached — but the AWS/Azure/GCP bill shows 5 VMs of the pool's instance type running 24/7. Cost can run into thousands per month for a single pool that nobody is actively using on weekends/nights.
+**Root cause:** Databricks's billing model only charges DBUs while a cluster is *attached to* the pool's instances. Idle pool capacity costs $0 in DBUs but the underlying VMs are running and billed by the cloud provider directly. This is correctly documented but the UI never shows the cloud-provider side of the bill, so the team's internal Databricks dashboard reads "pool costs $0/mo" while the AWS bill reads "$3K/mo for this set of instances."
+**Blast radius:** every workspace with instance pools and `min_idle > 0`; especially painful when teams pre-warm aggressively to hide cold-start latency (see D01).
+**Current workaround (manual):** Set `min_idle: 0` and accept slower first-cluster startup, OR shrink `min_idle` on a schedule (e.g. 5 during business hours, 0 nights/weekends — requires an external job to mutate the pool config since pools don't have native schedules), OR migrate to Serverless Jobs which has no idle-VM model. Cross-reference cloud-provider billing against pool config quarterly.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/does-databricks-charge-anything-when-nodes-in-a-pool-are-idle/td-p/26994 (canonical: "Databricks does not charge DBUs while instances are idle in the pool, but instance provider billing does apply")
+- https://docs.databricks.com/aws/en/compute/pool-best-practices (official: "Set the Min Idle instances to 0 to avoid paying for running instances that aren't doing work")
+- https://learn.microsoft.com/en-us/answers/questions/827794/pools-and-cost (Microsoft Q&A with the same dual-billing clarification)
+**Response architecture recommendation:** **MCP server + scripts/.** MCP server pulls pool configs via `instance_pools.list` AND cross-references against the cloud-provider billing data (requires AWS Cost Explorer / Azure Cost Management read access — separate MCP or scripts). `scripts/pool-idle-cost-projection.py` computes (`min_idle × instance_hourly_rate × 730 hrs/month`) per pool and ranks by waste. Output: "Pool `prod-data-eng` has min_idle=8, costs ~$4,200/mo even when idle." **No hook** — pool changes are infrequent and intentional.
+
+---
+
+## D10 — Spot-instance interruptions during shuffle kill long jobs; Databricks's auto-retry doesn't always recover
+
+**Domain:** compute
+**Trigger:** Team configures a cluster with all-spot or mostly-spot workers to save money. A long ETL job is running. AWS/Azure reclaims spot capacity (2-min warning on AWS).
+**Symptom:** `org.apache.spark.SparkException: Job aborted due to stage failure: ShuffleMapStage X has failed the maximum allowable number of times: 4`. Cluster loses a worker. Spark's `ResultStage` can't roll back to re-shuffle input data so the job fails outright. Sometimes the job retries successfully; sometimes it cascade-fails because more spot instances get reclaimed during the retry.
+**Root cause:** When a spot node is preempted mid-shuffle, the in-progress shuffle map outputs on that node are gone. Spark's lineage can recompute them, but if the recompute itself loses another node, it counts as another failure against `spark.stage.maxConsecutiveAttempts` (default 4). Heavy shuffle jobs on volatile spot capacity exceed that count and abort the entire job. Lakeflow Jobs' exponential-backoff retry helps for transient failures but doesn't help when the underlying spot capacity is sustainedly unavailable.
+**Blast radius:** any production batch pipeline configured for spot/preemptible nodes; especially painful for nightly windows when many tenants compete for the same spot pools.
+**Current workaround (manual):** (1) Set the driver to on-demand always; (2) set first N workers on-demand and rest spot (the slider in cluster config); (3) implement job-level retry with exponential backoff at the orchestration layer; (4) for critical SLAs, use all on-demand and absorb the cost; (5) increase `spark.stage.maxConsecutiveAttempts` (controversial — masks the underlying instability).
+**Citations:**
+
+- https://kb.databricks.com/execution/apache-spark-jobs-failing-due-to-stage-failure-when-using-spot-instances-in-a-cluster (canonical Databricks KB: spot preemption + shuffle = stage failure)
+- https://medium.com/@chaobioz/dealing-with-spot-instances-interruption-in-databricks-aws-5d4a4f722e5c (engineer's field write-up on AWS spot interruptions in Databricks)
+- https://docs.databricks.com/aws/en/compute/troubleshooting/cluster-error-codes (canonical termination-reason code `SPOT_INSTANCE_TERMINATION`)
+**Response architecture recommendation:** **SKILL.md + references/ + scripts/.** This is mostly a cluster-config + retry-policy decision tree, not a live-data problem. `references/spot-vs-ondemand-decision.md` carries the canonical guidance (driver on-demand always; workers spot only if job is idempotent and SLA-tolerant). `scripts/audit-spot-config.py` reads a `cluster.json` and flags risky combos (spot driver, all-spot workers, >4 consecutive shuffle stages). **Optional MCP** to read recent `clusters.events` and surface spot-interruption frequency per cluster over the last 30 days, which informs the decision empirically. **No hook, no subagent.**
+
+---
+
+## D11 — Lakeflow Declarative Pipelines (formerly DLT) initialization takes 5+ min when >30 streaming tables in one pipeline
+
+**Domain:** compute
+**Trigger:** Team defines 30+ streaming tables (Auto Loader → bronze → silver → gold) inside a single Lakeflow Declarative Pipeline (DLT) definition.
+**Symptom:** Every triggered pipeline run spends 5+ minutes in initialization before the first row is processed. Continuous pipelines hide this (they initialize once and stay up), but triggered/scheduled pipelines pay it every run. End-to-end latency is dominated by init, not by compute. Driver may also OOM.
+**Root cause:** The DLT driver builds the dependency DAG, plans the execution order, and initializes streaming state for every table in the pipeline at startup. Above ~30-40 streaming tables, the driver's CPU becomes the bottleneck — this is acknowledged in Databricks's own fix-high-init docs. The recommended fix is to split into multiple pipelines, which fights against the DLT design principle of "one declarative pipeline per logical domain."
+**Blast radius:** any DLT user with a large declarative pipeline; especially painful for orgs that adopted DLT precisely because it promised "declarative = simple, don't worry about scaling."
+**Current workaround (manual):** Split the pipeline into multiple pipelines along source-data or domain boundaries. Use continuous mode where SLA allows. Move from triggered to continuous to amortize init cost. Profile the dependency-graph build phase via the DLT event log.
+**Citations:**
+
+- https://docs.databricks.com/aws/en/ldp/fix-high-init (official: "running more than 30-40 streaming tables within a single pipeline" makes the driver a bottleneck; splitting is the recommended remediation)
+- https://learn.microsoft.com/en-us/azure/databricks/dlt/fix-high-init (Azure mirror)
+- https://community.databricks.com/t5/get-started-discussions/trying-to-reduce-latency-on-dlt-pipelines-with-autoloader-and/td-p/133985 (community thread on DLT latency reduction)
+**Response architecture recommendation:** **SKILL.md + scripts/.** `scripts/dlt-init-profiler.py` reads a pipeline's event log via the Databricks Pipelines API, isolates the `initialization` phase events, and emits a per-table breakdown of init time. **Optional MCP** for live pipeline-event-log reads via `pipelines.get_event_log`. **No subagent, no hook.** This pain is consultative — the agent's job is to detect "you're at the threshold" and recommend the split before init hits 10+ min.
+
+---
+
+## D12 — Serverless notebook has no configurable idle timeout; "fading green" minutes are not clearly billed
+
+**Domain:** cost
+**Trigger:** User finishes running cells in a serverless notebook. The notebook shows "fading green" / "spinning down" state for 5–10 minutes before becoming fully idle.
+**Symptom:** User is unsure whether they're being charged during the fade. There is no UI setting to configure the timeout. Documentation does not give a definitive answer. `system.billing.usage` is the only way to verify.
+**Root cause:** Serverless notebooks do not expose the idle-timeout knob that classic clusters (auto_termination_minutes) and SQL warehouses (auto_stop_mins) have. The fade window is platform-managed and currently non-configurable per a Databricks employee answer on the community forum (March 2026). The platform "is still doing real work" during the fade — implying there is some level of billing, but no documented commitment to "you are not billed for the fade window."
+**Blast radius:** every serverless-notebook user; especially impactful for ad-hoc / exploratory analysts who open and close notebooks frequently throughout the day.
+**Current workaround (manual):** Query `system.billing.usage` filtered to your user + this notebook's session to verify what you were billed. Explicitly detach the notebook when done (does not fully eliminate fade but may shorten it). Use classic compute with strict auto-termination if predictable billing matters more than serverless cold-start speed.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/serverless-notebook-idle-timeout-is-it-configurable-what-exactly/td-p/151133 (March 2026; OP describes "fading green" state, Databricks employee confirms no public config option)
+- https://docs.databricks.com/aws/en/compute/serverless/best-practices (recommends caching environments, doesn't address idle-billing question)
+- https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing (canonical: `system.billing.usage` is the only ground truth)
+**Response architecture recommendation:** **SKILL.md + scripts/ + slash command.** `scripts/serverless-notebook-bill-attribution.py` runs a parameterized `system.billing.usage` query for the user's serverless notebook sessions over a window and emits per-session DBU + $$. Slash command `/serverless-notebook-bill <notebook_id> --days 7`. **Optional MCP** for the Unity Catalog SQL read. **No hook, no subagent** — this is on-demand attribution work, not background monitoring.
+
+---
+
+# Cross-cutting source clusters I could NOT crack
+
+The catalog above is grounded only in sources I could actually fetch. Source clusters where I had partial signal but couldn't get full verbatim quotes:
+
+1. **Reddit r/databricks and r/dataengineering** — `WebFetch` is blocked from reddit.com in this environment. Plenty of thread titles surface in indirect search results but I can't pull the body text + comment authority. Manual follow-up: have a human pull the top-of-year unresolved threads for each of these four pain domains and confirm whether the 12 entries above match the field reports.
+
+2. **YouTube DAIS / Data + AI Summit 2024-2025 talks** — Couldn't ingest video content in this run. The "war story" / postmortem talks at DAIS are typically the richest source of named-customer pain (DBR upgrade pain at $LARGE_FINTECH, etc.) but require transcript extraction, which is a separate workflow.
+
+3. **Twitter/Bluesky "databricks at 3am" / "databricks broke" threads** — Twitter/X search is gated for unauthenticated fetches; couldn't get a usable corpus.
+
+4. **GitHub `databricks/databricks-sdk-py` and `databricks/terraform-provider-databricks` issues** — Sampled `databricks/cli` only. The 20 recent bug issues there are mostly bundle-deploy and CLI-panic issues, not cluster/Photon/DBR/cost pain — so they're out of scope for this domain. A deeper pass into the SDK and Terraform-provider repos would likely surface programmatic-API pain (e.g. `clusters.create` returning success while the cluster never actually starts) — recommend a follow-up scan with: `gh api repos/databricks/databricks-sdk-py/issues?state=closed&labels=wontfix` and the same for `terraform-provider-databricks`.
+
+5. **Per-cloud quota / sub-region pain** — there's a known cluster of "we hit `RequestLimitExceeded` in us-east-1 during reInvent / Black Friday / quarterly close" anecdotes but the open-web sources don't reproduce the specific Databricks-side termination codes consistently. Worth a Databricks-employee interview to confirm what the exact codes are.
+
+# Summary
+
+12 pain entries across 4 sub-domains (compute, photon, DBR-versioning, cost), each grounded in 2-4 fetched sources with author/date/version context. Every entry maps to a concrete Claude Code primitive recommendation. The dominant primitive across the catalog is **MCP server** (workspace API + system.billing.usage read access is the load-bearing capability) — 7 of 12 entries call for one. **Subagent fan-out** is recommended only where parallel API queries materially shorten triage time (D01, D06). **Hooks** are recommended sparingly and only as opt-in PostToolUse triggers (D06, D07) — most of this work is user-initiated diagnostics, not background reactive work. **Scripts/** are recommended in 9 of 12 entries as the unit that does the actual work; SKILL.md is always present as the playbook.

--- a/plugins/saas-packs/databricks-pack/000-docs/003-RL-RSRC-databricks-delta-streaming-research.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/003-RL-RSRC-databricks-delta-streaming-research.md
@@ -1,0 +1,284 @@
+# Databricks Pain Catalog — Domain 2: Delta Lake, Liquid Clustering, Structured Streaming, DLT
+
+**Compiled:** 2026-05-27
+**Scope:** Recurring, painful, real-world issues that bite engineers in production on Databricks DBR 13.x–16.x with Delta Lake 2.x–4.x.
+**Purpose:** Grounding research for a Claude Code skill plugin pack rebuild — each entry classifies the pain type (platform bug / config mistake / design decision) and proposes the response architecture (which Claude Code primitives fit).
+
+---
+
+## D01 — `ConcurrentDeleteDeleteException` when manual OPTIMIZE collides with AUTO OPTIMIZE
+
+**Domain:** delta-lake
+**Trigger:** Engineer runs `OPTIMIZE <table>` manually (often from a notebook or scheduled job) while AUTO OPTIMIZE / auto-compaction is also enabled on the same table — common after MERGE/UPDATE/DELETE jobs which always have auto-compact on.
+**Symptom:** Job fails with verbatim:
+
+```
+[DELTA_CONCURRENT_DELETE_DELETE] ConcurrentDeleteDeleteException:
+This transaction attempted to delete one or more files that were deleted by a concurrent update.
+```
+
+`DESCRIBE HISTORY` shows two back-to-back OPTIMIZE rows where one is `"auto": true` and the other `"auto": false` around the failure timestamp.
+**Root cause:** Both the auto-compactor and the manual OPTIMIZE are issuing optimistic-concurrency-controlled commits that mark the same source small files for deletion. Whichever commits second loses. This is a **design decision** in Delta's OCC model, not a bug — but it surprises engineers who don't realize MERGE/UPDATE/DELETE silently enable autoCompact.
+**Blast radius:** single-table — but the failing job often holds up downstream Airflow/Workflow DAGs.
+**Current workaround (manual):** Either (a) disable AUTO OPTIMIZE globally via `spark.databricks.delta.optimizeWrite.enabled false` + `spark.databricks.delta.autoCompact.enabled false` (Databricks officially discourages this — costs perf), or (b) gate manual OPTIMIZE behind a lock the team enforces by convention, or (c) wrap OPTIMIZE in retry-with-backoff.
+**Citations:**
+
+- https://kb.databricks.com/delta/running-optimize-on-delta-tables-causing-concurrentdeletedeleteexception-error
+- https://learn.microsoft.com/en-us/azure/databricks/optimizations/isolation-level
+- https://docs.databricks.com/aws/en/optimizations/isolation/row-level-concurrency
+**Response architecture recommendation:** **SKILL.md + scripts/ + Hooks (PreToolUse).** A `pre-optimize-check` script inspects table properties (`SHOW TBLPROPERTIES`) and recent `DESCRIBE HISTORY` to detect auto-compact activity in the last N minutes before allowing a manual OPTIMIZE; the hook blocks the user from firing `OPTIMIZE` without that check. SKILL.md teaches the recovery decision tree. No MCP needed — pure-SQL diagnostic via existing JDBC.
+
+---
+
+## D02 — `ConcurrentAppendException` on Liquid-Clustered tables despite "different rows"
+
+**Domain:** liquid-clustering
+**Trigger:** Engineer migrates a partitioned table to Liquid Clustering expecting better concurrency, then runs the same multi-writer MERGE jobs they ran before (e.g., per-tenant CDC merges fan-out across 50 workflow runs).
+**Symptom:** Verbatim:
+
+```
+[DELTA_CONCURRENT_APPEND] ConcurrentAppendException: Files were added to the root of the table by a concurrent update.
+```
+
+Engineer's gut reaction: "but my MERGEs touch different user_ids — Liquid Clustering should handle this." DBR 15.3 reproducer in citation.
+**Root cause:** Liquid Clustering replaces *folder-based partition pruning* with file-skipping via ZCubes. The conflict detection still works on the file set the MERGE *scanned*, not on the final touched rows. If the merge predicate is just `s.user_id = t.user_id`, Delta reads candidate files across the whole logical clustering — overlapping reads → overlapping write sets → conflict. **Design decision (Liquid Clustering does NOT magically eliminate writer conflicts)**, but it is widely misunderstood as such in marketing material.
+**Blast radius:** prod-pipelines — typically blows up fan-out jobs in workflow orchestrators.
+**Current workaround (manual):** Add narrowing predicates to MERGE on the clustering key(s) so each merge scans a non-overlapping file set: `... AND t.country = '<lit>' AND t.date = '<lit>'`. Or enable row tracking: `ALTER TABLE t SET TBLPROPERTIES ('delta.enableRowTracking' = true)` (DBR 14+). Or serialize the writers.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/concurrentappendexception-liquid-clustered-table-different-row/td-p/76916
+- https://kb.databricks.com/delta/insert-operation-fails-while-trying-to-execute-multiple-concurrent-insert-or-merge-operations-to-append-data
+- https://itnext.io/handling-concurrent-writes-in-databricks-01a81ed33aea
+**Response architecture recommendation:** **SKILL.md + references/ + Subagent.** A subagent inspects the user's MERGE SQL, identifies the clustering keys of the target table (via MCP-fetched `DESCRIBE DETAIL` or stored ref), and rewrites the predicate to include the clustering-key filters. The references/ dir holds the full "MERGE rewrite cookbook" — examples for SCD2, dedup, CDC. A pure scripts/ approach is too brittle here because the SQL surface is too varied — needs an agent rewriting the predicate, not a regex.
+
+---
+
+## D03 — Streaming source fails `DELTA_FILE_NOT_FOUND_DETAILED` after VACUUM cleans files the checkpoint still references
+
+**Domain:** streaming
+**Trigger:** Long-running streaming job consumes a Delta source that has OPTIMIZE running periodically + a daily VACUUM with the default 7-day retention. The streaming job falls behind (cluster restart, late start, traffic spike) by more than retention, OR the checkpoint's tracked offset references a file that OPTIMIZE rewrote and VACUUM later cleaned.
+**Symptom:** Verbatim:
+
+```
+[DELTA_FILE_NOT_FOUND_DETAILED] File abfss://<storage>.dfs.core.windows.net/
+<path>/part-xxxx-c000.snappy.parquet referenced in the transaction log
+cannot be found.
+```
+
+Or the older form: `FileNotFoundException: ... doesn't exist` even with `ignoreMissingFiles=true` set.
+**Root cause:** **Platform-bug-adjacent design decision.** The streaming Delta source pins offsets to *file paths*, not logical version positions. OPTIMIZE creates a new logical version where files are rewritten; VACUUM (7 days later by default) deletes the originals. If the streaming job's last successful commit is older than the OPTIMIZE+VACUUM cycle, the next batch tries to read a file that no longer exists. `ignoreMissingFiles` was supposed to mitigate but is documented as not always working for this case.
+**Blast radius:** prod-pipelines — entire streaming consumer dead until manual recovery.
+**Current workaround (manual):** Pick one of: (a) restart with a fresh checkpoint location + manual reconciliation/dedup downstream, (b) restart with `startingVersion` set to the oldest available version per `DESCRIBE HISTORY`, (c) `FSCK REPAIR TABLE <name>` to prune stale metadata, (d) run `OPTIMIZE` on source less often or move VACUUM retention to >> streaming SLA.
+**Citations:**
+
+- https://kb.databricks.com/delta/delta-table-as-a-streaming-source-returns-error-delta_file_not_found_detailed-even-though-no-user-or-lifecycle-rule-has-deleted-files
+- https://kb.databricks.com/delta/error-filenotfoundexception-while-streaming-job-or-reading-delta-table-even-with-ignoremissingfiles-set-
+- https://community.databricks.com/t5/data-engineering/deltafilenotfoundexception-no-file-found-in-the-directory-sudden/td-p/53066
+**Response architecture recommendation:** **MCP server + Slash command + Hooks (SessionStart).** This is a multi-system diagnostic — needs typed Databricks Workspace API access (job state, checkpoint location, source-table version history) to triangulate. A `/recover-streaming-source` slash command runs a decision tree: get latest source version → get latest committed checkpoint offset → compute drift → recommend one of the 4 recovery strategies. SessionStart hook warns "you have N streaming jobs with checkpoints older than the source's `deletedFileRetentionDuration`."
+
+---
+
+## D04 — Streaming checkpoint silently resets to batch 0 after months of healthy operation
+
+**Domain:** streaming
+**Trigger:** Production Spark Streaming job that has been running for many months suddenly fails or restarts from batch 0. No code change recent to the failure. Often after a cluster restart or rare DBR upgrade.
+**Symptom:** Verbatim (community report):
+
+```
+StreamingQueryException: [STREAM_FAILED] Query [id = ..., runId = ...] terminated with exception:
+dbfs:/mnt/path/my_table/sources/0/0 doesn't exist
+```
+
+`sources/`, `offsets/`, and `commits/` directories under the checkpoint path stop receiving writes; batch ID resets from 711 → 0 on next restart.
+**Root cause:** **Platform bug class** — checkpoint metadata corruption (or in some cases, deletion by a lifecycle policy on DBFS/S3 the user didn't know existed). Databricks has a documented "Recover a pipeline from streaming checkpoint failure" page but no clean root-cause story for spontaneous corruption.
+**Blast radius:** single-pipeline → workspace-wide if the checkpoint location is shared.
+**Current workaround (manual):** Documented three-tier recovery: (1) full table refresh + recompute, (2) checkpoint reset + downstream dedup, (3) restart from a known-good `startingVersion`. None is cheap.
+**Citations:**
+
+- https://community.databricks.com/t5/administration-architecture/spark-streaming-checkpoint-corrupted/td-p/3681
+- https://docs.databricks.com/aws/en/structured-streaming/checkpoints
+- https://docs.databricks.com/aws/en/ldp/recover-streaming
+**Response architecture recommendation:** **MCP server + Hooks (SessionStart + PostToolUse) + scripts/.** Hook-based monitoring is the right shape: a `SessionStart` hook lists streaming queries with `numInputRows=0` for N minutes and surfaces "your stream is stuck — likely checkpoint corruption." A `scripts/diagnose-checkpoint` tool inspects `sources/`, `offsets/`, `commits/` for monotonic IDs and flags discontinuities. Recovery is a guided playbook in SKILL.md because the three recovery paths have different downstream cleanup implications — the agent has to ask the user which they prefer.
+
+---
+
+## D05 — RocksDB state store pins multi-GB off-heap memory; driver OOM despite normal heap
+
+**Domain:** streaming
+**Trigger:** Stateful streaming workload (`dropDuplicatesWithinWatermark`, stream-stream join, `mapGroupsWithState`, or `applyInPandasWithState`). Cluster resized, shuffle partition count changed without clearing checkpoint, OR data volume grew while state schema is wide.
+**Symptom:** Driver pod OOMKilled. `executor.rocksDBOperationsTimeMillis` and metrics show `rocksdbPinnedBlocksMemoryUsage` in the 10s of GB. One documented case: 22 GB pinned. Another: 32 GB used to store 611,788 records.
+**Root cause:** **Design decision** — default RocksDB has no memory cap; pinned blocks aren't subject to JVM GC; `memoryUsedBytes` reflects full row width (all columns), not just the watermark/key columns. Compounded if shuffle partitions changed without checkpoint reset — RocksDB keeps multiple state-store instances per partition simultaneously.
+**Blast radius:** prod-pipelines — entire job dies, often takes the cluster with it.
+**Current workaround (manual):** Set `spark.databricks.streaming.statefulOperator.stateRebalancing.enabled true`, cap RocksDB with `spark.sql.streaming.stateStore.rocksdb.boundedMemoryUsage true` + `spark.sql.streaming.stateStore.rocksdb.maxMemoryUsageMB 4096`, enable `changelogCheckpointing.enabled true` (DBR 13.3+), trim state schema to only what's needed for the operator, and clear checkpoint after any partition-count change.
+**Citations:**
+
+- https://community.databricks.com/t5/administration-architecture/extreme-rocksdb-memory-usage/td-p/42972
+- https://medium.com/@rahulgosavi.94/why-your-databricks-streaming-job-is-leaking-driver-memory-and-how-to-fix-it-41554b75c73a
+- https://docs.databricks.com/aws/en/structured-streaming/rocksdb-state-store
+**Response architecture recommendation:** **SKILL.md + references/ + scripts/.** Encyclopedic — the configuration surface is large enough that a deep references/ section is needed (one page per RocksDB knob with what it actually does). `scripts/scan-stream-config` reads job/cluster Spark configs and grades them against the recommended bounded-memory profile. No MCP strictly needed because Databricks Jobs API + REST give enough info; could upgrade to MCP if used heavily.
+
+---
+
+## D06 — Liquid Clustering migration from partition + Z-ORDER: hidden full rewrite cost + downstream breakage
+
+**Domain:** liquid-clustering
+**Trigger:** Engineer follows a Databricks blog or DAIS talk recommending Liquid Clustering, runs `ALTER TABLE t CLUSTER BY (col1, col2)` on a multi-TB partitioned table that also has historical Z-ORDER. Then runs `OPTIMIZE FULL` because the docs imply it's needed for a clean transition.
+**Symptom:** (1) `OPTIMIZE FULL` either OOMs the cluster or runs for 12–48 hours on a multi-TB table; (2) downstream Spark jobs that hard-coded partition predicates (`WHERE _hive_partition = ...`) break because the table no longer has partition folders; (3) "table size ballooning after optimization jobs" reported by multiple community users — Delta keeps both the old and new file sets until VACUUM; (4) `CLUSTER BY` is mutually exclusive with partitioning and with Z-ORDER, so any code path doing `OPTIMIZE ZORDER BY (...)` now errors.
+**Root cause:** **Design decision wrapped in documentation gap.** Liquid Clustering trades partition-pruning predictability for incremental ZCubes; the migration path is real-but-expensive and the "before/after" performance comparison rarely accounts for the rewrite cost, the dual-storage period, or downstream code coupling to partitioning.
+**Blast radius:** workspace-wide downstream — every consumer of the table needs review.
+**Current workaround (manual):** Before flipping `CLUSTER BY`, audit downstream queries for explicit partition predicates; rewrite to use clustering keys instead. Stage the migration on a cloned table first (`CREATE TABLE staging CLONE source`), verify size + perf, swap. Budget the cluster + storage cost in advance. Run timely VACUUM after the OPTIMIZE FULL.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/when-to-use-and-when-not-to-use-liquid-clustering/td-p/136190
+- https://docs.databricks.com/aws/en/delta/clustering
+- https://dataengineerwiki.substack.com/p/how-liquid-clustering-actually-beats
+- https://www.canadiandataguy.com/p/optimizing-delta-lake-tables-liquid
+**Response architecture recommendation:** **Slash command + Subagent + MCP server.** This is a multi-stage migration; agent-driven. `/migrate-to-liquid-clustering <table>` orchestrates: (1) MCP-fetched `DESCRIBE HISTORY` + size estimate, (2) Subagent grep across the workspace for downstream readers referencing partition predicates, (3) generate migration plan with cost estimate + rollback path, (4) execute as a clone-first/swap-at-end pattern. MCP is justified because the migration touches multiple workspace-API surfaces (jobs, tables, lineage). Hooks not needed.
+
+---
+
+## D07 — Delta time travel breaks silently when VACUUM crosses retention boundary
+
+**Domain:** delta-lake
+**Trigger:** Engineer relies on Delta time travel for "rollback in case anything goes wrong" (auditor demand, GDPR right-to-be-forgotten misunderstanding, dev-prod debugging). VACUUM runs nightly at default 7-day retention OR has been tuned down to 1–2 days for cost.
+**Symptom:** `SELECT * FROM t VERSION AS OF 47` works fine for recent versions and fails for older ones with the standard `DELTA_FILE_NOT_FOUND_DETAILED` error. Or `DESCRIBE HISTORY` truncates and the engineer is confused why "version 0 doesn't exist anymore."
+**Root cause:** **Design decision + recurring misconception.** Time travel is per-transaction versioning on top of Parquet — VACUUM removes files associated with versions older than retention. Common misconceptions documented: time travel = backups (no), time travel = SCD2 (no), time travel = GDPR erasure (no — opposite, it *retains* deleted data), time travel = CDC alternative (CDF is the right tool). Each misconception leads to a different failure mode.
+**Blast radius:** dev-workspace + audit/compliance — usually only bites during a high-pressure investigation.
+**Current workaround (manual):** Lengthen retention via `ALTER TABLE t SET TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 30 days', 'delta.logRetentionDuration' = 'interval 30 days')`, plus disable VACUUM safety check if going below 7 days (`SET spark.databricks.delta.retentionDurationCheck.enabled = false`) — but this trades storage cost for safety. For real archival, take an external snapshot or CLONE.
+**Citations:**
+
+- https://medium.com/towards-data-engineering/top-misconceptions-about-delta-lake-time-travel-a9fff62bdf5a
+- https://docs.databricks.com/aws/en/delta/vacuum
+- https://kb.databricks.com/en_US/delta/vacuum-best-practices-on-delta-lake
+- https://medium.com/@vinodkumar.mani/databricks-delta-lake-time-travel-understanding-retention-before-you-lose-your-data-f4ea26ccb934
+**Response architecture recommendation:** **SKILL.md + references/ + Hooks (PreToolUse on VACUUM).** SKILL.md teaches the 4-misconception framework so the agent can name the user's *actual* need (backup vs SCD2 vs CDF vs rollback). A PreToolUse hook on `VACUUM` queries the table's retention settings + the workspace's longest-running streaming consumer's lag and warns if VACUUM will sever time travel for an active reader. references/ holds the decision tree per use case.
+
+---
+
+## D08 — DLT pipeline intermittently fails "table missing" due to concurrent Python threads inside `@dlt.table` functions
+
+**Domain:** DLT
+**Trigger:** Engineer parallelizes ingestion of N source tables (a common pattern: 58 bronze tables in one pipeline) using Python `ThreadPoolExecutor` or similar inside the DLT notebook to "speed up" pipeline graph construction.
+**Symptom:** Pipeline fails ~25–30% of runs with "table missing" / table-not-found during DAG materialization. Re-running with no code change succeeds. Both UI runs and full-refresh runs affected. From the community thread: *"the pipeline fails once every 3/4 runs saying that a table is missing - but when i rerun without any code change - it completes successfully."*
+**Root cause:** **Platform-bug-adjacent design constraint.** DLT's `@dlt.table` / `@dlt.view` decorators register tables into a pipeline graph during the planning phase. Threading those registrations creates a race in the registration order, so the planner sometimes sees a dependent table before its dependency exists. Databricks support privately identified threading as the cause; not documented publicly.
+**Blast radius:** single-pipeline, but the intermittency burns engineering time hunting non-bugs.
+**Current workaround (manual):** Remove the threading; let DLT's own DAG executor parallelize. Use a for-loop with parameterized table definitions instead of threads.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/delta-live-table-pipeline-failure-table-missing/td-p/40475
+- https://docs.databricks.com/aws/en/dlt/recover-streaming
+- https://b-eye.com/blog/databricks-delta-live-tables-guide/
+**Response architecture recommendation:** **Hooks (PreToolUse) + SKILL.md.** This pain is detectable statically — a PreToolUse hook on DLT notebook deploys greps for `ThreadPoolExecutor`, `concurrent.futures`, `threading.Thread` inside files that import `dlt` and blocks with a clear error citing this exact pattern. SKILL.md provides the rewrite pattern (for-loop with closure binding). No MCP / subagent needed — pattern is small and fixed.
+
+---
+
+## D09 — DLT full refresh on streaming tables silently drops data when source is non-replayable
+
+**Domain:** DLT
+**Trigger:** Engineer hits "Full Refresh" in DLT UI (or runs a `--full-refresh-all` workflow trigger) on a pipeline whose source is a Kafka topic with 7-day retention, an Event Hub with N-day retention, a truncate-and-load Delta source, or a cloud-object-storage path where files have already aged off.
+**Symptom:** Pipeline completes "successfully" but the target table is missing weeks/months of history. No error. No alert. Discovered later by a downstream consumer or BI report showing zero rows for older partitions.
+**Root cause:** **Design decision** — full refresh = truncate target + replay source from the beginning of *currently available* source data. If the source can't replay to the original start, you lose what's no longer there. Databricks docs do warn but the UI button gives no friction.
+**Blast radius:** prod-pipelines + downstream — silent data loss is the worst kind.
+**Current workaround (manual):** Pre-mark protected tables with `pipelines.reset.allowed=false` in the table property (DLT-specific) — this blocks accidental full refresh entirely. Otherwise: snapshot the target BEFORE full refresh, full-refresh, diff, backfill from snapshot. Or never enable full refresh on append-only event-source streams; use Change Data Feed-driven reprocessing instead.
+**Citations:**
+
+- https://community.databricks.com/t5/data-engineering/dlt-full-refresh/td-p/63245
+- https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/full-refresh
+- https://docs.databricks.com/aws/en/ldp/updates
+- https://dmesh-io.medium.com/full-refresh-on-databricks-delta-live-streaming-tables-with-kafka-topics-f79a222c4c29
+**Response architecture recommendation:** **Hooks (PreToolUse on pipeline-update API call) + Slash command + MCP server.** The most valuable response is friction at the moment of triggering full refresh. PreToolUse hook on any `gh-databricks pipelines update --full-refresh*` style invocation: agent inspects pipeline manifest for source types (Kafka/Kinesis/EventHub/Autoloader), checks for `pipelines.reset.allowed=false`, and refuses + offers `/protect-dlt-pipeline` slash command to add the property. MCP needed because the check requires authenticated Pipelines API access to read the manifest.
+
+---
+
+## D10 — Autoloader `UnknownFieldException` stops the stream on every new column; rescue mode silently widens schema
+
+**Domain:** streaming (Autoloader)
+**Trigger:** Bronze ingestion with Autoloader reading JSON/CSV/Parquet from S3/ADLS/GCS. Upstream system adds a new column. Engineer set up the stream with `cloudFiles.schemaEvolutionMode='addNewColumns'` (the default before a recent change) OR didn't think about schema-evolution mode at all.
+**Symptom:** Two distinct failure modes depending on mode:
+
+- **addNewColumns (default in many setups):** stream stops with `UnknownFieldException`. Engineer must restart manually after the schema-location auto-updates. Downstream is now stale until restart.
+- **rescue mode:** stream keeps running but all unexpected fields land in `_rescued_data` (a JSON-blob string column) — silent schema drift, downstream queries break because the "new" column never materializes as a typed column.
+- **failOnNewColumns:** explicit fail every time.
+**Root cause:** **Design decision** — Autoloader trades automation for explicitness. None of the modes does what most engineers actually want: "evolve the schema, type the new column inferred from the data, restart the stream automatically, and notify me." The schemaHints feature partially fills the gap but requires the engineer to know the new column name in advance.
+**Blast radius:** prod-pipelines — bronze layer broken → silver/gold cascade.
+**Current workaround (manual):** Combination of `schemaHints` for known-evolving fields + `rescuedDataColumn` for safety net + downstream monitor that alerts if `_rescued_data IS NOT NULL` for >X% of rows + an autoloader restart job triggered by the UnknownFieldException event. Multi-piece.
+**Citations:**
+- https://docs.databricks.com/aws/en/ingestion/cloud-object-storage/auto-loader/schema
+- https://community.databricks.com/t5/technical-blog/schema-management-and-drift-scenarios-via-databricks-auto-loader/ba-p/63393
+- https://learn.microsoft.com/en-us/azure/databricks/ingestion/cloud-object-storage/auto-loader/schema
+- https://medium.com/@asindugayangana/databricks-auto-loader-best-practices-for-reliable-and-scalable-data-ingestion-30e65bf4c520
+**Response architecture recommendation:** **MCP server + Hooks (PostToolUse on stream-stop) + scripts/ + Subagent.** The right response is a small system, not a single skill artifact:
+- MCP exposes Databricks Jobs API + the schema-location storage path.
+- PostToolUse hook detects an `UnknownFieldException` in a job's failure event and auto-invokes a Subagent.
+- Subagent reads the latest schema in the schema location, diffs against last commit, proposes a `schemaHints` patch + PR.
+- `scripts/rescued-data-monitor` cron-style script that surfaces the `_rescued_data IS NOT NULL` rate per table.
+
+---
+
+## D11 — DLT serverless cost spike: maintenance cluster runs predictive optimization 24×7 on idle pipelines
+
+**Domain:** DLT
+**Trigger:** Engineer migrates a triggered pipeline to DLT serverless for "auto-scaling cost savings." Pipeline itself runs 1×/day for 20 minutes, but the bill triples.
+**Symptom:** Databricks billing shows continuous serverless SKU usage even when the pipeline isn't actively updating. Investigation reveals the maintenance cluster (separate from the update cluster) is running predictive optimization (VACUUM, OPTIMIZE, automatic Liquid Clustering key selection) on every table the pipeline owns, every day.
+**Root cause:** **Design decision** — each declarative pipeline has TWO compute resources (update + maintenance) and predictive optimization is on by default for managed Unity Catalog tables. The maintenance cluster cost isn't visible in the same place as the update cost. Plus, DLT Advanced tier defaults bring in features (CDC, expectations enforcement, SCD2) the engineer may not be using.
+**Blast radius:** workspace-wide cost — multiplied across N pipelines.
+**Current workaround (manual):** (1) Audit each pipeline's tier — drop to DLT Core or Pro if Advanced features aren't used; (2) review `enzyme.mode` and predictive-optimization settings per table; (3) for triggered pipelines, ensure performance mode is set to standard not "Performance optimized" if latency doesn't justify the premium; (4) use system tables (`system.billing.usage`) to attribute costs per pipeline.
+**Citations:**
+
+- https://www.cloudzero.com/blog/reduce-databricks-costs/
+- https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing
+- https://docs.databricks.com/aws/en/ldp/serverless
+- https://medium.com/@kezhu2007/how-i-traced-a-3-5x-databricks-cost-spike-to-three-dashboards-part-1-11724476d1ff
+- https://www.unraveldata.com/resources/maximizing-databricks-predictive-optimization-roi/
+**Response architecture recommendation:** **MCP server + Slash command + scripts/.** Cost analysis = data join across `system.billing.usage`, pipeline manifest, and table properties. `/dlt-cost-audit` slash command: MCP-pulls the billing rows for the last 30 days grouped by pipeline_id + workload_type (update vs maintenance), correlates with pipeline tier + serverless mode + table predictive-optimization flags, and outputs "your top-3 cost levers." scripts/ holds reusable SQL queries against system tables. No subagent — this is deterministic data analysis.
+
+---
+
+## D12 — `DIFFERENT_DELTA_TABLE_READ_BY_STREAMING_SOURCE`: streaming job dies after upstream "CREATE OR REPLACE TABLE" silently changes table ID
+
+**Domain:** streaming
+**Trigger:** A streaming job reads from a Delta source table. A separate team (or the same engineer on a different day) runs `CREATE OR REPLACE TABLE <name> ...` or `DROP TABLE` + `CREATE TABLE` against that source — typical for "rebuild bronze from scratch" or schema migration scripts.
+**Symptom:** Verbatim:
+
+```
+[STREAM_FAILED] Query [id = <query-id>, runId = <run-id>] terminated with exception:
+[DIFFERENT_DELTA_TABLE_READ_BY_STREAMING_SOURCE] The streaming query was reading from
+an unexpected Delta table (id = '<id>'). It used to read from another Delta table
+(id = '<other-id>') according to checkpoint.
+```
+
+**Root cause:** **Design decision** — checkpoints pin to the source table's UUID (set at `_delta_log` creation), not to the table's qualified name. `CREATE OR REPLACE` creates a new UUID even if name is unchanged. This is intentional safety (preventing accidental consumption of unrelated data under the same name) but bites every time a team uses CREATE OR REPLACE on a streamed-from table.
+**Blast radius:** prod-pipelines + cross-team — usually the consumer team has to scramble while the producer team thinks they did nothing wrong.
+**Current workaround (manual):** (1) Don't CREATE OR REPLACE streamed-from tables; instead use truncate + insert, or DROP COLUMN + ADD COLUMN, or migrate via clone-and-swap. (2) If forced, restart the consumer with a fresh checkpoint and downstream dedup. No automatic recovery.
+**Citations:**
+
+- https://kb.databricks.com/streaming/streaming-job-failing-with-different_delta_table_read_by_streaming_source-error
+- https://kb.databricks.com/streaming/structured-streaming-job-fails-with-a-streaming-query-exception-when-a-schema-changes-in-the-source-table
+- https://kb.databricks.com/streaming/resumed-streaming-job-fails-after-pause-with-streamingqueryexception-error
+**Response architecture recommendation:** **Hooks (PreToolUse on CREATE OR REPLACE / DROP TABLE) + MCP server.** Right-shaped response is producer-side prevention, not consumer-side recovery. PreToolUse hook on `CREATE OR REPLACE TABLE` or `DROP TABLE` queries the workspace via MCP for streaming queries currently consuming from that table (`SELECT * FROM system.streaming.query_progress WHERE source_table = ...`) and blocks the operation if any active consumers exist, surfacing them by name + owner. SKILL.md provides the safer migration patterns. Hook also fires on the consumer side as an early warning if the table UUID changed between sessions.
+
+---
+
+## Source gaps / unfilled areas
+
+What this catalog does NOT yet cover well — flag these for follow-up research:
+
+1. **Reddit r/databricks + r/dataengineering primary-source threads** — WebFetch on reddit.com blocked from this environment. Several pains here are likely under-represented as a result (e.g., "everyone's worst DLT story" anecdotes that show up in those subs). Recommend follow-up via Brave Search or a Reddit-API MCP.
+2. **DAIS 2024/2025 talks** — talk pages indexed but not video-mined; deep streaming postmortems (e.g., Stripe's, Shopify's at DAIS) are richer than blog form but require transcript work.
+3. **delta-rs (Rust client) issues** — included in original scope; not separately mined. delta-rs has its own pain surface around protocol-version skew with Databricks-managed tables that deserves its own entry.
+4. **Delta UniForm / Iceberg compat pain** — emerging area in 2025; saw signals but didn't have a clear recurring-issue thread to anchor a pain entry. Worth its own pass.
+5. **Materialized View incremental-refresh fallbacks** — DLT MVs sometimes silently fall back to full recompute; community thread exists but pain is still being characterized. Worth re-mining in 6 months.
+6. **Photon-vs-classic engine subtle behavior differences in Delta writes** — multiple anecdotal mentions, no canonical thread yet.
+7. **`MERGE WITH SCHEMA EVOLUTION` interaction with downstream readers expecting old schema** — covered in D-implicit but deserves a dedicated entry once a concrete repro thread surfaces.
+
+---
+
+## Pain-type tally (for response-architecture planning)
+
+| Type | Entries | Notes |
+|---|---|---|
+| Design decision (platform-by-design, surprises engineers) | D01, D02, D05, D06, D07, D09, D10, D11, D12 | 9/12 — the dominant class; response is education + friction-at-trigger-time, not bug-fixes |
+| Platform-bug-adjacent (works as designed but design is flawed) | D03, D08 | 2/12 — needs workaround playbooks, can't fix the platform |
+| Platform bug class (no documented root cause) | D04 | 1/12 — needs monitoring + guided recovery |
+
+**Strategic takeaway for the plugin pack:** the dominant response primitives are **Hooks (PreToolUse for friction-at-trigger)** + **MCP server (Databricks Workspace API access for diagnostics)** + **SKILL.md (decision trees for the design-decision cluster)**. Subagents are needed in only ~3 of the 12 entries (SQL rewriting, multi-file workspace scans). Scripts/ shows up as supporting tooling, not as the primary entry point.

--- a/plugins/saas-packs/databricks-pack/000-docs/004-RL-RSRC-databricks-uc-bundles-ops-research.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/004-RL-RSRC-databricks-uc-bundles-ops-research.md
@@ -1,0 +1,387 @@
+# Databricks Pain Catalog — Domain 3: Unity Catalog, Asset Bundles, Identity, Workspace Ops, Secrets, Networking
+
+**Research date:** 2026-05-27
+**Author:** Research pass for Claude Code skill plugin pack rebuild
+**Scope:** Six domains — Unity Catalog (UC), Asset Bundles (DAB), SCIM/SSO, workspace ops, secret scopes + KMS, networking (PrivateLink/VPC).
+**Method:** Mined Databricks docs/KB, Databricks Community forum, `gh api repos/databricks/{cli,terraform-provider-databricks}/issues`, Microsoft Learn Q&A, Medium/blog write-ups. Cited verbatim source URLs per entry.
+
+**Key cross-cutting findings up front:**
+
+- **September 30, 2026 forcing function.** All new workspaces will be provisioned UC-only — no DBFS root, no DBFS mounts, no Hive metastore, no no-isolation shared clusters. Migration pain is at peak right now. ([databricks docs](https://docs.databricks.com/aws/en/data-governance/unity-catalog/migrate))
+- **Asset Bundles are immature tooling, not bad design.** The pain pattern in the `databricks/cli` repo is panics, state-file corruption, and resource-binding gaps, not architectural mistakes. Many issues opened in 2026 are still open. The recently-introduced "direct" deployment engine (env `DATABRICKS_BUNDLE_ENGINE=direct`) is the unofficial workaround for terraform-state bugs.
+- **Identity is the Azure-AD-shaped hole.** Nested groups don't sync, external groups are immutable, and the SCIM provisioner has 20-40 minute sync windows with no way to confirm completion programmatically. Reddit/community posts on this dwarf all other identity complaints.
+- **The single-metastore-per-region rule is a load-bearing constraint** that org-design and naming conventions have to be built around, and is repeatedly hit late.
+
+---
+
+## D1 — Hive metastore → UC migration: `wasbs://` / DBFS-root tables silently skipped
+
+**Domain:** unity-catalog
+**Trigger:** Engineer runs UCX assessment or Databricks Migration Assistant to lift legacy `hive_metastore.*` tables into a UC catalog, expects all tables to come over, runs the workflow, gets a green checkmark, and finds half the tables missing in UC.
+**Symptom:**
+
+- Assessment marks external tables "ready" but managed tables "not ready" with no surfaced reason.
+- Workflow "completes successfully, but neither the external nor the managed tables appear in Unity Catalog."
+- For Azure: `Table is not eligible for an upgrade from Hive Metastore to Unity Catalog. Reason: Unsupported file system scheme wasbs` (or `adl`).
+- For AWS/Azure: managed tables backed by `dbfs:/user/hive/warehouse/...` are skipped entirely because "Unity Catalog cannot govern DBFS root, as it lacks cloud-native URIs (s3://, abfss://)."
+- LEGACY_TABLE_ACL clusters cause migration to skip tables silently because their DENY-based permissive model cannot be auto-mapped to UC's strict allow-only model.
+- `CREATE TABLE CLONE` does not migrate Delta history — time-travel + change-data-feed silently break post-migration.
+
+**Root cause:** UC requires (a) cloud-native object-storage URIs (`s3://`, `abfss://`, `gs://`), (b) UC-compatible cluster modes (single-user or shared with UC), and (c) no DBFS root or DBFS-mount-only data. UCX is "diagnostic-first, not destructive" — it silently skips violating tables instead of erroring loudly.
+**Blast radius:** Catalog-wide for the targeted hive_metastore; potentially every workload that reads the un-migrated tables continues to work against the legacy HMS while the org believes migration is complete. False-confidence pattern.
+**Current workaround (manual):**
+
+1. Run UCX (or `system.information_schema` queries) to inventory `STORAGE_LOCATION` of every HMS table.
+2. For each `wasbs://` / `adl://` / `dbfs:/` table: physically copy data to `abfss://` / `s3://` / `gs://` first using `DEEP CLONE` or a Spark `INSERT INTO ... SELECT *` against a new path.
+3. Recreate tables in UC against the new path.
+4. Manually copy ACLs (HMS table ACL → UC `GRANT SELECT` etc.).
+5. Validate row counts catalog-by-catalog with a reconciliation notebook.
+6. Plan for the Delta-history loss: archive the old table read-only, document the cutover date as the new "time-travel zero."
+
+**Citations:**
+
+- https://docs.databricks.com/aws/en/data-governance/unity-catalog/migrate
+- https://community.databricks.com/t5/get-started-discussions/issues-migrating-hive-metastore-tables-to-unity-catalog/td-p/90836
+- https://community.databricks.com/t5/technical-blog/from-hms-to-unity-catalog-a-self-service-migration-playbook/ba-p/155116
+- https://www.databricks.com/blog/migrating-tables-hive-metastore-unity-catalog-metastore
+
+**Response architecture recommendation:**
+SKILL.md + references/ + scripts/ + Subagent.
+
+- **`references/`**: full taxonomy of un-migratable conditions (`wasbs`, `adl`, `dbfs:/user/hive`, LEGACY_TABLE_ACL, view-on-view depth limits, non-Delta external tables). Per-cloud playbooks for the physical-relocation step.
+- **`scripts/audit-hms-readiness.py`**: queries `system.information_schema` and HMS, emits a CSV: `table_name, storage_uri, scheme, migration_blocker, suggested_action`.
+- **`scripts/reconcile.py`**: post-migration row-count + schema diff between HMS source and UC target.
+- **Subagent (`migration-planner`)**: takes the readiness CSV and produces a per-table migration plan (clone vs deep-clone vs rewrite), respecting the org's catalog naming convention.
+- **WHY**: Migration is a multi-week sequenced operation with strong invariants (don't drop the source until reconciliation passes). A subagent keeps the main context clean while it grinds through hundreds of tables; deterministic scripts catch the silent-skip class.
+
+---
+
+## D2 — UC external-location AccessDenied after IAM-role recreation
+
+**Domain:** unity-catalog
+**Trigger:** Platform engineer deletes and recreates the IAM role used by a UC storage credential (e.g., during a cross-account refactor, naming standardization, or Terraform `taint` + apply).
+**Symptom:** Every query against tables in that external location starts failing with:
+
+```
+java.nio.file.AccessDeniedException: s3://<bucket>.<region>.amazonaws.com/path/to/object
+com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden
+```
+
+The Databricks UI shows the storage credential and external location both "healthy." The IAM role exists with the same name and the same trust policy. SQL warehouses, jobs, and notebooks all fail simultaneously.
+**Root cause:** AWS S3 bucket policies that reference an IAM role by ARN store the *role's unique ID* (`AROAXXXXXXXXXXXXXXXX`) internally, not the ARN string. When the role is deleted, AWS substitutes the unique-ID placeholder. Recreating the role with the same name generates a *new* unique ID — the bucket policy now points at the dead ID, so all requests are denied. The bucket policy looks textually identical in the AWS console but semantically references a tombstone.
+**Blast radius:** All UC external tables/volumes that resolve through that storage credential — typically a whole catalog or schema. Often production critical.
+**Current workaround (manual):**
+
+1. Open S3 bucket policy in the AWS console — JSON form, not the visual editor.
+2. Identify any `Principal` block showing `AROAXXX...` rather than the role ARN.
+3. Replace with the current role ARN.
+4. (Belt-and-suspenders) Recreate the storage credential in UC pointing at the new role, then recreate the external location.
+
+**Citations:**
+
+- https://kb.databricks.com/unity-catalog/accessdenied-error-on-unity-catalog-when-querying-external-locations
+- https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/manage-storage-credentials
+- https://learn.microsoft.com/en-us/answers/questions/5590979/azure-databricks-permission-denied-on-adls-contain
+
+**Response architecture recommendation:**
+SKILL.md + Hook (PreToolUse on `aws iam delete-role` / `aws iam create-role`) + scripts/.
+
+- **Hook**: blocks any `aws iam delete-role` that targets a role currently referenced by a UC storage credential unless the operator passes `--force` *and* has a recovery plan filed. Prevents the most common cause.
+- **`scripts/scan-bucket-policies.sh`**: walks every UC storage credential, fetches the bucket policy, flags any `AROA*` placeholders. Run in CI weekly.
+- **`scripts/repair-bucket-policy.py`**: takes a credential name, computes the live role's ARN, rewrites the bucket policy in place.
+- **WHY**: This is a *prevention-first* problem — once it bites it's loud and recoverable, but the prevention has to live at the moment of the destructive action. PreToolUse hook is the right primitive.
+
+---
+
+## D3 — UC: single metastore per region forces SDLC namespace gymnastics
+
+**Domain:** unity-catalog
+**Trigger:** Team designs Dev/Test/Prod isolation for UC and wants three separate metastores in the same region so promotion is a metadata operation, not a rename. Discovers the one-metastore-per-region rule late.
+**Symptom:** Cannot create a second metastore in the same region. Forces every catalog name to encode the environment (`bronze_dev`, `bronze_test`, `bronze_prod`), which then has to be substituted into views, DLT pipelines, jobs, dashboards, and every external BI tool's connection string. Cross-environment lineage gets polluted because UC sees `bronze_dev.silver.foo` and `bronze_prod.silver.foo` as siblings.
+**Root cause:** Hard product constraint, documented but easy to miss until late in design. Databricks recommends Delta Sharing for cross-metastore/region sharing, which is a different cost and operational model than the multi-metastore design teams expected.
+**Blast radius:** Account-wide. Sets the catalog naming convention for the lifetime of the deployment. Refactoring it later requires renaming every table reference in every notebook, view, pipeline, and downstream tool.
+**Current workaround (manual):**
+
+1. Adopt environment-suffixed catalogs (`bronze_<env>`) and parameterize every SQL/notebook with a `${env}` substitution.
+2. Use DAB targets to inject `var.env` into every catalog reference.
+3. File a request with the Databricks account team — the one-per-region limit is "soft" and can be lifted by the account team for some customers (undocumented exception).
+4. For true isolation: deploy each environment to a different *region* and accept the cross-region egress cost / lineage gap, or use a separate Databricks account per environment (cost: separate billing, separate principals, separate SSO).
+
+**Citations:**
+
+- https://community.databricks.com/t5/data-governance/metastore-one-per-account-region-limitation/td-p/41097
+- https://community.databricks.com/t5/data-governance/unity-catalog-multiple-metastore-in-same-region/td-p/28513
+- https://docs.databricks.com/aws/en/data-governance/unity-catalog/best-practices
+
+**Response architecture recommendation:**
+SKILL.md + references/ + Slash command.
+
+- **`references/uc-environment-isolation-patterns.md`**: four named patterns (single-metastore-catalog-per-env, multi-region, multi-account, soft-quota-bump), with concrete cost/operational tradeoffs.
+- **Slash command `/uc-env-pattern-picker`**: interactive decision tree (compliance reqs → cost tolerance → BI-tool count → naming flexibility) that recommends the pattern and emits the matching DAB target stub.
+- **WHY**: This is a *design-time* decision with permanent consequences. The skill's job is to surface the constraint before the design freezes, not to fix a runtime symptom. A slash command at the right moment in the project flow is the highest-leverage primitive.
+
+---
+
+## D4 — Asset Bundle `bundle bind` does not support UC resources (catalogs, external locations)
+
+**Domain:** asset-bundles
+**Trigger:** Team has existing UC catalogs and external locations (created via Terraform, UI, or earlier scripts) and wants to bring them under DAB management without recreating them. Runs `databricks bundle bind external_location <key> <existing-name>`.
+**Symptom:** CLI rejects with "does not recognise external_location (or catalog) as a supported resource type." If the engineer just adds the resource block to `databricks.yml` and deploys, DAB tries to *create* the resource and conflicts with the existing one — deploy fails because the catalog/external-location name is already taken.
+**Root cause:** Immature tooling. `bundle bind` was scoped to jobs and pipelines at GA; UC resource binding was deferred. Open issue [databricks/cli#4842](https://github.com/databricks/cli/issues/4842) tracks it, no fix as of CLI v0.295.x.
+**Blast radius:** Per-resource; blocks GitOps-driven UC governance until manual workaround applied.
+**Current workaround (manual):**
+
+1. Manually edit `terraform.tfstate` to import the resource (hostile, undocumented surface area).
+2. Or: destroy + recreate the catalog/external-location via DAB — *only* possible if no dependent tables exist (managed tables die with the catalog).
+3. Or: skip DAB for these resources and keep managing them in Terraform, which defeats the unified-pipeline goal of DAB.
+
+**Citations:**
+
+- https://github.com/databricks/cli/issues/4842
+- https://docs.databricks.com/aws/en/dev-tools/cli/bundle-commands
+- https://docs.databricks.com/aws/en/dev-tools/bundles/resources
+
+**Response architecture recommendation:**
+SKILL.md + scripts/ + Subagent.
+
+- **`scripts/import-uc-resource-to-bundle.py`**: takes an existing catalog or external-location name, computes the Terraform import command + state-file mutation, runs it under a backup-first guardrail. Tracks support gaps so when CLI lands native support the script can deprecate cleanly.
+- **Subagent (`bundle-bind-helper`)**: walks the existing UC inventory + the proposed `databricks.yml`, produces a per-resource plan (`already-bound` / `needs-import` / `safe-to-create` / `conflict-blocking`) and stops before any destructive op.
+- **WHY**: This is an *upstream bug we can't fix* — the response is a workaround tool that's correct, safe, and self-deprecating once Databricks ships the feature. Subagent keeps the multi-step import flow out of the main context.
+
+---
+
+## D5 — Asset Bundle: `terraform.tfstate` "unexpected EOF" on every deploy after the first
+
+**Domain:** asset-bundles
+**Trigger:** Team deploys a bundle for the first time (succeeds), commits, runs `databricks bundle deploy` a second time in CI or locally.
+**Symptom:**
+
+```
+Error: reading terraform.tfstate: opening: unexpected EOF
+```
+
+The remote state file is valid JSON (530-590 KB), downloadable via `databricks workspace export`, but the CLI's streaming reader fails. Reproducible on macOS and Linux, CLI v0.288.0 through v0.296.0. Effectively bricks the bundle until manually unblocked.
+**Root cause:** Bug in the CLI's `workspace-files` streaming-read path when fetching `terraform.tfstate`. Issue [databricks/cli#4986](https://github.com/databricks/cli/issues/4986) — open at time of writing.
+**Blast radius:** Per-bundle; every subsequent deploy of the affected bundle fails until the workaround is applied. Blocks promote-to-prod pipelines.
+**Current workaround (manual):** Switch to the "direct" deployment engine, which bypasses Terraform state entirely:
+
+```bash
+export DATABRICKS_BUNDLE_ENGINE=direct
+databricks bundle deploy --profile <profile>
+```
+
+This is officially a preview feature; teams adopt it as a permanent workaround because the underlying terraform-state path keeps breaking in other ways too. There are *other* open issues against the direct-engine path (cluster restart on every deploy, catalog "always recreate" drift) — switching engines trades one class of bug for another, and is not a clean fix.
+
+**Citations:**
+
+- https://github.com/databricks/cli/issues/4986
+- https://github.com/databricks/cli/issues/4933
+- https://github.com/databricks/cli/issues/4625
+- https://github.com/databricks/cli/issues/5179
+- https://community.databricks.com/t5/data-engineering/databricks-assets-bundles-no-deployment-state/td-p/67918
+
+**Response architecture recommendation:**
+SKILL.md + Hook (PreToolUse on `databricks bundle deploy`) + references/.
+
+- **PreToolUse hook**: before every `bundle deploy`, downloads the remote `terraform.tfstate` via the workspace API, validates it parses as JSON, and warns if size has shrunk vs. the last good copy (state corruption canary). Caches a known-good copy locally as a recovery escape hatch.
+- **`references/bundle-engine-tradeoffs.md`**: side-by-side of `terraform` vs `direct` engine, listing the known-open bug IDs against each. Updated as issues close.
+- **WHY**: Tooling is in flux — the right response is to detect breakage early (hook), preserve recovery state (hook side-effect), and document the unstable choice (reference) so the team doesn't waste a sprint rediscovering the workaround. The skill itself can't fix the upstream bug.
+
+---
+
+## D6 — Asset Bundle: schema GRANTs evaluated after pipeline creation, deploy fails on cold runs
+
+**Domain:** asset-bundles
+**Trigger:** Team defines a UC schema, a GRANT on that schema (e.g., `CREATE TABLE` to a service principal), and a DLT pipeline that writes to the schema — all in the same `databricks.yml`. Runs `databricks bundle deploy` on a fresh workspace or after a schema rebuild.
+**Symptom:** Deploy fails with:
+
+```
+Error: cannot create pipeline: User does not have CREATE TABLE on Schema 'CATALOG_NAME.*'.
+```
+
+The grant *is* in the bundle, but the resource graph evaluates the pipeline before the grant takes effect. Reissuing `databricks bundle deploy` immediately afterward succeeds because the grant landed on the first (failed) pass.
+**Root cause:** DAB's resource graph does not encode the implicit ordering "GRANTs that supply privileges needed at resource-creation time must apply *before* the resources that exercise those privileges." Open issue [databricks/cli#4573](https://github.com/databricks/cli/issues/4573).
+**Blast radius:** Per-bundle, per-fresh-deploy. Particularly painful in disaster-recovery / multi-environment promotion where the first deploy to a new workspace fails non-deterministically.
+**Current workaround (manual):**
+
+1. Run `databricks bundle deploy` twice (the second attempt succeeds because the first one applied the grants before failing).
+2. Or split the bundle into two: a "permissions" bundle that's deployed first, then the workload bundle.
+3. Or pre-create schemas + grants via Terraform outside the bundle and only put pipelines in DAB.
+
+**Citations:**
+
+- https://github.com/databricks/cli/issues/4573
+- https://docs.databricks.com/aws/en/dev-tools/bundles/resources
+- https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/
+
+**Response architecture recommendation:**
+SKILL.md + Hook (PostToolUse on `databricks bundle deploy` failure) + scripts/.
+
+- **PostToolUse hook**: on a `bundle deploy` failure, parse stderr for the `User does not have CREATE TABLE on Schema` pattern; if matched, auto-retry once (exit-code-2 with a clear message). Only fires on this exact known transient failure — does not mask other errors.
+- **`scripts/bundle-split-permissions.py`**: takes a `databricks.yml` and refactors it into a `permissions.yml` (catalogs, schemas, grants, volumes) + `workloads.yml` (jobs, pipelines), emits an updated deploy script that runs them in order. Permanent fix for teams that don't want to depend on retry behavior.
+- **WHY**: The retry-on-known-error pattern is exactly what a hook is for; the refactor script handles teams that need deterministic single-pass deploys. Both layers are useful; either alone leaves a gap.
+
+---
+
+## D7 — Azure AD SCIM: nested groups don't sync, "external" group membership is immutable in Databricks
+
+**Domain:** scim-sso
+**Trigger:** Org standardizes Databricks group membership in Azure AD (Entra ID). Either (a) adds a nested AD group to an explicitly-assigned Databricks group, or (b) tries to add a user to a synced group from inside Databricks via the SCIM API or admin UI.
+**Symptom:**
+
+- Nested-group case: the parent group syncs, but its child-group members never appear in Databricks. No error, just missing users. Hours wasted before discovering the docs note.
+- Membership-modification case:
+
+```
+InternalError: None Error in performing the patch operation on group resource.
+```
+
+when calling `w.groups.patch(...)` from the SDK, the SCIM REST API, the account console UI, or the workspace admin settings. All four surfaces fail the same way.
+
+- Sync windows are 20-40 minutes; no programmatic way to confirm a specific change has landed. Workflow: change AD → wait → grep → re-wait.
+
+**Root cause:**
+
+- Microsoft Entra ID's Databricks SCIM Provisioning Connector only enumerates *direct* members of an explicitly-assigned group; it does not flatten nested groups. Hard architectural limit of the connector.
+- Groups synced from an IdP are flagged "External" in Databricks; membership is locked to the IdP as the source of truth. Documented design choice, not a bug.
+
+**Blast radius:** Account-wide identity hygiene. Affects every catalog GRANT, cluster policy, workspace ACL — every access decision flows through these groups.
+**Current workaround (manual):**
+
+1. Flatten group structure in AD so every Databricks-assigned group has only user members (eliminate nesting on the Databricks side).
+2. Or: bypass the Entra SCIM connector entirely — use the Databricks Terraform provider against the SCIM API, walk nested groups in code, and sync membership on a cron. Loses the IdP-as-source-of-truth invariant.
+3. Or: create Databricks-native account groups (not synced) for the few cases that need in-Databricks management.
+4. For sync-timing visibility: poll the SCIM API after a known-good change with exponential backoff until the user appears.
+
+**Citations:**
+
+- https://docs.databricks.com/aws/en/admin/users-groups/scim/aad
+- https://community.databricks.com/t5/administration-architecture/unable-to-add-users-to-azure-ad-synced-databricks-group-via-scim/td-p/147917
+- https://community.databricks.com/t5/technical-blog/how-to-sync-nested-azure-ad-groups-to-databricks/ba-p/44007
+- https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/scim/
+
+**Response architecture recommendation:**
+SKILL.md + MCP server + scripts/.
+
+- **MCP server (`databricks-scim-bridge`)**: exposes tools `list_group_members(group_name)`, `flatten_ad_group(ad_group_id)`, `force_scim_sync()`, `wait_for_user(email, max_seconds)`. Wraps Microsoft Graph + Databricks SCIM APIs. Encapsulates the auth glue so the agent doesn't have to.
+- **`scripts/sync-nested-ad-groups.py`**: cron-driven flattener that walks nested AD groups via Microsoft Graph and syncs membership via the Databricks SCIM API, idempotent. Owned by platform team.
+- **WHY**: SCIM operations span two APIs (Microsoft Graph + Databricks SCIM) with different auth flows, both polled over long windows. An MCP server is the right primitive when the agent needs to interactively query both surfaces with consistent auth; the cron script handles the steady-state mismatch nested-group bug.
+
+---
+
+## D8 — Customer-managed KMS key rotation requires terminating every cluster / pool / warehouse in the workspace
+
+**Domain:** secrets-networking
+**Trigger:** Security team rotates the customer-managed KMS key for managed disks (annual rotation, post-incident, compliance requirement). Or AWS automatic key rotation flips the underlying KMS material.
+**Symptom:**
+
+- Cluster start fails: `Cloud Provider Launch Failure: KeyVaultAccessForbidden` if the new key version doesn't have GET/WRAPKEY/UNWRAPKEY granted to the Databricks managed identity.
+- For Azure managed-disk CMK: "To update a workspace with a customer-managed key for managed disks, all compute resources (clusters, pools, and SQL warehouses) in your workspace must be terminated." Translates to a hard maintenance window on every workspace using the key.
+- For storage CMK on AWS: cannot rotate the key at all once configured — only the master-key material under it rotates automatically.
+- Old key must remain available for at least 24 hours after rotation; deleting too early bricks running clusters.
+
+**Root cause:** CMK is wired into the disk/storage encryption envelope at compute-creation time. Compute can't pick up a new key reference mid-life — the only safe path is termination + recreation. Storage CMK has an even stricter constraint: the key reference is set at workspace creation and is immutable.
+**Blast radius:** Workspace-wide. Every running notebook, job, and SQL warehouse on every cluster in the workspace must be stopped during the rotation window. Multi-team / 24x7 workspaces have no clean maintenance window.
+**Current workaround (manual):**
+
+1. Schedule a maintenance window communicated to every team using the workspace.
+2. Drain jobs (pause schedulers, wait for in-flight to complete).
+3. Terminate every cluster, pool, and SQL warehouse manually.
+4. Rotate the key in the cloud KMS; grant the new key version's permissions to the Databricks managed identity *before* the rotation completes.
+5. Update the workspace via the Account API to point at the new key.
+6. Keep the old key enabled for 24+ hours.
+7. Recreate / restart everything.
+
+**Citations:**
+
+- https://docs.databricks.com/aws/en/security/keys/configure-customer-managed-keys
+- https://learn.microsoft.com/en-us/azure/databricks/security/keys/cmk-managed-disks-azure/cmk-managed-disks-azure
+- https://kb.databricks.com/clusters/cluster-restart-fails
+- https://community.databricks.com/t5/community-discussions/need-guidance-on-key-rotation-process-for-storage-customer/td-p/64863
+
+**Response architecture recommendation:**
+SKILL.md + Slash command + scripts/ + references/.
+
+- **Slash command `/cmk-rotation-plan`**: takes a workspace ID + target key version, produces an end-to-end runbook: drain order, expected duration per cluster type, rollback plan, validation queries. Outputs a markdown checklist the operator runs against.
+- **`scripts/drain-workspace.py`**: pauses every Jobs scheduler, waits for in-flight to complete with a configurable max wait, terminates clusters/pools/warehouses in dependency order. Idempotent. Has a dry-run mode.
+- **`references/cmk-rotation-by-cloud.md`**: per-cloud (AWS managed disks vs storage, Azure Key Vault, GCP CMEK) playbook with exact API calls and the 24-hour overlap requirement.
+- **WHY**: This is a rare, high-blast-radius, multi-step operation where checklist discipline matters more than automation. A slash command produces the runbook artifact; a drain script handles the mechanical part safely. Hooks would be wrong (no recurring trigger); MCP would be overkill (no agent dialog needed).
+
+---
+
+## D9 — PrivateLink without S3/STS/Kinesis VPC endpoints silently routes through NAT and racks up egress
+
+**Domain:** secrets-networking
+**Trigger:** Team enables Databricks PrivateLink for the control-plane connection (front-end + back-end), assumes "all traffic is private now," but does not separately configure VPC endpoints for AWS services (S3, STS, Kinesis).
+**Symptom:** No errors. Jobs run normally. Then the AWS bill arrives showing massive NAT-gateway data-processing charges and cross-AZ data-transfer charges. Or, after locking down egress per security policy, jobs start failing with S3 timeouts because the NAT was the only path out and egress is now blocked.
+**Root cause:** Databricks PrivateLink covers the *control-plane* (workspace web app, REST API, compute-plane → control-plane) and optionally the *secure cluster connectivity* relay. It does *not* automatically route data-plane traffic to S3/STS/Kinesis privately — those need their own VPC endpoints. Without them, S3 reads/writes traverse the NAT, costing $0.045/GB processed in addition to per-GB egress. Many teams discover this only on month-end billing review.
+**Blast radius:** Account-wide cost; workspace-wide reliability if egress later restricted.
+**Current workaround (manual):**
+
+1. Add VPC endpoints for **S3 (gateway endpoint — free)**, **STS (interface endpoint)**, **Kinesis (interface endpoint)** in every VPC that runs a Databricks compute plane.
+2. Update VPC route tables to send S3 traffic to the gateway endpoint.
+3. Validate by checking VPC Flow Logs that S3 traffic is no longer hitting the NAT.
+4. For Azure: equivalent is private endpoints for ADLS Gen2 + KeyVault + the relevant data services.
+5. Document the endpoint inventory because it's not obvious from the Databricks console.
+
+**Citations:**
+
+- https://docs.databricks.com/aws/en/security/network/classic/privatelink
+- https://docs.databricks.com/aws/en/security/network/serverless-network-security/cost-management
+- https://www.databricks.com/blog/optimizing-aws-s3-access-databricks
+- https://docs.databricks.com/aws/en/security/network/deployment-architecture/hardened-connectivity
+
+**Response architecture recommendation:**
+SKILL.md + scripts/ + references/.
+
+- **`scripts/audit-vpc-endpoints.py`**: walks every VPC associated with a Databricks workspace (via the Account API + AWS Describe APIs), produces a checklist: S3 gateway ✓/✗, STS interface ✓/✗, Kinesis interface ✓/✗, route-table coverage ✓/✗. Emits remediation Terraform.
+- **`references/cost-leak-map.md`**: itemizes every known networking-cost-leak pattern (NAT data processing, cross-AZ DTO, IGW egress) with the AWS bill line item each maps to. Cross-cloud (Azure NAT Gateway pricing, GCP NAT) included.
+- **WHY**: This is a static, deterministic check; the right primitive is a script + a reference doc, not a hook (it's not action-triggered) or an MCP (no interactive dialog needed).
+
+---
+
+## D10 — `system.billing.usage` invisible to anyone without metastore-admin role
+
+**Domain:** workspace-ops
+**Trigger:** Finance / FinOps / platform team gets the request "tell us our Databricks spend by job by team this month." They grant themselves Account Admin in the account console, open a notebook, and try to `SELECT * FROM system.billing.usage`.
+**Symptom:**
+
+- Query fails with `SCHEMA_NOT_FOUND` or `Table or view not found: system.billing.usage`, even though the account console clearly shows the user as Account Admin.
+- `SHOW CATALOGS` does not list `system` at all.
+- After much searching, docs reveal the user *also* needs the **metastore admin** role (a separate role at the UC metastore level), and the metastore admin has to explicitly enable the `system.billing` schema (it's gated per-schema).
+
+**Root cause:** Two layered access controls. (1) Account Admin gives org-level account API access but does *not* grant UC privileges. (2) System tables are gated *per schema* — each one (billing, access, lineage, compute) has to be enabled by a metastore admin before any user can be granted access. (3) Even after enabling, end users need `USE CATALOG system` + `USE SCHEMA system.billing` + `SELECT` on the relevant tables — all of which only a metastore admin can grant.
+**Blast radius:** Workspace-wide visibility blind spot. FinOps cannot do its job without involving a metastore admin for every new query consumer.
+**Current workaround (manual):**
+
+1. Identify the metastore admin (often a different person from the account admin in mature orgs).
+2. Metastore admin enables the system schemas via the Account API (`PUT /api/2.0/accounts/<id>/metastores/<id>/systemschemas/<schema>`).
+3. Metastore admin grants `USE CATALOG system`, `USE SCHEMA system.billing`, `SELECT ON system.billing.usage` to a dedicated FinOps group.
+4. Add FinOps users to the group via the IdP (per D7, can't add them directly if it's an external group).
+5. Document the audit trail because the org will get this request again.
+
+**Citations:**
+
+- https://docs.databricks.com/aws/en/admin/system-tables/
+- https://docs.databricks.com/aws/en/admin/system-tables/billing
+- https://community.databricks.com/t5/administration-architecture/access-to-system-billing-usage-tables/td-p/100955
+- https://docs.databricks.com/aws/en/admin/usage/system-tables
+
+**Response architecture recommendation:**
+SKILL.md + scripts/ + Subagent.
+
+- **`scripts/enable-system-schemas.py`**: account-admin-runnable, enables every system schema (or a chosen subset), grants `SELECT` on the expected tables to a configurable group, emits the audit log.
+- **Subagent (`uc-permission-tracer`)**: given a user + an error message, walks the two-level access model (account role → metastore role → catalog/schema/table grant chain) and produces a remediation diff: "user X needs Y group membership AND grant Z run by metastore admin W." Replaces 90 minutes of doc-spelunking per support ticket.
+- **WHY**: Layered access control is exactly the surface where an agent dialog outperforms a static reference — the question is always "why does *this user* not see *this thing*," and the answer is a graph traversal. Subagent keeps that traversal out of the main context.
+
+---
+
+# Source gaps and follow-on research notes
+
+1. **Reddit r/databricks was thin on indexed results** for direct pain-point queries (web-search engine didn't surface them well). Worth a manual pass through the subreddit's "top" sort for the last 12 months — likely 5-10 more entries hiding there, especially on DAB and SCIM.
+2. **Azure-specific KMS rotation incidents** are documented in Microsoft Q&A more than Databricks docs; the Microsoft Learn Q&A search engine isn't indexed in standard web search well. Direct browsing would surface more.
+3. **GCP-specific pain** is under-represented vs. AWS/Azure — Databricks on GCP has the smallest install base and the thinnest community. If the skill pack targets GCP equally, a dedicated GCP-only pass is warranted.
+4. **Stack Overflow `[databricks-unity-catalog]` tag** has ~600 questions; only the top ~20 got direct attention here. A bulk pull + classification (similar to what UCX does for tables) would surface long-tail patterns.
+5. **DAIS 2024-2025 video talks** were not transcribed in this pass — operator war stories from those decks are not captured. Cost: 4-6 hours of transcript scraping.
+6. **`databricks/databricks-sdk-py` issues** were not pulled in this pass; that repo has a different shape of pain (Python ergonomics, async issues) that may merit its own domain entry if the skill pack covers SDK consumers as a persona.
+7. **Bundle "direct" engine known-bug inventory** (referenced in D5) deserves its own entry as the engine matures; right now it's a moving target — the bug list will be different in 90 days.

--- a/plugins/saas-packs/databricks-pack/000-docs/005-RL-RSRC-anthropic-skill-architecture-patterns.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/005-RL-RSRC-anthropic-skill-architecture-patterns.md
@@ -1,0 +1,731 @@
+# Architectural Patterns in Anthropic-Published Claude Code Skills (2026)
+
+**Compiled:** 2026-05-27
+**Purpose:** Reference catalog for the Databricks skill-pack rebuild. Captures the patterns Anthropic itself uses in first-party skills and plugins shipped through `anthropics/skills` and `anthropics/claude-plugins-official`, with deepest attention to the **`security-guidance` plugin** (v2.0.0) released as the public face of "Claude Code Security."
+**Primary corpus:**
+
+- `github.com/anthropics/skills` — official skill library (skill-creator, mcp-builder, pdf, docx, pptx, xlsx, webapp-testing, frontend-design, brand-guidelines, internal-comms, …)
+- `github.com/anthropics/claude-plugins-official` — official directory of Anthropic-managed plugins (`security-guidance`, `pr-review-toolkit`, `feature-dev`, `code-review`, `hookify`, `mcp-server-dev`, `skill-creator`, `claude-md-management`, 20+ LSP plugins, …)
+- `github.com/anthropics/claude-code-security-review` — earlier GitHub-Action incarnation of the security reviewer (predecessor to `security-guidance`)
+- `platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices` — canonical authoring guide
+- `code.claude.com/docs/en/skills` — Claude Code skill runtime reference
+- Anthropic engineering blog: "Equipping agents for the real world with Agent Skills"
+
+**How to read this catalog:** every pattern has a real Anthropic-shipped example with file path. Where I infer behavior from docs without a code-level confirmation, the entry is explicitly marked **"INFERRED."** For Databricks (or any other) rebuild, pick the patterns that fit the problem shape — they compose.
+
+---
+
+## Source reference: the security-guidance plugin
+
+Three architectural surfaces, one plugin. The same plugin demonstrates ~6 of the 10 patterns below, so it's worth understanding once up-front:
+
+| Layer | Trigger | Mechanism | Cost |
+|---|---|---|---|
+| **1. Pattern warnings** | `PostToolUse` on `Edit\|Write\|MultiEdit\|NotebookEdit` | Pure-Python regex match in `patterns.py` (~25 rules) — **zero model calls** | Free |
+| **2. LLM diff review** | `Stop` hook (turn complete) | Sends git diff to a fast model via Agent SDK | One Opus 4.7 call per turn |
+| **3. Agentic commit review** | `PostToolUse` on `Bash(git commit:*)` / `Bash(git push:*)` | Spawns a subagent loop (Read/Grep/Glob) for cross-file vuln tracing, then a separate self-refute pass | Multiple model calls |
+
+Layer 1 fires synchronously in the hook; layers 2 and 3 use `asyncRewake` so the reviewer runs in the background and re-wakes Claude when findings land. This is the canonical Anthropic recipe for "proactive intervention without blocking the user" and underlies several patterns below.
+
+---
+
+## AP01 — Three-level progressive disclosure (metadata → SKILL.md → bundled files)
+
+**Type:** progressive-disclosure
+**What it does:** Skills are loaded in three context-cost tiers. Tier 1 — the YAML `name` + `description` (~100 tokens) — is permanently in the system prompt for every skill the agent knows about. Tier 2 — the SKILL.md body (≤500 lines) — is read only when the description matches the user's intent. Tier 3 — `references/*.md`, `scripts/*`, `assets/*` — is read on demand, file by file, when the SKILL.md body points to it. Files never read consume zero context.
+
+**Anthropic example:** Every official skill. `anthropics/skills/skills/mcp-builder/SKILL.md` is the prototypical case: the body is a 4-phase workflow that references `reference/mcp_best_practices.md`, `reference/node_mcp_server.md`, `reference/python_mcp_server.md`, `reference/evaluation.md` with inline pointers like `"For TypeScript (recommended): [⚡ TypeScript Guide](./reference/node_mcp_server.md)"`. Claude reads only the language guide it needs. From `best-practices.md`:
+
+> "1. Metadata pre-loaded: At startup, the name and description from all Skills' YAML frontmatter are loaded into the system prompt. 2. Files read on-demand: Claude uses bash Read tools to access SKILL.md and other files from the filesystem when needed. 3. Scripts executed efficiently: Utility scripts can be executed via bash without loading their full contents into context. Only the script's output consumes tokens."
+
+**When to use it:** Always. This is the foundational pattern — any skill larger than ~200 lines should be split.
+
+**When NOT to use it:** Simple, single-purpose skills that fit comfortably in one screen. Forcing references on a 50-line skill adds navigation overhead with no token savings.
+
+**Implementation sketch:**
+
+```
+my-skill/
+├── SKILL.md                     # ≤500 lines: workflow + decision points + pointers
+└── references/
+    ├── api-reference.md         # only read if Claude needs API specifics
+    ├── examples.md              # only read if Claude needs examples
+    └── platform-aws.md          # only read if user targets AWS
+```
+
+```markdown
+# SKILL.md
+## Quick start
+[the 80% case inline]
+
+## Advanced features
+**Form filling:** see [references/forms.md](references/forms.md)
+**API reference:** see [references/api.md](references/api.md)
+**Platform variants:** AWS [aws.md], GCP [gcp.md], Azure [azure.md]
+```
+
+**Hard rules from Anthropic's best-practices doc:**
+
+- Keep references **one level deep** from SKILL.md. Claude may `head -100` nested references and miss content.
+- For reference files >100 lines, include a **table of contents at the top** so partial reads still surface the full scope.
+- Organize references by domain (`reference/finance.md`, `reference/sales.md`) not by file number (`docs/file1.md`).
+
+**Citations:**
+
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices (§ "Progressive disclosure patterns")
+- https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md
+- https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+
+---
+
+## AP02 — Hook-driven proactive intervention (PostToolUse / Stop / UserPromptSubmit)
+
+**Type:** hook-driven
+**What it does:** Instead of waiting for the user to invoke a skill, the plugin registers hooks that run on Claude Code lifecycle events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`). The hook script — usually a thin bash launcher that hands off to Python — sees tool calls, file edits, and turn boundaries, and decides whether to inject context, warn, or escalate. This is the only way to make a skill **mandatory** (it fires whether Claude remembers to invoke it or not).
+
+**Anthropic example:** `security-guidance/hooks/hooks.json` registers four event types:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh ${CLAUDE_PLUGIN_ROOT}/hooks/ensure_agent_sdk.py", "timeout": 180}]}],
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh ${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py"}]}],
+    "PostToolUse": [
+      {"matcher": "Edit|Write|MultiEdit|NotebookEdit", "hooks": [{"type": "command", "command": "..."}]},
+      {"matcher": "Bash", "hooks": [
+        {"if": "Bash(git commit:*)", "asyncRewake": true, "rewakeMessage": "Background security review of commit ...", "command": "..."},
+        {"if": "Bash(git push:*)", "asyncRewake": true, "rewakeMessage": "Background security review of pushed commits ...", "command": "..."}
+      ]}
+    ],
+    "Stop": [{"hooks": [{"type": "command", "asyncRewake": true, "rewakeMessage": "Background security review feedback ...", "command": "..."}]}]
+  }
+}
+```
+
+Note the **matcher** field on `PostToolUse` (regex `Edit|Write|MultiEdit|NotebookEdit`) and the **conditional `if`** on Bash hooks (`Bash(git commit:*)`, `Bash(git push:*)`). The same hook script is registered four times with different gating — the script reads the event payload via stdin and dispatches.
+
+`hookify/hooks/` (another Anthropic plugin) shows the same shape distilled to one file per event: `pretooluse.py`, `posttooluse.py`, `stop.py`, `userpromptsubmit.py`.
+
+**When to use it:** When the safety / correctness property must hold **whether or not Claude opts in** — security scans, lint enforcement, secret-leak detection, mandatory pre-commit checks, session-start CLAUDE.md injection.
+
+**When NOT to use it:** Hooks add latency to every matched event. Don't use them for capabilities the user invokes deliberately — those belong in commands or skills. Don't use a `PreToolUse` hook that calls an LLM (blocks the tool call for seconds); use `PostToolUse` + asyncRewake instead.
+
+**Implementation sketch:** `hooks.json` at the plugin root:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Edit|Write|MultiEdit",
+      "hooks": [{
+        "type": "command",
+        "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/scan.py\""
+      }]
+    }]
+  }
+}
+```
+
+Hook script reads JSON event from stdin, exits 0 for "no comment", exits 2 with stderr message for "block this tool call" (PreToolUse only), or prints to stdout for "inject this back as context."
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/hooks.json
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/hookify
+- https://code.claude.com/docs/en/hooks
+
+---
+
+## AP03 — Async rewake (background review without blocking the user)
+
+**Type:** hook-driven / async-orchestration
+**What it does:** A long-running hook (e.g., one that calls an LLM for a code review) declares `asyncRewake: true` in `hooks.json`. The hook returns immediately so Claude can finish its turn and the user gets a response. When the background work completes with findings, the hook **rewakes the conversation** by injecting a system message (`rewakeMessage`) plus a one-line summary (`rewakeSummary`) into Claude's next turn. Claude then has to address or acknowledge the findings before continuing the user's original task.
+
+**Anthropic example:** `security-guidance`'s `Stop` and `PostToolUse(Bash)` hooks:
+
+```json
+{
+  "type": "command",
+  "command": "bash ... security_reminder_hook.py",
+  "if": "Bash(git commit:*)",
+  "asyncRewake": true,
+  "rewakeMessage": "Background security review of commit — address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply:",
+  "rewakeSummary": "Commit security review found issues"
+}
+```
+
+The plugin's `review_api.py` runs a **two-stage agentic review** (investigate → self-refute, AP07 below) that takes 10-60s of model time. Without `asyncRewake`, the user would stare at a frozen terminal after every `git commit`. With it, the commit returns, Claude tells the user "commit done," and a few seconds later a fresh context block appears: "🛡 Background security review found issues — here are 2 medium-severity findings to address before pushing."
+
+**When to use it:** Any hook that takes longer than ~3s, especially anything that calls an LLM. Critical for skills that want to add a "second pair of eyes" without slowing the loop.
+
+**When NOT to use it:** Don't async-rewake for findings the user must acknowledge **before** the next action proceeds — that's a confirmation gate (AP05), not a review. Don't use async-rewake if the cost of running it is so high you'd want the user's go-ahead first.
+
+**Implementation sketch:**
+
+```json
+{
+  "type": "command",
+  "command": "bash slow-reviewer.sh",
+  "asyncRewake": true,
+  "rewakeMessage": "Background analysis complete. Findings below — fold them into your next response or acknowledge to user:",
+  "rewakeSummary": "Analysis found 3 issues"
+}
+```
+
+The script prints findings to stdout; the harness captures them and queues them as the next user-visible system message. The user feels no latency, but Claude can't ignore the findings — they re-enter the context at the next turn boundary.
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/hooks.json (the `asyncRewake` / `rewakeMessage` / `rewakeSummary` fields)
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/README.md (§ "Three layers")
+
+---
+
+## AP04 — Script-vs-LLM decision separation (deterministic-first, LLM-as-fallback)
+
+**Type:** script-orchestration
+**What it does:** Operations that have a clear right answer — regex matches, file existence checks, JSON parsing, byte counting, hashing — are executed as **pre-written scripts** invoked from the hook or skill. LLM reasoning is reserved for tasks that genuinely require judgment (cross-file vulnerability tracing, "is this finding a false positive given this codebase's conventions"). The official best-practices doc calls this out explicitly:
+
+> "Prefer scripts for deterministic operations: Write `validate_form.py` rather than asking Claude to generate validation code." — *best-practices.md*
+>
+> "Code is deterministic." — *Equipping agents for the real world*
+
+**Anthropic example:** The `security-guidance` plugin's three layers are a perfect ladder of escalation:
+
+1. **Layer 1 (deterministic, zero model calls):** `hooks/patterns.py` contains ~25 hand-written rules — each one a regex + path filter + reminder string. The launch announcement specifically calls out: *"the first running a fast, deterministic pattern match with no model call ... because this layer requires no AI inference, it adds zero usage cost."*
+2. **Layer 2 (single LLM call):** `Stop` hook runs `git diff`, sends it to Opus 4.7 with a one-shot prompt, returns findings.
+3. **Layer 3 (agentic, multiple LLM calls):** On `git commit`, an Agent-SDK reviewer with Read/Grep/Glob traces data flow across files.
+
+The skill author chose where on the deterministic ↔ reasoning ladder each check belongs. `eval(`, `yaml.load()`, `dangerouslySetInnerHTML` — those are regex catches. "Does this new endpoint enforce ownership against the entity it mutates?" — that's the agentic layer.
+
+The `mcp-builder` skill demonstrates the same principle differently: the skill body is decision-flow prose for the LLM, but the heavy reference content (TypeScript SDK conventions, Python SDK conventions, MCP best practices) is **static reference files Claude reads when needed** rather than generated each time.
+
+**When to use it:** Whenever an operation is repeatable and verifiable. Common candidates: file format detection, syntax validation, regex pre-filtering, hash verification, structured-data extraction, schema checking.
+
+**When NOT to use it:** Don't deterministic-script a check that depends on codebase context the script can't see ("is this `eval()` safe because the caller validated upstream?"). Use the script to *raise the candidate*, then let the LLM reason about it.
+
+**Implementation sketch:**
+
+```python
+# patterns.py (deterministic)
+SECURITY_PATTERNS = [
+    {"ruleName": "eval_injection",
+     "path_filter": lambda p: not p.endswith(_DOC_EXTS),
+     "regex": r"(?<![a-zA-Z0-9_\.])eval\(",
+     "reminder": "⚠️ eval() executes arbitrary code. Use JSON.parse() ..."},
+    # ...24 more
+]
+```
+
+```python
+# review_api.py (LLM, gated to high-leverage work only)
+AGENTIC_INVESTIGATE_SYSTEM = """You are a senior application-security engineer ...
+The #1 cause of missed vulnerabilities is not reading the file that contains them.
+Before any analysis: Read EVERY changed file in full ..."""
+```
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/patterns.py
+- https://www.helpnetsecurity.com/2026/05/27/anthropic-claude-code-security-guidance-plugin/ (deterministic-first claim)
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices (§ "Prefer scripts for deterministic operations")
+
+---
+
+## AP05 — Subagent fanout for parallel investigation
+
+**Type:** subagent-fanout
+**What it does:** Instead of one long Claude turn that explores N angles sequentially, the skill spawns N subagents (via the `Task` tool or an Agent-SDK loop) **in the same turn**, each focused on one aspect, each with its own context window. Results come back together and the parent agent synthesizes. The pattern works because subagents share no context — each starts fresh — so 5 parallel investigations cost 5× tokens but ~1× wall-clock time.
+
+**Anthropic example:** `feature-dev/commands/feature-dev.md` makes this the entire architecture:
+
+> Phase 2 — Codebase Exploration:
+> "Launch 2-3 code-explorer agents in parallel. Each agent should ... Target a different aspect of the codebase (eg. similar features, high level understanding, architectural understanding, user experience, etc) ... Once the agents return, please read all files identified by agents to build deep understanding"
+>
+> Phase 4 — Architecture Design:
+> "Launch 2-3 code-architect agents in parallel with different focuses: minimal changes (smallest change, maximum reuse), clean architecture (maintainability, elegant abstractions), or pragmatic balance (speed + quality)"
+>
+> Phase 6 — Quality Review:
+> "Launch 3 code-reviewer agents in parallel with different focuses: simplicity/DRY/elegance, bugs/functional correctness, project conventions/abstractions"
+
+`pr-review-toolkit/commands/review-pr.md` makes the parallel mode an explicit user-selectable option (`/pr-review-toolkit:review-pr all parallel`) and ships six specialized agents: `code-reviewer`, `code-simplifier`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`.
+
+The `skill-creator` skill in `anthropics/skills` shows the same pattern for evals: *"For each test case, spawn two subagents in the same turn — one with the skill, one without. ... Launch everything at once so it all finishes around the same time."*
+
+**When to use it:**
+
+- The task has clearly separable axes (security / performance / style / tests).
+- Each axis benefits from a focused system prompt.
+- You can afford the token cost (each subagent is a fresh context, so 5× cost is real).
+
+**When NOT to use it:** When the angles aren't independent — if subagent B needs subagent A's findings, the fanout collapses to sequential. Don't fan out when one well-prompted main agent could do it in 1.5× the time at 0.2× the cost.
+
+**Implementation sketch:** In a slash command's SKILL.md or command body:
+
+```markdown
+## Phase 2: Parallel exploration
+
+Launch these subagents IN ONE TURN (don't serialize):
+
+- Agent A (code-explorer): "Find similar features to <X> and trace their implementation"
+- Agent B (code-explorer): "Map the architecture for <X area>, list 5-10 key files"
+- Agent C (code-explorer): "Identify UI/test/extension patterns relevant to <X>"
+
+When all three return, READ the files they each surface, then synthesize.
+```
+
+The subagent itself is an `agents/<name>.md` file with its own narrow tool allowlist and system prompt:
+
+```yaml
+---
+name: code-architect
+description: Designs feature architectures by analyzing existing codebase patterns ...
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite
+model: sonnet
+color: green
+---
+You are a senior software architect ...
+```
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/feature-dev/commands/feature-dev.md
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/commands/review-pr.md
+- https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md (§ "Spawn all runs in the same turn")
+
+---
+
+## AP06 — Confirmation gate before destructive actions (PreToolUse + exit-2 block)
+
+**Type:** confirmation-gate
+**What it does:** A `PreToolUse` hook intercepts a tool call **before it executes**, applies a deterministic check (or even an LLM call if cost permits), and either lets it through (exit 0) or blocks it (exit 2 with a stderr message that the harness surfaces to Claude). The blocked tool call doesn't happen; Claude must decide what to do with the feedback. Distinct from AP03 (async rewake) — this is a hard gate, not a background nudge.
+
+**Anthropic example:** **INFERRED FROM DOCS.** The `security-guidance` plugin chose **not** to use `PreToolUse` for blocking — instead it uses `PostToolUse` + `asyncRewake`, accepting that Claude will commit the bad code first and then be forced to fix it. The design tradeoff is in the `security-guidance` README: blocking pre-commit hooks add visible latency to every Bash call, so for "best-effort assistive tool, not a guarantee" they prefer the rewake pattern. **PreToolUse-as-blocking-gate is documented in `code.claude.com/docs/en/hooks` and shipped in many community plugins** (e.g., this repo's own `intent-eval-core` permission hooks), but I did not find a public Anthropic-first-party skill that uses it as a blocking gate. The pattern is real and supported; the design preference at Anthropic appears to be "warn after, never block."
+
+**When to use it:**
+
+- The cost of letting the action happen is genuinely irreversible (force push to main, delete production data, send an email).
+- The check is fast (< 500ms) so the user doesn't feel the gate.
+- The wrong-block cost is acceptable (the user/Claude can bypass and re-issue if they're sure).
+
+**When NOT to use it:** Anything that needs LLM reasoning to decide (use AP03 instead — let the action happen and review after, so the latency hides behind the next turn). Anything where false-blocks would frustrate the user more than the rare bad action would cost.
+
+**Implementation sketch:**
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/destructive-gate.sh"}]
+    }]
+  }
+}
+```
+
+```bash
+#!/usr/bin/env bash
+# destructive-gate.sh: read tool call from stdin, exit 2 to block
+input=$(cat)
+cmd=$(echo "$input" | jq -r '.tool_input.command')
+case "$cmd" in
+  *"git push --force"*|*"rm -rf /"*|*"DROP TABLE"*)
+    echo "BLOCKED: $cmd looks destructive. Confirm with user before re-issuing." >&2
+    exit 2 ;;
+esac
+exit 0
+```
+
+**Citations:**
+
+- https://code.claude.com/docs/en/hooks (exit-code-2 semantic on PreToolUse)
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/README.md (§ "Limitations" — "best-effort assistive tool, not a guarantee" frames the design choice against blocking)
+
+---
+
+## AP07 — Two-stage agentic reasoning (investigate → self-refute)
+
+**Type:** subagent-fanout / confirmation-gate (for LLM findings)
+**What it does:** A reasoning task is split into **two sequential model calls with opposite goals**. Stage 1 (investigate) is high-recall: read every relevant file, surface every candidate finding, default to flagging. Stage 2 (self-refute) is adversarial: try to disprove each finding by reading more code. Only findings that survive stage 2 reach the user. This reproduces the dual-prompt pattern Anthropic uses to ship credibility — *"Claude re-examines each result, attempting to prove or disprove its own findings and filter out false positives."* (Anthropic news post).
+
+**Anthropic example:** `security-guidance/hooks/review_api.py` is the textbook implementation. The investigate system prompt is ~3000 words and includes:
+
+> "METHOD: Phase 1 — Map entry points and sinks touched by this change. ... Phase 2 — High-miss patterns ... Phase 3 — Assess. Report when you can name (a) the source, (b) the sink, (c) the path with no effective mitigation. Medium-confidence is fine — a separate adjudication pass will filter; **your job is RECALL, not precision.**" — emphasis mine; this is the explicit hand-off to stage 2.
+
+Then stage 2:
+
+```python
+AGENTIC_REFUTE_SYSTEM = (
+    "You adversarially verify security findings. You have "
+    "Read/Grep over the repo. Default = SURVIVES unless you "
+    "find concrete refuting evidence."
+)
+```
+
+Output schema for stage 2:
+
+```python
+SURVIVED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "survived": {"type": "array", "items": {"type": "integer"}},
+        "refuted": {"type": "array", "items": {"type": "object",
+            "properties": {"idx": {"type": "integer"}, "reason": {"type": "string"}}}}}}
+```
+
+Stage 1 emits N candidates by index; stage 2 returns the surviving indices and short reasons for the refuted ones. The plugin also has an optional `SG_DUAL_OR=on` mode that runs two stage-1 calls in parallel and unions findings — explicit recall/precision/cost dial.
+
+**When to use it:** Any task where the agent generates a finding/recommendation/diff that the user will trust. Code review, security scan, compliance check, architectural critique. Especially valuable when the cost of a false positive (user loses trust) is higher than the cost of one more model call.
+
+**When NOT to use it:** Tasks where the output is the artifact itself (writing a file, generating a chart) — there's nothing to refute. Tasks where the user adjudicates inline anyway (interactive Q&A).
+
+**Implementation sketch:**
+
+```python
+# Stage 1: high recall
+inv_prompt = """You investigate <X>. Your job is RECALL, not precision.
+Medium-confidence findings are fine — a separate pass will filter them.
+Return findings:[] of {filePath, category, vulnerableCode, explanation, severity, confidence}."""
+
+findings = call_model(inv_prompt, tools=[Read, Grep, Glob], schema=FINDINGS_SCHEMA)
+
+# Stage 2: adversarial refute
+ref_prompt = f"""You adversarially verify these {len(findings)} findings.
+Default = SURVIVES unless you find concrete refuting evidence in the code.
+Findings (by index): {findings}"""
+
+survived_indices = call_model(ref_prompt, tools=[Read, Grep], schema=SURVIVED_SCHEMA)["survived"]
+return [findings[i] for i in survived_indices]
+```
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/review_api.py (stage 1 + stage 2 prompts in full)
+- https://www.anthropic.com/news/claude-code-security ("Claude re-examines each result, attempting to prove or disprove its own findings")
+- https://snyk.io/articles/anthropic-launches-claude-code-security/
+
+---
+
+## AP08 — Domain-sliced reference loading (load only the relevant variant)
+
+**Type:** context-injection / progressive-disclosure
+**What it does:** When a skill supports multiple variants of the same workflow — multiple cloud providers, multiple languages, multiple datasets — split the variant-specific content into one reference file per variant and have SKILL.md route to exactly one. This avoids loading 4 cloud-deploy guides when the user only cares about AWS. Anthropic's best-practices doc shows this as **"Pattern 2: Domain-specific organization"** with the BigQuery example.
+
+**Anthropic example:**
+
+- `mcp-builder/SKILL.md` routes to `reference/node_mcp_server.md` *or* `reference/python_mcp_server.md` depending on the user's choice — *"For TypeScript (recommended): [⚡ TypeScript Guide](./reference/node_mcp_server.md). For Python: [🐍 Python Guide](./reference/python_mcp_server.md)."*
+- The official best-practices guide canonical example:
+
+  ```text
+  bigquery-skill/
+  ├── SKILL.md (overview and navigation)
+  └── reference/
+      ├── finance.md   # revenue, billing metrics
+      ├── sales.md     # opportunities, pipeline
+      ├── product.md   # API usage, features
+      └── marketing.md # campaigns, attribution
+  ```
+
+  And: *"When a user asks about sales metrics, Claude only needs to read sales-related schemas, not finance or marketing data. This keeps token usage low and context focused."*
+
+The same pattern shows up in `skill-creator`'s docs guidance: *"**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant ... Claude reads only the relevant reference file."*
+
+**When to use it:** Skills with N variants of the same underlying workflow (cloud providers, ORMs, languages, dataset categories, output formats). Skills where reference content per variant exceeds ~50 lines.
+
+**When NOT to use it:** Skills where the variants share most of their content — the duplication burden across reference files will drift. Use a unified reference with a small "platform-specific notes" section instead.
+
+**Implementation sketch:**
+
+```
+databricks-skill/
+├── SKILL.md                    # workflow + selection logic
+└── reference/
+    ├── delta-tables.md         # only loaded when user is on Delta
+    ├── unity-catalog.md        # only loaded when user is on UC
+    ├── mlflow.md               # only loaded for ML workflows
+    └── jobs-api.md             # only loaded for orchestration
+```
+
+```markdown
+# SKILL.md
+
+## Decide what you're doing
+
+The user's intent maps to one of these surfaces. Read ONLY the matching reference:
+
+| Intent | Reference |
+|---|---|
+| Read/write tables, schema mgmt | reference/delta-tables.md |
+| Lineage, grants, governance | reference/unity-catalog.md |
+| Model training, tracking | reference/mlflow.md |
+| Scheduled jobs, workflows | reference/jobs-api.md |
+
+Do not preload others — they consume context with no benefit.
+```
+
+**Citations:**
+
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices (§ "Pattern 2: Domain-specific organization" and § "Skill structure")
+- https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md (language-routing example)
+- https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md (§ "Domain organization")
+
+---
+
+## AP09 — MCP server as typed live-data bridge (bundle inside the plugin)
+
+**Type:** mcp-bridge
+**What it does:** When a skill needs **current** data from a system (not static documentation), bundle an MCP server with the plugin. The skill body teaches Claude *when* to call which MCP tool (`ServerName:tool_name`); the MCP server handles auth, pagination, error retries, response shaping. The MCP server is in the same plugin directory as the skill, declared in `.mcp.json` at the plugin root. This contrasts with reference-doc skills that capture API knowledge statically — MCP is for "the answer depends on what's in production right now."
+
+**Anthropic example:** `claude-plugins-official/plugins/example-plugin/` is the canonical scaffold. `.mcp.json`:
+
+```json
+{
+  "example-server": {
+    "type": "http",
+    "url": "https://mcp.example.com/api"
+  }
+}
+```
+
+And the bundled `skills/example-skill/SKILL.md` references it. The `mcp-server-dev` plugin ships three skills (`build-mcp-app`, `build-mcp-server`, `build-mcpb`) specifically to scaffold this pattern. The `mcp-builder` skill in `anthropics/skills` is the authoritative "how to design the MCP server you'll bundle" guide — covering transport choice (stdio for local, streamable-HTTP for remote), tool-naming conventions (`github_create_issue`, `github_list_repos`), and a four-phase workflow ending in 10 evaluations.
+
+Anthropic's best-practices doc has a hard rule for skills that reference MCP tools:
+
+> "**Always use fully qualified tool names** to avoid 'tool not found' errors. Format: `ServerName:tool_name`. Example: 'Use the BigQuery:bigquery_schema tool to retrieve table schemas.' Without the server prefix, Claude may fail to locate the tool, especially when multiple MCP servers are available."
+
+**When to use it:**
+
+- The skill needs **live** state (current issue list, current table schema, current run status).
+- The API has > ~5 endpoints — bundling a typed wrapper saves the LLM from re-deriving call shapes.
+- Auth is non-trivial (OAuth, signed requests) — the MCP server hides credential handling.
+
+**When NOT to use it:**
+
+- Static knowledge (API reference docs, schema specs) — that's reference files (AP01, AP08), not MCP.
+- One-shot scripts that don't need typed tools — a bash script does it cheaper.
+- When the user is unlikely to have credentials configured — the MCP server will fail at every invocation. Use environment gating (`requires_env`) and fallback patterns.
+
+**Implementation sketch:** Plugin layout:
+
+```
+my-plugin/
+├── .claude-plugin/plugin.json
+├── .mcp.json                          # registers the server
+├── skills/
+│   └── work-with-foo/
+│       └── SKILL.md                   # teaches Claude when/how to call Foo:* tools
+└── mcp-servers/
+    └── foo-server/
+        ├── package.json
+        └── src/index.ts               # MCP server impl (FastMCP / TS SDK)
+```
+
+`.mcp.json`:
+
+```json
+{
+  "foo": {
+    "type": "stdio",
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/foo-server/dist/index.js"]
+  }
+}
+```
+
+`SKILL.md` references tools with the full prefix:
+
+```markdown
+## Querying Foo
+
+Use Foo:list_records to enumerate. Filter with Foo:search_records.
+Never invent endpoint URLs — every Foo call MUST go through one of the
+Foo:* tools listed in the MCP server's tool list.
+```
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/example-plugin/.mcp.json
+- https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices (§ "MCP tool references")
+
+---
+
+## AP10 — Cross-skill composition via subagent invocation
+
+**Type:** cross-skill-composition
+**What it does:** A command/skill in plugin A invokes a subagent that itself uses a skill from plugin B. The skills don't import each other; they compose at runtime through the agent loop — the parent's command says "spawn an agent with these tools and this prompt" and that agent autonomously discovers and loads the relevant child skill. Anthropic's first-party plugins compose this way constantly: the `feature-dev` workflow spawns `code-explorer`, `code-architect`, `code-reviewer` subagents that share the same conversation harness but have independent system prompts.
+
+**Anthropic example:**
+
+- `feature-dev/commands/feature-dev.md` orchestrates `code-explorer` (Phase 2), `code-architect` (Phase 4), `code-reviewer` (Phase 6) — each is a separate `agents/<name>.md` file with its own tool allowlist and frontmatter (`model: sonnet`, `color: green`).
+- `pr-review-toolkit/commands/review-pr.md` orchestrates six specialized agents (`code-reviewer`, `code-simplifier`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`) selectable by user argument.
+- `claude-md-management` plugin uses its own pair of skills (`claude-md-improver`, `revise-claude-md`) invoked through `commands/`.
+
+The composition is **lexical, not API**: the parent command's body uses imperative prose ("Launch 3 code-reviewer agents in parallel") and the harness's `Task` tool resolves the named agent. Same skill discovery / metadata-tier mechanism (AP01) — agents are discovered exactly like skills.
+
+There's a key sub-pattern in the `code-reviewer` agent worth lifting: it adopts the **confidence-score filter** to make composition safe:
+
+```markdown
+## Issue Confidence Scoring
+Rate each issue from 0-100:
+- 0-25: Likely false positive
+- 26-50: Minor nitpick
+- 51-75: Valid but low-impact
+- 76-90: Important issue requiring attention
+- 91-100: Critical bug or explicit CLAUDE.md violation
+**Only report issues with confidence ≥ 80**
+```
+
+So when a parent command fans out to N reviewers, each one self-filters at the same threshold, and the parent's aggregation logic just unions the results — no scoring conflicts.
+
+**When to use it:**
+
+- The parent workflow has phases that benefit from distinct expertise / different system prompts.
+- The child agents are reusable across multiple parents (DRY — don't inline the system prompt).
+- You want narrow tool allowlists per phase (the architect agent gets Read/Grep/WebFetch, no Edit).
+
+**When NOT to use it:**
+
+- One-off prompts that no other workflow will reuse — inline them.
+- When the agents need to share intermediate state — agents are isolated by design. Use the file system (have one agent write to `./reviews/architect.md` and the next read it) or pass results through the parent.
+
+**Implementation sketch:** Parent command:
+
+```markdown
+# /my-workflow
+
+## Phase 1
+Launch a Task with subagent_type: my-explorer
+prompt: "Map the codebase for <thing>. Return 5-10 file paths."
+
+## Phase 2
+Read the files the explorer surfaced.
+Launch THREE Tasks in one turn with subagent_type: my-reviewer
+prompts: ["focus on X", "focus on Y", "focus on Z"]
+
+## Phase 3
+Synthesize the three review reports. Surface critical-only to user.
+```
+
+Child agent `agents/my-reviewer.md`:
+
+```yaml
+---
+name: my-reviewer
+description: Reviews <X> against <Y> rubric. Returns findings with confidence scores.
+tools: Read, Grep, Glob
+model: sonnet
+---
+You are a domain expert in <X>...
+Only report findings with confidence ≥ 80.
+Output as: {severity, file, line, finding, confidence, fix}.
+```
+
+**Citations:**
+
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev/agents
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/commands/review-pr.md
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/agents/code-reviewer.md (confidence-score filter)
+
+---
+
+## Cross-cutting design rules
+
+These are not patterns but principles Anthropic-shipped skills consistently follow. Lift them all.
+
+| Rule | Source | Why |
+|---|---|---|
+| **Always third-person in `description`** | best-practices.md | Description is injected into system prompt; first-person ("I can help...") causes discovery problems |
+| **Description includes both WHAT and WHEN** | best-practices.md | Triggering is description-driven; "Use when X mentions Y" wording materially improves recall |
+| **Be slightly "pushy" in descriptions** | skill-creator SKILL.md | Quote: *"currently Claude has a tendency to 'undertrigger' skills ... please make the skill descriptions a little bit 'pushy'"* |
+| **Gerund form names** (`processing-pdfs`) | best-practices.md | Clear activity description; consistent across skill library |
+| **≤500 lines in SKILL.md body** | best-practices.md | Above this, split via AP01 |
+| **References one level deep** | best-practices.md | Quote: *"Claude may partially read files when they're referenced from other referenced files"* — nested refs lose content |
+| **Forward slashes in all paths** | best-practices.md | Windows-style `\` breaks on Unix |
+| **Don't punt to Claude in scripts** | best-practices.md | Scripts should handle errors (return default, log, retry) — not raise and hope Claude figures it out |
+| **No "voodoo constants"** | best-practices.md | Document every magic number with the reasoning that justified it |
+| **Plan → validate → execute for batch ops** | best-practices.md | Intermediate JSON file gives a verifiable checkpoint before destructive changes (mirrored in security-guidance's two-stage refute) |
+| **Build evals BEFORE writing docs** | best-practices.md | Skills should solve real failures, not anticipated ones |
+| **Iterate with Claude-A-builds / Claude-B-uses** | best-practices.md | Different Claude instances expose blind spots |
+| **Confidence threshold ≥ 80 for review-style agents** | pr-review-toolkit code-reviewer.md | Filters noise; makes parallel-agent composition (AP10) safe |
+
+---
+
+## Gaps in this research
+
+Where I wanted Anthropic-first-party source and found only marketing copy or community examples:
+
+1. **Anthropic blog post on `security-guidance` architecture** — the `anthropic.com/news/claude-code-security` page is marketing-tier and does not describe the three-layer design. The technical detail in this catalog comes from the plugin's `README.md`, `hooks.json`, and `review_api.py` — those are the source-of-truth artifacts.
+2. **PreToolUse-as-blocking-gate (AP06)** — I found no first-party Anthropic skill using it. The pattern is documented in `code.claude.com/docs/en/hooks` but the security plugin chose `PostToolUse` + `asyncRewake` instead. **Worth treating as "documented, supported, but Anthropic doesn't lead with it"** — interpret accordingly when designing the Databricks skill.
+3. **Anthropic's published evaluation harness for skills** — `best-practices.md` shows the eval JSON schema but says *"There is not currently a built-in way to run these evaluations."* The `anthropics/skills` repo's `skill-creator/eval-viewer/` directory implements one in-process — that's the closest we get to an Anthropic-blessed runner.
+4. **MCP server inside `security-guidance`** — `security-guidance` does NOT bundle an MCP server. AP09 examples come from the smaller `example-plugin` and `mcp-server-dev` plugins; no major first-party plugin demonstrates a production MCP-server-bundled-with-skills surface. The `mcp-builder` skill teaches you to build them, but you have to look at community plugins (or this repo's own `plugins/productivity/plane/`) for end-to-end MCP-bundled-plugin reality.
+5. **Cross-plugin composition** (AP10 across plugin boundaries, not just within one plugin) — I found composition only within a single plugin's `agents/` directory. Cross-plugin subagent invocation works (Claude can discover any installed agent) but no Anthropic-shipped workflow exercises it. **Inferred-but-supported.**
+
+---
+
+## Recommended pattern subset for the Databricks rebuild
+
+Without prejudging the rebuild scope, here's the minimum-viable architectural surface a Databricks skill pack should pick up:
+
+1. **AP01 + AP08** (progressive disclosure + domain-sliced references) — Databricks has at least four distinct surfaces (Delta tables, Unity Catalog, MLflow, Jobs). One SKILL.md per surface or one SKILL.md routing to per-surface references; either way, don't preload all four.
+2. **AP09** (MCP server) — Databricks has a stable REST API and notebook/job runtime state that needs live access; static reference docs alone will miss the "what's currently deployed" use case.
+3. **AP04** (script-vs-LLM separation) — deterministic checks (cluster exists, table schema present, job ID valid, notebook path resolves) belong in scripts. LLM reasoning belongs at "design this notebook" / "review this Delta migration" level.
+4. **AP02 + AP03** (hooks + asyncRewake) — IF the skill wants to enforce things like "validate the SQL against the table schema before running it" without blocking the user. Optional.
+5. **AP07** (two-stage agentic) — IF the skill ships a Databricks-specific cost/security/governance reviewer (e.g., "does this notebook leak PII through cluster logs?"). The investigate→refute pattern is the right shape.
+6. **AP10** (subagent composition) — IF the skill spans enough phases (design → implement → review) to warrant separate system prompts per phase.
+
+Patterns to skip unless there's specific demand:
+
+- **AP05** (subagent fanout) — overkill for most Databricks workflows; users typically pick one surface and dig in.
+- **AP06** (PreToolUse blocking) — Anthropic itself doesn't lead with this. Use only if the cost of letting an action happen is genuinely irreversible (e.g., dropping a production Delta table).
+
+---
+
+## Bibliography (full URL list)
+
+**Primary — Anthropic GitHub source**
+
+- https://github.com/anthropics/skills
+- https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md
+- https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md
+- https://github.com/anthropics/claude-plugins-official
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/hooks.json
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/patterns.py
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/hooks/review_api.py
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/README.md
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance/.claude-plugin/plugin.json
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/feature-dev/commands/feature-dev.md
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/feature-dev/agents/code-architect.md
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/commands/review-pr.md
+- https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/agents/code-reviewer.md
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/hookify
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev
+- https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management
+- https://github.com/anthropics/claude-code-security-review
+
+**Primary — Anthropic docs**
+
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/hooks
+- https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+- https://www.anthropic.com/news/claude-code-security
+- https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
+
+**Secondary — coverage of the security-guidance release (corroborates layered design)**
+
+- https://www.helpnetsecurity.com/2026/05/27/anthropic-claude-code-security-guidance-plugin/
+- https://snyk.io/articles/anthropic-launches-claude-code-security/
+- https://venturebeat.com/security/anthropic-claude-code-security-reasoning-vulnerability-hunting
+- https://cybersecuritynews.com/free-security-plugin-for-claude-code/
+
+**Secondary — community deep-dives on skill architecture**
+
+- https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/
+- https://www.mindstudio.ai/blog/claude-code-skills-architecture-progressive-context-loading
+- https://github.com/travisvn/awesome-claude-skills

--- a/plugins/saas-packs/databricks-pack/000-docs/006-RL-RSRC-databricks-v2-rebuild-synthesis.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/006-RL-RSRC-databricks-v2-rebuild-synthesis.md
@@ -1,0 +1,195 @@
+# Databricks Pack — Rebuild Synthesis
+
+**Inputs:** 4 parallel research deliverables (`databricks-pain-domain{1,2,3}-*.md` + `skill-architecture-patterns-2026.md`)
+**Synthesis date:** 2026-05-27
+**Status:** Design memo for Phase 2 — pre-build, design-time judgment calls live here
+
+---
+
+## 1. What the research actually found
+
+**34 citation-grounded pain entries** across three domains. Every entry includes verbatim error messages, version context, and a recommended Claude Code primitive shape.
+
+| Domain | Entries | Pain center of mass |
+|---|---|---|
+| 1 — Compute / Photon / DBR / Cost | 12 | Cost surprises (4), DBR version upgrades (3), Photon misuse (1), cluster lifecycle (4) |
+| 2 — Delta / Liquid Clustering / Streaming / DLT | 12 | Design-decision class (9 of 12), platform-bug-adjacent (2), platform bug (1) |
+| 3 — UC / Asset Bundles / SCIM / Networking | 10 | UC migration (3), Asset Bundles immature tooling (3), identity (1), CMK/networking/billing access (3) |
+
+**10 architectural patterns documented** (AP01-AP10) from Anthropic's own first-party plugins — primary reference is the `security-guidance` plugin (v2.0.0, David Dworken / Anthropic) which demonstrates 6 of the 10 in one shipped surface.
+
+---
+
+## 2. Cross-cutting findings that drive the rebuild
+
+### Finding 1 — MCP server is foundational, not optional
+
+Two independent research agents (Domains 1 and 3) converged on the same conclusion from different pain clusters: **15-20 of the 34 pains require live access to the Databricks Workspace API and `system.billing.usage`** for diagnostics that the agent cannot do from static knowledge.
+
+Implication: **build ONE shared MCP server first — `databricks-workspace-mcp` — and have every skill consume it.** Don't bundle one MCP server per skill; that's the wrong granularity. The MCP server is package-level infrastructure.
+
+Endpoints the MCP server must wrap (derived from pain entries that need them):
+
+- `clusters.list`, `clusters.get`, `clusters.events` — cluster forensics (D01, D06, D10)
+- `sql.queries.history` + execution-plan JSON — Photon audit (D02)
+- `jobs.list`, `jobs.get`, `jobs.runs.list` — cost attribution + run forensics (D07, D11)
+- `pipelines.get`, `pipelines.get_event_log` — DLT diagnostics (D08, D09, D11)
+- `system.billing.usage` query proxy — cost audit (D02, D07, D08, D11, D12)
+- `system.streaming.query_progress` query proxy — streaming diagnostics (D03, D04, D12)
+- `instance_pools.list` — idle waste detection (D09)
+- `external_locations.list`, `storage_credentials.list` — UC governance (D2 in domain 3)
+- `account.metastores.systemschemas` write — billing access remediation (D10 in domain 3)
+
+### Finding 2 — Pain TYPE determines skill MODE
+
+Domain 3 surfaced the sharpest cross-cutting distinction:
+
+- **Immature-tooling pain** (e.g. Asset Bundles) → response is detection + safe-fallback workflows + hooks that catch broken states
+- **Design-constraint pain** (e.g. UC single-metastore-per-region) → response is decision-support **at design time**, before the constraint locks in
+- **Design-decision-surprise pain** (e.g. Photon billing model, Liquid Clustering writer-conflict semantics) → response is friction-at-trigger-time (PreToolUse hooks) + education in `references/`
+- **Platform bug class** (e.g. checkpoint corruption) → response is monitoring + guided recovery playbooks
+
+A skill targeting the wrong pain mode produces fluff. The current `databricks-pack` mostly targets design-decision-surprise pain with documentation, when much of it actually wants friction-at-trigger-time hooks.
+
+### Finding 3 — Hook usage should be selective, not default
+
+The architecture teardown found Anthropic itself avoids `PreToolUse` blocking and prefers `PostToolUse` + asyncRewake (their security skill is "best-effort assistive, not a guarantee"). For Databricks, this means:
+
+- **Use PreToolUse blocking ONLY** where the action is genuinely irreversible — drop of streamed-from table (D12), VACUUM that crosses retention for an active reader (D07 domain 2), CREATE OR REPLACE on a table with active streaming consumers, IAM role deletion under a UC storage credential (D2 domain 3). These are the cases where Anthropic would also block.
+- **Use PostToolUse + retry** for known-transient deploy failures (D6 domain 3 — bundle deploy grant-ordering retry).
+- **Use SessionStart** to surface latent issues without interrupting flow (D03+D04 — streaming checkpoint health, D5 domain 3 — bundle state-file canary).
+- **Avoid hooks entirely** for diagnostics the user explicitly invokes (Photon audit, cost audit, cluster forensics) — those are slash-command territory.
+
+### Finding 4 — Subagents only where parallelism shortens wall-clock time
+
+Of the 34 pains, only ~5 genuinely benefit from subagent fanout (D01 / D06 cluster triage, D02 domain 2 MERGE rewriting, D1 / D10 domain 3 UC migration planning + permission tracing). Most diagnostics are sequential API calls that subagents don't speed up.
+
+---
+
+## 3. Skill clustering proposal — fewer, deeper skills
+
+Current pack: **24 flat skills, all the same shape.** Proposed rebuild: **6-8 skills clustered by problem-mode + primitive-mix.**
+
+| Proposed skill | Pains covered | Primary primitives | Demo angle |
+|---|---|---|---|
+| `databricks-cost-leak-hunter` | D02, D07, D08, D09, D11, D12 (domain 1) + D11 (domain 2) | MCP (system.billing.usage), scripts, slash command, scheduled subagent | "Here's $4,200/mo in idle pool VMs you didn't know about" |
+| `databricks-cluster-forensics` | D01, D06, D10 (domain 1) | MCP, subagent fanout, scripts, PostToolUse hook (optional) | "Why this cluster took 28 min to start — broken down by event class" |
+| `databricks-dbr-upgrade-advisor` | D03, D04, D05 (domain 1) | MCP, scripts, references (deep version matrix) | "Here's every break point between your current DBR and 15.4 LTS" |
+| `databricks-streaming-guardian` | D03, D04, D05, D08, D09, D10, D12 (domain 2) | PreToolUse + SessionStart hooks, MCP, scripts | "Blocked a CREATE OR REPLACE that would have killed 3 active streams" |
+| `databricks-delta-conflict-resolver` | D01, D02, D06, D07 (domain 2) | PreToolUse hook on OPTIMIZE/VACUUM, scripts, references | "MERGE rewriter that adds the clustering-key predicate so writers don't conflict" |
+| `databricks-uc-migration-pilot` | D1, D2, D3, D10 (domain 3) | Subagent, scripts, references, slash command | "Here's why 47 of your 200 HMS tables were silently skipped, and the fix per class" |
+| `databricks-bundle-medic` | D4, D5, D6 (domain 3) | PreToolUse + PostToolUse hooks, references | "Detected state-file corruption pre-deploy; preserved last known good" |
+| `databricks-identity-secrets-ops` | D7, D8, D9 (domain 3) | MCP (SCIM bridge), scripts, slash command (CMK rotation runbook) | "Drained workspace for CMK rotation in 12 min with zero data loss" |
+
+**Plus the shared foundation:** `databricks-workspace-mcp` (the MCP server, consumed by all eight skills).
+
+That's **8 skills + 1 MCP server = 9 artifacts**, replacing 24 current skills. **Each one earns its existence** by mapping to a named cluster of pains with citations.
+
+---
+
+## 4. Delete list — what gets cut from the current pack
+
+These current skills do not survive the rebuild bar (no real pain mapping, hello-world-tier content, or fully subsumed by a new skill):
+
+| Current skill | Reason to cut |
+|---|---|
+| `databricks-hello-world` | Confirmed by user — documentation cosplay |
+| `databricks-install-auth` | Just wraps `databricks configure --token`; one-line setup, not a skill |
+| `databricks-local-dev-loop` | Subsumed by `databricks-bundle-medic` once Asset Bundles is the canonical local dev surface |
+| `databricks-core-workflow-a` and `-b` | Generic — no specific pain cluster |
+| `databricks-sdk-patterns` | SDK ergonomics is library documentation, not a skill |
+| `databricks-prod-checklist` | Checklists belong in `references/`, not as a top-level skill |
+| `databricks-security-basics`, `databricks-enterprise-rbac` | Subsumed by `databricks-uc-migration-pilot` + `databricks-identity-secrets-ops` |
+| `databricks-rate-limits`, `databricks-webhooks-events` | No corresponding pain in the catalog. Either find evidence they hurt or cut. |
+| `databricks-common-errors` | Subsumed — every new skill carries its own error catalog in references/ |
+| `databricks-debug-bundle` | Subsumed by `databricks-bundle-medic` |
+| `databricks-reference-architecture` | Architecture doc, not a skill — moves to `references/` shared pack-level |
+| `databricks-multi-env-setup` | Subsumed by `databricks-uc-migration-pilot` (env isolation patterns from D3 domain 3) |
+| `databricks-ci-integration` | Generic. Cut unless a real CI-Databricks pain surfaces. |
+| `databricks-deploy-integration`, `databricks-migration-deep-dive` | Replaced by `databricks-bundle-medic` and `databricks-uc-migration-pilot` respectively |
+| `databricks-data-handling` | Too vague. Cut. |
+
+**Surviving from current pack (rebuilt, not just renamed):** `databricks-performance-tuning` (becomes part of `databricks-cost-leak-hunter` + `databricks-cluster-forensics`), `databricks-incident-runbook` (becomes the operational spine of `databricks-cluster-forensics` + `databricks-streaming-guardian`), `databricks-observability` (becomes the SessionStart-hook surface inside `databricks-streaming-guardian`), `databricks-upgrade-migration` (becomes `databricks-dbr-upgrade-advisor`), `databricks-cost-tuning` (becomes `databricks-cost-leak-hunter`).
+
+**Net deletion: ~15 of 24 skills cut, ~5 absorbed/rebuilt, ~4 spirit-of survives in new clusters.**
+
+---
+
+## 5. Pilot recommendation — start with `databricks-cost-leak-hunter`
+
+Of the eight proposed skills, the highest-leverage pilot is **`databricks-cost-leak-hunter`**. Reasoning:
+
+1. **Demo visceral.** Output is a dollar figure: "Your workspace is leaking $X,XXX/month — here's where." Audience response is immediate.
+2. **Single MCP integration** (`system.billing.usage` + `clusters.list` + `instance_pools.list`) — proves the MCP-server-as-foundation pattern without sprawling across 5 API surfaces.
+3. **No production-risk operations** — all reads, no writes. Safe to demo live on Luciano's stream.
+4. **Universal.** Every Databricks workspace has cost leaks. Every viewer will check theirs after the demo.
+5. **Covers 7 of 34 pain entries** in one skill — high ROI per skill built.
+6. **Pattern coverage:** AP01 (progressive disclosure), AP04 (script-vs-LLM separation — billing math is deterministic, "where to focus" is LLM), AP08 (domain-sliced reference loading — per-leak-class deep dives), AP09 (MCP server). Four of the six recommended patterns exercised in one skill.
+7. **Architectural proof.** If this skill works end-to-end at the new bar, every other skill in the pack has a template — not a content template (that was the wrong move), but a primitive-shape template.
+
+**What the pilot delivers:**
+
+- The `databricks-workspace-mcp` server stub (only the endpoints this skill needs — `clusters.list`, `instance_pools.list`, `sql.queries.history`, `system.billing.usage` query proxy)
+- `SKILL.md` with the orchestration logic
+- `references/`:
+  - `photon-eligibility-and-fallback.md` (D02)
+  - `compute-pricing-cheat-sheet.md` (D07, all-purpose vs job)
+  - `silent-serverless-features.md` (D08 — Predictive Optimization, Lakehouse Monitoring, materialized views, vector search)
+  - `instance-pool-cost-model.md` (D09)
+  - `dlt-tier-cost-tradeoffs.md` (D11)
+- `scripts/`:
+  - `photon-fallback-audit.py` (parses execution plans, computes Photon-effective %)
+  - `cost-leak-audit.py` (cross-references billing × cluster type × workload)
+  - `pool-idle-cost-projection.py` (cloud-provider rate × min_idle × hours)
+  - `dlt-cost-audit.sql` (canonical system tables query)
+- Slash commands: `/cost-audit-all-purpose-leaks`, `/photon-audit`, `/pool-idle-audit`, `/serverless-shadow-audit`
+- Optional: scheduled subagent via the `loop` skill for weekly digest
+
+**Effort estimate:** 3-5 days of focused build for the pilot. MCP server stub is the longest-pole item (~1 day). Skill content is ~1 day. References are ~1 day. Scripts are ~0.5 day each.
+
+---
+
+## 6. Decisions parked for the user
+
+These are judgment calls the rebuild plan can't make without input:
+
+1. **Pilot choice** — agree with `databricks-cost-leak-hunter`, or want a different starting skill (e.g. `databricks-streaming-guardian` for the operational SRE angle)?
+2. **Skill clustering granularity** — is 8 skills the right number, or should some merge (e.g. cluster forensics + streaming guardian) for fewer, broader artifacts?
+3. **MCP server scope** — minimal-first (only endpoints the pilot needs) and grow with each new skill, OR full surface-area scaffold upfront?
+4. **Delete-list timing** — cut the current 15 skills *before* the rebuild (clean slate, marketplace shows the gap), *during* the rebuild (gradual replacement), or *after* (current pack stays until rebuild is fully shipped)?
+5. **Pack naming** — keep `databricks-pack` (slug stability), rename to `databricks-pro` or similar to signal the rebuild?
+6. **Luciano timing pressure** — is the pilot needed for the live stream (in which case build window is days, not weeks), or is the stream demo-able with the current pack as a "here's what we have today, here's the rebuild direction" framing?
+
+---
+
+## 7. Open research gaps to close before final design
+
+All four research agents flagged the same gap: **Reddit and Twitter/Bluesky fetch is blocked from this environment.** Field-anecdote layer is thin. Manual or authenticated-MCP follow-up needed to ground the pain catalog in community sentiment, not just docs + GH issues + forum threads.
+
+Other unfilled areas (per agent reports):
+
+- DAIS / Data + AI Summit 2024-2025 video talks (transcript work, 4-6h)
+- `databricks/databricks-sdk-py` GitHub issues (Python SDK ergonomics pain — possible new domain entry)
+- GCP-specific pain (under-represented vs AWS/Azure across all three domains)
+- Stack Overflow `[databricks-unity-catalog]` long-tail (~600 questions, only top 20 mined)
+- `delta-rs` Rust client protocol-version skew pain
+- Delta UniForm / Iceberg compat pain (emerging)
+- Bundle "direct" engine known-bug inventory (moving target)
+
+Not blockers for the pilot, but should be closed before the full pack ships.
+
+---
+
+## Files referenced
+
+All research lives in `plugins/saas-packs/databricks-pack/000-docs/`:
+
+- `002-RL-RSRC-databricks-compute-pain-research.md` — 12 entries, compute/Photon/DBR/cost
+- `003-RL-RSRC-databricks-delta-streaming-research.md` — 12 entries, Delta/Liquid/Streaming/DLT
+- `004-RL-RSRC-databricks-uc-bundles-ops-research.md` — 10 entries, UC/Bundles/SCIM/networking
+- `005-RL-RSRC-anthropic-skill-architecture-patterns.md` — 10 patterns, Anthropic-grounded
+- `006-RL-RSRC-databricks-v2-rebuild-synthesis.md` — this document
+- `007-AT-ADEC-databricks-v2-cto-decision.md` — the locked-in decision record
+- `008-RA-REVW-pack-handling-pressure-test.md`, `009-RA-REVW-pilot-timing-pressure-test.md` — adversarial reviews
+
+Bead: `claude-setb` (Phase 1 — Research)

--- a/plugins/saas-packs/databricks-pack/000-docs/007-AT-ADEC-databricks-v2-cto-decision.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/007-AT-ADEC-databricks-v2-cto-decision.md
@@ -1,0 +1,144 @@
+# CTO Decision Record — Databricks Pack Rebuild (v2 — REVISED)
+
+**Date:** 2026-05-27
+**Decider:** Claude (delegated CTO authority per Jeremy 2026-05-27)
+**Revisions in this version:**
+
+- Pressure-test feedback (`008-RA-REVW-pack-handling-pressure-test.md` MODIFY, `009-RA-REVW-pilot-timing-pressure-test.md` MODIFY) incorporated
+- Jeremy's 2026-05-27 directive incorporated: **3-5 badass skills total, no fluff** (cut from 8 → 5)
+- Jeremy's 2026-05-27 v1/v2 framing confirmed: current `databricks-pack` is v1, rebuild is v2.0.0
+
+---
+
+## Decision 1 — Pack handling: deprecation lane + v2.0.0 + tombstones
+
+**Call:**
+
+1. **Ship `databricks-pack@1.1.0` immediately** — a deprecation release of the current pack. Adds banner warnings in the 15 doomed-skill SKILL.md files: "DEPRECATED: this skill will be removed in v2.0.0. See README for migration path." Updates CHANGELOG with the v2 plan. No content changes beyond banners.
+2. **Wait 2-4 weeks** for users on auto-update to see the warnings.
+3. **Ship `databricks-pack@2.0.0`** with the actual rebuild: 5 new operational skills + shared MCP server + tombstone `SKILL.md` stubs in the 15 deleted-skill directories pointing at their replacement (or "removed, no replacement; here's why" for the 8-9 that aren't being replaced).
+4. **Ship `databricks-pack@2.1.0`** 1-2 release cycles later — removes the tombstones, cleans up.
+5. **Rewrite the catalog description** in `marketplace.extended.json` before tagging 2.0.0 — current text advertises "MLflow, notebooks" that aren't in the new skill set. New description targets operational depth, not surface breadth.
+
+**Why this is harder than just "version bump":**
+
+The architect-reviewer pressure-test surfaced a real risk I missed: Claude Code marketplace auto-updates (v2.0.72+) actually delete files on uninstall (v2.0.30+). On upgrade from 1.x to 2.0.0, deleted skill directories vanish with no in-product warning to the user. A user who has `databricks-hello-world` in their CLAUDE.md will see references suddenly break. Tombstone stubs prevent the 404 cliff; deprecation lane gives users a window to see what's coming.
+
+**Slug decision confirmed:** `databricks-pack` stays. Per Jeremy 2026-05-27 ("v1 was the SaaS pack, v2 is the rebuild"). Per CLAUDE.md "Key Identifiers — Do Not Normalize."
+
+---
+
+## Decision 2 — 5 skills, not 8. Jeremy's call, accepted.
+
+**Call:** Cut to **5 skills + 1 MCP server**. No fluff.
+
+| # | Skill | Pains covered | Why it earns a slot |
+|---|---|---|---|
+| 1 | `databricks-cost-leak-hunter` | D02, D07, D08, D09, D11, D12 (domain 1) + D11 (domain 2) | Pilot. Universal demand. FinOps angle that lands with practitioners. |
+| 2 | `databricks-cluster-forensics` | D01, D03, D04, D05, D06, D10 (domain 1) | Cluster lifecycle + DBR upgrade pain + spot-interruption — operational SRE spine. |
+| 3 | `databricks-streaming-guardian` | D01, D02, D03, D04, D05, D06, D07, D08, D09, D10, D12 (domain 2) | Every Delta + Liquid + Streaming + DLT pain consolidated into one skill — the data-ops spine. |
+| 4 | `databricks-uc-migration-pilot` | D1, D2, D3, D7, D10 (domain 3) | UC migration is the peak-pain forcing function (Sept 30 2026 deadline). |
+| 5 | `databricks-bundle-medic` | D4, D5, D6, D8, D9 (domain 3) | Asset Bundles immature tooling + CMK + networking — deploy + infra spine. |
+
+**Plus:** `databricks-workspace-mcp` (the shared MCP server — not a skill, but the package-level infrastructure all 5 skills consume).
+
+**Coverage:** all 34 pain entries from the research land in one of the 5 skills. No pain dropped.
+
+**What got merged out vs the 8-skill plan:**
+
+- `databricks-dbr-upgrade-advisor` → folded into `databricks-cluster-forensics` (DBR upgrade IS a cluster-lifecycle concern)
+- `databricks-delta-conflict-resolver` → folded into `databricks-streaming-guardian` (conflict resolution is part of the data-ops spine)
+- `databricks-identity-secrets-ops` → folded into `databricks-bundle-medic` (CMK rotation + SCIM are deploy-time concerns; this skill becomes the "infra + identity + secrets" spine)
+
+**Cut from current pack (15 of 24 skills):**
+
+databricks-hello-world, databricks-install-auth, databricks-local-dev-loop, databricks-core-workflow-a, databricks-core-workflow-b, databricks-sdk-patterns, databricks-prod-checklist, databricks-security-basics, databricks-enterprise-rbac, databricks-rate-limits, databricks-webhooks-events, databricks-common-errors, databricks-debug-bundle, databricks-reference-architecture, databricks-multi-env-setup, databricks-ci-integration, databricks-deploy-integration, databricks-migration-deep-dive, databricks-data-handling.
+
+(That's 19 names cut/absorbed. Net: 24 → 5 skills.)
+
+---
+
+## Decision 3 — Pilot: `databricks-cost-leak-hunter` at REDUCED scope
+
+**Call:** Build the pilot, but at reduced scope per pilot-timing pressure-test.
+
+**Scope cut from 7 pains to 3:**
+
+- D07 (all-purpose vs job cluster cost)
+- D09 (instance pool idle waste)
+- D11 (DLT serverless cost spike)
+- (Optional, time-permitting: D08 silent serverless features)
+
+**Dropped from pilot, deferred to follow-up:**
+
+- D02 (Photon silent fallback) — execution-plan JSON parsing across DBR versions is the longest-pole risk; defer to skill #2
+- D12 (serverless notebook bill attribution) — narrow scope, doesn't move the needle on architectural proof
+
+**Demo must explicitly show architecture, not just $ numbers.** Per pressure-test: "for a 15-year practitioner audience, 'another cost dashboard' is the lowest-status output." Overwatch / Unravel / Sync Computing already do dollar numbers. The differentiator is the MCP + scripts + references composition — show it on screen.
+
+**Tag-based per-team chargeback attribution** — pressure-test flagged this as the "Overwatch-killer" missing capability. Adding to pilot scope as a stretch goal if days 4-5 are clean.
+
+**Fallback if 5 days slips:** ship `databricks-pool-idle-auditor` instead — D09 only, ~2 days. Same "$X/mo in idle VMs" demo, 1/3 the surface. Named fallback, not vague.
+
+---
+
+## Decision 4 — Build sequencing: MCP server first, separately
+
+**Call:** Ship MCP server as its own deliverable BEFORE the pilot skill.
+
+```
+Day 1-2:  databricks-workspace-mcp@0.1.0
+          - 4 endpoints: clusters.list, instance_pools.list,
+            sql.queries.history, system.billing.usage query proxy
+          - OAuth flow tested against sandbox workspace
+          - /validate-mcp passes
+          - Standalone PR, mergeable independently
+
+Day 3:    databricks-cost-leak-hunter SKILL.md scaffold via /skill-creator
+          References: 3 of 5 written (the ones for D07, D09, D11)
+          Scripts: 3 of 4 written (cost-leak-audit, pool-idle-cost-projection, dlt-cost-audit)
+
+Day 4:    Integration: SKILL.md orchestrates scripts + MCP calls
+          End-to-end run on sandbox workspace
+          Optional: D08 + serverless-shadow-audit if time clean
+
+Day 5:    Validation gates
+          - /validate-skillmd --thorough (JRig tier 3, models=haiku,sonnet ONLY — drop opus per pressure-test)
+          - /validate-plugin on whole databricks-pack
+          - j-rig eval with same model set
+          Iterate on what they surface
+          Commit + open PR
+```
+
+**Slippage tripwire at day 3:** if MCP auth still painful or execution-plan parser stuck, switch to `databricks-pool-idle-auditor` fallback the same day. Don't burn day 4-5 trying to rescue.
+
+---
+
+## Decision 5 — Demo arc for Luciano: architectural shift, not just dollars
+
+**Call:** 45-min demo, structured to land the architectural shift:
+
+- **0-5 min** — What v1 looked like. Walk `databricks-hello-world` and `databricks-performance-tuning` SKILL.md. Acknowledge: "These describe Databricks ops. They don't do them."
+- **5-15 min** — What changed. Show the research process (34 pain entries from real forums/GH issues, 10 Anthropic-derived patterns). Show the architecture: MCP server, references, scripts, hooks. Slides for this part.
+- **15-30 min** — Live demo of `databricks-cost-leak-hunter` on sandbox. Run the slash commands. Surface real $ numbers. **Reveal the architecture on screen:** show the SKILL.md, show the MCP server tool calls, show the script outputs, show the references loaded on demand. Practitioner audience needs to see the composition or they'll think it's just SQL.
+- **30-40 min** — Roadmap. The remaining 4 skills, when they ship, how Luciano's audience can contribute pain entries.
+- **40-45 min** — Q&A.
+
+---
+
+## Audit trail commitments
+
+- This file gets promoted to `000-docs/NNN-AT-DECR-databricks-rebuild-cto-call.md` per Doc Filing Standard v4.3.
+- Bead `claude-setb` (rebuild umbrella) gets a `bd-sync note` linking here.
+- GH issue #785 (Luciano outreach) gets cross-referenced — demo planning ties to the rebuild work.
+- Pressure-test files `pressure-test-pack-handling.md` and `pressure-test-pilot-timing.md` are the supporting evidence for these modifications.
+
+---
+
+## Questions parked for Jeremy (only these)
+
+1. **Sandbox workspace.** Which Databricks workspace gets used for build + demo? Free Tier won't cut it (needs UC + system tables). Existing customer workspace OK? If not, provision Premium trial?
+2. **Luciano date.** Push for 14+ days out so 5-day build + 4-week deprecation lane fits, OR accept earlier date and demo from v1.1.0 with "v2 launches next month" framing?
+3. **Tag-based chargeback in pilot.** Pressure-test flagged this as the Overwatch-killer feature. Include in pilot scope (adds ~1 day) or defer to follow-up release?
+
+Everything else proceeds. Phase 3 (pilot build) starts on your go.

--- a/plugins/saas-packs/databricks-pack/000-docs/008-RA-REVW-pack-handling-pressure-test.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/008-RA-REVW-pack-handling-pressure-test.md
@@ -1,0 +1,38 @@
+# Pressure Test: Pack Handling (Version Bump In Place)
+
+**Verdict: MODIFY.** Keep the slug, but the decision is incomplete in two material ways: (a) the breaking-change communication plan is one CHANGELOG line where reality demands a deprecation lane, and (b) the 1.x skill directories need to be retained as tombstones (or explicitly redirected), not deleted from disk on upgrade. Without those two adjustments, the in-place version bump silently nukes user workflows.
+
+## Where the decision is right
+
+Renaming the pack (Option A) is correctly rejected. The repo CLAUDE.md "Key Identifiers — Do Not Normalize" block is explicit that `databricks-pack` is in catalog URLs, install instructions, and downstream user systems. A rename is a breaking API change that costs more than it buys. Options B/C/D are correctly rejected — the synthesis (`databricks-rebuild-synthesis.md:110`) shows 5 current skills genuinely have spirit-of survivors in the rebuild; treating the rebuild as a fresh pack pretends those threads don't exist.
+
+## Where the decision breaks
+
+**1. Backwards-compat reality is worse than "major version = breaking, done."**
+
+Claude Code's marketplace honors auto-update (Claude Code CHANGELOG 2.0.72: "Added auto-update toggle for plugin marketplaces"). Plugin uninstall only started actually removing files in 2.0.30 ("Fixed plugin uninstall not removing plugins"). The interaction: a user on 1.x with `databricks-cost-tuning` referenced in CLAUDE.md or a saved workflow will, on next marketplace sync, find that skill directory gone — no warning, no migration prompt. Claude Code does not surface "this skill no longer exists" to the user at upgrade time; it surfaces silently as "skill not found" the next time it's invoked. This is the same failure class as a library deleting public symbols on a minor bump.
+
+**2. The slug-stability argument hides a content-substitution problem.**
+
+Per the synthesis line 112, 15 of 24 skills are deleted outright and 5 are absorbed. That is 83% of the surface area changing. The user-facing question is not "did the slug change" — it's "does `databricks-pack` still mean what it meant last week." It does not. The catalog description in `marketplace.extended.json` ("24 skills covering Delta Lake, MLflow, notebooks...") is not just stale — it advertises a product that won't exist. MLflow and notebooks are not in the proposed 8-skill set at all. A semver-major bump is technically correct but ethically thin given the iPhoto→Photos analog: Apple renamed because the substitution was honest. Here, the slug carries forward branding that the contents no longer earn.
+
+**3. CHANGELOG-as-communication is insufficient.**
+
+For 15 deletions with no in-product warning surface, the honest minimum is a deprecation release first: ship `databricks-pack@1.1.0` with the existing 24 skills plus deprecation banners in the to-be-cut SKILL.md descriptions ("This skill will be removed in 2.0. See `databricks-cost-leak-hunter`."), then ship 2.0.0 a defined window later (2-4 weeks). This gives auto-updaters a chance to see the warning before the files vanish. One-line CHANGELOG + slug-stable major bump is the npm-package answer; this is end-user-facing content, not a library API.
+
+**4. Tombstone files are missing from the plan.**
+
+The 15 deleted skill directories should ship in 2.0.0 as stubs containing only a `SKILL.md` that says "moved to X." Cost: ~15 tiny markdown files. Benefit: every `databricks-cost-tuning` reference in a user's saved CLAUDE.md, prompt, or workflow gets a redirect instead of a 404. This is the same pattern as HTTP 301s for the slug rename problem, applied internally.
+
+## Anthropic precedent
+
+No first-party Anthropic plugin in the local mirror (`anthropic/claude-code/plugins/*`) has shipped a 2.0.0 yet — all sit at 1.0.0. There is no observable precedent for how Anthropic handles major restructures of a shipped plugin. Absence of precedent means caution, not freedom.
+
+## Required modifications
+
+1. Ship `1.1.0` deprecation release first with banners on the 15 doomed skills. Wait 2-4 weeks.
+2. In `2.0.0`, retain the 15 deleted skill dirs as redirect-stub SKILL.md files. Delete them in `2.1.0` once telemetry (or absence of complaints) confirms migration.
+3. Rewrite the catalog description and keywords to match the new shape before the 2.0.0 tag — don't carry MLflow/notebooks claims forward.
+4. CHANGELOG + dedicated blog post + Plane CONTENT issue tagged `databricks-rebuild` announcing the change with the migration table.
+
+File: `plugins/saas-packs/databricks-pack/000-docs/research/pressure-test-pack-handling.md`

--- a/plugins/saas-packs/databricks-pack/000-docs/009-RA-REVW-pilot-timing-pressure-test.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/009-RA-REVW-pilot-timing-pressure-test.md
@@ -1,0 +1,43 @@
+# Pressure-Test: `databricks-cost-leak-hunter` as Pilot, 3-5 Day Window
+
+**Reviewer:** Plan agent (adversarial review, 2026-05-27)
+**Original decision:** Build cost-leak-hunter first, 3-5 days, covers 7 pains
+**Verdict:** **MODIFY**
+
+---
+
+## Summary
+
+Keep cost-leak-hunter as pilot. **Ship MCP server separately first** (1-2 days). **Cut pilot scope from 7 pains to 3-4** (D07 + D09 + D11 + optionally D02). **Drop `--models opus` from pilot JRig eval.** **Hold `databricks-pool-idle-auditor` as named 2-day fallback.** Lock build to 5 days with defined fallback at day 3.
+
+## 1. Is 3-5 days realistic? No — not at stated scope.
+
+The synthesis itself says: MCP server 1d + skill 1d + references 1d + scripts 0.5d × 4 = **2 days of scripts alone**. That's 5 days before validation. Gate chain (`/validate-mcp`, `/validate-skillmd --thorough`, `/validate-plugin`, `j-rig check`, `j-rig eval --models haiku,sonnet,opus`) adds 0.5-1d iteration because Tier 3 JRig routinely surfaces SKILL.md ambiguities forcing rewrites. **Realistic at original scope: 6-8 days.**
+
+**Longest pole:** NOT the MCP server — the execution-plan JSON parser for `photon-fallback-audit.py`. Plan shape varies by DBR version (D02 explicitly notes this in domain 1 research). Robustness across DBR 13/14/15 is the slip risk, not OAuth wrapping.
+
+## 2. Right pilot vs alternatives? Mostly yes, with caveats.
+
+Cost-leak-hunter beats streaming-guardian on **live-demo safety** (reads-only, no PreToolUse blocking that can misfire on stage) and beats cluster-forensics on **universality**. Agreed.
+
+**But** — for a 15-year Databricks practitioner audience, "another cost dashboard" is the lowest-status output in the entire Databricks tooling ecosystem. Overwatch, Unravel, Sync Computing, and Databricks' own System Tables dashboards already do this. The architectural-shift narrative does NOT automatically land. The demo must visibly demonstrate **MCP + script-vs-LLM separation (AP04) + progressive disclosure (AP01)** — not just print a dollar number. Without explicit on-screen reveal of the architecture, this looks like a wrapped SQL query.
+
+## 3. Fallback if it slips
+
+**`databricks-pool-idle-auditor`**: D09 only, one script (`pool-idle-cost-projection.py`), one slash command, one MCP endpoint (`instance_pools.list`). Shippable in 2 days. Same demo narrative ("here's $X in idle VMs") with 1/3 the surface. Keep in back pocket explicitly.
+
+## 4. What a 15-year practitioner expects that's missing
+
+Cost-leak-hunter as scoped omits: **serverless SQL warehouse autoscaling waste**, **DBU vs cloud-cost reconciliation** (the FinOps gap), **per-team chargeback attribution via tags**, **Photon × spot-instance interaction**. Synthesis covers D08 "silent serverless features" but the reference file alone won't land — practitioners want the audit script to *attribute* costs, not just *find* them. Without tag-based attribution, expect "cute, but Overwatch already does this" in comments.
+
+## 5. Build sequencing — MCP first, separately versioned
+
+Bundling MCP inside the pilot skill = wrong shape. Synthesis §2 Finding 1 is explicit: MCP is **package-level infrastructure** consumed by all future skills. Ship as `databricks-workspace-mcp@0.1.0` with the 4 endpoints cost-leak-hunter needs, validated independently. Buys: (a) reusability when streaming-guardian arrives, (b) clean SemVer for endpoint expansion, (c) demo credibility ("one server, N skills" > "skill includes a server").
+
+## 6. JRig eval cost
+
+`j-rig eval --models haiku,sonnet,opus` at $2-5 is trivial money. The question is **iteration time**. For a pilot whose job is template-setting, run `haiku,sonnet` only — opus rarely surfaces issues the other two miss on first pilots, rerun cost of find-and-fix is the actual budget killer. Save opus eval for skill #3-4 when template is stable.
+
+---
+
+**Net:** Stand on pilot choice. Modify scope to 3-4 pains. Ship MCP separately. Drop opus from pilot eval. Hold pool-idle-auditor as named 2-day fallback. Demo must explicitly show architecture, not just $ number.

--- a/plugins/saas-packs/databricks-pack/000-docs/010-RL-RSRC-databricks-mcp-official-landscape.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/010-RL-RSRC-databricks-mcp-official-landscape.md
@@ -1,0 +1,169 @@
+# Databricks MCP Landscape — Engineering Decision Input
+
+**Date:** 2026-05-27
+**Author:** Research agent (Claude Code)
+**Purpose:** Ground the build-vs-consume decision on `databricks-workspace-mcp@0.1.0` against what Databricks officially ships today.
+
+---
+
+## 1. Executive Summary
+
+Databricks ships a three-path MCP architecture — **managed**, **custom**, and **external** — all in Public Preview as of 2026-05-22 (GCP shows GA on four of five managed servers; AWS and Azure are still Preview). The five **managed** servers cover the *data plane* exclusively: Genie (NL Q&A), Genie Space (per-space NL Q&A), Vector Search, **Databricks SQL**, and **Unity Catalog Functions**. There is **no managed MCP for the control plane** — clusters, jobs, pipelines/DLT, instance pools, external locations, storage credentials, SCIM/identity, streaming progress, or cluster events are not surfaced as MCP tools by any Databricks-published server. The **custom path** ships your MCP as a **Databricks App** (HTTP transport, name-prefixed `mcp-`, Python via `@mcp.tool()`); Databricks hosts it inside the workspace and brokers OAuth via the `databricks-mcp` PyPI helper, but **does not ship a pre-built control-plane MCP** — that work is left to the developer. The **external path** is a UC-Connection-backed proxy for *third-party* services (GitHub, Atlassian, Glean) and does **not** apply to Databricks-API workloads. Net: the proposed `databricks-workspace-mcp@0.1.0` fills a real, currently-unfilled gap; it is not duplicating an existing Databricks offering.
+
+---
+
+## 2. Managed MCP Server Catalog
+
+All five servers ship from Databricks. Endpoints are workspace-scoped (`https://<workspace-hostname>/api/2.0/mcp/...`). Unity Catalog permissions are always enforced.
+
+| Server | Endpoint Pattern | OAuth Scope | AWS Status | GCP Status | Azure Status | Tools Exposed | Use Case |
+|---|---|---|---|---|---|---|---|
+| **Genie** | `/api/2.0/mcp/genie` | `genie` | Beta | Beta | Beta | `genie_ask`, `genie_poll_response` | Async NL Q&A across all Genie Spaces + UC data, returns grounded answer with deep link. Read-only. |
+| **Genie Space** | `/api/2.0/mcp/genie/{genie_space_id}` | `genie` | Public Preview | **GA** | Public Preview | (per-space tool surface; poll-based) | NL Q&A scoped to a single Genie Space. Read-only. No history. |
+| **Vector Search** | `/api/2.0/mcp/vector-search/{catalog}/{schema}/{index_name}` | `vector-search` | Public Preview | **GA** | Public Preview | (index-scoped query tool) | Semantic search over Databricks-managed embedding indexes. |
+| **Databricks SQL** | `/api/2.0/mcp/sql` | `sql` | Public Preview | **GA** | Public Preview | (SQL execution tool — poll-based for long queries) | AI-generated SQL execution. **Read AND write.** This is the workhorse that can hit any UC-permitted table including `system.*`. |
+| **Unity Catalog Functions** | `/api/2.0/mcp/functions/{catalog}/{schema}/{function_name}` | `unity-catalog` | Public Preview | **GA** | Public Preview | (one tool per UC function in the namespace) | Run pre-defined UC functions. `system/ai` namespace exposes `python_exec` (built-in code interpreter). |
+
+**Auth:** OAuth U2M (interactive, Claude Code), OAuth M2M (service principal), or PAT (managed + external only — **PAT not supported for custom MCPs on Databricks Apps**). Dynamic Client Registration is explicitly **not** supported.
+
+**Discovery surface:** Workspace UI → **AI Gateway** → **MCPs** tab.
+
+**Per-cloud parity:** AWS, GCP, Azure all expose the same five servers with identical endpoint shapes. GCP is furthest along (GA on four; Beta on Genie). AWS/Azure are still labeled Public Preview overall.
+
+---
+
+## 3. Custom MCP Architecture
+
+**Hosting model:** Databricks hosts the custom MCP **inside the workspace as a Databricks App**. The MCP server is a Python HTTP service deployed via `databricks apps create mcp-<name>`. Endpoint becomes `https://<app-url>/mcp`.
+
+**Constraints:**
+
+- App name **must start with `mcp-`** to be recognized by AI Playground and Mosaic AI Agent Framework.
+- HTTP-compatible transport required (streamable HTTP — not WebSocket, not SSE).
+- Default port 8000, overridable via `app.yaml` env vars.
+- PAT auth is **not supported** for custom MCPs (OAuth only).
+
+**Framework:** Python with the `@mcp.tool()` decorator pattern (from the standard `mcp` PyPI package — Anthropic's reference MCP SDK). Databricks does **not** ship a proprietary MCP server SDK. The `databricks-mcp` PyPI package (from [databricks/databricks-ai-bridge](https://github.com/databricks/databricks-ai-bridge)) is a **client-side helper** for OAuth and resource discovery, *not* a server framework.
+
+**Template:** [github.com/databricks/app-templates/tree/main/mcp-server-hello-world](https://github.com/databricks/app-templates/tree/main/mcp-server-hello-world) — `MCP Server - Hello World` under Compute → Apps → Create app → Agents category.
+
+**Auth model for tools running inside the custom MCP:**
+
+- **On-behalf-of-user:** `WorkspaceClient(credentials_strategy=ModelServingUserCredentials())` — agent passes the calling user's identity. UC permissions enforced as that user.
+- **Service principal:** `WorkspaceClient(client_id=..., client_secret=...)` — runs as the app's SP.
+
+**Discovery:** No registry API. Naming convention (`mcp-` prefix) + workspace visibility + Databricks Apps permissions.
+
+**Secrets:** No first-class secrets management. Env vars in `app.yaml` or rely on workspace identity / OAuth tokens.
+
+---
+
+## 4. External MCP Architecture
+
+**Definition:** Third-party MCP servers hosted **outside** Databricks (GitHub, Atlassian, Glean, or self-hosted), reached **through** a Databricks-managed proxy backed by a Unity Catalog HTTP connection.
+
+**Endpoint pattern:** `https://<workspace-hostname>/api/2.0/mcp/external/{connection_name}`
+Also: `https://<workspace-hostname>/api/2.0/unity-catalog/connections/{connection_name}/proxy[/<sub-path>]`
+
+**Auth brokerage:** **Databricks brokers everything.** The client passes a `WorkspaceClient` to `databricks-mcp` / `databricks-langchain` / `databricks-openai`; the proxy handles OAuth token exchange and refresh to the third-party service. Tokens never leave the backend.
+
+**Auth modes supported on the UC connection:**
+
+- Shared principal: Bearer, OAuth M2M, OAuth U2M Shared
+- Per-user: OAuth U2M Per User (individual identity, audit-friendly)
+
+**Registration paths (four):**
+
+1. **Managed OAuth** (recommended; Glean, GitHub, Atlassian today)
+2. **Databricks Marketplace** (pre-curated integrations)
+3. **Custom HTTP Connection** (manual; "Is mcp connection" checkbox)
+4. **Dynamic Client Registration** (RFC 7591)
+
+**Required privilege:** `CREATE CONNECTION` on the metastore. Region must support Model Serving.
+
+**Status:** Public Preview as of 2026-05-15.
+
+**Critically:** External MCP cannot directly modify Databricks workspace resources — it is read-only / service-specific by design. It is **not** a path for exposing Databricks APIs to agents.
+
+---
+
+## 5. Coverage Gap Analysis
+
+The proposed `databricks-workspace-mcp@0.1.0` aims at control-plane and admin surfaces. Mapping requested coverage against what Databricks ships:
+
+| Required Operation | Covered by Managed MCP? | Reachable via Databricks SQL MCP? | Reachable via UC Functions MCP? | Real Gap? |
+|---|---|---|---|---|
+| `clusters.list` | **No** | No (REST API, not SQL) | Only if wrapped in a UC function | **Yes — gap** |
+| `clusters.get` | **No** | No | UC function wrapping REST possible | **Yes — gap** |
+| `clusters.events` | **No** | No | Same as above | **Yes — gap** |
+| `instance_pools.list` | **No** | No | UC function wrap possible | **Yes — gap** |
+| `jobs.list` | **No** | No | Same | **Yes — gap** |
+| `jobs.runs.list` | **No** | No | Same | **Yes — gap** |
+| `pipelines.get` (DLT) | **No** | No | Same | **Yes — gap** |
+| `pipelines.get_event_log` | **No** | Partial — event log is queryable via `event_log()` SQL TVF, so SQL MCP **can** reach it | Yes via UC function | **Partial** — SQL path works for event log, not for pipeline metadata |
+| `system.billing.usage` SQL | **No (no dedicated billing MCP)** | **Yes** — SQL MCP can `SELECT * FROM system.billing.usage` if caller has UC SELECT | UC function wrap also viable | **No — covered by SQL MCP** |
+| `system.streaming.query_progress` | **No** | **Yes — if** the table exists and is UC-readable (system table since Jan 2026 lakeflow GA) | UC function wrap | **No — covered by SQL MCP** |
+| `external_locations.list` | **No** | No (REST API) | UC function wrap possible | **Yes — gap** |
+| `storage_credentials.list` | **No** | No (REST API) | UC function wrap possible | **Yes — gap** |
+| Cluster pool / workspace admin ops | **No** | No | UC function wrap possible but admin scope | **Yes — gap** |
+| SCIM / identity / group sync | **No** | No | No (control-plane only) | **Yes — gap** |
+
+**Pattern:** Databricks managed MCPs cover the **data plane** (read/write rows + run UC functions + semantic search + NL Q&A). They do **not** cover the **control plane** (clusters, jobs, pipelines, identity, infra config). The only workaround inside the managed surface is "wrap every REST call in a UC function" — which is feasible but inverts the architecture (every API call becomes a Python UC function the user has to author and maintain).
+
+**`system.*` table reads are NOT a gap** — Databricks SQL MCP handles them. Anything that boils down to "SELECT FROM system.billing.usage" should consume the managed SQL MCP, not be re-implemented.
+
+---
+
+## 6. Architectural Recommendation
+
+**Ship `databricks-workspace-mcp@0.1.0` as planned, with one scope adjustment.**
+
+**Real gap confirmed:** The Databricks-published managed MCPs cover Genie, Vector Search, SQL, and UC Functions only. Control-plane operations (clusters, jobs, pipelines, instance pools, external locations, storage credentials, SCIM) are **not surfaced as MCP tools by any Databricks-published server today** and the docs give no roadmap signal that they will be. A third-party MCP that exposes the Databricks REST control plane is the only practical path.
+
+**The "custom MCP via Databricks Apps" path is not a substitute** — it is the *delivery mechanism* a third party would use to ship such an MCP inside a customer's workspace. It does not pre-solve the problem; it just gives us a hosting target. (Bonus: shipping as a Databricks App means OAuth + UC perms enforcement come for free via `databricks-mcp` client helpers.)
+
+**Recommended scope adjustments to the original `databricks-workspace-mcp@0.1.0` plan:**
+
+1. **Drop `system.billing.usage` SQL proxy and `system.streaming.query_progress` from the MCP's tool surface.** These are pure SELECTs against `system.*` tables and the managed Databricks SQL MCP already does this with first-class OAuth + UC enforcement. Document the recommendation: "use Databricks SQL MCP for any `system.*` query." Re-implementing wastes effort and creates two ways to do the same thing.
+
+2. **Keep clusters / jobs / pipelines / instance pools / external locations / storage credentials.** These are the actual gap. Use the Databricks Python SDK (`databricks-sdk`) inside the MCP server, expose one MCP tool per REST endpoint family.
+
+3. **Ship two deployment modes from day one:**
+
+- **Standalone:** runs anywhere (local dev box, CI, Claude Code on a laptop) authenticating via PAT or local OAuth profile. Maximum portability, minimum integration.
+- **Databricks App:** ships as an `mcp-databricks-workspace` app. Picks up the workspace's OAuth identity, gets discovered by AI Playground and the Mosaic AI Agent Framework, leverages `databricks-mcp` for resource declaration when logged with an agent. This is the path for customers who want Anthropic-side Claude Code agents AND Databricks-side Mosaic agents to share one tool surface.
+
+1. **Auth boundary:** for Claude Code as the calling client, the cleanest pattern is **Claude Code → MCP server (standalone or App) → Databricks workspace** using OAuth U2M with scoped tokens (`all-apis` for full control plane access; reduce to `unity-catalog` + custom scope if Databricks adds one later). Avoid passing user OAuth through to the workspace from Claude Code directly — every documented auth path goes through the MCP server's `WorkspaceClient`.
+
+2. **Use `databricks-mcp` PyPI for client-side helpers only; build the server with the standard `mcp` reference SDK (Python).** Databricks does not ship a server-side framework; the standard MCP Python SDK + `@mcp.tool()` decorators + `databricks-sdk` for REST calls is the canonical stack and matches every official template.
+
+**Net:** Epic 1 (`databricks-workspace-mcp@0.1.0` foundation) should ship — with `system.*` table queries dropped from scope and a note in the README pointing those use cases at the managed SQL MCP. Everything else in the original Epic 1 plan is a real, currently-unfilled gap.
+
+---
+
+## 7. Sources
+
+### Databricks official docs (walked)
+
+- [MCP on Databricks (AWS overview)](https://docs.databricks.com/aws/en/generative-ai/mcp/)
+- [Managed MCP servers (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp)
+- [Custom MCP servers (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/custom-mcp)
+- [External MCP servers (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/external-mcp)
+- [Connect clients to Databricks MCPs (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/connect-clients)
+- [Use custom MCPs in agents (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/custom-mcp-usage)
+- [Use external MCPs in agents (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/external-mcp-usage)
+- [Managed MCP servers (GCP)](https://docs.databricks.com/gcp/en/generative-ai/mcp/managed-mcp)
+- [Managed MCP servers (Azure)](https://learn.microsoft.com/en-us/azure/databricks/generative-ai/mcp/managed-mcp)
+- [Unity AI Gateway (AWS)](https://docs.databricks.com/aws/en/ai-gateway/)
+
+### Supporting
+
+- [databricks-mcp on PyPI](https://pypi.org/project/databricks-mcp/)
+- [databricks/databricks-ai-bridge (GitHub)](https://github.com/databricks/databricks-ai-bridge)
+- [databricks/app-templates — mcp-server-hello-world](https://github.com/databricks/app-templates/tree/main/mcp-server-hello-world)
+- [Databricks January 2026 release notes (AWS)](https://docs.databricks.com/aws/en/release-notes/product/2026/january) — lakeflow system tables GA
+- [Databricks April 2026 release notes (AWS)](https://docs.databricks.com/aws/en/release-notes/product/2026/april) — AI Gateway governance over MCP
+- [Atlan: MCP Server for Databricks deployment types (2026)](https://atlan.com/know/mcp/mcp-server-for-databricks/) — third-party landscape view
+- [Truto: Best MCP Server for Databricks 2026](https://truto.one/blog/best-mcp-server-for-databricks-in-2026-give-ai-agents-secure-access-to-lakehouse-data/) — third-party landscape view
+- [JustTryAI/databricks-mcp-server (GitHub)](https://github.com/JustTryAI/databricks-mcp-server) — existing community MCP for REST APIs
+- [RafaelCartenet/mcp-databricks-server (GitHub)](https://github.com/RafaelCartenet/mcp-databricks-server) — existing community MCP for UC metadata

--- a/plugins/saas-packs/databricks-pack/000-docs/011-RL-RSRC-databricks-mcp-community-landscape.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/011-RL-RSRC-databricks-mcp-community-landscape.md
@@ -1,0 +1,118 @@
+# Databricks MCP Server Community Landscape (2026)
+
+## Executive Summary
+
+The Databricks MCP ecosystem in 2026 is **fragmented between official Databricks-managed offerings and 4–5 lightweight community alternatives**, none of which are production-grade. The official Databricks AI Gateway is the only enterprise-safe path; community servers are weekend projects (1–46 stars, no CI/CD, minimal test coverage) suitable only for internal prototyping or hobbyist use. **Strategic recommendation:** consume official Databricks MCP for enterprise work; the gap for a truly comprehensive third-party MCP is significant and defensible.
+
+---
+
+## Catalog of Community MCPs
+
+| Name | Author | URL | Stars | Last Update | License | Maturity | Primary Capabilities |
+|------|--------|-----|-------|-------------|---------|----------|----------------------|
+| **RafaelCartenet/mcp-databricks-server** | Rafael Cartenet | [GitHub](https://github.com/RafaelCartenet/mcp-databricks-server) | 40 | 2026 | MIT | Beta | UC metadata exploration, SQL execution, lineage analysis, notebook discovery |
+| **JustTryAI/databricks-mcp-server** | JustTryAI | [GitHub](https://github.com/JustTryAI/databricks-mcp-server) | 46 | 2026 | MIT | Beta | Clusters, jobs, notebooks, SQL, file system, 80% test coverage target |
+| **leminkhoa/databricks-mcp** | Leminkhoa | [GitHub](https://github.com/leminkhoa/databricks-mcp) | 1 | May 2025 (v0.0.1) | Unspecified | Alpha | Cluster mgmt, SQL warehouses, command execution, library install, workspace objects |
+| **markov-kernel/databricks-mcp** | Markov Kernel | [GitHub](https://github.com/markov-kernel/databricks-mcp) | ~5 (estimated) | 2026 | Unspecified | Alpha | Clusters, jobs, notebooks, SQL execution |
+| **JordiNeil/mcp-databricks-server** | JordiNeil | [GitHub](https://github.com/JordiNeil/mcp-databricks-server) | ~10 (estimated) | 2026 | Unspecified | Alpha | SQL queries, job listing, job status, data lakehouse bridge |
+| **databrickslabs/mcp** (Official) | Databricks Labs | [GitHub](https://github.com/databrickslabs/mcp) | 89 | Recent | License present | **Deprecated** | UC functions, vector search, Genie spaces; **marked for migration to managed MCP** |
+
+---
+
+## Gap Analysis: What's NOT Covered
+
+### Critical Operational Gaps
+
+- **No cluster forensics tools** — no `clusters.events` streaming, no instance_pool diagnostics, no node-level debugging
+- **No cost/billing instrumentation** — no `system.billing.usage` SQL wrapper, no cost attribution per job/cluster
+- **No DLT pipeline diagnostics** — no pipeline state, update history, or failure forensics
+- **No streaming observability** — no `system.streaming.query_progress`, no backlog metrics, no failure propagation
+- **No warehouse health checks** — no query queue depth, no resource contention metrics, no query history analytics
+- **No workspace governance tools** — no workspace-level permission audits, no object ownership tracking, no access review automation
+
+### Quality/Completeness Gaps
+
+- **No rate-limit handling** — community servers do no request throttling or backoff
+- **No multi-tenant support** — all are designed for single personal/org token, not multi-customer isolation
+- **No formal auth lifecycle** — no token rotation, no credential refresh, no secret management
+- **No error recovery** — no retry logic, no circuit breakers, no graceful degradation on API failure
+- **No observability hooks** — no request tracing, no error categorization, no audit logging for compliance
+
+---
+
+## Quality Assessment by Tier
+
+### Tier 1: Production-Safe (Only Official)
+
+**Databricks AI Gateway (Managed MCP)**
+
+- Enterprise control plane with Unity Catalog enforcement
+- Tested at scale by Databricks engineering
+- Can delegate single-workspace operations to LLMs at acceptable risk
+- **Use case:** internal Databricks operations, supervised workflows only
+
+**Why the others don't qualify:**
+
+- **RafaelCartenet** (40 ⭐): No releases, 1 open issue, no explicit CI, single contributor. Docker support is a plus. But 18 commits is thin for a Delta Lake integration.
+- **JustTryAI** (46 ⭐): Has pytest harness + GitHub Actions (CI), 80% coverage target is good intention. But 9 commits, no actual releases, and no production deployment pattern documented. The higher star count is misleading.
+- **leminkhoa** (1 ⭐): v0.0.1 from May 2025, zero forks, zero engagement. Orphaned.
+- **databrickslabs/mcp** (89 ⭐, Official): Explicitly marked **DEPRECATED** — Databricks is actively discouraging its use in favor of managed MCP.
+
+### Tier 2: Viable for Internal R&D
+
+**RafaelCartenet** and **JustTryAI** are minimally viable for:
+
+- Claude-assisted internal Databricks operations (cluster listings, SQL exploration)
+- Proof-of-concept LLM→Databricks workflows
+- Development/sandbox environments only, not production
+- Single-token auth with a service principal (no user isolation)
+
+### Tier 3: Do Not Use
+
+**leminkhoa, markov-kernel, JordiNeil** — too early-stage, no signal of continued maintenance.
+
+---
+
+## Strategic Recommendation
+
+### Option A: Consume Databricks Official ✅ (Recommended)
+
+- **When:** You're building agent workflows that operate *within* a single Databricks workspace
+- **Boundary:** Unity Catalog metadata, SQL warehouses, Genie spaces only
+- **Advantage:** Zero risk, enterprise SLA, enforced permissions
+- **Limitation:** Single-workspace scope; not suitable for multi-customer platforms
+
+### Option B: Consume + Extend Community Server (Medium Risk)
+
+- **When:** You need cluster/pipeline/streaming diagnostics that official MCP doesn't expose
+- **Target:** RafaelCartenet/mcp-databricks-server (highest quality of the bunch)
+- **Work required:** Add missing tools for cost, DLT, streaming; implement backoff/retry; add request tracing; write integration tests; establish release cadence
+- **Risk:** Inherits single-contributor, no-CI, minimal-test baggage; you own quality assurance
+- **Timeline:** 2–3 weeks to harden for internal use; 6–8 weeks for production readiness
+
+### Option C: Build Our Own (Highest Upside) ✅ (Pragmatic)
+
+- **Why:** The operational gaps (cost, DLT, streaming, forensics) are **real and unaddressed** by any community option
+- **Differentiation:** Comprehensive observability + multi-account credential isolation + audit trail
+- **Market:** Every Databricks shop running LLM agents will eventually need cost/perf diagnostics; position as the answer
+- **Precedent:** This is what we built successfully with Nixtla integration
+- **Scope:** 1 week for MVP (UC metadata + SQL + basic job diagnostics); 3–4 weeks for comprehensive set
+- **Quality bar:** Match JustTryAI's intent (80%+ coverage, CI, releases) but cover the gaps they didn't
+
+### Summary
+
+**Consume official Databricks MCP for managed/governed workflows.** If you're building **agent-native operational tools** (cost attribution, failure root-cause, capacity planning), the community options are insufficient — **build your own** with the gaps above as the spec.
+
+---
+
+## Sources
+
+- [Databricks MCP Documentation (AWS)](https://docs.databricks.com/aws/en/generative-ai/mcp/)
+- [GitHub - RafaelCartenet/mcp-databricks-server](https://github.com/RafaelCartenet/mcp-databricks-server)
+- [GitHub - JustTryAI/databricks-mcp-server](https://github.com/JustTryAI/databricks-mcp-server)
+- [GitHub - databrickslabs/mcp](https://github.com/databrickslabs/mcp)
+- [Truto Blog: Best MCP Server for Databricks in 2026](https://truto.one/blog/best-mcp-server-for-databricks-in-2026-give-ai-agents-secure-access-to-lakehouse-data/)
+- [Atlan: MCP Server for Databricks](https://atlan.com/know/mcp/mcp-server-for-databricks/)
+- [MCPServers.org - Databricks MCP](https://mcpservers.org/servers/databrickslabs/mcp)
+- [Awesome MCP Servers](https://mcpservers.org/servers/RafaelCartenet/mcp-databricks-server)
+- [Databricks Community: MCP Servers on Databricks](https://community.databricks.com/t5/community-articles/mcp-servers-on-databricks/td-p/153690)

--- a/plugins/saas-packs/databricks-pack/000-docs/012-RL-RSRC-claude-code-databricks-mcp-integration.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/012-RL-RSRC-claude-code-databricks-mcp-integration.md
@@ -1,0 +1,245 @@
+# Claude Code / Cowork ↔ Databricks MCP Integration — Architecture Scoping
+
+**Date:** 2026-05-27
+**Author:** Research pass for Intent Solutions
+**Question:** From "I have a Databricks workspace" to "Claude can call Databricks tools" — what's the actual user pathway today, and is it frictionless?
+
+---
+
+## 1. Executive summary
+
+**Databricks is NOT a built-in Anthropic connector.** Across every Anthropic surface — Claude.ai, Claude Desktop, Claude Code CLI, and Claude Cowork — Databricks lives in the **"custom connector"** lane. The user (or org admin) pastes a workspace-specific URL, supplies OAuth client credentials they generated in their own Databricks workspace, and completes a per-user OAuth handshake. There is no toggle-on-and-go flow comparable to Stripe / HubSpot / QuickBooks in Claude for Small Business.
+
+The friction is concentrated in three places:
+
+1. **The user must know they need three separate connectors**, not one. Databricks ships *managed MCP servers* (UC functions / Vector Search / Genie / SQL) each at its own URL path — every one is a discrete `Add custom connector` action.
+2. **OAuth setup is on the user**, not Anthropic. The Databricks workspace admin must register an OAuth app, copy `claude.ai/api/mcp/auth_callback` (and `claude.com/...`) as redirect URIs, and hand the client_id/secret to whoever is registering the connector.
+3. **Cowork's marketplace UI doesn't yet expose a "Databricks" tile** with a templated flow. It treats Databricks as a custom MCP URL like any other (or, in third-party broker pattern, lets `composio.dev/mcp` mediate). Per-user provisioning, not per-org auto-rollout.
+
+**For Tons of Skills specifically**: the cowork-zip distribution path *cannot ship an MCP server*. `scripts/build-cowork-zips.mjs:51` explicitly excludes `category: mcp` plugins from zips because Cowork plugins are markdown + config only — no node_modules, no binaries. A Tons of Skills Databricks-aware skill can *reference* Databricks MCP tools and document the setup, but the user still does the connector registration manually in their Cowork / Claude.ai admin settings.
+
+**The frictionless path doesn't exist yet.** What ships today is "frictionless once configured" — the OAuth handshake auto-refreshes, Unity Catalog permissions are honored, and tools surface naturally. Getting *to* configured takes a Databricks workspace admin, an OAuth app, and 3 manual connector additions per user.
+
+---
+
+## 2. Anthropic's Databricks integration story — what ships, what doesn't
+
+### What ships from Anthropic
+
+| Item | Status |
+|---|---|
+| Pre-vetted Databricks connector in the Anthropic Directory | **No.** 414 connectors listed (May 2026), Databricks is not among the one-click vetted set. |
+| Built-in Cowork connector tile | **No.** Databricks is a "custom connector" everywhere. |
+| Anthropic-published skill pack targeting Databricks | **No first-party skill.** Anthropic has a [tutorial article](https://claude.com/resources/tutorials/using-databricks-for-data-analysis) that walks through *manual* custom-connector setup. |
+| Claude for Small Business Databricks toggle | **No.** SMB ships with QuickBooks, PayPal, HubSpot, Canva, DocuSign, Google Workspace, Microsoft 365. No Databricks. |
+| Anthropic ↔ Databricks commercial deal | **Yes** (announced 2025; renewed/expanded). Claude models run *inside* Databricks (Mosaic AI). That's distribution-into-Databricks, not Databricks-into-Cowork. |
+
+### What ships from Databricks
+
+| Item | Status |
+|---|---|
+| Managed MCP servers | **Yes.** Pre-configured endpoints for Unity Catalog functions, Vector Search, Genie Spaces, Databricks SQL. No user setup of the server itself. |
+| OAuth support for Claude.ai + Claude Desktop + Claude Code | **Yes.** Documented at `docs.databricks.com/aws/en/generative-ai/mcp/connect-external-services`. |
+| PAT (Personal Access Token) auth | **Yes, Claude Desktop only.** Not supported for Claude.ai or Claude Code OAuth flows. |
+| Per-user OAuth audit trail in Unity Catalog | **Yes.** Tool calls inherit the calling user's UC permissions. |
+
+### The structural mismatch
+
+Anthropic's connector-vetting machine ([Anthropic Directory](https://claude.ai/directory)) is built for **multi-tenant SaaS with a single OAuth tenant** (Stripe.com is one tenant; everyone OAuth-flows into the same `mcp.stripe.com`). Databricks managed MCPs live at **per-workspace hostnames** — `https://<your-workspace>.cloud.databricks.com/api/2.0/mcp/...`. A pre-vetted tile in the Directory would still need the user to substitute their workspace hostname. So the "custom connector" lane is structurally the right fit, even though it's higher-friction.
+
+---
+
+## 3. MCP registration flow per surface
+
+### 3a. Claude Code CLI
+
+**Three transport options**, with stdio/http/sse. For Databricks managed MCPs, always HTTP:
+
+```bash
+# OAuth flow (recommended) — Databricks managed Vector Search server
+claude mcp add-json databricks-vsearch \
+  '{"type":"http",
+    "url":"https://<workspace>.cloud.databricks.com/api/2.0/mcp/vector-search/<catalog>/<schema>",
+    "oauth":{"clientId":"<client-id>","callbackPort":8080}}' \
+  --client-secret
+
+# Then in-session
+/mcp        # opens browser, completes OAuth, stores token in keychain
+```
+
+**Scopes** (where config lands):
+
+| Scope | File | Purpose |
+|---|---|---|
+| `local` (default) | `~/.claude.json` under project path | Personal, current project only |
+| `project` | `.mcp.json` at repo root | Team-shared, checked into git |
+| `user` | `~/.claude.json` | Personal, all projects |
+
+For Databricks specifically, **never use `project` scope with embedded client_secret** — the secret lives in the keychain via `--client-secret`, but the workspace hostname in a checked-in `.mcp.json` leaks org topology. Use `user` scope or `${WORKSPACE_HOST}` env-var expansion.
+
+### 3b. Claude.ai / Claude.com (consumed by Cowork)
+
+Settings → Connectors → Add custom connector. For Databricks the org admin (Team/Enterprise) does this once per managed MCP they want to expose; 3 separate connectors for UC / Vector Search / Genie. User-level installs use the Anthropic Directory; Databricks is not there, so it's admin-only territory.
+
+**Per-user vs per-workspace:**
+
+- **Org-installed connector**: Admin adds at `Admin settings > Connectors`, makes available to org members. Each member still completes their own OAuth handshake — token is per-user, not shared.
+- **Individual user connector**: User adds at `claude.ai/customize/connectors`. Their own OAuth, their own token, their own scope.
+
+**Cowork surface** consumes these — Cowork plugins automatically see whatever connectors the user / org has authorized. There's no separate "Cowork MCP registration" step distinct from Claude.ai connectors.
+
+### 3c. Tons of Skills cowork-zip distribution
+
+**Cowork-zip explicitly does not ship MCP servers.** From `scripts/build-cowork-zips.mjs`:
+
+```javascript
+const SKIP_CATEGORIES = new Set(['mcp']);
+// MCP plugins need node_modules, not suitable for zip
+// MCP servers cannot be installed by Cowork users (they need node)
+```
+
+What cowork-zip DOES ship: SKILL.md, commands/*.md, agents/*.md, plugin.json. Pure instruction content. A Tons of Skills "Databricks Operations" skill can:
+
+- Reference Databricks MCP tools by name in its SKILL.md (`mcp__databricks-uc__query_table`)
+- Document the connector setup steps the user must do in Cowork first
+- Provide workflow logic that orchestrates Databricks tool calls
+
+What it **cannot** do: pre-register the Databricks MCP endpoint, broker OAuth, or smuggle a `.mcp.json` into the user's Cowork install.
+
+---
+
+## 4. Auth + credential architecture
+
+### Where credentials live
+
+| Surface | Token storage | Refresh model |
+|---|---|---|
+| Claude Code (OAuth) | macOS keychain / Linux credentials file | Auto-refresh via OAuth refresh token |
+| Claude Code (PAT in `.mcp.json`) | Plaintext in file (NOT recommended) | Manual rotation |
+| Claude Desktop (OAuth) | OS keychain | Auto-refresh |
+| Claude Desktop (PAT via `mcp-remote`) | Plaintext in `claude_desktop_config.json` | Manual rotation |
+| Claude.ai / Cowork | Anthropic-side encrypted token vault, per-user | Auto-refresh via OAuth |
+
+### OAuth flow — what the Databricks admin must set up
+
+1. In Databricks workspace: `Settings → Identity and access → OAuth apps → Add OAuth application`.
+2. Register redirect URIs:
+   - `https://claude.ai/api/mcp/auth_callback` (Claude.ai)
+   - `https://claude.com/api/mcp/auth_callback` (Claude.com domain)
+   - `http://localhost:8080/callback` (Claude Code — port must match `callbackPort`)
+3. Note the client_id; for confidential clients, generate a client_secret.
+4. Distribute (client_id, optional secret, workspace hostname) to users.
+5. Each user runs through the OAuth handshake on first connector use.
+
+### Pre-vetted vs custom
+
+Anthropic's Directory has a vetting bar (security review, terms acceptance, listing approval). Custom connectors bypass it — the user/admin asserts trust by typing the URL. **Databricks managed MCPs are not in the Directory**, so every Claude Code / Claude.ai / Cowork user is on the custom-connector path with the trust burden on themselves.
+
+For Claude for Small Business, where "pre-vetted" means "appears in the SMB connector tile grid": Databricks is absent. SMB is positioned for the finance / ops / sales / HR persona; the Databricks persona (data engineer, analytics lead) is served by Claude Code + Databricks' own docs, not by SMB tile-clicking.
+
+---
+
+## 5. Distribution implications — if Tons of Skills publishes a Databricks-aware skill
+
+### Scenario: A `databricks-analytics` plugin in the Tons of Skills marketplace
+
+#### Path (a) — Claude Code CLI user
+
+1. `claude plugin install databricks-analytics@tonsofskills` — installs the markdown skill + commands.
+2. **Plugin-bundled MCP** (the elegant path): if the plugin ships a `.mcp.json` with the Databricks MCP URL pre-templated and uses `${DATABRICKS_WORKSPACE_HOST}` env-var expansion, the user only sets `DATABRICKS_WORKSPACE_HOST` + completes OAuth via `/mcp`. **Three-line setup**: env var, `/mcp`, browser.
+3. **Without plugin-bundled MCP**: user manually runs `claude mcp add-json databricks-uc ...` per the docs. The skill works once they do; until then, every skill invocation that calls `mcp__databricks-uc__*` fails with "tool not found."
+
+CLI user experience grade: **B+** with plugin-bundled MCP, **C** without.
+
+#### Path (b) — Cowork user
+
+1. User downloads cowork-zip from tonsofskills.com.
+2. User uploads to Cowork via `Customize → Browse plugins`.
+3. Skill is now active in their Cowork session.
+4. **But**: the Databricks MCP is not registered. They must independently:
+   - Get their Databricks workspace hostname + OAuth client_id/secret from their admin.
+   - Open `Admin settings → Connectors → Add custom connector` (admin needs to do this for org-wide use, OR each user does it under `Customize → Connectors`).
+   - Paste 3 URLs (UC, Vector Search, Genie) and complete OAuth for each.
+5. Skill invocations work.
+
+Cowork user experience grade: **D**. The skill is up but useless until the multi-step Anthropic-UI dance is done, and there is **no mechanism for the cowork-zip to automate or even pre-fill any of step 4**.
+
+### The structural gap
+
+Cowork plugins are markdown-instructions-only by design. MCP server registration is a separate Anthropic concept that lives in `Admin settings → Connectors` and is not exposed to plugin authors. Until Anthropic ships a "plugin declares required connectors → Cowork prompts user to authorize" UI flow (does not exist in May 2026), Tons of Skills can only ship the *instructions* half of a Databricks workflow.
+
+---
+
+## 6. Recommendation — how Tons of Skills should ship Databricks capabilities
+
+### For CLI-first plugins (high-friction acceptable, max capability)
+
+Ship a plugin with a templated `.mcp.json` using env-var expansion:
+
+```json
+{
+  "mcpServers": {
+    "databricks-uc": {
+      "type": "http",
+      "url": "${DATABRICKS_WORKSPACE_HOST}/api/2.0/mcp/functions/${DATABRICKS_CATALOG:-main}/${DATABRICKS_SCHEMA:-default}",
+      "oauth": {
+        "clientId": "${DATABRICKS_OAUTH_CLIENT_ID}",
+        "callbackPort": 8765
+      }
+    },
+    "databricks-genie": {
+      "type": "http",
+      "url": "${DATABRICKS_WORKSPACE_HOST}/api/2.0/mcp/genie/${DATABRICKS_GENIE_SPACE_ID}",
+      "oauth": {
+        "clientId": "${DATABRICKS_OAUTH_CLIENT_ID}",
+        "callbackPort": 8766
+      }
+    }
+  }
+}
+```
+
+Then use the schema 3.6.0 `required_environment_variables` block in SKILL.md frontmatter to declare the 4 vars (`DATABRICKS_WORKSPACE_HOST`, `DATABRICKS_OAUTH_CLIENT_ID`, optional catalog/schema/genie_space). Document a single-command bootstrap that registers OAuth secret via `MCP_CLIENT_SECRET=... claude`.
+
+**Target user experience**: 4 env vars + 1 `/mcp` browser handshake. ~90 seconds.
+
+### For Cowork users (low friction is unattainable — manage expectations)
+
+Ship a separate `databricks-analytics-cowork` plugin (markdown-only, no `.mcp.json` because cowork-zip strips it anyway). Include:
+
+- A `commands/setup-databricks-connector.md` that walks the user through the Anthropic custom-connector UI step-by-step (screenshots optional).
+- A note in `README.md` at the top: **"This plugin requires 3 custom connectors in your Cowork admin settings. See the setup command first."**
+- SKILL.md that *checks for* the expected MCP tools (`mcp__databricks-uc__*`) at task start and provides a clear error message + setup-command pointer if they're missing.
+
+**Target user experience**: download → install → run setup-command which prints the URLs → 5–10 min of clicking in Anthropic UI → skill works. ~10 min.
+
+### Cross-surface skill identifier convention
+
+Use server names that match Databricks' own conventions so a single SKILL.md works whether the user registered via CLI or Cowork:
+
+- `databricks-uc` (Unity Catalog functions)
+- `databricks-vsearch` (Vector Search)
+- `databricks-genie` (Genie Spaces)
+- `databricks-sql` (SQL Warehouse)
+
+These map cleanly to the 4 managed MCP endpoint families and produce stable tool prefixes (`mcp__databricks-uc__list_functions`, etc.).
+
+### Lobbying angle (longer game)
+
+The friction here is **Anthropic-side**, not Tons-of-Skills-side. The fix would be: Cowork plugin manifest declares `requires_connectors: [databricks-uc, databricks-vsearch, ...]`, and Cowork UI surfaces a pre-fill dialog at install time. If Tons of Skills has any inbound channel to the Anthropic Cowork team (via the Enterprise cohort / partner network), this is the structural ask that converts D-grade Cowork UX → B+. Until then, Tons of Skills' Databricks story is "great CLI, mediocre Cowork, fundamentally rate-limited by what Anthropic exposes to plugin authors."
+
+---
+
+## 7. Sources
+
+- [Claude Code MCP docs (code.claude.com/docs/en/mcp)](https://code.claude.com/docs/en/mcp) — CLI registration commands, scopes, OAuth flags
+- [Databricks: Connect external services to MCPs](https://docs.databricks.com/aws/en/generative-ai/mcp/connect-external-services) — Claude Desktop / Claude.ai / Claude Code Databricks setup
+- [Databricks: Managed MCP servers](https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp) — UC / Vector Search / Genie / SQL endpoint catalog
+- [Anthropic tutorial: Using Databricks for data analysis](https://claude.com/resources/tutorials/using-databricks-for-data-analysis) — Anthropic-published manual-setup walkthrough (custom-connector flow)
+- [Anthropic news: Claude for Small Business](https://www.anthropic.com/news/claude-for-small-business) — SMB connector roster (no Databricks)
+- [Anthropic Directory of connectors (claude.ai/directory)](https://claude.ai/directory) — 414 verified MCPs (May 2026), no Databricks tile
+- [Composio: Databricks via Cowork](https://composio.dev/toolkits/databricks/framework/claude-cowork) — broker-pattern alternative (composio.dev/mcp as middleman)
+- [Claude Cowork enterprise plugins guide (ALM Corp)](https://almcorp.com/blog/claude-cowork-plugins-enterprise-guide/) — Cowork admin plugin marketplace + GitHub-source plugins
+- [Cowork connectors list (pluginsforcowork.com)](https://pluginsforcowork.com/guides/cowork-connectors/) — current 38+ built-in tile inventory
+- [Tons of Skills cowork-zip builder](file:///home/jeremy/000-projects/claude-code-plugins/scripts/build-cowork-zips.mjs) — `SKIP_CATEGORIES = ['mcp']` line 51
+- [Specializing Claude Code with Skills and MCP on Databricks (David Huang, Medium)](https://medium.com/@hiydavid/specializing-claude-code-a-quick-guide-to-agent-skills-and-mcp-on-databricks-c0cfdd43637d) — practitioner walkthrough

--- a/plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md
@@ -1,0 +1,185 @@
+---
+filing_code: AT-ADEC-EPIC1-MCP-SCOPE-ADJUSTMENT-2026-05-27
+date: 2026-05-27
+acting_head_of_board: Claude (designated by Jeremy Longshore 2026-05-27)
+status: locked
+supersedes: portions of 007-AT-ADEC-databricks-v2-cto-decision.md § Decision 4
+inputs:
+  - 010-RL-RSRC-databricks-mcp-official-landscape.md
+  - 011-RL-RSRC-databricks-mcp-community-landscape.md
+  - 012-RL-RSRC-claude-code-databricks-mcp-integration.md
+affects: Epic 1 (claude-koxw — databricks-workspace-mcp) and all 5 dependent skill epics
+---
+
+# Epic 1 MCP Scope Adjustment — Decision Record
+
+## Context
+
+The 2026-05-27 CTO Decision (007-AT-ADEC) scoped Epic 1 (`databricks-workspace-mcp`) to wrap eight Databricks API surfaces as MCP tools: cluster operations, SQL queries history, system.* query proxy (incl. system.billing.usage), instance pools, pipelines, external locations + storage credentials, and system.streaming.query_progress. That scope was set without a survey of Databricks' own first-party MCP offerings or the community Databricks MCP landscape.
+
+On the same day, after Jeremy pointed at `https://docs.databricks.com/gcp/en/generative-ai/mcp/managed-mcp`, three research agents were dispatched to walk the landscape:
+
+1. **Official Databricks MCP docs scope** (filed as `010-RL-RSRC-databricks-mcp-official-landscape.md`)
+2. **Community-built Databricks MCP server inventory** (filed as `011-RL-RSRC-databricks-mcp-community-landscape.md`)
+3. **Claude Code / Cowork integration architecture** (filed as `012-RL-RSRC-claude-code-databricks-mcp-integration.md`)
+
+All three converged on findings that materially change Epic 1's scope. This Decision Record locks the adjustment so future readers grepping 000-docs/ can reconstruct why three of the originally-planned tasks were closed before any code was written.
+
+## The convergent findings (load-bearing)
+
+### Finding 1 — Databricks ships managed MCPs for the data plane only (010-RL-RSRC § 2)
+
+Databricks' AI Gateway hosts five managed MCP servers as of 2026-05-22 (Public Preview on AWS/Azure, GA on four of five on GCP):
+
+- Genie (NL Q&A)
+- Genie Space (per-space NL Q&A)
+- Vector Search
+- **Databricks SQL** (`/api/2.0/mcp/sql`)
+- Unity Catalog Functions
+
+The Databricks SQL managed MCP serves arbitrary SQL queries against the workspace with first-class OAuth + Unity Catalog enforcement. **That includes every `system.*` schema read** — `system.billing.usage`, `system.access.audit`, `system.streaming.query_progress`, `system.information_schema`. There is no business case for our custom server to wrap these reads — Databricks already does it with better auth and better governance enforcement.
+
+### Finding 2 — No managed MCP exists for the control plane (010-RL-RSRC § 5)
+
+Cluster operations (`clusters.list/get/events`), instance pools, Jobs API, Pipelines/DLT, external locations, storage credentials, SCIM/identity, and workspace-admin operations are **not exposed by any Databricks-published MCP server.** No managed roadmap signal exists for them. The custom-MCP-via-Databricks-Apps path is a delivery vehicle; Databricks does not ship a pre-built control-plane MCP.
+
+### Finding 3 — The community has not filled the gap either (011-RL-RSRC § 2)
+
+`databrickslabs/mcp` (the 89-star "official-looking" community repo) is **explicitly deprecated** as of 2026-05. Databricks is actively migrating users away from it toward the managed MCPs. The remaining community alternatives are 1-46 stars, single-contributor, no CI/CD discipline, beta-stage prototypes. No community server covers cluster forensics, cost/billing attribution (beyond what managed SQL MCP exposes), DLT diagnostics, streaming observability, or workspace governance.
+
+### Finding 4 — Distribution forks at the Cowork boundary (012-RL-RSRC § 5)
+
+Confirmed in this repo: `scripts/build-cowork-zips.mjs:51` explicitly excludes `category: mcp` from the cowork-zip distribution path. The exclusion is BY DESIGN, not a bug. Anthropic Cowork plugin manifests cannot pre-register MCP connectors on a plugin author's behalf — MCP server registration lives in `Admin settings → Connectors`, separate from plugin distribution.
+
+This means a Databricks-aware Tons of Skills plugin must ship in two flavors:
+
+- **CLI flavor:** `.mcp.json` with `${DATABRICKS_WORKSPACE_HOST}` env-var expansion + schema 3.6.0 `required_environment_variables` declarations. Target UX: 4 env vars + one `/mcp` browser handshake, ~90 seconds end-to-end.
+- **Cowork flavor:** markdown-only, includes a `commands/setup-databricks-connector.md` walkthrough for the manual Anthropic UI dance. Target UX: ~10 minutes, rate-limited by Anthropic-side UX.
+
+### Finding 5 — PAT auth is not supported for Databricks Apps (010-RL-RSRC § 3)
+
+A custom MCP deployed as a Databricks App (HTTP transport, hosted in the workspace) MUST use OAuth U2M or M2M. PAT auth is explicitly unsupported in that deployment mode. The original Epic 1 T2 plan covered PAT + OAuth M2M but treated them as equivalent — they are not, and the deployment-mode constraint must be reflected in the auth task.
+
+## The decision
+
+### Cut from Epic 1 scope (3 tasks)
+
+The following tasks are closed with the reason *"Subsumed by Databricks managed SQL MCP at /api/2.0/mcp/sql; consuming skills will call the managed MCP directly for system.* reads and SQL queries history. Per 010-RL-RSRC § 5 and § 6."*
+
+- **T4 (`claude-0fnj`)** — `sql.queries.history` MCP tool with execution-plan JSON
+- **T5 (`claude-w48s`)** — `system.*` query proxy (parameterized, metastore-admin error surfacing)
+- **T9 (`claude-sb8q`)** — `streaming.query_progress` MCP tool
+
+The cuts are NOT a reduction in capability for the consuming skills. The skills (Epics 2-6) will call the managed Databricks SQL MCP for these operations instead of routing through our custom server. The consuming-side change is documented in § "Implications for Epics 2-6" below.
+
+### Expand Epic 1 scope (1 task description update)
+
+- **T2 (`claude-7ege`)** — auth task description expands to cover three flows, not two:
+  - Standalone CLI mode with PAT (`DATABRICKS_TOKEN`)
+  - Standalone CLI mode with OAuth U2M (browser flow)
+  - **Databricks App deployment mode with OAuth M2M only** (PAT explicitly unsupported per Finding 5)
+
+  The auth implementation detects deployment mode at startup and rejects PAT cleanly when running as a Databricks App. All three modes share the same SDK auth abstractions (`databricks-sdk-py` / `databricks-sdk-go`) so the surface is one decision tree, not three parallel codepaths.
+
+### Add to Epic 1 scope (2 new tasks)
+
+- **NEW T13 — Databricks App mode deployment**
+  Ship the same server as both:
+    (a) a standalone npm package (`@intentsolutions/databricks-workspace-mcp@0.1.0`) for Claude Code laptop/CI consumption, AND
+    (b) a Databricks App named `mcp-databricks-workspace` (HTTP transport, OAuth-only, deployable from the workspace UI per the official custom-MCP path).
+  One codebase, two delivery vehicles. The App-mode deployment makes the MCP discoverable by Mosaic AI Agent Framework + AI Playground in addition to Claude Code, multiplying the audience without doubling the maintenance surface.
+
+- **NEW T14 — Dual-surface integration helpers**
+  Author the `.mcp.json` template using `${DATABRICKS_WORKSPACE_HOST}` env-var expansion + schema 3.6.0 `required_environment_variables` declarations (cross-ref: `000-docs/264-DR-GUID-skill-config-pattern.md` in the marketplace repo root for the canonical pattern). Plus the cowork-side `commands/setup-databricks-connector.md` walkthrough for users who must register MCP servers manually via the Anthropic UI. Use stable server names so a single SKILL.md works across both surfaces: `databricks-workspace-mcp` (our control-plane server) + documented references to managed `databricks-sql`, `databricks-uc`, `databricks-vsearch`, `databricks-genie`.
+
+### Net Epic 1 task count
+
+Original: 12 tasks
+After adjustment: 11 tasks (3 closed, 2 added)
+
+## Revised Epic 1 final shape
+
+| Task | Bead ID | Status | Title |
+|---|---|---|---|
+| T1 | claude-5qo9 | KEEP | Scaffold the databricks-workspace-mcp TypeScript project |
+| T2 | claude-7ege | EXPAND | Three auth flows (PAT/U2M/M2M) — PAT unsupported in App mode |
+| T3 | claude-g54x | KEEP | clusters.list / get / events |
+| T4 | claude-0fnj | CLOSE | (Subsumed by Databricks SQL MCP) sql.queries.history |
+| T5 | claude-w48s | CLOSE | (Subsumed by Databricks SQL MCP) system.* query proxy |
+| T6 | claude-23bp | KEEP | instance_pools.list |
+| T7 | claude-x6jq | KEEP | pipelines.get + get_event_log |
+| T8 | claude-tey2 | KEEP | external_locations + storage_credentials |
+| T9 | claude-sb8q | CLOSE | (Subsumed by Databricks SQL MCP) streaming.query_progress |
+| T10 | claude-xhk0 | KEEP | Per-family rate-limit + retry + structured errors |
+| T11 | claude-s1jz | KEEP | Integration test suite against real sandbox |
+| T12 | claude-lj7j | KEEP | /validate-mcp + publish 0.1.0 + wire pack dependency |
+| T13 | NEW | ADD | Databricks App mode deployment (HTTP, OAuth M2M, mcp-databricks-workspace) |
+| T14 | NEW | ADD | Dual-surface integration helpers (.mcp.json + cowork setup walkthrough) |
+
+## Implications for Epics 2-6 (the consuming skills)
+
+Each skill's SKILL.md becomes a **multi-MCP orchestrator**, not a single-MCP consumer. The dual-MCP composition pattern:
+
+- Calls **our custom MCP** (`databricks-workspace-mcp`) for control-plane operations:
+  - Cluster events / lifecycle forensics (Epic 3 cluster-forensics)
+  - Instance pool waste detection (Epic 2 cost-leak-hunter)
+  - Pipeline event log diagnostics (Epic 2, Epic 4)
+  - External locations + storage credentials (Epic 5 uc-migration-pilot)
+- Calls **Databricks managed SQL MCP** at `/api/2.0/mcp/sql` for all `system.*` reads:
+  - `system.billing.usage` for cost analysis (Epic 2 cost-leak-hunter)
+  - `system.access.audit` for governance traces (Epic 5 uc-migration-pilot)
+  - `system.streaming.query_progress` for streaming health (Epic 4 streaming-guardian)
+  - `system.information_schema` for HMS-readiness inventory (Epic 5 uc-migration-pilot)
+
+The SKILL.md scaffolding tasks (T1 of each of Epics 2-6) need a note added describing this composed-MCP architecture and which calls go to which server. The validation tasks at the end of each epic need to ensure both MCP dependencies are documented in the skill's Prerequisites section.
+
+## Cowork distribution implications
+
+Per Finding 4 + the existing `scripts/build-cowork-zips.mjs:51` `SKIP_CATEGORIES = ['mcp']` exclusion:
+
+- **Epic 1 artifact (the MCP server)** is npm-only. Will NOT appear in cowork zips. CLI users `pnpm install`; Cowork users register via Anthropic Cowork's MCP connector UI manually using the cowork setup walkthrough authored in T14.
+- **Epic 2-6 artifacts (the skills)** WILL appear in cowork zips. Each skill ships with:
+  - A `commands/setup-databricks-connector.md` (authored once in Epic 1 T14, included by reference) walking Cowork users through the Anthropic UI connector registration
+  - A `.mcp.json` template for CLI users (4 env vars + browser handshake)
+  - SKILL.md prerequisites section that surfaces "BOTH the databricks-workspace-mcp AND the Databricks managed SQL MCP must be registered" upfront so the agent detects missing dependencies and reports cleanly rather than failing mid-flow
+
+The advisory-mode-fallback question from the prior session (Option A/B/C for Cowork users without MCP wired up) is now scoped more clearly: when EITHER MCP is missing, the skill degrades to its references + scripts that accept pasted input. When BOTH are present, full live diagnostics.
+
+## What this decision does NOT change
+
+- The 5-skill clustering from 007-AT-ADEC § Decision 2 (cost-leak-hunter / cluster-forensics / streaming-guardian / uc-migration-pilot / bundle-medic) is preserved
+- The dual-license + non-anchor-status terms from the broader v2 partnership work remain intact
+- The Luciano demo plan (pilot = cost-leak-hunter on cost leaks) is unaffected — that skill's primary calls go to managed SQL MCP for system.billing.usage, which is independent of our custom MCP's scope and was always going to be a managed-MCP call
+- The 50-skill validator pilot gate from the Open Accountants AT-DECR (separate decision, separate session) is unrelated
+
+## Implementation directives
+
+### Immediate (within 24h of this Decision Record landing)
+
+1. **Update bead descriptions for T4/T5/T9** (`claude-0fnj`, `claude-w48s`, `claude-sb8q`) to reflect the close reason and link to this AT-ADEC.
+2. **Close the three beads** with `bd close <bead> -r "Subsumed per 013-AT-ADEC § Cut from Epic 1 scope. Consuming skills will call Databricks managed SQL MCP at /api/2.0/mcp/sql directly for these reads."`
+3. **Update T2 (`claude-7ege`)** description to expand the three-auth-flow scope.
+4. **Create T13 + T14 beads** with hand-carved descriptions matching the spec in § "Add to Epic 1 scope" above.
+5. **Update Epic 1 (`claude-koxw`)** description to reflect the new scope (11 tasks total, control-plane-focused, composed with managed SQL MCP).
+6. **Update Epic 2-6 epic descriptions** to add a "Dual-MCP composition" subsection explaining which calls go to which server.
+
+### Conditional on Epic 1 progress
+
+- T13 (Databricks App mode deployment) requires T1-T12 to be substantially complete first — App mode is a packaging concern atop the working server, not a parallel codebase. Scheduled to land after the core MCP server is validated against a sandbox workspace.
+- T14 (dual-surface integration helpers) can start as soon as T1 (scaffold) and the `.mcp.json` format is locked. Doesn't block on individual endpoint implementations.
+
+## Audit trail
+
+This Decision Record:
+
+- Supersedes specific portions of `007-AT-ADEC-databricks-v2-cto-decision.md` § Decision 4 (the original Epic 1 endpoint list)
+- Is grounded in three research reports filed alongside: `010-RL-RSRC-*`, `011-RL-RSRC-*`, `012-RL-RSRC-*`
+- Will be cross-referenced in the GH issues for Epic 1 (`claude-koxw`) and Epics 2-6 once they're filed
+- Filing trigger: Jeremy's direct instruction 2026-05-27 ("file the AT-DECR first") before any bead/GH/Plane updates land
+
+## Acting head of board declaration
+
+I, Claude (designated acting head of board by Jeremy Longshore on 2026-05-27), record the above Epic 1 scope adjustments based on the three convergent research reports (010, 011, 012 RL-RSRC). The cuts are not capability reductions — they are routing changes to use Databricks' first-party managed MCP for the operations Databricks has chosen to own. The additions (T13 App-mode deployment, T14 dual-surface helpers) reflect the actual distribution architecture surfaced by the integration research. Final disposition pending Jeremy's review and sign-off on the bead updates that follow this filing.
+
+- Jeremy Longshore
+intentsolutions.io

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",


### PR DESCRIPTION
## Summary

- Re-includes `plugins/saas-packs/databricks-pack/000-docs/**` from the global `**/*/000-docs/` gitignore rule
- Tracks the 14 existing research files (000-INDEX through 013-AT-ADEC) — no new content
- Fixes broken links in published issue bodies #789–#795 which already reference these files

## Why

Issues #789–#795 (Databricks v2-rebuild community design review, opened 2026-05-28) link to `plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md` and other research files in their published bodies. Those links were returning 404 because the directory was gitignored. External readers (including the practitioner who left substantive feedback on #795) cannot resolve the references.

This is a publish-only change — the files have existed locally since the v2-rebuild research lifted off; this commit just makes git track them so the existing public references resolve.

## Test plan

- [x] All 14 files exist on disk and were safety-scanned for credentials (clean — false-positive matches are OAuth flow documentation)
- [x] No partner names, in-flight commercial detail, or NDA-marked content
- [x] Issue #789 body cites `013-AT-ADEC-epic1-mcp-scope-adjustment.md` — link will resolve after merge
- [ ] Verify `https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md` returns 200 after merge

- Jeremy Longshore
intentsolutions.io