### PR TITLE
Add skillrot to external plugin sources

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1145,6 +1145,30 @@ sources:
       - '.git/**'
       - '*.log'
 
+
+  # ============================================================
+  # skillrot (Michael Nefedov)
+  # https://github.com/mishanefedov/skillrot
+  # ============================================================
+
+  - name: skillrot
+    description: Lint agent skills for external-CLI drift — finds skills calling tools (codex, gh, docker, supabase, ...) with flags or subcommands the installed version no longer accepts, plus a --cost context-budget audit
+    repo: mishanefedov/skillrot
+    source_path: skills/skillrot
+    target_path: plugins/community/skillrot
+    author:
+      name: Michael Nefedov
+      github: mishanefedov
+      email: 48260330+mishanefedov@users.noreply.github.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
## Summary

Adds [**skillrot**](https://github.com/mishanefedov/skillrot) to `sources.yaml` so it's mirrored daily into the community marketplace.

skillrot is a linter that audits coding-agent skills for **external-CLI drift**: it reads each skill's bash, extracts the `command subcommand --flags` it uses, and checks them against the installed CLI's own `--help`. When a tool ships a new version and renames a flag or drops a subcommand, the skill keeps emitting the dead command and fails mid-task — skillrot catches that before it bites. Read-only (only ever runs `--help`/`--version`). Also ships a `--cost` context-budget audit measuring the always-on token tax each skill adds per session.

- Repo: https://github.com/mishanefedov/skillrot (MIT)
- Source path: `skills/skillrot` (mirrors `SKILL.md`)
- Works across Claude Code, Codex, opencode, Cursor — any `SKILL.md`-format agent

## Test plan

- [x] `sources.yaml` parses as valid YAML (49 sources)
- [x] Entry follows the existing external-source schema (name/description/repo/source_path/target_path/author/license/category/include/exclude)
- [ ] Maintainer: daily sync mirrors `skills/skillrot/SKILL.md` into `plugins/community/skillrot`