### PR TITLE
feat(ci): add broken-link checkers (lychee + live issue-body audit)

### DIFF
--- a/.github/workflows/check-issue-body-links.yml
+++ b/.github/workflows/check-issue-body-links.yml
@@ -1,0 +1,73 @@
+name: Check Live Issue/PR Body Links
+
+# Audits live GitHub issue + PR bodies for broken repo-relative links.
+# Closes the gap that bit us on 2026-05-30 (issue #789 cited a gitignored
+# 000-docs/ path; lychee couldn't catch it because the broken reference
+# lived in a GitHub issue body, not a committed .md file).
+#
+# Runs weekly + on demand. Uploads the report as a build artifact.
+# Failure does not block any PR — this is a watchdog, not a gate. If
+# the report shows broken links, fix them by either publishing the
+# referenced path (gitignore re-include + commit) or by updating the
+# issue/PR body to point elsewhere.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — runs an hour after the repo-side lychee job.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      include_closed:
+        description: 'Include closed issues + PRs in the audit'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run live-body audit
+        id: audit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          ARGS=""
+          if [ "${{ inputs.include_closed }}" = "true" ]; then
+            ARGS="--closed"
+          fi
+          node scripts/check-issue-body-links.mjs $ARGS \
+            > issue-body-link-report.md 2> audit.stderr
+          AUDIT_EXIT=$?
+          cat audit.stderr
+          echo "audit_exit=${AUDIT_EXIT}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: issue-body-link-report-${{ github.run_id }}
+          path: issue-body-link-report.md
+          retention-days: 90
+
+      - name: Surface failure to summary
+        if: steps.audit.outputs.audit_exit != '0'
+        run: |
+          {
+            echo "## Live issue/PR body link audit found broken references"
+            echo ""
+            cat issue-body-link-report.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,63 @@
+name: Check Markdown Links
+
+# Runs lychee against every .md file in the repo. Catches broken intra-repo
+# relative links AND broken external links. Required on PRs touching .md;
+# also runs weekly on a schedule so external-host rot gets surfaced.
+#
+# Gap this closes: prior to 2026-05-30 the repo had no broken-link checker.
+# A link in issue #789 (and later in PR #805's pre-merge body) pointed at a
+# gitignored file path; no CI gate caught it because no link checker existed.
+# This workflow + .lychee.toml at the repo root close the repo-side half of
+# that gap. The live-issue-body half is closed by check-issue-body-links.yml.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.lychee.toml'
+      - '.github/workflows/check-links.yml'
+  schedule:
+    # Mondays 05:00 UTC — catch external-host rot weekly.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .lychee.toml
+            --base .
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            './**/*.md'
+            './**/*.mdx'
+          # Fail PR builds; on schedule, upload report and surface failure non-fatally
+          fail: ${{ github.event_name == 'pull_request' }}
+          output: ./lychee-report.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report-${{ github.run_id }}
+          path: ./lychee-report.md
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           args: >-
             --config .lychee.toml
-            --root-dir /github/workspace
+            --root-dir ${{ github.workspace }}
             --no-progress
             --cache
             --max-cache-age 1d

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           args: >-
             --config .lychee.toml
-            --base .
+            --root-dir /github/workspace
             --no-progress
             --cache
             --max-cache-age 1d

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,64 @@
+# lychee config — repo-side broken-link checker
+# Invoked by .github/workflows/check-links.yml on PRs touching .md files
+# and on the weekly schedule. Local: `lychee --config .lychee.toml '**/*.md'`
+
+# Skip these directories entirely
+exclude_path = [
+  "node_modules",
+  ".git",
+  "marketplace/dist",
+  "marketplace/.astro",
+  "marketplace/.cache",
+  "marketplace/public/downloads",
+  "plugins/*/dist",
+  "plugins/*/node_modules",
+  "freshie/cache",
+  ".audit-harness",
+  "coverage",
+  ".pnpm-store",
+]
+
+# HTTP statuses to treat as success.
+# 403 / 429 are routinely returned by GitHub, Twitter/X, and other rate-limiting
+# hosts even when the link is fine — accept them rather than spam false positives.
+accept = [200, 206, 301, 302, 304, 403, 429]
+
+# Per-request timeout (seconds)
+timeout = 20
+
+# Allow up to N redirects before giving up
+max_redirects = 10
+
+# Cache successful checks for a day so re-runs don't re-hit every host
+cache = true
+max_cache_age = "1d"
+
+# Be polite — don't fire 100 concurrent requests at one host
+max_concurrency = 4
+
+# Skip these URL patterns entirely
+exclude = [
+  # Local dev hosts
+  "^https?://localhost",
+  "^https?://127\\.0\\.0\\.1",
+  "^https?://\\[::1\\]",
+  # Tailnet hosts (intentsolutions VPS internal)
+  "^https?://intentsolutions(\\.|:)",
+  "^https?://167\\.86\\.106\\.29",
+  # Pure anchor links (no path component)
+  "^#",
+  # Example placeholder domains
+  "^https?://example\\.(com|org|net)",
+  "^https?://target\\.example",
+  "^https?://your-",
+  # Placeholder schemes from code samples
+  "^mailto:.*example",
+  # Known-flaky external sources we cite in references
+  # (add as discovered; document why per entry)
+]
+
+# Respect Cache-Control / 429 retry-after
+retry_wait_time = 2
+
+# User-agent so target hosts can identify us in their logs
+user_agent = "lychee/intentsolutions-claude-code-plugins-link-check"

--- a/scripts/check-issue-body-links.mjs
+++ b/scripts/check-issue-body-links.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Audits live GitHub issue + PR bodies for broken repo-relative links.
+ *
+ * Why this exists: lychee/markdown-link-check scan files committed to the repo.
+ * They cannot catch the failure mode that bit us on 2026-05-30, where an issue
+ * body cited a repo path (`plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md`)
+ * that was gitignored — the linked path did not exist in the public tree, so
+ * the `github.com/.../blob/main/...` URL returned 404. No repo-side checker
+ * scans issue bodies; this script does.
+ *
+ * Logic:
+ *   1. Fetch all open issues + PRs via `gh` CLI.
+ *   2. Extract every markdown-style and bare URL from each body.
+ *   3. Categorize each URL:
+ *      - GitHub blob/tree pointing into this repo → verify the path is tracked
+ *        by `git ls-files`. If not tracked, it's broken (gitignored / deleted).
+ *      - Repo-rooted (`/plugins/...`) or relative (`./...`) → same check.
+ *      - External (non-github) URLs → out of scope (use lychee/repo workflow).
+ *      - Anchor-only (`#section`) → out of scope.
+ *   4. Report broken repo-path references grouped by container (issue/PR).
+ *   5. Exit 1 if any broken; 0 otherwise.
+ *
+ * Local usage:
+ *   node scripts/check-issue-body-links.mjs
+ *   node scripts/check-issue-body-links.mjs --max 1000   # widen the cap
+ *   node scripts/check-issue-body-links.mjs --closed    # include closed too
+ *
+ * CI usage:
+ *   See .github/workflows/check-issue-body-links.yml.
+ */
+
+import { execSync } from 'child_process';
+
+const REPO_OWNER = 'jeremylongshore';
+const REPO_NAME = 'claude-code-plugins-plus-skills';
+const REPO_SLUG = `${REPO_OWNER}/${REPO_NAME}`;
+
+const args = process.argv.slice(2);
+const MAX_ITEMS = (() => {
+  const i = args.indexOf('--max');
+  return i >= 0 ? Number(args[i + 1]) : 500;
+})();
+const INCLUDE_CLOSED = args.includes('--closed');
+const STATE = INCLUDE_CLOSED ? 'all' : 'open';
+
+function ghJson(cmd) {
+  return JSON.parse(execSync(cmd, { encoding: 'utf-8', maxBuffer: 200 * 1024 * 1024 }));
+}
+
+function gitTrackedFiles() {
+  return new Set(
+    execSync('git ls-files', { encoding: 'utf-8', maxBuffer: 200 * 1024 * 1024 })
+      .split('\n')
+      .filter(Boolean),
+  );
+}
+
+process.stderr.write(`Fetching ${STATE} issues from ${REPO_SLUG}...\n`);
+const issues = ghJson(
+  `gh issue list --repo ${REPO_SLUG} --state ${STATE} --limit ${MAX_ITEMS} --json number,title,body,url`,
+);
+process.stderr.write(`  ${issues.length} issues\n`);
+
+process.stderr.write(`Fetching ${STATE} PRs from ${REPO_SLUG}...\n`);
+const prs = ghJson(
+  `gh pr list --repo ${REPO_SLUG} --state ${STATE} --limit ${MAX_ITEMS} --json number,title,body,url`,
+);
+process.stderr.write(`  ${prs.length} PRs\n`);
+
+const tracked = gitTrackedFiles();
+process.stderr.write(`Git tree: ${tracked.size} tracked files\n\n`);
+
+// Match markdown links: [text](url) — capture the url
+const MD_LINK_RE = /\[(?:[^\]]*)\]\(([^)]+)\)/g;
+// Match bare URLs in prose (but not URLs already captured by MD_LINK_RE since
+// they're inside parens — the negative lookbehind excludes them).
+const BARE_URL_RE = /(?<![([\w])https?:\/\/[^\s<>"'`)]+/g;
+
+function extractLinks(body) {
+  const out = new Set();
+  if (!body) return out;
+  for (const m of body.matchAll(MD_LINK_RE)) out.add(m[1]);
+  for (const m of body.matchAll(BARE_URL_RE)) out.add(m[0]);
+  return out;
+}
+
+const GH_BLOB_RE = new RegExp(
+  `^https?://github\\.com/${REPO_OWNER}/${REPO_NAME}/(?:blob|tree|raw)/[^/]+/(.+)$`,
+  'i',
+);
+
+function categorize(url) {
+  const cleaned = url.trim().replace(/[.,;]$/, '');
+  if (cleaned.startsWith('#')) return { kind: 'anchor' };
+
+  if (/^https?:\/\//i.test(cleaned)) {
+    const m = cleaned.match(GH_BLOB_RE);
+    if (m) {
+      // Strip query/fragment from the path
+      const path = m[1].replace(/[#?].*$/, '');
+      return { kind: 'github-blob', path, original: cleaned };
+    }
+    return { kind: 'external', url: cleaned };
+  }
+
+  if (cleaned.startsWith('/')) {
+    return {
+      kind: 'repo-rooted',
+      path: cleaned.slice(1).replace(/[#?].*$/, ''),
+      original: cleaned,
+    };
+  }
+
+  if (cleaned.startsWith('./') || cleaned.startsWith('../')) {
+    return { kind: 'relative', original: cleaned };
+  }
+
+  // Bare schemes like mailto:, irc:, etc.
+  if (cleaned.match(/^[a-z]+:/i)) return { kind: 'other-scheme', original: cleaned };
+
+  return { kind: 'unknown', original: cleaned };
+}
+
+const broken = [];
+
+for (const list of [
+  { kind: 'issue', items: issues },
+  { kind: 'pr', items: prs },
+]) {
+  for (const item of list.items) {
+    const urls = extractLinks(item.body);
+    for (const url of urls) {
+      const cat = categorize(url);
+      if (cat.kind === 'github-blob' || cat.kind === 'repo-rooted') {
+        if (!tracked.has(cat.path)) {
+          broken.push({
+            container: `${list.kind} #${item.number}`,
+            title: item.title,
+            itemUrl: item.url,
+            link: cat.original,
+            reason: `path "${cat.path}" not in git tree (gitignored or deleted)`,
+          });
+        }
+      }
+    }
+  }
+}
+
+process.stderr.write(
+  `Found ${broken.length} broken repo-path references across ${issues.length + prs.length} items.\n\n`,
+);
+
+if (broken.length === 0) {
+  console.log('# Live issue / PR body link audit\n');
+  console.log(
+    `All repo-path references across **${issues.length} ${STATE} issues** and ` +
+      `**${prs.length} ${STATE} PRs** resolve to tracked files in the current main tree.`,
+  );
+  process.exit(0);
+}
+
+// Group by container for the report
+const byContainer = new Map();
+for (const b of broken) {
+  if (!byContainer.has(b.container)) {
+    byContainer.set(b.container, {
+      title: b.title,
+      itemUrl: b.itemUrl,
+      items: [],
+    });
+  }
+  byContainer.get(b.container).items.push(b);
+}
+
+console.log('# Live issue / PR body link audit — broken repo paths\n');
+console.log(`Scanned ${issues.length} issues + ${prs.length} PRs (state: ${STATE}).`);
+console.log(
+  `Found **${broken.length} broken repo-path references** across ${byContainer.size} containers.\n`,
+);
+console.log('Repo paths here are checked against `git ls-files` on the current main tree. ');
+console.log('A "broken" link means the cited path is gitignored, deleted, or never existed.\n');
+console.log('---\n');
+
+for (const [container, info] of byContainer) {
+  console.log(`## ${container}: ${info.title}\n`);
+  console.log(`Source: ${info.itemUrl}\n`);
+  for (const b of info.items) {
+    console.log(`- \`${b.link}\``);
+    console.log(`  - ${b.reason}`);
+  }
+  console.log('');
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary

Closes two gaps surfaced by the 2026-05-30 incident where issue #789's body cited a gitignored 000-docs/ path that 404'd publicly:

1. **Repo-side broken-link checker** — `lychee` via `.lychee.toml` + `.github/workflows/check-links.yml`. Catches broken links in any committed `.md` / `.mdx` file. PR-gated on markdown changes; weekly scheduled run catches external rot.
2. **Live GitHub issue/PR body audit** — `scripts/check-issue-body-links.mjs` + `.github/workflows/check-issue-body-links.yml`. Fetches every open issue + PR body and verifies repo-relative path citations against `git ls-files` on main. Catches the exact failure mode that bit us (link in issue body to gitignored path). Watchdog only; not a PR gate.

## Why two separate tools

`lychee` scans files committed to the repo. The 2026-05-30 broken link lived in a GitHub issue body, not a committed file. No repo-side link checker can catch issue-body rot; the live-body audit is a separate concern with its own data source (the GitHub API).

## Test plan

- [x] Run `node scripts/check-issue-body-links.mjs` locally against current main. Result: scanned 13 open issues + 2 open PRs, zero broken repo-path refs. Confirms PR #805 retroactively healed the original #789 body link.
- [ ] CI: lychee workflow fires on this PR (touches no `.md` files outside docs, so the path filter should still trigger via the workflow self-edit).
- [ ] CI: issue-body workflow runs on schedule (Mon 06:00 UTC); manual `workflow_dispatch` available for one-off audits.
- [ ] Future: when the next broken-repo-path reference lands in an issue body, the Monday job catches it and surfaces in the workflow summary + uploads the report artifact.

## Configuration

`.lychee.toml` excludes localhost / tailnet hosts / example placeholder domains. Accepts 403 / 429 as success because GitHub, Twitter/X, and other rate-limiting hosts emit them on otherwise-fine links.

`scripts/check-issue-body-links.mjs` supports `--max <N>` (default 500) and `--closed` for historical audits.

- Jeremy Longshore
intentsolutions.io