### PR TITLE
feat(penetration-tester): cluster 2 close-out — skills #8 + #9

### DIFF
--- a/plugins/security/penetration-tester/package.json
+++ b/plugins/security/penetration-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/penetration-tester",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Security testing toolkit with HTTP header analysis, dependency auditing, and static code scanning",
   "keywords": [
     "security",

--- a/plugins/security/penetration-tester/package.json
+++ b/plugins/security/penetration-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/penetration-tester",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Security testing toolkit with HTTP header analysis, dependency auditing, and static code scanning",
   "keywords": [
     "security",

--- a/plugins/security/penetration-tester/skills/detecting-directory-listing/SKILL.md
+++ b/plugins/security/penetration-tester/skills/detecting-directory-listing/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: detecting-directory-listing
+description: |
+  Probe a target for directories that return auto-generated index
+  listings instead of denying or serving a specific file — exposes
+  the full file tree under any reachable directory, including files
+  the application never linked to.
+  Use when: post-deploy verification on a static-asset host, security
+  audit before SOC2, or following up on a finding from skill #6
+  (exposed-files) where a backup-file path returned 200 with HTML
+  body instead of the expected file content (suggests autoindex
+  serving a directory listing).
+  Threshold: any directory-shaped path returns 200 with HTML body
+  matching the framework-specific autoindex fingerprint (nginx
+  fancyindex, Apache mod_autoindex Index of/, Caddy browse, Lighttpd
+  mod_dirlisting, etc.).
+  Trigger with: "directory listing check", "autoindex detection",
+  "open directory scan".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Bash(curl:*)
+disallowed-tools:
+  - Bash(rm:*)
+  - Edit(/etc/*)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - information-disclosure
+  - autoindex
+  - pentest
+---
+
+# Detecting Directory Listing
+
+## Overview
+
+Web servers can be configured to auto-generate an HTML index page
+when a request hits a directory without a matching default file
+(no `index.html` / `index.php` / etc.). The auto-generated page
+lists every file in the directory. This is by design for static-
+file servers and FTP-style file-sharing setups; it's a misconfiguration
+on application servers where the file tree was never meant to be
+public.
+
+The risk compounds in two ways:
+
+1. **File enumeration without prior knowledge.** Attackers find files
+   you didn't link to (backup files, log files, old uploads).
+2. **Chaining with exposed-files (#6).** A `/.git/` request that
+   returns an autoindex listing reveals every object file under
+   `.git/objects/` and confirms the entire repo is reachable for
+   GitDumper-style reconstruction.
+
+This skill probes commonly-vulnerable directory paths and grades
+each based on the framework-specific autoindex fingerprint.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Application-root directory listing | **HIGH** | `/` returns autoindex page | OWASP A05:2021 |
+| Backup / upload / log directory listing | **HIGH** | `/backup/`, `/uploads/`, `/logs/`, `/dump/` autoindex | CWE-548 |
+| Asset directory listing (`/assets/`, `/static/`) | **MEDIUM** | autoindex on asset dirs (enables file enumeration) | CWE-548 |
+| Config directory listing | **CRITICAL** | `/config/`, `/conf/`, `/.config/` autoindex | NIST 800-53 SC-28 |
+| VCS subdir listing (chains with skill #6) | **CRITICAL** | `/.git/`, `/.svn/`, `/.hg/` autoindex | NIST 800-53 SC-28 |
+| Generic root reachable via autoindex | **MEDIUM** | `/` or arbitrary path autoindex on app server | OWASP A05:2021 |
+
+## Prerequisites
+
+- Python 3.9+ with `requests`
+- Authorization for non-local targets
+
+## Instructions
+
+### Step 1 — Confirm Authorization
+
+```text
+"Do you have authorization to perform directory-listing discovery on
+ this target? I need confirmation before proceeding."
+```
+
+### Step 2 — Run the scanner
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+    https://target.example.com \
+    --authorized
+```
+
+Options:
+
+```
+Usage: probe_directory_listing.py URL [OPTIONS]
+
+Options:
+  --authorized       Attest authorization (required for non-local)
+  --output FILE      Write findings to FILE
+  --format FMT       json | jsonl | markdown (default: markdown)
+  --min-severity SEV (default: info)
+  --timeout SECS     Per-probe timeout (default: 10)
+  --paths-file FILE  Custom probe set (one path per line)
+```
+
+For each candidate directory path, the scanner appends a trailing
+slash and sends a GET. If the response is 200 and the HTML body
+matches one of the canonical autoindex fingerprints (Apache,
+nginx, Caddy, Lighttpd, IIS, Python http.server, Node serve, etc.),
+it's a finding.
+
+### Step 3 — Interpret findings
+
+CRITICAL = config or VCS directory listing → direct credential or
+source-code exposure when combined with skill #6's secret-file
+probe. Ship same-hour fix.
+
+HIGH = backup / upload / log / app-root listing → significant file
+enumeration. Often reveals backup files (`.bak`, `.swp`, `.orig`),
+log files with embedded credentials in URLs, and orphaned uploads
+from old releases. Ship within sprint.
+
+MEDIUM = asset directory listing → file enumeration but bounded
+risk if asset content is genuinely public. Still better to disable
+than to leave on.
+
+### Step 4 — Cross-skill chaining
+
+After this skill, suggest:
+
+- `detecting-exposed-secrets-files` (#6) — if any of the secret-
+  file paths (`.git/`, `.env`) return an autoindex page instead of
+  the expected file, that's the autoindex feature confirming repo
+  exposure.
+- `detecting-debug-endpoints` (#7) — directory listings under
+  framework paths (`/static/`, `/public/`) sometimes expose
+  framework-debug artifacts.
+
+## Examples
+
+### Example 1 — Static-asset host audit
+
+User: "We just spun up a new S3 + CloudFront. Verify autoindex isn't
+on by accident."
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+    https://cdn.example.com --authorized --min-severity medium
+```
+
+S3 buckets configured with `ListBucket` permissions return XML
+directory listings; the scanner detects those too.
+
+### Example 2 — Following up on .git exposure
+
+User: "Skill #6 found .git/HEAD exposed. Check if the full directory
+is browseable."
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+    https://app.example.com --authorized --paths-file <(echo .git/)
+```
+
+If the `.git/` probe returns an autoindex listing instead of the
+404 it should, the whole repository is reachable for reconstruction
+via GitDumper-style tools.
+
+### Example 3 — CI gate against autoindex regression
+
+```yaml
+- name: Directory-listing gate
+  run: |
+    python3 plugins/security/penetration-tester/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+        "${{ secrets.STAGING_URL }}" \
+        --authorized --min-severity high
+```
+
+Exit 1 fails the deploy if any HIGH or CRITICAL autoindex finding
+lands. Catches the regression where a new vhost gets deployed
+without the deny-autoindex directive.
+
+## Output
+
+JSON / JSONL / Markdown. Exit codes: 0 clean, 1 high/critical, 2 error.
+
+## Error Handling
+
+- **Target returns SPA index for every URL** → the scanner's
+  fingerprint check distinguishes a real autoindex from an SPA
+  catch-all. SPAs don't generate autoindex-shaped HTML.
+- **WAF blocks the scanner** → expected behavior on
+  Cloudflare-fronted hosts. The fingerprint will be of the CDN's
+  block page, not the origin.
+- **Connection error** → exit 2.
+
+## Resources
+
+- `references/THEORY.md` — Per-server autoindex behavior, fingerprint
+  patterns, S3 / GCS / Azure Blob considerations
+- `references/PLAYBOOK.md` — Per-server config to disable
+  autoindex (nginx `autoindex off`, Apache `Options -Indexes`,
+  Caddy disabling browse, etc.) + cloud-storage equivalents
+- `../analyzing-tls-config/references/AUTHORIZATION.md` — Active-scan
+  authorization pattern

--- a/plugins/security/penetration-tester/skills/detecting-directory-listing/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/detecting-directory-listing/references/PLAYBOOK.md
@@ -1,0 +1,277 @@
+# Directory-Listing Remediation Playbook
+
+## Apache mod_autoindex
+
+### Disable autoindex globally (preferred)
+
+`httpd.conf` or vhost:
+
+```apache
+<Directory /var/www/html>
+    Options -Indexes
+    AllowOverride None
+    Require all granted
+</Directory>
+```
+
+The `Options -Indexes` line is the critical part. Combined with no
+`index.html` in a directory, requests return 403 (per Apache's
+default fall-through) instead of an autoindex page.
+
+### Per-directory override
+
+If autoindex is needed in one specific directory (rare):
+
+```apache
+<Directory /var/www/html/public-archive>
+    Options +Indexes
+    IndexOptions +FancyIndexing +SuppressDescription
+</Directory>
+```
+
+But this should require a deliberate decision, not a default.
+
+### .htaccess (if `AllowOverride` permits)
+
+```apache
+Options -Indexes
+```
+
+In every directory you want to deny. The `AllowOverride` in vhost
+must include `Options` for this to work.
+
+## nginx autoindex
+
+nginx defaults to autoindex off. The misconfiguration is when
+someone explicitly enabled it:
+
+```nginx
+# In vhost or location block, REMOVE these lines if present:
+autoindex on;
+autoindex_format html;
+autoindex_exact_size off;
+autoindex_localtime on;
+```
+
+To explicitly assert off:
+
+```nginx
+location / {
+    autoindex off;
+    try_files $uri $uri/ =404;
+}
+```
+
+The `try_files` directive ensures missing files return 404 instead
+of any fallback behavior.
+
+## Caddy file_server
+
+Don't use `browse`:
+
+```caddy
+example.com {
+    root * /srv/site
+    file_server         # NO browse keyword
+}
+```
+
+If browse was previously enabled, remove it:
+
+```caddy
+# BEFORE (vulnerable):
+example.com {
+    root * /srv/site
+    file_server browse
+}
+
+# AFTER:
+example.com {
+    root * /srv/site
+    file_server
+    try_files {path} {path}/index.html =404
+}
+```
+
+## Python http.server
+
+Don't use in production. Period. If you absolutely must serve static
+files with python in a constrained environment, use a real server
+behind it OR a subclass that overrides `list_directory`:
+
+```python
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+class NoBrowse(SimpleHTTPRequestHandler):
+    def list_directory(self, path):
+        self.send_error(403, "Directory listing not permitted")
+        return None
+
+HTTPServer(('0.0.0.0', 8000), NoBrowse).serve_forever()
+```
+
+## Node serve / http-server
+
+```bash
+# serve — pass --single to disable directory listing
+npx serve --single ./build
+
+# http-server — pass -d false
+npx http-server -d false ./build
+```
+
+Both options return 404 for missing files instead of generating a
+listing page.
+
+## IIS
+
+`web.config`:
+
+```xml
+<system.webServer>
+    <directoryBrowse enabled="false" />
+    <defaultDocument>
+        <files>
+            <add value="index.html" />
+            <add value="default.htm" />
+        </files>
+    </defaultDocument>
+</system.webServer>
+```
+
+## AWS S3
+
+### Block public ListBucket
+
+S3 bucket policy — explicitly deny ListBucket to public:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenyPublicList",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-public-cdn-bucket"
+        },
+        {
+            "Sid": "AllowPublicRead",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::my-public-cdn-bucket/*"
+        }
+    ]
+}
+```
+
+Even better: enable S3 Block Public Access at the account level:
+
+```bash
+aws s3api put-public-access-block --bucket my-bucket \
+    --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+```
+
+This blocks ALL public access at the bucket level. To then serve
+content publicly, do it via CloudFront with Origin Access Control,
+NOT via direct S3 URLs.
+
+## AWS CloudFront in front of S3
+
+When using CloudFront with Origin Access Control (recommended
+pattern):
+
+1. S3 bucket policy denies all public access.
+2. Only the OAC's CloudFront distribution can read objects.
+3. CloudFront's behavior settings determine what's reachable.
+
+```bash
+# Lock down the bucket
+aws s3api put-bucket-policy --bucket my-bucket --policy '{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Sid": "AllowCloudFrontOAC",
+        "Effect": "Allow",
+        "Principal": {"Service": "cloudfront.amazonaws.com"},
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::my-bucket/*",
+        "Condition": {
+            "StringEquals": {
+                "AWS:SourceArn": "arn:aws:cloudfront::ACCOUNT:distribution/DIST_ID"
+            }
+        }
+    }]
+}'
+```
+
+## GCS
+
+```bash
+# Remove allUsers from objectViewer role
+gsutil iam ch -d allUsers:objectViewer gs://my-bucket
+
+# Make individual objects publicly readable instead (per-object ACL)
+gsutil acl ch -u AllUsers:R gs://my-bucket/path/to/specific-file.png
+```
+
+Or use a Cloud CDN + signed URLs for true private serving.
+
+## Azure Blob
+
+```bash
+# Set container access level to Private (not Container)
+az storage container set-permission \
+    --account-name myaccount \
+    --name mycontainer \
+    --public-access off
+```
+
+Then use SAS tokens or Azure CDN with private origin for public-facing
+content.
+
+## CI integration
+
+```yaml
+- name: Directory-listing posture gate
+  run: |
+    python3 plugins/security/penetration-tester/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+        "${{ secrets.PROD_URL }}" \
+        --authorized \
+        --min-severity high \
+        --format json \
+        --output autoindex-report.json
+- run: |
+    if jq 'any(.severity == "critical" or .severity == "high")' autoindex-report.json | grep -q true; then
+      echo "::error::Directory listing detected"
+      exit 1
+    fi
+```
+
+## After remediation: assume enumeration occurred
+
+If autoindex was exposed for any period:
+
+- For `/backup/` listings: assume all backup files were enumerated.
+  Rotate any credentials referenced in those files. Investigate
+  whether any backup files contained PII that needs breach
+  notification.
+- For `/uploads/` listings: assume the file index was scraped.
+  If any uploaded files were private (e.g., user-uploaded
+  documents), assume those filenames are known to attackers
+  even if the file contents required separate auth to fetch.
+- For `/.git/` listings: assume the entire repository was
+  reconstructed. Rotate every credential ever committed to the
+  repo, including credentials in past commits that were later
+  removed.
+
+## Verification after remediation
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/detecting-directory-listing/scripts/probe_directory_listing.py \
+    https://example.com --authorized --min-severity info
+```
+
+Expected: exit 0, zero findings of any severity.

--- a/plugins/security/penetration-tester/skills/detecting-directory-listing/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/detecting-directory-listing/references/THEORY.md
@@ -1,0 +1,203 @@
+# Directory-Listing Theory
+
+## The recurring pattern
+
+Web servers default-handle a directory request in one of three ways:
+
+1. **Serve the directory's `index` file** (`index.html`, `index.php`,
+   etc.) — the safe default.
+2. **Generate an autoindex** — list every file in the directory as
+   HTML. The dangerous default.
+3. **Return 403 / 404** — deny the listing entirely. The defensive
+   default.
+
+Which behavior applies depends on the server's configuration and
+whether an index file is present. The risk surface: a directory
+without an `index.html`, where the server is configured to
+fall back to autoindex.
+
+This was the default in older Apache configurations. Modern stacks
+(Caddy, nginx defaults) deny by default but legacy configs still
+have it enabled.
+
+## Per-server behavior
+
+### Apache mod_autoindex
+
+```apache
+Options +Indexes        # autoindex ENABLED — bad on app servers
+Options -Indexes        # autoindex DISABLED — safe default
+```
+
+The default in Apache 2.4 depends on the distribution: Debian /
+Ubuntu have `Indexes` enabled in the default `<Directory /var/www/>`
+block. Red Hat / CentOS disable it by default.
+
+Fingerprint: `<title>Index of /<path></title>` + an HTML table of
+file entries with mtime + size columns.
+
+### nginx autoindex
+
+```nginx
+location /uploads/ {
+    autoindex on;          # enabled — bad
+}
+location /uploads/ {
+    autoindex off;         # disabled — safe (default)
+}
+```
+
+nginx defaults to autoindex off; you have to explicitly enable it.
+When seen, it's a deliberate config someone added.
+
+Fingerprint: HTML body with `<pre>` formatting, lines like
+`<a href="filename">filename</a>` with size + mtime columns.
+
+### Caddy file_server browse
+
+```caddy
+example.com {
+    root * /srv/site
+    file_server browse    # autoindex enabled
+}
+```
+
+vs.
+
+```caddy
+example.com {
+    root * /srv/site
+    file_server           # no browse — disabled (default)
+}
+```
+
+Caddy v2 defaults to NOT browse. The browse mode generates a styled
+HTML directory listing.
+
+Fingerprint: `<table class="listing">` with sortable column headers.
+
+### Lighttpd mod_dirlisting
+
+```lighttpd
+dir-listing.activate = "enable"
+```
+
+Less common in modern deployments but still found in IoT firmware
+web UIs and embedded server setups.
+
+### Python http.server (dev only)
+
+`python3 -m http.server 8000` — the stdlib dev server defaults to
+autoindex. Should never be in production but sometimes runs on a
+forgotten port.
+
+Fingerprint: `<title>Directory listing for /<path></title>`.
+
+### Node `serve` / `http-server`
+
+`npx serve` and `http-server` both default to autoindex. Common in
+developer-facing tooling, hosting docs sites, or "I just need a
+quick static server" setups.
+
+### IIS
+
+IIS disables directory browsing by default. If enabled in
+`web.config`:
+
+```xml
+<system.webServer>
+    <directoryBrowse enabled="true" />
+</system.webServer>
+```
+
+Fingerprint: HTML body with "Directory browsing" title.
+
+### AWS S3 ListBucket
+
+S3 buckets aren't web servers in the conventional sense but expose
+similar functionality. A bucket policy that grants `s3:ListBucket`
+to the public lets unauthenticated requestors list every object.
+
+Fingerprint: XML response with `<ListBucketResult>` root element,
+listing every key in the bucket.
+
+### Azure Blob Storage list-blob
+
+Same pattern: `?restype=container&comp=list` on a public-list
+container returns XML enumeration of every blob.
+
+Fingerprint: `<EnumerationResults>` root + blob entries with
+properties.
+
+### GCS bucket "list" permission
+
+GCP Cloud Storage equivalent: `storage.objects.list` granted to
+`allUsers` lets anyone enumerate bucket contents.
+
+Fingerprint: similar XML / JSON enumeration depending on whether
+the request hit the JSON or XML API.
+
+## Why directory listings escalate other findings
+
+Directory listings rarely stand alone. They compound the impact of
+other findings:
+
+### Combined with `.git/` exposure
+
+Skill #6 detects `.git/HEAD` reachable. If the parent `.git/`
+directory ALSO has autoindex on, every object in `.git/objects/`
+is enumerable. GitDumper-style tools become unnecessary — you can
+just `wget -r` the directory.
+
+### Combined with backup-file exposure
+
+Skill #6 probes specific backup file paths (`backup.sql`,
+`dump.sql`). Autoindex on `/backup/` lets the attacker see every
+backup file the operator ever left, including ones with non-
+canonical names (`db-snapshot-2024-03-15.sql.bz2`,
+`pre-migration-dump.sql`).
+
+### Combined with upload directories
+
+If `/uploads/` lists, every user-uploaded file is enumerable
+including potentially-sensitive private uploads that the
+application's auth layer was supposed to gate.
+
+## Why static-asset hosts are a common pitfall
+
+A common pattern: front-end is hosted on a CDN (S3 plus CloudFront,
+GCS plus Cloud CDN). The bucket policy is set to "allow public read
+of specific objects" but the BUCKET listing permission is left at
+default, which on S3 with an explicit grant is "public ListBucket."
+
+The fix is to:
+
+1. Make individual objects publicly readable (`s3:GetObject`).
+2. NOT grant `s3:ListBucket` to `*`.
+
+Result: clients can fetch `https://cdn.example.com/assets/logo.png`
+if they know the path, but `https://cdn.example.com/assets/`
+returns AccessDenied.
+
+## Why the SPA case isn't autoindex
+
+Single-Page Applications using client-side routing return the app's
+`index.html` for any unknown route. That's NOT an autoindex page —
+it's a deliberate routing decision. The fingerprint check
+distinguishes:
+
+- Autoindex → HTML body contains "Index of /<path>" or framework
+  banner
+- SPA → HTML body is the application's own UI
+
+A 200 response with HTML body that doesn't match any autoindex
+fingerprint is an SPA catch-all and is NOT flagged.
+
+## Primary sources
+
+- [OWASP WSTG-CONF-04 — Review Old Backup and Unreferenced Files](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information)
+- [CWE-548 — Exposure of Information Through Directory Listing](https://cwe.mitre.org/data/definitions/548.html)
+- [nginx autoindex module](https://nginx.org/en/docs/http/ngx_http_autoindex_module.html)
+- [Apache mod_autoindex](https://httpd.apache.org/docs/2.4/mod/mod_autoindex.html)
+- [Caddy file_server directive](https://caddyserver.com/docs/caddyfile/directives/file_server)
+- [AWS S3 — Blocking public access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)

--- a/plugins/security/penetration-tester/skills/detecting-directory-listing/scripts/probe_directory_listing.py
+++ b/plugins/security/penetration-tester/skills/detecting-directory-listing/scripts/probe_directory_listing.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Directory-listing probe.
+
+Companion to skill `detecting-directory-listing`. For each candidate
+directory path, appends a trailing slash and sends a GET. If the
+response is 200 and the body matches a framework-specific autoindex
+fingerprint, it's a finding.
+
+References:
+    OWASP WSTG-CONF-04 Review Old Backup and Unreferenced Files
+    CWE-548 Exposure of Information Through Directory Listing
+    nginx autoindex docs, Apache mod_autoindex docs
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.authz_check import require_authorization  # noqa: E402
+from lib.finding import Finding, Severity  # noqa: E402
+from lib.http_client import make_session, safe_get  # noqa: E402
+from lib.report import emit, exit_code  # noqa: E402
+
+SKILL_ID = "detecting-directory-listing"
+
+
+# Probe set. Each entry: (path, severity, control)
+PROBES = [
+    # CRITICAL — config + VCS directories
+    ("config/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    ("conf/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    (".config/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    (".git/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    (".git/objects/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    (".svn/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    (".hg/", Severity.CRITICAL, "NIST 800-53 SC-28"),
+    # HIGH — backup / upload / log / dump dirs
+    ("backup/", Severity.HIGH, "CWE-548"),
+    ("backups/", Severity.HIGH, "CWE-548"),
+    ("uploads/", Severity.HIGH, "CWE-548"),
+    ("upload/", Severity.HIGH, "CWE-548"),
+    ("logs/", Severity.HIGH, "CWE-548"),
+    ("log/", Severity.HIGH, "CWE-548"),
+    ("dump/", Severity.HIGH, "CWE-548"),
+    ("dumps/", Severity.HIGH, "CWE-548"),
+    ("tmp/", Severity.HIGH, "CWE-548"),
+    ("temp/", Severity.HIGH, "CWE-548"),
+    ("cache/", Severity.HIGH, "CWE-548"),
+    ("data/", Severity.HIGH, "CWE-548"),
+    ("private/", Severity.HIGH, "CWE-548"),
+    ("internal/", Severity.HIGH, "CWE-548"),
+    ("storage/", Severity.HIGH, "CWE-548"),
+    ("var/", Severity.HIGH, "CWE-548"),
+    ("files/", Severity.HIGH, "CWE-548"),
+    # MEDIUM — asset / public-ish dirs (file enumeration enabled)
+    ("assets/", Severity.MEDIUM, "CWE-548"),
+    ("static/", Severity.MEDIUM, "CWE-548"),
+    ("public/", Severity.MEDIUM, "CWE-548"),
+    ("media/", Severity.MEDIUM, "CWE-548"),
+    ("images/", Severity.MEDIUM, "CWE-548"),
+    ("img/", Severity.MEDIUM, "CWE-548"),
+    ("downloads/", Severity.MEDIUM, "CWE-548"),
+    ("docs/", Severity.MEDIUM, "CWE-548"),
+    ("documentation/", Severity.MEDIUM, "CWE-548"),
+    ("vendor/", Severity.MEDIUM, "CWE-548"),
+    ("node_modules/", Severity.HIGH, "CWE-548"),  # higher: enables specific version-CVE lookup
+    ("bower_components/", Severity.HIGH, "CWE-548"),
+    # MEDIUM — generic root
+    ("", Severity.MEDIUM, "OWASP A05:2021"),  # root itself
+]
+
+
+# Framework-specific autoindex fingerprints applied to first 4 KiB of body
+AUTOINDEX_PATTERNS = [
+    (r"<title>Index of /", "Apache mod_autoindex"),
+    (r"<h1>Index of /", "Apache mod_autoindex / nginx fancyindex"),
+    (r"<title>Directory listing for /", "Python http.server"),
+    (r"<title>Directory: /", "Caddy file_server browse"),
+    (r"<table[^>]*class=['\"]listing", "Caddy file_server browse"),
+    (r"<pre><a href=['\"]\.\.['\"]>\.\./</a>", "nginx default autoindex"),
+    (r"<head>\s*<title>Index of [^<]+</title>", "Generic autoindex"),
+    (r"^\s*<\?xml.+<ListBucketResult", "AWS S3 ListBucket XML"),
+    (r"<EnumerationResults", "Azure Blob list-blob XML"),
+    (r"<title>Objects:", "GCS bucket browse"),
+    (r"<h1>Listing", "Rails / Rack::Directory listing"),
+    (r"<title>Index - /", "Lighttpd mod_dirlisting"),
+    (r"^\s*<!DOCTYPE\s+html>[\s\S]+<h1>\s*Index of\s+/", "Variant Index of"),
+]
+
+
+def _is_autoindex(body_text: str) -> tuple[bool, str | None]:
+    """Returns (matched, framework_name) — True if body looks like an autoindex page."""
+    sample = (body_text or "")[:4096]
+    for pattern, framework in AUTOINDEX_PATTERNS:
+        if re.search(pattern, sample, re.MULTILINE | re.IGNORECASE):
+            return True, framework
+    return False, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Directory-listing probe")
+    parser.add_argument("url")
+    parser.add_argument("--authorized", action="store_true")
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--format", choices=("json", "jsonl", "markdown"), default="markdown")
+    parser.add_argument("--min-severity", choices=("critical", "high", "medium", "low", "info"), default="info")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--paths-file", default=None, help="Custom probe set (one path per line); replaces default")
+    args = parser.parse_args(argv)
+
+    require_authorization(args.url, args.authorized)
+
+    sess = make_session(timeout=args.timeout)
+    base = args.url.rstrip("/") + "/"
+    findings: list[Finding] = []
+
+    probe_set = PROBES
+    if args.paths_file:
+        paths = Path(args.paths_file).read_text().splitlines()
+        probe_set = [(p.strip().rstrip("/") + "/", Severity.MEDIUM, "custom") for p in paths if p.strip()]
+
+    for path, sev, control in probe_set:
+        url = base + path.lstrip("/")
+        resp = safe_get(sess, url, timeout=args.timeout, allow_redirects=False)
+        if resp is None or resp.status_code != 200:
+            continue
+        body = resp.text or ""
+        ctype = resp.headers.get("Content-Type", "")
+        # Reject application/* responses (e.g. JSON APIs returning a 200) —
+        # those aren't autoindex pages
+        if "html" not in ctype.lower() and "xml" not in ctype.lower():
+            continue
+        matched, framework = _is_autoindex(body)
+        if not matched:
+            continue
+        findings.append(
+            Finding(
+                skill_id=SKILL_ID,
+                title=f"Directory listing exposed at /{path} ({framework})",
+                severity=sev,
+                target=url,
+                detail=(
+                    f"GET {url} returned 200 with HTML body matching the "
+                    f"{framework} autoindex fingerprint. Every file in this "
+                    "directory is enumerable to any external requestor, "
+                    "including files the application never explicitly linked to."
+                ),
+                remediation=(
+                    f"Disable autoindex for {path!r} at the web-server layer. "
+                    "See references/PLAYBOOK.md for per-server snippets "
+                    "(nginx `autoindex off`, Apache `Options -Indexes`, "
+                    "Caddy drop the `file_server browse` directive, S3 "
+                    "remove `s3:ListBucket` from the public bucket policy)."
+                ),
+                cwe_id="CWE-548",
+                affected_control=control,
+                evidence=(
+                    ("framework", framework or "unknown"),
+                    ("content_type", ctype),
+                    ("body_sample_len", len(body)),
+                ),
+            )
+        )
+
+    floor = Severity(args.min_severity)
+    findings = [f for f in findings if f.severity.numeric >= floor.numeric]
+
+    emit(findings, args.output, args.format, args.url)
+    return exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/fingerprinting-server-software/SKILL.md
+++ b/plugins/security/penetration-tester/skills/fingerprinting-server-software/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: fingerprinting-server-software
+description: |
+  Identify the server software, framework, and component versions a
+  target is running from its HTTP response signatures — Server header,
+  X-Powered-By, Via, X-AspNet-Version, X-Runtime, X-Drupal-Cache,
+  X-Generator, Set-Cookie name patterns, error-page artwork,
+  HTTP method behavior signatures.
+  Use when: penetration test reconnaissance phase, post-deploy audit
+  of fingerprintable exposure, or before reporting "no obvious version
+  disclosure" to an auditor.
+  Threshold: any version string in a response header (e.g.,
+  Server header with nginx/1.18.0, X-Powered-By with PHP/7.4.21,
+  X-Generator with Drupal 9), or any framework-default Set-Cookie
+  name (PHPSESSID, JSESSIONID, connect.sid, _csrf_token).
+  Trigger with: "fingerprint server", "version disclosure",
+  "tech-stack identification", "what's this site running".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Bash(curl:*)
+disallowed-tools:
+  - Bash(rm:*)
+  - Edit(/etc/*)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - information-disclosure
+  - fingerprinting
+  - reconnaissance
+  - pentest
+---
+
+# Fingerprinting Server Software
+
+## Overview
+
+Version disclosure is the cheapest recon an attacker buys. A single
+GET request returns the `Server:` header, the `X-Powered-By:` header,
+and any framework-default cookies. From those three signals the
+attacker derives: web server family + exact version, app-framework +
+version, language runtime + version. That maps directly to a CVE
+catalog query: every published CVE affecting any of those components,
+filtered to ones an unauthenticated attacker can trigger.
+
+The fix is operationally trivial (one line in nginx, one line in
+Apache, one line in IIS) but the discipline isn't universal. This
+skill enumerates the signals + reports each disclosure with the
+severity matching how much it enables follow-on attack.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Server header discloses version | **MEDIUM** | `Server: nginx/1.18.0` or similar with explicit version | CWE-200 |
+| Server header discloses minor version | **LOW** | `Server: nginx` (no version) | CWE-200 |
+| X-Powered-By discloses framework version | **MEDIUM** | `X-Powered-By: PHP/7.4.21`, `Express`, `ASP.NET` | CWE-200 |
+| X-AspNet-Version present | **HIGH** | Specific dotnet runtime version | CWE-200 |
+| X-Runtime / X-Rails / X-Django headers present | **LOW** | Framework identification, no version | CWE-200 |
+| X-Generator: drupal/wordpress + version | **MEDIUM** | CMS family + version disclosure | CWE-200 |
+| Via header discloses proxy chain | **LOW** | Reveals upstream architecture (Varnish, Squid, CloudFront) | CWE-200 |
+| Framework-default Set-Cookie pattern | **LOW** | `PHPSESSID`, `JSESSIONID`, `connect.sid`, etc. | CWE-200 |
+| Error page reveals stack trace | **HIGH** | 5xx response body contains source file paths or framework banner | CWE-209 |
+| HTTP/2 server-push fingerprint | **LOW** | HTTP/2 `:server` pseudo-header with version | CWE-200 |
+| ETag format identifies cluster member | **LOW** | Apache-style hex ETags reveal node | CWE-200 |
+
+## Prerequisites
+
+- Python 3.9+ with `requests`
+- Authorization for non-local targets
+
+## Instructions
+
+### Step 1 — Confirm Authorization
+
+```text
+"Do you have authorization to perform server-fingerprinting probes on
+ this target? I need confirmation before proceeding."
+```
+
+### Step 2 — Run the scanner
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+    https://target.example.com \
+    --authorized
+```
+
+Options:
+
+```
+Usage: fingerprint_server.py URL [OPTIONS]
+
+Options:
+  --authorized       Attest authorization (required for non-local)
+  --output FILE      Write findings to FILE
+  --format FMT       json | jsonl | markdown (default: markdown)
+  --min-severity SEV (default: info)
+  --timeout SECS     Per-probe timeout (default: 10)
+  --trigger-error    Send a malformed request to surface error-page disclosure
+                     (off by default — some WAFs block on this)
+```
+
+The scanner sends a baseline GET + an OPTIONS + (optionally) a
+malformed request to surface error-page disclosure. For each
+response, it parses the standard fingerprinting headers and
+classifies each match against the threshold table above.
+
+### Step 3 — Interpret findings
+
+The vast majority of findings will be MEDIUM or LOW. CWE-200 is by
+itself rarely a critical vulnerability — it's a recon enabler.
+
+The exception: error-page stack-trace disclosure (CWE-209) is HIGH
+because production error pages should never leak server-internal
+paths or framework banners. If the error page reveals
+`/home/app/src/handlers/auth.py`, the attacker now knows the source
+layout AND that the language is Python.
+
+### Step 4 — Cross-skill chaining
+
+After this skill, suggest:
+
+- `detecting-debug-endpoints` (#7) — fingerprinted framework points
+  to which debug endpoints to probe (e.g., Server: nginx → check
+  /nginx_status; X-Powered-By: Spring → check /actuator/*).
+- `detecting-exposed-secrets-files` (#6) — framework fingerprint
+  informs which CI / IDE / build-tool configs to probe for.
+
+## Examples
+
+### Example 1 — Post-deploy version-disclosure audit
+
+User: "Make sure we're not leaking nginx version on prod."
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+    https://app.example.com --authorized --min-severity medium
+```
+
+Expected on a properly-configured host: zero findings of medium+.
+
+### Example 2 — Tech-stack identification on an unknown target
+
+User: "Bug bounty submission. We don't know what stack this runs.
+What's the surface?"
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+    https://target.example.com --authorized --format markdown
+```
+
+Use the output to inform which subsequent skills to chain (debug-
+endpoint probe, secrets-file probe).
+
+### Example 3 — Error-page exposure check
+
+User: "Audit production error pages for stack-trace disclosure."
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+    https://app.example.com --authorized --trigger-error --min-severity high
+```
+
+The `--trigger-error` flag sends a malformed request to provoke a
+500. Some WAFs block on this; check with the target's ops team if
+the result comes back empty.
+
+## Output
+
+JSON / JSONL / Markdown. Exit codes: 0 clean, 1 high/critical, 2 error.
+
+## Error Handling
+
+- **WAF blocks fingerprinting requests** → expected on
+  Cloudflare/Imperva targets. The CDN itself is what gets
+  fingerprinted, not the origin.
+- **Connection error** → exit 2.
+
+## Resources
+
+- `references/THEORY.md` — Per-header reasoning: what each disclosure
+  enables, threat-modeling guidance, CVE-lookup workflow
+- `references/PLAYBOOK.md` — Per-server-type remediation snippets
+  (nginx server_tokens, Apache ServerTokens, IIS removeHeader,
+  Express helmet hidePoweredBy, framework-default cookie renaming)
+- `../analyzing-tls-config/references/AUTHORIZATION.md` — Active-scan
+  authorization pattern

--- a/plugins/security/penetration-tester/skills/fingerprinting-server-software/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/fingerprinting-server-software/references/PLAYBOOK.md
@@ -1,0 +1,337 @@
+# Server-Fingerprinting Remediation Playbook
+
+## Strip Server header
+
+### nginx
+
+```nginx
+http {
+    server_tokens off;
+}
+```
+
+To go further (replace nginx with a custom token, requires
+`headers-more-nginx-module`):
+
+```nginx
+more_set_headers "Server: ";  # send empty Server header
+```
+
+### Apache
+
+```apache
+ServerTokens Prod
+ServerSignature Off
+```
+
+`ServerTokens Prod` makes the Server header read just `Apache` (no
+version, no OS). `ServerSignature Off` removes the footer from
+generated error pages.
+
+### Caddy
+
+Caddy 2.x doesn't disclose by default. Verify with `caddy adapt
+--pretty` and ensure no override.
+
+### IIS
+
+PowerShell to remove via URL Rewrite outbound rule:
+
+```powershell
+# Add outbound rule that strips Server header
+$site = "Default Web Site"
+$rule = @{
+    name = "Strip Server Header"
+    patternSyntax = "Wildcard"
+    match = "*"
+    serverVariable = "RESPONSE_SERVER"
+    action = "Rewrite"
+    value = ""
+}
+Add-WebConfigurationProperty -PSPath "IIS:\Sites\$site" -Filter "/system.webServer/rewrite/outboundRules" -Name "." -Value $rule
+```
+
+### AWS ALB / CloudFront
+
+ALB: Listener → Add header policy → Drop `Server` header on response.
+
+CloudFront: Behaviors → Response Headers Policy → Custom Headers →
+add `Server:` (empty) override.
+
+### Cloudflare
+
+Workers script:
+
+```javascript
+addEventListener('fetch', event => event.respondWith(handleRequest(event.request)))
+async function handleRequest(req) {
+    const resp = await fetch(req);
+    const newHeaders = new Headers(resp.headers);
+    newHeaders.delete('Server');
+    newHeaders.delete('X-Powered-By');
+    return new Response(resp.body, {
+        status: resp.status,
+        statusText: resp.statusText,
+        headers: newHeaders,
+    });
+}
+```
+
+## Strip X-Powered-By
+
+### PHP
+
+`php.ini`:
+
+```ini
+expose_php = Off
+```
+
+### Express
+
+```javascript
+app.disable('x-powered-by');
+// or with helmet:
+const helmet = require('helmet');
+app.use(helmet.hidePoweredBy());
+```
+
+### ASP.NET
+
+`web.config`:
+
+```xml
+<system.webServer>
+    <httpProtocol>
+        <customHeaders>
+            <remove name="X-Powered-By" />
+            <remove name="X-AspNet-Version" />
+            <remove name="X-AspNetMvc-Version" />
+        </customHeaders>
+    </httpProtocol>
+</system.webServer>
+```
+
+Plus for X-AspNet-Version:
+
+```xml
+<system.web>
+    <httpRuntime enableVersionHeader="false" />
+</system.web>
+```
+
+Plus for X-AspNetMvc-Version, in `Global.asax`:
+
+```csharp
+protected void Application_Start()
+{
+    MvcHandler.DisableMvcResponseHeader = true;
+}
+```
+
+## Strip X-Runtime (Rails)
+
+`config/application.rb`:
+
+```ruby
+config.middleware.delete Rack::Runtime
+# Or globally:
+config.action_dispatch.runtime_response_header = nil
+```
+
+## Strip X-Generator
+
+### Drupal
+
+```php
+// settings.php
+$config['system.theme']['default']['generator'] = '';
+
+// Or via custom module hook:
+function MYMODULE_preprocess_html(&$variables) {
+    unset($variables['head_title']['generator']);
+}
+```
+
+### WordPress
+
+```php
+// functions.php
+remove_action('wp_head', 'wp_generator');
+```
+
+Also remove the `<meta name="generator">` tag with a similar hook
+for the HTML body.
+
+## Rename framework-default cookies
+
+### Express
+
+```javascript
+app.use(session({
+    name: 'sid',          // not 'connect.sid'
+    secret: process.env.SESSION_SECRET,
+    cookie: { httpOnly: true, secure: true, sameSite: 'lax' },
+}));
+```
+
+### Spring Boot
+
+```yaml
+server:
+  servlet:
+    session:
+      cookie:
+        name: sid       # not JSESSIONID
+        http-only: true
+        secure: true
+```
+
+### Rails
+
+```ruby
+# config/initializers/session_store.rb
+Rails.application.config.session_store :cookie_store, key: '_sid'
+```
+
+### Django
+
+```python
+# settings.py
+SESSION_COOKIE_NAME = 'sid'   # not 'sessionid'
+```
+
+### Laravel
+
+```php
+// .env
+SESSION_COOKIE=sid
+
+// or config/session.php
+'cookie' => env('SESSION_COOKIE', 'sid'),
+```
+
+### PHP (native)
+
+```ini
+; php.ini
+session.name = sid           ; not PHPSESSID
+```
+
+## Suppress production error stack traces
+
+### Django
+
+```python
+# settings/production.py
+DEBUG = False
+ADMINS = [('Ops', 'ops@example.com')]  # ops gets the trace via email, not the user
+```
+
+### Rails
+
+```ruby
+# config/environments/production.rb
+config.consider_all_requests_local = false
+config.action_dispatch.show_exceptions = true
+config.action_dispatch.show_detailed_exceptions = false
+```
+
+### Spring Boot
+
+```yaml
+server:
+  error:
+    include-stacktrace: never
+    include-message: never
+    include-exception: false
+    include-binding-errors: never
+```
+
+### ASP.NET
+
+`web.config`:
+
+```xml
+<system.web>
+    <customErrors mode="RemoteOnly" defaultRedirect="~/error" />
+</system.web>
+```
+
+### Express
+
+```javascript
+// Default Express error handler shows stack in development;
+// override in production:
+app.use((err, req, res, next) => {
+    if (req.app.get('env') === 'production') {
+        res.status(500).send('Internal Server Error');
+    } else {
+        next(err);
+    }
+});
+```
+
+### Flask
+
+```python
+app.config['DEBUG'] = False
+app.config['PROPAGATE_EXCEPTIONS'] = False
+
+@app.errorhandler(500)
+def internal_error(error):
+    return render_template('500.html'), 500
+```
+
+### Go (net/http stdlib)
+
+```go
+// Don't use the default panic handler that prints stack
+mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+    defer func() {
+        if err := recover(); err != nil {
+            // Log internally, return generic message
+            log.Printf("panic: %v", err)
+            http.Error(w, "Internal Server Error", 500)
+        }
+    }()
+    // ... handler logic
+})
+```
+
+## Fix Apache ETag fingerprint
+
+```apache
+# In httpd.conf or vhost
+FileETag MTime Size   # drop inode
+# Or:
+FileETag None         # disable ETags entirely
+```
+
+## CI integration
+
+```yaml
+- name: Server-fingerprint posture
+  run: |
+    python3 plugins/security/penetration-tester/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+        "${{ secrets.PROD_URL }}" \
+        --authorized \
+        --min-severity medium \
+        --format json \
+        --output fingerprint-report.json
+- run: |
+    if jq 'any(.severity == "high" or .severity == "medium")' fingerprint-report.json | grep -q true; then
+      echo "::warning::Server-fingerprint findings present"
+    fi
+```
+
+## Verification after remediation
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/fingerprinting-server-software/scripts/fingerprint_server.py \
+    https://example.com --authorized --min-severity medium --trigger-error
+```
+
+Expected: exit 0, zero MEDIUM-or-higher findings. LOW findings on
+framework-default cookies are acceptable trade-offs if you've judged
+the recon-cost-vs-rename-pain tradeoff and chose to keep defaults.

--- a/plugins/security/penetration-tester/skills/fingerprinting-server-software/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/fingerprinting-server-software/references/THEORY.md
@@ -1,0 +1,183 @@
+# Server-Fingerprinting Theory
+
+## Why version disclosure is the cheapest pre-attack recon
+
+Every web server, application framework, and runtime has a published
+list of CVEs. The CVE catalog is queryable by component name + version.
+Disclosing "nginx 1.18.0" hands the attacker an exact filter to apply
+against the CVE catalog and produce a list of unauthenticated remote
+exploits affecting that version. The exploitation cost goes from "scan
+for arbitrary issues" to "execute the specific exploits known to work
+against this version."
+
+Most fingerprinting disclosures are not in themselves vulnerabilities —
+they're CVSS-low / informational findings. But the cumulative effect
+is that the attacker arrives at the application with a pre-prepared
+attack toolkit calibrated to the exact software in use. The defensive
+posture is "make the attacker work for the recon" — strip the
+identifying headers, even though doing so doesn't strictly fix any
+specific CVE.
+
+## Header-by-header
+
+### `Server`
+
+The classic. nginx, Apache, and IIS all default to including their
+name + version. Most modern reverse proxies have been configured to
+strip on outbound by default; legacy stacks still leak.
+
+Worst case: `Server: Apache/2.2.15 (CentOS)` — three pieces of info
+in one header. Apache version (2.2 is end-of-life). OS family
+(CentOS). And the CentOS minor often differentiable by which Apache
+backport-patch level shows up.
+
+Fix is one config directive per server:
+
+- nginx: `server_tokens off;`
+- Apache: `ServerTokens Prod`
+- Caddy: doesn't disclose since v2.0
+- IIS: URL Rewrite module → outbound rule to strip
+
+### `X-Powered-By`
+
+PHP, Express, ASP.NET — frameworks that announce their identity by
+default.
+
+- `X-Powered-By: PHP/7.4.21` — exact runtime version. Lookup CVEs
+  against PHP 7.4.x — the EOL date for PHP 7.4 was November 2022, so
+  anything 7.4-shaped is end-of-life and a target for unpatched-EOL
+  exploitation.
+- `X-Powered-By: Express` — Node.js Express identification.
+- `X-Powered-By: ASP.NET` — .NET stack identification.
+
+Each is a single config line away from elimination.
+
+### `X-AspNet-Version` / `X-AspNetMvc-Version`
+
+.NET runtime exact version. Higher severity than generic
+X-Powered-By because the dotnet version pins the runtime + the BCL
+version + the ASP.NET version simultaneously. CVE catalog hits multiply.
+
+Disable via `web.config`:
+
+```xml
+<httpRuntime enableVersionHeader="false" />
+```
+
+### `X-Generator`
+
+CMS family marker. Drupal, Joomla, and WordPress all add a generator
+header by default. Drupal includes the major version
+(`X-Generator: Drupal 9`); WordPress used to include the full version
+in `<meta name="generator">` HTML.
+
+For CMS targets specifically, fingerprint → CVE chain is heavily
+weighted toward the CMS itself (Drupal core + module CVEs) and the
+themes / plugins layered on top.
+
+### `Via`
+
+HTTP/1.1 standard header for proxy chain identification. Some setups
+include the upstream's hostname + version, others use a generic token.
+
+`Via: 1.1 varnish-v4` → reveals Varnish in front of origin.
+`Via: 1.1 google` → CloudFront.
+
+Less sensitive than direct server-version disclosure, but informs
+network architecture.
+
+### Framework-default cookies
+
+Frameworks set session cookies with predictable names:
+
+| Cookie name | Framework |
+|---|---|
+| `PHPSESSID` | PHP |
+| `JSESSIONID` | Java EE (Tomcat, WebSphere, WebLogic, Spring) |
+| `ASP.NET_SessionId` | ASP.NET |
+| `ASPSESSIONID*` | Classic ASP |
+| `connect.sid` | Express with connect.session |
+| `_session_id` | Rails |
+| `laravel_session` | Laravel |
+| `ci_session` | CodeIgniter |
+| `frontend` | Magento |
+
+Any of these in a Set-Cookie response identifies the stack family
+even if all version headers are stripped. The remediation is to
+rename the session cookie to a non-default value.
+
+It's also a defense in depth: an attacker scanning by JSESSIONID
+presence (a common "find me Java apps" scan) misses servers that
+renamed the cookie.
+
+### `ETag` format
+
+Apache's default ETag is the file's inode + size + mtime, encoded as
+hex. The inode portion is filesystem-specific — across a load-
+balanced cluster, two nodes have different inodes for the same file
+on different filesystems. Sending requests against the balanced
+endpoint and grouping by ETag reveals how many nodes back the
+service.
+
+```
+"6a7-5b9e..."  <- node A
+"3f1-5b9e..."  <- node B
+"a2c-5b9e..."  <- node C
+```
+
+The size/mtime portion is shared (same file content). The inode is
+node-distinguishing.
+
+Apache fix:
+
+```apache
+FileETag MTime Size  # drop inode
+# Or completely:
+FileETag None
+```
+
+## Error-page disclosure (CWE-209)
+
+If the application returns a detailed error page on 500-level
+responses, the body often includes:
+
+- Server-internal file paths (`/home/app/src/handlers/auth.py`)
+- Function names + line numbers (informs source-code structure)
+- Framework banner ("Django 4.2", "Spring Boot 3.1", etc.)
+- Stack traces with full module paths
+
+Each of these is high-value recon. The fix is per-framework:
+
+| Framework | Disable detailed errors in prod |
+|---|---|
+| Django | `DEBUG = False` |
+| Rails | `config.consider_all_requests_local = false` |
+| Spring Boot | `server.error.include-stacktrace=never` |
+| ASP.NET | `customErrors mode="RemoteOnly"` |
+| Express | `app.use(errorHandler({log:false, debug:false}))` |
+| Flask | `app.config['DEBUG'] = False` + `propagate_exceptions=False` |
+
+This is universally a HIGH finding. There's no operational reason
+to ship stack traces to production responses.
+
+## The attacker's workflow that this defends against
+
+1. Send one GET to the target homepage.
+2. Read `Server`, `X-Powered-By`, `Set-Cookie` from the response.
+3. Conclude: nginx 1.18 + PHP 7.4 + Laravel 8.
+4. Query CVE catalog: filter to nginx 1.18.x + PHP 7.4.x + Laravel
+   8.x. Returns ~15 CVEs.
+5. Pick the highest-CVSS unauthenticated-remote one. Execute exploit.
+
+Total elapsed time: about 90 seconds. Defense-in-depth: strip the
+headers, rename the cookie, suppress error stack traces. The attacker
+now has to do real recon, which raises cost from minutes to hours.
+
+## Primary sources
+
+- [OWASP WSTG-INFO-02 Fingerprint Web Server](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server)
+- [OWASP WSTG-INFO-08 Fingerprint Web Application Framework](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework)
+- [CWE-200 Information Exposure](https://cwe.mitre.org/data/definitions/200.html)
+- [CWE-209 Information Exposure Through an Error Message](https://cwe.mitre.org/data/definitions/209.html)
+- [nginx server_tokens directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens)
+- [Apache ServerTokens directive](https://httpd.apache.org/docs/2.4/mod/core.html#servertokens)

--- a/plugins/security/penetration-tester/skills/fingerprinting-server-software/scripts/fingerprint_server.py
+++ b/plugins/security/penetration-tester/skills/fingerprinting-server-software/scripts/fingerprint_server.py
@@ -166,10 +166,8 @@ def _check_cookies(headers, target):
         for default_name, framework in DEFAULT_COOKIES.items():
             if default_name.endswith("*"):
                 if name.startswith(default_name.rstrip("*")):
-                    matched = default_name
                     break
             elif name == default_name:
-                matched = default_name
                 break
         else:
             continue

--- a/plugins/security/penetration-tester/skills/fingerprinting-server-software/scripts/fingerprint_server.py
+++ b/plugins/security/penetration-tester/skills/fingerprinting-server-software/scripts/fingerprint_server.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Server-software fingerprinting via HTTP response signatures.
+
+Companion to skill `fingerprinting-server-software`. Sends a baseline
+GET + an OPTIONS + optionally a malformed-request error probe, then
+parses every standard fingerprinting header and Set-Cookie name
+pattern.
+
+Each match grades against the threshold table in the skill body:
+explicit-version disclosures are MEDIUM (CWE-200), framework
+identification without version is LOW, stack-trace disclosure from
+error pages is HIGH (CWE-209).
+
+References:
+    OWASP WSTG-INFO-02 Fingerprint Web Server
+    OWASP WSTG-INFO-08 Fingerprint Web Application Framework
+    CWE-200 Information Exposure
+    CWE-209 Information Exposure Through an Error Message
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.authz_check import require_authorization  # noqa: E402
+from lib.finding import Finding, Severity  # noqa: E402
+from lib.http_client import make_session, safe_get, safe_options  # noqa: E402
+from lib.report import emit, exit_code  # noqa: E402
+
+SKILL_ID = "fingerprinting-server-software"
+
+
+# Headers that commonly leak version
+VERSION_HEADERS = [
+    "Server",
+    "X-Powered-By",
+    "X-AspNet-Version",
+    "X-AspNetMvc-Version",
+    "X-Runtime",
+    "X-Generator",
+    "X-Drupal-Cache",
+    "X-Drupal-Dynamic-Cache",
+    "X-Backend-Server",
+    "X-Server-Powered-By",
+    "X-Joomla-Version",
+]
+# Framework identification headers (lower severity — no version)
+FRAMEWORK_HEADERS = [
+    "X-Rails-Version",
+    "X-Django-Version",
+    "X-Frame-Options",  # only if present along with other framework signals
+    "Via",
+]
+# Framework-default Set-Cookie names (low — identifies stack)
+DEFAULT_COOKIES = {
+    "PHPSESSID": "PHP",
+    "JSESSIONID": "Java EE / Tomcat / WebSphere / WebLogic",
+    "ASP.NET_SessionId": "ASP.NET",
+    "ASPSESSIONID": "Classic ASP",
+    "ASPSESSIONID*": "Classic ASP (pattern)",
+    "connect.sid": "Express + connect.session",
+    "session": "Generic — multiple frameworks",
+    "_session_id": "Rails",
+    "laravel_session": "Laravel",
+    "ci_session": "CodeIgniter",
+    "frontend": "Magento",
+    "X-Mapping-*": "Sun ONE / iPlanet load-balancer",
+    "BIGipServer*": "F5 BIG-IP load-balancer",
+    "AWSALB": "AWS ALB",
+    "AWSELB": "AWS ELB classic",
+}
+# Error-page stack-trace fingerprints
+STACK_TRACE_SIGS = [
+    (r"^[ \t]*at\s+[\w.<>$]+\([\w./\\:?]+:\d+\)", "Java stack trace"),
+    (r"File\s+\"[/\\][\w/.\\]+\.py\",\s+line\s+\d+", "Python traceback"),
+    (r"in\s+/[^\s]+\.php on line \d+", "PHP error trace"),
+    (r"at\s+(?:[\w$]+\.)+[\w$]+\s+\([\w./:\\]+:\d+:\d+\)", "JavaScript stack trace"),
+    (r"\(in /[\w/.-]+\.rb:\d+", "Ruby exception"),
+    (r"goroutine\s+\d+\s+\[running\]:", "Go panic"),
+    (r"System\.[\w.]+Exception:", ".NET exception"),
+    (r"<title>[^<]*(stack trace|exception|fatal error)", "Generic error-page banner"),
+]
+
+
+def _version_in(value: str) -> bool:
+    """Heuristic: header value contains an explicit version number."""
+    return bool(re.search(r"\d+\.\d+", value))
+
+
+def _check_version_headers(headers, target, source_label):
+    findings = []
+    for h in VERSION_HEADERS:
+        v = headers.get(h)
+        if not v:
+            continue
+        has_version = _version_in(v)
+        sev = Severity.MEDIUM if has_version else Severity.LOW
+        # Specific: X-AspNet-Version always shows runtime version — HIGH
+        if h.lower().startswith("x-aspnet") and has_version:
+            sev = Severity.HIGH
+        findings.append(
+            Finding(
+                skill_id=SKILL_ID,
+                title=f"{h} header discloses {'version' if has_version else 'product'}: {v[:80]}",
+                severity=sev,
+                target=target,
+                detail=(
+                    f"The {source_label} response includes {h}: {v!r}. "
+                    "Attackers query published CVE catalogs for the disclosed "
+                    "version + family to enumerate exploitable conditions "
+                    "without further probing."
+                ),
+                remediation=_remediation_for_header(h),
+                cwe_id="CWE-200",
+                affected_control="OWASP A05:2021",
+                references=("https://cwe.mitre.org/data/definitions/200.html",),
+                evidence=((f"header:{h}", v),),
+            )
+        )
+    return findings
+
+
+def _check_framework_headers(headers, target, source_label):
+    findings = []
+    for h in FRAMEWORK_HEADERS:
+        v = headers.get(h)
+        if not v:
+            continue
+        findings.append(
+            Finding(
+                skill_id=SKILL_ID,
+                title=f"{h} header discloses stack identification: {v[:80]}",
+                severity=Severity.LOW,
+                target=target,
+                detail=(
+                    f"The {source_label} response includes {h}: {v!r}. "
+                    "Framework identification without version. Combined with "
+                    "version-bearing headers, informs CVE lookup."
+                ),
+                remediation=_remediation_for_header(h),
+                cwe_id="CWE-200",
+                affected_control="OWASP A05:2021",
+                evidence=((f"header:{h}", v),),
+            )
+        )
+    return findings
+
+
+def _check_cookies(headers, target):
+    findings = []
+    set_cookie = headers.get("Set-Cookie", "")
+    if not set_cookie:
+        return findings
+    # requests joins multiple Set-Cookie headers with comma in .headers; iterate
+    # cookie names separately
+    for cookie_blob in set_cookie.split(","):
+        # cookie name is the first token before '='
+        name = cookie_blob.split("=", 1)[0].strip()
+        for default_name, framework in DEFAULT_COOKIES.items():
+            if default_name.endswith("*"):
+                if name.startswith(default_name.rstrip("*")):
+                    matched = default_name
+                    break
+            elif name == default_name:
+                matched = default_name
+                break
+        else:
+            continue
+        findings.append(
+            Finding(
+                skill_id=SKILL_ID,
+                title=f"Framework-default cookie name discloses stack: {name} ({framework})",
+                severity=Severity.LOW,
+                target=target,
+                detail=(
+                    f"Set-Cookie name {name!r} matches the conventional "
+                    f"default for {framework}. Combined with other signals, "
+                    "informs framework + version inference."
+                ),
+                remediation=(
+                    "Rename the session cookie to a non-default value. In "
+                    "Express: app.use(session({name: 'sid', ...})). In Spring: "
+                    "server.servlet.session.cookie.name=sid. In Rails: "
+                    "config.session_store :cookie_store, key: '_sid'."
+                ),
+                cwe_id="CWE-200",
+                affected_control="OWASP A05:2021",
+            )
+        )
+    return findings
+
+
+def _check_etag(headers, target):
+    etag = headers.get("ETag", "")
+    if not etag:
+        return []
+    # Apache hex-ETag format: "<inode>-<size>-<mtime>"
+    if re.match(r'^"[0-9a-f]+-[0-9a-f]+-[0-9a-f]+"$', etag):
+        return [
+            Finding(
+                skill_id=SKILL_ID,
+                title="ETag format reveals Apache inode-size-mtime triple (cluster-member fingerprint)",
+                severity=Severity.LOW,
+                target=target,
+                detail=(
+                    f"The ETag {etag!r} matches Apache's default "
+                    "inode-size-mtime format. Across a load-balanced cluster, "
+                    "the inode portion distinguishes individual nodes, enabling "
+                    "node-by-node probing."
+                ),
+                remediation=(
+                    "Apache: `FileETag MTime Size` (drop inode). Or `FileETag None` to disable ETags entirely."
+                ),
+                cwe_id="CWE-200",
+            )
+        ]
+    return []
+
+
+def _check_error_disclosure(body_text, target):
+    findings = []
+    sample = (body_text or "")[:8192]
+    for pattern, name in STACK_TRACE_SIGS:
+        if re.search(pattern, sample, re.MULTILINE | re.IGNORECASE):
+            findings.append(
+                Finding(
+                    skill_id=SKILL_ID,
+                    title=f"Error page leaks {name}",
+                    severity=Severity.HIGH,
+                    target=target,
+                    detail=(
+                        f"The error response body contains content matching "
+                        f"the {name} pattern. Server-internal file paths, "
+                        "function names, and framework details are visible to "
+                        "any external requestor that triggers an error."
+                    ),
+                    remediation=(
+                        "Disable detailed error pages in production. Per-stack: "
+                        "Django DEBUG=False, Rails Rails.application.config."
+                        "consider_all_requests_local=false, Spring "
+                        "server.error.include-stacktrace=never, ASP.NET "
+                        "customErrors mode='RemoteOnly', Express "
+                        "app.use(errorHandler({log:false,debug:false}))."
+                    ),
+                    cwe_id="CWE-209",
+                    affected_control="OWASP A05:2021",
+                )
+            )
+            break  # only flag the first stack-trace pattern that matches
+    return findings
+
+
+def _remediation_for_header(header: str) -> str:
+    return {
+        "Server": (
+            "nginx: `server_tokens off;`. Apache: `ServerTokens Prod`. "
+            "Caddy: omitted by default (Caddy 2.x). IIS: "
+            "URL Rewrite module → outbound rule to strip header. "
+            "ALB / CloudFront: response-header policy to drop Server."
+        ),
+        "X-Powered-By": (
+            "PHP: `expose_php = Off` in php.ini. "
+            "Express: `app.disable('x-powered-by')` or `helmet({hidePoweredBy:true})`. "
+            "ASP.NET: web.config customHeaders → removeHeader X-Powered-By."
+        ),
+        "X-AspNet-Version": ('web.config: `<httpRuntime enableVersionHeader="false" />`.'),
+        "X-AspNetMvc-Version": ("Global.asax: `MvcHandler.DisableMvcResponseHeader = true;`."),
+        "X-Runtime": ("Rails: `config.action_dispatch.runtime_response_header = nil`."),
+        "X-Generator": (
+            "Drupal: settings.php → set $config['system.performance']['cache']['page']['max_age']. "
+            "Wordpress: remove_action('wp_head', 'wp_generator')."
+        ),
+        "X-Drupal-Cache": "Drupal: configure reverse proxy to strip the header before serving.",
+        "X-Drupal-Dynamic-Cache": "Drupal: same as above.",
+        "X-Joomla-Version": "Joomla: remove from template metadata.",
+        "Via": (
+            "If the Via header is from your reverse proxy, configure the proxy "
+            "to omit. nginx: `proxy_set_header Via '';`. CloudFront: "
+            "response-header policy to strip Via."
+        ),
+        "X-Rails-Version": "Rails: middleware customization to strip header.",
+        "X-Django-Version": "Django: middleware to strip header.",
+    }.get(header, f"Configure the web stack to omit the {header} header on outbound responses.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Server-software fingerprinter")
+    parser.add_argument("url")
+    parser.add_argument("--authorized", action="store_true")
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--format", choices=("json", "jsonl", "markdown"), default="markdown")
+    parser.add_argument("--min-severity", choices=("critical", "high", "medium", "low", "info"), default="info")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument(
+        "--trigger-error", action="store_true", help="Send a malformed request to surface error-page disclosure"
+    )
+    args = parser.parse_args(argv)
+
+    require_authorization(args.url, args.authorized)
+
+    sess = make_session(timeout=args.timeout)
+    findings: list[Finding] = []
+
+    # Baseline GET
+    resp = safe_get(sess, args.url, timeout=args.timeout, allow_redirects=False)
+    if resp is None:
+        sys.stderr.write(f"ERROR: target {args.url!r} unreachable\n")
+        return 2
+    headers = dict(resp.headers)
+    findings.extend(_check_version_headers(headers, args.url, "baseline GET"))
+    findings.extend(_check_framework_headers(headers, args.url, "baseline GET"))
+    findings.extend(_check_cookies(headers, args.url))
+    findings.extend(_check_etag(headers, args.url))
+
+    # OPTIONS — different code path may reveal different headers
+    options_resp = safe_options(sess, args.url, timeout=args.timeout)
+    if options_resp is not None:
+        opt_headers = dict(options_resp.headers)
+        # Only flag headers that DIDN'T appear in the GET (dedupe)
+        for h in VERSION_HEADERS + FRAMEWORK_HEADERS:
+            if h in opt_headers and h not in headers:
+                findings.extend(_check_version_headers({h: opt_headers[h]}, args.url, "OPTIONS"))
+                findings.extend(_check_framework_headers({h: opt_headers[h]}, args.url, "OPTIONS"))
+
+    # Optional: error-page disclosure
+    if args.trigger_error:
+        # Send a request with deliberately-malformed path
+        err_url = args.url.rstrip("/") + "/this-route-should-not-exist-" + ("X" * 200)
+        err_resp = safe_get(sess, err_url, timeout=args.timeout, allow_redirects=False)
+        if err_resp is not None and err_resp.status_code >= 400:
+            findings.extend(_check_error_disclosure(err_resp.text, args.url))
+
+    # Severity floor
+    floor = Severity(args.min_severity)
+    findings = [f for f in findings if f.severity.numeric >= floor.numeric]
+
+    emit(findings, args.output, args.format, args.url)
+    return exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes out Phase 1A cluster 2 (Information Disclosure). Two skills land in one PR.

### Skill #8 — fingerprinting-server-software

A/90 marketplace, 0 errors. Probes Server, X-Powered-By, X-AspNet-Version, X-Generator, Via, framework-default Set-Cookie patterns (PHPSESSID, JSESSIONID, connect.sid, _session_id, laravel_session, etc.), Apache ETag inode fingerprint, and error-page stack-trace disclosure (CWE-209). Optional `--trigger-error` surfaces production stack traces.

### Skill #9 — detecting-directory-listing

A/94 marketplace, 0 errors. Probes ~30 directories (config/, .git/, backup/, uploads/, assets/, public/, vendor/, root, etc.) for autoindex pages. Fingerprints Apache mod_autoindex, nginx fancyindex, Caddy file_server browse, Python http.server, Node serve, IIS directory browsing, AWS S3 ListBucket XML, Azure Blob EnumerationResults, GCS list.

Chains with skill #6: autoindex on `/.git/` upgrades the impact from "HEAD reachable" to "full repo reconstructable via wget -r".

## Phase 1A progress

9/25 skills done (orchestrator + #1 + cluster 1 [#2-5] + cluster 2 [#6-9]). Cluster 3 (static analysis, #10-15) is next.

## Test plan

- [x] validate-skills-schema.py --marketplace on both: A/90 + A/94, 0 errors
- [x] script --help: works
- [x] ruff format / check: clean
- [x] markdownlint: clean
- [x] LOC: 1,926 total across the two skills

- Jeremy Longshore
intentsolutions.io