### PR TITLE
Add RunAPI MCP Server (external source)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1145,6 +1145,35 @@ sources:
       - '.git/**'
       - '*.log'
 
+  # ============================================================
+  # RunAPI MCP Server
+  # https://github.com/runapi-ai/mcp
+  # ============================================================
+
+  - name: runapi
+    description: 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. Free catalog tools for model discovery and pricing; authenticated tools for media task creation, polling, and LLM chat. Run with `npx @runapi.ai/mcp`.
+    repo: runapi-ai/mcp
+    source_path: plugin
+    target_path: plugins/mcp/runapi
+    author:
+      name: RunAPI
+      github: runapi-ai
+      email: contact@runapi.ai
+    license: MIT
+    category: mcp
+    verified: false
+    include:
+      - 'README.md'
+      - '.claude-plugin/**'
+      - 'skills/**'
+      - 'commands/**'
+      - 'agents/**'
+      - 'output-styles/**'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds RunAPI MCP Server as an external auto-synced source (Path B from CONTRIBUTING).

**RunAPI MCP Server** — 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. Free catalog tools for model discovery and pricing; authenticated tools for media task creation, polling, and LLM chat.

- Repo: https://github.com/runapi-ai/mcp
- Run: `npx @runapi.ai/mcp`
- Category: `mcp`

The source repo's `plugin/` directory ships a Claude Code plugin (`.claude-plugin/plugin.json`, skills, commands, agents, output-styles) plus a README, so the weekly sync can mirror it into `plugins/mcp/runapi`.