### PR TITLE
fix(marketplace): de-AI-ify homepage feature grid + kill dead purple token

### DIFF
--- a/marketplace/DESIGN.md
+++ b/marketplace/DESIGN.md
@@ -297,6 +297,12 @@ Paste that block into any prompt that asks AI to render UI for this codebase.
 
 ## Changelog
 
+- **2026-06-03** — VibeCheck PR 1 follow-up. The 2026-05-31 pass flattened radii, removed gradients/blur, and added `lint-design-tells.mjs`. This pass targets the residual AI-tell layouts on the highest-visibility page (homepage `/`):
+  1. **Rules over boxes — operative on the homepage feature list.** The 6-tile 3-column emoji-icon `.feature-card` grid (Signals 1, 6, 7 from the VibeCheck audit: card chrome + icon-in-colored-box + equal-column grid) is replaced with a numbered horizontal-rule list (`<ol class="features-list">`). Each row: mono numeric kicker (`01`–`06`), title, single-line description. No box wrappers, no decorative icons, no equal-column grid. Hairline rules carry the structure.
+  2. **Dead `--purple` token removed from `pages/tools.astro`.** The 2026-05-06 redesign left an unused `--purple: #8b5cf6` declaration. The accent palette is intentionally yellow-only (`--signal`); secondary `--blue` and `--orange` remain because they're actually referenced.
+  3. Existing `lint-design-tells.mjs` gates continue to pass (em-dash density in visible chrome: 1 / threshold 12). Mass em-dash hand-editing across `pages/` (346 raw hits) deferred — the lint's narrow scope already catches the ones that affect render.
+  4. **Follow-up PR scope:** 31 vendor `/learn/<vendor>/` templates and ~20 secondary pages still carry card-chrome wrappers. They're already gradient-stripped from the 2026-05-31 pass, so the residual is structural (not visual) and can land incrementally without breaking the visual constitution.
+
 - **2026-05-31** — VibeCheck audit (vibecheck.fail) returned 25/100 on the deployed site. Investigation found constitution drift: ~190 `linear-gradient` declarations and ~230 large-radius card chrome surfaces across components and pages, in direct contradiction of §1 and §8. Enforcement actions:
   1. Border-radius scale flattened to 2 px across all tiers (`--radius-sm/md/lg/xl`). Square corners are the anti-default; pills and tags still get the small radius. Circles (`50%`) and 1 px hairlines untouched.
   2. All chrome `linear-gradient` declarations replaced with solid tokens. Allowlist: `mask-image: linear-gradient(...)` for progressive scroll fades.

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -536,71 +536,50 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             color: var(--text);
         }
 
-        .features-grid {
+        /* Numbered list — rules over boxes (DESIGN.md 2026-05-31 changelog).
+           Replaces the prior 3-column emoji-icon feature-card grid (Signals 1/6/7 from
+           the VibeCheck 25/100 audit). Each row separated by hairline rule; mono
+           numeric kicker; no box chrome, no decorative icons. */
+        .features-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            border-top: 1px solid var(--border);
+        }
+
+        .feature-row {
             display: grid;
-            grid-template-columns: repeat(3, 1fr);
+            grid-template-columns: 64px 1fr;
             gap: 1.5rem;
+            padding: 1.5rem 0;
+            border-bottom: 1px solid var(--border);
+            align-items: baseline;
         }
 
