### PR TITLE
docs(databricks-pack): pin two-MCP architecture note + ADR link per #795

### DIFF
--- a/plugins/saas-packs/databricks-pack/README.md
+++ b/plugins/saas-packs/databricks-pack/README.md
@@ -79,6 +79,25 @@ Skills trigger automatically on Databricks topics:
 - "Set up Unity Catalog permissions" -- `databricks-enterprise-rbac`
 - "Migrate from Snowflake" -- `databricks-migration-deep-dive`
 
+## Architecture
+
+### Why two MCP servers, not one
+
+The v2 rebuild ships with a deliberate split across **two** MCP servers, not a single shared one. Common question on contributor PRs — answering it once at the top so future readers don't have to re-derive it.
+
+- **Databricks managed SQL MCP** — serves `system.*` reads (cost data, query history, streaming progress). Operated by Databricks; we consume it.
+- **Custom workspace MCP** — serves cluster events, instance pools, pipeline event logs, external locations, storage credentials. Operated by this pack.
+
+The two authenticate independently. Losing access to one does not disable the other; `cost-leak-hunter` (SQL MCP) and `cluster-forensics` (workspace MCP) fail independently when their respective MCP is unavailable. Single skills can be installed without pulling in the other MCP's dependency surface.
+
+Full scope-boundary rationale — including the 8 → 6 endpoint cut and the auth-flow decisions — is in [`000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md`](000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md). Reference document for any "why is this skill not pulling X?" question.
+
+Thanks to [@Gingiris-1031](https://github.com/Gingiris-1031) ([#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795)) for surfacing the isolation-story framing that made this section necessary.
+
+## Design Records
+
+All architecture decisions, pain research, and pressure tests for this pack live in [`000-docs/`](000-docs/). Index: [`000-INDEX.md`](000-docs/000-INDEX.md).
+
 ## License
 
 MIT

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",


### PR DESCRIPTION
## Summary

Acts on the design review @Gingiris-1031 (Yipei Wei) gave on [#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795). Her ask was specific: link the two-MCP scope-boundary ADR from the pack README so future contributors don't repeatedly land on "why two MCPs?" without context.

## What changed in `plugins/saas-packs/databricks-pack/README.md`

Three new sections directly above `## License`:

### `## Architecture`

Explains the **two-MCP split** that was deliberately chosen during the v2 rebuild:
- Databricks managed SQL MCP — `system.*` reads (cost, query history, streaming progress)
- Custom workspace MCP — cluster events, instance pools, pipeline event logs, external locations, storage credentials

Plus the isolation story Yipei flagged as the missing piece: independent auth surfaces, independent failure modes, single-skill install paths.

### ADR link

Pinned link to [`000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md`](../blob/main/plugins/saas-packs/databricks-pack/000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md) — the full 8 → 6 endpoint scope-cut rationale, auth-flow decisions, and why each cut was made.

### `## Design Records`

Single-line pointer at `000-docs/` + `000-INDEX.md` so future contributors have one entry point for architectural context. Closes the "where's the deeper docs?" gap.

## Credit

@Gingiris-1031 surfaced the framing that made this section necessary. Crediting via:

- Inline thank-you in the new section
- `Co-authored-by: Iris Wei <gingiris1031@gmail.com>` on the commit

## Other items from her review

Tracking the rest she raised on #795:

- **FinOps cost-leak CFO-grokkable output draft** — promised within a week of [my reply](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795#issuecomment-4608759269). Separate PR; not in this branch.
- **OSS→commercial playbook lessons** — filed in the issue thread for reference if/when monetization conversation reopens. No code action; the Q3 line in my earlier comment has been explicitly retracted in the same thread.
- **Identification question** — answered in-thread; her GitHub bio is the source, no detective work.

## Test plan

- [x] README renders cleanly (markdown preview)
- [x] ADR link target exists at the referenced path
- [x] `000-docs/000-INDEX.md` exists at the referenced path
- [ ] CI validators pass

Refs #795