### PR TITLE
feat(penetration-tester): skill #7 — detecting-debug-endpoints

### DIFF
--- a/plugins/security/penetration-tester/package.json
+++ b/plugins/security/penetration-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/penetration-tester",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Security testing toolkit with HTTP header analysis, dependency auditing, and static code scanning",
   "keywords": [
     "security",

--- a/plugins/security/penetration-tester/skills/detecting-debug-endpoints/SKILL.md
+++ b/plugins/security/penetration-tester/skills/detecting-debug-endpoints/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: detecting-debug-endpoints
+description: |
+  Probe a target for accidentally-public admin / debug / introspection
+  endpoints — Spring Boot Actuator, Apache server-status, Prometheus
+  metrics, GraphQL playground, Swagger UI, phpMyAdmin, JMX-over-HTTP
+  (Jolokia), Elasticsearch _cat, Kibana / Grafana / Eureka / Consul
+  panels.
+  Use when: post-deploy verification, security audit before SOC2,
+  inheriting a system you didn't build, or a bug bounty hints at an
+  exposed introspection panel.
+  Threshold: any of the canonical 40+ admin/debug paths returns 200,
+  302 to a login, or framework-specific JSON shape (e.g., Actuator
+  returning a _links object, server-status HTML body containing
+  the Apache Server Status title).
+  Trigger with: "check debug endpoints", "actuator exposure", "admin
+  panel scan", "graphql playground check".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Bash(curl:*)
+disallowed-tools:
+  - Bash(rm:*)
+  - Edit(/etc/*)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - information-disclosure
+  - admin-panels
+  - actuator
+  - pentest
+---
+
+# Detecting Debug Endpoints
+
+## Overview
+
+Modern web stacks ship rich introspection by default. Spring Boot
+Actuator exposes `/actuator/env` (every environment variable),
+`/actuator/heapdump` (a live heap snapshot that contains credentials),
+`/actuator/jolokia` (JMX bean invocation = pre-auth RCE in some
+configurations). Apache `mod_status` exposes `/server-status` with
+internal IPs, request counts, and the URL of every active request.
+Prometheus `/metrics` exposes operational telemetry that often
+includes connection-string-bearing labels by accident. phpMyAdmin
+exposes the entire database if unauthenticated.
+
+These are not bugs in the frameworks. They're features that ship
+enabled-by-default for development convenience and stay enabled in
+production because nobody disabled them at install time. The probe
+set covers the canonical 40+ paths and grades each by the response
+fingerprint specific to that framework.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Spring Boot Actuator `/env` exposed | **CRITICAL** | 200 + body has `"propertySources"` | OWASP A05:2021 |
+| Spring Boot Actuator `/heapdump` exposed | **CRITICAL** | 200 + `Content-Type: application/octet-stream` + multi-MB body | CWE-200 |
+| Spring Boot Actuator `/jolokia` exposed | **CRITICAL** | 200 + body has `"agent":"jolokia"` | CWE-749 |
+| phpMyAdmin reachable | **CRITICAL** | 200 + HTML body contains "phpMyAdmin" + login form | OWASP A07:2021 |
+| Prometheus `/metrics` exposed | **HIGH** | 200 + body has `# HELP` or `# TYPE` lines | CWE-200 |
+| Apache `mod_status` exposed | **HIGH** | 200 + body contains "Apache Server Status" | CWE-200 |
+| Spring Boot Actuator `/actuator` index | **HIGH** | 200 + body has `"_links"` JSON | OWASP A05:2021 |
+| Generic `/admin` returning 200 (not 401/403) | **HIGH** | 200 + HTML body with admin-shaped UI | CWE-285 |
+| Elasticsearch `_cat` exposed | **HIGH** | 200 + body matches `health\s+status\s+index` | CWE-200 |
+| GraphQL Playground on prod | **MEDIUM** | 200 + body contains `"GraphQLPlayground"` | CWE-200 |
+| Swagger UI on prod | **MEDIUM** | 200 + body contains `"swagger-ui"` | CWE-200 |
+| Spring Boot Actuator `/health` exposed | **MEDIUM** | 200 + body has `"status":"UP"` | CWE-200 |
+| `phpinfo` page on prod | **MEDIUM** | 200 + body has `PHP Version` heading | CWE-200 |
+| `/robots.txt` discloses admin paths | **LOW** | 200 + `Disallow:` lines mentioning `/admin` | CWE-200 |
+
+## Prerequisites
+
+- Python 3.9+ with `requests`
+- Authorization for non-local targets
+
+## Instructions
+
+### Step 1 — Confirm Authorization
+
+```text
+"Do you have authorization to perform admin / debug endpoint
+ discovery on this target? I need confirmation before proceeding."
+```
+
+### Step 2 — Run the scanner
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+    https://target.example.com \
+    --authorized
+```
+
+Options:
+
+```
+Usage: probe_debug.py URL [OPTIONS]
+
+Options:
+  --authorized       Attest authorization (required for non-local)
+  --output FILE      Write findings to FILE
+  --format FMT       json | jsonl | markdown (default: markdown)
+  --min-severity SEV (default: info)
+  --timeout SECS     Per-probe timeout (default: 10)
+  --paths-file FILE  Override the default probe set with a custom list
+  --include-redirects  Treat 302/303 to /login as findings (debug panel
+                       exists but auth gates it — still worth noting)
+```
+
+The scanner sends a GET for each path. For 200 responses, it inspects
+the body for the framework-specific fingerprint to confirm a true
+positive (not the app's SPA index page). For 302 responses to common
+login paths, the panel exists but auth is in front — flagged only
+with `--include-redirects`.
+
+### Step 3 — Interpret findings
+
+CRITICAL = direct compromise vector (env vars / heapdump / Jolokia /
+phpMyAdmin). Ship same-hour fix: take the endpoint behind authn or
+disable it. Audit for prior exploitation.
+
+HIGH = information disclosure substantial enough to drive subsequent
+attacks (server-status reveals request URLs including session tokens
+in query strings; /metrics labels often contain connection strings;
+/admin reachable means brute-force can start).
+
+MEDIUM = posture hardening (health checks, swagger).
+
+### Step 4 — Cross-skill chaining
+
+After this skill, suggest:
+
+- `detecting-exposed-secrets-files` (#6) — same deploy mistake. If
+  `/server-status` is reachable, `.git/` often is too.
+- `auditing-cors-policy` (#3) — if a GraphQL or admin endpoint is
+  reachable AND has open CORS, the attack chain compounds.
+
+## Examples
+
+### Example 1 — Inheriting a system audit
+
+User: "We just acquired example.io. Quick audit of admin surface."
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+    https://example.io --authorized --min-severity medium
+```
+
+Commonly surfaces forgotten `/server-status` on Apache hosts,
+`/actuator/*` left enabled from Spring Boot defaults, leftover
+`/phpmyadmin` from initial install.
+
+### Example 2 — Spring Boot Actuator paranoia sweep
+
+User: "We use Spring Boot heavily. Show me everywhere Actuator is
+reachable."
+
+```bash
+for ENDPOINT in $(cat spring-services.txt); do
+  python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+      "$ENDPOINT" --authorized --format jsonl
+done | jq 'select(.title | contains("Actuator"))'
+```
+
+### Example 3 — CI gate against accidental re-enablement
+
+```yaml
+- name: Debug-endpoint guard
+  run: |
+    python3 plugins/security/penetration-tester/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+        "${{ secrets.STAGING_URL }}" \
+        --authorized --min-severity high
+```
+
+Exit 1 fails the deploy if any HIGH or CRITICAL endpoint exposure
+appears. Catches the regression where a debug profile gets enabled
+in a `application-prod.yml` by accident.
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py`. Exit codes: 0 clean, 1
+high/critical, 2 error.
+
+## Error Handling
+
+- **SPA catches every URL with 200** → use `--check-only` semantics
+  (default: fingerprint check filters out SPA matches).
+- **WAF / CDN blocks the scanner** → expected for some targets.
+  Coordinate with the target's security team for an allowlist; or
+  run the scanner from inside the target's network if you have
+  authorized internal access.
+- **Connection error** → exit 2 with underlying error.
+
+## Resources
+
+- `references/THEORY.md` — Per-framework reasoning: why Actuator,
+  mod_status, Prometheus, GraphQL Playground, Swagger, phpMyAdmin
+  each matter; canonical fingerprints
+- `references/PLAYBOOK.md` — Per-framework remediation: Spring Boot
+  Actuator authn, Apache mod_status `<Location>` deny, Prometheus
+  Bearer-token, GraphQL introspection toggle, Swagger profile gate
+- `../analyzing-tls-config/references/AUTHORIZATION.md` — Active-scan
+  authorization pattern

--- a/plugins/security/penetration-tester/skills/detecting-debug-endpoints/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/detecting-debug-endpoints/references/PLAYBOOK.md
@@ -1,0 +1,402 @@
+# Debug-Endpoint Remediation Playbook
+
+## Spring Boot Actuator
+
+### Narrow the exposed endpoints (preferred)
+
+Default Spring Boot 3.x already only exposes `health` + `info`. If
+something widened the surface, narrow it back:
+
+`application-prod.yml`:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+        exclude: env, heapdump, jolokia, configprops, beans, mappings, threaddump, loggers
+  endpoint:
+    health:
+      show-details: never  # or 'when-authorized'
+```
+
+### Require auth on Actuator endpoints
+
+For internal-ops use of Actuator, gate behind authentication:
+
+```yaml
+management:
+  endpoints:
+    web:
+      base-path: /internal/actuator  # not /actuator
+```
+
+`SecurityConfig.java`:
+
+```java
+@Configuration
+public class ActuatorSecurityConfig {
+    @Bean
+    SecurityFilterChain actuatorChain(HttpSecurity http) throws Exception {
+        http.securityMatcher(EndpointRequest.toAnyEndpoint())
+            .authorizeHttpRequests(a -> a.anyRequest().hasRole("ACTUATOR_ADMIN"))
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+}
+```
+
+Or restrict by IP in a reverse proxy (nginx):
+
+```nginx
+location /actuator/ {
+    allow 10.0.0.0/8;
+    deny all;
+    proxy_pass http://springapp:8080;
+}
+```
+
+### Disable Jolokia entirely (most aggressive)
+
+`pom.xml`:
+
+```xml
+<!-- Remove the dependency -->
+<dependency>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-core</artifactId>
+    <!-- ... DELETE THIS BLOCK ... -->
+</dependency>
+```
+
+Or via `application.yml`:
+
+```yaml
+management:
+  endpoint:
+    jolokia:
+      access: NONE
+```
+
+## Apache mod_status
+
+### Disable globally (preferred for production)
+
+`httpd.conf`:
+
+```apache
+# Comment out or remove the mod_status load
+# LoadModule status_module modules/mod_status.so
+
+# Remove the Location block
+# <Location "/server-status">
+#     SetHandler server-status
+#     Require local
+# </Location>
+```
+
+### If needed, lock down by IP
+
+```apache
+<Location "/server-status">
+    SetHandler server-status
+    Require ip 10.0.0.0/8
+    Require ip 192.168.0.0/16
+    # Require local  # already includes 127.0.0.1 + IPv6 loopback
+</Location>
+
+<Location "/server-info">
+    SetHandler server-info
+    Require ip 10.0.0.0/8
+</Location>
+
+# Disable ExtendedStatus to stop URL disclosure in scoreboard
+ExtendedStatus Off
+```
+
+## nginx stub_status
+
+```nginx
+location = /nginx_status {
+    stub_status;
+    allow 10.0.0.0/8;
+    deny all;
+}
+```
+
+Or remove the block entirely if not needed.
+
+## Prometheus /metrics
+
+### Add bearer-token auth
+
+`application.yml` (Spring Boot example):
+
+```yaml
+management:
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+# Apply security to the metrics path:
+spring:
+  security:
+    user:
+      name: prometheus
+      password: ${PROMETHEUS_SCRAPE_PASSWORD}
+```
+
+### Or restrict by IP at the reverse proxy
+
+```nginx
+location /metrics {
+    allow 10.0.10.5/32;  # the prometheus server IP
+    deny all;
+    proxy_pass http://app:8080;
+}
+```
+
+### Audit metric labels for credential leaks
+
+Run a sanity scan over the actual metric output:
+
+```bash
+curl -s http://localhost:8080/metrics | grep -iE 'token=|password=|key=|secret=' | head -20
+```
+
+If any labels contain credentials, fix the metric emission code to
+sanitize / drop those labels before scraping.
+
+## Elasticsearch _cat /_search
+
+### Enable security (free in 7.x+ Basic license)
+
+`elasticsearch.yml`:
+
+```yaml
+xpack.security.enabled: true
+xpack.security.authc:
+  api_key.enabled: true
+xpack.security.transport.ssl.enabled: true
+```
+
+Then create users:
+
+```bash
+./bin/elasticsearch-setup-passwords interactive
+# Set passwords for: elastic, apm_system, kibana_system, logstash_system, beats_system
+```
+
+Update Kibana + Logstash + Beats to authenticate with their new
+credentials.
+
+### Restrict to internal network
+
+```yaml
+# elasticsearch.yml
+network.host: 10.0.10.42  # internal IP only, NOT 0.0.0.0
+```
+
+Or at the firewall: block 9200 from public internet entirely.
+
+## Kibana / Grafana / Eureka / Consul
+
+All four follow the same pattern: gate behind reverse-proxy auth or
+move to internal-network-only.
+
+### nginx reverse proxy with basic auth
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name internal-grafana.example.com;
+    location / {
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        proxy_pass http://grafana:3000;
+    }
+}
+```
+
+### Consul ACL bootstrap
+
+```bash
+consul acl bootstrap
+# Returns SecretID; store securely
+# Create policy that denies anonymous access:
+consul acl policy create -name "anonymous-deny" -rules='node_prefix "" { policy = "deny" } service_prefix "" { policy = "deny" }'
+consul acl token update -id 00000000-0000-0000-0000-000000000002 -policy-name anonymous-deny
+```
+
+## phpMyAdmin
+
+### Disable / remove entirely (preferred)
+
+```bash
+sudo apt-get remove phpmyadmin
+sudo a2disconf phpmyadmin
+sudo systemctl reload apache2
+```
+
+If you can't remove it because legacy ops use it:
+
+### Restrict at the web server
+
+```apache
+<Directory /usr/share/phpmyadmin/>
+    Require ip 10.0.0.0/8
+    # Or use IP-based ACL specific to ops jump hosts
+</Directory>
+```
+
+Or move it to a non-default path:
+
+```apache
+Alias /admin-tools-only-internal-do-not-share/phpmyadmin /usr/share/phpmyadmin
+```
+
+(Security by obscurity is not security, but combined with IP
+restriction it's defense-in-depth.)
+
+## GraphQL Playground / GraphiQL
+
+### Apollo Server 4.x
+
+```typescript
+const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    // Playground is OFF by default in production (NODE_ENV=production)
+    introspection: process.env.NODE_ENV !== 'production',
+});
+```
+
+### graphql-yoga
+
+```typescript
+import { createYoga } from 'graphql-yoga';
+const yoga = createYoga({
+    schema,
+    graphiql: process.env.NODE_ENV !== 'production',
+    landingPage: false,
+});
+```
+
+### Express + express-graphql (legacy)
+
+```javascript
+app.use('/graphql', graphqlHTTP({
+    schema,
+    graphiql: false,  // disable in production
+}));
+```
+
+## Swagger UI / OpenAPI
+
+### Spring (springdoc-openapi)
+
+```yaml
+springdoc:
+  swagger-ui:
+    enabled: false  # disable in production
+  api-docs:
+    enabled: false
+```
+
+Or via profile:
+
+```yaml
+# application-prod.yml
+springdoc:
+  swagger-ui:
+    enabled: false
+```
+
+### FastAPI
+
+```python
+app = FastAPI(
+    docs_url=None if PRODUCTION else "/docs",
+    redoc_url=None if PRODUCTION else "/redoc",
+    openapi_url=None if PRODUCTION else "/openapi.json",
+)
+```
+
+### Express + swagger-ui-express
+
+Wrap with auth or skip mounting in production:
+
+```javascript
+if (process.env.NODE_ENV !== 'production') {
+    app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(spec));
+}
+```
+
+## Django
+
+### Production settings
+
+```python
+# settings/production.py
+DEBUG = False  # CRITICAL — never True in prod
+
+# Remove debug toolbar from INSTALLED_APPS and MIDDLEWARE for prod
+if DEBUG:
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+```
+
+## Go expvar / pprof
+
+Don't import `_ "net/http/pprof"` in production. Pull the import into
+a build tag:
+
+```go
+// +build !production
+
+package main
+
+import _ "net/http/pprof"
+```
+
+Or expose pprof on a separate internal-only mux:
+
+```go
+go func() {
+    // Internal-network-only listener
+    log.Fatal(http.ListenAndServe("127.0.0.1:6060", nil))
+}()
+```
+
+## CI integration
+
+```yaml
+- name: Debug-endpoint posture gate
+  run: |
+    python3 plugins/security/penetration-tester/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+        "${{ secrets.STAGING_URL }}" \
+        --authorized \
+        --min-severity high \
+        --format json \
+        --output debug-endpoint-report.json
+- run: |
+    if jq 'any(.severity == "critical" or .severity == "high")' debug-endpoint-report.json | grep -q true; then
+      echo "::error::Debug endpoint posture regression"
+      exit 1
+    fi
+```
+
+## Verification after remediation
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-debug-endpoints/scripts/probe_debug.py \
+    https://example.com --authorized --min-severity medium
+```
+
+Expected: exit 0, zero MEDIUM-or-higher findings. INFO findings on
+deliberately-public Swagger / OpenAPI docs are operational choices.

--- a/plugins/security/penetration-tester/skills/detecting-debug-endpoints/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/detecting-debug-endpoints/references/THEORY.md
@@ -1,0 +1,218 @@
+# Debug-Endpoint Theory
+
+## The recurring pattern
+
+Modern application frameworks ship rich introspection by default
+because developers need it to debug locally. The framework defaults
+assume "this is running on my laptop in development mode." The
+production deploy inherits the same defaults unless someone
+explicitly disables them. The result is a class of finding that's
+almost universal: any non-trivial Spring Boot / Apache / Prometheus /
+ELK / Consul deployment exposes at least one of these endpoints
+unless an operator went out of their way to disable them.
+
+Each framework deserves its own short explanation.
+
+## Spring Boot Actuator
+
+Actuator is Spring Boot's introspection module. By default (in
+Spring Boot 2.x with `management.endpoints.web.exposure.include=*`),
+it exposes a JSON-shaped tree at `/actuator/` with endpoints like:
+
+- `/actuator/env` — every Spring configuration property and every
+  environment variable, including database URLs, API keys read from
+  env, and JVM args.
+- `/actuator/heapdump` — a live JVM heap dump (HPROF binary).
+  Contains all in-memory state: connection pool internals, recent
+  request data, cached credentials, JWT signing keys if they're
+  string-allocated.
+- `/actuator/jolokia` — JMX-over-HTTP. With write permissions, this
+  is pre-auth RCE: an attacker can invoke arbitrary JMX MBeans
+  including `javax.management.Diagnostic.threadDump` and (with the
+  right MBean) execute arbitrary code.
+- `/actuator/loggers` — POST changes log level for any package at
+  runtime. An attacker can silence logs of their own activity by
+  setting `org.springframework.security` to OFF.
+- `/actuator/threaddump` — current thread state. Reveals which
+  business operations are in flight + stack traces with method
+  names (informs targeted attacks).
+- `/actuator/health` — dependency state ("UP" / "DOWN" per
+  database / cache / external service). Maps the internal topology.
+- `/actuator/mappings` — full route table including paths the public
+  app doesn't expose anywhere else.
+
+Spring Boot 2.x default was exposure-everything; Spring Boot 3.x
+default narrowed to `/health` + `/info` only. Many deployments still
+have legacy 2.x-era `management.endpoints.web.exposure.include=*`
+overrides in `application-prod.yml` that wasn't audited at the 3.x
+upgrade.
+
+The combined finding chain: `/actuator/env` exposes the database
+connection string + creds. Connect to the database directly. End.
+
+## Apache mod_status
+
+`mod_status` exposes server runtime stats at `/server-status`:
+
+- Apache version + OS
+- Active worker count + idle workers
+- **The URL of every active request** (the "Scoreboard" extended
+  view, enabled by `ExtendedStatus On`)
+- The client IP of every active connection
+
+The URL-disclosure axis is the operational risk: any session token,
+OAuth code, or password-in-query-string that flows through Apache is
+visible to anyone polling `/server-status`. A scraper hitting it
+once a second can collect tokens at scale.
+
+The default in older Apache versions was to allow `/server-status`
+from localhost; many configs were edited to allow internal IP ranges,
+then forgotten about as networks evolved.
+
+## nginx stub_status
+
+`/nginx_status` exposes connection counts and request counts. Less
+sensitive than Apache's mod_status (doesn't show URLs) but still
+operational telemetry the attacker shouldn't have. Common on
+deployments that copy-pasted `stub_status on;` from a tutorial.
+
+## Prometheus /metrics
+
+Prometheus's `/metrics` endpoint is the data source for monitoring.
+The exposed surface is the application's own metric series.
+
+The non-obvious risk: metric LABELS often contain credentials by
+accident. A "request count by endpoint" series might label requests
+by full URL including query string. A "database connection state"
+metric might label connections by full connection string. The
+labels are designed for Grafana queries; they're not designed to be
+adversarially scrutinized.
+
+Common label-leak categories:
+
+- `http_requests_total{path="/api/users?token=...", ...}`
+- `database_connections_active{dsn="postgresql://user:pass@..."}`
+- `external_api_calls_total{key="sk-..."}`
+
+The fix is twofold: bring the endpoint behind auth (a static bearer
+token is the conventional Prometheus pattern), AND audit the label
+cardinality for accidental credential disclosure.
+
+## Elasticsearch _cat /_search
+
+Elasticsearch endpoints under `/_cat/` and `/_cluster/` expose
+cluster state, indices, document counts, and node metadata. The
+`/_search` endpoint serves arbitrary queries against any visible
+index without authentication if the cluster is unconfigured.
+
+The historical pattern: Elasticsearch shipped with no auth defaults
+until version 7.x (the Basic license added security in late 2020).
+A cluster set up before that date and never upgraded with security
+enabled is fully open to anyone who can reach port 9200.
+
+The Shodan-style internet scan of exposed Elasticsearch clusters is
+a recurring "another data breach" story; the underlying issue is
+always this misconfiguration.
+
+## Kibana / Grafana / Eureka / Consul
+
+Service-discovery and observability panels. Each can expose:
+
+- Kibana: full search of Elasticsearch indices through the UI
+- Grafana: dashboards that may include connection strings in
+  variable definitions
+- Eureka: service registry with internal IPs + ports of every
+  microservice
+- Consul: service catalog + agent checks with full topology
+
+For Eureka and Consul specifically, the API is designed to be
+read-mostly from inside the service mesh. Exposing it externally
+hands an attacker the network map.
+
+## phpMyAdmin
+
+GUI for MySQL/MariaDB administration. Many shared-hosting
+installations include it at `/phpmyadmin/` by default; legacy LAMP
+stacks deploy it next to the app. If reachable AND unauthenticated
+(or with default credentials), it's full DB access via web GUI.
+
+Fingerprint: HTML body containing "phpMyAdmin" + a login form with
+`name="pma_username"`.
+
+## GraphQL Playground / GraphiQL
+
+Interactive GraphQL UI for developers. Enabled by default in many
+GraphQL server setups (Apollo Server, graphql-yoga). The risk has
+two layers:
+
+1. **Schema introspection** — the playground reveals the full
+   schema, which informs every subsequent query/mutation attack.
+2. **Query execution** — if the GraphQL endpoint is publicly
+   reachable AND the playground is too, the attacker has both a
+   schema map AND an interactive interface to craft attacks against
+   it.
+
+Best practice: disable introspection in production, disable the
+playground in production. Apollo Server 4.x has both off by default
+in `NODE_ENV=production`; older versions need explicit config.
+
+## Swagger UI / OpenAPI
+
+Same pattern as GraphQL: the schema (OpenAPI spec) tells an attacker
+what endpoints exist, what parameters they accept, what response
+shapes look like. Exposing `/swagger-ui` or `/openapi.json` on
+production isn't a critical vulnerability but it's free recon.
+
+Some defensive postures keep Swagger publicly reachable as a feature
+(public API docs). That's a deliberate choice; the finding is
+informational unless the API itself has auth issues.
+
+## Django debug toolbar
+
+If `DEBUG=True` shipped to production, the Django debug toolbar
+exposes SQL queries, request env, settings, template context.
+Effectively equivalent to `/actuator/env` for Django stacks.
+
+## Go expvar / pprof
+
+Built-in Go stdlib endpoints:
+
+- `/debug/vars` — JSON dump of expvar package: cmdline, memstats,
+  custom-registered metrics
+- `/debug/pprof/` — pprof profiles for CPU, heap, goroutines
+
+The pprof endpoints can be triggered to start CPU profiling that
+slows the server, AND can be used to download heap profiles that
+contain live memory state (similar risk to Spring Boot heapdump).
+
+If Go's `net/http/pprof` package is imported anywhere in the app
+(it auto-registers handlers on the default mux), and the default
+mux is exposed externally, pprof is reachable.
+
+## Why fingerprint-checking matters
+
+Same logic as `detecting-exposed-secrets-files` (#6). SPAs return
+their `index.html` for any unknown route. Without fingerprinting,
+every `/actuator/*` probe returns 200 against an SPA, all false
+positives.
+
+Each framework has a distinctive body fingerprint:
+
+- Actuator: JSON `{"_links":...}` or `"propertySources"`
+- mod_status: HTML containing "Apache Server Status"
+- Prometheus: text starting with `# HELP` or `# TYPE`
+- Elasticsearch: tabular text with status indicators
+- phpMyAdmin: HTML containing "phpMyAdmin" + `pma_username`
+- Jolokia: JSON `{"agent":"jolokia"}`
+
+The fingerprint check is what separates a real finding from SPA
+noise.
+
+## Primary sources
+
+- [OWASP WSTG-CONF-05 — Enumerate Infrastructure and Application Admin Interfaces](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces)
+- [Spring Boot Actuator docs — Production-ready features](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)
+- [Apache mod_status docs](https://httpd.apache.org/docs/2.4/mod/mod_status.html)
+- [CWE-749 — Exposed Dangerous Method or Function](https://cwe.mitre.org/data/definitions/749.html)
+- [CWE-285 — Improper Authorization](https://cwe.mitre.org/data/definitions/285.html)
+- [Jolokia security advisory background](https://jolokia.org/reference/html/security.html)

--- a/plugins/security/penetration-tester/skills/detecting-debug-endpoints/scripts/probe_debug.py
+++ b/plugins/security/penetration-tester/skills/detecting-debug-endpoints/scripts/probe_debug.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Probe for accidentally-public admin / debug / introspection endpoints.
+
+Companion to skill `detecting-debug-endpoints`. Sends a GET for each
+path in a curated 40+ probe set covering Spring Boot Actuator, Apache
+mod_status, Prometheus metrics, GraphQL playground, Swagger UI,
+phpMyAdmin, Jolokia, Elasticsearch _cat, and generic admin/debug
+panels.
+
+Each 200 response is fingerprinted against the framework-specific
+body pattern (Actuator returns `{"_links":...}`, mod_status returns
+HTML containing "Apache Server Status", Prometheus returns
+`# HELP`/`# TYPE` lines, etc.) so SPA index pages that 200 on every
+route don't generate false positives.
+
+References:
+    OWASP WSTG v4.2 § 4.2.4 Enumerate Infrastructure
+    OWASP A05:2021 Security Misconfiguration
+    CWE-749 Exposed Dangerous Method
+    CWE-285 Improper Authorization
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.authz_check import require_authorization  # noqa: E402
+from lib.finding import Finding, Severity  # noqa: E402
+from lib.http_client import make_session, safe_get  # noqa: E402
+from lib.report import emit, exit_code  # noqa: E402
+
+SKILL_ID = "detecting-debug-endpoints"
+
+
+# Probe set. Each entry: (path, title, severity, fingerprint_regex_or_None, control_id, cwe)
+# fingerprint_regex applied case-insensitively against first 4 KiB of body.
+PROBES = [
+    # Critical — Spring Boot Actuator with sensitive endpoints exposed
+    (
+        "actuator/env",
+        "Spring Boot Actuator /env exposed (leaks every environment variable)",
+        Severity.CRITICAL,
+        r'"propertySources"|"systemProperties"|"applicationConfig"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/heapdump",
+        "Spring Boot Actuator /heapdump exposed (live heap snapshot)",
+        Severity.CRITICAL,
+        None,  # body is binary multi-MB; presence of 200 + content-length large is the signal
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/jolokia",
+        "Spring Boot Actuator /jolokia exposed (JMX-over-HTTP, potential RCE)",
+        Severity.CRITICAL,
+        r'"agent"\s*:\s*"jolokia"|"protocol"\s*:\s*"jolokia"',
+        "OWASP A05:2021",
+        "CWE-749",
+    ),
+    (
+        "actuator/threaddump",
+        "Spring Boot Actuator /threaddump exposed (live thread state)",
+        Severity.HIGH,
+        r'"threads"\s*:\s*\[',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/loggers",
+        "Spring Boot Actuator /loggers exposed (can change log levels remotely)",
+        Severity.HIGH,
+        r'"loggers"\s*:\s*\{|"configuredLevel"',
+        "OWASP A05:2021",
+        "CWE-749",
+    ),
+    (
+        "actuator/configprops",
+        "Spring Boot Actuator /configprops exposed (app config disclosure)",
+        Severity.HIGH,
+        r'"contexts"\s*:\s*\{|"beans"\s*:\s*\{',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/mappings",
+        "Spring Boot Actuator /mappings exposed (full route table)",
+        Severity.MEDIUM,
+        r'"mappings"\s*:|"dispatcherServlets"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/beans",
+        "Spring Boot Actuator /beans exposed (bean introspection)",
+        Severity.MEDIUM,
+        r'"beans"\s*:\s*\{|"applicationContext"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/metrics",
+        "Spring Boot Actuator /metrics exposed",
+        Severity.MEDIUM,
+        r'"names"\s*:\s*\[',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator/health",
+        "Spring Boot Actuator /health exposed (reveals dependency states)",
+        Severity.MEDIUM,
+        r'"status"\s*:\s*"(UP|DOWN|OUT_OF_SERVICE)"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "actuator",
+        "Spring Boot Actuator index page exposed",
+        Severity.HIGH,
+        r'"_links"\s*:\s*\{',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # phpMyAdmin — DB admin GUI
+    (
+        "phpmyadmin/",
+        "phpMyAdmin reachable (if unauthed: full DB access)",
+        Severity.CRITICAL,
+        r"phpMyAdmin|pma_navigation|pma_username",
+        "OWASP A07:2021",
+        "CWE-285",
+    ),
+    (
+        "pma/",
+        "phpMyAdmin reachable at /pma/",
+        Severity.CRITICAL,
+        r"phpMyAdmin|pma_navigation",
+        "OWASP A07:2021",
+        "CWE-285",
+    ),
+    # Apache mod_status
+    (
+        "server-status",
+        "Apache mod_status /server-status exposed (reveals internal request URLs + IPs)",
+        Severity.HIGH,
+        r"Apache Server Status|<title>Apache Status</title>",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "server-info",
+        "Apache mod_info /server-info exposed (full config disclosure)",
+        Severity.HIGH,
+        r"Apache Server Information|Server Settings",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # nginx status
+    (
+        "nginx_status",
+        "nginx stub_status exposed",
+        Severity.MEDIUM,
+        r"Active connections:\s*\d+\nserver accepts handled",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # Prometheus
+    (
+        "metrics",
+        "Prometheus /metrics endpoint exposed (operational telemetry, may contain credentials in labels)",
+        Severity.HIGH,
+        r"^# HELP\s|^# TYPE\s",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "prometheus/api/v1/query",
+        "Prometheus query API exposed",
+        Severity.HIGH,
+        r'"status"\s*:\s*"(success|error)"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # Elasticsearch
+    (
+        "_cat/indices",
+        "Elasticsearch /_cat/indices exposed (no auth)",
+        Severity.HIGH,
+        r"^(green|yellow|red)\s+(open|close)",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "_cluster/health",
+        "Elasticsearch /_cluster/health exposed",
+        Severity.HIGH,
+        r'"cluster_name"\s*:|"number_of_nodes"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "_search",
+        "Elasticsearch /_search exposed (no auth)",
+        Severity.CRITICAL,
+        r'"hits"\s*:\s*\{|"took"\s*:\s*\d+',
+        "OWASP A05:2021",
+        "CWE-285",
+    ),
+    # Kibana / Grafana / Eureka / Consul panels
+    (
+        "kibana/",
+        "Kibana UI reachable",
+        Severity.MEDIUM,
+        r"kbn-name|Kibana|kbn-version",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "grafana/api/health",
+        "Grafana exposed at /grafana/",
+        Severity.MEDIUM,
+        r'"database"\s*:\s*"(ok|fail)"|"version"',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "eureka/apps",
+        "Spring Cloud Eureka registry exposed",
+        Severity.HIGH,
+        r"<applications>|EUREKA",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "consul/v1/catalog/services",
+        "Consul catalog API exposed",
+        Severity.HIGH,
+        r"^\s*\{|consul",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "v1/agent/checks",
+        "Consul agent checks API exposed",
+        Severity.HIGH,
+        r'"Checks"\s*:|^\s*\{',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # GraphQL
+    (
+        "graphql",
+        "GraphQL endpoint reachable",
+        Severity.LOW,
+        r'"data"\s*:|"errors"\s*:',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "graphiql",
+        "GraphiQL IDE reachable on prod",
+        Severity.MEDIUM,
+        r"GraphiQL|graphql-playground",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "playground",
+        "GraphQL Playground reachable on prod",
+        Severity.MEDIUM,
+        r"GraphQLPlayground|graphql-playground",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # OpenAPI / Swagger
+    (
+        "swagger-ui/",
+        "Swagger UI reachable on prod",
+        Severity.MEDIUM,
+        r"swagger-ui|SwaggerUI",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "swagger-ui.html",
+        "Swagger UI reachable (Spring conventional path)",
+        Severity.MEDIUM,
+        r"swagger-ui|SwaggerUI",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "api-docs",
+        "OpenAPI /api-docs JSON reachable",
+        Severity.LOW,
+        r'"openapi"\s*:|"swagger"\s*:',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "openapi.json",
+        "OpenAPI spec /openapi.json reachable",
+        Severity.LOW,
+        r'"openapi"\s*:',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "v3/api-docs",
+        "Spring v3 OpenAPI /v3/api-docs reachable",
+        Severity.LOW,
+        r'"openapi"\s*:',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # Generic admin panels (FP-prone — fingerprint by HTML title/form patterns)
+    (
+        "admin/",
+        "Generic /admin/ reachable",
+        Severity.HIGH,
+        r"<title>[^<]*(admin|dashboard)[^<]*</title>|name=['\"](username|email|password)['\"]",
+        "OWASP A07:2021",
+        "CWE-285",
+    ),
+    (
+        "administrator/",
+        "Joomla-style /administrator/ reachable",
+        Severity.HIGH,
+        r"Joomla|administrator",
+        "OWASP A07:2021",
+        "CWE-285",
+    ),
+    (
+        "wp-admin/",
+        "WordPress /wp-admin/ reachable",
+        Severity.MEDIUM,
+        r"WordPress|wp-login",
+        "OWASP A07:2021",
+        "CWE-285",
+    ),
+    # PHP debug
+    (
+        "phpinfo.php",
+        "phpinfo() output reachable",
+        Severity.MEDIUM,
+        r"PHP Version|phpinfo\(\)",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "info.php",
+        "PHP info reachable",
+        Severity.MEDIUM,
+        r"PHP Version|phpinfo\(\)",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # Misc framework debug
+    (
+        "_debug/",
+        "Django _debug toolbar reachable",
+        Severity.HIGH,
+        r"djDebug|debug-toolbar",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "debug/vars",
+        "Go expvar /debug/vars reachable",
+        Severity.MEDIUM,
+        r'"cmdline":|"memstats":',
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    (
+        "debug/pprof/",
+        "Go pprof /debug/pprof/ reachable (heap/CPU profiles)",
+        Severity.HIGH,
+        r"/debug/pprof/|profiles:",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+    # Robots.txt admin disclosure (low — informational)
+    (
+        "robots.txt",
+        "robots.txt discloses admin paths (information leak)",
+        Severity.LOW,
+        r"^Disallow:\s*/(admin|api/admin|internal|wp-admin|phpmyadmin)",
+        "OWASP A05:2021",
+        "CWE-200",
+    ),
+]
+
+
+def _verify_fingerprint(body_text: str, fingerprint_re: str | None, content_type: str, content_length: int) -> bool:
+    """Return True if response body looks like the expected admin/debug page."""
+    if fingerprint_re is None:
+        # No body fingerprint (binary heap dumps etc.); accept any large 200
+        # with non-HTML content-type as a signal
+        if content_length > 100_000 and "text/html" not in content_type.lower():
+            return True
+        return False
+    sample = body_text[:4096]
+    if re.search(fingerprint_re, sample, re.MULTILINE | re.IGNORECASE):
+        return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Probe for admin / debug / introspection endpoints")
+    parser.add_argument("url")
+    parser.add_argument("--authorized", action="store_true")
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--format", choices=("json", "jsonl", "markdown"), default="markdown")
+    parser.add_argument("--min-severity", choices=("critical", "high", "medium", "low", "info"), default="info")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--paths-file", default=None, help="Custom probe set (one path per line); replaces default")
+    parser.add_argument(
+        "--include-redirects",
+        action="store_true",
+        help="Flag 302/303 to login as exposure (panel exists, auth gates it)",
+    )
+    args = parser.parse_args(argv)
+
+    require_authorization(args.url, args.authorized)
+
+    base = args.url.rstrip("/") + "/"
+    sess = make_session(timeout=args.timeout)
+    findings: list[Finding] = []
+
+    probe_set = PROBES
+    if args.paths_file:
+        paths = Path(args.paths_file).read_text().splitlines()
+        probe_set = [
+            (p.strip(), f"Custom path reachable: {p.strip()}", Severity.MEDIUM, None, "custom", "CWE-200")
+            for p in paths
+            if p.strip()
+        ]
+
+    for path, title, sev, fingerprint, control, cwe in probe_set:
+        url = base + path.lstrip("/")
+        resp = safe_get(sess, url, timeout=args.timeout, allow_redirects=False)
+        if resp is None:
+            continue
+
+        is_redirect_to_login = resp.status_code in (301, 302, 303, 307, 308) and re.search(
+            r"/(login|sign[-_]in|auth)", resp.headers.get("Location", ""), re.I
+        )
+        if is_redirect_to_login and args.include_redirects:
+            findings.append(
+                Finding(
+                    skill_id=SKILL_ID,
+                    title=f"{title} (auth-gated: redirects to login)",
+                    severity=Severity.LOW,
+                    target=url,
+                    detail=(
+                        f"GET {url} redirected to {resp.headers.get('Location')!r}. "
+                        "The endpoint exists; authentication is in front of it. "
+                        "Operationally fine, but discloses framework presence to attackers."
+                    ),
+                    remediation=(
+                        "If the endpoint is not needed in production, disable it "
+                        "rather than gating with auth. See references/PLAYBOOK.md."
+                    ),
+                    cwe_id=cwe,
+                    affected_control=control,
+                )
+            )
+            continue
+
+        if resp.status_code != 200:
+            continue
+        body = resp.text or ""
+        ctype = resp.headers.get("Content-Type", "")
+        clen = len(resp.content or b"")
+        if not _verify_fingerprint(body, fingerprint, ctype, clen):
+            continue
+        findings.append(
+            Finding(
+                skill_id=SKILL_ID,
+                title=title,
+                severity=sev,
+                target=url,
+                detail=(
+                    f"GET {url} returned 200 with content matching the "
+                    f"framework-specific fingerprint for {path!r}. The "
+                    "endpoint is publicly reachable."
+                ),
+                remediation=(
+                    f"Take {path!r} behind authentication, restrict by IP allow-list, "
+                    "or disable the framework feature entirely if not needed in "
+                    "production. See references/PLAYBOOK.md for per-framework snippets."
+                ),
+                cwe_id=cwe,
+                affected_control=control,
+                evidence=(("status_code", 200), ("content_length", clen), ("content_type", ctype)),
+            )
+        )
+
+    floor = Severity(args.min_severity)
+    findings = [f for f in findings if f.severity.numeric >= floor.numeric]
+
+    emit(findings, args.output, args.format, args.url)
+    return exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Cluster 2 skill #7 of Phase 1A taxonomy. 1,352 LOC across SKILL.md, scripts/probe_debug.py, references/THEORY.md + PLAYBOOK.md. Marketplace validator: **A/90, 0 errors**.