-        .feature-card {
-            padding: 2rem;
+        .feature-row:hover {
             background: var(--surface-2);
-            border: 1px solid var(--border);
-            border-radius: 14px;
-            transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-            position: relative;
-            overflow: hidden;
-            text-align: center;
         }
 
-        .feature-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 3px;
-            background: var(--primary);
-            transform: scaleX(0);
-            transform-origin: left;
-            transition: transform var(--duration-normal) var(--ease-out);
+        .feature-kicker {
+            font-family: var(--font-mono, 'JetBrains Mono', monospace);
+            font-size: 0.8rem;
+            color: var(--text-2);
+            letter-spacing: 0.05em;
+            font-variant-numeric: tabular-nums;
         }
 
-        .feature-card:hover {
-            transform: translateY(-6px);
-            border-color: var(--border-bright);
-            
-        }
-
-        .feature-card:hover::before {
-            transform: scaleX(1);
-        }
-
-        .feature-icon {
-            font-size: 1.5rem;
-            margin-bottom: 1rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 44px;
-            height: 44px;
-            background: rgb(250 255 105 / 0.1);
-            border-radius: 10px;
-            margin-left: auto;
-            margin-right: auto;
-        }
-
-        .feature-card h3 {
-            font-size: 1.3rem;
+        .feature-row h3 {
+            font-size: 1.15rem;
             font-weight: 600;
-            margin-bottom: 1rem;
+            margin: 0 0 0.35rem 0;
             color: var(--text);
         }
 
-        .feature-card p {
+        .feature-row p {
             color: var(--text-2);
-            line-height: 1.7;
+            line-height: 1.6;
             margin: 0;
+            max-width: 60ch;
         }
 
         /* Client showcase removed — sponsor now inline in hero */
@@ -1345,9 +1324,10 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 padding: 4rem 2rem;
             }
 
-            .features-grid {
-                grid-template-columns: 1fr;
-                gap: 1.5rem;
+            .feature-row {
+                grid-template-columns: 48px 1fr;
+                gap: 1rem;
+                padding: 1.25rem 0;
             }
 
             .install-box {
@@ -1903,38 +1883,50 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
     <section class="features" id="features">
         <h2 class="section-title">Community-driven, production-ready plugins</h2>
 
-        <div class="features-grid reveal-stagger">
-            <div class="feature-card">
-                <div class="feature-icon">🚀</div>
-                <h3>{totalPlugins} Plugins</h3>
-                <p>Browse plugins across {totalCategories} categories: DevOps, security, testing, data, AI/ML, and more.</p>
-            </div>
-            <div class="feature-card">
-                <div class="feature-icon">🤖</div>
-                <h3>{totalSkills} Skills (Embedded in Plugins)</h3>
-                <p>Agent Skills embedded in {totalPlugins} plugins activate automatically based on conversation context.</p>
-            </div>
-            <div class="feature-card">
-                <div class="feature-icon">⚡</div>
-                <h3>Instant Install</h3>
-                <p>One command to add the marketplace, then install any plugin instantly. No configuration needed.</p>
-            </div>
-            <div class="feature-card">
-                <div class="feature-icon">📚</div>
-                <h3>Full Documentation</h3>
-                <p>Every plugin includes comprehensive docs, examples, and usage guides. Learn as you build.</p>
-            </div>
-            <div class="feature-card">
-                <div class="feature-icon">🔄</div>
-                <h3>Regular Updates</h3>
-                <p>Active development with new plugins added weekly. Community contributions welcome.</p>
-            </div>
-            <div class="feature-card">
-                <div class="feature-icon">🛡️</div>
-                <h3>Open Source</h3>
-                <p>100% open source under MIT license. Inspect, modify, and contribute to any plugin.</p>
-            </div>
-        </div>
+        <ol class="features-list reveal-stagger">
+            <li class="feature-row">
+                <span class="feature-kicker">01</span>
+                <div>
+                    <h3>{totalPlugins} Plugins</h3>
+                    <p>Browse plugins across {totalCategories} categories: DevOps, security, testing, data, AI/ML, and more.</p>
+                </div>
+            </li>
+            <li class="feature-row">
+                <span class="feature-kicker">02</span>
+                <div>
+                    <h3>{totalSkills} Skills, embedded in plugins</h3>
+                    <p>Agent Skills embedded in {totalPlugins} plugins activate automatically based on conversation context.</p>
+                </div>
+            </li>
+            <li class="feature-row">
+                <span class="feature-kicker">03</span>
+                <div>
+                    <h3>Instant install</h3>
+                    <p>One command to add the marketplace, then install any plugin instantly. No configuration needed.</p>
+                </div>
+            </li>
+            <li class="feature-row">
+                <span class="feature-kicker">04</span>
+                <div>
+                    <h3>Full documentation</h3>
+                    <p>Every plugin includes comprehensive docs, examples, and usage guides. Learn as you build.</p>
+                </div>
+            </li>
+            <li class="feature-row">
+                <span class="feature-kicker">05</span>
+                <div>
+                    <h3>Regular updates</h3>
+                    <p>Active development with new plugins added weekly. Community contributions welcome.</p>
+                </div>
+            </li>
+            <li class="feature-row">
+                <span class="feature-kicker">06</span>
+                <div>
+                    <h3>Open source</h3>
+                    <p>100% open source under MIT license. Inspect, modify, and contribute to any plugin.</p>
+                </div>
+            </li>
+        </ol>
     </section>
 
     <!-- Email Signup -->

--- a/marketplace/src/pages/tools.astro
+++ b/marketplace/src/pages/tools.astro
@@ -32,7 +32,6 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         --accent: #10b981;
         --accent-hover: #059669;
         --blue: #3b82f6;
-        --purple: #8b5cf6;
         --orange: #f59e0b;
         --radius: 12px;
       }


### PR DESCRIPTION
## Summary

VibeCheck audit follow-up. Builds on the 2026-05-31 enforcement pass (radii flattened, gradients/glassmorphism removed, `lint-design-tells.mjs` added). This PR targets the residual AI-tell layouts on the homepage — the single highest-visibility surface — and removes one orphan accent token.

## What changes

- **`pages/index.astro` — homepage feature list.** The 6-tile 3-column emoji-icon `.feature-card` grid is replaced with a numbered horizontal-rule list (`<ol class="features-list">`). Targets three VibeCheck signals at once:
  - **Signal 1** (cards-everywhere): card chrome wrappers removed; structure carried by hairline rules.
  - **Signal 6** (icon-in-colored-box): emoji icons in `rgb(250 255 105 / 0.1)` rounded squares deleted.
  - **Signal 7** (equal-column grids): the `repeat(3, 1fr)` symmetry replaced with a left-aligned vertical list, mono numeric kicker (`01`–`06`) per row.

- **`pages/tools.astro` — dead `--purple: #8b5cf6` token.** The 2026-05-06 redesign left this declaration in but never referenced it. The accent palette is intentionally yellow-only (`--signal`); `--blue` and `--orange` remain because they're actually used in the rendered output.

- **`DESIGN.md` changelog entry** logging this pass and scoping the residual work (31 vendor `/learn/<vendor>/` templates and ~20 secondary pages still carry card-chrome wrappers — already gradient-stripped, so the residual is structural and lands incrementally).

## Why this scope

The original VibeCheck plan called for full card surgery across 55 files (kill ~38 of 46 wrappers). Reality after the 2026-05-31 work: most of those wrappers are already structurally sound (2px radius, no gradient, no shadow). The remaining AI-tell is concentrated on the homepage feature list because it combines all three weighted signals in one place. Fix that first; let the long tail land in follow-up PRs with their own screenshot diffs.

The plan's Signal 3 (pure-black) and Signal 4 (purple→forest-green) were re-scoped during planning: the codebase already uses near-black `#0a0a0c` per DESIGN.md §2, the accent is locked to neon-yellow per the 2026-05-06 family pick, and the only remaining purple was the dead `tools.astro` token now removed.

## Verification

- `node scripts/lint-design-tells.mjs` passes (em-dash count in visible chrome: 1 / threshold 12).
- No orphan references to the old `.feature-card` / `.feature-icon` / `.features-grid` classes remain anywhere in `marketplace/src`.
- Mobile breakpoint at 1348 updated: the old `grid-template-columns: 1fr` override is replaced with a tighter padding/gap override for the new `.feature-row`.

## Test plan

- [ ] Open the homepage at `/` locally (`cd marketplace && npm run dev`) and confirm the feature section renders as a numbered list with hairline rules, no box chrome.
- [ ] Resize to mobile (375 px) and confirm the kicker column compresses to 48 px.
- [ ] Visit `/tools` and confirm nothing in the page references the removed `--purple` variable (visual check — there shouldn't be any color-shift).
- [ ] Re-run VibeCheck on the deployed site after merge; first-pass target ≥ 60/100 (per plan).

## Follow-up work (NOT in this PR)

- Card-chrome cleanup in 31 vendor `/learn/<vendor>/index.astro` templates (gradients gone, structure remains).
- ~20 secondary pages with card wrappers (`blog/`, `changelog/`, `community.astro`, etc.).
- Mass em-dash hand-editing in `pages/` (346 raw hits, but the lint's narrow scope already catches the ones that affect render — visible chrome is at 1/12).
- Saas-pack section hardcoded radii (`.saas-card` 12px icon radius, `.saas-cmd` 6px) — third-party brand showcase, lower priority.

- Jeremy Longshore
intentsolutions.io