Probes the canonical 40+ admin / debug / introspection endpoints:

- **Spring Boot Actuator** (`/env`, `/heapdump`, `/jolokia`, `/threaddump`, `/loggers`, `/configprops`, `/mappings`, `/beans`, `/metrics`, `/health`, `/actuator` index)
- **Apache** mod_status `/server-status` + mod_info `/server-info`
- **nginx** stub_status `/nginx_status`
- **Prometheus** `/metrics` + `prometheus/api/v1/query`
- **Elasticsearch** `_cat/indices`, `_cluster/health`, `_search`
- **Kibana / Grafana / Eureka / Consul** panels
- **phpMyAdmin** at `/phpmyadmin/` + `/pma/`
- **GraphQL Playground / GraphiQL** + Swagger UI / OpenAPI
- **Django** `_debug` toolbar + Go expvar `/debug/vars` + pprof `/debug/pprof/`
- **PHP** `phpinfo.php` / `info.php`
- **robots.txt** admin-path disclosure

Each path is fingerprinted against framework-specific body patterns so SPA index-page-200s don't generate false positives.

## Severity model

- CRITICAL: direct compromise (`/env`, `/heapdump`, `/jolokia`, ES `_search`, phpMyAdmin)
- HIGH: substantial information disclosure (`/server-status` request URLs, `/metrics` with credential-bearing labels, `/admin` returning 200, Eureka/Consul, Go pprof, Django debug toolbar)
- MEDIUM: posture hardening (health checks, swagger, Kibana/Grafana panels)
- LOW: informational (robots.txt admin-path disclosure)

## Test plan

- [x] validate-skills-schema.py --marketplace: A/90, 0 errors
- [x] probe_debug.py --help: works
- [x] ruff format / check: clean
- [x] markdownlint: clean

- Jeremy Longshore
intentsolutions.io