### PR TITLE
fix(skill-paths): resolve ${CLAUDE_SKILL_DIR} paths to ./ for GitHub browse view

### DIFF
--- a/plugins/ai-agency/shipwright/package.json
+++ b/plugins/ai-agency/shipwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/shipwright",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
   "keywords": [
     "app-builder",

--- a/plugins/ai-agency/shipwright/skills/shipwright-pipeline/SKILL.md
+++ b/plugins/ai-agency/shipwright/skills/shipwright-pipeline/SKILL.md
@@ -84,4 +84,4 @@ Shipwright converts a plain-English app description into a fully built, tested, 
 
 - [Shipwright on GitHub](https://github.com/Wynelson94/shipwright)
 - [product-agent on PyPI](https://pypi.org/project/product-agent/)
-- See `${CLAUDE_SKILL_DIR}/references/examples.md` for usage examples.
+- See `./references/examples.md` for usage examples.

--- a/plugins/ai-ml/ai-sdk-agents/package.json
+++ b/plugins/ai-ml/ai-sdk-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/ai-sdk-agents",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Multi-agent orchestration with AI SDK v5 - handoffs, routing, and coordination for any AI provider (OpenAI, Anthropic, Google)",
   "keywords": [
     "ai-sdk",

--- a/plugins/ai-ml/ai-sdk-agents/skills/orchestrating-multi-agent-systems/SKILL.md
+++ b/plugins/ai-ml/ai-sdk-agents/skills/orchestrating-multi-agent-systems/SKILL.md
@@ -47,7 +47,7 @@ Design and implement multi-agent systems using AI SDK v5 with structured handoff
 9. Implement circuit breakers and timeout guards to prevent workflow deadlocks
 10. Test each agent in isolation, then validate end-to-end handoff chains with representative inputs
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implementation guide.
+See `./references/implementation.md` for the detailed implementation guide.
 
 ## Output
 
@@ -68,7 +68,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implemen
 | Tool access violation | Agent invoked a tool outside its scoped permission set | Review `tools` array per agent; ensure tool names match registered definitions exactly |
 | Workflow timeout | Multi-step workflow exceeded deadline without completion | Set per-step timeouts with `AbortController`; add workflow-level deadline and partial-result handling |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for the full error reference.
+See `./references/errors.md` for the full error reference.
 
 ## Examples
 
@@ -78,7 +78,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for the full error reference.
 
 **Scenario 3: Code Review Multi-Agent** -- A supervisor agent distributes pull request diffs to specialized reviewers (security, performance, style). Each reviewer returns findings with severity scores. The supervisor aggregates results into a unified review with prioritized action items.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/ai-ml/anomaly-detection-system/package.json
+++ b/plugins/ai-ml/anomaly-detection-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/anomaly-detection-system",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Detect anomalies and outliers in data",
   "keywords": [
     "anomaly",

--- a/plugins/ai-ml/anomaly-detection-system/skills/detecting-data-anomalies/SKILL.md
+++ b/plugins/ai-ml/anomaly-detection-system/skills/detecting-data-anomalies/SKILL.md
@@ -52,7 +52,7 @@ Identify anomalies and outliers in datasets using statistical and machine learni
 9. Analyze flagged anomalies for common characteristics, temporal clusters, or feature correlations
 10. Generate a summary report with detection counts, score distributions, and visualization plots
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implementation guide.
+See `./references/implementation.md` for the detailed implementation guide.
 
 ## Output
 
@@ -73,7 +73,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implemen
 | Feature scaling mismatch | Mixed numeric and categorical features without proper encoding | One-hot encode categoricals separately; scale numeric features independently |
 | No ground truth for validation | Unlabeled dataset prevents accuracy measurement | Use domain expert review on top-N anomalies; implement feedback loop to refine threshold |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for the full error reference.
+See `./references/errors.md` for the full error reference.
 
 ## Examples
 

--- a/plugins/ai-ml/automl-pipeline-builder/package.json
+++ b/plugins/ai-ml/automl-pipeline-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/automl-pipeline-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Build AutoML pipelines",
   "keywords": [
     "automl",

--- a/plugins/ai-ml/automl-pipeline-builder/skills/building-automl-pipelines/SKILL.md
+++ b/plugins/ai-ml/automl-pipeline-builder/skills/building-automl-pipelines/SKILL.md
@@ -50,7 +50,7 @@ Before using this skill, ensure you have:
 10. Set up data validation checks
 11. Initialize AutoML pipeline with configuration
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -63,11 +63,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/ai-ml/jeremy-adk-orchestrator/package.json
+++ b/plugins/ai-ml/jeremy-adk-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-adk-orchestrator",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
   "keywords": [
     "vertex-ai",

--- a/plugins/ai-ml/jeremy-adk-orchestrator/skills/adk-deployment-specialist/SKILL.md
+++ b/plugins/ai-ml/jeremy-adk-orchestrator/skills/adk-deployment-specialist/SKILL.md
@@ -48,11 +48,11 @@ Expert in building and deploying production multi-agent systems using Google's A
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/ai-ml/jeremy-adk-software-engineer/package.json
+++ b/plugins/ai-ml/jeremy-adk-software-engineer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-adk-software-engineer",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "ADK software engineer for creating production-ready agents with testing, deployment, and multi-agent orchestration",
   "keywords": [
     "adk",

--- a/plugins/ai-ml/jeremy-adk-software-engineer/skills/adk-engineer/SKILL.md
+++ b/plugins/ai-ml/jeremy-adk-software-engineer/skills/adk-engineer/SKILL.md
@@ -70,7 +70,7 @@ Use this skill to design and implement ADK agent code that is maintainable and s
 
 ## Resources
 
-- Full detailed playbook (kept for reference): `${CLAUDE_SKILL_DIR}/references/SKILL.full.md`
+- Full detailed playbook (kept for reference): `./references/SKILL.full.md`
 - Repo standards (source of truth):
   - `000-docs/6767-a-SPEC-DR-STND-claude-code-plugins-standard.md`
   - `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`

--- a/plugins/ai-ml/jeremy-gcp-starter-examples/package.json
+++ b/plugins/ai-ml/jeremy-gcp-starter-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-gcp-starter-examples",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Google Cloud starter kits and example code aggregator with ADK samples",
   "keywords": [
     "google-cloud",

--- a/plugins/ai-ml/jeremy-gcp-starter-examples/skills/gcp-examples-expert/SKILL.md
+++ b/plugins/ai-ml/jeremy-gcp-starter-examples/skills/gcp-examples-expert/SKILL.md
@@ -35,7 +35,7 @@ Generate production-ready Google Cloud Platform code examples sourced from offic
 ## Instructions
 
 1. Identify the target framework by matching the request to one of six categories: ADK agents, Agent Starter Pack, Genkit flows, Vertex AI training, Generative AI multimodal, or AgentSmithy orchestration
-2. Select the appropriate source repository and code pattern from `${CLAUDE_SKILL_DIR}/references/code-example-categories.md`
+2. Select the appropriate source repository and code pattern from `./references/code-example-categories.md`
 3. Adapt the template to the specified programming language (TypeScript, Python, or Go)
 4. Configure security settings: IAM least-privilege service accounts, VPC Service Controls, Model Armor for prompt injection protection
 5. Add monitoring instrumentation: Cloud Monitoring dashboards, alerting policies, structured logging, OpenTelemetry tracing
@@ -45,7 +45,7 @@ Generate production-ready Google Cloud Platform code examples sourced from offic
 9. Provide Terraform or IaC templates for reproducible infrastructure provisioning
 10. Cite the source repository and link to official documentation for each pattern used
 
-See `${CLAUDE_SKILL_DIR}/references/workflow.md` for the phased workflow and `${CLAUDE_SKILL_DIR}/references/best-practices-applied.md` for the full best-practices checklist.
+See `./references/workflow.md` for the phased workflow and `./references/best-practices-applied.md` for the full best-practices checklist.
 
 ## Output
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/workflow.md` for the phased workflow and `${
 | Quota exceeded for API calls | Rate limit hit on Vertex AI prediction endpoint | Request quota increase via Cloud Console; implement exponential backoff with jitter |
 | Dependency version conflict | Incompatible versions of AI SDK, Genkit, or provider packages | Pin versions in `package.json` or `requirements.txt`; use lockfile to ensure reproducibility |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
+See `./references/errors.md` for additional error scenarios.
 
 ## Examples
 
@@ -76,7 +76,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
 
 **Scenario 3: Gemini Multimodal Analysis** -- Analyze video content using the `generative-ai` repository patterns. Create a multimodal prompt combining video URIs with text questions using Gemini 2.5 Pro. Include safety filter configuration, token counting for cost estimation, and structured output parsing.
 
-See `${CLAUDE_SKILL_DIR}/references/example-interactions.md` for detailed interaction examples.
+See `./references/example-interactions.md` for detailed interaction examples.
 
 ## Resources
 

--- a/plugins/ai-ml/jeremy-genkit-pro/package.json
+++ b/plugins/ai-ml/jeremy-genkit-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-genkit-pro",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
   "keywords": [
     "firebase",

--- a/plugins/ai-ml/jeremy-genkit-pro/skills/genkit-production-expert/SKILL.md
+++ b/plugins/ai-ml/jeremy-genkit-pro/skills/genkit-production-expert/SKILL.md
@@ -46,7 +46,7 @@ Build production-grade Firebase Genkit applications including RAG systems, multi
 9. Enable OpenTelemetry tracing with custom span attributes for cost and latency tracking
 10. Test locally using the Genkit Developer UI, then deploy to Firebase Functions or Cloud Run with auto-scaling configuration
 
-See `${CLAUDE_SKILL_DIR}/references/how-it-works.md` for the phased workflow and `${CLAUDE_SKILL_DIR}/references/production-best-practices-applied.md` for the production checklist.
+See `./references/how-it-works.md` for the phased workflow and `./references/production-best-practices-applied.md` for the production checklist.
 
 ## Output
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/how-it-works.md` for the phased workflow and
 | Retriever returns empty results | Vector database query found no matches above similarity threshold | Lower similarity threshold; verify embeddings are indexed; check embedding model version match |
 | Deployment timeout | Cold start exceeds Firebase Functions 60s limit | Increase memory allocation; use Cloud Run for long-running flows; enable min instances > 0 |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
+See `./references/errors.md` for additional error scenarios.
 
 ## Examples
 
@@ -77,7 +77,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
 
 **Scenario 3: Multi-Tool Agent** -- Define weather and calendar tools with typed schemas. Create an agent flow that routes user queries to appropriate tools, handles multi-turn conversations, and traces each tool execution for debugging. Deploy to Cloud Run with auto-scaling (2-10 instances).
 
-See `${CLAUDE_SKILL_DIR}/references/workflow-examples.md` for complete code examples.
+See `./references/workflow-examples.md` for complete code examples.
 
 ## Resources
 

--- a/plugins/ai-ml/jeremy-google-adk/package.json
+++ b/plugins/ai-ml/jeremy-google-adk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-google-adk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Google Agent Development Kit (ADK) SDK starter kit for building Claude-powered AI agents with React patterns, multi-agent orchestration, and tool integration",
   "keywords": [
     "google",

--- a/plugins/ai-ml/jeremy-google-adk/skills/adk-agent-builder/SKILL.md
+++ b/plugins/ai-ml/jeremy-google-adk/skills/adk-agent-builder/SKILL.md
@@ -73,8 +73,8 @@ Build production-ready agents with Google’s Agent Development Kit (ADK): scaff
 
 ## Resources
 
-- Implementation patterns (scaffolds, tool wiring, orchestration): `${CLAUDE_SKILL_DIR}/references/implementation.md`
-- Worked examples (single-agent + multi-agent): `${CLAUDE_SKILL_DIR}/references/examples.md`
-- Error-handling and recovery patterns: `${CLAUDE_SKILL_DIR}/references/errors.md`
-- Product / architecture context: `${CLAUDE_SKILL_DIR}/PRD.md`, `${CLAUDE_SKILL_DIR}/ARD.md`
+- Implementation patterns (scaffolds, tool wiring, orchestration): `./references/implementation.md`
+- Worked examples (single-agent + multi-agent): `./references/examples.md`
+- Error-handling and recovery patterns: `./references/errors.md`
+- Product / architecture context: `./PRD.md`, `./ARD.md`
 - ADK / Agent Engine docs:

--- a/plugins/ai-ml/jeremy-vertex-ai/package.json
+++ b/plugins/ai-ml/jeremy-vertex-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-vertex-ai",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Comprehensive Vertex AI integration plugin for building generative AI agents with Gemini, Vertex AI Studio, and production deployment on Google Cloud",
   "keywords": [
     "vertex-ai",

--- a/plugins/ai-ml/jeremy-vertex-ai/skills/vertex-agent-builder/SKILL.md
+++ b/plugins/ai-ml/jeremy-vertex-ai/skills/vertex-agent-builder/SKILL.md
@@ -70,9 +70,9 @@ Build and deploy production-ready agents on Vertex AI with Gemini models, retrie
 
 ## Resources
 
-- Implementation patterns (model selection, RAG wiring, deployment config): `${CLAUDE_SKILL_DIR}/references/implementation.md`
-- Worked examples (RAG support agent, multimodal extraction): `${CLAUDE_SKILL_DIR}/references/examples.md`
-- Error-handling and recovery patterns: `${CLAUDE_SKILL_DIR}/references/errors.md`
-- Product / architecture context: `${CLAUDE_SKILL_DIR}/PRD.md`, `${CLAUDE_SKILL_DIR}/ARD.md`
+- Implementation patterns (model selection, RAG wiring, deployment config): `./references/implementation.md`
+- Worked examples (RAG support agent, multimodal extraction): `./references/examples.md`
+- Error-handling and recovery patterns: `./references/errors.md`
+- Product / architecture context: `./PRD.md`, `./ARD.md`
 - Vertex AI docs: https://cloud.google.com/vertex-ai/docs
 - Agent Engine docs:

--- a/plugins/ai-ml/jeremy-vertex-engine/package.json
+++ b/plugins/ai-ml/jeremy-vertex-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-vertex-engine",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
   "keywords": [
     "vertex-ai",

--- a/plugins/ai-ml/jeremy-vertex-engine/skills/vertex-engine-inspector/SKILL.md
+++ b/plugins/ai-ml/jeremy-vertex-engine/skills/vertex-engine-inspector/SKILL.md
@@ -52,7 +52,7 @@ Inspect and validate Vertex AI Agent Engine deployments across seven categories:
 9. Calculate weighted scores across all categories and determine overall production readiness status
 10. Generate a prioritized list of recommendations with estimated score improvement per remediation
 
-See `${CLAUDE_SKILL_DIR}/references/inspection-workflow.md` for the phased inspection process and `${CLAUDE_SKILL_DIR}/references/inspection-categories.md` for detailed check criteria.
+See `./references/inspection-workflow.md` for the phased inspection process and `./references/inspection-categories.md` for detailed check criteria.
 
 ## Output
 
@@ -63,7 +63,7 @@ See `${CLAUDE_SKILL_DIR}/references/inspection-workflow.md` for the phased inspe
 - Performance metrics dashboard: error rate, latency percentiles, token usage, daily cost estimate
 - Prioritized recommendations with estimated score improvement per item
 
-See `${CLAUDE_SKILL_DIR}/references/example-inspection-report.md` for a complete sample report.
+See `./references/example-inspection-report.md` for a complete sample report.
 
 ## Error Handling
 
@@ -75,7 +75,7 @@ See `${CLAUDE_SKILL_DIR}/references/example-inspection-report.md` for a complete
 | VPC-SC perimeter blocking access | Inspector running outside VPC Service Controls perimeter | Add inspector service account to access level; use VPC-SC bridge or access policy |
 | Code Execution TTL out of range | State TTL set below 1 day or above 14 days | Adjust TTL to 7-14 days for production; values above 14 days are rejected by Agent Engine |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
+See `./references/errors.md` for additional error scenarios.
 
 ## Examples
 

--- a/plugins/ai-ml/model-versioning-tracker/package.json
+++ b/plugins/ai-ml/model-versioning-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/model-versioning-tracker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Track and manage model versions",
   "keywords": [
     "versioning",

--- a/plugins/ai-ml/model-versioning-tracker/skills/tracking-model-versions/SKILL.md
+++ b/plugins/ai-ml/model-versioning-tracker/skills/tracking-model-versions/SKILL.md
@@ -38,10 +38,10 @@ Track and manage AI/ML model versions using MLflow, DVC, or Weights & Biases. Lo
 4. Register the model in the MLflow Model Registry using `mlflow.register_model()` with the run URI and a descriptive model name.
 5. Transition the model version through stages: `None` -> `Staging` -> `Production` using `client.transition_model_version_stage()`. Archive previous production versions.
 6. Compare model versions by querying metrics across runs with `mlflow.search_runs()` and generating comparison tables showing metric improvements between versions.
-7. Generate a model card from the registered model metadata, including training data description, evaluation metrics, intended use, limitations, and ethical considerations. See `${CLAUDE_SKILL_DIR}/assets/model_card_template.md`.
+7. Generate a model card from the registered model metadata, including training data description, evaluation metrics, intended use, limitations, and ethical considerations. See `./assets/model_card_template.md`.
 8. Set up automated alerts for model performance degradation by comparing production metrics against baseline thresholds stored in the model registry.
 
-See `${CLAUDE_SKILL_DIR}/assets/example_mlflow_workflow.yaml` for a complete workflow configuration.
+See `./assets/example_mlflow_workflow.yaml` for a complete workflow configuration.
 
 ## Examples
 

--- a/plugins/ai-ml/ollama-local-ai/package.json
+++ b/plugins/ai-ml/ollama-local-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/ollama-local-ai",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
   "keywords": [
     "ollama",

--- a/plugins/ai-ml/ollama-local-ai/skills/ollama-setup/SKILL.md
+++ b/plugins/ai-ml/ollama-local-ai/skills/ollama-setup/SKILL.md
@@ -55,7 +55,7 @@ Auto-configure Ollama for local LLM deployment, eliminating hosted API costs and
 9. Configure model persistence and cache directory if non-default storage location is required
 10. Validate end-to-end inference latency and throughput for the selected model
 
-See `${CLAUDE_SKILL_DIR}/references/skill-workflow.md` for the detailed workflow with code snippets.
+See `./references/skill-workflow.md` for the detailed workflow with code snippets.
 
 ## Output
 
@@ -76,7 +76,7 @@ See `${CLAUDE_SKILL_DIR}/references/skill-workflow.md` for the detailed workflow
 | GPU not detected | CUDA drivers missing or incompatible version | Install CUDA toolkit >= 11.8; verify with `nvidia-smi`; restart Ollama service after driver install |
 | Port 11434 already in use | Another service occupying the default Ollama port | Stop conflicting service; or set `OLLAMA_HOST=0.0.0.0:11435` environment variable |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error scenarios.
+See `./references/errors.md` for additional error scenarios.
 
 ## Examples
 

--- a/plugins/analytics/web-analytics/agents/anomaly-detector.md
+++ b/plugins/analytics/web-analytics/agents/anomaly-detector.md
@@ -25,13 +25,13 @@ whether it's bots. When they see a drop, you ask whether tracking broke.
 
 ### Step 1: Load Baselines
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` for:
+Read the site registry at `./references/site-registry.md` for:
 
 - Baseline daily visitors per site
 - Alert thresholds per site
 - Seasonal adjustments (weekends, holidays, announcements)
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` for
+Read the interpretation guide at `./references/interpretation-guide.md` for
 framing standards.
 
 ### Step 2: Statistical Baseline Comparison

--- a/plugins/analytics/web-analytics/agents/audience-segmentation.md
+++ b/plugins/analytics/web-analytics/agents/audience-segmentation.md
@@ -25,13 +25,13 @@ audience segments and flag churn risk in key cohorts.
 
 ### Step 1: Load Context
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` for:
+Read the site registry at `./references/site-registry.md` for:
 
 - Custom segment definitions (AI referrals, GitHub traffic, etc.)
 - Baseline visitor counts per site
 - Business goals per site
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` for
+Read the interpretation guide at `./references/interpretation-guide.md` for
 voice and framing.
 
 ### Step 2: Geographic Analysis

--- a/plugins/analytics/web-analytics/agents/content-seo.md
+++ b/plugins/analytics/web-analytics/agents/content-seo.md
@@ -24,13 +24,13 @@ grounded in actual traffic data, not guesswork.
 
 ### Step 1: Load Context
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` for:
+Read the site registry at `./references/site-registry.md` for:
 
 - Key pages per site (what matters most)
 - Business goals (what content should drive)
 - Conversion events (content → action mapping)
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` for
+Read the interpretation guide at `./references/interpretation-guide.md` for
 voice and framing.
 
 ### Step 2: Page Performance Analysis

--- a/plugins/analytics/web-analytics/agents/conversion-funnel.md
+++ b/plugins/analytics/web-analytics/agents/conversion-funnel.md
@@ -25,13 +25,13 @@ business impact of conversion changes.
 
 ### Step 1: Load Context
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` for:
+Read the site registry at `./references/site-registry.md` for:
 
 - Conversion events per site
 - Defined funnels per site
 - Business goals (what conversions matter most)
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` for
+Read the interpretation guide at `./references/interpretation-guide.md` for
 voice and framing.
 
 ### Step 2: Event Analysis

--- a/plugins/analytics/web-analytics/agents/data-collector.md
+++ b/plugins/analytics/web-analytics/agents/data-collector.md
@@ -25,7 +25,7 @@ You NEVER interpret, analyze, or editorialize. You collect and format.
 
 ### Step 1: Resolve Sites
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` to get:
+Read the site registry at `./references/site-registry.md` to get:
 
 - Site IDs for the requested sites (or all sites if none specified)
 - Default time ranges and timezone
@@ -44,7 +44,7 @@ Convert the requested period to epoch milliseconds (ET timezone):
 
 ### Step 3: Fetch Data
 
-Use the MCP tool reference at `${CLAUDE_SKILL_DIR}/references/mcp-tool-reference.md` for
+Use the MCP tool reference at `./references/mcp-tool-reference.md` for
 exact tool signatures. Execute calls in this order:
 
 > **Tool naming:** call MCP tools by their full name `mcp__umami__<tool>`. Param keys are

--- a/plugins/analytics/web-analytics/agents/memory-agent.md
+++ b/plugins/analytics/web-analytics/agents/memory-agent.md
@@ -25,7 +25,7 @@ arbitrary thresholds.
 ## Storage Location
 
 Analytics memory is stored in the skill's data directory:
-`${CLAUDE_SKILL_DIR}/data/`
+`./data/`
 
 **Files:**
 
@@ -147,7 +147,7 @@ After anomaly-detector runs, record results in `alerts-log.md`:
 
 On first run when no data directory exists:
 
-1. Create `${CLAUDE_SKILL_DIR}/data/` directory
+1. Create `./data/` directory
 2. Create `baselines.md` with header and empty tables
 3. Create `patterns.md` with header only
 4. Create `alerts-log.md` with header only

--- a/plugins/analytics/web-analytics/agents/reporting-narrative.md
+++ b/plugins/analytics/web-analytics/agents/reporting-narrative.md
@@ -23,7 +23,7 @@ you synthesize what specialists have already concluded.
 
 ## Voice and Framing
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` before
+Read the interpretation guide at `./references/interpretation-guide.md` before
 composing any output. Key principles:
 
 - Advisory, not diagnostic — "consider" not "you must"

--- a/plugins/analytics/web-analytics/agents/traffic-intelligence.md
+++ b/plugins/analytics/web-analytics/agents/traffic-intelligence.md
@@ -25,14 +25,14 @@ referral analysis, and detecting emerging traffic patterns (especially AI referr
 
 ### Step 1: Read Context
 
-Read the site registry at `${CLAUDE_SKILL_DIR}/references/site-registry.md` for:
+Read the site registry at `./references/site-registry.md` for:
 
 - Expected traffic sources per site
 - Baseline visitor counts
 - Alert thresholds
 - Seasonal adjustments (weekend drops, holiday impacts)
 
-Read the interpretation guide at `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` for
+Read the interpretation guide at `./references/interpretation-guide.md` for
 voice and framing standards.
 
 ### Step 2: Traffic Source Analysis

--- a/plugins/analytics/web-analytics/package.json
+++ b/plugins/analytics/web-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/web-analytics",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Push-based web analytics intelligence — self-hosted Umami (primary) via MCP + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims, and deliver narrative re",
   "keywords": [
     "analytics",

--- a/plugins/analytics/web-analytics/skills/web-analytics/SKILL.md
+++ b/plugins/analytics/web-analytics/skills/web-analytics/SKILL.md
@@ -45,7 +45,7 @@ via console, email, or Slack.
 ## Prerequisites
 
 - Umami credentials in `~/.env` (UMAMI_PASSWORD for the admin user)
-- Sites configured in `${CLAUDE_SKILL_DIR}/references/site-registry.md`
+- Sites configured in `./references/site-registry.md`
 - For email delivery: `/email` skill working
 - For Slack delivery: `/slack` skill working
 
@@ -98,10 +98,10 @@ Examples:
 
 Read these reference files for context:
 
-1. `${CLAUDE_SKILL_DIR}/references/site-registry.md` — site config, baselines, thresholds
-2. `${CLAUDE_SKILL_DIR}/references/mcp-tool-reference.md` — MCP tool signatures
-3. `${CLAUDE_SKILL_DIR}/references/reporting-tiers.md` — output format specs (medium/full tiers)
-4. `${CLAUDE_SKILL_DIR}/references/interpretation-guide.md` — advisory voice standards
+1. `./references/site-registry.md` — site config, baselines, thresholds
+2. `./references/mcp-tool-reference.md` — MCP tool signatures
+3. `./references/reporting-tiers.md` — output format specs (medium/full tiers)
+4. `./references/interpretation-guide.md` — advisory voice standards
 
 ### Step 3: Route by Tier
 
@@ -142,8 +142,8 @@ Launch these agents using the Agent tool with subagent_type:
    - Sites: {sites from request}
    - Period: {calculated time range}
    - Data needed: stats, referrers, top pages, time series
-   - Provide the full content of `${CLAUDE_SKILL_DIR}/references/mcp-tool-reference.md`
-   - Provide the full content of `${CLAUDE_SKILL_DIR}/references/site-registry.md`
+   - Provide the full content of `./references/mcp-tool-reference.md`
+   - Provide the full content of `./references/site-registry.md`
 
 **Phase B — Parallel Analysis (after data returns):**
 2. Spawn `traffic-intelligence` agent with data-collector output
@@ -209,15 +209,15 @@ For full-tier reports, spawn the `memory-agent` to:
 
 | Agent | File | Tier | Purpose |
 |-------|------|------|---------|
-| data-collector | `${CLAUDE_SKILL_DIR}/agents/data-collector.md` | All | MCP data fetching |
-| traffic-intelligence | `${CLAUDE_SKILL_DIR}/agents/traffic-intelligence.md` | Medium+ | Source attribution |
-| content-seo | `${CLAUDE_SKILL_DIR}/agents/content-seo.md` | Medium+ | Page performance |
-| anomaly-detector | `${CLAUDE_SKILL_DIR}/agents/anomaly-detector.md` | Medium+ | Spike/drop detection |
-| conversion-funnel | `${CLAUDE_SKILL_DIR}/agents/conversion-funnel.md` | Full | Event/goal analysis |
-| audience-segmentation | `${CLAUDE_SKILL_DIR}/agents/audience-segmentation.md` | Full | Cohort analysis |
-| verification-agent | `${CLAUDE_SKILL_DIR}/agents/verification-agent.md` | Full | Output quality check |
-| reporting-narrative | `${CLAUDE_SKILL_DIR}/agents/reporting-narrative.md` | Medium+ | Narrative compilation |
-| memory-agent | `${CLAUDE_SKILL_DIR}/agents/memory-agent.md` | Full | Rolling context |
+| data-collector | `./agents/data-collector.md` | All | MCP data fetching |
+| traffic-intelligence | `./agents/traffic-intelligence.md` | Medium+ | Source attribution |
+| content-seo | `./agents/content-seo.md` | Medium+ | Page performance |
+| anomaly-detector | `./agents/anomaly-detector.md` | Medium+ | Spike/drop detection |
+| conversion-funnel | `./agents/conversion-funnel.md` | Full | Event/goal analysis |
+| audience-segmentation | `./agents/audience-segmentation.md` | Full | Cohort analysis |
+| verification-agent | `./agents/verification-agent.md` | Full | Output quality check |
+| reporting-narrative | `./agents/reporting-narrative.md` | Medium+ | Narrative compilation |
+| memory-agent | `./agents/memory-agent.md` | Full | Rolling context |
 
 ## Troubleshooting
 

--- a/plugins/api-development/api-authentication-builder/package.json
+++ b/plugins/api-development/api-authentication-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-authentication-builder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Build authentication systems with JWT, OAuth2, and API keys",
   "keywords": [
     "authentication",

--- a/plugins/api-development/api-authentication-builder/skills/building-api-authentication/SKILL.md
+++ b/plugins/api-development/api-authentication-builder/skills/building-api-authentication/SKILL.md
@@ -45,17 +45,17 @@ Build secure API authentication systems supporting JWT Bearer tokens, OAuth 2.0 
 8. Add brute-force protection on login endpoints: rate limit to 5 attempts per minute per IP, implement progressive lockout (15 min, 1 hour) after repeated failures, and log all authentication attempts.
 9. Write security tests covering: valid/invalid/expired tokens, refresh token rotation, role enforcement, API key validation, brute-force lockout, and token revocation.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/auth/jwt.js` - JWT token issuance, verification, and refresh logic
-- `${CLAUDE_SKILL_DIR}/src/auth/middleware.js` - Bearer token authentication middleware
-- `${CLAUDE_SKILL_DIR}/src/auth/rbac.js` - Role-based and scope-based access control middleware
-- `${CLAUDE_SKILL_DIR}/src/auth/api-keys.js` - API key generation, hashing, and validation
-- `${CLAUDE_SKILL_DIR}/src/auth/oauth.js` - OAuth 2.0 flow implementations
-- `${CLAUDE_SKILL_DIR}/src/routes/auth.js` - Login, register, refresh, and logout endpoints
-- `${CLAUDE_SKILL_DIR}/tests/auth/` - Authentication and authorization security tests
+- `./src/auth/jwt.js` - JWT token issuance, verification, and refresh logic
+- `./src/auth/middleware.js` - Bearer token authentication middleware
+- `./src/auth/rbac.js` - Role-based and scope-based access control middleware
+- `./src/auth/api-keys.js` - API key generation, hashing, and validation
+- `./src/auth/oauth.js` - OAuth 2.0 flow implementations
+- `./src/routes/auth.js` - Login, register, refresh, and logout endpoints
+- `./tests/auth/` - Authentication and authorization security tests
 
 ## Error Handling
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Refresh token reuse | Previously rotated refresh token used (possible token theft) | Invalidate all user sessions immediately; alert user of potential compromise; require re-authentication |
 | API key leaked | API key exposed in client-side code, logs, or version control | Revoke compromised key immediately; issue replacement; scan for exposure source |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **API key with scoped permissions**: Generate API keys with specific scopes (`read:analytics`, `write:webhooks`), stored as SHA-256 hashes, displayed to the user only once at creation, with key rotation support.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-authentication-builder/skills/building-api-authentication/references/implementation.md
+++ b/plugins/api-development/api-authentication-builder/skills/building-api-authentication/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-batch-processor/package.json
+++ b/plugins/api-development/api-batch-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-batch-processor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Implement batch API operations with bulk processing and job queues",
   "keywords": [
     "batch",

--- a/plugins/api-development/api-batch-processor/skills/processing-api-batches/SKILL.md
+++ b/plugins/api-development/api-batch-processor/skills/processing-api-batches/SKILL.md
@@ -43,17 +43,17 @@ Optimize bulk API operations with batch request endpoints, parallel execution wi
 8. Implement batch size limits and validation: maximum 1000 items per batch, reject oversized batches with 413, validate all items before processing any, and return all validation errors upfront.
 9. Write tests covering: small sync batches, large async batches, partial failure handling, progress tracking, concurrency limits, and batch size validation.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/routes/batch.js` - Batch request endpoint with sync/async routing
-- `${CLAUDE_SKILL_DIR}/src/batch/processor.js` - Batch execution engine with concurrency control
-- `${CLAUDE_SKILL_DIR}/src/batch/validator.js` - Batch request validation and size limit enforcement
-- `${CLAUDE_SKILL_DIR}/src/batch/progress.js` - Redis-backed progress tracking for async batches
-- `${CLAUDE_SKILL_DIR}/src/batch/workers/` - Background worker for async batch processing
-- `${CLAUDE_SKILL_DIR}/src/batch/results.js` - Per-item result aggregation with summary statistics
-- `${CLAUDE_SKILL_DIR}/tests/batch/` - Batch processing integration tests
+- `./src/routes/batch.js` - Batch request endpoint with sync/async routing
+- `./src/batch/processor.js` - Batch execution engine with concurrency control
+- `./src/batch/validator.js` - Batch request validation and size limit enforcement
+- `./src/batch/progress.js` - Redis-backed progress tracking for async batches
+- `./src/batch/workers/` - Background worker for async batch processing
+- `./src/batch/results.js` - Per-item result aggregation with summary statistics
+- `./tests/batch/` - Batch processing integration tests
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Partial transaction failure | Database transaction rolls back all items due to one failure | Use savepoints for per-item isolation; or process items individually outside a wrapping transaction |
 | Progress tracking stale | Worker crashed mid-batch; progress stops updating | Implement heartbeat monitoring; mark batch as failed after heartbeat timeout; enable retry from last checkpoint |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Idempotent batch retry**: Client includes `idempotencyKey` per batch item; on retry, already-completed items return their cached result without re-execution, while failed items are re-attempted.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-batch-processor/skills/processing-api-batches/references/implementation.md
+++ b/plugins/api-development/api-batch-processor/skills/processing-api-batches/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-cache-manager/package.json
+++ b/plugins/api-development/api-cache-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-cache-manager",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
   "keywords": [
     "caching",

--- a/plugins/api-development/api-cache-manager/skills/managing-api-cache/SKILL.md
+++ b/plugins/api-development/api-cache-manager/skills/managing-api-cache/SKILL.md
@@ -45,16 +45,16 @@ Implement intelligent API response caching using Redis, Memcached, or in-memory 
 8. Add cache warming for critical endpoints: pre-populate cache entries on application startup or schedule for frequently accessed resources.
 9. Write tests verifying cache hits, misses, invalidation correctness, TTL expiration, and stale-while-revalidate behavior.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/cache.js` - Cache-aside middleware with hit/miss tracking
-- `${CLAUDE_SKILL_DIR}/src/cache/key-generator.js` - Deterministic cache key generation
-- `${CLAUDE_SKILL_DIR}/src/cache/invalidator.js` - Tag-based cache invalidation on mutations
-- `${CLAUDE_SKILL_DIR}/src/cache/store.js` - Redis/Memcached cache store abstraction
-- `${CLAUDE_SKILL_DIR}/src/config/cache-policies.js` - Per-endpoint TTL and caching policy configuration
-- `${CLAUDE_SKILL_DIR}/tests/cache/` - Cache behavior verification tests
+- `./src/middleware/cache.js` - Cache-aside middleware with hit/miss tracking
+- `./src/cache/key-generator.js` - Deterministic cache key generation
+- `./src/cache/invalidator.js` - Tag-based cache invalidation on mutations
+- `./src/cache/store.js` - Redis/Memcached cache store abstraction
+- `./src/config/cache-policies.js` - Per-endpoint TTL and caching policy configuration
+- `./tests/cache/` - Cache behavior verification tests
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Cache key collision | Different requests generating identical cache keys | Include all varying parameters in key; hash the full normalized request for uniqueness |
 | Memory pressure | Cache grows unbounded consuming all available Redis memory | Configure Redis `maxmemory-policy` to `allkeys-lru`; set per-key size limits; monitor memory usage |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **CDN edge caching**: Set `Cache-Control: public, max-age=300, stale-while-revalidate=60` on public endpoints, enabling CloudFront to serve cached responses at the edge while revalidating asynchronously.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-cache-manager/skills/managing-api-cache/references/implementation.md
+++ b/plugins/api-development/api-cache-manager/skills/managing-api-cache/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-contract-generator/package.json
+++ b/plugins/api-development/api-contract-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-contract-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate API contracts for consumer-driven contract testing",
   "keywords": [
     "contract",

--- a/plugins/api-development/api-contract-generator/skills/generating-api-contracts/SKILL.md
+++ b/plugins/api-development/api-contract-generator/skills/generating-api-contracts/SKILL.md
@@ -43,16 +43,16 @@ Generate OpenAPI 3.0/3.1 specifications and consumer-driven contract tests from 
 7. Set up provider verification that replays Pact interactions against the actual API implementation, verifying the provider satisfies all consumer expectations.
 8. Generate contract artifacts: OpenAPI spec file, Postman collection, and consumer contract (Pact JSON), all versioned alongside the API source code.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/openapi.yaml` - Complete OpenAPI 3.0/3.1 specification
-- `${CLAUDE_SKILL_DIR}/contracts/pact/` - Consumer-driven contract definitions (Pact JSON)
-- `${CLAUDE_SKILL_DIR}/contracts/postman/` - Generated Postman collection for API testing
-- `${CLAUDE_SKILL_DIR}/tests/contract/consumer/` - Consumer contract test implementations
-- `${CLAUDE_SKILL_DIR}/tests/contract/provider/` - Provider verification test suite
-- `${CLAUDE_SKILL_DIR}/scripts/generate-contract.sh` - Contract generation automation script
+- `./openapi.yaml` - Complete OpenAPI 3.0/3.1 specification
+- `./contracts/pact/` - Consumer-driven contract definitions (Pact JSON)
+- `./contracts/postman/` - Generated Postman collection for API testing
+- `./tests/contract/consumer/` - Consumer contract test implementations
+- `./tests/contract/provider/` - Provider verification test suite
+- `./scripts/generate-contract.sh` - Contract generation automation script
 
 ## Error Handling
 
@@ -64,7 +64,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Circular schema reference | Components reference each other creating infinite recursion | Break cycles with `allOf` composition or introduce intermediate types |
 | Example/schema mismatch | Example values do not validate against their own schema | Auto-validate all examples during spec generation; reject mismatched examples |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -74,7 +74,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Design-first workflow**: Author OpenAPI spec in Stoplight Studio, generate server stubs and client SDKs from the spec, then implement business logic in the stubs -- spec stays as the single source of truth.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-contract-generator/skills/generating-api-contracts/references/implementation.md
+++ b/plugins/api-development/api-contract-generator/skills/generating-api-contracts/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-documentation-generator/package.json
+++ b/plugins/api-development/api-documentation-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-documentation-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
   "keywords": [
     "api",

--- a/plugins/api-development/api-documentation-generator/skills/generating-api-docs/SKILL.md
+++ b/plugins/api-development/api-documentation-generator/skills/generating-api-docs/SKILL.md
@@ -44,16 +44,16 @@ Create comprehensive, interactive API documentation from OpenAPI specifications 
 7. Configure documentation versioning so consumers can switch between API versions (v1, v2) with visual diff highlighting showing changes between versions.
 8. Set up automated documentation deployment: on OpenAPI spec changes, regenerate the documentation site and deploy to hosting with cache invalidation.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/docs/site/` - Generated documentation website (HTML/CSS/JS)
-- `${CLAUDE_SKILL_DIR}/docs/guides/authentication.md` - Authentication flow guide with code examples
-- `${CLAUDE_SKILL_DIR}/docs/guides/getting-started.md` - Quick-start tutorial for first API call
-- `${CLAUDE_SKILL_DIR}/docs/reference/errors.md` - Complete error code reference with resolution steps
-- `${CLAUDE_SKILL_DIR}/docs/examples/` - Per-endpoint code examples in multiple languages
-- `${CLAUDE_SKILL_DIR}/docs/config/redoc.yaml` - Documentation generator configuration with branding
+- `./docs/site/` - Generated documentation website (HTML/CSS/JS)
+- `./docs/guides/authentication.md` - Authentication flow guide with code examples
+- `./docs/guides/getting-started.md` - Quick-start tutorial for first API call
+- `./docs/reference/errors.md` - Complete error code reference with resolution steps
+- `./docs/examples/` - Per-endpoint code examples in multiple languages
+- `./docs/config/redoc.yaml` - Documentation generator configuration with branding
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Code example errors | Generated code example uses deprecated SDK method or wrong import path | Auto-test code examples against a staging API; version examples alongside SDK releases |
 | Search not working | Full-text search index not rebuilt after content update | Include search index regeneration in documentation build pipeline; verify Algolia/Lunr config |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Developer portal**: Combine API reference docs with getting-started tutorials, use-case guides, webhooks documentation, and SDK installation instructions in a single searchable portal.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-documentation-generator/skills/generating-api-docs/references/implementation.md
+++ b/plugins/api-development/api-documentation-generator/skills/generating-api-docs/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-error-handler/package.json
+++ b/plugins/api-development/api-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-error-handler",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Implement standardized error handling with proper HTTP status codes",
   "keywords": [
     "error-handling",

--- a/plugins/api-development/api-error-handler/skills/handling-api-errors/SKILL.md
+++ b/plugins/api-development/api-error-handler/skills/handling-api-errors/SKILL.md
@@ -44,16 +44,16 @@ Implement standardized API error handling with RFC 7807 Problem Details response
 8. Handle unhandled rejections and uncaught exceptions at the process level, returning 500 with a generic error message while logging the full failure and triggering alerts.
 9. Write tests verifying that each error type produces the correct HTTP status code, RFC 7807 response body, and that stack traces are hidden in production mode.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/errors/` - Typed error classes (ValidationError, NotFoundError, etc.)
-- `${CLAUDE_SKILL_DIR}/src/middleware/error-handler.js` - Centralized error handling middleware
-- `${CLAUDE_SKILL_DIR}/src/errors/formatters.js` - Error-to-RFC-7807 response transformation
-- `${CLAUDE_SKILL_DIR}/src/errors/codes.js` - Error code registry with human-readable descriptions
-- `${CLAUDE_SKILL_DIR}/src/config/error-config.js` - Environment-aware error detail configuration
-- `${CLAUDE_SKILL_DIR}/tests/errors/` - Error handling tests for each error type and scenario
+- `./src/errors/` - Typed error classes (ValidationError, NotFoundError, etc.)
+- `./src/middleware/error-handler.js` - Centralized error handling middleware
+- `./src/errors/formatters.js` - Error-to-RFC-7807 response transformation
+- `./src/errors/codes.js` - Error code registry with human-readable descriptions
+- `./src/config/error-config.js` - Environment-aware error detail configuration
+- `./tests/errors/` - Error handling tests for each error type and scenario
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Database error exposed | Raw SQL error message returned to client containing table/column names | Map database errors to generic messages at the error handler layer; log full details server-side |
 | Error monitoring noise | High volume of expected 4xx errors flooding Sentry/Bugsnag | Configure error monitoring to capture only 5xx; track 4xx via metrics, not error monitoring |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Graceful upstream failure**: When a downstream payment service returns 500, wrap it in a `ServiceUnavailableError` with a user-friendly message, log the upstream response for debugging, and trigger a circuit breaker.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-error-handler/skills/handling-api-errors/references/implementation.md
+++ b/plugins/api-development/api-error-handler/skills/handling-api-errors/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-event-emitter/package.json
+++ b/plugins/api-development/api-event-emitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-event-emitter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Implement event-driven APIs with message queues and event streaming",
   "keywords": [
     "events",

--- a/plugins/api-development/api-event-emitter/skills/emitting-api-events/SKILL.md
+++ b/plugins/api-development/api-event-emitter/skills/emitting-api-events/SKILL.md
@@ -44,17 +44,17 @@ Build event-driven API architectures using outbound webhooks, Server-Sent Events
 7. Create a dead-letter queue for events that exhaust all delivery retry attempts, with alerting and manual replay capability.
 8. Write integration tests covering event emission, webhook delivery with signature verification, SSE stream connection with reconnection, and dead-letter queue behavior.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/events/emitter.js` - Event emission service with outbox pattern
-- `${CLAUDE_SKILL_DIR}/src/events/schemas/` - Versioned event type schema definitions
-- `${CLAUDE_SKILL_DIR}/src/events/webhooks/` - Webhook delivery, signing, and retry logic
-- `${CLAUDE_SKILL_DIR}/src/events/sse.js` - Server-Sent Events streaming endpoint
-- `${CLAUDE_SKILL_DIR}/src/routes/webhooks.js` - Webhook subscription management API
-- `${CLAUDE_SKILL_DIR}/src/events/dead-letter.js` - Dead-letter queue handler with replay
-- `${CLAUDE_SKILL_DIR}/tests/events/` - Event emission and delivery integration tests
+- `./src/events/emitter.js` - Event emission service with outbox pattern
+- `./src/events/schemas/` - Versioned event type schema definitions
+- `./src/events/webhooks/` - Webhook delivery, signing, and retry logic
+- `./src/events/sse.js` - Server-Sent Events streaming endpoint
+- `./src/routes/webhooks.js` - Webhook subscription management API
+- `./src/events/dead-letter.js` - Dead-letter queue handler with replay
+- `./tests/events/` - Event emission and delivery integration tests
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | SSE connection memory leak | Server accumulates stale SSE connections without cleanup | Implement heartbeat comments (`:keepalive\n\n`) every 15 seconds; detect and close dead connections |
 | Schema version mismatch | Consumer expects v1 event format but receives v2 | Include `version` field in event envelope; support simultaneous v1/v2 delivery; deprecate old versions with notice |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Transactional outbox**: Write the event record to an `outbox` table within the same database transaction as the API mutation, then poll the outbox table every 100ms to publish events to Kafka, ensuring at-least-once delivery.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-event-emitter/skills/emitting-api-events/references/implementation.md
+++ b/plugins/api-development/api-event-emitter/skills/emitting-api-events/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-gateway-builder/package.json
+++ b/plugins/api-development/api-gateway-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-gateway-builder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Build API gateway with routing, authentication, and rate limiting",
   "keywords": [
     "api-gateway",

--- a/plugins/api-development/api-gateway-builder/skills/building-api-gateway/SKILL.md
+++ b/plugins/api-development/api-gateway-builder/skills/building-api-gateway/SKILL.md
@@ -45,18 +45,18 @@ Create an API gateway that provides unified entry point routing, load balancing,
 8. Configure health check aggregation: gateway `/health` endpoint reports overall status based on individual backend service health, with degraded state support for non-critical service failures.
 9. Write integration tests covering routing correctness, auth enforcement, rate limiting, circuit breaker behavior, and response aggregation.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/gateway/config/routes.yaml` - Route mapping definitions (path -> service)
-- `${CLAUDE_SKILL_DIR}/gateway/middleware/auth.js` - Gateway-level authentication enforcement
-- `${CLAUDE_SKILL_DIR}/gateway/middleware/rate-limiter.js` - Centralized rate limiting
-- `${CLAUDE_SKILL_DIR}/gateway/middleware/circuit-breaker.js` - Per-service circuit breaker
-- `${CLAUDE_SKILL_DIR}/gateway/middleware/transform.js` - Request/response transformation logic
-- `${CLAUDE_SKILL_DIR}/gateway/aggregators/` - Response aggregation for composite endpoints
-- `${CLAUDE_SKILL_DIR}/gateway/health.js` - Aggregated health check endpoint
-- `${CLAUDE_SKILL_DIR}/tests/gateway/` - Gateway integration test suite
+- `./gateway/config/routes.yaml` - Route mapping definitions (path -> service)
+- `./gateway/middleware/auth.js` - Gateway-level authentication enforcement
+- `./gateway/middleware/rate-limiter.js` - Centralized rate limiting
+- `./gateway/middleware/circuit-breaker.js` - Per-service circuit breaker
+- `./gateway/middleware/transform.js` - Request/response transformation logic
+- `./gateway/aggregators/` - Response aggregation for composite endpoints
+- `./gateway/health.js` - Aggregated health check endpoint
+- `./tests/gateway/` - Gateway integration test suite
 
 ## Error Handling
 
@@ -68,7 +68,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Routing miss | Request path does not match any configured route | Return 404 with list of available API paths; log unmatched routes for route configuration review |
 | Auth header stripping | Proxy strips Authorization header before forwarding to backend | Configure gateway to preserve or transform auth headers; verify proxy `proxy_pass_header` settings |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -78,7 +78,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **API versioning gateway**: Route requests to different backend deployments based on `Accept-Version` header, enabling blue-green deployments and gradual version migration without client-side URL changes.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-gateway-builder/skills/building-api-gateway/references/implementation.md
+++ b/plugins/api-development/api-gateway-builder/skills/building-api-gateway/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-load-tester/package.json
+++ b/plugins/api-development/api-load-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-load-tester",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Load test APIs with k6, Gatling, or Artillery",
   "keywords": [
     "load-testing",

--- a/plugins/api-development/api-load-tester/skills/load-testing-apis/SKILL.md
+++ b/plugins/api-development/api-load-tester/skills/load-testing-apis/SKILL.md
@@ -46,16 +46,16 @@ Execute comprehensive load, stress, and soak tests to validate API performance, 
 8. Analyze results: correlate latency spikes with server metrics (CPU, memory, DB connections, event loop lag), identify the bottleneck (database, network, compute), and document findings.
 9. Generate a performance report comparing results against SLO thresholds with recommendations for optimization.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/load-tests/scenarios/` - k6/Artillery test scripts per traffic scenario
-- `${CLAUDE_SKILL_DIR}/load-tests/data/` - Test data fixtures (users, payloads, tokens)
-- `${CLAUDE_SKILL_DIR}/load-tests/thresholds.json` - Pass/fail threshold configuration
-- `${CLAUDE_SKILL_DIR}/reports/load-test-results.json` - Raw test results with timing data
-- `${CLAUDE_SKILL_DIR}/reports/load-test-summary.md` - Human-readable performance analysis report
-- `${CLAUDE_SKILL_DIR}/reports/bottleneck-analysis.md` - Identified bottlenecks with remediation recommendations
+- `./load-tests/scenarios/` - k6/Artillery test scripts per traffic scenario
+- `./load-tests/data/` - Test data fixtures (users, payloads, tokens)
+- `./load-tests/thresholds.json` - Pass/fail threshold configuration
+- `./reports/load-test-results.json` - Raw test results with timing data
+- `./reports/load-test-summary.md` - Human-readable performance analysis report
+- `./reports/bottleneck-analysis.md` - Identified bottlenecks with remediation recommendations
 
 ## Error Handling
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Inconsistent baseline results | Shared staging environment with other traffic | Isolate test environment; run tests during off-hours; use dedicated performance environment |
 | Memory leak detected | Soak test shows steadily increasing memory over hours | Flag for development team; identify leaking endpoint by isolating test scenarios |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Soak test for memory leaks**: Sustain 200 concurrent users for 4 hours, monitoring server memory, connection counts, and response times for degradation patterns indicating resource leaks.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-load-tester/skills/load-testing-apis/references/implementation.md
+++ b/plugins/api-development/api-load-tester/skills/load-testing-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-migration-tool/package.json
+++ b/plugins/api-development/api-migration-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-migration-tool",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Migrate APIs between versions with backward compatibility",
   "keywords": [
     "migration",

--- a/plugins/api-development/api-migration-tool/skills/migrating-apis/SKILL.md
+++ b/plugins/api-development/api-migration-tool/skills/migrating-apis/SKILL.md
@@ -44,16 +44,16 @@ Implement API migrations between versions, frameworks, or platforms with minimal
 7. Execute phased cutover: shadow (compare only) -> canary (1% traffic to target) -> gradual ramp (10%, 25%, 50%, 100%) -> legacy decommission, with automatic rollback triggers.
 8. Validate migration completeness by running the full integration test suite against the target implementation and comparing response bodies with legacy for a representative request sample.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/migration/endpoint-mapping.json` - Legacy-to-target endpoint mapping with change annotations
-- `${CLAUDE_SKILL_DIR}/migration/adapters/` - Request/response transformation functions per endpoint
-- `${CLAUDE_SKILL_DIR}/migration/router.js` - Traffic routing middleware with phase-based switching
-- `${CLAUDE_SKILL_DIR}/migration/shadow-compare.js` - Traffic shadow comparison and diff reporting
-- `${CLAUDE_SKILL_DIR}/migration/dashboard.md` - Migration progress tracking per endpoint
-- `${CLAUDE_SKILL_DIR}/tests/migration/` - Parity tests comparing legacy and target responses
+- `./migration/endpoint-mapping.json` - Legacy-to-target endpoint mapping with change annotations
+- `./migration/adapters/` - Request/response transformation functions per endpoint
+- `./migration/router.js` - Traffic routing middleware with phase-based switching
+- `./migration/shadow-compare.js` - Traffic shadow comparison and diff reporting
+- `./migration/dashboard.md` - Migration progress tracking per endpoint
+- `./tests/migration/` - Parity tests comparing legacy and target responses
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Consumer authentication break | Target uses different auth scheme than legacy | Run auth adapter translating legacy tokens to target format during transition |
 | Data inconsistency | Database schema migration introduced transformation errors | Run data validation queries comparing legacy and target data stores; fix transformation logic |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Monolith to microservices**: Extract a user management module from a monolithic API into a standalone service, using the strangler fig pattern with API gateway routing to direct `/users/*` traffic to the new service while other endpoints remain on the monolith.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-migration-tool/skills/migrating-apis/references/implementation.md
+++ b/plugins/api-development/api-migration-tool/skills/migrating-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-mock-server/package.json
+++ b/plugins/api-development/api-mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-mock-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Create mock API servers from OpenAPI specs for testing",
   "keywords": [
     "mock",

--- a/plugins/api-development/api-mock-server/skills/mocking-apis/SKILL.md
+++ b/plugins/api-development/api-mock-server/skills/mocking-apis/SKILL.md
@@ -44,17 +44,17 @@ Generate mock API servers from OpenAPI specifications that return realistic, sch
 7. Enable request recording that captures all incoming requests with timestamps and headers for later replay in contract tests.
 8. Create a startup script that launches the mock server on a configurable port with hot-reload when fixture files change.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/mocks/server.js` - Mock server entry point with route registration
-- `${CLAUDE_SKILL_DIR}/mocks/fixtures/` - Per-endpoint response fixture JSON files
-- `${CLAUDE_SKILL_DIR}/mocks/generators/` - Dynamic response generators using Faker.js
-- `${CLAUDE_SKILL_DIR}/mocks/scenarios/` - Error scenario configurations (4xx, 5xx responses)
-- `${CLAUDE_SKILL_DIR}/mocks/state.js` - In-memory state store for CRUD behavior
-- `${CLAUDE_SKILL_DIR}/mocks/recordings/` - Captured request logs for contract testing
-- `${CLAUDE_SKILL_DIR}/docker-compose.mock.yml` - Docker configuration for mock server
+- `./mocks/server.js` - Mock server entry point with route registration
+- `./mocks/fixtures/` - Per-endpoint response fixture JSON files
+- `./mocks/generators/` - Dynamic response generators using Faker.js
+- `./mocks/scenarios/` - Error scenario configurations (4xx, 5xx responses)
+- `./mocks/state.js` - In-memory state store for CRUD behavior
+- `./mocks/recordings/` - Captured request logs for contract testing
+- `./docker-compose.mock.yml` - Docker configuration for mock server
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Port conflict | Mock server port already in use by another dev service | Make port configurable via environment variable; default to spec-defined server URL port |
 | State leak between tests | Stateful mock retains data from previous test run | Reset in-memory state before each test suite; expose `POST /mock/reset` admin endpoint |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Contract testing**: Record all requests to the mock server during frontend E2E tests, then replay them against the real backend to verify the mock accurately represents actual API behavior.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-mock-server/skills/mocking-apis/references/implementation.md
+++ b/plugins/api-development/api-mock-server/skills/mocking-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-monitoring-dashboard/package.json
+++ b/plugins/api-development/api-monitoring-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-monitoring-dashboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Create monitoring dashboards for API health, metrics, and alerts",
   "keywords": [
     "monitoring",

--- a/plugins/api-development/api-monitoring-dashboard/skills/monitoring-apis/SKILL.md
+++ b/plugins/api-development/api-monitoring-dashboard/skills/monitoring-apis/SKILL.md
@@ -45,16 +45,16 @@ Build real-time API monitoring with metrics collection (request rate, latency pe
 8. Implement synthetic monitoring that sends periodic requests to critical endpoints from external locations, measuring availability and latency from the consumer perspective.
 9. Add SLO tracking with error budget calculation: define SLO (99.9% availability, p95 < 500ms), compute burn rate, and alert when error budget consumption exceeds projected pace.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/metrics.js` - Prometheus metrics collection middleware
-- `${CLAUDE_SKILL_DIR}/src/routes/health.js` - Health check and readiness endpoints
-- `${CLAUDE_SKILL_DIR}/monitoring/dashboards/` - Grafana dashboard JSON definitions
-- `${CLAUDE_SKILL_DIR}/monitoring/alerts/` - Alerting rule definitions (Prometheus AlertManager or Grafana)
-- `${CLAUDE_SKILL_DIR}/monitoring/synthetic/` - Synthetic monitoring probe scripts
-- `${CLAUDE_SKILL_DIR}/monitoring/slo.yaml` - SLO definitions and error budget configuration
+- `./src/middleware/metrics.js` - Prometheus metrics collection middleware
+- `./src/routes/health.js` - Health check and readiness endpoints
+- `./monitoring/dashboards/` - Grafana dashboard JSON definitions
+- `./monitoring/alerts/` - Alerting rule definitions (Prometheus AlertManager or Grafana)
+- `./monitoring/synthetic/` - Synthetic monitoring probe scripts
+- `./monitoring/slo.yaml` - SLO definitions and error budget configuration
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Dashboard data gap | Metrics not collected during deployment rollout window | Configure Prometheus scrape interval < deployment duration; use push-based metrics during deploys |
 | SLO miscalculation | Error budget calculation uses wrong time window or includes planned maintenance | Exclude maintenance windows from SLO calculation; align window with business reporting period |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Dependency health matrix**: Dashboard showing real-time health status of all downstream dependencies (database, cache, external APIs) with latency sparklines and circuit breaker state indicators.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-monitoring-dashboard/skills/monitoring-apis/references/implementation.md
+++ b/plugins/api-development/api-monitoring-dashboard/skills/monitoring-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-rate-limiter/package.json
+++ b/plugins/api-development/api-rate-limiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-rate-limiter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Implement rate limiting with token bucket, sliding window, and Redis",
   "keywords": [
     "rate-limiting",

--- a/plugins/api-development/api-rate-limiter/skills/rate-limiting-apis/SKILL.md
+++ b/plugins/api-development/api-rate-limiter/skills/rate-limiting-apis/SKILL.md
@@ -44,16 +44,16 @@ Implement sophisticated rate limiting using sliding window, token bucket, and fi
 8. Implement rate limit bypass for internal service-to-service calls using shared secret or mutual TLS identification to prevent internal traffic from consuming consumer quotas.
 9. Write tests that verify rate limits engage at exact thresholds, headers reflect correct remaining counts, and limits reset at the configured window boundary.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/rate-limiter.js` - Rate limiting middleware with algorithm selection
-- `${CLAUDE_SKILL_DIR}/src/config/rate-limits.js` - Per-endpoint and per-tier rate limit configuration
-- `${CLAUDE_SKILL_DIR}/src/utils/rate-limit-store.js` - Redis-backed distributed counter implementation
-- `${CLAUDE_SKILL_DIR}/src/middleware/rate-limit-headers.js` - Standard rate limit response header injection
-- `${CLAUDE_SKILL_DIR}/tests/rate-limiting/` - Rate limit threshold verification tests
-- `${CLAUDE_SKILL_DIR}/docs/rate-limits.md` - Consumer-facing rate limit documentation
+- `./src/middleware/rate-limiter.js` - Rate limiting middleware with algorithm selection
+- `./src/config/rate-limits.js` - Per-endpoint and per-tier rate limit configuration
+- `./src/utils/rate-limit-store.js` - Redis-backed distributed counter implementation
+- `./src/middleware/rate-limit-headers.js` - Standard rate limit response header injection
+- `./tests/rate-limiting/` - Rate limit threshold verification tests
+- `./docs/rate-limits.md` - Consumer-facing rate limit documentation
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Inconsistent counts | Race condition in read-check-increment cycle | Use Redis `MULTI/EXEC` transaction or Lua script for atomic increment-and-check operations |
 | Bypass abuse | Internal bypass mechanism exploited by external client | Validate bypass credentials per-request; restrict bypass to specific IP ranges or mTLS certificates |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Login endpoint protection**: Apply strict rate limit of 5 attempts per minute per IP on `/auth/login` to prevent brute force attacks, with progressive lockout (15 min, 1 hour, 24 hours) after repeated violations.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-rate-limiter/skills/rate-limiting-apis/references/implementation.md
+++ b/plugins/api-development/api-rate-limiter/skills/rate-limiting-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-request-logger/package.json
+++ b/plugins/api-development/api-request-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-request-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Log API requests with structured logging and correlation IDs",
   "keywords": [
     "logging",

--- a/plugins/api-development/api-request-logger/skills/logging-api-requests/SKILL.md
+++ b/plugins/api-development/api-request-logger/skills/logging-api-requests/SKILL.md
@@ -45,16 +45,16 @@ Implement structured API request logging with correlation IDs, performance timin
 8. Set up log rotation and retention policies: 30 days for application logs, 90 days for audit logs, with automatic compression of logs older than 7 days.
 9. Write tests verifying that PII redaction works correctly, correlation IDs propagate through nested calls, and log output matches expected JSON structure.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/request-logger.js` - Structured request/response logging middleware
-- `${CLAUDE_SKILL_DIR}/src/middleware/correlation-id.js` - Correlation ID generation and propagation
-- `${CLAUDE_SKILL_DIR}/src/utils/pii-redactor.js` - Field-level PII redaction with configurable patterns
-- `${CLAUDE_SKILL_DIR}/src/utils/audit-logger.js` - Security audit event logger for sensitive operations
-- `${CLAUDE_SKILL_DIR}/src/config/logging.js` - Log level, format, and output destination configuration
-- `${CLAUDE_SKILL_DIR}/tests/logging/` - Logging middleware tests including PII redaction verification
+- `./src/middleware/request-logger.js` - Structured request/response logging middleware
+- `./src/middleware/correlation-id.js` - Correlation ID generation and propagation
+- `./src/utils/pii-redactor.js` - Field-level PII redaction with configurable patterns
+- `./src/utils/audit-logger.js` - Security audit event logger for sensitive operations
+- `./src/config/logging.js` - Log level, format, and output destination configuration
+- `./tests/logging/` - Logging middleware tests including PII redaction verification
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Log parsing failure | Log message contains unescaped characters breaking JSON structure | Use structured logging library that handles serialization; never concatenate user input into log strings |
 | Audit log gap | Async logging dropped events during high-load period | Use synchronous logging for audit events; implement write-ahead buffer for audit trail completeness |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Compliance audit trail**: Tag all data modification operations (POST, PUT, DELETE) with `audit: true`, capturing the authenticated user, modified resource ID, and change summary for SOC 2 compliance evidence.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-request-logger/skills/logging-api-requests/references/implementation.md
+++ b/plugins/api-development/api-request-logger/skills/logging-api-requests/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-response-validator/package.json
+++ b/plugins/api-development/api-response-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-response-validator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Validate API responses against schemas and contracts",
   "keywords": [
     "validation",

--- a/plugins/api-development/api-response-validator/skills/validating-api-responses/SKILL.md
+++ b/plugins/api-development/api-response-validator/skills/validating-api-responses/SKILL.md
@@ -44,16 +44,16 @@ Validate API responses against OpenAPI schemas, JSON Schema definitions, and con
 7. Implement schema drift detection that compares the current response shape against the documented schema after each deployment, alerting when undocumented fields appear or documented fields disappear.
 8. Generate a validation coverage report showing which endpoints and response codes have schema validation, identifying gaps in the specification.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/response-validator.js` - Response schema validation middleware
-- `${CLAUDE_SKILL_DIR}/src/validators/` - Compiled JSON Schema validators per endpoint
-- `${CLAUDE_SKILL_DIR}/tests/contract/` - Contract test suite validating all endpoint responses
-- `${CLAUDE_SKILL_DIR}/reports/validation-coverage.md` - Schema coverage report per endpoint and status code
-- `${CLAUDE_SKILL_DIR}/reports/schema-drift.json` - Detected undocumented response field changes
-- `${CLAUDE_SKILL_DIR}/src/config/validation.js` - Per-environment validation strictness configuration
+- `./src/middleware/response-validator.js` - Response schema validation middleware
+- `./src/validators/` - Compiled JSON Schema validators per endpoint
+- `./tests/contract/` - Contract test suite validating all endpoint responses
+- `./reports/validation-coverage.md` - Schema coverage report per endpoint and status code
+- `./reports/schema-drift.json` - Detected undocumented response field changes
+- `./src/config/validation.js` - Per-environment validation strictness configuration
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Null value on non-nullable | Field returns null but schema does not include `nullable: true` | Update schema to allow null, or fix data source to guarantee non-null values |
 | Format validation failure | Date field does not match RFC 3339 format or email field format invalid | Apply format serialization at the ORM/model level before response construction |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Backward compatibility check**: Compare v1 and v2 response schemas to verify that v2 is a superset of v1 (no removed fields, no type changes), ensuring existing consumers are not broken.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-response-validator/skills/validating-api-responses/references/implementation.md
+++ b/plugins/api-development/api-response-validator/skills/validating-api-responses/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-schema-validator/package.json
+++ b/plugins/api-development/api-schema-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-schema-validator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
   "keywords": [
     "schema",

--- a/plugins/api-development/api-schema-validator/skills/validating-api-schemas/SKILL.md
+++ b/plugins/api-development/api-schema-validator/skills/validating-api-schemas/SKILL.md
@@ -43,16 +43,16 @@ Validate API specifications against OpenAPI 3.0/3.1, JSON Schema Draft 2020-12, 
 7. Validate consistency across endpoints: pagination parameters use the same naming (`page`/`limit` vs `offset`/`count`), error response envelopes follow a single standard, and date formats are consistent.
 8. Generate a validation report with severity levels (error, warning, info) and specific file:line references for each finding.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/reports/schema-validation.json` - Machine-readable validation findings with severity
-- `${CLAUDE_SKILL_DIR}/reports/schema-validation.md` - Human-readable report with fix recommendations
-- `${CLAUDE_SKILL_DIR}/reports/breaking-changes.md` - Breaking change analysis between schema versions
-- `${CLAUDE_SKILL_DIR}/.spectral.yaml` - Custom Spectral linting rule configuration
-- `${CLAUDE_SKILL_DIR}/scripts/validate-schema.sh` - CI-ready schema validation script
-- `${CLAUDE_SKILL_DIR}/reports/schema-coverage.md` - Endpoint documentation completeness matrix
+- `./reports/schema-validation.json` - Machine-readable validation findings with severity
+- `./reports/schema-validation.md` - Human-readable report with fix recommendations
+- `./reports/breaking-changes.md` - Breaking change analysis between schema versions
+- `./.spectral.yaml` - Custom Spectral linting rule configuration
+- `./scripts/validate-schema.sh` - CI-ready schema validation script
+- `./reports/schema-coverage.md` - Endpoint documentation completeness matrix
 
 ## Error Handling
 
@@ -64,7 +64,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Breaking change detected | Required field added to existing request schema | Make new field optional with default value; or create new API version for breaking changes |
 | Schema too permissive | Use of `additionalProperties: true` or missing type constraints | Set `additionalProperties: false` by default; require explicit type and format on all properties |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -74,7 +74,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Schema completeness audit**: Generate a matrix showing every endpoint vs. documentation status (description, request schema, response schemas for 200/400/401/404/500, examples), highlighting gaps with coverage percentage.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-schema-validator/skills/validating-api-schemas/references/implementation.md
+++ b/plugins/api-development/api-schema-validator/skills/validating-api-schemas/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-sdk-generator/package.json
+++ b/plugins/api-development/api-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-sdk-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate client SDKs from OpenAPI specs for multiple languages",
   "keywords": [
     "sdk",

--- a/plugins/api-development/api-sdk-generator/skills/generating-api-sdks/SKILL.md
+++ b/plugins/api-development/api-sdk-generator/skills/generating-api-sdks/SKILL.md
@@ -43,16 +43,16 @@ Generate type-safe client SDKs in multiple languages (TypeScript, Python, Go, Ja
 8. Generate comprehensive JSDoc/docstring/Javadoc comments from OpenAPI `description` and `summary` fields for full IDE IntelliSense support.
 9. Create a test suite that validates SDK methods against a mock server running the OpenAPI spec, covering authentication, error handling, and pagination.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/sdk/typescript/src/client.ts` - Main SDK client class with typed methods
-- `${CLAUDE_SKILL_DIR}/sdk/typescript/src/models/` - TypeScript interfaces and type definitions
-- `${CLAUDE_SKILL_DIR}/sdk/python/client.py` - Python SDK with dataclass models and async support
-- `${CLAUDE_SKILL_DIR}/sdk/go/client.go` - Go SDK with struct types and context-based methods
-- `${CLAUDE_SKILL_DIR}/sdk/*/README.md` - Per-language installation and usage documentation
-- `${CLAUDE_SKILL_DIR}/sdk/*/tests/` - SDK test suites per language
+- `./sdk/typescript/src/client.ts` - Main SDK client class with typed methods
+- `./sdk/typescript/src/models/` - TypeScript interfaces and type definitions
+- `./sdk/python/client.py` - Python SDK with dataclass models and async support
+- `./sdk/go/client.go` - Go SDK with struct types and context-based methods
+- `./sdk/*/README.md` - Per-language installation and usage documentation
+- `./sdk/*/tests/` - SDK test suites per language
 
 ## Error Handling
 
@@ -64,7 +64,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Pagination exhaustion | Iterator consumes all pages without termination condition | Enforce maximum page count safety limit; detect empty result sets as termination signal |
 | Rate limit handling | SDK retry logic conflicts with application-level retry logic | Expose `retryConfig` option to disable built-in retries; emit retry events for observability |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -74,7 +74,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Multi-language CI pipeline**: On OpenAPI spec change, automatically regenerate SDKs in all target languages, run tests against a mock server, bump semantic versions, and publish to respective package registries.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-sdk-generator/skills/generating-api-sdks/references/implementation.md
+++ b/plugins/api-development/api-sdk-generator/skills/generating-api-sdks/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-security-scanner/package.json
+++ b/plugins/api-development/api-security-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-security-scanner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
   "keywords": [
     "security",

--- a/plugins/api-development/api-security-scanner/skills/scanning-api-security/SKILL.md
+++ b/plugins/api-development/api-security-scanner/skills/scanning-api-security/SKILL.md
@@ -46,14 +46,14 @@ Detect API security vulnerabilities by scanning endpoint implementations, authen
 8. Check security headers (CORS, CSP, HSTS, X-Content-Type-Options) and verify CORS `Access-Control-Allow-Origin` is not set to wildcard `*` on authenticated endpoints.
 9. Scan dependencies for known CVEs and generate a prioritized remediation report with severity ratings and fix recommendations.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/reports/security-scan.json` - Machine-readable vulnerability report with severity ratings
-- `${CLAUDE_SKILL_DIR}/reports/security-scan.md` - Human-readable report with remediation guidance
-- `${CLAUDE_SKILL_DIR}/reports/endpoint-auth-matrix.md` - Endpoint-to-auth-middleware mapping table
-- `${CLAUDE_SKILL_DIR}/reports/data-exposure-audit.md` - Fields returned vs. fields documented per endpoint
+- `./reports/security-scan.json` - Machine-readable vulnerability report with severity ratings
+- `./reports/security-scan.md` - Human-readable report with remediation guidance
+- `./reports/endpoint-auth-matrix.md` - Endpoint-to-auth-middleware mapping table
+- `./reports/data-exposure-audit.md` - Fields returned vs. fields documented per endpoint
 - Inline code comments marking identified vulnerabilities with `// SECURITY:` annotations
 
 ## Error Handling
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | CORS misconfiguration missed | CORS configured at reverse proxy level, not in application code | Extend scan to include nginx/Apache config files and cloud provider CORS settings |
 | Dependency scan timeout | Large dependency tree with many transitive dependencies | Run dependency scan in parallel; cache vulnerability database locally |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Authentication flow review**: Trace the complete auth flow from login through token issuance, refresh, and revocation, identifying token lifetime issues, missing refresh rotation, and insecure token storage patterns.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-security-scanner/skills/scanning-api-security/references/implementation.md
+++ b/plugins/api-development/api-security-scanner/skills/scanning-api-security/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-throttling-manager/package.json
+++ b/plugins/api-development/api-throttling-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-throttling-manager",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Manage API throttling with dynamic rate limits and quota management",
   "keywords": [
     "throttling",

--- a/plugins/api-development/api-throttling-manager/skills/throttling-apis/SKILL.md
+++ b/plugins/api-development/api-throttling-manager/skills/throttling-apis/SKILL.md
@@ -41,15 +41,15 @@ Implement API throttling policies that protect backend services from overload by
 7. Implement graceful degradation strategies per endpoint: serve cached responses, return partial results, or queue requests for deferred processing.
 8. Write load tests that verify throttle engagement at expected thresholds, proper 503 responses with `Retry-After`, and recovery behavior when load subsides.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/middleware/throttle.js` - Concurrency and request rate throttling middleware
-- `${CLAUDE_SKILL_DIR}/src/middleware/circuit-breaker.js` - Circuit breaker for downstream service protection
-- `${CLAUDE_SKILL_DIR}/src/middleware/priority-queue.js` - Tier-based request prioritization
-- `${CLAUDE_SKILL_DIR}/src/config/throttle-config.js` - Per-endpoint throttle policy definitions
-- `${CLAUDE_SKILL_DIR}/tests/throttle/` - Load tests validating throttle engagement and recovery
+- `./src/middleware/throttle.js` - Concurrency and request rate throttling middleware
+- `./src/middleware/circuit-breaker.js` - Circuit breaker for downstream service protection
+- `./src/middleware/priority-queue.js` - Tier-based request prioritization
+- `./src/config/throttle-config.js` - Per-endpoint throttle policy definitions
+- `./tests/throttle/` - Load tests validating throttle engagement and recovery
 
 ## Error Handling
 
@@ -61,7 +61,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Stale throttle state | Redis connection lost; throttle counters become inaccurate | Fall back to in-process counters; reconnect with backoff; log state inconsistency |
 | Priority starvation | Low-tier requests never served under sustained high-tier load | Reserve minimum throughput percentage for each tier to prevent complete starvation |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -71,7 +71,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Adaptive autoscaling trigger**: Throttle middleware emits metrics that trigger horizontal pod autoscaling when throttle engagement rate exceeds 20% sustained over 5 minutes.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-throttling-manager/skills/throttling-apis/references/implementation.md
+++ b/plugins/api-development/api-throttling-manager/skills/throttling-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/api-versioning-manager/package.json
+++ b/plugins/api-development/api-versioning-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/api-versioning-manager",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Manage API versions with migration strategies and backward compatibility",
   "keywords": [
     "api",

--- a/plugins/api-development/api-versioning-manager/skills/versioning-apis/SKILL.md
+++ b/plugins/api-development/api-versioning-manager/skills/versioning-apis/SKILL.md
@@ -44,16 +44,16 @@ Implement API versioning strategies -- URL path (`/v1/`, `/v2/`), header-based (
 7. Create a breaking change detector that compares OpenAPI specs between versions and flags removed fields, changed types, new required parameters, and altered response structures.
 8. Write version compatibility tests that send v1-formatted requests and verify correct responses, ensuring the compatibility layer preserves backward compatibility.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/routes/v1/` - Version 1 route definitions
-- `${CLAUDE_SKILL_DIR}/src/routes/v2/` - Version 2 route definitions
-- `${CLAUDE_SKILL_DIR}/src/middleware/version-router.js` - Version extraction and routing middleware
-- `${CLAUDE_SKILL_DIR}/src/compatibility/` - Request/response transformation layers between versions
-- `${CLAUDE_SKILL_DIR}/src/utils/breaking-change-detector.js` - OpenAPI diff tool for breaking changes
-- `${CLAUDE_SKILL_DIR}/docs/migration-guide-v1-to-v2.md` - Consumer migration documentation
+- `./src/routes/v1/` - Version 1 route definitions
+- `./src/routes/v2/` - Version 2 route definitions
+- `./src/middleware/version-router.js` - Version extraction and routing middleware
+- `./src/compatibility/` - Request/response transformation layers between versions
+- `./src/utils/breaking-change-detector.js` - OpenAPI diff tool for breaking changes
+- `./docs/migration-guide-v1-to-v2.md` - Consumer migration documentation
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Version header ignored | Client sets version header but reverse proxy strips custom headers | Document required proxy configuration; add URL path fallback for header-based versioning |
 | Breaking change undetected | Semantic change (same field name, different meaning) not caught by schema diff | Add contract tests with business-logic assertions beyond schema structure |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Sunset lifecycle management**: Announce v1 deprecation with 6-month sunset timeline, add `Sunset` headers immediately, log v1 usage metrics to track migration progress, and auto-disable after sunset date.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/api-versioning-manager/skills/versioning-apis/references/implementation.md
+++ b/plugins/api-development/api-versioning-manager/skills/versioning-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/graphql-server-builder/package.json
+++ b/plugins/api-development/graphql-server-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/graphql-server-builder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
   "keywords": [
     "graphql",

--- a/plugins/api-development/graphql-server-builder/skills/building-graphql-server/SKILL.md
+++ b/plugins/api-development/graphql-server-builder/skills/building-graphql-server/SKILL.md
@@ -45,17 +45,17 @@ Build production-ready GraphQL servers with SDL-first or code-first schema desig
 8. Generate TypeScript types from the schema using `graphql-codegen` to ensure type safety between schema definitions and resolver implementations.
 9. Write integration tests using `executeOperation` for query/mutation testing and WebSocket client tests for subscription verification.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/schema/` - GraphQL SDL type definitions organized by domain
-- `${CLAUDE_SKILL_DIR}/src/resolvers/` - Resolver implementations per type with DataLoader integration
-- `${CLAUDE_SKILL_DIR}/src/dataloaders/` - DataLoader factories for batched database queries
-- `${CLAUDE_SKILL_DIR}/src/directives/` - Custom schema directives (auth, validation, caching)
-- `${CLAUDE_SKILL_DIR}/src/scalars/` - Custom scalar type definitions (DateTime, JSON, Email)
-- `${CLAUDE_SKILL_DIR}/src/subscriptions/` - Subscription resolvers with pub/sub configuration
-- `${CLAUDE_SKILL_DIR}/generated/types.ts` - Auto-generated TypeScript types from schema
+- `./src/schema/` - GraphQL SDL type definitions organized by domain
+- `./src/resolvers/` - Resolver implementations per type with DataLoader integration
+- `./src/dataloaders/` - DataLoader factories for batched database queries
+- `./src/directives/` - Custom schema directives (auth, validation, caching)
+- `./src/scalars/` - Custom scalar type definitions (DateTime, JSON, Email)
+- `./src/subscriptions/` - Subscription resolvers with pub/sub configuration
+- `./generated/types.ts` - Auto-generated TypeScript types from schema
 
 ## Error Handling
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Partial resolver failure | One field resolver throws while others succeed | Return partial data with `errors` array per GraphQL spec; log failed resolver with context |
 | Schema stitching conflict | Duplicate type names when merging multiple schema modules | Use schema namespacing or federation with `@key` directives to resolve type ownership |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Federated microservice graph**: Apollo Federation with `@key` and `@external` directives across User, Order, and Product subgraphs, composed into a unified supergraph with a gateway router.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/graphql-server-builder/skills/building-graphql-server/references/implementation.md
+++ b/plugins/api-development/graphql-server-builder/skills/building-graphql-server/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/grpc-service-generator/package.json
+++ b/plugins/api-development/grpc-service-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/grpc-service-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate gRPC services with Protocol Buffers and streaming support",
   "keywords": [
     "grpc",

--- a/plugins/api-development/grpc-service-generator/skills/generating-grpc-services/SKILL.md
+++ b/plugins/api-development/grpc-service-generator/skills/generating-grpc-services/SKILL.md
@@ -45,17 +45,17 @@ Generate gRPC service definitions, client/server stubs, and implementations from
 8. Write integration tests using an in-process test server, validating all RPC methods including streaming scenarios with multiple messages and error conditions.
 9. Generate a REST-to-gRPC gateway using `grpc-gateway` annotations for HTTP/JSON clients that need to access gRPC services.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/proto/` - Protocol Buffer service and message definitions
-- `${CLAUDE_SKILL_DIR}/generated/` - Auto-generated stubs and client/server code
-- `${CLAUDE_SKILL_DIR}/src/services/` - RPC method handler implementations
-- `${CLAUDE_SKILL_DIR}/src/interceptors/` - Auth, logging, and metrics interceptors
-- `${CLAUDE_SKILL_DIR}/src/health/` - Health check service implementation
-- `${CLAUDE_SKILL_DIR}/gateway/` - REST-to-gRPC gateway configuration (optional)
-- `${CLAUDE_SKILL_DIR}/tests/` - Integration tests with in-process test server
+- `./proto/` - Protocol Buffer service and message definitions
+- `./generated/` - Auto-generated stubs and client/server code
+- `./src/services/` - RPC method handler implementations
+- `./src/interceptors/` - Auth, logging, and metrics interceptors
+- `./src/health/` - Health check service implementation
+- `./gateway/` - REST-to-gRPC gateway configuration (optional)
+- `./tests/` - Integration tests with in-process test server
 
 ## Error Handling
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | DEADLINE_EXCEEDED (4) | RPC took longer than client-specified deadline | Propagate deadlines to downstream calls; implement cascading timeout budgets |
 | UNAVAILABLE (14) | Server overloaded or downstream dependency unreachable | Client should retry with exponential backoff; server should implement backpressure |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **gRPC-Web frontend**: Generate gRPC-Web compatible stubs for browser clients using Envoy proxy for HTTP/2 to gRPC translation, enabling direct proto-based communication from React/Vue applications.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/grpc-service-generator/skills/generating-grpc-services/references/implementation.md
+++ b/plugins/api-development/grpc-service-generator/skills/generating-grpc-services/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/rest-api-generator/package.json
+++ b/plugins/api-development/rest-api-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/rest-api-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
   "keywords": [
     "api",

--- a/plugins/api-development/rest-api-generator/skills/generating-rest-apis/SKILL.md
+++ b/plugins/api-development/rest-api-generator/skills/generating-rest-apis/SKILL.md
@@ -45,17 +45,17 @@ Generate complete, production-ready REST API implementations from OpenAPI specif
 8. Create integration tests covering happy paths, validation failures, 404s, and auth rejection for every endpoint.
 9. Produce or update the OpenAPI 3.0 specification to match the generated implementation.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full step-by-step implementation guide.
+See `./references/implementation.md` for the full step-by-step implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/routes/` - Express/Fastify route definitions with HTTP method handlers
-- `${CLAUDE_SKILL_DIR}/src/controllers/` - Business logic separated from routing
-- `${CLAUDE_SKILL_DIR}/src/models/` - ORM models with validation rules and relationships
-- `${CLAUDE_SKILL_DIR}/src/middleware/auth.js` - JWT/API key authentication middleware
-- `${CLAUDE_SKILL_DIR}/src/middleware/validate.js` - Request schema validation middleware
-- `${CLAUDE_SKILL_DIR}/openapi.yaml` - Generated OpenAPI 3.0 specification
-- `${CLAUDE_SKILL_DIR}/tests/` - Integration test suite per resource endpoint
+- `./src/routes/` - Express/Fastify route definitions with HTTP method handlers
+- `./src/controllers/` - Business logic separated from routing
+- `./src/models/` - ORM models with validation rules and relationships
+- `./src/middleware/auth.js` - JWT/API key authentication middleware
+- `./src/middleware/validate.js` - Request schema validation middleware
+- `./openapi.yaml` - Generated OpenAPI 3.0 specification
+- `./tests/` - Integration test suite per resource endpoint
 
 ## Error Handling
 
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full step-by-step
 | 409 Conflict | Unique constraint violation on create/update | Include conflicting field name and existing value hint in error response |
 | 429 Too Many Requests | Client exceeds rate limit | Return `Retry-After` header with seconds until next allowed request window |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Public read API with admin writes**: Create a dual-access API where `GET` endpoints are publicly cacheable (Cache-Control headers) while `POST/PUT/DELETE` require admin-role JWT tokens.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/rest-api-generator/skills/generating-rest-apis/references/implementation.md
+++ b/plugins/api-development/rest-api-generator/skills/generating-rest-apis/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/webhook-handler-creator/package.json
+++ b/plugins/api-development/webhook-handler-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/webhook-handler-creator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Create secure webhook endpoints with signature verification and retry logic",
   "keywords": [
     "webhook",

--- a/plugins/api-development/webhook-handler-creator/skills/creating-webhook-handlers/SKILL.md
+++ b/plugins/api-development/webhook-handler-creator/skills/creating-webhook-handlers/SKILL.md
@@ -44,16 +44,16 @@ Create secure webhook receiver endpoints with HMAC signature verification, idemp
 7. Implement dead-letter handling for events that fail processing after maximum retry attempts, logging the full payload for manual inspection.
 8. Write tests that replay recorded webhook payloads with valid and tampered signatures to verify acceptance and rejection behavior.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/webhooks/receiver.js` - Webhook endpoint with signature verification
-- `${CLAUDE_SKILL_DIR}/src/webhooks/handlers/` - Per-event-type handler functions
-- `${CLAUDE_SKILL_DIR}/src/webhooks/verify.js` - HMAC signature verification utilities
-- `${CLAUDE_SKILL_DIR}/src/webhooks/idempotency.js` - Duplicate event detection logic
-- `${CLAUDE_SKILL_DIR}/src/queues/webhook-processor.js` - Async event processing queue worker
-- `${CLAUDE_SKILL_DIR}/tests/webhooks/` - Replay tests with recorded payloads
+- `./src/webhooks/receiver.js` - Webhook endpoint with signature verification
+- `./src/webhooks/handlers/` - Per-event-type handler functions
+- `./src/webhooks/verify.js` - HMAC signature verification utilities
+- `./src/webhooks/idempotency.js` - Duplicate event detection logic
+- `./src/queues/webhook-processor.js` - Async event processing queue worker
+- `./tests/webhooks/` - Replay tests with recorded payloads
 
 ## Error Handling
 
@@ -65,7 +65,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | 504 Gateway Timeout | Synchronous processing exceeded provider timeout (typically 5-30s) | Move processing to async queue; respond 200 immediately upon signature verification |
 | 500 Handler Exception | Business logic threw unhandled error during processing | Catch at dispatch layer; log full error with event payload; allow provider to retry |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -75,7 +75,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Multi-provider router**: Single `/webhooks/:provider` endpoint that loads provider-specific signature verifier and event schema from a registry, supporting Stripe, GitHub, Twilio, and custom providers.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/webhook-handler-creator/skills/creating-webhook-handlers/references/implementation.md
+++ b/plugins/api-development/webhook-handler-creator/skills/creating-webhook-handlers/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/api-development/websocket-server-builder/package.json
+++ b/plugins/api-development/websocket-server-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/websocket-server-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Build WebSocket servers for real-time bidirectional communication",
   "keywords": [
     "websocket",

--- a/plugins/api-development/websocket-server-builder/skills/building-websocket-server/SKILL.md
+++ b/plugins/api-development/websocket-server-builder/skills/building-websocket-server/SKILL.md
@@ -44,17 +44,17 @@ Build scalable WebSocket servers for real-time bidirectional communication using
 8. Configure Redis pub/sub adapter for horizontal scaling so messages broadcast from any server instance reach all connected clients across the cluster.
 9. Write connection lifecycle tests covering connect, authenticate, subscribe, message exchange, reconnect, and graceful disconnect scenarios.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation guide.
+See `./references/implementation.md` for the full implementation guide.
 
 ## Output
 
-- `${CLAUDE_SKILL_DIR}/src/ws/server.js` - WebSocket server setup and upgrade handling
-- `${CLAUDE_SKILL_DIR}/src/ws/handlers/` - Per-message-type handler functions
-- `${CLAUDE_SKILL_DIR}/src/ws/rooms.js` - Room/channel subscription management
-- `${CLAUDE_SKILL_DIR}/src/ws/registry.js` - Active connection tracking registry
-- `${CLAUDE_SKILL_DIR}/src/ws/heartbeat.js` - Ping/pong keepalive logic
-- `${CLAUDE_SKILL_DIR}/src/ws/adapters/redis.js` - Redis pub/sub adapter for scaling
-- `${CLAUDE_SKILL_DIR}/tests/ws/` - WebSocket connection and messaging tests
+- `./src/ws/server.js` - WebSocket server setup and upgrade handling
+- `./src/ws/handlers/` - Per-message-type handler functions
+- `./src/ws/rooms.js` - Room/channel subscription management
+- `./src/ws/registry.js` - Active connection tracking registry
+- `./src/ws/heartbeat.js` - Ping/pong keepalive logic
+- `./src/ws/adapters/redis.js` - Redis pub/sub adapter for scaling
+- `./tests/ws/` - WebSocket connection and messaging tests
 
 ## Error Handling
 
@@ -66,7 +66,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementati
 | Memory leak | Connection registry grows unbounded from stale entries | Implement heartbeat-based cleanup sweep every 60s; enforce max connections per server |
 | Message storm | Single client flooding messages beyond acceptable rate | Apply per-connection message rate limiting; disconnect abusive clients with 1008 |
 
-Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patterns.
+Refer to `./references/errors.md` for comprehensive error patterns.
 
 ## Examples
 
@@ -76,7 +76,7 @@ Refer to `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error patt
 
 **Collaborative editing**: Operational transformation relay server that receives edit operations from clients, transforms against concurrent operations, and broadcasts resolved changes to all document subscribers.
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for additional examples.
+See `./references/examples.md` for additional examples.
 
 ## Resources
 

--- a/plugins/api-development/websocket-server-builder/skills/building-websocket-server/references/implementation.md
+++ b/plugins/api-development/websocket-server-builder/skills/building-websocket-server/references/implementation.md
@@ -4,7 +4,7 @@
 
 Plan the API architecture and endpoints:
 
-1. Use Read tool to examine existing API specifications from ${CLAUDE_SKILL_DIR}/api-specs/
+1. Use Read tool to examine existing API specifications from ./api-specs/
 2. Define resource models, endpoints, and HTTP methods
 3. Document request/response schemas and data types
 4. Identify authentication and authorization requirements

--- a/plugins/business-tools/excel-analyst-pro/package.json
+++ b/plugins/business-tools/excel-analyst-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/excel-analyst-pro",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
   "keywords": [
     "excel",

--- a/plugins/business-tools/excel-analyst-pro/skills/excel-dcf-modeler/SKILL.md
+++ b/plugins/business-tools/excel-analyst-pro/skills/excel-dcf-modeler/SKILL.md
@@ -67,4 +67,4 @@ Result: Model with synergy adjustments, scenario analysis, and per-share valuati
 
 - [Damodaran Online DCF Resources](https://pages.stern.nyu.edu/~adamodar/)
 - [WSO DCF Modeling Guide](https://www.wallstreetoasis.com/)
-- `${CLAUDE_SKILL_DIR}/references/dcf-formulas.md` for Excel formula templates
+- `./references/dcf-formulas.md` for Excel formula templates

--- a/plugins/business-tools/excel-analyst-pro/skills/excel-lbo-modeler/SKILL.md
+++ b/plugins/business-tools/excel-analyst-pro/skills/excel-lbo-modeler/SKILL.md
@@ -66,4 +66,4 @@ Result: Integrated model with synergy phase-in and accretion analysis
 
 - [Macabacus LBO Modeling](https://macabacus.com/)
 - [WSO PE Interview Prep](https://www.wallstreetoasis.com/)
-- `${CLAUDE_SKILL_DIR}/references/lbo-formulas.md` for debt schedule templates
+- `./references/lbo-formulas.md` for debt schedule templates

--- a/plugins/business-tools/excel-analyst-pro/skills/excel-pivot-wizard/SKILL.md
+++ b/plugins/business-tools/excel-analyst-pro/skills/excel-pivot-wizard/SKILL.md
@@ -66,4 +66,4 @@ Result: Time-series pivot with calculated YoY growth fields
 ## Resources
 
 - [Microsoft Pivot Table Guide](https://support.microsoft.com/)
-- `${CLAUDE_SKILL_DIR}/references/pivot-formulas.md` for calculated field syntax
+- `./references/pivot-formulas.md` for calculated field syntax

--- a/plugins/business-tools/excel-analyst-pro/skills/excel-variance-analyzer/SKILL.md
+++ b/plugins/business-tools/excel-analyst-pro/skills/excel-variance-analyzer/SKILL.md
@@ -67,4 +67,4 @@ Result: Ranked list by variance magnitude with drill-down to line items
 ## Resources
 
 - [FP&A Best Practices](https://www.fpanda.org/)
-- `${CLAUDE_SKILL_DIR}/references/variance-formulas.md` for calculation templates
+- `./references/variance-formulas.md` for calculation templates

--- a/plugins/community/claude-never-forgets/package.json
+++ b/plugins/community/claude-never-forgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/claude-never-forgets",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Persistent memory across sessions. Learns preferences, conventions, and corrections automatically.",
   "keywords": [
     "memory",

--- a/plugins/community/claude-never-forgets/skills/memory/SKILL.md
+++ b/plugins/community/claude-never-forgets/skills/memory/SKILL.md
@@ -33,7 +33,7 @@ Memory provides persistent context across Claude Code sessions by storing and re
 
 ## Instructions
 
-1. **Access stored memories.** On session start, locate and read the memory file at `.claude/memories/project_memory.json` using the Read tool. Parse the JSON structure containing timestamped memory entries. See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full retrieval workflow.
+1. **Access stored memories.** On session start, locate and read the memory file at `.claude/memories/project_memory.json` using the Read tool. Parse the JSON structure containing timestamped memory entries. See `./references/implementation.md` for the full retrieval workflow.
 2. **Match memories to current context.** Scan memory entries for keywords and topics relevant to the current task. Extract applicable decisions (e.g., "use pnpm instead of npm"), architectural patterns, library choices, and coding style preferences.
 3. **Apply memories silently.** Incorporate remembered preferences into responses and tool usage without announcing them. When a memory dictates a package manager, testing framework, or naming convention, follow it automatically.
 4. **Store new memories.** When significant decisions occur -- library selections, architectural choices, user-stated preferences, or tool rejections -- write them to the memory file with a timestamp. Add entries via the `/remember` command or through automatic capture of conversation signals.
@@ -92,8 +92,8 @@ User declines a suggested `npm install` action
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` -- Step-by-step guide for accessing, applying, updating, and resolving memory conflicts
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- Detailed error scenarios with recovery procedures
+- `./references/implementation.md` -- Step-by-step guide for accessing, applying, updating, and resolving memory conflicts
+- `./references/errors.md` -- Detailed error scenarios with recovery procedures
 - `/remember [text]` -- Add a new memory entry manually
 - `/forget [text]` -- Remove a matching memory from storage
 - `/memories` -- Display all currently stored memories with timestamps

--- a/plugins/community/contributing-clanker/package.json
+++ b/plugins/community/contributing-clanker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/contributing-clanker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes",
   "keywords": [
     "oss",

--- a/plugins/community/contributing-clanker/skills/contribute/SKILL.md
+++ b/plugins/community/contributing-clanker/skills/contribute/SKILL.md
@@ -171,7 +171,7 @@ fi
 ```
 
 Delegate dossier build/refresh to the **`@researcher`** subagent (defined
-at `${CLAUDE_SKILL_DIR}/agents/researcher.md`). It runs in its own context window so
+at `./agents/researcher.md`). It runs in its own context window so
 the verbose CONTRIBUTING.md fetch + depth-1 link follows stay out of your
 main conversation. It writes the dossier to disk and reports back a
 one-paragraph summary.
@@ -186,7 +186,7 @@ Find issues worth contributing to. Sources, in priority order:
 - **Existing candidates** with `status: open` or `status: shortlist` already in `~/.contribute-system/candidates/` — already discovered + vetted, ranked by `scout_score:` frontmatter field
 - **Fresh GitHub label searches** scoped to repos / languages in `~/.contribute-system/profile.md`: `gh search issues "label:'good first issue' state:open language:<lang>" --limit 50`
 
-Delegate discovery to the **`@scout`** subagent (defined at `${CLAUDE_SKILL_DIR}/agents/scout.md`). It runs in its own context window so the verbose `gh search` output stays out of your main conversation. Pass it a mode: `baseline` (full per-tier sweep), `refresh` (re-evaluate existing candidates for momentum), or an ad-hoc query like "TypeScript repos at mainstream tier with no competing PRs." Scout writes ranked candidate markdown files to `~/.contribute-system/candidates/` and appends events to `~/.contribute-system/log.jsonl`. Summarize the top picks for the user from those files; do not re-run the search yourself.
+Delegate discovery to the **`@scout`** subagent (defined at `./agents/scout.md`). It runs in its own context window so the verbose `gh search` output stays out of your main conversation. Pass it a mode: `baseline` (full per-tier sweep), `refresh` (re-evaluate existing candidates for momentum), or an ad-hoc query like "TypeScript repos at mainstream tier with no competing PRs." Scout writes ranked candidate markdown files to `~/.contribute-system/candidates/` and appends events to `~/.contribute-system/log.jsonl`. Summarize the top picks for the user from those files; do not re-run the search yourself.
 
 ### Step 2 — Qualify
 
@@ -348,11 +348,11 @@ When the user asks "what gates am I overriding most?" or "audit my contribution
 history" or "show me override frequency":
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/audit-overrides.sh                       # all-time
-${CLAUDE_SKILL_DIR}/scripts/audit-overrides.sh --since=30             # last 30 days
-${CLAUDE_SKILL_DIR}/scripts/audit-overrides.sh --scope=org:posthog    # one org
-${CLAUDE_SKILL_DIR}/scripts/audit-overrides.sh --gate=A05             # one gate
-${CLAUDE_SKILL_DIR}/scripts/audit-overrides.sh --json                 # JSON
+./scripts/audit-overrides.sh                       # all-time
+./scripts/audit-overrides.sh --since=30             # last 30 days
+./scripts/audit-overrides.sh --scope=org:posthog    # one org
+./scripts/audit-overrides.sh --gate=A05             # one gate
+./scripts/audit-overrides.sh --json                 # JSON
 ```
 
 Output is a per-gate table with `[overrides, blocks, override_rate, top_reason]`,
@@ -392,7 +392,7 @@ User invokes `/contribute` or asks "what's in flight?"
 User asks "what should I work on next?" or "scout opportunities."
 
 1. Run Step 0 first (state summary)
-2. Delegate to `@scout` (the user-scope subagent at `${CLAUDE_SKILL_DIR}/agents/scout.md`)
+2. Delegate to `@scout` (the user-scope subagent at `./agents/scout.md`)
 3. Output Tracker / Fresh GitHub / Algora sections, top 3 highlighted
 4. Optional: per top pick, run Step 2 (Qualify) to surface CLA / competing-PR signals
 
@@ -428,8 +428,8 @@ User asks to verify a working branch.
 
 ### Bundled subagents (load with `Read agents/<name>.md`)
 
-- `@scout` (user-scope subagent at `${CLAUDE_SKILL_DIR}/agents/scout.md`) — discovery sweep, GitHub-only, ranked by star-tier brackets. Each candidate it writes carries a `research_path:` frontmatter field pointing at the matching dossier (or empty if not yet built).
-- `@researcher` (user-scope subagent at `${CLAUDE_SKILL_DIR}/agents/researcher.md`) — build / refresh the per-repo dossier at `~/.contribute-system/research/<owner>__<repo>.md`. Auto-invoked when a candidate's dossier is missing or older than 14 days.
+- `@scout` (user-scope subagent at `./agents/scout.md`) — discovery sweep, GitHub-only, ranked by star-tier brackets. Each candidate it writes carries a `research_path:` frontmatter field pointing at the matching dossier (or empty if not yet built).
+- `@researcher` (user-scope subagent at `./agents/researcher.md`) — build / refresh the per-repo dossier at `~/.contribute-system/research/<owner>__<repo>.md`. Auto-invoked when a candidate's dossier is missing or older than 14 days.
 - `agents/repo-analyzer.md` — DEPRECATED. Most of its function is now in the dossier system. Keep until Slice 3 retires it.
 - `agents/draft-writer.md` — draft a Design Issue or PR body from a working branch's diff
 - `agents/test-runner.md` — detect upstream stack and run the native test suite, log to disk

--- a/plugins/community/contributing-clanker/skills/contribute/agents/scout.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/scout.md
@@ -67,7 +67,7 @@ mode**: pick the single tier from the user's prompt.
 > already exists at `~/.contribute-system/research/<owner>__<repo>.md`,
 > the path is recorded; otherwise it's left empty. The `/contribute`
 > SKILL.md Step 0.5 handler invokes the `@researcher` subagent
-> (`${CLAUDE_SKILL_DIR}/agents/researcher.md`, on disk at `~/.claude/skills/contribute/agents/researcher.md`) to build/refresh the dossier before
+> (`./agents/researcher.md`, on disk at `~/.claude/skills/contribute/agents/researcher.md`) to build/refresh the dossier before
 > any lifecycle transition that needs it. You don't build dossiers — you
 > just discover candidates and let the workflow trigger researcher
 > downstream. Don't pre-emptively rebuild dossiers in scout flows.

--- a/plugins/community/gastown/package.json
+++ b/plugins/community/gastown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/gastown",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
   "keywords": [
     "multi-agent",

--- a/plugins/community/gastown/skills/gastown/SKILL.md
+++ b/plugins/community/gastown/skills/gastown/SKILL.md
@@ -52,11 +52,11 @@ The Cognition Engine. Track work with convoys; sling to agents.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/community/jeremy-firebase/package.json
+++ b/plugins/community/jeremy-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-firebase",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
   "keywords": [
     "firebase",

--- a/plugins/community/jeremy-firebase/skills/firebase-vertex-ai/SKILL.md
+++ b/plugins/community/jeremy-firebase/skills/firebase-vertex-ai/SKILL.md
@@ -77,7 +77,7 @@ Use this skill to design, implement, and deploy Firebase applications that call 
 
 ## Resources
 
-- Full detailed guide (kept for reference): `${CLAUDE_SKILL_DIR}/references/SKILL.full.md`
+- Full detailed guide (kept for reference): `./references/SKILL.full.md`
 - Firebase docs: https://firebase.google.com/docs
 - Cloud Functions for Firebase: https://firebase.google.com/docs/functions
 - Vertex AI docs: https://cloud.google.com/vertex-ai/docs

--- a/plugins/community/jeremy-firestore/package.json
+++ b/plugins/community/jeremy-firestore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-firestore",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Firestore database specialist for schema design, queries, and real-time sync",
   "keywords": [
     "firebase",

--- a/plugins/community/jeremy-firestore/skills/firestore-operations-manager/SKILL.md
+++ b/plugins/community/jeremy-firestore/skills/firestore-operations-manager/SKILL.md
@@ -73,6 +73,6 @@ Use this skill to design Firestore data access patterns and implement changes wi
 
 ## Resources
 
-- Full detailed guide (kept for reference): `${CLAUDE_SKILL_DIR}/references/SKILL.full.md`
+- Full detailed guide (kept for reference): `./references/SKILL.full.md`
 - Firestore docs: https://firebase.google.com/docs/firestore
 - Firestore indexes: https://firebase.google.com/docs/firestore/query-data/indexing

--- a/plugins/community/sprint/package.json
+++ b/plugins/community/sprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/sprint",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Autonomous multi-agent development framework with spec-driven sprints and convergent iteration",
   "keywords": [
     "autonomous",

--- a/plugins/community/sprint/skills/agent-patterns/SKILL.md
+++ b/plugins/community/sprint/skills/agent-patterns/SKILL.md
@@ -45,7 +45,7 @@ Agent Patterns defines the coordination protocol for multi-agent sprint executio
 3. Collect structured reports from every agent upon completion. Each report must include: work completed, files modified, tests added, and conformity status against the specification.
 4. When running agents in parallel, partition work by domain boundary (e.g., backend vs. frontend vs. CI/CD). Never assign overlapping file paths to concurrent agents.
 5. Feed agent reports back to the project architect for review. The architect decides whether to iterate (re-spawn with narrowed specs) or advance to the next phase.
-6. For testing agents, pass the UI test report format shown in `${CLAUDE_SKILL_DIR}/references/ui-test-report.md` so results follow a consistent schema including test counts, coverage, failures, and console errors.
+6. For testing agents, pass the UI test report format shown in `./references/ui-test-report.md` so results follow a consistent schema including test counts, coverage, failures, and console errors.
 
 ## Output
 
@@ -110,7 +110,7 @@ Run After: qa-test-agent
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/ui-test-report.md` -- Structured UI test report format with coverage and failure tracking
+- `./references/ui-test-report.md` -- Structured UI test report format with coverage and failure tracking
 - Sprint workflow skill for phase lifecycle context
 - API contract skill for shared interface design
 - Sprint plugin README for agent architecture overview

--- a/plugins/community/sprint/skills/api-contract/SKILL.md
+++ b/plugins/community/sprint/skills/api-contract/SKILL.md
@@ -32,11 +32,11 @@ API Contract guides the creation of `api-contract.md` files that serve as the sh
 
 ## Instructions
 
-1. Create `api-contract.md` in the sprint directory (`.claude/sprint/[N]/api-contract.md`). Define each endpoint using the standard format: HTTP method, route path, description, request body, response body with status code, and error codes. See `${CLAUDE_SKILL_DIR}/references/writing-endpoints.md` for the full template.
-2. Define TypeScript interfaces for all request and response types. Use explicit types instead of `any`, mark optional fields with `?`, and use `string | null` for nullable values. Reference `${CLAUDE_SKILL_DIR}/references/typescript-interfaces.md` for canonical type patterns.
-3. For list endpoints, include pagination parameters and the `PaginatedResponse<T>` wrapper. Standardize on `page`, `limit`, `sort`, and `order` query parameters as documented in `${CLAUDE_SKILL_DIR}/references/pagination.md`.
+1. Create `api-contract.md` in the sprint directory (`.claude/sprint/[N]/api-contract.md`). Define each endpoint using the standard format: HTTP method, route path, description, request body, response body with status code, and error codes. See `./references/writing-endpoints.md` for the full template.
+2. Define TypeScript interfaces for all request and response types. Use explicit types instead of `any`, mark optional fields with `?`, and use `string | null` for nullable values. Reference `./references/typescript-interfaces.md` for canonical type patterns.
+3. For list endpoints, include pagination parameters and the `PaginatedResponse<T>` wrapper. Standardize on `page`, `limit`, `sort`, and `order` query parameters as documented in `./references/pagination.md`.
 4. Document all response states: success (200, 201, 204), client errors (400, 401, 403, 404, 422), and empty states. Use a consistent error response format with `code`, `message`, and optional `details` fields.
-5. Follow best practices from `${CLAUDE_SKILL_DIR}/references/best-practices.md`: be specific about field constraints (e.g., "string, required, valid email format"), include request/response examples, reference shared types instead of duplicating, and omit implementation details (no database columns, framework names, or file paths).
+5. Follow best practices from `./references/best-practices.md`: be specific about field constraints (e.g., "string, required, valid email format"), include request/response examples, reference shared types instead of duplicating, and omit implementation details (no database columns, framework names, or file paths).
 6. Share the contract file path in SPAWN REQUEST blocks so both backend and frontend agents read the same interface definition.
 
 ## Output
@@ -120,7 +120,7 @@ interface ApiError {
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/writing-endpoints.md` -- Endpoint definition template and key elements
-- `${CLAUDE_SKILL_DIR}/references/typescript-interfaces.md` -- Canonical type definitions and guidelines
-- `${CLAUDE_SKILL_DIR}/references/pagination.md` -- Pagination parameters and PaginatedResponse interface
-- `${CLAUDE_SKILL_DIR}/references/best-practices.md` -- Contract authoring rules (specificity, DRY, no implementation details)
+- `./references/writing-endpoints.md` -- Endpoint definition template and key elements
+- `./references/typescript-interfaces.md` -- Canonical type definitions and guidelines
+- `./references/pagination.md` -- Pagination parameters and PaginatedResponse interface
+- `./references/best-practices.md` -- Contract authoring rules (specificity, DRY, no implementation details)

--- a/plugins/community/sprint/skills/spec-writing/SKILL.md
+++ b/plugins/community/sprint/skills/spec-writing/SKILL.md
@@ -33,7 +33,7 @@ Spec Writing provides guidance on authoring effective `specs.md` files that driv
 
 1. Open the generated `specs.md` file at `.claude/sprint/[N]/specs.md` and define a concise goal statement at the top. State what the sprint delivers in one sentence (e.g., "Add user authentication with email/password login").
 2. Define explicit scope boundaries using **In Scope** and **Out of Scope** sections. List specific features, endpoints, or components in each. Agents only implement what appears in scope; ambiguity leads to drift.
-3. Add the **Testing** section to control which testing agents run and how. Configure three settings as documented in `${CLAUDE_SKILL_DIR}/references/testing-configuration.md`:
+3. Add the **Testing** section to control which testing agents run and how. Configure three settings as documented in `./references/testing-configuration.md`:
    - `QA`: `required` | `optional` | `skip` -- Controls API and unit test execution
    - `UI Testing`: `required` | `optional` | `skip` -- Controls browser-based E2E tests
    - `UI Testing Mode`: `automated` | `manual` -- Auto-run or user-driven testing
@@ -114,6 +114,6 @@ Redesign the admin dashboard with responsive layout
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/testing-configuration.md` -- Testing section options with guidance on when to use each setting
+- `./references/testing-configuration.md` -- Testing section options with guidance on when to use each setting
 - Sprint workflow skill for understanding how specs feed into the phase lifecycle
 - API contract skill for designing endpoint contracts referenced by specs

--- a/plugins/community/sprint/skills/sprint-workflow/SKILL.md
+++ b/plugins/community/sprint/skills/sprint-workflow/SKILL.md
@@ -32,7 +32,7 @@ Sprint Workflow describes the convergent diffusion execution model used by the S
 
 ## Instructions
 
-1. **Phase 0 -- Load Specifications.** The orchestrator locates the sprint directory at `.claude/sprint/[N]/`, reads `specs.md` for requirements, reads `status.md` if resuming a prior iteration, and detects the project type for framework-specific agent selection. See `${CLAUDE_SKILL_DIR}/references/sprint-phases.md` for the full phase reference.
+1. **Phase 0 -- Load Specifications.** The orchestrator locates the sprint directory at `.claude/sprint/[N]/`, reads `specs.md` for requirements, reads `status.md` if resuming a prior iteration, and detects the project type for framework-specific agent selection. See `./references/sprint-phases.md` for the full phase reference.
 2. **Phase 1 -- Architectural Planning.** The project-architect agent reads `project-map.md` for architecture context and `project-goals.md` for business objectives. It produces specification files (`api-contract.md`, `backend-specs.md`, `frontend-specs.md`) and returns SPAWN REQUEST blocks for implementation agents.
 3. **Phase 2 -- Implementation.** The orchestrator spawns implementation agents in parallel based on the architect's SPAWN REQUEST blocks. Agents include `python-dev`, `nextjs-dev`, `cicd-agent`, and `allpurpose-agent`. Each agent reads its assigned spec files and the shared `api-contract.md`, then returns a structured report.
 4. **Phase 3 -- Testing.** Testing agents execute sequentially: `qa-test-agent` runs first (API and unit tests), then `ui-test-agent` runs browser-based E2E tests. Framework-specific diagnostics agents (e.g., `nextjs-diagnostics-agent`) run in parallel with UI tests. All agents produce test reports.
@@ -86,7 +86,7 @@ Iteration 3: All specs satisfied → FINALIZE
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/sprint-phases.md` -- Detailed reference for all six phases with agent assignments and handoff rules
+- `./references/sprint-phases.md` -- Detailed reference for all six phases with agent assignments and handoff rules
 - Agent patterns skill for SPAWN REQUEST format and report structure
 - Spec writing skill for authoring effective `specs.md` files
 - API contract skill for designing the shared interface between agents

--- a/plugins/community/zai-cli/package.json
+++ b/plugins/community/zai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/zai-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
   "keywords": [
     "vision",

--- a/plugins/community/zai-cli/skills/zai-cli/SKILL.md
+++ b/plugins/community/zai-cli/skills/zai-cli/SKILL.md
@@ -44,11 +44,11 @@ Use `--output-format json` for `{ success, data, timestamp }` wrapping.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/crypto/arbitrage-opportunity-finder/package.json
+++ b/plugins/crypto/arbitrage-opportunity-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/arbitrage-opportunity-finder",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
   "keywords": [
     "arbitrage",

--- a/plugins/crypto/arbitrage-opportunity-finder/skills/finding-arbitrage-opportunities/SKILL.md
+++ b/plugins/crypto/arbitrage-opportunity-finder/skills/finding-arbitrage-opportunities/SKILL.md
@@ -37,7 +37,7 @@ Detect and analyze arbitrage opportunities across cryptocurrency exchanges and D
 1. **Quick spread scan** on a specific pair:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py scan ETH USDC
+   python ./scripts/arb_finder.py scan ETH USDC
    ```
 
    Shows current prices per exchange, spread %, estimated profit after fees, and recommended action.
@@ -45,14 +45,14 @@ Detect and analyze arbitrage opportunities across cryptocurrency exchanges and D
 2. **Multi-exchange comparison** across specific exchanges:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py scan ETH USDC \
+   python ./scripts/arb_finder.py scan ETH USDC \
      --exchanges binance,coinbase,kraken,kucoin,okx
    ```
 
 3. **DEX price comparison** across decentralized exchanges:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py scan ETH USDC --dex-only
+   python ./scripts/arb_finder.py scan ETH USDC --dex-only
    ```
 
    Compares Uniswap V3, SushiSwap, Curve, Balancer with gas cost estimates.
@@ -60,27 +60,27 @@ Detect and analyze arbitrage opportunities across cryptocurrency exchanges and D
 4. **Triangular arbitrage discovery** within a single exchange:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py triangular binance --min-profit 0.5
+   python ./scripts/arb_finder.py triangular binance --min-profit 0.5
    ```
 
 5. **Cross-chain opportunities** across different blockchains:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py cross-chain USDC \
+   python ./scripts/arb_finder.py cross-chain USDC \
      --chains ethereum,polygon,arbitrum
    ```
 
 6. **Real-time monitoring** with threshold alerts:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py monitor ETH USDC \
+   python ./scripts/arb_finder.py monitor ETH USDC \
      --threshold 0.5 --interval 5
    ```
 
 7. **Export opportunities** for bot integration:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py scan ETH USDC --output json > opportunities.json
+   python ./scripts/arb_finder.py scan ETH USDC --output json > opportunities.json
    ```
 
 ## Output
@@ -89,7 +89,7 @@ Detect and analyze arbitrage opportunities across cryptocurrency exchanges and D
 - **Detailed mode** (`--detailed`): All exchange prices, fee breakdown, slippage estimates, historical spread context
 - **Monitor mode**: Real-time updates with threshold alerts and trend indicators
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for exchange fee tables and output format examples.
+See `./references/implementation.md` for exchange fee tables and output format examples.
 
 ## Error Handling
 
@@ -105,7 +105,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for exchange fee tables a
 **Quick ETH/USDC spread scan** - Find best buy/sell across all CEX exchanges:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py scan ETH USDC
+python ./scripts/arb_finder.py scan ETH USDC
 ```
 
 Sample detection output:
@@ -120,19 +120,19 @@ Sample detection output:
 **Triangular arb on Binance** - Discover circular paths with minimum 0.5% net profit:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py triangular binance --min-profit 0.5
+python ./scripts/arb_finder.py triangular binance --min-profit 0.5
 ```
 
 **Cross-chain USDC opportunities** - Compare stablecoin prices across L1/L2 chains:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py cross-chain USDC --chains ethereum,polygon,arbitrum
+python ./scripts/arb_finder.py cross-chain USDC --chains ethereum,polygon,arbitrum
 ```
 
 **Calculate exact profit** - Detailed fee breakdown for a specific trade:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py calc \
+python ./scripts/arb_finder.py calc \
   --buy-exchange binance --sell-exchange coinbase --pair ETH/USDC --amount 10  # 10 = trade size in ETH
 ```
 
@@ -141,4 +141,4 @@ python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py calc \
 - [CoinGecko API](https://www.coingecko.com/en/api) - Free price data
 - [CCXT Library](https://github.com/ccxt/ccxt) - Unified exchange API
 - Uniswap Subgraph - DEX data
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Exchange fee tables, configuration, advanced arbitrage types, disclaimer
+- `./references/implementation.md` - Exchange fee tables, configuration, advanced arbitrage types, disclaimer

--- a/plugins/crypto/arbitrage-opportunity-finder/skills/finding-arbitrage-opportunities/references/implementation.md
+++ b/plugins/crypto/arbitrage-opportunity-finder/skills/finding-arbitrage-opportunities/references/implementation.md
@@ -23,7 +23,7 @@
 
 ## Configuration
 
-Configure price sources in `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Configure price sources in `./config/settings.yaml`:
 
 ```yaml
 # Primary data sources
@@ -55,7 +55,7 @@ export COINBASE_API_KEY="your-key"
 Find profitable circular paths within a single exchange:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py triangular binance --min-profit 0.5
+python ./scripts/arb_finder.py triangular binance --min-profit 0.5
 ```
 
 Example output:
@@ -73,7 +73,7 @@ Net:   +0.52%
 Compare prices across different blockchains:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py cross-chain USDC \
+python ./scripts/arb_finder.py cross-chain USDC \
   --chains ethereum,polygon,arbitrum
 ```
 
@@ -88,7 +88,7 @@ Shows:
 Continuously monitor for opportunities:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py monitor ETH USDC \
+python ./scripts/arb_finder.py monitor ETH USDC \
   --threshold 0.5 \
   --interval 5
 ```
@@ -106,7 +106,7 @@ Alert format:
 Calculate exact profit for a trade:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/arb_finder.py calc \
+python ./scripts/arb_finder.py calc \
   --buy-exchange binance \
   --sell-exchange coinbase \
   --pair ETH/USDC \

--- a/plugins/crypto/blockchain-explorer-cli/package.json
+++ b/plugins/crypto/blockchain-explorer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/blockchain-explorer-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
   "keywords": [
     "blockchain",

--- a/plugins/crypto/blockchain-explorer-cli/skills/exploring-blockchain-data/SKILL.md
+++ b/plugins/crypto/blockchain-explorer-cli/skills/exploring-blockchain-data/SKILL.md
@@ -46,7 +46,7 @@ Query and analyze blockchain data across multiple EVM-compatible networks includ
 10. Export any query result in JSON or CSV format using `--format json` or `--format csv` and redirect to a file for downstream processing.
 11. Enable verbose mode with `--verbose` to display API request URLs, response times, cache hit/miss status, and rate limit counters for debugging.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full four-step implementation workflow.
+See `./references/implementation.md` for the full four-step implementation workflow.
 
 ## Output
 

--- a/plugins/crypto/blockchain-explorer-cli/skills/exploring-blockchain-data/references/implementation.md
+++ b/plugins/crypto/blockchain-explorer-cli/skills/exploring-blockchain-data/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/cross-chain-bridge-monitor/package.json
+++ b/plugins/crypto/cross-chain-bridge-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/cross-chain-bridge-monitor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
   "keywords": [
     "crypto",

--- a/plugins/crypto/cross-chain-bridge-monitor/skills/monitoring-cross-chain-bridges/SKILL.md
+++ b/plugins/crypto/cross-chain-bridge-monitor/skills/monitoring-cross-chain-bridges/SKILL.md
@@ -100,7 +100,7 @@ Shows supported bridge protocols with their chains.
 1. **Check bridge TVL rankings**:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts
+   cd ./scripts
    python bridge_monitor.py tvl
    ```
 
@@ -152,7 +152,7 @@ Shows supported bridge protocols with their chains.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling including:
+See `./references/errors.md` for comprehensive error handling including:
 
 - API unavailability and fallback behavior
 - Transaction tracking edge cases
@@ -160,7 +160,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling 
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples including:
+See `./references/examples.md` for detailed examples including:
 
 - Finding best route for large transfers
 - Monitoring transactions after bridging

--- a/plugins/crypto/cross-chain-bridge-monitor/skills/monitoring-cross-chain-bridges/references/implementation.md
+++ b/plugins/crypto/cross-chain-bridge-monitor/skills/monitoring-cross-chain-bridges/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/crypto-derivatives-tracker/package.json
+++ b/plugins/crypto/crypto-derivatives-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/crypto-derivatives-tracker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
   "keywords": [
     "crypto",

--- a/plugins/crypto/crypto-derivatives-tracker/skills/tracking-crypto-derivatives/SKILL.md
+++ b/plugins/crypto/crypto-derivatives-tracker/skills/tracking-crypto-derivatives/SKILL.md
@@ -105,7 +105,7 @@ The skill produces structured reports per market type:
 - **Options Overview**: Put/call ratio, IV rank, max pain, and large flow alerts
 - **Basis Report**: Spot-perp and quarterly basis with annualized carry rates
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output format examples.
+See `./references/implementation.md` for detailed output format examples.
 
 ## Error Handling
 
@@ -146,4 +146,4 @@ python derivatives_tracker.py basis --all --min-yield 5  # 5 = minimum annualize
 - **Coinglass**: Aggregated derivatives data
 - **Exchange APIs**: Binance, Bybit, OKX, Deribit
 - **The Graph**: DEX perpetuals data
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Detailed output formats, options/basis guides, key concepts
+- `./references/implementation.md` - Detailed output formats, options/basis guides, key concepts

--- a/plugins/crypto/crypto-news-aggregator/package.json
+++ b/plugins/crypto/crypto-news-aggregator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/crypto-news-aggregator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
   "keywords": [
     "news",

--- a/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/SKILL.md
+++ b/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/SKILL.md
@@ -44,22 +44,22 @@ Aggregate cryptocurrency news from 50+ authoritative sources via RSS feeds with 
 
    ```bash
    # Default scan (top 20, past 24h, relevance sorted)
-   python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py
+   python ./scripts/news_aggregator.py
 
    # Coin-specific scan
-   python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coin BTC --period 4h
+   python ./scripts/news_aggregator.py --coin BTC --period 4h
 
    # Category filter
-   python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category defi --top 30
+   python ./scripts/news_aggregator.py --category defi --top 30
 
    # Multiple filters
-   python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coin ETH --category defi --period 24h --top 15
+   python ./scripts/news_aggregator.py --coin ETH --category defi --period 24h --top 15
    ```
 
 3. **Export results** for downstream processing:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --format json --output news.json
+   python ./scripts/news_aggregator.py --format json --output news.json
    ```
 
 4. **Present results** to the user:
@@ -99,7 +99,7 @@ Table showing articles ranked by relevance score (0-100) based on market-moving 
 | No results | Filters too strict | Suggest relaxing filters |
 | Invalid coin | Unknown symbol | List similar valid symbols |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
@@ -107,26 +107,26 @@ Filtering patterns for common news monitoring scenarios:
 
 ```bash
 # Latest crypto news (defaults)
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py
+python ./scripts/news_aggregator.py
 
 # Bitcoin news from past 4 hours
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coin BTC --period 4h
+python ./scripts/news_aggregator.py --coin BTC --period 4h
 
 # DeFi category news
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category defi
+python ./scripts/news_aggregator.py --category defi
 
 # High-relevance news only
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --min-score 70 --top 10
+python ./scripts/news_aggregator.py --min-score 70 --top 10
 
 # Multiple coins
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coins BTC,ETH,SOL
+python ./scripts/news_aggregator.py --coins BTC,ETH,SOL
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - CLI options, categories, JSON format, advanced filtering
-- `${CLAUDE_SKILL_DIR}/references/errors.md` - Comprehensive error handling
-- `${CLAUDE_SKILL_DIR}/references/examples.md` - Detailed usage examples
-- `${CLAUDE_SKILL_DIR}/config/sources.yaml` - Full source registry
+- `./references/implementation.md` - CLI options, categories, JSON format, advanced filtering
+- `./references/errors.md` - Comprehensive error handling
+- `./references/examples.md` - Detailed usage examples
+- `./config/sources.yaml` - Full source registry
 - CoinDesk RSS: https://www.coindesk.com/arc/outboundfeeds/rss/
 - feedparser docs: https://feedparser.readthedocs.io/

--- a/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/references/examples.md
+++ b/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/references/examples.md
@@ -9,7 +9,7 @@ Comprehensive examples for the aggregating-crypto-news skill.
 The simplest use case - get the latest crypto news:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py
+python ./scripts/news_aggregator.py
 ```
 
 **Output:**
@@ -41,7 +41,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py
 Filter for Bitcoin-related news only:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coin BTC
+python ./scripts/news_aggregator.py --coin BTC
 ```
 
 Only shows articles mentioning Bitcoin, BTC, or related terms.
@@ -53,7 +53,7 @@ Only shows articles mentioning Bitcoin, BTC, or related terms.
 Track news for your portfolio:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coins BTC,ETH,SOL
+python ./scripts/news_aggregator.py --coins BTC,ETH,SOL
 ```
 
 Shows articles mentioning any of the specified coins.
@@ -65,7 +65,7 @@ Shows articles mentioning any of the specified coins.
 Get news from the past hour only:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --period 1h --top 10
+python ./scripts/news_aggregator.py --period 1h --top 10
 ```
 
 Perfect for catching breaking news during active trading.
@@ -77,7 +77,7 @@ Perfect for catching breaking news during active trading.
 ### Example 5: DeFi News
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category defi
+python ./scripts/news_aggregator.py --category defi
 ```
 
 Shows DeFi protocol news, yield farming updates, DEX announcements.
@@ -87,7 +87,7 @@ Shows DeFi protocol news, yield farming updates, DEX announcements.
 ### Example 6: Regulatory News
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category regulatory
+python ./scripts/news_aggregator.py --category regulatory
 ```
 
 SEC, CFTC, congressional hearings, legal developments.
@@ -97,7 +97,7 @@ SEC, CFTC, congressional hearings, legal developments.
 ### Example 7: Security Alerts
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category security --period 4h
+python ./scripts/news_aggregator.py --category security --period 4h
 ```
 
 Hacks, exploits, vulnerabilities - time-sensitive security news.
@@ -107,7 +107,7 @@ Hacks, exploits, vulnerabilities - time-sensitive security news.
 ### Example 8: Exchange News
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category exchange
+python ./scripts/news_aggregator.py --category exchange
 ```
 
 Listings, delistings, exchange announcements.
@@ -117,7 +117,7 @@ Listings, delistings, exchange announcements.
 ### Example 9: Layer 2 Updates
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --category layer2
+python ./scripts/news_aggregator.py --category layer2
 ```
 
 Arbitrum, Optimism, Base, zkSync news.
@@ -131,7 +131,7 @@ Arbitrum, Optimism, Base, zkSync news.
 For programmatic processing:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --format json --output crypto_news.json
+python ./scripts/news_aggregator.py --format json --output crypto_news.json
 ```
 
 **Output (crypto_news.json):**
@@ -171,7 +171,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --format json --output cry
 For spreadsheet analysis:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --format csv --output crypto_news.csv
+python ./scripts/news_aggregator.py --format csv --output crypto_news.csv
 ```
 
 **Output (crypto_news.csv):**
@@ -189,7 +189,7 @@ rank,title,url,source,published,age,category,relevance_score,coins_mentioned
 ### Example 12: Sort by Recency
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --sort-by recency
+python ./scripts/news_aggregator.py --sort-by recency
 ```
 
 Newest articles first, regardless of relevance score.
@@ -199,7 +199,7 @@ Newest articles first, regardless of relevance score.
 ### Example 13: High-Score News Only
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --min-score 70
+python ./scripts/news_aggregator.py --min-score 70
 ```
 
 Only shows articles with relevance score >= 70.
@@ -211,7 +211,7 @@ Only shows articles with relevance score >= 70.
 ### Example 14: DeFi Breaking News
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --category defi \
   --period 4h \
   --min-score 50 \
@@ -225,7 +225,7 @@ DeFi news from past 4 hours with decent relevance.
 ### Example 15: Bitcoin Regulatory Updates
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --coin BTC \
   --category regulatory \
   --period 7d \
@@ -240,7 +240,7 @@ Bitcoin-related regulatory news from past week.
 ### Example 16: Exchange Security Alerts
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --category security \
   --period 1h \
   --sort-by recency
@@ -253,7 +253,7 @@ Recent security-related news, perfect for immediate alerts.
 ### Example 17: Solana Ecosystem News
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --coin SOL \
   --period 24h \
   --top 15
@@ -266,7 +266,7 @@ All Solana-related news from past day.
 ### Example 18: Multi-Coin DeFi
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --coins ETH,AAVE,UNI,MKR \
   --category defi \
   --period 24h
@@ -281,7 +281,7 @@ DeFi news mentioning major DeFi tokens.
 ### Example 19: Debug with Verbose
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --verbose
+python ./scripts/news_aggregator.py --verbose
 ```
 
 **Output:**
@@ -317,7 +317,7 @@ OUTPUT_DIR=~/crypto_news
 
 mkdir -p $OUTPUT_DIR
 
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --period 4h \
   --format json \
   --output "$OUTPUT_DIR/news_$TIMESTAMP.json"
@@ -333,7 +333,7 @@ echo "Scan complete: $OUTPUT_DIR/news_$TIMESTAMP.json"
 #!/bin/bash
 # Check for high-scoring news
 
-RESULT=$(python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+RESULT=$(python ./scripts/news_aggregator.py \
   --period 1h \
   --min-score 80 \
   --format json)
@@ -354,7 +354,7 @@ fi
 #!/bin/bash
 # daily_digest.sh - Generate daily news digest
 
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --period 24h \
   --top 30 \
   --format json \
@@ -372,13 +372,13 @@ cat /tmp/daily_digest.json | jq '.articles[] | "\(.rank). \(.title) - \(.source)
 
 ```bash
 # Morning routine before trading
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --period 12h \
   --min-score 60 \
   --top 15
 
 # Check specific coins in watchlist
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --coins BTC,ETH,SOL,ARB \
   --period 12h
 ```
@@ -389,7 +389,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
 
 ```bash
 # Run every hour via cron
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --category security \
   --period 1h \
   --sort-by recency \
@@ -403,7 +403,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
 
 ```bash
 # Generate data for weekly report
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py \
+python ./scripts/news_aggregator.py \
   --period 7d \
   --top 100 \
   --format csv \

--- a/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/references/implementation.md
+++ b/plugins/crypto/crypto-news-aggregator/skills/aggregating-crypto-news/references/implementation.md
@@ -56,16 +56,16 @@
 
 ```bash
 # Multiple filters combined
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coin ETH --category defi --period 24h --top 15
+python ./scripts/news_aggregator.py --coin ETH --category defi --period 24h --top 15
 
 # High-relevance news only
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --min-score 70 --top 10
+python ./scripts/news_aggregator.py --min-score 70 --top 10
 
 # Multiple coins
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --coins BTC,ETH,SOL
+python ./scripts/news_aggregator.py --coins BTC,ETH,SOL
 
 # Export to JSON file
-python ${CLAUDE_SKILL_DIR}/scripts/news_aggregator.py --format json --output crypto_news.json
+python ./scripts/news_aggregator.py --format json --output crypto_news.json
 ```
 
 ---

--- a/plugins/crypto/crypto-portfolio-tracker/package.json
+++ b/plugins/crypto/crypto-portfolio-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/crypto-portfolio-tracker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
   "keywords": [
     "crypto",

--- a/plugins/crypto/crypto-portfolio-tracker/skills/tracking-crypto-portfolio/SKILL.md
+++ b/plugins/crypto/crypto-portfolio-tracker/skills/tracking-crypto-portfolio/SKILL.md
@@ -44,20 +44,20 @@ Track cryptocurrency holdings with real-time CoinGecko valuations, allocation an
 
    ```bash
    # Quick portfolio summary
-   python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json
+   python ./scripts/portfolio_tracker.py --portfolio holdings.json
 
    # Full holdings breakdown
-   python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --holdings
+   python ./scripts/portfolio_tracker.py --portfolio holdings.json --holdings
 
    # Detailed analysis with P&L and allocations
-   python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --detailed
+   python ./scripts/portfolio_tracker.py --portfolio holdings.json --detailed
    ```
 
 3. **Export results** for analysis tools or tax reporting:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --format json --output portfolio_export.json
-   python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output portfolio.csv
+   python ./scripts/portfolio_tracker.py --portfolio holdings.json --format json --output portfolio_export.json
+   python ./scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output portfolio.csv
    ```
 
 4. **Present results** to the user:
@@ -103,7 +103,7 @@ Summary showing total value, 24h/7d changes, per-asset allocation, and concentra
 | Coin not found | Unknown symbol | Check symbol spelling, use standard symbols |
 | API rate limited | Too many requests | Wait and retry, use caching |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
@@ -111,22 +111,22 @@ Portfolio tracking workflows from quick checks to detailed analysis and export:
 
 ```bash
 # Basic portfolio check
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio ~/crypto/holdings.json
+python ./scripts/portfolio_tracker.py --portfolio ~/crypto/holdings.json
 
 # All holdings sorted by allocation
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --holdings --sort allocation
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --holdings --sort allocation
 
 # Detailed analysis with custom 15% threshold
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --detailed --threshold 15
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --detailed --threshold 15
 
 # Export for tax software
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output tax_export.csv
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output tax_export.csv
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Portfolio file format, CLI options, allocation thresholds, JSON format
-- `${CLAUDE_SKILL_DIR}/references/errors.md` - Comprehensive error handling
-- `${CLAUDE_SKILL_DIR}/references/examples.md` - Detailed usage examples
+- `./references/implementation.md` - Portfolio file format, CLI options, allocation thresholds, JSON format
+- `./references/errors.md` - Comprehensive error handling
+- `./references/examples.md` - Detailed usage examples
 - CoinGecko API: https://www.coingecko.com/en/api
-- `${CLAUDE_SKILL_DIR}/config/settings.yaml` - Configuration options
+- `./config/settings.yaml` - Configuration options

--- a/plugins/crypto/crypto-portfolio-tracker/skills/tracking-crypto-portfolio/references/implementation.md
+++ b/plugins/crypto/crypto-portfolio-tracker/skills/tracking-crypto-portfolio/references/implementation.md
@@ -74,16 +74,16 @@ By default, positions > 25% allocation are flagged:
 
 ```bash
 # Show all holdings sorted by allocation
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --holdings --sort allocation
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --holdings --sort allocation
 
 # Detailed analysis with 15% threshold
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --detailed --threshold 15
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --detailed --threshold 15
 
 # Export for tax software
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output tax_export.csv
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --format csv --output tax_export.csv
 
 # JSON export for trading bot
-python ${CLAUDE_SKILL_DIR}/scripts/portfolio_tracker.py --portfolio holdings.json --format json --output portfolio_data.json
+python ./scripts/portfolio_tracker.py --portfolio holdings.json --format json --output portfolio_data.json
 ```
 
 ---

--- a/plugins/crypto/crypto-signal-generator/package.json
+++ b/plugins/crypto/crypto-signal-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/crypto-signal-generator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Generate trading signals from technical indicators and market analysis",
   "keywords": [
     "trading",

--- a/plugins/crypto/crypto-signal-generator/skills/generating-trading-signals/SKILL.md
+++ b/plugins/crypto/crypto-signal-generator/skills/generating-trading-signals/SKILL.md
@@ -46,7 +46,7 @@ Optional for visualization: `pip install matplotlib`
 1. **Quick signal scan** across multiple assets:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_top10 --period 6m
+   python ./scripts/scanner.py --watchlist crypto_top10 --period 6m
    ```
 
    Output shows signal type (STRONG_BUY/BUY/NEUTRAL/SELL/STRONG_SELL) and confidence per asset.
@@ -54,7 +54,7 @@ Optional for visualization: `pip install matplotlib`
 2. **Detailed signal analysis** for a specific symbol:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --symbols BTC-USD --detail
+   python ./scripts/scanner.py --symbols BTC-USD --detail
    ```
 
    Shows each indicator's individual signal, value, and reasoning.
@@ -63,17 +63,17 @@ Optional for visualization: `pip install matplotlib`
 
    ```bash
    # Only buy signals with 70%+ confidence
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --filter buy --min-confidence 70 --rank confidence
+   python ./scripts/scanner.py --filter buy --min-confidence 70 --rank confidence
 
    # Save results to JSON
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --output signals.json
+   python ./scripts/scanner.py --output signals.json
    ```
 
 4. **Use predefined watchlists**:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --list-watchlists
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_defi
+   python ./scripts/scanner.py --list-watchlists
+   python ./scripts/scanner.py --watchlist crypto_defi
    ```
 
    Available: `crypto_top10`, `crypto_defi`, `crypto_layer2`, `stocks_tech`, `etfs_major`
@@ -86,7 +86,7 @@ The scanner produces a summary table with symbol, signal type, confidence %, pri
 
 **Confidence ranges**: 70-100% high conviction | 50-70% moderate | 30-50% weak | 0-30% avoid
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for full output format examples and signal type tables.
+See `./references/implementation.md` for full output format examples and signal type tables.
 
 ## Error Handling
 
@@ -96,32 +96,32 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for full output format ex
 | Insufficient data | Period too short for indicators | Use `--period 6m` minimum |
 | Rate limit exceeded | Too many rapid API calls | Add delay between scans |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
 **Morning crypto scan** - Check all top-10 crypto assets for entry opportunities:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_top10 --period 6m
+python ./scripts/scanner.py --watchlist crypto_top10 --period 6m
 ```
 
 **Deep dive on Bitcoin** - Full indicator breakdown with risk management levels:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --symbols BTC-USD --detail
+python ./scripts/scanner.py --symbols BTC-USD --detail
 ```
 
 **Find strongest DeFi buy signals** - Filter and rank by confidence:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_defi --filter buy --rank confidence
+python ./scripts/scanner.py --watchlist crypto_defi --filter buy --rank confidence
 ```
 
 **Export results** - Save to JSON for automated pipeline or further analysis:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_top10 --output signals.json
+python ./scripts/scanner.py --watchlist crypto_top10 --output signals.json
 ```
 
 ## Resources
@@ -129,4 +129,4 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --watchlist crypto_top10 --output 
 - **yfinance** for price data
 - **pandas/numpy** for calculations
 - Compatible with trading-strategy-backtester plugin
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Output formats, configuration, backtester integration, file reference
+- `./references/implementation.md` - Output formats, configuration, backtester integration, file reference

--- a/plugins/crypto/crypto-signal-generator/skills/generating-trading-signals/references/implementation.md
+++ b/plugins/crypto/crypto-signal-generator/skills/generating-trading-signals/references/implementation.md
@@ -67,7 +67,7 @@
 
 ## Configuration
 
-Edit `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Edit `./config/settings.yaml`:
 
 ```yaml
 indicators:
@@ -91,10 +91,10 @@ Test signals historically:
 
 ```bash
 # Generate signal
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --symbols BTC-USD --detail
+python ./scripts/scanner.py --symbols BTC-USD --detail
 
 # Backtest the strategy that generated the signal
-python ${CLAUDE_SKILL_DIR}/../trading-strategy-backtester/skills/backtesting-trading-strategies/scripts/backtest.py \
+python ../trading-strategy-backtester/skills/backtesting-trading-strategies/scripts/backtest.py \
   --strategy rsi_reversal --symbol BTC-USD --period 1y
 ```
 

--- a/plugins/crypto/crypto-tax-calculator/package.json
+++ b/plugins/crypto/crypto-tax-calculator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/crypto-tax-calculator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
   "keywords": [
     "crypto",

--- a/plugins/crypto/crypto-tax-calculator/skills/calculating-crypto-taxes/SKILL.md
+++ b/plugins/crypto/crypto-tax-calculator/skills/calculating-crypto-taxes/SKILL.md
@@ -43,18 +43,18 @@ Calculate cryptocurrency tax obligations from transaction history. Supports FIFO
    | Coinbase | Reports > Tax documents > Transaction history CSV |
    | Binance | Orders > Trade History > Export |
    | Kraken | History > Export |
-   | Generic | See `${CLAUDE_SKILL_DIR}/references/exchange_formats.md` for column mapping |
+   | Generic | See `./references/exchange_formats.md` for column mapping |
 
 2. **Run basic tax calculation** using FIFO (IRS default):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/tax_calculator.py --transactions your_trades.csv --year 2025  # 2025 = tax year
+   python ./scripts/tax_calculator.py --transactions your_trades.csv --year 2025  # 2025 = tax year
    ```
 
 3. **Compare cost basis methods** to understand tax implications:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/tax_calculator.py --transactions trades.csv --compare-methods
+   python ./scripts/tax_calculator.py --transactions trades.csv --compare-methods
    ```
 
    Methods: `--method fifo` (IRS default), `--method lifo` (Last In First Out), `--method hifo` (minimize gains)
@@ -62,26 +62,26 @@ Calculate cryptocurrency tax obligations from transaction history. Supports FIFO
 4. **Generate Form 8949 report** as CSV:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/tax_calculator.py --transactions trades.csv --method fifo --year 2025 --output form_8949.csv --format csv  # 2025 = tax year
+   python ./scripts/tax_calculator.py --transactions trades.csv --method fifo --year 2025 --output form_8949.csv --format csv  # 2025 = tax year
    ```
 
 5. **Handle income events** (staking, airdrops, mining, DeFi yield):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/tax_calculator.py --transactions all_events.csv --income-report
+   python ./scripts/tax_calculator.py --transactions all_events.csv --income-report
    ```
 
 6. **Consolidate multi-exchange data** into a unified report:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/tax_calculator.py --transactions coinbase.csv binance.csv kraken.csv --year 2025  # 2025 = tax year
+   python ./scripts/tax_calculator.py --transactions coinbase.csv binance.csv kraken.csv --year 2025  # 2025 = tax year
    ```
 
 ## Output
 
 Reports include short-term and long-term capital gains/losses broken down by transaction, with proceeds, cost basis, and gain/loss per disposal. Summary shows total proceeds, total cost basis, net capital gain, and short/long-term split. Income report lists staking, airdrop, and mining income with fair market values.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output format examples.
+See `./references/implementation.md` for detailed output format examples.
 
 ## Error Handling
 
@@ -122,4 +122,4 @@ python tax_calculator.py --transactions trades.csv --verbose --show-lots
 - IRS Virtual Currency Guidance: https://www.irs.gov/businesses/small-businesses-self-employed/virtual-currencies
 - Form 8949 Instructions: https://www.irs.gov/instructions/i8949
 - CoinGecko API for historical prices
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Detailed output formats, configuration, advanced usage
+- `./references/implementation.md` - Detailed output formats, configuration, advanced usage

--- a/plugins/crypto/crypto-tax-calculator/skills/calculating-crypto-taxes/references/implementation.md
+++ b/plugins/crypto/crypto-tax-calculator/skills/calculating-crypto-taxes/references/implementation.md
@@ -51,7 +51,7 @@ Total Income:                                     $485.00
 
 ## Configuration
 
-Settings in `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Settings in `./config/settings.yaml`:
 
 - **Default method**: Cost basis method (fifo, lifo, hifo)
 - **Tax year start**: January 1 (US) or fiscal year

--- a/plugins/crypto/defi-yield-optimizer/package.json
+++ b/plugins/crypto/defi-yield-optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/defi-yield-optimizer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
   "keywords": [
     "defi",

--- a/plugins/crypto/defi-yield-optimizer/skills/optimizing-defi-yields/SKILL.md
+++ b/plugins/crypto/defi-yield-optimizer/skills/optimizing-defi-yields/SKILL.md
@@ -38,37 +38,37 @@ Before using this skill, ensure you have:
 1. Search for yield opportunities across all chains or filter by a specific chain:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --top 20
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --chain ethereum --top 10
+   python ./scripts/yield_optimizer.py --top 20
+   python ./scripts/yield_optimizer.py --chain ethereum --top 10
    ```
 
 2. Filter by criteria -- minimum TVL (for safety), asset type, or protocol:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --min-tvl 10000000 --top 15  # 10000000 = 10M limit
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --asset USDC --chain ethereum
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --protocol aave,compound,curve
+   python ./scripts/yield_optimizer.py --min-tvl 10000000 --top 15  # 10000000 = 10M limit
+   python ./scripts/yield_optimizer.py --asset USDC --chain ethereum
+   python ./scripts/yield_optimizer.py --protocol aave,compound,curve
    ```
 
 3. Apply risk filters -- show only audited protocols or filter by risk level (`--risk low`, `--risk medium`, `--risk high`):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --audited-only --min-tvl 1000000  # 1000000 = 1M limit
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --risk low --min-apy 3
+   python ./scripts/yield_optimizer.py --audited-only --min-tvl 1000000  # 1000000 = 1M limit
+   python ./scripts/yield_optimizer.py --risk low --min-apy 3
    ```
 
 4. Analyze specific opportunities -- get detailed pool breakdown or compare protocols:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --pool "aave-v3-usdc-ethereum" --detailed
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --compare aave,compound,spark --asset USDC
+   python ./scripts/yield_optimizer.py --pool "aave-v3-usdc-ethereum" --detailed
+   python ./scripts/yield_optimizer.py --compare aave,compound,spark --asset USDC
    ```
 
 5. Export results to JSON or CSV for further analysis:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --top 50 --format json --output yields.json
-   python ${CLAUDE_SKILL_DIR}/scripts/yield_optimizer.py --chain ethereum --format csv --output eth_yields.csv
+   python ./scripts/yield_optimizer.py --top 50 --format json --output yields.json
+   python ./scripts/yield_optimizer.py --chain ethereum --format csv --output eth_yields.csv
    ```
 
 ## Output
@@ -119,7 +119,7 @@ Before using this skill, ensure you have:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 Common issues:
 
@@ -129,7 +129,7 @@ Common issues:
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed usage examples.
+See `./references/examples.md` for detailed usage examples.
 
 ### Quick Examples
 
@@ -159,7 +159,7 @@ python yield_optimizer.py --top 100 --format json --output all_yields.json
 
 ## Configuration
 
-Settings in `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Settings in `./config/settings.yaml`:
 
 - **Default chain**: Primary chain to search
 - **Cache TTL**: How long to cache API responses

--- a/plugins/crypto/dex-aggregator-router/package.json
+++ b/plugins/crypto/dex-aggregator-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/dex-aggregator-router",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Find optimal DEX routes for token swaps across multiple exchanges",
   "keywords": [
     "dex",

--- a/plugins/crypto/dex-aggregator-router/skills/routing-dex-trades/SKILL.md
+++ b/plugins/crypto/dex-aggregator-router/skills/routing-dex-trades/SKILL.md
@@ -36,44 +36,44 @@ Optimal trade routing across decentralized exchanges by aggregating quotes from 
 1. Install Python 3.9+ with `httpx`, `pydantic`, and `rich` packages
 2. Verify network access to aggregator APIs (1inch, Paraswap, 0x)
 3. Optionally add API keys for 1inch and 0x (higher rate limits)
-4. Copy settings: `cp ${CLAUDE_SKILL_DIR}/config/settings.yaml.example ${CLAUDE_SKILL_DIR}/config/settings.yaml`
+4. Copy settings: `cp ./config/settings.yaml.example ./config/settings.yaml`
 
 ## Instructions
 
 1. Get a quick quote for the single best price with gas cost and effective rate:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 1.0
+   python ./scripts/dex_router.py ETH USDC 1.0
    ```
 
 2. Compare all DEXs to see quotes ranked by effective rate (after gas):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 5.0 --compare
+   python ./scripts/dex_router.py ETH USDC 5.0 --compare
    ```
 
 3. Analyze multi-hop routes to compare direct vs. multi-hop (2-3 pools) with hop-by-hop breakdown:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 10.0 --routes
+   python ./scripts/dex_router.py ETH USDC 10.0 --routes
    ```
 
 4. Split large orders ($10K+) across multiple DEXs to minimize total price impact:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 100.0 --split
+   python ./scripts/dex_router.py ETH USDC 100.0 --split
    ```
 
 5. Assess MEV risk (sandwich attack risk score: LOW/MEDIUM/HIGH) before executing:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 50.0 --mev-check
+   python ./scripts/dex_router.py ETH USDC 50.0 --mev-check
    ```
 
 6. Run full analysis combining all features for comprehensive output:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 25.0 --full --output json
+   python ./scripts/dex_router.py ETH USDC 25.0 --full --output json
    ```
 
 ## Output
@@ -84,7 +84,7 @@ Optimal trade routing across decentralized exchanges by aggregating quotes from 
 - **Split Mode**: Optimal allocation percentages with dollar savings vs. single-venue
 - **MEV Assessment**: Risk score, exposure estimate, protection recommendations
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output examples.
+See `./references/implementation.md` for detailed output examples.
 
 ## Error Handling
 
@@ -95,33 +95,33 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output examp
 | No Route Found | Low liquidity token | Try larger DEXs or reduce trade size |
 | Network Timeout | Aggregator down | Retry or check aggregator status page |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
 **Compare prices for a 5 ETH swap:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 5.0 --compare
+python ./scripts/dex_router.py ETH USDC 5.0 --compare
 ```
 
 **Find optimal split for a large order:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 100.0 --split
+python ./scripts/dex_router.py ETH USDC 100.0 --split
 ```
 
 **Check MEV risk before executing:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/dex_router.py ETH USDC 50.0 --mev-check
+python ./scripts/dex_router.py ETH USDC 50.0 --mev-check
 ```
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for multi-hop discovery and MEV-protected execution examples.
+See `./references/examples.md` for multi-hop discovery and MEV-protected execution examples.
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Trade size guide, split optimization, MEV scoring, API config
+- `./references/implementation.md` - Trade size guide, split optimization, MEV scoring, API config
 - [1inch API](https://docs.1inch.io/) - Primary aggregator
 - [Paraswap API](https://developers.paraswap.network/) - Secondary aggregator
 - [0x API](https://0x.org/docs/api) - Third aggregator

--- a/plugins/crypto/dex-aggregator-router/skills/routing-dex-trades/references/implementation.md
+++ b/plugins/crypto/dex-aggregator-router/skills/routing-dex-trades/references/implementation.md
@@ -80,7 +80,7 @@ Risk levels:
 
 ## API Configuration
 
-Edit `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Edit `./config/settings.yaml`:
 
 ```yaml
 api_keys:

--- a/plugins/crypto/flash-loan-simulator/package.json
+++ b/plugins/crypto/flash-loan-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/flash-loan-simulator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
   "keywords": [
     "crypto",

--- a/plugins/crypto/flash-loan-simulator/skills/simulating-flash-loans/SKILL.md
+++ b/plugins/crypto/flash-loan-simulator/skills/simulating-flash-loans/SKILL.md
@@ -34,47 +34,47 @@ Simulate flash loan strategies across Aave V3, dYdX, and Balancer with profitabi
 1. Install Python 3.9+ with `web3`, `httpx`, and `rich` packages
 2. Configure RPC endpoint access (free public RPCs via https://chainlist.org work fine)
 3. Optionally add Etherscan API key for better gas estimates
-4. Set RPC in `${CLAUDE_SKILL_DIR}/config/settings.yaml` or use `ETH_RPC_URL` env var
+4. Set RPC in `./config/settings.yaml` or use `ETH_RPC_URL` env var
 
 ## Instructions
 
 1. Simulate a two-DEX arbitrage with automatic fee and gas calculation:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 \
+   python ./scripts/flash_simulator.py arbitrage ETH USDC 100 \
      --dex-buy uniswap --dex-sell sushiswap
    ```
 
 2. Compare flash loan providers to find the cheapest for your strategy:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 --compare-providers
+   python ./scripts/flash_simulator.py arbitrage ETH USDC 100 --compare-providers
    ```
 
 3. Analyze liquidation profitability on lending protocols:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py liquidation \
+   python ./scripts/flash_simulator.py liquidation \
      --protocol aave --health-factor 0.95
    ```
 
 4. Simulate triangular arbitrage with multi-hop circular paths:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py triangular \
+   python ./scripts/flash_simulator.py triangular \
      ETH USDC WBTC ETH --amount 50
    ```
 
 5. Add risk assessment (MEV competition, execution, protocol, liquidity) to any simulation:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 --risk-analysis
+   python ./scripts/flash_simulator.py arbitrage ETH USDC 100 --risk-analysis
    ```
 
 6. Run full analysis combining all features:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 \
+   python ./scripts/flash_simulator.py arbitrage ETH USDC 100 \
      --full --output json > simulation.json
    ```
 
@@ -85,7 +85,7 @@ Simulate flash loan strategies across Aave V3, dYdX, and Balancer with profitabi
 - **Comparison Mode**: All providers ranked by net profit with fee differences
 - **Risk Analysis**: Competition, execution, protocol, and liquidity scores (0-100) with viability grade (A-F)
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output examples and risk scoring methodology.
+See `./references/implementation.md` for detailed output examples and risk scoring methodology.
 
 ## Error Handling
 
@@ -96,34 +96,34 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output examp
 | No Profitable Route | All routes lose after costs | Try different pairs or amounts |
 | Insufficient Liquidity | Trade exceeds pool depth | Reduce amount or split across pools |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
 **Basic arbitrage simulation:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 \
+python ./scripts/flash_simulator.py arbitrage ETH USDC 100 \
   --dex-buy uniswap --dex-sell sushiswap
 ```
 
 **Find cheapest provider:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py arbitrage ETH USDC 100 --compare-providers
+python ./scripts/flash_simulator.py arbitrage ETH USDC 100 --compare-providers
 ```
 
 **Liquidation opportunity scan:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/flash_simulator.py liquidation --protocol aave --health-factor 0.95
+python ./scripts/flash_simulator.py liquidation --protocol aave --health-factor 0.95
 ```
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for multi-provider comparison and backtesting examples.
+See `./references/examples.md` for multi-provider comparison and backtesting examples.
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Provider comparison, strategy details, risk scoring, output modes
+- `./references/implementation.md` - Provider comparison, strategy details, risk scoring, output modes
 - [Aave V3 Flash Loans](https://docs.aave.com/developers/guides/flash-loans)
 - dYdX Flash Loans
 - Balancer Flash Loans

--- a/plugins/crypto/gas-fee-optimizer/package.json
+++ b/plugins/crypto/gas-fee-optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/gas-fee-optimizer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Optimize transaction gas fees with timing and routing recommendations",
   "keywords": [
     "gas",

--- a/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/SKILL.md
+++ b/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/SKILL.md
@@ -42,46 +42,46 @@ Gas fee optimization skill that:
 1. Check current gas prices (optionally for a specific chain):
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py current
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py current --chain polygon
+   cd ./scripts && python3 gas_optimizer.py current
+   cd ./scripts && python3 gas_optimizer.py current --chain polygon
    ```
 
 2. Estimate transaction cost for known operations or custom gas limits (available operations: `eth_transfer`, `erc20_transfer`, `erc20_approve`, `uniswap_v2_swap`, `uniswap_v3_swap`, `sushiswap_swap`, `curve_swap`, `nft_mint`, `nft_transfer`, `opensea_listing`, `aave_deposit`, `aave_withdraw`, `compound_supply`, `compound_borrow`, `bridge_deposit`):
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py estimate --operation uniswap_v2_swap --all-tiers
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py estimate --gas-limit 150000 --tier fast  # 150000 = configured value
+   cd ./scripts && python3 gas_optimizer.py estimate --operation uniswap_v2_swap --all-tiers
+   cd ./scripts && python3 gas_optimizer.py estimate --gas-limit 150000 --tier fast  # 150000 = configured value
    ```
 
 3. Find the optimal transaction window with lowest expected gas:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py optimal
+   cd ./scripts && python3 gas_optimizer.py optimal
    ```
 
 4. View gas patterns (hourly or daily):
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py patterns
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py patterns --daily
+   cd ./scripts && python3 gas_optimizer.py patterns
+   cd ./scripts && python3 gas_optimizer.py patterns --daily
    ```
 
 5. Predict future gas prices for a given hour:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py predict --time 14
+   cd ./scripts && python3 gas_optimizer.py predict --time 14
    ```
 
 6. Compare gas prices across multiple chains:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py compare
+   cd ./scripts && python3 gas_optimizer.py compare
    ```
 
 7. View base fee history for recent blocks:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts && python3 gas_optimizer.py history --blocks 50
+   cd ./scripts && python3 gas_optimizer.py history --blocks 50
    ```
 
 ## Output
@@ -114,7 +114,7 @@ Gas fee optimization skill that:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
+See `./references/errors.md` for:
 
 - RPC connection issues
 - API rate limiting
@@ -123,7 +123,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for:
+See `./references/examples.md` for:
 
 - Quick start commands
 - Cost estimation scenarios

--- a/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/references/implementation.md
+++ b/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/liquidity-pool-analyzer/package.json
+++ b/plugins/crypto/liquidity-pool-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/liquidity-pool-analyzer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
   "keywords": [
     "liquidity",

--- a/plugins/crypto/liquidity-pool-analyzer/skills/analyzing-liquidity-pools/SKILL.md
+++ b/plugins/crypto/liquidity-pool-analyzer/skills/analyzing-liquidity-pools/SKILL.md
@@ -36,48 +36,48 @@ Analyze DEX liquidity pools across Uniswap, Curve, and Balancer to evaluate TVL,
 1. **Analyze a specific pool** by address or token pair:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --pool 0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --pair ETH/USDC --protocol uniswap-v3
+   python ./scripts/pool_analyzer.py --pool 0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640
+   python ./scripts/pool_analyzer.py --pair ETH/USDC --protocol uniswap-v3
    ```
 
 2. **Calculate impermanent loss** for a price change:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --il-calc --entry-price 2000 --current-price 3000  # 2000/3000 = ETH price at entry/now in USD
+   python ./scripts/pool_analyzer.py --il-calc --entry-price 2000 --current-price 3000  # 2000/3000 = ETH price at entry/now in USD
    ```
 
    Project IL for various scenarios:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --il-scenarios --token-pair ETH/USDC
+   python ./scripts/pool_analyzer.py --il-scenarios --token-pair ETH/USDC
    ```
 
 3. **Estimate LP returns** with fee APR and position projections:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --pool [address] --detailed
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --pool [address] --position 10000  # 10000 = LP position size in USD
+   python ./scripts/pool_analyzer.py --pool [address] --detailed
+   python ./scripts/pool_analyzer.py --pool [address] --position 10000  # 10000 = LP position size in USD
    ```
 
 4. **Compare pools** across protocols or fee tiers:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --compare --pair ETH/USDC --protocols uniswap-v3,curve,balancer
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --compare --pair ETH/USDC --fee-tiers 0.05,0.30,1.00
+   python ./scripts/pool_analyzer.py --compare --pair ETH/USDC --protocols uniswap-v3,curve,balancer
+   python ./scripts/pool_analyzer.py --compare --pair ETH/USDC --fee-tiers 0.05,0.30,1.00
    ```
 
 5. **Export results** to JSON or CSV:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --pool [address] --format json --output pool_analysis.json
-   python ${CLAUDE_SKILL_DIR}/scripts/pool_analyzer.py --compare --pair ETH/USDC --format csv --output pools.csv
+   python ./scripts/pool_analyzer.py --pool [address] --format json --output pool_analysis.json
+   python ./scripts/pool_analyzer.py --compare --pair ETH/USDC --format csv --output pools.csv
    ```
 
 ## Output
 
 Pool analysis reports include chain, TVL, 24h volume, fee tier, fee APR, volume/TVL ratio, and token composition with current price. Impermanent loss reports show IL percentage, dollar impact, HODL vs LP value comparison, and breakeven analysis with days-to-recover based on fee income.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output format examples.
+See `./references/implementation.md` for detailed output format examples.
 
 ## Error Handling
 
@@ -118,4 +118,4 @@ python pool_analyzer.py --token ETH --format json --output eth_pools.json
 - The Graph: https://thegraph.com/ - Subgraph queries
 - Uniswap Info: https://info.uniswap.org/ - Pool explorer
 - DeFiLlama: https://defillama.com/ - TVL data
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Detailed output formats, configuration, cross-protocol comparison guide
+- `./references/implementation.md` - Detailed output formats, configuration, cross-protocol comparison guide

--- a/plugins/crypto/liquidity-pool-analyzer/skills/analyzing-liquidity-pools/references/implementation.md
+++ b/plugins/crypto/liquidity-pool-analyzer/skills/analyzing-liquidity-pools/references/implementation.md
@@ -55,7 +55,7 @@
 
 ## Configuration
 
-Settings in `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Settings in `./config/settings.yaml`:
 
 - **Default chain**: Primary chain to query
 - **Cache TTL**: How long to cache subgraph data

--- a/plugins/crypto/market-movers-scanner/package.json
+++ b/plugins/crypto/market-movers-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/market-movers-scanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
   "keywords": [
     "market",

--- a/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/ARD.md
+++ b/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/ARD.md
@@ -108,7 +108,7 @@ This skill follows a pipeline pattern where market data flows through sequential
 **Command:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py
+python ./scripts/scanner.py
 ```
 
 **What happens:**
@@ -127,7 +127,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py
 **Command:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-change 10 --volume-spike 3x --top 50
+python ./scripts/scanner.py --min-change 10 --volume-spike 3x --top 50
 ```
 
 **What happens:**
@@ -146,7 +146,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-change 10 --volume-spike 3x 
 **Command:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
+python ./scripts/scanner.py \
   --preset aggressive \
   --category defi \
   --sort-by significance \

--- a/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/PRD.md
+++ b/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/PRD.md
@@ -389,7 +389,7 @@ This skill does NOT:
 ### Example 1: Daily Scan
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --timeframe 24h --top 20
+python ./scripts/scanner.py --timeframe 24h --top 20
 ```
 
 Output shows top 20 gainers and losers with volume confirmation.
@@ -397,7 +397,7 @@ Output shows top 20 gainers and losers with volume confirmation.
 ### Example 2: High-Volume Movers
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --volume-spike 3x --min-volume 1000000
+python ./scripts/scanner.py --volume-spike 3x --min-volume 1000000
 ```
 
 Output shows assets with 3x+ average volume and > $1M daily volume.
@@ -405,7 +405,7 @@ Output shows assets with 3x+ average volume and > $1M daily volume.
 ### Example 3: DeFi Sector Scan
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category defi --min-change 5
+python ./scripts/scanner.py --category defi --min-change 5
 ```
 
 Output shows DeFi tokens with > 5% change.

--- a/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/SKILL.md
+++ b/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/SKILL.md
@@ -39,39 +39,39 @@ Real-time detection of significant price movements and unusual volume patterns a
 1. **Run a default scan** for top gainers and losers (top 20 each by 24h change with volume confirmation):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py
+   python ./scripts/scanner.py
    ```
 
 2. **Set custom thresholds** for minimum change and volume spike:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-change 10 --volume-spike 3
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-cap 100000000 --max-cap 1000000000  # 100000000 = $100M min cap, 1000000000 = $1B max cap
+   python ./scripts/scanner.py --min-change 10 --volume-spike 3
+   python ./scripts/scanner.py --min-cap 100000000 --max-cap 1000000000  # 100000000 = $100M min cap, 1000000000 = $1B max cap
    ```
 
 3. **Filter by category** (defi, layer2, nft, gaming, meme):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category defi
+   python ./scripts/scanner.py --category defi
    ```
 
 4. **Scan different timeframes** (1h, 24h, 7d):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --timeframe 1h
+   python ./scripts/scanner.py --timeframe 1h
    ```
 
 5. **Export results** to JSON or CSV:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format json --output movers.json
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format csv --output movers.csv
+   python ./scripts/scanner.py --format json --output movers.json
+   python ./scripts/scanner.py --format csv --output movers.csv
    ```
 
 6. **Use named presets** for predefined threshold sets:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --preset aggressive
+   python ./scripts/scanner.py --preset aggressive
    ```
 
 ## Output
@@ -113,7 +113,7 @@ Default table shows top gainers and losers ranked by significance score (0-100),
 | `Rate limit exceeded` | Too many API calls | Wait or use cached data |
 | `Partial results` | Some assets unavailable | Normal, proceed with available data |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
@@ -121,22 +121,22 @@ Common scanning patterns for different market analysis scenarios:
 
 ```bash
 # Daily scan - top 20 gainers/losers
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --timeframe 24h --top 20
+python ./scripts/scanner.py --timeframe 24h --top 20
 
 # Volume spike hunt (5x+ volume, $1M+ daily volume)
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --volume-spike 5 --min-volume 1000000  # 1000000 = $1M min volume
+python ./scripts/scanner.py --volume-spike 5 --min-volume 1000000  # 1000000 = $1M min volume
 
 # DeFi movers exported to CSV
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category defi --format csv --output defi_movers.csv
+python ./scripts/scanner.py --category defi --format csv --output defi_movers.csv
 
 # High-cap gainers only (>$1B market cap)
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-cap 1000000000 --gainers-only --top 10  # 1000000000 = $1B cap
+python ./scripts/scanner.py --min-cap 1000000000 --gainers-only --top 10  # 1000000000 = $1B cap
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Configuration, presets, JSON format, scoring details
-- `${CLAUDE_SKILL_DIR}/references/errors.md` - Comprehensive error handling
-- `${CLAUDE_SKILL_DIR}/references/examples.md` - Detailed usage examples
+- `./references/implementation.md` - Configuration, presets, JSON format, scoring details
+- `./references/errors.md` - Comprehensive error handling
+- `./references/examples.md` - Detailed usage examples
 - Depends on: tracking-crypto-prices skill
 - CoinGecko API: https://www.coingecko.com/en/api

--- a/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/references/examples.md
+++ b/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/references/examples.md
@@ -9,7 +9,7 @@ Comprehensive examples for the scanning-market-movers skill.
 The simplest use case - scan for significant movers:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py
+python ./scripts/scanner.py
 ```
 
 **Output:**
@@ -47,7 +47,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py
 Find assets with extreme volume spikes:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --volume-spike 5 --min-volume 1000000
+python ./scripts/scanner.py --volume-spike 5 --min-volume 1000000
 ```
 
 This finds assets with:
@@ -62,7 +62,7 @@ This finds assets with:
 Focus on established assets only:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-cap 1000000000
+python ./scripts/scanner.py --min-cap 1000000000
 ```
 
 Only shows assets with > $1B market cap.
@@ -76,7 +76,7 @@ Only shows assets with > $1B market cap.
 Find even small moves:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-change 3 --volume-spike 1.5 --top 50
+python ./scripts/scanner.py --min-change 3 --volume-spike 1.5 --top 50
 ```
 
 Lower thresholds = more results.
@@ -86,7 +86,7 @@ Lower thresholds = more results.
 Only significant moves:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-change 15 --volume-spike 4 --min-cap 500000000
+python ./scripts/scanner.py --min-change 15 --volume-spike 4 --min-cap 500000000
 ```
 
 Higher thresholds = fewer, higher-quality results.
@@ -96,7 +96,7 @@ Higher thresholds = fewer, higher-quality results.
 Find mid-cap opportunities:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --min-cap 50000000 --max-cap 500000000
+python ./scripts/scanner.py --min-cap 50000000 --max-cap 500000000
 ```
 
 Market cap between $50M and $500M.
@@ -108,7 +108,7 @@ Market cap between $50M and $500M.
 ### Example 7: DeFi Movers
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category defi
+python ./scripts/scanner.py --category defi
 ```
 
 Only DeFi protocol tokens.
@@ -116,7 +116,7 @@ Only DeFi protocol tokens.
 ### Example 8: Layer 2 Movers
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category layer2
+python ./scripts/scanner.py --category layer2
 ```
 
 Arbitrum, Optimism, Polygon ecosystem tokens.
@@ -124,7 +124,7 @@ Arbitrum, Optimism, Polygon ecosystem tokens.
 ### Example 9: Meme Coins
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --category meme --min-change 20
+python ./scripts/scanner.py --category meme --min-change 20
 ```
 
 Meme tokens with significant moves (warning: high risk).
@@ -136,7 +136,7 @@ Meme tokens with significant moves (warning: high risk).
 ### Example 10: Hourly Movers
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --timeframe 1h
+python ./scripts/scanner.py --timeframe 1h
 ```
 
 Changes in the last hour.
@@ -144,7 +144,7 @@ Changes in the last hour.
 ### Example 11: Weekly Movers
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --timeframe 7d
+python ./scripts/scanner.py --timeframe 7d
 ```
 
 Weekly change perspective.
@@ -158,7 +158,7 @@ Weekly change perspective.
 For programmatic processing:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format json --output movers.json
+python ./scripts/scanner.py --format json --output movers.json
 ```
 
 **Output (movers.json):**
@@ -196,7 +196,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format json --output movers.json
 For spreadsheet analysis:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format csv --output movers.csv
+python ./scripts/scanner.py --format csv --output movers.csv
 ```
 
 **Output (movers.csv):**
@@ -226,7 +226,7 @@ top_n: 30
 Use it:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --preset momentum
+python ./scripts/scanner.py --preset momentum
 ```
 
 ### Example 15: Aggressive Day Trading
@@ -244,7 +244,7 @@ top_n: 50
 Use it:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --preset daytrader --timeframe 1h
+python ./scripts/scanner.py --preset daytrader --timeframe 1h
 ```
 
 ---
@@ -254,7 +254,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --preset daytrader --timeframe 1h
 ### Example 16: Gainers Only
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --gainers-only
+python ./scripts/scanner.py --gainers-only
 ```
 
 Only shows positive movers.
@@ -262,7 +262,7 @@ Only shows positive movers.
 ### Example 17: Losers Only
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --losers-only
+python ./scripts/scanner.py --losers-only
 ```
 
 For dip buying or short opportunities.
@@ -274,7 +274,7 @@ For dip buying or short opportunities.
 ### Example 18: Sort by Change
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --sort-by change
+python ./scripts/scanner.py --sort-by change
 ```
 
 Highest % changes first.
@@ -282,7 +282,7 @@ Highest % changes first.
 ### Example 19: Sort by Volume
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --sort-by volume
+python ./scripts/scanner.py --sort-by volume
 ```
 
 Highest volume ratios first.
@@ -290,7 +290,7 @@ Highest volume ratios first.
 ### Example 20: Sort by Market Cap
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --sort-by market_cap
+python ./scripts/scanner.py --sort-by market_cap
 ```
 
 Largest caps first.
@@ -302,7 +302,7 @@ Largest caps first.
 ### Example 21: Morning Momentum Scan
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
+python ./scripts/scanner.py \
   --timeframe 1h \
   --min-change 5 \
   --volume-spike 3 \
@@ -316,7 +316,7 @@ Find fresh morning momentum plays.
 ### Example 22: Distressed Asset Hunt
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
+python ./scripts/scanner.py \
   --timeframe 24h \
   --min-change 20 \
   --losers-only \
@@ -330,7 +330,7 @@ Find oversold large-cap assets.
 ### Example 23: DeFi Blue Chips
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
+python ./scripts/scanner.py \
   --category defi \
   --min-cap 500000000 \
   --min-change 3 \
@@ -350,7 +350,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 OUTPUT_DIR=~/crypto_scans
 
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py \
+python ./scripts/scanner.py \
   --format json \
   --output "$OUTPUT_DIR/movers_$TIMESTAMP.json"
 
@@ -363,7 +363,7 @@ echo "Scan complete: $OUTPUT_DIR/movers_$TIMESTAMP.json"
 #!/bin/bash
 # Check for exceptional movers
 
-RESULT=$(python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format json)
+RESULT=$(python ./scripts/scanner.py --format json)
 HIGH_SCORE=$(echo "$RESULT" | jq '.gainers[0].significance_score')
 
 if (( $(echo "$HIGH_SCORE > 90" | bc -l) )); then

--- a/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/references/implementation.md
+++ b/plugins/crypto/market-movers-scanner/skills/scanning-market-movers/references/implementation.md
@@ -45,7 +45,7 @@ Higher scores indicate more significant, higher-conviction moves.
 
 ## Configuration
 
-Edit `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Edit `./config/settings.yaml`:
 
 ```yaml
 # Default Thresholds
@@ -85,7 +85,7 @@ categories:
 
 ## Named Presets
 
-Create presets in `${CLAUDE_SKILL_DIR}/config/presets/`:
+Create presets in `./config/presets/`:
 
 **aggressive.yaml:**
 
@@ -108,7 +108,7 @@ top_n: 10
 Use with:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --preset aggressive
+python ./scripts/scanner.py --preset aggressive
 ```
 
 ## Integration with Other Skills
@@ -119,7 +119,7 @@ This skill can be combined with other crypto skills:
 
 ```bash
 # Get movers, then generate signals for top gainers
-python ${CLAUDE_SKILL_DIR}/scripts/scanner.py --format json | \
+python ./scripts/scanner.py --format json | \
   python ../crypto-signal-generator/.../scanner.py --from-stdin
 ```
 

--- a/plugins/crypto/market-price-tracker/package.json
+++ b/plugins/crypto/market-price-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/market-price-tracker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
   "keywords": [
     "market",

--- a/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/ARD.md
+++ b/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/ARD.md
@@ -262,7 +262,7 @@ plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/
 
 ```bash
 # Correct
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
+python ./scripts/price_tracker.py --symbol BTC
 
 # Incorrect
 python scripts/price_tracker.py --symbol BTC  # Missing ${CLAUDE_SKILL_DIR}
@@ -586,13 +586,13 @@ This skill can run independently for direct user queries:
 
 ```bash
 # Single price
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
+python ./scripts/price_tracker.py --symbol BTC
 
 # Multiple prices
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH,SOL
+python ./scripts/price_tracker.py --symbols BTC,ETH,SOL
 
 # Historical data
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 30d --output csv
+python ./scripts/price_tracker.py --symbol BTC --period 30d --output csv
 ```
 
 ### 8.2 Skill Stacking Patterns
@@ -604,7 +604,7 @@ Other skills import price_tracker functions directly:
 ```python
 # In crypto-portfolio-tracker/scripts/portfolio.py
 import sys
-sys.path.insert(0, "${CLAUDE_SKILL_DIR}/../market-price-tracker/skills/tracking-crypto-prices/scripts")
+sys.path.insert(0, "../market-price-tracker/skills/tracking-crypto-prices/scripts")
 from price_tracker import get_current_prices
 
 def calculate_portfolio_value(holdings: dict) -> float:
@@ -618,7 +618,7 @@ def calculate_portfolio_value(holdings: dict) -> float:
 
 ```bash
 # In another skill's script
-PRICES=$(python ${CLAUDE_SKILL_DIR}/../market-price-tracker/scripts/price_tracker.py \
+PRICES=$(python ../market-price-tracker/scripts/price_tracker.py \
   --symbols BTC,ETH \
   --format json)
 ```
@@ -747,7 +747,7 @@ def test_cache_miss():
 
 ```bash
 # Test full workflow
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --test
+python ./scripts/price_tracker.py --symbol BTC --test
 
 # Expected: Fetches real data, validates response format
 ```

--- a/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/SKILL.md
+++ b/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/SKILL.md
@@ -38,42 +38,42 @@ Foundation skill providing real-time and historical cryptocurrency price data fo
 1. Install dependencies: `pip install requests pandas yfinance`
 2. Optional: `pip install python-dotenv` for API key management
 3. Optional: Get free API key from https://www.coingecko.com/en/api for higher rate limits
-4. Add API key to `${CLAUDE_SKILL_DIR}/config/settings.yaml` or set `COINGECKO_API_KEY` env var
+4. Add API key to `./config/settings.yaml` or set `COINGECKO_API_KEY` env var
 
 ## Instructions
 
 1. Check current prices for one or more symbols:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH,SOL
+   python ./scripts/price_tracker.py --symbol BTC
+   python ./scripts/price_tracker.py --symbols BTC,ETH,SOL
    ```
 
 2. Use watchlists to scan predefined groups (available: `top10`, `defi`, `layer2`, `stablecoins`, `memecoins`):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist top10     # Top 10 by market cap
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist defi      # DeFi tokens
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist layer2    # Layer 2 tokens
+   python ./scripts/price_tracker.py --watchlist top10     # Top 10 by market cap
+   python ./scripts/price_tracker.py --watchlist defi      # DeFi tokens
+   python ./scripts/price_tracker.py --watchlist layer2    # Layer 2 tokens
    ```
 
 3. Fetch historical data by period or custom date range:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 30d
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 90d --output csv
-   python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --start 2024-01-01 --end 2024-12-31  # 2024 full year
+   python ./scripts/price_tracker.py --symbol BTC --period 30d
+   python ./scripts/price_tracker.py --symbol BTC --period 90d --output csv
+   python ./scripts/price_tracker.py --symbol ETH --start 2024-01-01 --end 2024-12-31  # 2024 full year
    ```
 
-4. Configure settings by editing `${CLAUDE_SKILL_DIR}/config/settings.yaml` to customize cache TTLs, default currency, and custom watchlists. See `references/implementation.md` for the full configuration reference.
+4. Configure settings by editing `./config/settings.yaml` to customize cache TTLs, default currency, and custom watchlists. See `references/implementation.md` for the full configuration reference.
 
 ## Output
 
 - **Table** (default): Symbol, price, 24h change, volume, market cap in formatted columns
 - **JSON** (`--format json`): Machine-readable with prices array and metadata
-- **CSV** (`--output csv`): OHLCV historical data export to `${CLAUDE_SKILL_DIR}/data/`
+- **CSV** (`--output csv`): OHLCV historical data export to `./data/`
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed output format examples.
+See `./references/implementation.md` for detailed output format examples.
 
 ## Error Handling
 
@@ -91,25 +91,25 @@ The skill auto-manages rate limits: cache first, exponential backoff, yfinance f
 **Quick price check:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
+python ./scripts/price_tracker.py --symbol BTC
 # Output: BTC (Bitcoin) $97,234.56 USD +2.34% (24h) | Vol: $28.5B | MCap: $1.92T
 ```
 
 **Watchlist scan:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist top10
+python ./scripts/price_tracker.py --watchlist top10
 ```
 
 **Historical export:**
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --period 90d --output csv
-# Creates: ${CLAUDE_SKILL_DIR}/data/ETH_90d_[date].csv
+python ./scripts/price_tracker.py --symbol ETH --period 90d --output csv
+# Creates: ./data/ETH_90d_[date].csv
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Output formats, full config, integration guide, file map
+- `./references/implementation.md` - Output formats, full config, integration guide, file map
 - [CoinGecko API](https://www.coingecko.com/en/api) - Primary data source
 - [yfinance](https://github.com/ranaroussi/yfinance) - Fallback for historical data

--- a/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/references/examples.md
+++ b/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/references/examples.md
@@ -9,7 +9,7 @@ Comprehensive examples for the tracking-crypto-prices skill.
 The simplest use case - check the current price of Bitcoin:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
+python ./scripts/price_tracker.py --symbol BTC
 ```
 
 **Output:**
@@ -27,7 +27,7 @@ $97,234.56 USD
 Get prices for a portfolio of assets:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH,SOL,AVAX,DOT
+python ./scripts/price_tracker.py --symbols BTC,ETH,SOL,AVAX,DOT
 ```
 
 **Output:**
@@ -59,16 +59,16 @@ Scan predefined watchlists for quick market overview:
 
 ```bash
 # Top 10 by market cap
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist top10
+python ./scripts/price_tracker.py --watchlist top10
 
 # DeFi tokens
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist defi
+python ./scripts/price_tracker.py --watchlist defi
 
 # Layer 2 solutions
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist layer2
+python ./scripts/price_tracker.py --watchlist layer2
 
 # Stablecoins
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist stablecoins
+python ./scripts/price_tracker.py --watchlist stablecoins
 ```
 
 ---
@@ -80,7 +80,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist stablecoins
 Machine-readable output for scripting:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --format json
+python ./scripts/price_tracker.py --symbol ETH --format json
 ```
 
 **Output:**
@@ -116,7 +116,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --format json
 Export prices for spreadsheet analysis:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH,SOL --format csv --output prices.csv
+python ./scripts/price_tracker.py --symbols BTC,ETH,SOL --format csv --output prices.csv
 ```
 
 **Output (prices.csv):**
@@ -135,7 +135,7 @@ SOL,Solana,142.34,USD,5.12,12.8,2100000000,61400000000,2025-01-14T15:30:00.00000
 Single-line output for shell scripts:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH --format minimal
+python ./scripts/price_tracker.py --symbols BTC,ETH --format minimal
 ```
 
 **Output:**
@@ -148,7 +148,7 @@ Use in shell scripts:
 
 ```bash
 #!/bin/bash
-PRICES=$(python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH --format minimal)
+PRICES=$(python ./scripts/price_tracker.py --symbols BTC,ETH --format minimal)
 echo "Current prices: $PRICES"
 ```
 
@@ -161,7 +161,7 @@ echo "Current prices: $PRICES"
 Get price history for the last 30 days:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 30d
+python ./scripts/price_tracker.py --symbol BTC --period 30d
 ```
 
 **Output:**
@@ -191,7 +191,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 30d
 Fetch history for a specific period:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --start 2024-01-01 --end 2024-12-31
+python ./scripts/price_tracker.py --symbol ETH --start 2024-01-01 --end 2024-12-31
 ```
 
 ---
@@ -201,7 +201,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol ETH --start 2024-01
 Export OHLCV data for analysis:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 90d --format csv --output btc_90d.csv
+python ./scripts/price_tracker.py --symbol BTC --period 90d --format csv --output btc_90d.csv
 ```
 
 **Output (btc_90d.csv):**
@@ -223,13 +223,13 @@ Get prices in alternative currencies:
 
 ```bash
 # Euro
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --currency EUR
+python ./scripts/price_tracker.py --symbol BTC --currency EUR
 
 # British Pound
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --currency GBP
+python ./scripts/price_tracker.py --symbol BTC --currency GBP
 
 # Japanese Yen
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --currency JPY
+python ./scripts/price_tracker.py --symbol BTC --currency JPY
 ```
 
 ---
@@ -242,10 +242,10 @@ Find available cryptocurrencies:
 
 ```bash
 # Search by name
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --list --query ethereum
+python ./scripts/price_tracker.py --list --query ethereum
 
 # Search by partial name
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --list --query layer
+python ./scripts/price_tracker.py --list --query layer
 ```
 
 **Output:**
@@ -274,7 +274,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --list --query layer
 Force fresh data fetch:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --no-cache
+python ./scripts/price_tracker.py --symbol BTC --no-cache
 ```
 
 ---
@@ -284,7 +284,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --no-cache
 Remove all cached data:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --clear-cache
+python ./scripts/price_tracker.py --clear-cache
 ```
 
 ---
@@ -321,7 +321,7 @@ Use in automated scripts:
 #!/bin/bash
 
 # Get BTC price as JSON and extract value
-BTC_PRICE=$(python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --format json | jq '.prices[0].price')
+BTC_PRICE=$(python ./scripts/price_tracker.py --symbol BTC --format json | jq '.prices[0].price')
 
 # Alert if price drops below threshold
 if (( $(echo "$BTC_PRICE < 90000" | bc -l) )); then
@@ -338,7 +338,7 @@ Automated price logging:
 ```bash
 # Add to crontab (crontab -e)
 # Log prices every 5 minutes
-*/5 * * * * python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist top10 --format csv >> /var/log/crypto_prices.csv
+*/5 * * * * python ./scripts/price_tracker.py --watchlist top10 --format csv >> /var/log/crypto_prices.csv
 ```
 
 ---
@@ -351,16 +351,16 @@ Combine spot and historical data:
 
 ```bash
 # Current price
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC
+python ./scripts/price_tracker.py --symbol BTC
 
 # 7-day trend
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 7d
+python ./scripts/price_tracker.py --symbol BTC --period 7d
 
 # 30-day trend
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --period 30d
+python ./scripts/price_tracker.py --symbol BTC --period 30d
 
 # Year-to-date
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --start 2025-01-01 --end $(date +%Y-%m-%d)
+python ./scripts/price_tracker.py --symbol BTC --start 2025-01-01 --end $(date +%Y-%m-%d)
 ```
 
 ---
@@ -370,7 +370,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --start 2025-01
 Debug API and cache behavior:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --verbose
+python ./scripts/price_tracker.py --symbol BTC --verbose
 ```
 
 **Output:**
@@ -411,7 +411,7 @@ watchlists:
 1. Use it:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --watchlist custom
+python ./scripts/price_tracker.py --watchlist custom
 ```
 
 ---
@@ -429,7 +429,7 @@ When rate limited, the skill automatically:
 ```bash
 # Force yfinance fallback (for testing)
 # Temporarily disable CoinGecko by rate limiting
-python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbol BTC --verbose
+python ./scripts/price_tracker.py --symbol BTC --verbose
 ```
 
 **Output with fallback:**

--- a/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/references/implementation.md
+++ b/plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/references/implementation.md
@@ -56,7 +56,7 @@ date,open,high,low,close,volume
 
 ## Full Configuration Reference
 
-Edit `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Edit `./config/settings.yaml`:
 
 ```yaml
 # API Configuration
@@ -134,11 +134,11 @@ prices = get_current_prices(["BTC", "ETH", "SOL"])
 **CLI Subprocess** (for non-Python or isolation):
 
 ```bash
-PRICES=$(python ${CLAUDE_SKILL_DIR}/scripts/price_tracker.py --symbols BTC,ETH --format json)
+PRICES=$(python ./scripts/price_tracker.py --symbols BTC,ETH --format json)
 ```
 
 **Shared Cache** (efficient for batch):
-Multiple skills can read from `${CLAUDE_SKILL_DIR}/data/cache.json` to avoid redundant API calls.
+Multiple skills can read from `./data/cache.json` to avoid redundant API calls.
 
 ## Files
 

--- a/plugins/crypto/market-sentiment-analyzer/package.json
+++ b/plugins/crypto/market-sentiment-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/market-sentiment-analyzer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Analyze market sentiment from social media, news, and on-chain data",
   "keywords": [
     "sentiment",

--- a/plugins/crypto/market-sentiment-analyzer/skills/analyzing-market-sentiment/SKILL.md
+++ b/plugins/crypto/market-sentiment-analyzer/skills/analyzing-market-sentiment/SKILL.md
@@ -43,22 +43,22 @@ Cryptocurrency market sentiment analysis combining Fear & Greed Index, news keyw
 
    ```bash
    # Quick market sentiment check
-   python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py
+   python ./scripts/sentiment_analyzer.py
 
    # Coin-specific sentiment
-   python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --coin BTC
+   python ./scripts/sentiment_analyzer.py --coin BTC
 
    # Detailed breakdown with all components
-   python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --detailed
+   python ./scripts/sentiment_analyzer.py --detailed
 
    # Custom time period
-   python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --period 7d --detailed
+   python ./scripts/sentiment_analyzer.py --period 7d --detailed
    ```
 
 3. **Export results** for trading models or analysis:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --format json --output sentiment.json
+   python ./scripts/sentiment_analyzer.py --format json --output sentiment.json
    ```
 
 4. **Present results** to the user:
@@ -99,7 +99,7 @@ Composite sentiment score (0-100) with classification and weighted component bre
 | News fetch failed | Network issue | Reduces weight of news component |
 | Invalid coin | Unknown symbol | Proceeds with market-wide analysis |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
@@ -107,26 +107,26 @@ Sentiment analysis patterns from quick checks to custom-weighted deep analysis:
 
 ```bash
 # Quick market sentiment
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py
+python ./scripts/sentiment_analyzer.py
 
 # Bitcoin-specific sentiment
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --coin BTC
+python ./scripts/sentiment_analyzer.py --coin BTC
 
 # Detailed analysis with component breakdown
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --detailed
+python ./scripts/sentiment_analyzer.py --detailed
 
 # Custom weights emphasizing news
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --weights "news:0.5,fng:0.3,momentum:0.2"
+python ./scripts/sentiment_analyzer.py --weights "news:0.5,fng:0.3,momentum:0.2"
 
 # Weekly sentiment trend
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --period 7d --detailed
+python ./scripts/sentiment_analyzer.py --period 7d --detailed
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - CLI options, classifications, JSON format, contrarian theory
-- `${CLAUDE_SKILL_DIR}/references/errors.md` - Comprehensive error handling
-- `${CLAUDE_SKILL_DIR}/references/examples.md` - Detailed usage examples
+- `./references/implementation.md` - CLI options, classifications, JSON format, contrarian theory
+- `./references/errors.md` - Comprehensive error handling
+- `./references/examples.md` - Detailed usage examples
 - Alternative.me Fear & Greed: https://alternative.me/crypto/fear-and-greed-index/
 - CoinGecko API: https://www.coingecko.com/en/api
-- `${CLAUDE_SKILL_DIR}/config/settings.yaml` - Configuration options
+- `./config/settings.yaml` - Configuration options

--- a/plugins/crypto/market-sentiment-analyzer/skills/analyzing-market-sentiment/references/implementation.md
+++ b/plugins/crypto/market-sentiment-analyzer/skills/analyzing-market-sentiment/references/implementation.md
@@ -62,16 +62,16 @@
 
 ```bash
 # Custom weights (emphasize news)
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --weights "news:0.5,fng:0.3,momentum:0.2"
+python ./scripts/sentiment_analyzer.py --weights "news:0.5,fng:0.3,momentum:0.2"
 
 # Weekly sentiment comparison
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --period 7d --detailed
+python ./scripts/sentiment_analyzer.py --period 7d --detailed
 
 # Export for trading model
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --format json --output sentiment.json
+python ./scripts/sentiment_analyzer.py --format json --output sentiment.json
 
 # Bitcoin-specific detailed analysis
-python ${CLAUDE_SKILL_DIR}/scripts/sentiment_analyzer.py --coin BTC --detailed
+python ./scripts/sentiment_analyzer.py --coin BTC --detailed
 ```
 
 ## Contrarian Indicator Theory

--- a/plugins/crypto/mempool-analyzer/package.json
+++ b/plugins/crypto/mempool-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/mempool-analyzer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
   "keywords": [
     "crypto",

--- a/plugins/crypto/mempool-analyzer/skills/analyzing-mempool/SKILL.md
+++ b/plugins/crypto/mempool-analyzer/skills/analyzing-mempool/SKILL.md
@@ -40,7 +40,7 @@ Monitor Ethereum mempool for pending transactions, analyze gas prices, detect DE
 ### Step 1: Navigate to Scripts Directory
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts
+cd ./scripts
 ```
 
 ### Step 2: Choose a Command
@@ -85,7 +85,7 @@ python mempool_analyzer.py --chain arbitrum pending # Or use Arbitrum
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
+See `./references/errors.md` for:
 
 - RPC connection issues and timeout recovery
 - Mempool access limitations per chain
@@ -113,11 +113,11 @@ python mempool_analyzer.py swaps --limit 200  # 200: max results to scan
 python mempool_analyzer.py mev -v
 ```
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for more usage patterns.
+See `./references/examples.md` for more usage patterns.
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Gas analysis, MEV detection, multi-chain details
+- `./references/implementation.md` - Gas analysis, MEV detection, multi-chain details
 - [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) - RPC specification
 - [Flashbots](https://flashbots.net) - MEV research and infrastructure
 - [DEX Subgraphs](https://thegraph.com) - Pool and swap data

--- a/plugins/crypto/mempool-analyzer/skills/analyzing-mempool/references/implementation.md
+++ b/plugins/crypto/mempool-analyzer/skills/analyzing-mempool/references/implementation.md
@@ -56,7 +56,7 @@ The `watch` command monitors pending transactions to a specific contract address
 
 ## Configuration
 
-Edit `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Edit `./config/settings.yaml`:
 
 ```yaml
 rpc_endpoints:

--- a/plugins/crypto/nft-rarity-analyzer/package.json
+++ b/plugins/crypto/nft-rarity-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/nft-rarity-analyzer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Analyze NFT rarity scores and valuations across collections",
   "keywords": [
     "nft",

--- a/plugins/crypto/nft-rarity-analyzer/skills/analyzing-nft-rarity/SKILL.md
+++ b/plugins/crypto/nft-rarity-analyzer/skills/analyzing-nft-rarity/SKILL.md
@@ -40,7 +40,7 @@ NFT rarity analysis skill that:
 ### 1. Analyze a Collection
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py collection boredapeyachtclub
+cd ./scripts && python3 rarity_analyzer.py collection boredapeyachtclub
 ```
 
 Options:
@@ -54,19 +54,19 @@ Options:
 ### 2. Check Specific Token
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py token pudgypenguins 1234  # port 1234 - example/test
+cd ./scripts && python3 rarity_analyzer.py token pudgypenguins 1234  # port 1234 - example/test
 ```
 
 ### 3. Compare Multiple Tokens
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py compare azuki 1234,5678,9012  # 5678: 1234: 9012 = configured value
+cd ./scripts && python3 rarity_analyzer.py compare azuki 1234,5678,9012  # 5678: 1234: 9012 = configured value
 ```
 
 ### 4. View Trait Distribution
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py traits doodles
+cd ./scripts && python3 rarity_analyzer.py traits doodles
 ```
 
 ### 5. Export Rankings
@@ -74,20 +74,20 @@ cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py traits doodles
 JSON:
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py export coolcats > rankings.json
+cd ./scripts && python3 rarity_analyzer.py export coolcats > rankings.json
 ```
 
 CSV:
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py export coolcats --format csv > rankings.csv
+cd ./scripts && python3 rarity_analyzer.py export coolcats --format csv > rankings.csv
 ```
 
 ### 6. Manage Cache
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py cache --list
-cd ${CLAUDE_SKILL_DIR}/scripts && python3 rarity_analyzer.py cache --clear
+cd ./scripts && python3 rarity_analyzer.py cache --list
+cd ./scripts && python3 rarity_analyzer.py cache --clear
 ```
 
 ## Rarity Algorithms
@@ -116,7 +116,7 @@ Works with any ERC-721/ERC-1155 collection that has:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
+See `./references/errors.md` for:
 
 - API rate limiting
 - IPFS gateway issues
@@ -125,7 +125,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for:
+See `./references/examples.md` for:
 
 - Collection analysis workflows
 - Token comparison

--- a/plugins/crypto/nft-rarity-analyzer/skills/analyzing-nft-rarity/references/implementation.md
+++ b/plugins/crypto/nft-rarity-analyzer/skills/analyzing-nft-rarity/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/on-chain-analytics/package.json
+++ b/plugins/crypto/on-chain-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/on-chain-analytics",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
   "keywords": [
     "on-chain",

--- a/plugins/crypto/on-chain-analytics/skills/analyzing-on-chain-data/SKILL.md
+++ b/plugins/crypto/on-chain-analytics/skills/analyzing-on-chain-data/SKILL.md
@@ -45,7 +45,7 @@ Analyze DeFi protocol metrics, chain-level TVL, fee revenue, DEX volumes, yield 
 9. Run `python onchain_analytics.py trends --threshold 5` to detect protocols with significant TVL changes (threshold is percentage).
 10. Export results in JSON or CSV format using `--format json` or `--format csv` and redirect to file for downstream analysis.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full four-step implementation workflow.
+See `./references/implementation.md` for the full four-step implementation workflow.
 
 ## Output
 

--- a/plugins/crypto/on-chain-analytics/skills/analyzing-on-chain-data/references/implementation.md
+++ b/plugins/crypto/on-chain-analytics/skills/analyzing-on-chain-data/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/options-flow-analyzer/package.json
+++ b/plugins/crypto/options-flow-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/options-flow-analyzer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Track institutional options flow, unusual activity, and smart money movements",
   "keywords": [
     "options",

--- a/plugins/crypto/options-flow-analyzer/skills/analyzing-options-flow/SKILL.md
+++ b/plugins/crypto/options-flow-analyzer/skills/analyzing-options-flow/SKILL.md
@@ -34,7 +34,7 @@ Track and analyze crypto options flow on centralized derivatives exchanges (Deri
 
 ## Instructions
 
-1. Load exchange API credentials from `${CLAUDE_SKILL_DIR}/config/crypto-apis.env` using the Read tool to authenticate against derivatives exchange endpoints.
+1. Load exchange API credentials from `./config/crypto-apis.env` using the Read tool to authenticate against derivatives exchange endpoints.
 2. Run `Bash(crypto:options-*)` to connect to the Deribit options data feed and pull the current options chain for BTC or ETH, including all active strikes and expiries.
 3. Retrieve open interest data across all strike prices and expiration dates to build an open interest heatmap showing where positions are concentrated.
 4. Calculate the aggregate put/call ratio by volume and by open interest to assess overall market sentiment (ratio above 1.0 indicates bearish bias; below 1.0 indicates bullish).
@@ -45,7 +45,7 @@ Track and analyze crypto options flow on centralized derivatives exchanges (Deri
 9. Generate a flow summary report with actionable signals: bullish large-block calls, bearish put sweeps, IV skew shifts, and OI buildup at key strikes.
 10. Export results using `--format json` or `--format csv` for integration with trading dashboards or alerting systems.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full implementation workflow.
+See `./references/implementation.md` for the full implementation workflow.
 
 ## Output
 

--- a/plugins/crypto/options-flow-analyzer/skills/analyzing-options-flow/references/implementation.md
+++ b/plugins/crypto/options-flow-analyzer/skills/analyzing-options-flow/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/staking-rewards-optimizer/package.json
+++ b/plugins/crypto/staking-rewards-optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/staking-rewards-optimizer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Optimize staking rewards across multiple protocols and chains",
   "keywords": [
     "crypto",

--- a/plugins/crypto/staking-rewards-optimizer/skills/optimizing-staking-rewards/SKILL.md
+++ b/plugins/crypto/staking-rewards-optimizer/skills/optimizing-staking-rewards/SKILL.md
@@ -37,7 +37,7 @@ Analyze staking opportunities across PoS blockchains and liquid staking protocol
 1. **Compare staking options** for a specific asset:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH
+   python ./scripts/staking_optimizer.py --asset ETH
    ```
 
    Shows protocol name, type (native vs liquid), gross/net APY, risk score, TVL, and lock-up period.
@@ -45,7 +45,7 @@ Analyze staking opportunities across PoS blockchains and liquid staking protocol
 2. **Analyze with position size** for gas-adjusted yields:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH --amount 10
+   python ./scripts/staking_optimizer.py --asset ETH --amount 10
    ```
 
    Calculates effective APY accounting for gas costs and projects returns at 1M, 3M, 6M, and 1Y.
@@ -53,7 +53,7 @@ Analyze staking opportunities across PoS blockchains and liquid staking protocol
 3. **Optimize existing portfolio** with current positions:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --optimize \
+   python ./scripts/staking_optimizer.py --optimize \
      --positions "10 ETH @ lido 4.0%, 100 ATOM @ native 18%, 50 DOT @ native 14%"
    ```
 
@@ -62,14 +62,14 @@ Analyze staking opportunities across PoS blockchains and liquid staking protocol
 4. **Compare protocols or run risk assessment**:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --compare --protocols lido,rocket-pool,frax-ether
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH --detailed
+   python ./scripts/staking_optimizer.py --compare --protocols lido,rocket-pool,frax-ether
+   python ./scripts/staking_optimizer.py --asset ETH --detailed
    ```
 
 5. **Export results** in JSON or CSV:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH --format json --output staking.json
+   python ./scripts/staking_optimizer.py --asset ETH --format json --output staking.json
    ```
 
 ## Output
@@ -95,7 +95,7 @@ Comparison table ranked by risk-adjusted return (Net APY multiplied by Risk Scor
 | Rate limited | Too many API calls | Automatic retry with backoff |
 | No data found | Protocol not indexed | Falls back to known protocol list |
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
@@ -103,23 +103,23 @@ Common staking analysis workflows from single-asset comparison to full portfolio
 
 ```bash
 # Quick ETH staking comparison
-python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH
+python ./scripts/staking_optimizer.py --asset ETH
 
 # Large position with full risk analysis
-python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --asset ETH --amount 100 --detailed
+python ./scripts/staking_optimizer.py --asset ETH --amount 100 --detailed
 
 # Multi-asset comparison exported to CSV
-python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --assets ETH,SOL,ATOM --format csv
+python ./scripts/staking_optimizer.py --assets ETH,SOL,ATOM --format csv
 
 # Portfolio optimization with current positions
-python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --optimize \
+python ./scripts/staking_optimizer.py --optimize \
   --positions "50 ETH @ lido 3.6%, 500 SOL @ marinade 7.5%"  # 500 - minimum stake amount in tokens
 ```
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Optimization reports, risk assessment details, disclaimers
-- `${CLAUDE_SKILL_DIR}/references/errors.md` - Comprehensive error handling
+- `./references/implementation.md` - Optimization reports, risk assessment details, disclaimers
+- `./references/errors.md` - Comprehensive error handling
 - DeFiLlama Yields: https://defillama.com/yields
 - StakingRewards: https://www.stakingrewards.com
 - Lido: https://lido.fi | Rocket Pool: https://rocketpool.net

--- a/plugins/crypto/staking-rewards-optimizer/skills/optimizing-staking-rewards/references/implementation.md
+++ b/plugins/crypto/staking-rewards-optimizer/skills/optimizing-staking-rewards/references/implementation.md
@@ -74,7 +74,7 @@ Use `--protocol <name> --detailed` for full protocol analysis including:
 - Slashing incident reports
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/staking_optimizer.py --protocol rocket-pool --detailed
+python ./scripts/staking_optimizer.py --protocol rocket-pool --detailed
 ```
 
 ## Important Notes

--- a/plugins/crypto/token-launch-tracker/package.json
+++ b/plugins/crypto/token-launch-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/token-launch-tracker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
   "keywords": [
     "crypto",

--- a/plugins/crypto/token-launch-tracker/skills/tracking-token-launches/SKILL.md
+++ b/plugins/crypto/token-launch-tracker/skills/tracking-token-launches/SKILL.md
@@ -105,7 +105,7 @@ python launch_tracker.py chains
 1. **Check recent launches** on a specific chain:
 
    ```bash
-   cd ${CLAUDE_SKILL_DIR}/scripts
+   cd ./scripts
    python launch_tracker.py recent --chain ethereum --hours 6
    ```
 
@@ -163,7 +163,7 @@ python launch_tracker.py chains
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling including:
+See `./references/errors.md` for comprehensive error handling including:
 
 - RPC connection issues and fallback chain
 - Rate limiting and backoff strategies
@@ -171,7 +171,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling 
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples including:
+See `./references/examples.md` for detailed examples including:
 
 - Finding high-risk tokens
 - Multi-chain monitoring scripts

--- a/plugins/crypto/token-launch-tracker/skills/tracking-token-launches/references/implementation.md
+++ b/plugins/crypto/token-launch-tracker/skills/tracking-token-launches/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/trading-strategy-backtester/package.json
+++ b/plugins/crypto/trading-strategy-backtester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/trading-strategy-backtester",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
   "keywords": [
     "trading",

--- a/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/SKILL.md
+++ b/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/SKILL.md
@@ -58,17 +58,17 @@ pip install ta-lib scipy scikit-learn
 
 ## Instructions
 
-1. Fetch historical data (cached to `${CLAUDE_SKILL_DIR}/data/` for reuse):
+1. Fetch historical data (cached to `./data/` for reuse):
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/fetch_data.py --symbol BTC-USD --period 2y --interval 1d
+   python ./scripts/fetch_data.py --symbol BTC-USD --period 2y --interval 1d
    ```
 
 2. Run a backtest with default or custom parameters:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/backtest.py --strategy sma_crossover --symbol BTC-USD --period 1y
-   python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
+   python ./scripts/backtest.py --strategy sma_crossover --symbol BTC-USD --period 1y
+   python ./scripts/backtest.py \
      --strategy rsi_reversal \
      --symbol ETH-USD \
      --period 1y \
@@ -76,11 +76,11 @@ pip install ta-lib scipy scikit-learn
      --params '{"period": 14, "overbought": 70, "oversold": 30}'
    ```
 
-3. Analyze results saved to `${CLAUDE_SKILL_DIR}/reports/` -- includes `*_summary.txt` (performance metrics), `*_trades.csv` (trade log), `*_equity.csv` (equity curve data), and `*_chart.png` (visual equity curve).
+3. Analyze results saved to `./reports/` -- includes `*_summary.txt` (performance metrics), `*_trades.csv` (trade log), `*_equity.csv` (equity curve data), and `*_chart.png` (visual equity curve).
 4. Optimize parameters via grid search to find the best combination:
 
    ```bash
-   python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
+   python ./scripts/optimize.py \
      --strategy sma_crossover \
      --symbol BTC-USD \
      --period 1y \
@@ -152,7 +152,7 @@ pip install ta-lib scipy scikit-learn
 
 ## Configuration
 
-Create `${CLAUDE_SKILL_DIR}/config/settings.yaml`:
+Create `./config/settings.yaml`:
 
 ```yaml
 data:
@@ -172,11 +172,11 @@ risk:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for common issues and solutions.
+See `./references/errors.md` for common issues and solutions.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed usage examples including:
+See `./references/examples.md` for detailed usage examples including:
 
 - Multi-asset comparison
 - Walk-forward analysis

--- a/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/backtest-strategy.md
+++ b/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/backtest-strategy.md
@@ -57,14 +57,14 @@ def run_backtest(
 Basic SMA crossover backtest:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
+python ./scripts/backtest.py \
   --strategy sma_crossover --symbol BTC-USD --period 1y
 ```
 
 RSI reversal with custom parameters and $50k capital:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
+python ./scripts/backtest.py \
   --strategy rsi_reversal --symbol ETH-USD --period 6m \
   --capital 50000 \
   --params '{"period": 14, "overbought": 75, "oversold": 25}'
@@ -73,7 +73,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
 Specific date range with low commission:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
+python ./scripts/backtest.py \
   --strategy macd --symbol SOL-USD \
   --start 2024-01-01 --end 2025-01-01 \
   --commission 0.0005 --slippage 0.0002
@@ -82,7 +82,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
 List all available strategies:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/backtest.py --list
+python ./scripts/backtest.py --list
 ```
 
 ## Available Strategies
@@ -100,7 +100,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/backtest.py --list
 
 ## Configuration
 
-Settings are loaded from `${CLAUDE_SKILL_DIR}/config/settings.yaml` with this priority:
+Settings are loaded from `./config/settings.yaml` with this priority:
 
 1. CLI arguments (highest)
 2. `settings.yaml` values
@@ -117,7 +117,7 @@ risk:
 
 ## Output
 
-Results are saved to `${CLAUDE_SKILL_DIR}/reports/`:
+Results are saved to `./reports/`:
 
 - `*_summary.txt` -- Performance metrics table
 - `*_trades.csv` -- Trade log with entry/exit times, PnL

--- a/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/compare-strategies.md
+++ b/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/compare-strategies.md
@@ -27,7 +27,7 @@ Run multiple strategies on the same data and compare performance side by side.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path("${CLAUDE_SKILL_DIR}/scripts")))
+sys.path.insert(0, str(Path("./scripts")))
 
 from backtest import load_data, run_backtest
 from fetch_data import parse_period
@@ -41,7 +41,7 @@ end = datetime.now()
 start = end - parse_period("1y")
 
 # Load data once
-data_dir = Path("${CLAUDE_SKILL_DIR}/data")
+data_dir = Path("./data")
 data = load_data(symbol, start, end, data_dir)
 data.attrs["symbol"] = symbol
 
@@ -69,7 +69,7 @@ Run individual backtests and compare the summary files:
 
 ```bash
 for strategy in sma_crossover ema_crossover rsi_reversal macd bollinger_bands; do
-  python ${CLAUDE_SKILL_DIR}/scripts/backtest.py \
+  python ./scripts/backtest.py \
     --strategy $strategy --symbol BTC-USD --period 1y --quiet
 done
 ```

--- a/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/optimize-parameters.md
+++ b/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/optimize-parameters.md
@@ -16,14 +16,14 @@ Find optimal strategy parameters via grid search over historical data.
 
 ## How It Works
 
-The optimizer in `${CLAUDE_SKILL_DIR}/scripts/optimize.py` runs a full backtest for every combination of parameters in your grid, ranks results by a target metric (default: Sharpe ratio), and reports the top performers.
+The optimizer in `./scripts/optimize.py` runs a full backtest for every combination of parameters in your grid, ranks results by a target metric (default: Sharpe ratio), and reports the top performers.
 
 ## Examples
 
 Optimize SMA crossover periods:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
+python ./scripts/optimize.py \
   --strategy sma_crossover --symbol BTC-USD --period 2y \
   --param-grid '{"fast_period": [10, 15, 20, 30], "slow_period": [50, 100, 150, 200]}'
 ```
@@ -31,7 +31,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
 Optimize RSI thresholds targeting win rate:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
+python ./scripts/optimize.py \
   --strategy rsi_reversal --symbol ETH-USD --period 1y \
   --param-grid '{"period": [7, 14, 21], "overbought": [65, 70, 75], "oversold": [25, 30, 35]}' \
   --metric win_rate
@@ -40,7 +40,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
 Optimize with custom capital and output:
 
 ```bash
-python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
+python ./scripts/optimize.py \
   --strategy macd --symbol SOL-USD --period 1y \
   --param-grid '{"fast": [8, 12, 16], "slow": [20, 26, 32], "signal": [7, 9, 11]}' \
   --capital 50000 --output ./my-reports
@@ -57,7 +57,7 @@ python ${CLAUDE_SKILL_DIR}/scripts/optimize.py \
 | `--start/--end` | Explicit date range | -- |
 | `--capital` | Starting capital | `10000` |
 | `--metric` | Sort/rank metric | `sharpe_ratio` |
-| `--output` | Output directory | `${CLAUDE_SKILL_DIR}/reports` |
+| `--output` | Output directory | `./reports` |
 
 ## Available Metrics
 

--- a/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/walk-forward.md
+++ b/plugins/crypto/trading-strategy-backtester/skills/backtesting-trading-strategies/commands/walk-forward.md
@@ -28,7 +28,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timedelta
 
-sys.path.insert(0, str(Path("${CLAUDE_SKILL_DIR}/scripts")))
+sys.path.insert(0, str(Path("./scripts")))
 
 from backtest import load_data, run_backtest
 from optimize import grid_search
@@ -45,7 +45,7 @@ total_years = 3
 # Load full dataset
 end = datetime.now()
 start = end - parse_period(f"{total_years}y")
-data_dir = Path("${CLAUDE_SKILL_DIR}/data")
+data_dir = Path("./data")
 full_data = load_data(symbol, start, end, data_dir)
 full_data.attrs["symbol"] = symbol
 

--- a/plugins/crypto/wallet-security-auditor/package.json
+++ b/plugins/crypto/wallet-security-auditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/wallet-security-auditor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
   "keywords": [
     "crypto",

--- a/plugins/crypto/wallet-security-auditor/skills/auditing-wallet-security/SKILL.md
+++ b/plugins/crypto/wallet-security-auditor/skills/auditing-wallet-security/SKILL.md
@@ -43,7 +43,7 @@ Before using this skill, ensure you have:
 Scan wallet for all active ERC20 token approvals:
 
 ```text
-cd ${CLAUDE_SKILL_DIR}/scripts
+cd ./scripts
 python wallet_auditor.py approvals <address> --chain <chain>
 ```
 
@@ -171,7 +171,7 @@ python wallet_auditor.py chains
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling:
+See `./references/errors.md` for comprehensive error handling:
 
 | Error | Cause | Solution |
 |-------|-------|----------|
@@ -182,7 +182,7 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling:
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ### Quick Security Check
 

--- a/plugins/crypto/wallet-security-auditor/skills/auditing-wallet-security/references/implementation.md
+++ b/plugins/crypto/wallet-security-auditor/skills/auditing-wallet-security/references/implementation.md
@@ -4,7 +4,7 @@
 
 Set up connections to crypto data providers:
 
-1. Use Read tool to load API credentials from ${CLAUDE_SKILL_DIR}/config/crypto-apis.env
+1. Use Read tool to load API credentials from ./config/crypto-apis.env
 2. Configure blockchain RPC endpoints for target networks
 3. Set up exchange API connections if required
 4. Verify rate limits and subscription tiers
@@ -32,7 +32,7 @@ Process crypto data to generate insights:
 
 ### Step 4: Generate Reports
 
-Document findings in ${CLAUDE_SKILL_DIR}/crypto-reports/:
+Document findings in ./crypto-reports/:
 
 - Market summary with key price movements
 - Detailed analysis with charts and metrics

--- a/plugins/crypto/whale-alert-monitor/package.json
+++ b/plugins/crypto/whale-alert-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/whale-alert-monitor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Monitor large crypto transactions and whale wallet movements in real-time",
   "keywords": [
     "whale",

--- a/plugins/crypto/whale-alert-monitor/skills/monitoring-whale-activity/SKILL.md
+++ b/plugins/crypto/whale-alert-monitor/skills/monitoring-whale-activity/SKILL.md
@@ -40,7 +40,7 @@ Track large cryptocurrency transactions and whale wallet movements across multip
 ### Step 1: Navigate to Scripts Directory
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts
+cd ./scripts
 ```
 
 ### Step 2: Choose a Command
@@ -83,7 +83,7 @@ python whale_monitor.py labels --type exchange               # Or use type filte
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for:
+See `./references/errors.md` for:
 
 - API rate limit handling and backoff
 - Network timeout recovery
@@ -117,11 +117,11 @@ python whale_monitor.py track 0x28c6c...
 python whale_monitor.py recent --format json > whales.json
 ```
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for more usage patterns.
+See `./references/examples.md` for more usage patterns.
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` - Flow analysis, wallet database, multi-chain details
+- `./references/implementation.md` - Flow analysis, wallet database, multi-chain details
 - [Whale Alert](https://whale-alert.io) - Real-time whale transaction API
 - [Etherscan](https://etherscan.io) - Ethereum blockchain explorer
 - [CoinGecko](https://coingecko.com) - Price data API

--- a/plugins/crypto/whale-alert-monitor/skills/monitoring-whale-activity/references/implementation.md
+++ b/plugins/crypto/whale-alert-monitor/skills/monitoring-whale-activity/references/implementation.md
@@ -41,7 +41,7 @@ python whale_monitor.py labels --type exchange    # List by type (exchange, fund
 
 ## Watchlist Persistence
 
-Watchlists are stored in `${CLAUDE_SKILL_DIR}/config/watchlist.json`:
+Watchlists are stored in `./config/watchlist.json`:
 
 ```json
 {

--- a/plugins/database/database-backup-automator/package.json
+++ b/plugins/database/database-backup-automator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/database-backup-automator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
   "keywords": [
     "database",

--- a/plugins/database/database-backup-automator/skills/automating-database-backups/SKILL.md
+++ b/plugins/database/database-backup-automator/skills/automating-database-backups/SKILL.md
@@ -93,7 +93,7 @@ Ask the user for:
 Use `scripts/backup_script_generator.py` to create a customized backup script:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/backup_script_generator.py \
+python3 ./scripts/backup_script_generator.py \
   --db-type postgresql \
   --database mydb \
   --output /opt/backup-scripts/mydb-backup.sh \
@@ -106,7 +106,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/backup_script_generator.py \
 Use `scripts/backup_scheduler.py` to create cron entries:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/backup_scheduler.py \
+python3 ./scripts/backup_scheduler.py \
   --script /opt/backup-scripts/mydb-backup.sh \
   --schedule "0 2 * * *" \
   --user postgres
@@ -117,7 +117,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/backup_scheduler.py \
 After backup completes, validate integrity:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/backup_validator.py \
+python3 ./scripts/backup_validator.py \
   --backup-file /var/backups/postgresql/mydb_20250115.sql.gz \
   --db-type postgresql
 ```
@@ -127,7 +127,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/backup_validator.py \
 Create matching restore script:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/restore_script_generator.py \
+python3 ./scripts/restore_script_generator.py \
   --db-type postgresql \
   --database mydb \
   --output /opt/backup-scripts/mydb-restore.sh
@@ -172,12 +172,12 @@ find /var/backups/monthly -mtime +365 -delete     # 365: Monthly cleanup
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/postgresql_backup_restore.md` - PostgreSQL backup guide
-- `${CLAUDE_SKILL_DIR}/references/mysql_backup_restore.md` - MySQL backup guide
-- `${CLAUDE_SKILL_DIR}/references/mongodb_backup_restore.md` - MongoDB backup guide
-- `${CLAUDE_SKILL_DIR}/references/sqlite_backup_restore.md` - SQLite backup guide
-- `${CLAUDE_SKILL_DIR}/references/backup_best_practices.md` - Security and storage best practices
-- `${CLAUDE_SKILL_DIR}/references/cron_syntax.md` - Cron scheduling reference
+- `./references/postgresql_backup_restore.md` - PostgreSQL backup guide
+- `./references/mysql_backup_restore.md` - MySQL backup guide
+- `./references/mongodb_backup_restore.md` - MongoDB backup guide
+- `./references/sqlite_backup_restore.md` - SQLite backup guide
+- `./references/backup_best_practices.md` - Security and storage best practices
+- `./references/cron_syntax.md` - Cron scheduling reference
 
 ## Overview
 

--- a/plugins/database/database-documentation-gen/package.json
+++ b/plugins/database/database-documentation-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/database-documentation-gen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Database plugin for database-documentation-gen",
   "keywords": [
     "database",

--- a/plugins/database/database-documentation-gen/skills/database-documentation-gen/scripts/README.md
+++ b/plugins/database/database-documentation-gen/skills/database-documentation-gen/scripts/README.md
@@ -12,13 +12,13 @@ All scripts are executable Python scripts that can be run directly:
 
 ```bash
 # Initialize a new database documentation project
-python ${CLAUDE_SKILL_DIR}/scripts/init_db_docs.py --project my_database --db-type postgresql
+python ./scripts/init_db_docs.py --project my_database --db-type postgresql
 
 # Validate the configuration
-python ${CLAUDE_SKILL_DIR}/scripts/validate_config.py --config ./my_database/db_docs_config.json
+python ./scripts/validate_config.py --config ./my_database/db_docs_config.json
 
 # Generate ERD diagrams
-python ${CLAUDE_SKILL_DIR}/scripts/erd_generator.py --config ./my_database/db_docs_config.json --format all
+python ./scripts/erd_generator.py --config ./my_database/db_docs_config.json --format all
 ```
 
 ## Requirements

--- a/plugins/database/stored-procedure-generator/package.json
+++ b/plugins/database/stored-procedure-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/stored-procedure-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Database plugin for stored-procedure-generator",
   "keywords": [
     "database",

--- a/plugins/database/stored-procedure-generator/skills/generating-stored-procedures/SKILL.md
+++ b/plugins/database/stored-procedure-generator/skills/generating-stored-procedures/SKILL.md
@@ -198,12 +198,12 @@ Use the validation script to check procedure syntax:
 
 ```bash
 # Validate PostgreSQL procedure
-python3 ${CLAUDE_SKILL_DIR}/scripts/stored_procedure_syntax_validator.py \
+python3 ./scripts/stored_procedure_syntax_validator.py \
     --db-type postgresql \
     --file procedure.sql
 
 # Validate MySQL procedure
-python3 ${CLAUDE_SKILL_DIR}/scripts/stored_procedure_syntax_validator.py \
+python3 ./scripts/stored_procedure_syntax_validator.py \
     --db-type mysql \
     --file procedure.sql
 ```
@@ -212,14 +212,14 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/stored_procedure_syntax_validator.py \
 
 ```bash
 # Deploy to PostgreSQL
-python3 ${CLAUDE_SKILL_DIR}/scripts/stored_procedure_deployer.py \
+python3 ./scripts/stored_procedure_deployer.py \
     --db-type postgresql \
     --host localhost \
     --database mydb \
     --file procedure.sql
 
 # Deploy to MySQL
-python3 ${CLAUDE_SKILL_DIR}/scripts/stored_procedure_deployer.py \
+python3 ./scripts/stored_procedure_deployer.py \
     --db-type mysql \
     --host localhost \
     --database mydb \
@@ -270,11 +270,11 @@ Claude: I'll create an audit trigger that:
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/postgresql_stored_procedure_best_practices.md`
-- `${CLAUDE_SKILL_DIR}/references/mysql_stored_procedure_best_practices.md`
-- `${CLAUDE_SKILL_DIR}/references/sqlserver_stored_procedure_best_practices.md`
-- `${CLAUDE_SKILL_DIR}/references/database_security_guidelines.md`
-- `${CLAUDE_SKILL_DIR}/references/stored_procedure_optimization_techniques.md`
+- `./references/postgresql_stored_procedure_best_practices.md`
+- `./references/mysql_stored_procedure_best_practices.md`
+- `./references/sqlserver_stored_procedure_best_practices.md`
+- `./references/database_security_guidelines.md`
+- `./references/stored_procedure_optimization_techniques.md`
 
 ## Overview
 

--- a/plugins/devops/engineer-design-diagram/package.json
+++ b/plugins/devops/engineer-design-diagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/engineer-design-diagram",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo top",
   "keywords": [
     "architecture",

--- a/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/SKILL.md
+++ b/plugins/devops/engineer-design-diagram/skills/engineer-design-diagram/SKILL.md
@@ -125,7 +125,7 @@ If node count >50 OR the model signals layout failure (overlapping boxes, arrows
 For generate/diff/watch modes, write structural state to `${CLAUDE_PLUGIN_DATA}/arch-state.json` (or `~/.claude-state/arch-state.json` fallback if the env var is unset):
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/fingerprint.py write --input /tmp/graph.json
+python3 ./scripts/fingerprint.py write --input /tmp/graph.json
 ```
 
 Schema documented in [fingerprint-spec.md](references/fingerprint-spec.md). Fingerprint persists across sessions so `watch` mode can detect drift.
@@ -135,12 +135,12 @@ Schema documented in [fingerprint-spec.md](references/fingerprint-spec.md). Fing
 Run the HTML validator before presenting output:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate_html.py $CWD/.arch/<mode>-<timestamp>.html
+python3 ./scripts/validate_html.py $CWD/.arch/<mode>-<timestamp>.html
 ```
 
 Validator confirms: ARIA labels present, reduced-motion rule exists, no unexpected external script sources beyond Google Fonts. If validation fails, iterate on the template fill — don't ship an inaccessible diagram.
 
-Open the result via `${CLAUDE_SKILL_DIR}/scripts/open_in_browser.sh` (OS-aware: `xdg-open` on Linux, `open` on macOS, `wslview` on WSL). Echo the Mermaid equivalent to the chat as a copy-pasteable text block.
+Open the result via `./scripts/open_in_browser.sh` (OS-aware: `xdg-open` on Linux, `open` on macOS, `wslview` on WSL). Echo the Mermaid equivalent to the chat as a copy-pasteable text block.
 
 ### Feedback Loop
 

--- a/plugins/devops/jeremy-adk-terraform/package.json
+++ b/plugins/devops/jeremy-adk-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-adk-terraform",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
   "keywords": [
     "terraform",

--- a/plugins/devops/jeremy-adk-terraform/skills/adk-infra-expert/SKILL.md
+++ b/plugins/devops/jeremy-adk-terraform/skills/adk-infra-expert/SKILL.md
@@ -56,15 +56,15 @@ See Terraform implementation details for output format specifications.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 
 - Agent Engine: https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview
 - VPC-SC: https://cloud.google.com/vpc-service-controls/docs
 - Terraform Google Provider: https://registry.terraform.io/providers/hashicorp/google/latest
-- ADK Terraform examples in ${CLAUDE_SKILL_DIR}/examples/
+- ADK Terraform examples in ./examples/

--- a/plugins/devops/jeremy-genkit-terraform/package.json
+++ b/plugins/devops/jeremy-genkit-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-genkit-terraform",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
   "keywords": [
     "terraform",

--- a/plugins/devops/jeremy-genkit-terraform/skills/genkit-infra-expert/SKILL.md
+++ b/plugins/devops/jeremy-genkit-terraform/skills/genkit-infra-expert/SKILL.md
@@ -56,14 +56,14 @@ See Terraform implementation details for output format specifications.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 
 - Genkit Deployment:
 - Firebase Terraform: https://registry.terraform.io/providers/hashicorp/google/latest
-- Genkit examples in ${CLAUDE_SKILL_DIR}/genkit-examples/
+- Genkit examples in ./genkit-examples/

--- a/plugins/devops/jeremy-github-actions-gcp/package.json
+++ b/plugins/devops/jeremy-github-actions-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-github-actions-gcp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
   "keywords": [
     "github-actions",

--- a/plugins/devops/jeremy-github-actions-gcp/skills/gh-actions-validator/SKILL.md
+++ b/plugins/devops/jeremy-github-actions-gcp/skills/gh-actions-validator/SKILL.md
@@ -58,11 +58,11 @@ Before using this skill, ensure:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 
@@ -70,4 +70,4 @@ See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
 - GitHub OIDC: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments
 - Vertex AI Agent Engine: https://cloud.google.com/vertex-ai/docs/agent-engine
 - google-github-actions/auth: https://github.com/google-github-actions/auth
-- WIF setup guide in ${CLAUDE_SKILL_DIR}/docs/wif-setup.md
+- WIF setup guide in ./docs/wif-setup.md

--- a/plugins/devops/jeremy-vertex-terraform/package.json
+++ b/plugins/devops/jeremy-vertex-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-vertex-terraform",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Terraform configurations for Vertex AI platform and Agent Engine",
   "keywords": [
     "terraform",

--- a/plugins/devops/jeremy-vertex-terraform/skills/vertex-infra-expert/SKILL.md
+++ b/plugins/devops/jeremy-vertex-terraform/skills/vertex-infra-expert/SKILL.md
@@ -56,11 +56,11 @@ See Terraform implementation details for output format specifications.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 
@@ -68,4 +68,4 @@ See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
 - Vertex AI documentation: https://cloud.google.com/vertex-ai/docs
 - Model Garden: https://cloud.google.com/model-garden
 - Vector Search guide:
-- Terraform examples in ${CLAUDE_SKILL_DIR}/vertex-examples/
+- Terraform examples in ./vertex-examples/

--- a/plugins/devops/kubernetes-deployment-creator/package.json
+++ b/plugins/devops/kubernetes-deployment-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/kubernetes-deployment-creator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Create Kubernetes deployments, services, and configurations with best practices",
   "keywords": [
     "kubernetes",

--- a/plugins/devops/kubernetes-deployment-creator/skills/creating-kubernetes-deployments/SKILL.md
+++ b/plugins/devops/kubernetes-deployment-creator/skills/creating-kubernetes-deployments/SKILL.md
@@ -357,7 +357,7 @@ spec:
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive troubleshooting.
+See `./references/errors.md` for comprehensive troubleshooting.
 
 | Error | Quick Fix |
 |-------|-----------|
@@ -368,14 +368,14 @@ See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive troubleshooting
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed walkthroughs.
+See `./references/examples.md` for detailed walkthroughs.
 
 ## Resources
 
 - Kubernetes documentation: https://kubernetes.io/docs/
 - kubectl reference: https://kubernetes.io/docs/reference/kubectl/
-- Templates in `${CLAUDE_SKILL_DIR}/assets/`
-- Scripts in `${CLAUDE_SKILL_DIR}/scripts/`
+- Templates in `./assets/`
+- Scripts in `./scripts/`
 
 ## Overview
 

--- a/plugins/devops/load-balancer-configurator/package.json
+++ b/plugins/devops/load-balancer-configurator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/load-balancer-configurator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
   "keywords": [
     "load-balancer",

--- a/plugins/devops/load-balancer-configurator/skills/configuring-load-balancers/SKILL.md
+++ b/plugins/devops/load-balancer-configurator/skills/configuring-load-balancers/SKILL.md
@@ -72,4 +72,4 @@ Configure load balancers across AWS (ALB, NLB), GCP (HTTP(S) LB, TCP/UDP LB), Ng
 - HAProxy configuration: https://www.haproxy.org/download/2.8/doc/configuration.txt
 - AWS ALB: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/
 - GCP Load Balancing: https://cloud.google.com/load-balancing/docs
-- See `${CLAUDE_SKILL_DIR}/references/errors.md` for additional error handling patterns
+- See `./references/errors.md` for additional error handling patterns

--- a/plugins/devops/mattyp-changelog/package.json
+++ b/plugins/devops/mattyp-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/mattyp-changelog",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Automate changelog generation: fetch recent changes, synthesize release notes, run quality gates, and prepare a PR.",
   "keywords": [
     "changelog",

--- a/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/SKILL.md
+++ b/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/SKILL.md
@@ -30,38 +30,38 @@ This skill turns raw repo activity (merged PRs, issues, commits, optional Slack 
 ## Instructions
 
 1. Read `.changelog-config.json` from the repo root.
-2. Validate it with `${CLAUDE_SKILL_DIR}/scripts/validate_config.py`.
+2. Validate it with `./scripts/validate_config.py`.
 3. Decide date range:
-4. Load the configured markdown template (or fall back to `${CLAUDE_SKILL_DIR}/assets/weekly-template.md`).
-5. Render the final markdown using `${CLAUDE_SKILL_DIR}/scripts/render_template.py`.
+4. Load the configured markdown template (or fall back to `./assets/weekly-template.md`).
+5. Render the final markdown using `./scripts/render_template.py`.
 6. Ensure frontmatter contains at least `date` (ISO) and `version` (SemVer if known; otherwise `0.0.0`).
-7. Run deterministic checks using `${CLAUDE_SKILL_DIR}/scripts/quality_score.py`.
+7. Run deterministic checks using `./scripts/quality_score.py`.
 8. If score is below threshold:
 9. Write the changelog file to the configured `output_path`.
 10. Create a branch `changelog-YYYY-MM-DD`, commit with `docs: add changelog for YYYY-MM-DD`.
 11. If `gh` is configured, open a PR; otherwise, print the exact commands the user should run.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
 - A markdown changelog draft (usually `CHANGELOG.md`), plus an optional PR URL.
-- A quality report (score + findings) from `${CLAUDE_SKILL_DIR}/scripts/quality_score.py`.
+- A quality report (score + findings) from `./scripts/quality_score.py`.
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 
-- Validate config: `${CLAUDE_SKILL_DIR}/scripts/validate_config.py`
-- Render template: `${CLAUDE_SKILL_DIR}/scripts/render_template.py`
-- Quality scoring: `${CLAUDE_SKILL_DIR}/scripts/quality_score.py`
+- Validate config: `./scripts/validate_config.py`
+- Render template: `./scripts/render_template.py`
+- Quality scoring: `./scripts/quality_score.py`
 - Default templates:
-  - `${CLAUDE_SKILL_DIR}/assets/default-changelog.md`
-  - `${CLAUDE_SKILL_DIR}/assets/weekly-template.md`
-  - `${CLAUDE_SKILL_DIR}/assets/release-template.md`
+  - `./assets/default-changelog.md`
+  - `./assets/weekly-template.md`
+  - `./assets/release-template.md`

--- a/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/references/errors.md
+++ b/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/references/errors.md
@@ -2,7 +2,7 @@
 
 - Missing config: instruct the user to copy `${CLAUDE_PLUGIN_ROOT}/config/changelog-config.example.json` to `.changelog-config.json`.
 - Missing token env var: show which `token_env` is required and how to export it.
-- Missing template: fall back to `${CLAUDE_SKILL_DIR}/assets/default-changelog.md` and note it in output.
+- Missing template: fall back to `./assets/default-changelog.md` and note it in output.
 - No changes found: produce an empty changelog with a short “No user-visible changes” note.
 
 ---

--- a/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/references/implementation.md
+++ b/plugins/devops/mattyp-changelog/skills/changelog-orchestrator/references/implementation.md
@@ -3,7 +3,7 @@
 ### Phase 1: Initialize & Load Config
 
 1. Read `.changelog-config.json` from the repo root.
-2. Validate it with `${CLAUDE_SKILL_DIR}/scripts/validate_config.py`.
+2. Validate it with `./scripts/validate_config.py`.
 3. Decide date range:
    - Weekly mode: today minus 7 days → today
    - Custom mode: use provided `start_date`/`end_date`
@@ -28,13 +28,13 @@ Create a first draft that:
 
 ### Phase 4: Template Formatting + Frontmatter
 
-1. Load the configured markdown template (or fall back to `${CLAUDE_SKILL_DIR}/assets/weekly-template.md`).
-2. Render the final markdown using `${CLAUDE_SKILL_DIR}/scripts/render_template.py`.
+1. Load the configured markdown template (or fall back to `./assets/weekly-template.md`).
+2. Render the final markdown using `./scripts/render_template.py`.
 3. Ensure frontmatter contains at least `date` (ISO) and `version` (SemVer if known; otherwise `0.0.0`).
 
 ### Phase 5: Quality Gate (Deterministic + Editorial)
 
-1. Run deterministic checks using `${CLAUDE_SKILL_DIR}/scripts/quality_score.py`.
+1. Run deterministic checks using `./scripts/quality_score.py`.
 2. If score is below threshold:
    - Fix structural issues first (missing sections, broken links, invalid frontmatter)
    - Rewrite only the weakest sections (max 2 iterations)

--- a/plugins/examples/formatter/package.json
+++ b/plugins/examples/formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/formatter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Comprehensive code formatting plugin with Prettier integration. Use when you need to format code, validate formatting, or maintain consistent code style. Activates with phrases like 'format my code', ",
   "keywords": [
     "formatting",

--- a/plugins/examples/formatter/skills/code-formatter/SKILL.md
+++ b/plugins/examples/formatter/skills/code-formatter/SKILL.md
@@ -37,7 +37,7 @@ Formats and validates code files using Prettier and related formatting tools. Su
 ## Instructions
 
 1. Check whether Prettier is available by running `npx prettier --version`. If missing, install it locally with `npm install --save-dev prettier` or globally with `npm install -g prettier`.
-2. Detect existing configuration by searching for `.prettierrc`, `.prettierrc.json`, `prettier.config.js`, or a `"prettier"` key in `package.json`. If no configuration exists, create a `.prettierrc` with sensible defaults (see `${CLAUDE_SKILL_DIR}/references/implementation.md`).
+2. Detect existing configuration by searching for `.prettierrc`, `.prettierrc.json`, `prettier.config.js`, or a `"prettier"` key in `package.json`. If no configuration exists, create a `.prettierrc` with sensible defaults (see `./references/implementation.md`).
 3. Run `npx prettier --check "**/*.{js,jsx,ts,tsx,json,css,md}" --ignore-path .prettierignore` to identify files that need formatting. Report the count and list of non-conforming files.
 4. Apply formatting to identified files using `npx prettier --write` on the target paths. For single files, specify the exact path; for directories, use glob patterns.
 5. Create or update `.prettierignore` to exclude generated outputs (`dist/`, `build/`, `*.min.js`, `*.min.css`), dependencies (`node_modules/`, `vendor/`), and lock files.
@@ -80,8 +80,8 @@ Process: Run `npx prettier --check "**/*.{js,jsx,ts,tsx,json,css,md}"`. Report n
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/implementation.md` -- detailed implementation guide with configuration examples
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- common error scenarios and solutions
+- `./references/implementation.md` -- detailed implementation guide with configuration examples
+- `./references/errors.md` -- common error scenarios and solutions
 - [Prettier documentation](https://prettier.io/docs/en/) -- official configuration and CLI reference
 - [ESLint](https://eslint.org/) -- complementary linting and code quality tool
 - [Husky](https://typicode.github.io/husky/) -- git hooks for pre-commit formatting enforcement

--- a/plugins/examples/jeremy-plugin-tool/commands/create-plugin.md
+++ b/plugins/examples/jeremy-plugin-tool/commands/create-plugin.md
@@ -183,7 +183,7 @@ Result: [expected output]
 
 ## Resources
 
-- ${CLAUDE_SKILL_DIR}/references/[reference-file.md] - [Description]
+- ./references/[reference-file.md] - [Description]
 - External link: [Resource name]
 ```
 
@@ -192,7 +192,7 @@ Result: [expected output]
 After creating all files, run:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/skills/plugin-validator/scripts/validate_plugin_nixtla.py plugins/[category]/[plugin-name]/
+python3 ./skills/plugin-validator/scripts/validate_plugin_nixtla.py plugins/[category]/[plugin-name]/
 ```
 
 **Requirements for passing validation:**

--- a/plugins/examples/jeremy-plugin-tool/package.json
+++ b/plugins/examples/jeremy-plugin-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/jeremy-plugin-tool",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Ultimate plugin management toolkit with 4 auto-invoked Skills for creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
   "keywords": [
     "skills",

--- a/plugins/examples/jeremy-plugin-tool/skills/plugin-auditor/SKILL.md
+++ b/plugins/examples/jeremy-plugin-tool/skills/plugin-auditor/SKILL.md
@@ -34,11 +34,11 @@ Audits Claude Code plugins for security vulnerabilities, best practices complian
 ## Instructions
 
 1. Identify the target plugin path (e.g., `plugins/security/plugin-name/`). Confirm the directory exists and contains `.claude-plugin/plugin.json`.
-2. Run a security scan across all plugin files (see `${CLAUDE_SKILL_DIR}/references/audit-categories.md` for full pattern list):
+2. Run a security scan across all plugin files (see `./references/audit-categories.md` for full pattern list):
    - Search for hardcoded secrets, API keys, AWS access keys (`AKIA...`), and private key headers.
    - Detect dangerous commands (`rm -rf /`, `eval()`, `exec()`) and command injection vectors.
    - Flag suspicious URLs (non-HTTPS, raw IP addresses) and obfuscated code (base64 decode, hex encoding).
-3. Validate plugin structure and best practices (see `${CLAUDE_SKILL_DIR}/references/audit-process.md`):
+3. Validate plugin structure and best practices (see `./references/audit-process.md`):
    - Confirm required files exist: `plugin.json`, `README.md`, `LICENSE`.
    - Verify semantic versioning format in `plugin.json`.
    - Check that all `.sh` scripts have execute permissions.
@@ -52,7 +52,7 @@ Audits Claude Code plugins for security vulnerabilities, best practices complian
    - Check for duplicate plugin names in the catalog.
 6. Assess git hygiene: no committed `node_modules/`, `.env` files, large binaries, or merge conflict markers.
 7. For MCP plugins: validate `package.json` dependencies, TypeScript configuration, `dist/` in `.gitignore`, and build scripts.
-8. Generate a scored audit report following the format in `${CLAUDE_SKILL_DIR}/references/audit-report-format.md`, with per-category scores out of 10 and an overall quality rating.
+8. Generate a scored audit report following the format in `./references/audit-report-format.md`, with per-category scores out of 10 and an overall quality rating.
 
 ## Output
 
@@ -78,7 +78,7 @@ A structured audit report containing:
 
 **Full audit before publishing:**
 Trigger: "Audit the security-scanner plugin."
-Process: Run all eight audit categories against `plugins/security/security-scanner/`. Generate a comprehensive report with per-category scores. Report overall rating and prioritized fix list (see `${CLAUDE_SKILL_DIR}/references/examples.md`).
+Process: Run all eight audit categories against `plugins/security/security-scanner/`. Generate a comprehensive report with per-category scores. Report overall rating and prioritized fix list (see `./references/examples.md`).
 
 **Publish readiness check:**
 Trigger: "Is this plugin safe to publish?"
@@ -90,8 +90,8 @@ Process: Run full audit with elevated quality thresholds. Apply featured plugin 
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/audit-categories.md` -- all eight audit categories with specific checks
-- `${CLAUDE_SKILL_DIR}/references/audit-process.md` -- step-by-step audit execution procedures
-- `${CLAUDE_SKILL_DIR}/references/audit-report-format.md` -- report template with scoring rubric
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- audit scenario walkthroughs
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- error handling patterns
+- `./references/audit-categories.md` -- all eight audit categories with specific checks
+- `./references/audit-process.md` -- step-by-step audit execution procedures
+- `./references/audit-report-format.md` -- report template with scoring rubric
+- `./references/examples.md` -- audit scenario walkthroughs
+- `./references/errors.md` -- error handling patterns

--- a/plugins/examples/jeremy-plugin-tool/skills/plugin-auditor/references/audit-categories.md
+++ b/plugins/examples/jeremy-plugin-tool/skills/plugin-auditor/references/audit-categories.md
@@ -29,7 +29,7 @@ grep -r "AKIA[0-9A-Z]{16}" --exclude=README.md
 grep -r "BEGIN.*PRIVATE KEY" --exclude=README.md
 
 # Check for dangerous patterns
-grep -r "rm -rf /" | grep -v "/var/" | grep -v "${CLAUDE_SKILL_DIR}/tmp/"
+grep -r "rm -rf /" | grep -v "/var/" | grep -v "./tmp/"
 grep -r "eval\s*\(" --exclude=README.md
 ```
 

--- a/plugins/examples/jeremy-plugin-tool/skills/plugin-creator/SKILL.md
+++ b/plugins/examples/jeremy-plugin-tool/skills/plugin-creator/SKILL.md
@@ -32,7 +32,7 @@ Scaffolds new Claude Code plugins with proper directory structure, required file
 
 ## Instructions
 
-1. Gather requirements from the user request: plugin name (kebab-case), category (`productivity`, `security`, `devops`, `testing`, etc.), plugin type (commands, agents, skills, MCP, or combination), description, and keywords. Default author to the repository owner if unspecified (see `${CLAUDE_SKILL_DIR}/references/plugin-creation-process.md`).
+1. Gather requirements from the user request: plugin name (kebab-case), category (`productivity`, `security`, `devops`, `testing`, etc.), plugin type (commands, agents, skills, MCP, or combination), description, and keywords. Default author to the repository owner if unspecified (see `./references/plugin-creation-process.md`).
 2. Create the plugin directory structure under `plugins/[category]/[plugin-name]/`:
 
    ```
@@ -44,7 +44,7 @@ Scaffolds new Claude Code plugins with proper directory structure, required file
    └── [commands/ | agents/ | skills/ | hooks/ | mcp/]
    ```
 
-3. Generate `.claude-plugin/plugin.json` using the template from `${CLAUDE_SKILL_DIR}/references/file-templates.md`. Populate all required fields: `name`, `version` (default `1.0.0`), `description`, `author` (name and email), `repository`, `license` (default MIT), and `keywords` (minimum 2).
+3. Generate `.claude-plugin/plugin.json` using the template from `./references/file-templates.md`. Populate all required fields: `name`, `version` (default `1.0.0`), `description`, `author` (name and email), `repository`, `license` (default MIT), and `keywords` (minimum 2).
 4. Generate `README.md` with installation instructions, usage examples, a description section, and contributor information.
 5. Create a `LICENSE` file with MIT license text (or the specified license).
 6. Generate component files based on the plugin type:
@@ -80,7 +80,7 @@ A complete, CI-ready plugin containing:
 
 **Create a command plugin:**
 Trigger: "Create a new security plugin called 'owasp-scanner' with commands."
-Process: Create `plugins/security/owasp-scanner/` directory, generate `plugin.json`, `README.md`, `LICENSE`, and `commands/scan.md` with proper frontmatter. Add to marketplace, sync, validate (see `${CLAUDE_SKILL_DIR}/references/examples.md`).
+Process: Create `plugins/security/owasp-scanner/` directory, generate `plugin.json`, `README.md`, `LICENSE`, and `commands/scan.md` with proper frontmatter. Add to marketplace, sync, validate (see `./references/examples.md`).
 
 **Scaffold a skills plugin:**
 Trigger: "Scaffold a skills plugin for code review."
@@ -92,7 +92,7 @@ Process: Create `plugins/mcp/db-query/` with `package.json` (including `@modelco
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/plugin-creation-process.md` -- detailed creation workflow
-- `${CLAUDE_SKILL_DIR}/references/file-templates.md` -- templates for `plugin.json`, commands, agents, and skills
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- creation scenario walkthroughs
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- error handling patterns
+- `./references/plugin-creation-process.md` -- detailed creation workflow
+- `./references/file-templates.md` -- templates for `plugin.json`, commands, agents, and skills
+- `./references/examples.md` -- creation scenario walkthroughs
+- `./references/errors.md` -- error handling patterns

--- a/plugins/examples/jeremy-plugin-tool/skills/plugin-validator/SKILL.md
+++ b/plugins/examples/jeremy-plugin-tool/skills/plugin-validator/SKILL.md
@@ -33,7 +33,7 @@ Validates Claude Code plugin structure, JSON schemas, frontmatter format, securi
 ## Instructions
 
 1. Identify the target plugin path from context or user request. Default to the current working directory if the path contains a `.claude-plugin/` subdirectory.
-2. Validate required files exist (see `${CLAUDE_SKILL_DIR}/references/validation-checks.md`):
+2. Validate required files exist (see `./references/validation-checks.md`):
    - `.claude-plugin/plugin.json` present and valid JSON.
    - `README.md` present and non-empty.
    - `LICENSE` file present.
@@ -45,7 +45,7 @@ Validates Claude Code plugin structure, JSON schemas, frontmatter format, securi
    - **Commands** (`commands/*.md`): require `name`, `description`, `model` (one of `sonnet`, `opus`, `haiku`).
    - **Agents** (`agents/*.md`): require `name`, `description`, `model`.
    - **Skills** (`skills/*/SKILL.md`): require `name`, `description`; `allowed-tools` optional but validated against the allowed tools list if present.
-5. Validate directory structure matches the expected hierarchy (see `${CLAUDE_SKILL_DIR}/references/validation-checks.md` for the complete structure diagram).
+5. Validate directory structure matches the expected hierarchy (see `./references/validation-checks.md` for the complete structure diagram).
 6. Check script permissions: find all `.sh` files and verify they have execute permission. Report any that lack it with a fix command.
 7. Run security scans: search for hardcoded secrets, AWS keys, private keys, dangerous commands, and suspicious URLs.
 8. Validate marketplace compliance:
@@ -54,7 +54,7 @@ Validates Claude Code plugin structure, JSON schemas, frontmatter format, securi
    - Check for duplicate plugin names.
 9. Validate README content: confirm it contains installation, usage, and description sections.
 10. Check hook path variables: verify hooks use `${CLAUDE_PLUGIN_ROOT}` instead of hardcoded absolute paths (`/home/`, `/Users/`).
-11. Compile results into a validation report following the format in `${CLAUDE_SKILL_DIR}/references/validation-report-format.md`.
+11. Compile results into a validation report following the format in `./references/validation-report-format.md`.
 
 ## Output
 
@@ -81,7 +81,7 @@ A structured validation report containing:
 
 **Validate a specific plugin:**
 Trigger: "Validate the skills-powerkit plugin."
-Process: Run all 10 validation checks against `plugins/community/skills-powerkit/`. Identify 2 failures (script permissions, version mismatch). Provide fix commands: `chmod +x scripts/*.sh` and version update instruction. Report overall: FAILED (see `${CLAUDE_SKILL_DIR}/references/examples.md`).
+Process: Run all 10 validation checks against `plugins/community/skills-powerkit/`. Identify 2 failures (script permissions, version mismatch). Provide fix commands: `chmod +x scripts/*.sh` and version update instruction. Report overall: FAILED (see `./references/examples.md`).
 
 **Pre-commit readiness check:**
 Trigger: "Check if my plugin is ready to commit."
@@ -93,7 +93,7 @@ Process: Run the same validation checks that CI executes (`validate-all-plugins.
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/validation-checks.md` -- complete list of all 10 validation categories with specific checks
-- `${CLAUDE_SKILL_DIR}/references/validation-report-format.md` -- report template with pass/fail formatting
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- validation scenario walkthroughs
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- error handling patterns
+- `./references/validation-checks.md` -- complete list of all 10 validation categories with specific checks
+- `./references/validation-report-format.md` -- report template with pass/fail formatting
+- `./references/examples.md` -- validation scenario walkthroughs
+- `./references/errors.md` -- error handling patterns

--- a/plugins/examples/jeremy-plugin-tool/skills/version-bumper/SKILL.md
+++ b/plugins/examples/jeremy-plugin-tool/skills/version-bumper/SKILL.md
@@ -32,12 +32,12 @@ Automates semantic version bumps across all version-bearing files in a Claude Co
 
 1. Identify the target plugin directory and read the current version from `.claude-plugin/plugin.json` using `jq -r '.version'`.
 2. Determine the bump type (major, minor, or patch) from the user request. If unspecified, infer from the nature of changes: breaking changes warrant major, new features warrant minor, and fixes warrant patch.
-3. Parse the current version into its `major.minor.patch` components and compute the new version according to semver rules (see `${CLAUDE_SKILL_DIR}/references/version-bump-process.md`).
+3. Parse the current version into its `major.minor.patch` components and compute the new version according to semver rules (see `./references/version-bump-process.md`).
 4. Update the `"version"` field in `.claude-plugin/plugin.json` with the new version string.
-5. Locate the plugin entry in `.claude-plugin/marketplace.extended.json` and update its `"version"` field to match (see `${CLAUDE_SKILL_DIR}/references/update-locations.md`).
+5. Locate the plugin entry in `.claude-plugin/marketplace.extended.json` and update its `"version"` field to match (see `./references/update-locations.md`).
 6. Run `pnpm run sync-marketplace` at the repository root to regenerate `marketplace.json`.
 7. Verify version consistency across all three files by reading each and confirming the version strings match.
-8. Optionally create a git tag (`git tag -a "v<new_version>" -m "Release v<new_version>"`) and prepare a commit message following the `chore: Release v<version>` convention (see `${CLAUDE_SKILL_DIR}/references/release-workflow.md`).
+8. Optionally create a git tag (`git tag -a "v<new_version>" -m "Release v<new_version>"`) and prepare a commit message following the `chore: Release v<version>` convention (see `./references/release-workflow.md`).
 
 ## Output
 
@@ -74,8 +74,8 @@ Process: Detect minor bump, compute 1.2.3 to 1.3.0, update all version locations
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/version-bump-process.md` -- step-by-step bump algorithm
-- `${CLAUDE_SKILL_DIR}/references/update-locations.md` -- all files requiring version updates
-- `${CLAUDE_SKILL_DIR}/references/release-workflow.md` -- full release process including git tags
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage scenarios
+- `./references/version-bump-process.md` -- step-by-step bump algorithm
+- `./references/update-locations.md` -- all files requiring version updates
+- `./references/release-workflow.md` -- full release process including git tags
+- `./references/examples.md` -- additional usage scenarios
 - [Semantic Versioning specification](https://semver.org/)

--- a/plugins/examples/pi-pathfinder/package.json
+++ b/plugins/examples/pi-pathfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/pi-pathfinder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does.",
   "keywords": [
     "agent-skills",

--- a/plugins/examples/pi-pathfinder/skills/skill-adapter/SKILL.md
+++ b/plugins/examples/pi-pathfinder/skills/skill-adapter/SKILL.md
@@ -30,7 +30,7 @@ Analyzes existing plugins in the repository to extract their capabilities, then 
 
 ## Instructions
 
-1. Analyze the user's task to identify the core capability needed, the domain (security, devops, testing, documentation, etc.), and key requirements or constraints (see `${CLAUDE_SKILL_DIR}/references/how-it-works.md`).
+1. Analyze the user's task to identify the core capability needed, the domain (security, devops, testing, documentation, etc.), and key requirements or constraints (see `./references/how-it-works.md`).
 2. Search existing plugins for relevant capabilities using file globbing across `plugins/community/`, `plugins/packages/`, and `plugins/examples/` directories. Match on `plugin.json` descriptions and keyword fields.
 3. For each relevant plugin discovered, extract capabilities from its components:
    - **Commands** (`commands/*.md`): read content, extract approach and input/output patterns.
@@ -63,7 +63,7 @@ A structured adaptation report containing:
 
 **Learning code analysis from security plugins:**
 Task: "Analyze this codebase for issues."
-Process: Discover `owasp-top-10-scanner`, `code-quality-enforcer`, and `security-audit-agent`. Extract OWASP vulnerability checks, complexity/duplication metrics, and dependency scanning patterns. Synthesize a multi-layer analysis covering security, quality, and dependencies. Apply to the target codebase (see `${CLAUDE_SKILL_DIR}/references/example-workflows.md`).
+Process: Discover `owasp-top-10-scanner`, `code-quality-enforcer`, and `security-audit-agent`. Extract OWASP vulnerability checks, complexity/duplication metrics, and dependency scanning patterns. Synthesize a multi-layer analysis covering security, quality, and dependencies. Apply to the target codebase (see `./references/example-workflows.md`).
 
 **Adopting documentation skills:**
 Task: "Generate API documentation."
@@ -75,6 +75,6 @@ Process: Search DevOps category for deployment, CI/CD, and Docker plugins. Extra
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/how-it-works.md` -- detailed five-phase adaptation process
-- `${CLAUDE_SKILL_DIR}/references/example-workflows.md` -- end-to-end workflow examples
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- error handling patterns
+- `./references/how-it-works.md` -- detailed five-phase adaptation process
+- `./references/example-workflows.md` -- end-to-end workflow examples
+- `./references/errors.md` -- error handling patterns

--- a/plugins/examples/security-agent/package.json
+++ b/plugins/examples/security-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/security-agent",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Specialized security review subagent",
   "keywords": [
     "security",

--- a/plugins/examples/security-agent/skills/performing-security-code-review/SKILL.md
+++ b/plugins/examples/security-agent/skills/performing-security-code-review/SKILL.md
@@ -91,4 +91,4 @@ Process: Execute all seven scan categories (secrets, injection, auth, dependenci
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/) -- industry-standard vulnerability classification
 - [Node.js Security Checklist](https://blog.risingstack.com/node-js-security-checklist/) -- Node-specific security guidance
 - [CWE/SANS Top 25](https://cwe.mitre.org/top25/) -- most dangerous software weaknesses
-- `${CLAUDE_SKILL_DIR}/references/README.md` -- bundled reference materials
+- `./references/README.md` -- bundled reference materials

--- a/plugins/mcp/x-bug-triage/skills/x-bug-triage/SKILL.md
+++ b/plugins/mcp/x-bug-triage/skills/x-bug-triage/SKILL.md
@@ -92,7 +92,7 @@ Assign evidence tiers (1-4) per [evidence-policy.md](references/evidence-policy.
 
 Load evidence tier definitions:
 ```
-!cat ${CLAUDE_SKILL_DIR}/references/evidence-policy.md
+!cat ./references/evidence-policy.md
 ```
 
 ### Step 6: Route Ownership
@@ -109,7 +109,7 @@ Apply routing overrides from prior runs. Flag stale signals (>30 days).
 
 Load routing precedence rules:
 ```
-!cat ${CLAUDE_SKILL_DIR}/references/routing-rules.md
+!cat ./references/routing-rules.md
 ```
 
 ### Step 7: Evaluate Severity + Escalation
@@ -121,7 +121,7 @@ Compute severity (low/medium/high/critical) based on:
 
 Load escalation trigger definitions:
 ```
-!cat ${CLAUDE_SKILL_DIR}/references/escalation-rules.md
+!cat ./references/escalation-rules.md
 ```
 
 ### Step 8: Display Results
@@ -158,7 +158,7 @@ After each command executes successfully, display the confirmation message from 
 
 Load override and memory policy when processing review commands:
 ```
-!cat ${CLAUDE_SKILL_DIR}/references/review-memory-policy.md
+!cat ./references/review-memory-policy.md
 ```
 
 ### Step 11: Persist Learning
@@ -198,7 +198,7 @@ Produces cluster summary, then user interacts:
 
 ## Resources
 
-**References:** `${CLAUDE_SKILL_DIR}/references/`
+**References:** `./references/`
 
 - [schemas.md](references/schemas.md) — Data model reference (BugCandidate, BugCluster, 9 DB tables)
 - [routing-rules.md](references/routing-rules.md) — 6-level routing precedence

--- a/plugins/performance/error-rate-monitor/package.json
+++ b/plugins/performance/error-rate-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/error-rate-monitor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Monitor and analyze application error rates",
   "keywords": [
     "errors",

--- a/plugins/performance/error-rate-monitor/skills/monitoring-error-rates/SKILL.md
+++ b/plugins/performance/error-rate-monitor/skills/monitoring-error-rates/SKILL.md
@@ -71,7 +71,7 @@ This skill can be integrated with other monitoring and alerting tools, such as P
 
 - Access to application logs and metrics
 - Monitoring infrastructure (Prometheus, Grafana, or similar)
-- Read permissions for log files in ${CLAUDE_SKILL_DIR}/logs/
+- Read permissions for log files in ./logs/
 - Network access to monitoring endpoints
 
 ## Instructions

--- a/plugins/performance/infrastructure-metrics-collector/package.json
+++ b/plugins/performance/infrastructure-metrics-collector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/infrastructure-metrics-collector",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Collect comprehensive infrastructure performance metrics",
   "keywords": [
     "infrastructure",

--- a/plugins/performance/infrastructure-metrics-collector/skills/collecting-infrastructure-metrics/SKILL.md
+++ b/plugins/performance/infrastructure-metrics-collector/skills/collecting-infrastructure-metrics/SKILL.md
@@ -74,7 +74,7 @@ This skill can be integrated with other plugins for deployment, configuration ma
 - Access to infrastructure monitoring systems (Prometheus, Datadog, CloudWatch)
 - System permissions for metrics agent installation
 - Network access to monitored infrastructure components
-- Storage for metrics data in ${CLAUDE_SKILL_DIR}/metrics/
+- Storage for metrics data in ./metrics/
 
 ## Instructions
 

--- a/plugins/performance/load-test-runner/package.json
+++ b/plugins/performance/load-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/load-test-runner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Create and execute load tests for performance validation",
   "keywords": [
     "load-testing",

--- a/plugins/performance/load-test-runner/skills/running-load-tests/SKILL.md
+++ b/plugins/performance/load-test-runner/skills/running-load-tests/SKILL.md
@@ -73,7 +73,7 @@ This skill can be integrated with CI/CD pipelines to automate performance testin
 - Load testing tools installed (k6, JMeter, or Artillery)
 - Access to target application endpoints
 - Test scenario definitions and expected load patterns
-- Results storage location at ${CLAUDE_SKILL_DIR}/load-tests/
+- Results storage location at ./load-tests/
 
 ## Instructions
 

--- a/plugins/performance/log-analysis-tool/package.json
+++ b/plugins/performance/log-analysis-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/log-analysis-tool",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Analyze logs for performance insights and issues",
   "keywords": [
     "logs",

--- a/plugins/performance/log-analysis-tool/skills/analyzing-logs/SKILL.md
+++ b/plugins/performance/log-analysis-tool/skills/analyzing-logs/SKILL.md
@@ -72,7 +72,7 @@ This skill can be integrated with other tools for monitoring and alerting. For e
 
 ## Prerequisites
 
-- Access to application log files in ${CLAUDE_SKILL_DIR}/logs/
+- Access to application log files in ./logs/
 - Log parsing tools (grep, awk, sed)
 - Understanding of application log format and structure
 - Read permissions for log directories

--- a/plugins/performance/memory-leak-detector/package.json
+++ b/plugins/performance/memory-leak-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/memory-leak-detector",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Detect memory leaks and analyze memory usage patterns",
   "keywords": [
     "memory",

--- a/plugins/performance/memory-leak-detector/skills/detecting-memory-leaks/SKILL.md
+++ b/plugins/performance/memory-leak-detector/skills/detecting-memory-leaks/SKILL.md
@@ -67,7 +67,7 @@ This skill can be used in conjunction with other performance analysis tools to p
 
 ## Prerequisites
 
-- Access to application source code in ${CLAUDE_SKILL_DIR}/
+- Access to application source code in ./
 - Memory profiling tools (valgrind, heapdump, etc.)
 - Understanding of application memory architecture
 - Runtime environment for testing

--- a/plugins/performance/metrics-aggregator/package.json
+++ b/plugins/performance/metrics-aggregator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/metrics-aggregator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Aggregate and centralize performance metrics",
   "keywords": [
     "metrics",

--- a/plugins/performance/metrics-aggregator/skills/aggregating-performance-metrics/SKILL.md
+++ b/plugins/performance/metrics-aggregator/skills/aggregating-performance-metrics/SKILL.md
@@ -74,7 +74,7 @@ This skill integrates with other plugins that manage infrastructure, deploy appl
 
 - Access to metrics collection tools (Prometheus, StatsD, CloudWatch)
 - Network connectivity to metric sources
-- Metrics storage configuration in ${CLAUDE_SKILL_DIR}/metrics/
+- Metrics storage configuration in ./metrics/
 - Understanding of metrics taxonomy
 
 ## Instructions

--- a/plugins/performance/performance-budget-validator/package.json
+++ b/plugins/performance/performance-budget-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/performance-budget-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validate application against performance budgets",
   "keywords": [
     "performance-budget",

--- a/plugins/performance/performance-budget-validator/skills/validating-performance-budgets/SKILL.md
+++ b/plugins/performance/performance-budget-validator/skills/validating-performance-budgets/SKILL.md
@@ -71,7 +71,7 @@ This skill can be integrated with other plugins that provide performance metrics
 
 ## Prerequisites
 
-- Performance budget definitions in ${CLAUDE_SKILL_DIR}/performance-budgets.json
+- Performance budget definitions in ./performance-budgets.json
 - Access to performance testing tools (Lighthouse, WebPageTest)
 - Build output directory for bundle analysis
 - Historical performance metrics for comparison

--- a/plugins/performance/performance-optimization-advisor/package.json
+++ b/plugins/performance/performance-optimization-advisor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/performance-optimization-advisor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Get comprehensive performance optimization recommendations",
   "keywords": [
     "optimization",

--- a/plugins/performance/performance-optimization-advisor/skills/providing-performance-optimization-advice/SKILL.md
+++ b/plugins/performance/performance-optimization-advisor/skills/providing-performance-optimization-advice/SKILL.md
@@ -72,7 +72,7 @@ This skill integrates well with other plugins that provide code analysis, infras
 
 ## Prerequisites
 
-- Access to application codebase in ${CLAUDE_SKILL_DIR}/
+- Access to application codebase in ./
 - Infrastructure configuration files
 - Performance profiling tools
 - Current performance metrics and baselines

--- a/plugins/performance/performance-regression-detector/package.json
+++ b/plugins/performance/performance-regression-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/performance-regression-detector",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Detect performance regressions in CI/CD pipeline",
   "keywords": [
     "regression",

--- a/plugins/performance/performance-regression-detector/skills/detecting-performance-regressions/SKILL.md
+++ b/plugins/performance/performance-regression-detector/skills/detecting-performance-regressions/SKILL.md
@@ -70,7 +70,7 @@ This skill can be integrated with other CI/CD tools to automatically trigger reg
 
 ## Prerequisites
 
-- Historical performance baselines in ${CLAUDE_SKILL_DIR}/performance/baselines/
+- Historical performance baselines in ./performance/baselines/
 - Access to CI/CD performance metrics
 - Statistical analysis tools
 - Defined regression thresholds

--- a/plugins/performance/real-user-monitoring/package.json
+++ b/plugins/performance/real-user-monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/real-user-monitoring",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Implement Real User Monitoring for actual performance data",
   "keywords": [
     "rum",

--- a/plugins/performance/real-user-monitoring/skills/implementing-real-user-monitoring/SKILL.md
+++ b/plugins/performance/real-user-monitoring/skills/implementing-real-user-monitoring/SKILL.md
@@ -68,7 +68,7 @@ This skill can be used in conjunction with other monitoring and analytics tools 
 
 ## Prerequisites
 
-- Access to web application frontend code in ${CLAUDE_SKILL_DIR}/
+- Access to web application frontend code in ./
 - RUM platform account (Google Analytics, Datadog, New Relic)
 - Understanding of Core Web Vitals metrics
 - Privacy compliance documentation (GDPR, CCPA)

--- a/plugins/performance/resource-usage-tracker/package.json
+++ b/plugins/performance/resource-usage-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/resource-usage-tracker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track and optimize resource usage across the stack",
   "keywords": [
     "resources",

--- a/plugins/performance/resource-usage-tracker/skills/tracking-resource-usage/SKILL.md
+++ b/plugins/performance/resource-usage-tracker/skills/tracking-resource-usage/SKILL.md
@@ -76,7 +76,7 @@ This skill can be integrated with other monitoring and alerting tools to provide
 
 - Access to system monitoring tools (top, ps, vmstat, iostat)
 - Resource metrics collection infrastructure
-- Historical usage data in ${CLAUDE_SKILL_DIR}/metrics/resources/
+- Historical usage data in ./metrics/resources/
 - Performance baseline definitions
 
 ## Instructions

--- a/plugins/performance/response-time-tracker/package.json
+++ b/plugins/performance/response-time-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/response-time-tracker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track and optimize application response times",
   "keywords": [
     "response-time",

--- a/plugins/performance/response-time-tracker/skills/tracking-application-response-times/SKILL.md
+++ b/plugins/performance/response-time-tracker/skills/tracking-application-response-times/SKILL.md
@@ -70,7 +70,7 @@ This skill can be integrated with other monitoring and alerting tools to provide
 ## Prerequisites
 
 - Access to application monitoring infrastructure
-- Response time data collection in ${CLAUDE_SKILL_DIR}/metrics/response-times/
+- Response time data collection in ./metrics/response-times/
 - APM tools or custom instrumentation
 - Performance SLO definitions
 

--- a/plugins/performance/sla-sli-tracker/package.json
+++ b/plugins/performance/sla-sli-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/sla-sli-tracker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track SLAs, SLIs, and SLOs for service reliability",
   "keywords": [
     "sla",

--- a/plugins/performance/sla-sli-tracker/skills/tracking-service-reliability/SKILL.md
+++ b/plugins/performance/sla-sli-tracker/skills/tracking-service-reliability/SKILL.md
@@ -68,7 +68,7 @@ This skill can be integrated with monitoring tools to automatically collect SLI 
 
 ## Prerequisites
 
-- SLI definitions stored in ${CLAUDE_SKILL_DIR}/slos/sli-definitions.yaml
+- SLI definitions stored in ./slos/sli-definitions.yaml
 - Access to monitoring and metrics systems
 - Historical performance data for baseline
 - Business requirements for service reliability

--- a/plugins/performance/synthetic-monitoring-setup/package.json
+++ b/plugins/performance/synthetic-monitoring-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/synthetic-monitoring-setup",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Set up synthetic monitoring for proactive performance tracking",
   "keywords": [
     "synthetic-monitoring",

--- a/plugins/performance/synthetic-monitoring-setup/skills/setting-up-synthetic-monitoring/SKILL.md
+++ b/plugins/performance/synthetic-monitoring-setup/skills/setting-up-synthetic-monitoring/SKILL.md
@@ -69,7 +69,7 @@ This skill can be integrated with other plugins for incident management and aler
 ## Prerequisites
 
 - Access to synthetic monitoring platform (Pingdom, Datadog, New Relic)
-- List of critical endpoints and user journeys in ${CLAUDE_SKILL_DIR}/monitoring/endpoints.yaml
+- List of critical endpoints and user journeys in ./monitoring/endpoints.yaml
 - Alerting infrastructure configuration
 - Geographic monitoring location requirements
 

--- a/plugins/performance/throughput-analyzer/package.json
+++ b/plugins/performance/throughput-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/throughput-analyzer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Analyze and optimize system throughput",
   "keywords": [
     "throughput",

--- a/plugins/performance/throughput-analyzer/skills/analyzing-system-throughput/SKILL.md
+++ b/plugins/performance/throughput-analyzer/skills/analyzing-system-throughput/SKILL.md
@@ -71,7 +71,7 @@ This skill can be used in conjunction with other monitoring and performance anal
 
 ## Prerequisites
 
-- Access to throughput metrics in ${CLAUDE_SKILL_DIR}/metrics/throughput/
+- Access to throughput metrics in ./metrics/throughput/
 - System performance monitoring tools
 - Historical throughput baselines
 - Current capacity and scaling limits

--- a/plugins/productivity/000-jeremy-content-consistency-validator/package.json
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Read-only validator that generates comprehensive discrepancy reports comparing messaging consistency across ANY HTML-based website (WordPress, Hugo, Next.js, React, Vue, static HTML, etc.), GitHub rep",
   "keywords": [
     "documentation",

--- a/plugins/productivity/000-jeremy-content-consistency-validator/skills/000-jeremy-content-consistency-validator/SKILL.md
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/skills/000-jeremy-content-consistency-validator/SKILL.md
@@ -109,6 +109,6 @@ The skill produces a timestamped Markdown report saved to `consistency-reports/Y
 
 ## Resources
 
-- Content source discovery logic: `${CLAUDE_SKILL_DIR}/references/how-it-works.md`
-- Trust priority and validation timing: `${CLAUDE_SKILL_DIR}/references/best-practices.md`
-- Use-case walkthroughs: `${CLAUDE_SKILL_DIR}/references/example-use-cases.md`
+- Content source discovery logic: `./references/how-it-works.md`
+- Trust priority and validation timing: `./references/best-practices.md`
+- Use-case walkthroughs: `./references/example-use-cases.md`

--- a/plugins/productivity/002-jeremy-yaml-master-agent/package.json
+++ b/plugins/productivity/002-jeremy-yaml-master-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/002-jeremy-yaml-master-agent",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
   "keywords": [
     "yaml",

--- a/plugins/productivity/002-jeremy-yaml-master-agent/skills/yaml-master/SKILL.md
+++ b/plugins/productivity/002-jeremy-yaml-master-agent/skills/yaml-master/SKILL.md
@@ -63,6 +63,6 @@ This skill activates when working with `.yml`/`.yaml` files to detect structural
 
 ## Resources
 
-- Full detailed guide (kept for reference): `${CLAUDE_SKILL_DIR}/references/SKILL.full.md`
+- Full detailed guide (kept for reference): `./references/SKILL.full.md`
 - YAML spec: https://yaml.org/spec/
 - GitHub Actions workflow syntax: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

--- a/plugins/productivity/002-jeremy-yaml-master-agent/skills/yaml-master/references/SKILL.full.md
+++ b/plugins/productivity/002-jeremy-yaml-master-agent/skills/yaml-master/references/SKILL.full.md
@@ -757,7 +757,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 ## Prerequisites
 
-- Access to project files in ${CLAUDE_SKILL_DIR}/
+- Access to project files in ./
 - Required tools and dependencies installed
 - Understanding of skill functionality
 - Permissions for file operations

--- a/plugins/productivity/003-jeremy-vertex-ai-media-master/package.json
+++ b/plugins/productivity/003-jeremy-vertex-ai-media-master/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/003-jeremy-vertex-ai-media-master",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content ge",
   "keywords": [
     "vertex-ai",

--- a/plugins/productivity/003-jeremy-vertex-ai-media-master/skills/vertex-ai-media-master/SKILL.md
+++ b/plugins/productivity/003-jeremy-vertex-ai-media-master/skills/vertex-ai-media-master/SKILL.md
@@ -83,7 +83,7 @@ Multimodal media operations on Google Cloud Vertex AI covering video understandi
 
 ## Resources
 
-- Detailed model capabilities and code patterns: `${CLAUDE_SKILL_DIR}/references/core-capabilities.md`
+- Detailed model capabilities and code patterns: `./references/core-capabilities.md`
 - Vertex AI Multimodal overview: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/overview
 - Imagen documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview
 - Video understanding guide: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding

--- a/plugins/productivity/004-jeremy-google-cloud-agent-sdk/package.json
+++ b/plugins/productivity/004-jeremy-google-cloud-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/004-jeremy-google-cloud-agent-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReA",
   "keywords": [
     "agent-development-kit",

--- a/plugins/productivity/004-jeremy-google-cloud-agent-sdk/skills/google-cloud-agent-sdk-master/SKILL.md
+++ b/plugins/productivity/004-jeremy-google-cloud-agent-sdk/skills/google-cloud-agent-sdk-master/SKILL.md
@@ -56,6 +56,6 @@ Use this skill to quickly answer “how do I do X with Google ADK?” and to pro
 
 ## Resources
 
-- Full detailed guide (kept for reference): `${CLAUDE_SKILL_DIR}/references/SKILL.full.md`
+- Full detailed guide (kept for reference): `./references/SKILL.full.md`
 - ADK / Agent Engine docs:
 - Canonical repo standards: `000-docs/6767-a-SPEC-DR-STND-claude-code-plugins-standard.md`

--- a/plugins/productivity/004-jeremy-google-cloud-agent-sdk/skills/google-cloud-agent-sdk-master/references/SKILL.full.md
+++ b/plugins/productivity/004-jeremy-google-cloud-agent-sdk/skills/google-cloud-agent-sdk-master/references/SKILL.full.md
@@ -569,7 +569,7 @@ This skill automatically activates when you mention:
 
 ## Prerequisites
 
-- Access to project files in ${CLAUDE_SKILL_DIR}/
+- Access to project files in ./
 - Required tools and dependencies installed
 - Understanding of skill functionality
 - Permissions for file operations

--- a/plugins/productivity/navigating-github/commands/github-learn.md
+++ b/plugins/productivity/navigating-github/commands/github-learn.md
@@ -52,7 +52,7 @@ Only ask the comfort question via `AskUserQuestion` when signals are genuinely a
 
 ### Step 4 — Execute
 
-**Setup:** Read and follow the Setup mode instructions in `${CLAUDE_SKILL_DIR}/skills/navigating-github/SKILL.md`. Walk through each prerequisite interactively, skip completed steps. After completion, show the lesson menu.
+**Setup:** Read and follow the Setup mode instructions in `./skills/navigating-github/SKILL.md`. Walk through each prerequisite interactively, skip completed steps. After completion, show the lesson menu.
 
 **Lesson menu** (when no specific lesson requested and setup is complete):
 
@@ -76,7 +76,7 @@ Present via `AskUserQuestion`:
 > 8. GitHub Actions — write a CI workflow, watch it run
 > 9. Code Review Apps — CodeRabbit, Copilot Review, and the ecosystem
 
-**Specific lesson:** Read `${CLAUDE_SKILL_DIR}/skills/navigating-github/references/learning-curriculum.md` and execute the matching lesson. Follow do-then-explain methodology: run real commands, observe results, explain afterward. Verify understanding after each step.
+**Specific lesson:** Read `./skills/navigating-github/references/learning-curriculum.md` and execute the matching lesson. Follow do-then-explain methodology: run real commands, observe results, explain afterward. Verify understanding after each step.
 
 After each lesson, summarize what was learned and suggest the next lesson.
 

--- a/plugins/productivity/navigating-github/package.json
+++ b/plugins/productivity/navigating-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/navigating-github",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Adaptive GitHub companion for all skill levels. AI-driven assessment that meets you where you are — from first commit to team workflows.",
   "keywords": [
     "github",

--- a/plugins/productivity/navigating-github/skills/navigating-github/SKILL.md
+++ b/plugins/productivity/navigating-github/skills/navigating-github/SKILL.md
@@ -66,7 +66,7 @@ Each mode runs `git status` as part of its normal operation. Infer level from th
 - Branch naming conventions + conventional commits → **Advanced**
 - Complex history, multiple remotes, CI configured → **Expert**
 
-Only ask via `AskUserQuestion` when signals are genuinely ambiguous. Read `${CLAUDE_SKILL_DIR}/references/skill-assessment-guide.md` for the full adaptive behavior matrix. Apply:
+Only ask via `AskUserQuestion` when signals are genuinely ambiguous. Read `./references/skill-assessment-guide.md` for the full adaptive behavior matrix. Apply:
 
 | Level | Language | Depth | Autonomy |
 |-------|----------|-------|----------|
@@ -89,7 +89,7 @@ Skip completed steps. Explain each step at the inferred level. After completion,
 
 Hands-on lessons using real commands on the user's actual project. Every lesson follows **do-then-explain**: run a real command, observe the result, THEN explain what happened. Verify understanding after each step before proceeding.
 
-Read `${CLAUDE_SKILL_DIR}/references/learning-curriculum.md` for the full curriculum. Route by trigger:
+Read `./references/learning-curriculum.md` for the full curriculum. Route by trigger:
 
 **Beginner track:**
 
@@ -107,7 +107,7 @@ Read `${CLAUDE_SKILL_DIR}/references/learning-curriculum.md` for the full curric
 
 - "teach me rebase" → **Rebase vs Merge** — interactive rebase, squash, clean history
 - "teach me CI/CD" / "github actions" → **GitHub Actions** — write a workflow, watch it run
-- "how do code review apps work" → **Review Ecosystem** — CodeRabbit, Copilot Review, and the ecosystem (read `${CLAUDE_SKILL_DIR}/references/github-review-apps.md`)
+- "how do code review apps work" → **Review Ecosystem** — CodeRabbit, Copilot Review, and the ecosystem (read `./references/github-review-apps.md`)
 
 After each lesson: summarize what was learned (2-3 bullets), give a small challenge to try solo, suggest the next lesson.
 
@@ -156,7 +156,7 @@ Agent: [guides through git rebase -i, explains pick/squash/fixup]
 
 ## Output
 
-Calibrate all output to the inferred skill level. Beginner: plain English with analogies, explain every command. Intermediate: concise summaries, explain rationale. Advanced: minimal commentary. Expert: raw output only. Read `${CLAUDE_SKILL_DIR}/references/git-concepts-glossary.md` when a term definition is needed.
+Calibrate all output to the inferred skill level. Beginner: plain English with analogies, explain every command. Intermediate: concise summaries, explain rationale. Advanced: minimal commentary. Expert: raw output only. Read `./references/git-concepts-glossary.md` when a term definition is needed.
 
 ## Error Handling
 
@@ -168,10 +168,10 @@ Calibrate all output to the inferred skill level. Beginner: plain English with a
 
 ## Resources
 
-- `${CLAUDE_SKILL_DIR}/references/learning-curriculum.md` — 9 progressive lesson plans from beginner through advanced
-- `${CLAUDE_SKILL_DIR}/references/git-concepts-glossary.md` — term definitions at beginner and technical levels
-- `${CLAUDE_SKILL_DIR}/references/skill-assessment-guide.md` — adaptive behavior matrix with level-up and level-down signals
-- `${CLAUDE_SKILL_DIR}/references/safety-rules.md` — branch protection, secret detection, destructive operation guards
-- `${CLAUDE_SKILL_DIR}/references/error-recovery-playbook.md` — conflict resolution, auth repair, detached HEAD, rebase recovery
-- `${CLAUDE_SKILL_DIR}/references/github-review-apps.md` — CodeRabbit, Copilot Review, Greptile, CodeQL, Qodo
-- `${CLAUDE_SKILL_DIR}/references/claude-github-platforms.md` — platform capabilities across Claude Code, Cursor, Windsurf, and others
+- `./references/learning-curriculum.md` — 9 progressive lesson plans from beginner through advanced
+- `./references/git-concepts-glossary.md` — term definitions at beginner and technical levels
+- `./references/skill-assessment-guide.md` — adaptive behavior matrix with level-up and level-down signals
+- `./references/safety-rules.md` — branch protection, secret detection, destructive operation guards
+- `./references/error-recovery-playbook.md` — conflict resolution, auth repair, detached HEAD, rebase recovery
+- `./references/github-review-apps.md` — CodeRabbit, Copilot Review, Greptile, CodeQL, Qodo
+- `./references/claude-github-platforms.md` — platform capabilities across Claude Code, Cursor, Windsurf, and others

--- a/plugins/productivity/navigating-github/skills/navigating-github/references/learning-curriculum.md
+++ b/plugins/productivity/navigating-github/skills/navigating-github/references/learning-curriculum.md
@@ -320,7 +320,7 @@ jobs:
 
 **Trigger:** "code review apps", "how do code review apps work", "automated review"
 
-**Reference:** See `${CLAUDE_SKILL_DIR}/references/github-review-apps.md` for full details.
+**Reference:** See `./references/github-review-apps.md` for full details.
 
 **Concepts covered:**
 

--- a/plugins/productivity/overnight-dev/package.json
+++ b/plugins/productivity/overnight-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/overnight-dev",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
   "keywords": [
     "overnight",

--- a/plugins/productivity/overnight-dev/skills/overnight-development/SKILL.md
+++ b/plugins/productivity/overnight-dev/skills/overnight-development/SKILL.md
@@ -21,7 +21,7 @@ This skill automates software development overnight by leveraging Git hooks to e
 
 ## Prerequisites
 
-- Access to project files in ${CLAUDE_SKILL_DIR}/
+- Access to project files in ./
 - Required tools and dependencies installed
 - Understanding of skill functionality
 - Permissions for file operations
@@ -45,11 +45,11 @@ This skill automates software development overnight by leveraging Git hooks to e
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/langchain-py-pack/package.json
+++ b/plugins/saas-packs/langchain-py-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/langchain-py-pack",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Claude Code skill pack for LangChain 1.0 + LangGraph 1.0 (Python) - 34 skills covering chains, agents, RAG, middleware, checkpointing, HITL, streaming, and production patterns",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/env-manifest-template.md
+++ b/plugins/saas-packs/langchain-py-pack/skills/langchain-debug-bundle/references/env-manifest-template.md
@@ -91,7 +91,7 @@ notes: |
 ## Population at runtime
 
 ```python
-# ${CLAUDE_SKILL_DIR}/bundle_builder.py  -- conceptual, adapt to your app
+# ./bundle_builder.py  -- conceptual, adapt to your app
 import platform, sys, os, datetime, subprocess, json
 from langchain import __version__ as lc_version
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-api-development/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-api-development/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted API development workflows within Windsurf. Cascad
 4. **Create Documentation**
 5. **Test and Validate**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-audit-logging/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-audit-logging/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive audit logging for Windsurf Enterprise deploymen
 4. **Create Reports**
 5. **Monitor and Alert**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-agents/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-agents/SKILL.md
@@ -33,7 +33,7 @@ This skill enables creation of specialized Cascade agents tailored for specific 
 4. **Set Activation Triggers**
 5. **Test and Refine**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-context/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-context/SKILL.md
@@ -33,7 +33,7 @@ This skill enables advanced context management for Cascade AI in large-scale pro
 4. **Optimize for Workflow**
 5. **Monitor and Refine**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-onboarding/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cascade-onboarding/SKILL.md
@@ -33,7 +33,7 @@ This skill enables rapid onboarding of projects to Windsurf with optimized Casca
 4. **Train Team Members**
 5. **Iterate Based on Feedback**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cicd-github-actions/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-cicd-github-actions/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted CI/CD workflow creation within Windsurf. Cascade 
 4. **Test Workflows**
 5. **Deploy and Monitor**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-code-completion/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-code-completion/SKILL.md
@@ -33,7 +33,7 @@ This skill enables configuration and optimization of Windsurf's Supercomplete AI
 4. **Optimize Performance**
 5. **Personalize Experience**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-code-privacy/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-code-privacy/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive privacy configuration for Windsurf deployments.
 4. **Enable Regional Compliance**
 5. **Document and Monitor**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-custom-prompts/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-custom-prompts/SKILL.md
@@ -33,7 +33,7 @@ This skill enables creation and management of custom prompt libraries for Cascad
 4. **Organize and Index**
 5. **Enable Team Sharing**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-debugging-ai/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-debugging-ai/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted debugging within Windsurf. Cascade analyzes error
 4. **Apply Fix**
 5. **Document for Prevention**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-dependency-management/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-dependency-management/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive dependency management within Windsurf projects.
 4. **Apply and Verify**
 5. **Establish Monitoring**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-dockerfile-generation/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-dockerfile-generation/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted Docker configuration within Windsurf. Cascade ana
 4. **Configure Security**
 5. **Test and Validate**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-enterprise-sso/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-enterprise-sso/SKILL.md
@@ -34,7 +34,7 @@ This skill enables enterprise Single Sign-On (SSO) integration for Windsurf depl
 4. **Configure Policies**
 5. **Test and Enable**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -45,11 +45,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-extension-pack/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-extension-pack/SKILL.md
@@ -33,7 +33,7 @@ This skill enables rapid setup of Windsurf with essential extensions for product
 4. **Create Team Configuration**
 5. **Document and Share**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-flows-automation/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-flows-automation/SKILL.md
@@ -33,7 +33,7 @@ This skill enables creation and management of Windsurf Flows - automated workflo
 4. **Test and Validate**
 5. **Deploy and Monitor**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-git-integration/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-git-integration/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted Git workflows within Windsurf. Cascade can genera
 4. **Configure Team Standards**
 5. **Train on Workflow**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-keyboard-shortcuts/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-keyboard-shortcuts/SKILL.md
@@ -33,7 +33,7 @@ This skill enables customization of Windsurf keyboard shortcuts for optimal prod
 4. **Create Custom Bindings**
 5. **Document and Share**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-license-management/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-license-management/SKILL.md
@@ -33,7 +33,7 @@ This skill enables enterprise license management for Windsurf deployments. It co
 4. **Optimize Subscription**
 5. **Monitor and Report**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-linting-config/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-linting-config/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive linting configuration within Windsurf. Cascade 
 4. **Add Pre-Commit Hooks**
 5. **Integrate with CI**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-mcp-integration/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-mcp-integration/SKILL.md
@@ -34,7 +34,7 @@ This skill enables integration of MCP (Model Context Protocol) servers with Wind
 4. **Test Integration**
 5. **Deploy to Team**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -45,11 +45,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-multi-file-editing/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-multi-file-editing/SKILL.md
@@ -33,7 +33,7 @@ This skill enables coordinated multi-file editing operations within Windsurf usi
 4. **Execute with Preview**
 5. **Verify Results**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-performance-profiling/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-performance-profiling/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted performance profiling within Windsurf. Cascade an
 4. **Implement Optimizations**
 5. **Document and Monitor**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-refactoring-large/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-refactoring-large/SKILL.md
@@ -34,7 +34,7 @@ This skill enables large-scale refactoring operations that span hundreds or thou
 4. **Execute with Cascade**
 5. **Verify Completion**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -46,11 +46,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-release-automation/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-release-automation/SKILL.md
@@ -33,7 +33,7 @@ This skill enables automated release workflows within Windsurf using Cascade AI.
 4. **Execute Release**
 5. **Post-Release Tasks**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -45,11 +45,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-team-settings/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-team-settings/SKILL.md
@@ -33,7 +33,7 @@ This skill enables centralized management of Windsurf settings across teams and 
 4. **Deploy Settings**
 5. **Monitor and Iterate**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-terminal-ai/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-terminal-ai/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-assisted terminal operations within Windsurf. Cascade can 
 4. **Optimize Workflows**
 5. **Build Team Knowledge**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-test-generation/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-test-generation/SKILL.md
@@ -33,7 +33,7 @@ This skill enables AI-powered test generation for any codebase using Windsurf's 
 4. **Add Custom Scenarios**
 5. **Integrate into Workflow**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-theme-customization/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-theme-customization/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive theme customization within Windsurf. It covers 
 4. **Enable Accessibility Features**
 5. **Verify Compliance**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-usage-analytics/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-usage-analytics/SKILL.md
@@ -33,7 +33,7 @@ This skill enables comprehensive usage analytics for Windsurf deployments. It tr
 4. **Define Baselines**
 5. **Monitor and Optimize**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -44,11 +44,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-workspace-setup/SKILL.md
+++ b/plugins/saas-packs/skill-databases/windsurf/skills/windsurf-workspace-setup/SKILL.md
@@ -33,7 +33,7 @@ This skill enables rapid workspace setup for Windsurf projects. It covers creati
 4. **Configure Cross-Editor Consistency**
 5. **Establish Team Standards**
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementation guide.
+See `./references/implementation.md` for detailed implementation guide.
 
 ## Output
 
@@ -45,11 +45,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for detailed implementati
 
 ## Error Handling
 
-See `${CLAUDE_SKILL_DIR}/references/errors.md` for comprehensive error handling.
+See `./references/errors.md` for comprehensive error handling.
 
 ## Examples
 
-See `${CLAUDE_SKILL_DIR}/references/examples.md` for detailed examples.
+See `./references/examples.md` for detailed examples.
 
 ## Resources
 

--- a/plugins/security/access-control-auditor/package.json
+++ b/plugins/security/access-control-auditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/access-control-auditor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Audit access control implementations",
   "keywords": [
     "security",

--- a/plugins/security/access-control-auditor/skills/auditing-access-control/SKILL.md
+++ b/plugins/security/access-control-auditor/skills/auditing-access-control/SKILL.md
@@ -25,11 +25,11 @@ grants, and violations of the principle of least privilege.
 
 ## Prerequisites
 
-- Access to the target codebase and configuration files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase and configuration files in `./`
 - Familiarity with the authorization model in use (RBAC, ABAC, ACL, or IAM)
 - `grep`, `find`, and standard shell utilities available via Bash
 - For cloud audits: CLI tools such as `aws iam`, `gcloud`, or `az role` installed and authenticated
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for IAM best practices, ACL vulnerability patterns, and NIST/GDPR access control standards
+- Reference: `./references/README.md` for IAM best practices, ACL vulnerability patterns, and NIST/GDPR access control standards
 
 ## Instructions
 
@@ -66,7 +66,7 @@ grants, and violations of the principle of least privilege.
 
 ### Auditing a Node.js Express API
 
-Scan route definitions in `${CLAUDE_SKILL_DIR}/src/routes/` for missing authorization
+Scan route definitions in `./src/routes/` for missing authorization
 middleware. Grep for `router.post`, `router.put`, `router.delete` and verify
 each has a corresponding `authMiddleware` or `requireRole()` call. Flag any
 state-changing endpoint lacking authorization as CWE-862 (Missing Authorization),
@@ -74,14 +74,14 @@ severity high.
 
 ### Reviewing AWS IAM Policies
 
-Parse all JSON policy files in `${CLAUDE_SKILL_DIR}/infra/iam/`. Flag policies containing
+Parse all JSON policy files in `./infra/iam/`. Flag policies containing
 `"Effect": "Allow"` with `"Resource": "*"` or `"Action": "*"` as CWE-269
 (Improper Privilege Management), severity critical. Recommend scoping to specific
 ARNs and actions per the principle of least privilege.
 
 ### RBAC Configuration Audit
 
-Analyze role definitions in `${CLAUDE_SKILL_DIR}/config/roles.yaml`. Build a permission
+Analyze role definitions in `./config/roles.yaml`. Build a permission
 matrix, identify roles with overlapping admin-level privileges, and flag any role
 that can both create and approve its own resources as a separation-of-duties
 violation (NIST AC-5), severity medium.

--- a/plugins/security/authentication-validator/package.json
+++ b/plugins/security/authentication-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/authentication-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validate authentication implementations",
   "keywords": [
     "security",

--- a/plugins/security/authentication-validator/skills/validating-authentication-implementations/SKILL.md
+++ b/plugins/security/authentication-validator/skills/validating-authentication-implementations/SKILL.md
@@ -25,10 +25,10 @@ and NIST standards.
 
 ## Prerequisites
 
-- Access to the target codebase and configuration files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase and configuration files in `./`
 - Familiarity with the authentication framework in use (Passport.js, Spring Security, Django Auth, NextAuth, etc.)
 - Standard shell utilities and Grep/Glob available for codebase scanning
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for OWASP authentication cheat sheet, NIST password guidelines, and JWT RFC specifications
+- Reference: `./references/README.md` for OWASP authentication cheat sheet, NIST password guidelines, and JWT RFC specifications
 
 ## Instructions
 
@@ -65,7 +65,7 @@ and NIST standards.
 
 ### JWT Implementation Review
 
-Scan `${CLAUDE_SKILL_DIR}/src/auth/` and `${CLAUDE_SKILL_DIR}/src/middleware/` for JWT signing and
+Scan `./src/auth/` and `./src/middleware/` for JWT signing and
 verification logic. Flag any use of `jwt.sign()` with `algorithm: 'none'` or
 `HS256` paired with a secret shorter than 256 bits as CWE-327 (Use of Broken
 Crypto Algorithm), severity critical. Verify that `jwt.verify()` validates
@@ -80,7 +80,7 @@ Verify salt generation uses `crypto.randomBytes()` or equivalent CSPRNG.
 
 ### Session Cookie Hardening
 
-Locate session configuration in `${CLAUDE_SKILL_DIR}/config/` or middleware setup files.
+Locate session configuration in `./config/` or middleware setup files.
 Verify cookie attributes include `httpOnly: true`, `secure: true`,
 `sameSite: 'strict'`, and `maxAge` under 24 hours. Flag missing `httpOnly` as
 CWE-1004 (Sensitive Cookie Without HttpOnly), severity high.

--- a/plugins/security/compliance-report-generator/package.json
+++ b/plugins/security/compliance-report-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/compliance-report-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Generate compliance reports",
   "keywords": [
     "security",

--- a/plugins/security/compliance-report-generator/skills/generating-compliance-reports/SKILL.md
+++ b/plugins/security/compliance-report-generator/skills/generating-compliance-reports/SKILL.md
@@ -25,10 +25,10 @@ documentation with evidence references and gap analysis.
 
 ## Prerequisites
 
-- Access to the target codebase, infrastructure configs, and policy documents in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase, infrastructure configs, and policy documents in `./`
 - Knowledge of the target compliance framework and its applicable scope
 - Standard shell utilities and Grep/Glob available for evidence gathering
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for PCI DSS guidelines, HIPAA compliance checklist, SOC 2 framework overview, config schema, and API documentation
+- Reference: `./references/README.md` for PCI DSS guidelines, HIPAA compliance checklist, SOC 2 framework overview, config schema, and API documentation
 
 ## Instructions
 
@@ -39,8 +39,8 @@ documentation with evidence references and gap analysis.
 5. For Partially Compliant and Non-Compliant controls, describe the specific gap: what is missing, what risk it introduces, and what remediation is required.
 6. Calculate an overall compliance score as percentage of applicable controls that are fully compliant.
 7. Generate the report with these sections: Executive Summary, Scope and Methodology, Control-by-Control Assessment, Gap Analysis, Risk Rating, Remediation Roadmap with priority and effort estimates, and Evidence Appendix.
-8. Write the report to `${CLAUDE_SKILL_DIR}/compliance-report-[framework]-[date].md` using the Write tool.
-9. Validate the report against the config schema in `${CLAUDE_SKILL_DIR}/references/README.md` if applicable.
+8. Write the report to `./compliance-report-[framework]-[date].md` using the Write tool.
+9. Validate the report against the config schema in `./references/README.md` if applicable.
 
 ## Output
 
@@ -64,7 +64,7 @@ documentation with evidence references and gap analysis.
 
 ### PCI DSS Compliance Report
 
-Scan an e-commerce application in `${CLAUDE_SKILL_DIR}/` for PCI DSS v4.0 compliance.
+Scan an e-commerce application in `./` for PCI DSS v4.0 compliance.
 Assess Requirement 2 (Apply Secure Configurations) by checking for default
 credentials in config files, Requirement 3 (Protect Stored Account Data) by
 verifying encryption of cardholder data fields, and Requirement 6 (Develop and

--- a/plugins/security/cors-policy-validator/package.json
+++ b/plugins/security/cors-policy-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/cors-policy-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validate CORS policies",
   "keywords": [
     "security",

--- a/plugins/security/cors-policy-validator/skills/validating-cors-policies/SKILL.md
+++ b/plugins/security/cors-policy-validator/skills/validating-cors-policies/SKILL.md
@@ -24,10 +24,10 @@ overly permissive header/method exposure.
 
 ## Prerequisites
 
-- Access to the target codebase and configuration files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase and configuration files in `./`
 - For live endpoint testing: WebFetch tool available and target URLs accessible
 - Familiarity with the web framework in use (Express, Django, Flask, Spring, ASP.NET, etc.)
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for CORS specification details, common vulnerability patterns, and example policies
+- Reference: `./references/README.md` for CORS specification details, common vulnerability patterns, and example policies
 
 ## Instructions
 
@@ -63,21 +63,21 @@ overly permissive header/method exposure.
 
 ### Express.js CORS Middleware Audit
 
-Scan `${CLAUDE_SKILL_DIR}/src/app.js` and `${CLAUDE_SKILL_DIR}/src/middleware/` for `cors()`
+Scan `./src/app.js` and `./src/middleware/` for `cors()`
 configuration. Flag `origin: true` (reflects any origin) as CWE-942, severity
 critical. Recommend replacing with an explicit allowlist:
 `origin: ['https://app.example.com', 'https://admin.example.com']`.
 
 ### Nginx CORS Header Review
 
-Grep `${CLAUDE_SKILL_DIR}/nginx/` for `add_header Access-Control-Allow-Origin`. Flag any
+Grep `./nginx/` for `add_header Access-Control-Allow-Origin`. Flag any
 `$http_origin` variable usage that reflects the origin without validation. Verify
 that `Access-Control-Allow-Credentials` is only set for origins in the allowlist
 using an `if` block or `map` directive.
 
 ### API Gateway CORS Configuration
 
-Review `${CLAUDE_SKILL_DIR}/infra/api-gateway.yaml` or equivalent IaC definitions for
+Review `./infra/api-gateway.yaml` or equivalent IaC definitions for
 CORS settings. Flag wildcard `*` in allowed origins when credentials are enabled.
 Verify that `Access-Control-Allow-Methods` is scoped to only the HTTP methods
 each endpoint actually supports.

--- a/plugins/security/csrf-protection-validator/package.json
+++ b/plugins/security/csrf-protection-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/csrf-protection-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Validate CSRF protection",
   "keywords": [
     "security",

--- a/plugins/security/csrf-protection-validator/skills/validating-csrf-protection/SKILL.md
+++ b/plugins/security/csrf-protection-validator/skills/validating-csrf-protection/SKILL.md
@@ -24,10 +24,10 @@ operations vulnerable to CSRF attacks.
 
 ## Prerequisites
 
-- Access to the target codebase and configuration files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase and configuration files in `./`
 - Familiarity with the web framework in use (Express, Django, Rails, Spring, Laravel, etc.)
 - Standard shell utilities and Grep/Glob available for codebase scanning
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for CSRF protection methods, OWASP CSRF Prevention Cheat Sheet, and framework-specific API examples
+- Reference: `./references/README.md` for CSRF protection methods, OWASP CSRF Prevention Cheat Sheet, and framework-specific API examples
 
 ## Instructions
 
@@ -64,14 +64,14 @@ operations vulnerable to CSRF attacks.
 
 ### Express.js CSRF Token Validation
 
-Scan `${CLAUDE_SKILL_DIR}/src/routes/` for `router.post` and `router.put` handlers. Verify
+Scan `./src/routes/` for `router.post` and `router.put` handlers. Verify
 each includes `csurf` middleware or equivalent token validation. Flag any POST
 handler that directly processes `req.body` without `csrfProtection` middleware
 as CWE-352, severity critical for financial operations, high for other state changes.
 
 ### Django CSRF Middleware Audit
 
-Grep `${CLAUDE_SKILL_DIR}/settings.py` for `django.middleware.csrf.CsrfViewMiddleware` in
+Grep `./settings.py` for `django.middleware.csrf.CsrfViewMiddleware` in
 the `MIDDLEWARE` list. Scan views for `@csrf_exempt` decorators -- flag each
 exempted view as a potential CSRF vulnerability requiring justification. Verify
 templates include `{% csrf_token %}` in all form tags.

--- a/plugins/security/data-privacy-scanner/package.json
+++ b/plugins/security/data-privacy-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/data-privacy-scanner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Scan for data privacy issues",
   "keywords": [
     "security",

--- a/plugins/security/data-privacy-scanner/skills/scanning-for-data-privacy-issues/SKILL.md
+++ b/plugins/security/data-privacy-scanner/skills/scanning-for-data-privacy-issues/SKILL.md
@@ -24,10 +24,10 @@ anonymization or pseudonymization of sensitive fields.
 
 ## Prerequisites
 
-- Access to the target codebase and configuration files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target codebase and configuration files in `./`
 - Knowledge of the data types processed by the application (PII categories, PHI, financial data)
 - Standard shell utilities and Grep/Glob available for pattern matching
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for scanner API documentation, GDPR compliance guide, and sensitive data pattern definitions
+- Reference: `./references/README.md` for scanner API documentation, GDPR compliance guide, and sensitive data pattern definitions
 
 ## Instructions
 
@@ -64,14 +64,14 @@ anonymization or pseudonymization of sensitive fields.
 
 ### PII in Application Logs
 
-Grep `${CLAUDE_SKILL_DIR}/src/` for logging statements that reference user fields:
+Grep `./src/` for logging statements that reference user fields:
 `logger.info.*email`, `console.log.*password`, `Log.d.*phone`. Flag each match
 as CWE-532, severity high. Recommend implementing a log sanitizer middleware
 that redacts PII fields before writing to log output.
 
 ### GDPR Data Subject Rights
 
-Scan `${CLAUDE_SKILL_DIR}/src/api/` for endpoints supporting data subject rights: user
+Scan `./src/api/` for endpoints supporting data subject rights: user
 data export (`GET /api/users/:id/export`), data deletion (`DELETE /api/users/:id`),
 and consent withdrawal. Flag missing endpoints as GDPR Article 15/17/21 gaps,
 severity high. Recommend implementing a data subject request handler.

--- a/plugins/security/dependency-checker/package.json
+++ b/plugins/security/dependency-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/dependency-checker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
   "keywords": [
     "security",

--- a/plugins/security/dependency-checker/skills/analyzing-dependencies/SKILL.md
+++ b/plugins/security/dependency-checker/skills/analyzing-dependencies/SKILL.md
@@ -25,20 +25,20 @@ actionable remediation guidance with upgrade paths.
 
 ## Prerequisites
 
-- Access to the target project directory and manifest files in `${CLAUDE_SKILL_DIR}/`
+- Access to the target project directory and manifest files in `./`
 - At least one package manager CLI available: `npm`, `pip`/`pip-audit`, `composer`, `gem`, `go`, or `cargo`
 - Network access for querying vulnerability databases (NVD, GitHub Advisory Database, OSV)
-- Reference: `${CLAUDE_SKILL_DIR}/references/README.md` for npm/pip audit report formats, license compatibility matrix, and dependency management best practices
+- Reference: `./references/README.md` for npm/pip audit report formats, license compatibility matrix, and dependency management best practices
 
 ## Instructions
 
-1. Detect the project ecosystem by scanning `${CLAUDE_SKILL_DIR}/` for manifest files: `package.json` and `package-lock.json` (npm/Node.js), `requirements.txt`/`pyproject.toml`/`Pipfile.lock` (Python), `composer.json`/`composer.lock` (PHP), `Gemfile`/`Gemfile.lock` (Ruby), `go.mod`/`go.sum` (Go), `Cargo.toml`/`Cargo.lock` (Rust).
+1. Detect the project ecosystem by scanning `./` for manifest files: `package.json` and `package-lock.json` (npm/Node.js), `requirements.txt`/`pyproject.toml`/`Pipfile.lock` (Python), `composer.json`/`composer.lock` (PHP), `Gemfile`/`Gemfile.lock` (Ruby), `go.mod`/`go.sum` (Go), `Cargo.toml`/`Cargo.lock` (Rust).
 2. For npm projects, run `npm audit --json` and parse the structured output. Map each advisory to its CVE identifier, CVSS score, severity level, vulnerable version range, and patched version.
 3. For Python projects, run `pip-audit --format=json` or parse `safety check --json` output. Cross-reference each vulnerability against the OSV database for additional context.
 4. For other ecosystems, run the equivalent audit command (`composer audit`, `bundle audit`, `cargo audit`, `govulncheck`) and normalize the output to a common finding format.
 5. Analyze the dependency tree for transitive vulnerabilities -- identify which direct dependency pulls in the vulnerable transitive dependency, and whether upgrading the direct dependency resolves the issue.
 6. Check for outdated packages by comparing installed versions against the latest available versions. Categorize updates as patch (safe), minor (likely safe), or major (breaking changes possible).
-7. Audit license compliance by extracting license declarations from each dependency. Flag packages using copyleft licenses (GPL, AGPL) in proprietary projects, packages with no declared license, and packages with license conflicts per the compatibility matrix in `${CLAUDE_SKILL_DIR}/references/README.md`.
+7. Audit license compliance by extracting license declarations from each dependency. Flag packages using copyleft licenses (GPL, AGPL) in proprietary projects, packages with no declared license, and packages with license conflicts per the compatibility matrix in `./references/README.md`.
 8. Identify abandoned or unmaintained packages: flag dependencies with no releases in over 2 years, archived repositories, or known deprecation notices.
 9. Classify each finding by severity (critical, high, medium, low) using CVSS scores: critical >= 9.0, high >= 7.0, medium >= 4.0, low < 4.0.
 10. Generate a remediation plan with specific upgrade commands, alternative packages for abandoned dependencies, and a priority order based on severity and exploitability.
@@ -67,7 +67,7 @@ actionable remediation guidance with upgrade paths.
 
 ### npm Pre-Deployment Audit
 
-Run `npm audit --json` in `${CLAUDE_SKILL_DIR}/`. Parse the output to identify critical
+Run `npm audit --json` in `./`. Parse the output to identify critical
 and high severity advisories. For each, trace the dependency chain from direct
 dependency to vulnerable package. Produce upgrade commands:
 `npm install express@4.19.2` to resolve CVE-2024-XXXXX in `path-to-regexp`.
@@ -75,7 +75,7 @@ Flag any advisory without a fix available as requiring a workaround or alternati
 
 ### Python Dependency Security Check
 
-Run `pip-audit --format=json -r ${CLAUDE_SKILL_DIR}/requirements.txt`. Map each
+Run `pip-audit --format=json -r ./requirements.txt`. Map each
 vulnerability to its CVE, CVSS score, and fixed version. For transitive
 dependencies, identify the direct dependency pulling in the vulnerable package.
 Recommend pinning to safe versions in `requirements.txt` and adding
@@ -83,7 +83,7 @@ Recommend pinning to safe versions in `requirements.txt` and adding
 
 ### License Compliance Scan
 
-Extract licenses from `${CLAUDE_SKILL_DIR}/node_modules/` using `license-checker --json`
+Extract licenses from `./node_modules/` using `license-checker --json`
 or equivalent. Flag any GPL-3.0 or AGPL-3.0 licensed package used in a
 proprietary application as a license conflict. Flag packages with `UNLICENSED`
 or missing license fields as requiring legal review before production use.

--- a/plugins/security/encryption-tool/package.json
+++ b/plugins/security/encryption-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/encryption-tool",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Encrypt and decrypt data with various algorithms",
   "keywords": [
     "security",

--- a/plugins/security/encryption-tool/skills/encrypting-and-decrypting-data/SKILL.md
+++ b/plugins/security/encryption-tool/skills/encrypting-and-decrypting-data/SKILL.md
@@ -69,7 +69,7 @@ This skill can be integrated with other Claude Code plugins, such as file manage
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/gdpr-compliance-scanner/package.json
+++ b/plugins/security/gdpr-compliance-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/gdpr-compliance-scanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Scan for GDPR compliance issues",
   "keywords": [
     "security",

--- a/plugins/security/gdpr-compliance-scanner/skills/scanning-for-gdpr-compliance/SKILL.md
+++ b/plugins/security/gdpr-compliance-scanner/skills/scanning-for-gdpr-compliance/SKILL.md
@@ -71,7 +71,7 @@ This skill can be integrated with other security and compliance tools to provide
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/hipaa-compliance-checker/package.json
+++ b/plugins/security/hipaa-compliance-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/hipaa-compliance-checker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Check HIPAA compliance",
   "keywords": [
     "security",

--- a/plugins/security/hipaa-compliance-checker/skills/checking-hipaa-compliance/SKILL.md
+++ b/plugins/security/hipaa-compliance-checker/skills/checking-hipaa-compliance/SKILL.md
@@ -71,7 +71,7 @@ This skill can be integrated with other security and compliance tools to provide
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/input-validation-scanner/package.json
+++ b/plugins/security/input-validation-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/input-validation-scanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Scan input validation practices",
   "keywords": [
     "security",

--- a/plugins/security/input-validation-scanner/skills/scanning-input-validation-practices/SKILL.md
+++ b/plugins/security/input-validation-scanner/skills/scanning-input-validation-practices/SKILL.md
@@ -66,7 +66,7 @@ This skill can be used in conjunction with other security-related skills to prov
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/owasp-compliance-checker/package.json
+++ b/plugins/security/owasp-compliance-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/owasp-compliance-checker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Check OWASP Top 10 compliance",
   "keywords": [
     "security",

--- a/plugins/security/owasp-compliance-checker/skills/checking-owasp-compliance/SKILL.md
+++ b/plugins/security/owasp-compliance-checker/skills/checking-owasp-compliance/SKILL.md
@@ -70,7 +70,7 @@ This skill can be integrated with other plugins to automate vulnerability remedi
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/pci-dss-validator/package.json
+++ b/plugins/security/pci-dss-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/pci-dss-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validate PCI DSS compliance",
   "keywords": [
     "security",

--- a/plugins/security/pci-dss-validator/skills/validating-pci-dss-compliance/SKILL.md
+++ b/plugins/security/pci-dss-validator/skills/validating-pci-dss-compliance/SKILL.md
@@ -69,7 +69,7 @@ This skill can be integrated with other security tools and plugins to provide a 
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/secret-scanner/package.json
+++ b/plugins/security/secret-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/secret-scanner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
   "keywords": [
     "security",

--- a/plugins/security/secret-scanner/skills/scanning-for-secrets/SKILL.md
+++ b/plugins/security/secret-scanner/skills/scanning-for-secrets/SKILL.md
@@ -70,7 +70,7 @@ This skill can be integrated with other security tools, such as vulnerability sc
 
 ## Prerequisites
 
-- Access to codebase and configuration files in ${CLAUDE_SKILL_DIR}/
+- Access to codebase and configuration files in ./
 - Security scanning tools installed as needed
 - Understanding of security standards and best practices
 - Permissions for security analysis operations

--- a/plugins/security/security-audit-reporter/package.json
+++ b/plugins/security/security-audit-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/security-audit-reporter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate comprehensive security audit reports",
   "keywords": [
     "security",

--- a/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/SKILL.md
+++ b/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/SKILL.md
@@ -27,15 +27,15 @@ Aggregate vulnerability scan results, configuration analyses, and compliance ass
 
 ## Prerequisites
 
-- Vulnerability scanner outputs (Nmap, Nessus, OpenVAS, OWASP ZAP) available in `${CLAUDE_SKILL_DIR}/security/`
+- Vulnerability scanner outputs (Nmap, Nessus, OpenVAS, OWASP ZAP) available in `./security/`
 - Application and infrastructure configuration files accessible
 - SAST/DAST tool results (e.g., Semgrep, Snyk, Trivy, Bandit)
 - Applicable compliance framework documentation identified (PCI-DSS v4.0, HIPAA Security Rule, SOC 2 TSC, GDPR)
-- Write permissions for report output directory `${CLAUDE_SKILL_DIR}/reports/`
+- Write permissions for report output directory `./reports/`
 
 ## Instructions
 
-1. Inventory all available security data sources by scanning `${CLAUDE_SKILL_DIR}/security/` for scanner outputs, log files, and configuration exports.
+1. Inventory all available security data sources by scanning `./security/` for scanner outputs, log files, and configuration exports.
 2. Parse vulnerability findings and normalize severity using CVSS 3.1 base scores: Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.1-3.9).
 3. Cross-reference each finding against applicable compliance controls. Map to specific PCI-DSS requirements (e.g., Req 6.5 for injection flaws), HIPAA safeguards, or SOC 2 Common Criteria.
 4. Deduplicate findings across scanners and merge related vulnerabilities into consolidated entries with all affected assets listed.
@@ -44,13 +44,13 @@ Aggregate vulnerability scan results, configuration analyses, and compliance ass
 7. Build a detailed findings table: finding ID, CWE number, affected component, CVSS score, compliance mapping, remediation steps, and evidence links.
 8. Produce a compliance status matrix showing pass/fail/partial for each applicable standard requirement.
 9. Create remediation recommendations with effort estimates (hours), priority ranking, and suggested timelines.
-10. Format the final report as Markdown to `${CLAUDE_SKILL_DIR}/reports/security-audit-YYYYMMDD.md`. Optionally produce JSON for Jira/ServiceNow import.
+10. Format the final report as Markdown to `./reports/security-audit-YYYYMMDD.md`. Optionally produce JSON for Jira/ServiceNow import.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed four-phase implementation workflow.
+See `./references/implementation.md` for the detailed four-phase implementation workflow.
 
 ## Output
 
-- **Audit Report**: `${CLAUDE_SKILL_DIR}/reports/security-audit-YYYYMMDD.md` containing executive summary, detailed findings, compliance matrix, and remediation plan
+- **Audit Report**: `./reports/security-audit-YYYYMMDD.md` containing executive summary, detailed findings, compliance matrix, and remediation plan
 - **Findings JSON**: Machine-readable findings for ticketing system import
 - **Compliance Matrix**: Per-requirement pass/fail/partial status for each applicable framework
 - **Remediation Backlog**: Prioritized list with effort estimates and owner assignments
@@ -59,7 +59,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed four-pha
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| No security scan results found | Scanner outputs missing from `${CLAUDE_SKILL_DIR}/security/` | Specify alternate data source paths or run preliminary scans with `nmap -sV` or `trivy fs .` |
+| No security scan results found | Scanner outputs missing from `./security/` | Specify alternate data source paths or run preliminary scans with `nmap -sV` or `trivy fs .` |
 | Cannot assess compliance -- requirements unavailable | Compliance framework checklist not provided | Fall back to OWASP Top 10 and CWE Top 25 as baseline; note limitation in report |
 | Permission denied reading config files | Insufficient filesystem access | Request elevated permissions or provide exported configuration snapshots |
 | Scan results exceed processing capacity | Thousands of findings from multiple scanners | Process in batches by severity (Critical/High first), then merge |
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed four-pha
 
 ## Examples
 
-- "Generate a SOC 2 security audit report for the API using scan results in `${CLAUDE_SKILL_DIR}/security/`."
+- "Generate a SOC 2 security audit report for the API using scan results in `./security/`."
 - "Create a PCI-DSS compliance-focused security assessment with a prioritized remediation plan for all Critical and High findings."
 - "Produce a HIPAA security audit from the Nessus and Trivy outputs, mapping each finding to the relevant HIPAA safeguard."
 
@@ -78,6 +78,6 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed four-pha
 - NIST Cybersecurity Framework: https://www.nist.gov/cyberframework
 - PCI-DSS v4.0 Requirements: https://www.pcisecuritystandards.org/
 - CVSS 3.1 Calculator: https://www.first.org/cvss/calculator/3.1
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/references/errors.md
+++ b/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/references/errors.md
@@ -13,7 +13,7 @@
    - Fallback: Note limitation in report with partial assessment
 
 3. **Access Denied to Configuration Files**
-   - Error: "Permission denied reading ${CLAUDE_SKILL_DIR}/config/"
+   - Error: "Permission denied reading ./config/"
    - Resolution: Request elevated permissions or provide configuration exports
    - Fallback: Generate report with available data, note gaps
 

--- a/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/references/examples.md
+++ b/plugins/security/security-audit-reporter/skills/generating-security-audit-reports/references/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-- "Generate a SOC 2 security audit report for our API using the scan results in ${CLAUDE_SKILL_DIR}/security/."
+- "Generate a SOC 2 security audit report for our API using the scan results in ./security/."
 - "Create a PCI-DSS compliance-focused security assessment and remediation plan."
 
 ---

--- a/plugins/security/security-headers-analyzer/package.json
+++ b/plugins/security/security-headers-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/security-headers-analyzer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Analyze HTTP security headers",
   "keywords": [
     "security",

--- a/plugins/security/security-headers-analyzer/skills/analyzing-security-headers/SKILL.md
+++ b/plugins/security/security-headers-analyzer/skills/analyzing-security-headers/SKILL.md
@@ -31,7 +31,7 @@ Evaluate HTTP response headers for web applications against OWASP Secure Headers
 - Target URL or domain name accessible over the network
 - Authorization to perform HTTP requests against the target domain
 - Network connectivity for both HTTP and HTTPS protocols
-- Optional: write access to `${CLAUDE_SKILL_DIR}/security-reports/` for persisting results
+- Optional: write access to `./security-reports/` for persisting results
 
 ## Instructions
 
@@ -51,7 +51,7 @@ Evaluate HTTP response headers for web applications against OWASP Secure Headers
 7. Calculate a security grade: A+ (95-100), A (85-94), B (75-84), C (65-74), D (50-64), F (<50) based on weighted presence and correctness of each header.
 8. Generate per-header remediation directives with configuration examples for Nginx, Apache, and Cloudflare.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the five-phase implementation workflow.
+See `./references/implementation.md` for the five-phase implementation workflow.
 
 ## Output
 
@@ -83,6 +83,6 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the five-phase implem
 - Security Headers Scanner: https://securityheaders.com/
 - Content Security Policy Reference: https://content-security-policy.com/
 - HSTS Preload Submission: https://hstspreload.org/
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/security-incident-responder/package.json
+++ b/plugins/security/security-incident-responder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/security-incident-responder",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Assist with security incident response",
   "keywords": [
     "security",

--- a/plugins/security/security-incident-responder/skills/responding-to-security-incidents/SKILL.md
+++ b/plugins/security/security-incident-responder/skills/responding-to-security-incidents/SKILL.md
@@ -29,11 +29,11 @@ Guide the full NIST SP 800-61 incident response lifecycle: detection, containmen
 
 ## Prerequisites
 
-- System and application logs accessible in `${CLAUDE_SKILL_DIR}/logs/` (auth logs, web server logs, database access logs)
+- System and application logs accessible in `./logs/` (auth logs, web server logs, database access logs)
 - Network traffic captures (PCAP) or SIEM alert exports available
 - Incident response team contact information and escalation paths documented
 - Backup systems operational and recovery procedures tested
-- Write permissions for incident documentation in `${CLAUDE_SKILL_DIR}/incidents/`
+- Write permissions for incident documentation in `./incidents/`
 - Forensic tools available: Volatility (memory), Autopsy/FTK Imager (disk), tcpdump/Wireshark (network)
 
 ## Instructions
@@ -41,19 +41,19 @@ Guide the full NIST SP 800-61 incident response lifecycle: detection, containmen
 1. **Classify the incident**: determine type (ransomware, data breach, DDoS, phishing, insider threat), assign severity (Critical/High/Medium/Low), and record initial detection timestamp and method.
 2. **Scope affected systems**: identify all compromised hosts, user accounts, data stores, and network segments. Map the blast radius.
 3. **Preserve evidence before any changes**: capture memory dumps (`volatility -f memdump.raw imageinfo`), create disk images, export running process lists (`ps auxf`), and snapshot network connection state (`ss -tulnp`).
-4. **Collect log evidence**: gather authentication logs (successful and failed), application error logs, firewall/IDS alerts, DNS query logs, and proxy server logs. Store originals in `${CLAUDE_SKILL_DIR}/incidents/evidence/`.
+4. **Collect log evidence**: gather authentication logs (successful and failed), application error logs, firewall/IDS alerts, DNS query logs, and proxy server logs. Store originals in `./incidents/evidence/`.
 5. **Contain the threat**: isolate affected systems from the network, disable compromised accounts, block malicious IPs at the firewall, and revoke compromised API keys or tokens.
 6. **Investigate and reconstruct timeline**: identify initial access vector, map lateral movement, determine data exfiltration scope, locate persistence mechanisms (cron jobs, startup scripts, web shells), and document all IOCs (IPs, hashes, domains, file paths).
 7. **Eradicate the threat**: remove malware and backdoors, patch exploited vulnerabilities, reset all potentially compromised credentials, and update firewall rules.
 8. **Recover operations**: restore from verified clean backups, rebuild compromised systems from hardened images, validate system integrity, and monitor for reinfection with heightened alerting.
-9. **Document the incident**: produce a comprehensive report at `${CLAUDE_SKILL_DIR}/incidents/incident-YYYYMMDD-HHMM.md` containing executive summary, detailed timeline, root cause analysis, IOC list, and lessons learned.
+9. **Document the incident**: produce a comprehensive report at `./incidents/incident-YYYYMMDD-HHMM.md` containing executive summary, detailed timeline, root cause analysis, IOC list, and lessons learned.
 10. **Create remediation backlog**: list all follow-up actions (patch gaps, monitoring improvements, policy changes) with owners and deadlines.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the seven-phase implementation workflow.
+See `./references/implementation.md` for the seven-phase implementation workflow.
 
 ## Output
 
-- **Incident Report**: `${CLAUDE_SKILL_DIR}/incidents/incident-YYYYMMDD-HHMM.md` with timeline, root cause, IOCs, and impact assessment
+- **Incident Report**: `./incidents/incident-YYYYMMDD-HHMM.md` with timeline, root cause, IOCs, and impact assessment
 - **IOC List**: machine-readable indicators (IP addresses, file hashes, domains, YARA rules)
 - **After-Action Review**: lessons learned, process gaps, and recommended improvements
 - **Remediation Backlog**: prioritized follow-up tasks with owners and deadlines
@@ -62,7 +62,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the seven-phase imple
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| Critical logs missing from `${CLAUDE_SKILL_DIR}/logs/` | Log rotation, deletion, or attacker tampering | Work with available data; note gaps; improve logging retention for future incidents |
+| Critical logs missing from `./logs/` | Log rotation, deletion, or attacker tampering | Work with available data; note gaps; improve logging retention for future incidents |
 | System state modified before evidence collection | First responder made changes before forensic capture | Document contamination; collect remaining evidence; prioritize network and SIEM logs |
 | Attacker still has active access during investigation | Ongoing compromise detected | Prioritize containment over investigation; implement emergency network isolation |
 | Permission denied accessing system memory | Insufficient forensic tool privileges | Escalate to obtain root/admin access; fall back to available log and network data |
@@ -70,7 +70,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the seven-phase imple
 
 ## Examples
 
-- "Credential stuffing detected. Use logs in `${CLAUDE_SKILL_DIR}/logs/` to triage the incident, scope affected accounts, and propose containment steps."
+- "Credential stuffing detected. Use logs in `./logs/` to triage the incident, scope affected accounts, and propose containment steps."
 - "Create an incident response plan for a suspected data breach: list evidence to collect, containment actions, and notification requirements."
 - "Investigate a web shell found at `/var/www/html/uploads/cmd.php`. Trace the initial access vector, identify persistence mechanisms, and produce an IOC list."
 
@@ -81,6 +81,6 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the seven-phase imple
 - CISA Incident Response Guide:
 - Volatility Framework (memory forensics): https://www.volatilityfoundation.org/
 - Autopsy (disk forensics): https://www.autopsy.com/
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/security-incident-responder/skills/responding-to-security-incidents/references/errors.md
+++ b/plugins/security/security-incident-responder/skills/responding-to-security-incidents/references/errors.md
@@ -3,7 +3,7 @@
 **Common Issues and Resolutions**:
 
 1. **Incomplete Log Data**
-   - Error: "Critical logs missing from ${CLAUDE_SKILL_DIR}/logs/"
+   - Error: "Critical logs missing from ./logs/"
    - Resolution: Work with available data, note gaps in report
    - Action: Improve logging for future incidents
 

--- a/plugins/security/security-incident-responder/skills/responding-to-security-incidents/references/examples.md
+++ b/plugins/security/security-incident-responder/skills/responding-to-security-incidents/references/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-- "We suspect credential stuffing. Use logs in ${CLAUDE_SKILL_DIR}/logs/ to triage and propose containment steps."
+- "We suspect credential stuffing. Use logs in ./logs/ to triage and propose containment steps."
 - "Create an incident response plan for a suspected data breach and list evidence to collect."
 
 ---

--- a/plugins/security/security-misconfiguration-finder/package.json
+++ b/plugins/security/security-misconfiguration-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/security-misconfiguration-finder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Find security misconfigurations",
   "keywords": [
     "security",

--- a/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/SKILL.md
+++ b/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/SKILL.md
@@ -30,16 +30,16 @@ Scan infrastructure-as-code templates, application configuration files, and syst
 
 ## Prerequisites
 
-- Infrastructure-as-code files accessible in `${CLAUDE_SKILL_DIR}/` (Terraform `.tf`, CloudFormation `.yaml/.json`, Ansible playbooks, Kubernetes manifests)
+- Infrastructure-as-code files accessible in `./` (Terraform `.tf`, CloudFormation `.yaml/.json`, Ansible playbooks, Kubernetes manifests)
 - Application configuration files available (`application.yml`, `config.json`, `.env.example`, `web.config`)
 - Container definitions (`Dockerfile`, `docker-compose.yml`, Helm charts)
 - Web server configs (`nginx.conf`, `httpd.conf`, `.htaccess`) if applicable
-- Write permissions for findings output in `${CLAUDE_SKILL_DIR}/security-findings/`
+- Write permissions for findings output in `./security-findings/`
 - Optional: `tfsec`, `checkov`, or `trivy config` installed for automated pre-scanning
 
 ## Instructions
 
-1. Discover all configuration files by scanning `${CLAUDE_SKILL_DIR}/` for IaC templates (`.tf`, `.yaml`, `.json`, `.template`), application configs, container definitions, and web server configs.
+1. Discover all configuration files by scanning `./` for IaC templates (`.tf`, `.yaml`, `.json`, `.template`), application configs, container definitions, and web server configs.
 2. **Cloud storage**: check for publicly accessible S3 buckets, unencrypted storage accounts, missing versioning, and overly permissive bucket policies (CIS AWS 2.1.1, 2.1.2).
 3. **Network security**: flag security groups allowing `0.0.0.0/0` ingress on sensitive ports (22, 3389, 3306, 5432, 27017), missing VPC flow logs, and absent network segmentation.
 4. **IAM and access**: detect wildcard (`*`) permissions in IAM policies, service accounts with admin privileges, missing MFA enforcement, and hardcoded credentials in source (CWE-798).
@@ -48,13 +48,13 @@ Scan infrastructure-as-code templates, application configuration files, and syst
 7. **Application config**: detect debug mode enabled in production, default credentials, CORS wildcard (`*`), missing CSRF protection, disabled authentication endpoints, and API keys in config files.
 8. **Container security**: check for containers running as root, missing resource limits, `privileged: true`, writable root filesystems, and images without pinned digests.
 9. Classify each finding: **Critical** (immediate exploitation risk), **High** (significant security impact), **Medium** (configuration weakness), **Low** (best practice violation).
-10. Generate findings report at `${CLAUDE_SKILL_DIR}/security-findings/misconfig-YYYYMMDD.md` with per-finding severity, CIS/CWE mapping, affected file and line, remediation code, and verification command.
+10. Generate findings report at `./security-findings/misconfig-YYYYMMDD.md` with per-finding severity, CIS/CWE mapping, affected file and line, remediation code, and verification command.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full six-section implementation guide covering IaC, application, and system checks.
+See `./references/implementation.md` for the full six-section implementation guide covering IaC, application, and system checks.
 
 ## Output
 
-- **Findings Report**: `${CLAUDE_SKILL_DIR}/security-findings/misconfig-YYYYMMDD.md` with all misconfigurations categorized by severity
+- **Findings Report**: `./security-findings/misconfig-YYYYMMDD.md` with all misconfigurations categorized by severity
 - **Remediation Plan**: minimal-change fixes with before/after config snippets and verification commands
 - **Compliance Mapping**: each finding linked to CIS Benchmark, OWASP, or CWE reference
 - **Summary Dashboard**: finding counts by severity and category
@@ -63,7 +63,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full six-section 
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| Syntax error in `${CLAUDE_SKILL_DIR}/terraform/main.tf` | Malformed HCL, YAML, or JSON | Validate file syntax first; skip malformed files and note parse errors in report |
+| Syntax error in `./terraform/main.tf` | Malformed HCL, YAML, or JSON | Validate file syntax first; skip malformed files and note parse errors in report |
 | Cannot determine cloud provider from configuration | Missing provider blocks or ambiguous file structure | Look for provider blocks and file naming conventions; fall back to generic security checks |
 | Cannot read encrypted configuration | SOPS-encrypted or binary config files | Request decrypted version or exported config; document inability to audit |
 | Too many config files (500+) | Large monorepo or multi-service project | Prioritize by file type: IaC first, then app configs, then system configs |
@@ -71,7 +71,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full six-section 
 
 ## Examples
 
-- "Scan Terraform files in `${CLAUDE_SKILL_DIR}/` for overly permissive security groups and IAM wildcard policies."
+- "Scan Terraform files in `./` for overly permissive security groups and IAM wildcard policies."
 - "Review Kubernetes manifests for insecure defaults: privileged containers, missing resource limits, and root execution."
 - "Audit the Nginx and application configs for debug mode, information disclosure, and missing security headers."
 
@@ -83,6 +83,6 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the full six-section 
 - tfsec (Terraform scanner): https://github.com/aquasecurity/tfsec
 - Checkov (multi-cloud IaC scanner): https://www.checkov.io/
 - CWE-16 Configuration: https://cwe.mitre.org/data/definitions/16.html
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/references/errors.md
+++ b/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/references/errors.md
@@ -3,7 +3,7 @@
 **Common Issues and Resolutions**:
 
 1. **Unable to Parse Configuration File**
-   - Error: "Syntax error in ${CLAUDE_SKILL_DIR}/terraform/main.tf"
+   - Error: "Syntax error in ./terraform/main.tf"
    - Resolution: Validate file syntax first, report parse errors separately
    - Fallback: Skip malformed files, note in report
 
@@ -18,7 +18,7 @@
    - Note: Document inability to audit in report
 
 4. **Large Configuration Sets**
-   - Error: "Too many files to analyze (${CLAUDE_SKILL_DIR}/ has 500+ configs)"
+   - Error: "Too many files to analyze (./ has 500+ configs)"
    - Resolution: Prioritize by file type and location
    - Strategy: Start with IaC, then app configs, then system configs
 

--- a/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/references/examples.md
+++ b/plugins/security/security-misconfiguration-finder/skills/finding-security-misconfigurations/references/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-- "Scan our Terraform in ${CLAUDE_SKILL_DIR}/ for overly permissive security groups and IAM wildcards."
+- "Scan our Terraform in ./ for overly permissive security groups and IAM wildcards."
 - "Review Kubernetes manifests for insecure defaults and propose fixes."
 
 ---

--- a/plugins/security/session-security-checker/package.json
+++ b/plugins/security/session-security-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/session-security-checker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Check session security implementation",
   "keywords": [
     "security",

--- a/plugins/security/session-security-checker/skills/checking-session-security/SKILL.md
+++ b/plugins/security/session-security-checker/skills/checking-session-security/SKILL.md
@@ -28,11 +28,11 @@ Audit session management implementations in web applications to identify vulnera
 
 ## Prerequisites
 
-- Application source code accessible in `${CLAUDE_SKILL_DIR}/`
+- Application source code accessible in `./`
 - Session management code locations identified (auth modules, middleware, session stores)
 - Framework and language identified (Express.js, Django, Spring Boot, Rails, ASP.NET, etc.)
 - Session configuration files available (`session.config.*`, `settings.py`, `application.yml`)
-- Write permissions for reports in `${CLAUDE_SKILL_DIR}/security-reports/`
+- Write permissions for reports in `./security-reports/`
 
 ## Instructions
 
@@ -44,13 +44,13 @@ Audit session management implementations in web applications to identify vulnera
 6. **Audit session invalidation**: verify logout handlers destroy server-side session state and clear client cookies. Confirm password reset and privilege escalation flows invalidate existing sessions.
 7. **Inspect session storage**: flag in-memory stores in production (no persistence across restarts), unencrypted session data at rest, and missing integrity checks on session payloads (e.g., unsigned JWT session tokens).
 8. **Identify attack vectors**: assess exposure to session fixation, CSRF via session riding, replay attacks from stolen tokens, and session prediction from weak ID generation.
-9. Produce the session security report at `${CLAUDE_SKILL_DIR}/security-reports/session-security-YYYYMMDD.md` with per-finding severity, CWE mapping, vulnerable code snippet, and remediated code example.
+9. Produce the session security report at `./security-reports/session-security-YYYYMMDD.md` with per-finding severity, CWE mapping, vulnerable code snippet, and remediated code example.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implementation guide. See `${CLAUDE_SKILL_DIR}/references/critical-findings.md` for example vulnerability patterns with before/after code.
+See `./references/implementation.md` for the detailed implementation guide. See `./references/critical-findings.md` for example vulnerability patterns with before/after code.
 
 ## Output
 
-- **Session Security Report**: `${CLAUDE_SKILL_DIR}/security-reports/session-security-YYYYMMDD.md` with findings by severity
+- **Session Security Report**: `./security-reports/session-security-YYYYMMDD.md` with findings by severity
 - **Cookie Attribute Matrix**: per-cookie compliance table (HttpOnly, Secure, SameSite, prefix)
 - **Vulnerable Code Listings**: each finding with file path, line number, vulnerable snippet, and fix
 - **Framework-Specific Remediation**: configuration changes tailored to the detected framework
@@ -59,7 +59,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implemen
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| No session handling code found in `${CLAUDE_SKILL_DIR}/` | Unusual file structure or framework | Search for framework-specific patterns; request explicit file paths |
+| No session handling code found in `./` | Unusual file structure or framework | Search for framework-specific patterns; request explicit file paths |
 | Unknown session framework | Custom or uncommon session library | Apply fundamental session security principles; note limited framework-specific guidance |
 | Cannot analyze minified/compiled code | Production bundles instead of source | Request unminified source code; document limitation |
 | Non-standard session implementation | Custom session management bypassing framework | Apply extra scrutiny; custom implementations are higher risk (CWE-384, CWE-613) |
@@ -78,6 +78,6 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detailed implemen
 - CWE-613 Insufficient Session Expiration: https://cwe.mitre.org/data/definitions/613.html
 - CWE-319 Cleartext Transmission: https://cwe.mitre.org/data/definitions/319.html
 - NIST 800-63B Digital Authentication: https://pages.nist.gov/800-63-3/sp800-63b.html
-- `${CLAUDE_SKILL_DIR}/references/critical-findings.md` -- example vulnerability patterns
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
+- `./references/critical-findings.md` -- example vulnerability patterns
+- `./references/errors.md` -- full error handling reference
 - https://intentsolutions.io

--- a/plugins/security/session-security-checker/skills/checking-session-security/references/critical-findings.md
+++ b/plugins/security/session-security-checker/skills/checking-session-security/references/critical-findings.md
@@ -4,7 +4,7 @@
 
 ### 1. Session Fixation Vulnerability
 
-**File**: ${CLAUDE_SKILL_DIR}/src/auth/login.js
+**File**: ./src/auth/login.js
 **Line**: 45
 **Issue**: Session ID not regenerated after authentication
 **Risk**: Attacker can hijack authenticated session
@@ -34,7 +34,7 @@ function handleLogin(req, res) {
 
 ### 2. Missing HttpOnly Flag
 
-**File**: ${CLAUDE_SKILL_DIR}/config/session.js
+**File**: ./config/session.js
 **Line**: 12
 **Issue**: Session cookies accessible to JavaScript
 **Risk**: XSS attacks can steal session tokens

--- a/plugins/security/session-security-checker/skills/checking-session-security/references/errors.md
+++ b/plugins/security/session-security-checker/skills/checking-session-security/references/errors.md
@@ -3,7 +3,7 @@
 **Common Issues and Resolutions**:
 
 1. **Cannot Locate Session Management Code**
-   - Error: "No session handling code found in ${CLAUDE_SKILL_DIR}/"
+   - Error: "No session handling code found in ./"
    - Resolution: Search for framework-specific patterns
    - Fallback: Request explicit file paths from user
 

--- a/plugins/security/soc2-audit-helper/package.json
+++ b/plugins/security/soc2-audit-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/soc2-audit-helper",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Assist with SOC2 audit preparation",
   "keywords": [
     "security",

--- a/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/SKILL.md
+++ b/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/SKILL.md
@@ -28,12 +28,12 @@ Automate SOC 2 Type I and Type II audit preparation by assessing controls across
 
 ## Prerequisites
 
-- Policy and procedure documentation accessible in `${CLAUDE_SKILL_DIR}/docs/` (information security policy, incident response plan, BCP/DR plan, vendor management procedures)
+- Policy and procedure documentation accessible in `./docs/` (information security policy, incident response plan, BCP/DR plan, vendor management procedures)
 - Infrastructure-as-code and configuration files available for control verification
 - Cloud provider audit logs accessible (AWS CloudTrail, Azure Activity Log, GCP Audit Logs) or exported
 - Employee onboarding/offboarding and security awareness training records available
 - Change management and access review logs accessible
-- Write permissions for audit workspace in `${CLAUDE_SKILL_DIR}/soc2-audit/`
+- Write permissions for audit workspace in `./soc2-audit/`
 
 ## Instructions
 
@@ -42,17 +42,17 @@ Automate SOC 2 Type I and Type II audit preparation by assessing controls across
 3. **Assess CC6 -- Logical and Physical Access Controls**: verify MFA implementation, RBAC policies, password policy enforcement, access review cadence, and automated deprovisioning. Flag privileged access without monitoring.
 4. **Assess CC7 -- System Operations**: check monitoring and alerting configurations, backup procedures and testing records, incident response logs, and capacity planning documentation.
 5. **Assess CC8 -- Change Management**: review change approval workflows, deployment pipelines, rollback procedures, and change logs for the audit period.
-6. **Collect evidence artifacts**: organize evidence into the standard directory structure under `${CLAUDE_SKILL_DIR}/soc2-audit/` with subdirectories per criteria (CC1-control-environment/, CC6-access-controls/, CC7-system-operations/, etc.).
+6. **Collect evidence artifacts**: organize evidence into the standard directory structure under `./soc2-audit/` with subdirectories per criteria (CC1-control-environment/, CC6-access-controls/, CC7-system-operations/, etc.).
 7. **Test control effectiveness**: for each control, verify design adequacy (properly designed?) and operating effectiveness (working as intended during the audit period?). Document test results with screenshots, log excerpts, or configuration exports.
 8. **Perform gap analysis**: classify findings as missing controls (critical gap), partially implemented controls (needs improvement), improperly documented controls (evidence gap), or ineffective controls (design/operating failure).
-9. **Generate readiness report**: produce `${CLAUDE_SKILL_DIR}/soc2-audit/readiness-report-YYYYMMDD.md` with overall readiness score, per-criteria assessment with percentage, remediation roadmap with timelines, and evidence collection checklist.
+9. **Generate readiness report**: produce `./soc2-audit/readiness-report-YYYYMMDD.md` with overall readiness score, per-criteria assessment with percentage, remediation roadmap with timelines, and evidence collection checklist.
 10. **Prepare auditor interview guide**: draft expected auditor questions by criteria area with suggested evidence references and talking points.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the six-phase implementation guide. See `${CLAUDE_SKILL_DIR}/references/readiness-by-trust-service-category.md` for example per-criteria readiness breakdowns.
+See `./references/implementation.md` for the six-phase implementation guide. See `./references/readiness-by-trust-service-category.md` for example per-criteria readiness breakdowns.
 
 ## Output
 
-- **Readiness Report**: `${CLAUDE_SKILL_DIR}/soc2-audit/readiness-report-YYYYMMDD.md` with overall score and per-criteria pass/gap status
+- **Readiness Report**: `./soc2-audit/readiness-report-YYYYMMDD.md` with overall score and per-criteria pass/gap status
 - **Evidence Inventory**: organized artifact list mapped to specific CC control points
 - **Gap Analysis**: missing and partially implemented controls with severity and remediation priority
 - **Remediation Backlog**: prioritized tasks with effort estimates, owners, and target dates
@@ -62,11 +62,11 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the six-phase impleme
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| Cannot locate security policy in `${CLAUDE_SKILL_DIR}/docs/` | Documentation stored elsewhere or not yet created | Request document locations; flag as critical evidence gap requiring immediate creation |
+| Cannot locate security policy in `./docs/` | Documentation stored elsewhere or not yet created | Request document locations; flag as critical evidence gap requiring immediate creation |
 | Log retention < SOC 2 requirement (1 year) | Insufficient log retention configuration | Note current retention period; flag as gap; recommend extending to 12+ months |
 | No incident response playbook found | Undocumented procedure | Flag as critical gap; provide template for creating IR playbook |
 | Cannot assess cloud controls without API access | No CloudTrail/Audit Log exports available | Request console screenshots or JSON exports as alternative evidence |
-| Production and dev configs mixed in `${CLAUDE_SKILL_DIR}/` | Environment separation unclear | Request environment labeling; risk of auditing wrong environment |
+| Production and dev configs mixed in `./` | Environment separation unclear | Request environment labeling; risk of auditing wrong environment |
 
 ## Examples
 
@@ -80,7 +80,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the six-phase impleme
 - SOC 2 Compliance Checklist:
 - CIS Controls v8: https://www.cisecurity.org/controls/
 - NIST Cybersecurity Framework: https://www.nist.gov/cyberframework
-- `${CLAUDE_SKILL_DIR}/references/readiness-by-trust-service-category.md` -- example per-criteria readiness breakdown
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/readiness-by-trust-service-category.md` -- example per-criteria readiness breakdown
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/references/errors.md
+++ b/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/references/errors.md
@@ -3,7 +3,7 @@
 **Common Issues and Resolutions**:
 
 1. **Missing Evidence Files**
-   - Error: "Cannot locate security policy in ${CLAUDE_SKILL_DIR}/docs/"
+   - Error: "Cannot locate security policy in ./docs/"
    - Resolution: Request document locations from user
    - Fallback: Mark as evidence gap in report
 
@@ -23,7 +23,7 @@
    - Alternative: Provide manual checklist for cloud controls
 
 5. **Multiple Environments Not Distinguished**
-   - Error: "Production and dev configs mixed in ${CLAUDE_SKILL_DIR}/"
+   - Error: "Production and dev configs mixed in ./"
    - Resolution: Request environment separation or clear labeling
    - Risk: May audit wrong environment
 

--- a/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/references/implementation.md
+++ b/plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/references/implementation.md
@@ -89,7 +89,7 @@ Compare current state against SOC 2 requirements:
 Organize evidence by Trust Service Criteria:
 
 ```
-${CLAUDE_SKILL_DIR}/soc2-audit/
+./soc2-audit/
 ├── CC1-control-environment/
 │   ├── org-chart.pdf
 │   ├── security-policy.md

--- a/plugins/security/sql-injection-detector/package.json
+++ b/plugins/security/sql-injection-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/sql-injection-detector",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Detect SQL injection vulnerabilities",
   "keywords": [
     "security",

--- a/plugins/security/sql-injection-detector/skills/detecting-sql-injection-vulnerabilities/SKILL.md
+++ b/plugins/security/sql-injection-detector/skills/detecting-sql-injection-vulnerabilities/SKILL.md
@@ -28,11 +28,11 @@ Scan application source code for SQL injection vulnerabilities (CWE-89, OWASP A0
 
 ## Prerequisites
 
-- Application source code accessible in `${CLAUDE_SKILL_DIR}/`
+- Application source code accessible in `./`
 - Database query files, ORM models, and repository/DAO layers available
 - Framework and language identified (Django, Rails, Express, Spring, Laravel, ASP.NET, Go, etc.)
 - Database type known (MySQL, PostgreSQL, SQLite, MSSQL, Oracle) for syntax-specific detection
-- Write permissions for reports in `${CLAUDE_SKILL_DIR}/security-reports/`
+- Write permissions for reports in `./security-reports/`
 
 ## Instructions
 
@@ -48,13 +48,13 @@ Scan application source code for SQL injection vulnerabilities (CWE-89, OWASP A0
 6. **Assess impact per finding**: determine data exposure scope (authentication bypass, data exfiltration, data modification, OS command execution via `xp_cmdshell` or `LOAD_FILE()`).
 7. **Generate remediation code**: provide parameterized equivalents for each vulnerable query. Use framework-idiomatic patterns -- `%s` placeholders for Python DB-API, `?` for Node.js, `$1` for PostgreSQL, named parameters for Spring JPA.
 8. **Recommend defense-in-depth measures**: input validation (allowlists over denylists), stored procedures with parameterized calls, least-privilege database accounts, WAF rules, and ORM-only data access policies.
-9. **Produce the vulnerability report** at `${CLAUDE_SKILL_DIR}/security-reports/sqli-scan-YYYYMMDD.md` with per-finding severity, CWE-89 mapping, file path and line number, vulnerable code snippet, attack vector demonstration, and remediated code.
+9. **Produce the vulnerability report** at `./security-reports/sqli-scan-YYYYMMDD.md` with per-finding severity, CWE-89 mapping, file path and line number, vulnerable code snippet, attack vector demonstration, and remediated code.
 
-See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detection pattern library. See `${CLAUDE_SKILL_DIR}/references/critical-findings.md` for example vulnerability write-ups with attack demonstrations.
+See `./references/implementation.md` for the detection pattern library. See `./references/critical-findings.md` for example vulnerability write-ups with attack demonstrations.
 
 ## Output
 
-- **Vulnerability Report**: `${CLAUDE_SKILL_DIR}/security-reports/sqli-scan-YYYYMMDD.md` with all findings classified by severity
+- **Vulnerability Report**: `./security-reports/sqli-scan-YYYYMMDD.md` with all findings classified by severity
 - **Finding Details**: per-finding file path, line number, vulnerable code, attack vector, CVSS score, and remediation code
 - **Remediation Summary**: parameterized query replacements grouped by language/framework
 - **Defense Recommendations**: input validation rules, database privilege changes, and WAF configuration
@@ -67,7 +67,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detection pattern
 | Cannot analyze compiled/minified code | Production bundles or bytecode instead of source | Request unminified source; document reduced detection accuracy |
 | False positive on sanitized input | Proper sanitization exists but not recognized | Trace sanitization implementation manually; whitelist verified-safe patterns |
 | Complex dynamic query builder logic | Multi-step query construction across modules | Trace full data flow manually; flag for manual security review |
-| Cannot analyze stored procedure definitions | SQL source files not available in `${CLAUDE_SKILL_DIR}/` | Request `.sql` files or database schema exports; focus on application-layer code |
+| Cannot analyze stored procedure definitions | SQL source files not available in `./` | Request `.sql` files or database schema exports; focus on application-layer code |
 
 ## Examples
 
@@ -81,7 +81,7 @@ See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the detection pattern
 - CWE-89 Improper Neutralization of SQL Syntax: https://cwe.mitre.org/data/definitions/89.html
 - OWASP A03:2021 Injection: https://owasp.org/Top10/A03_2021-Injection/
 - CAPEC-66 SQL Injection: https://capec.mitre.org/data/definitions/66.html
-- `${CLAUDE_SKILL_DIR}/references/critical-findings.md` -- example vulnerability write-ups with attack vectors
-- `${CLAUDE_SKILL_DIR}/references/errors.md` -- full error handling reference
-- `${CLAUDE_SKILL_DIR}/references/examples.md` -- additional usage examples
+- `./references/critical-findings.md` -- example vulnerability write-ups with attack vectors
+- `./references/errors.md` -- full error handling reference
+- `./references/examples.md` -- additional usage examples
 - https://intentsolutions.io

--- a/plugins/security/sql-injection-detector/skills/detecting-sql-injection-vulnerabilities/references/critical-findings.md
+++ b/plugins/security/sql-injection-detector/skills/detecting-sql-injection-vulnerabilities/references/critical-findings.md
@@ -4,7 +4,7 @@
 
 ### 1. Authentication Bypass via SQL Injection
 
-**File**: ${CLAUDE_SKILL_DIR}/src/auth/login.py
+**File**: ./src/auth/login.py
 **Line**: 45
 **Severity**: CRITICAL (CVSS 9.8)
 
@@ -51,7 +51,7 @@ def authenticate_user(username, password):
 
 ### 2. Data Exfiltration via UNION-based SQLi
 
-**File**: ${CLAUDE_SKILL_DIR}/src/api/products.py
+**File**: ./src/api/products.py
 **Line**: 78
 **Severity**: CRITICAL (CVSS 8.6)
 

--- a/plugins/skill-enhancers/skill-creator/package.json
+++ b/plugins/skill-enhancers/skill-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/skill-creator",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Create and validate production-grade agent skills with 100-point marketplace grading",
   "keywords": [
     "skill-creation",

--- a/plugins/skill-enhancers/skill-creator/references/advanced-eval-workflow.md
+++ b/plugins/skill-enhancers/skill-creator/references/advanced-eval-workflow.md
@@ -59,7 +59,7 @@ skills (writing style, design) are better evaluated qualitatively — don't forc
 onto things that need human judgment.
 
 Update `eval_metadata.json` files and `evals/evals.json` with the assertions. See
-`${CLAUDE_SKILL_DIR}/references/schemas.md` for the full schema.
+`./references/schemas.md` for the full schema.
 
 ### Step E3: As runs complete, capture timing data
 
@@ -80,7 +80,7 @@ capture this data:
 Once all runs are done:
 
 1. **Grade each run** — spawn a grader subagent that reads
-   `${CLAUDE_SKILL_DIR}/agents/grader.md` and evaluates each assertion against the outputs.
+   `./agents/grader.md` and evaluates each assertion against the outputs.
    Save results to `grading.json` in each run directory. The grading.json expectations array
    must use fields `text`, `passed`, and `evidence` — the viewer depends on these exact field
    names. For programmatically checkable assertions, write and run a script rather than
@@ -94,17 +94,17 @@ Once all runs are done:
 
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for
    each configuration, with mean +/- stddev and the delta. If generating benchmark.json
-   manually, see `${CLAUDE_SKILL_DIR}/references/schemas.md` for the exact schema the
+   manually, see `./references/schemas.md` for the exact schema the
    viewer expects.
 
 3. **Analyst pass** — read the benchmark data and surface patterns. See
-   `${CLAUDE_SKILL_DIR}/agents/analyzer.md` (the "Analyzing Benchmark Results" section) for
+   `./agents/analyzer.md` (the "Analyzing Benchmark Results" section) for
    what to look for — non-discriminating assertions, high-variance evals, time/token tradeoffs.
 
 4. **Launch the viewer**:
 
    ```bash
-   nohup python ${CLAUDE_SKILL_DIR}/eval-viewer/generate_review.py \
+   nohup python ./eval-viewer/generate_review.py \
      <workspace>/iteration-N \
      --skill-name "my-skill" \
      --benchmark <workspace>/iteration-N/benchmark.json \
@@ -234,7 +234,7 @@ Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called s
 
 Present the eval set using the HTML template:
 
-1. Read `${CLAUDE_SKILL_DIR}/assets/eval_review.html`
+1. Read `./assets/eval_review.html`
 2. Replace placeholders: `__EVAL_DATA_PLACEHOLDER__` (JSON array, no quotes — it's a JS
    variable assignment), `__SKILL_NAME_PLACEHOLDER__`, `__SKILL_DESCRIPTION_PLACEHOLDER__`
 3. Write to `/tmp/eval_review_<skill-name>.html` and open it
@@ -281,7 +281,7 @@ Show the user before/after and report the scores.
 ## Advanced: Blind Comparison
 
 For rigorous comparison between two skill versions, use the blind comparison system. Read
-`${CLAUDE_SKILL_DIR}/agents/comparator.md` and `${CLAUDE_SKILL_DIR}/agents/analyzer.md` for
+`./agents/comparator.md` and `./agents/analyzer.md` for
 details.
 
 The basic idea: give two outputs to an independent agent without telling it which is which,

--- a/plugins/skill-enhancers/skill-creator/references/source-of-truth.md
+++ b/plugins/skill-enhancers/skill-creator/references/source-of-truth.md
@@ -75,7 +75,7 @@ skill-name/
 
 - **`${CLAUDE_SKILL_DIR}`** - resolves to the skill's root directory at runtime (2026 standard)
 - **`{baseDir}`** - legacy alias, still works in Claude Code
-- All internal references SHOULD use `${CLAUDE_SKILL_DIR}/` prefix
+- All internal references SHOULD use `./` prefix
 - One-level-deep file references only (no `{baseDir}/references/subdir/file.md`)
 - No absolute paths (`/home/...`, `/Users/...`, `C:\...`)
 - No path escapes (`{baseDir}/../other-skill/`)
@@ -344,8 +344,8 @@ Session tracking: ${CLAUDE_SESSION_ID}
 
 | Scenario | Method | Why |
 |----------|--------|-----|
-| Always-needed, small (<5KB) | `` !`cat ${CLAUDE_SKILL_DIR}/references/small.md` `` | Saves a Read tool call, always available |
-| Conditional (mode-dependent) | Manual `Load ${CLAUDE_SKILL_DIR}/references/...` | Only loads when the branch executes |
+| Always-needed, small (<5KB) | `` !`cat ./references/small.md` `` | Saves a Read tool call, always available |
+| Conditional (mode-dependent) | Manual `Load ./references/...` | Only loads when the branch executes |
 | Large (>5KB) | Manual load | Avoids bloating context on every activation |
 | Dynamic state (git log, env) | `` !`git log --oneline -5` `` | Fresh data at activation time |
 

--- a/plugins/skill-enhancers/skill-creator/references/validation-rules.md
+++ b/plugins/skill-enhancers/skill-creator/references/validation-rules.md
@@ -121,9 +121,9 @@ The marketplace 100-point validator scores them at top-level.
 | Has examples | Warning | Should have `## Examples` or example content |
 | Instructions have steps | Warning | Should have numbered steps or `### Step N` headings |
 | Error handling | Warning | Should document error cases |
-| Resources section | Warning | Should list `${CLAUDE_SKILL_DIR}/` references if resources exist |
-| All `${CLAUDE_SKILL_DIR}/` refs exist | Error | Referenced scripts, references, templates must exist |
-| No path escapes | Error | No `${CLAUDE_SKILL_DIR}/../` |
+| Resources section | Warning | Should list `./` references if resources exist |
+| All `./` refs exist | Error | Referenced scripts, references, templates must exist |
+| No path escapes | Error | No `../` |
 | Word count | Warning | Over 5000 words suggests splitting to references |
 | Consistent terminology | Warning | No synonym rotation for key concepts |
 | Concrete examples | Warning | Examples should show input AND output, not abstract |
@@ -170,7 +170,7 @@ Bash(docker:*)
 | Anti-Pattern | Check | Level |
 |-------------|-------|-------|
 | Windows paths | `C:\` or backslash paths | Error |
-| Nested references | `${CLAUDE_SKILL_DIR}/references/sub/dir/file` | Warning |
+| Nested references | `./references/sub/dir/file` | Warning |
 | Hardcoded model IDs | `claude-*-20\d{6}` pattern | Warning |
 | Voodoo constants | Unexplained magic numbers | Info |
 | Over-verbose | >5000 words in SKILL.md | Warning |
@@ -218,7 +218,7 @@ Skills can use `` !`command` `` syntax (Anthropic spec preprocessing) to inject 
 
 | Scenario | Method |
 |----------|--------|
-| Always-needed, small references (<5KB) | `` !`cat ${CLAUDE_SKILL_DIR}/references/small.md` `` |
+| Always-needed, small references (<5KB) | `` !`cat ./references/small.md` `` |
 | Dynamic state (git log, env vars) | `` !`git log --oneline -5` `` |
 | Conditional or large references (>5KB) | Manual `Load ...` instructions |
 
@@ -272,10 +272,10 @@ Also recognized: `${CLAUDE_SESSION_ID}` — current session identifier (official
 
 ### Resource Validation
 
-1. All `${CLAUDE_SKILL_DIR}/scripts/*` references exist
-2. All `${CLAUDE_SKILL_DIR}/references/*` references exist
-3. All `${CLAUDE_SKILL_DIR}/templates/*` references exist
-4. All `${CLAUDE_SKILL_DIR}/assets/*` references exist
+1. All `./scripts/*` references exist
+2. All `./references/*` references exist
+3. All `./templates/*` references exist
+4. All `./assets/*` references exist
 5. Relative markdown links (e.g., `ref`, `api`) point to existing files
 6. No path escape attempts
 

--- a/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
+++ b/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
@@ -126,7 +126,7 @@ All production agents should follow this body structure:
 ### Step 3: Write the Agent File
 
 Generate the agent .md using the template from
-`${CLAUDE_SKILL_DIR}/../skill-creator/templates/agent-template.md`.
+`../skill-creator/templates/agent-template.md`.
 
 **Frontmatter Rules (Anthropic 16-field schema):**
 
@@ -217,7 +217,7 @@ Run validation against the Anthropic 16-field schema:
 **Automated validation:**
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/../skill-creator/scripts/validate-skill.py --agents-only {plugin-dir}/
+python3 ../skill-creator/scripts/validate-skill.py --agents-only {plugin-dir}/
 ```
 
 ### Step 5: Test the Agent

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/SKILL.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/SKILL.md
@@ -113,7 +113,7 @@ Before writing, determine:
 
 Think of it as **narrow bridge vs open field**: a deployment skill is a narrow bridge (one safe path, guard rails everywhere), while a writing skill is an open field (Claude roams freely within broad boundaries). Match constraint level to the task.
 
-**Workflow Pattern** (see `${CLAUDE_SKILL_DIR}/references/workflows.md`):
+**Workflow Pattern** (see `./references/workflows.md`):
 
 - Sequential: fixed steps in order
 - Conditional: branch based on input
@@ -123,7 +123,7 @@ Think of it as **narrow bridge vs open field**: a deployment skill is a narrow b
 - Checklist Workflow: copy-pasteable progress tracking for complex multi-step processes
 - Search-Analyze-Report: explore and summarize
 
-**Output Pattern** (see `${CLAUDE_SKILL_DIR}/references/output-patterns.md`):
+**Output Pattern** (see `./references/output-patterns.md`):
 
 - Strict template (exact format)
 - Flexible template (structure with creative content)
@@ -157,7 +157,7 @@ Key rules:
 - No XML tags in name or description (Anthropic spec prohibition)
 - No time-sensitive information; use 'old patterns' section for deprecated approaches
 - Include feedback loops for quality-critical workflows
-- Run `python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade {skill-dir}/SKILL.md` to validate
+- Run `python3 ./scripts/validate-skill.py --grade {skill-dir}/SKILL.md` to validate
 - Create `evals/evals.json` with 3+ scenarios, iterate until all assertions pass
 
 ## Validation Workflow
@@ -165,7 +165,7 @@ Key rules:
 When the user wants to validate, grade, or audit an existing skill. For detailed steps (V1-V5), see [Creation Guide](references/creation-guide.md).
 
 1. Locate the SKILL.md (global `~/.claude/skills/` or project `.claude/skills/`)
-2. Run `python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade {path}/SKILL.md`
+2. Run `python3 ./scripts/validate-skill.py --grade {path}/SKILL.md`
 3. Review grade against the 100-point rubric (A: 90+, B: 80-89, C: 70-79, D: 60-69, F: <60)
 4. Report results with prioritized fix recommendations
 5. Auto-fix if requested: add missing sections, fix description patterns, move nested metadata to top-level
@@ -231,7 +231,7 @@ Uses context: fork for isolated execution.
 ```
 User: Grade my skill at ~/.claude/skills/code-review/SKILL.md
 
-Runs: python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade ~/.claude/skills/code-review/SKILL.md
+Runs: python3 ./scripts/validate-skill.py --grade ~/.claude/skills/code-review/SKILL.md
 
 Output:
   Grade: B (84/100)
@@ -258,35 +258,35 @@ Output:
 | Name exists | Directory already present | Choose different name or confirm overwrite |
 | Invalid name | Not kebab-case or >64 chars | Fix to lowercase-with-hyphens |
 | Validation fails | Missing fields or anti-patterns | Run validator, fix reported issues |
-| Resource missing | `${CLAUDE_SKILL_DIR}/` ref points to nonexistent file | Create the file or fix the reference |
+| Resource missing | `./` ref points to nonexistent file | Create the file or fix the reference |
 | Undertriggering | Description too passive | Add "Make sure to use whenever..." phrasing |
 | Eval failures | Skill not producing expected output | Iterate on instructions and re-test |
 | Low grade | Missing scored sections or fields | Add Overview, Prerequisites, Output sections |
 
 ## Resources
 
-**References:** `${CLAUDE_SKILL_DIR}/references/`
+**References:** `./references/`
 
 - `creation-guide.md` — Detailed Steps 4-10 and Validation Workflow (V1-V5)
 - `source-of-truth.md` — Canonical spec ([AgentSkills.io](https://agentskills.io/specification), [Anthropic docs](https://code.claude.com/docs/en/skills), [Lee Han Chung deep dive](https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/)) | `frontmatter-spec.md` — Field reference | `validation-rules.md` — 100-point rubric
 - `workflows.md` — Workflow patterns | `output-patterns.md` — Output formats | `schemas.md` — JSON schemas (evals, grading, benchmarks)
 - `anthropic-comparison.md` — Gap analysis | `advanced-eval-workflow.md` — Eval, iteration, optimization, platform notes
 
-**Agents** (read when spawning subagents): `${CLAUDE_SKILL_DIR}/agents/`
+**Agents** (read when spawning subagents): `./agents/`
 
 - `grader.md` — Assertion evaluation | `comparator.md` — Blind A/B comparison | `analyzer.md` — Benchmark analysis
 
-**Scripts:** `${CLAUDE_SKILL_DIR}/scripts/`
+**Scripts:** `./scripts/`
 
 - `validate-skill.py` — 100-point rubric grading | `quick_validate.py` — Lightweight validation
 - `aggregate_benchmark.py` — Benchmark stats | `run_eval.py` — Trigger accuracy testing
 - `run_loop.py` — Description optimization loop | `improve_description.py` — LLM-powered rewriting
 - `generate_report.py` — HTML reports | `package_skill.py` — .skill packaging | `utils.py` — Shared utilities
 
-**Eval Viewer:** `${CLAUDE_SKILL_DIR}/eval-viewer/` — `generate_review.py` + `viewer.html` (interactive output comparison)
-**Assets:** `${CLAUDE_SKILL_DIR}/assets/eval_review.html` (trigger eval set editor)
-**Templates:** `${CLAUDE_SKILL_DIR}/templates/skill-template.md` (SKILL.md skeleton)
+**Eval Viewer:** `./eval-viewer/` — `generate_review.py` + `viewer.html` (interactive output comparison)
+**Assets:** `./assets/eval_review.html` (trigger eval set editor)
+**Templates:** `./templates/skill-template.md` (SKILL.md skeleton)
 
 ---
 
-For advanced workflows (empirical eval, description optimization, blind comparison, packaging, platform notes), see [Creation Guide](references/creation-guide.md) and `${CLAUDE_SKILL_DIR}/references/advanced-eval-workflow.md`.
+For advanced workflows (empirical eval, description optimization, blind comparison, packaging, platform notes), see [Creation Guide](references/creation-guide.md) and `./references/advanced-eval-workflow.md`.

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/advanced-eval-workflow.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/advanced-eval-workflow.md
@@ -59,7 +59,7 @@ skills (writing style, design) are better evaluated qualitatively — don't forc
 onto things that need human judgment.
 
 Update `eval_metadata.json` files and `evals/evals.json` with the assertions. See
-`${CLAUDE_SKILL_DIR}/references/schemas.md` for the full schema.
+`./references/schemas.md` for the full schema.
 
 ### Step E3: As runs complete, capture timing data
 
@@ -80,7 +80,7 @@ capture this data:
 Once all runs are done:
 
 1. **Grade each run** — spawn a grader subagent that reads
-   `${CLAUDE_SKILL_DIR}/agents/grader.md` and evaluates each assertion against the outputs.
+   `./agents/grader.md` and evaluates each assertion against the outputs.
    Save results to `grading.json` in each run directory. The grading.json expectations array
    must use fields `text`, `passed`, and `evidence` — the viewer depends on these exact field
    names. For programmatically checkable assertions, write and run a script rather than
@@ -94,17 +94,17 @@ Once all runs are done:
 
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for
    each configuration, with mean +/- stddev and the delta. If generating benchmark.json
-   manually, see `${CLAUDE_SKILL_DIR}/references/schemas.md` for the exact schema the
+   manually, see `./references/schemas.md` for the exact schema the
    viewer expects.
 
 3. **Analyst pass** — read the benchmark data and surface patterns. See
-   `${CLAUDE_SKILL_DIR}/agents/analyzer.md` (the "Analyzing Benchmark Results" section) for
+   `./agents/analyzer.md` (the "Analyzing Benchmark Results" section) for
    what to look for — non-discriminating assertions, high-variance evals, time/token tradeoffs.
 
 4. **Launch the viewer**:
 
    ```bash
-   nohup python ${CLAUDE_SKILL_DIR}/eval-viewer/generate_review.py \
+   nohup python ./eval-viewer/generate_review.py \
      <workspace>/iteration-N \
      --skill-name "my-skill" \
      --benchmark <workspace>/iteration-N/benchmark.json \
@@ -234,7 +234,7 @@ Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called s
 
 Present the eval set using the HTML template:
 
-1. Read `${CLAUDE_SKILL_DIR}/assets/eval_review.html`
+1. Read `./assets/eval_review.html`
 2. Replace placeholders: `__EVAL_DATA_PLACEHOLDER__` (JSON array, no quotes — it's a JS
    variable assignment), `__SKILL_NAME_PLACEHOLDER__`, `__SKILL_DESCRIPTION_PLACEHOLDER__`
 3. Write to `/tmp/eval_review_<skill-name>.html` and open it
@@ -281,7 +281,7 @@ Show the user before/after and report the scores.
 ## Advanced: Blind Comparison
 
 For rigorous comparison between two skill versions, use the blind comparison system. Read
-`${CLAUDE_SKILL_DIR}/agents/comparator.md` and `${CLAUDE_SKILL_DIR}/agents/analyzer.md` for
+`./agents/comparator.md` and `./agents/analyzer.md` for
 details.
 
 The basic idea: give two outputs to an independent agent without telling it which is which,

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/creation-guide.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/creation-guide.md
@@ -5,9 +5,9 @@ Referred from the main SKILL.md Steps 4-10.
 
 ## Step 4: Write SKILL.md
 
-Generate the SKILL.md using the template from `${CLAUDE_SKILL_DIR}/templates/skill-template.md`.
+Generate the SKILL.md using the template from `./templates/skill-template.md`.
 
-**Frontmatter rules** (see `${CLAUDE_SKILL_DIR}/references/frontmatter-spec.md`):
+**Frontmatter rules** (see `./references/frontmatter-spec.md`):
 
 Required fields:
 
@@ -94,7 +94,7 @@ Additional guidelines:
 - Concise — Claude is smart, don't over-explain
 - Concrete examples over abstract descriptions
 - Reference supporting files with relative markdown links: `details` or `API` — Claude reads these on demand
-- Use `${CLAUDE_SKILL_DIR}/` in DCI/bash contexts only: exclamation + backtick-wrapped command, e.g. `cat ${CLAUDE_SKILL_DIR}/references/config.md`
+- Use `./` in DCI/bash contexts only: exclamation + backtick-wrapped command, e.g. `cat ./references/config.md`
 - Sections >20 lines (Output, Error Handling, Examples) → offload to `references/` with relative links
 - If skill has 3+ distinct user operations → split into individual `commands/*.md` files
 - Add DCI for common discovery: file existence checks, git status, tool version detection
@@ -112,9 +112,9 @@ Additional guidelines:
 - `${CLAUDE_SESSION_ID}` - current session ID
 - `` !`command` `` syntax — dynamic context injection (Anthropic spec feature):
   - Runs shell command at skill activation time, injects stdout into body
-  - **Use for**: always-needed, small references (<5KB) — e.g., `!`cat ${CLAUDE_SKILL_DIR}/references/config.md``
+  - **Use for**: always-needed, small references (<5KB) — e.g., `!`cat ./references/config.md``
   - **Don't use for**: large references (>5KB), conditional content, or anything that varies by mode
-  - Conditional or large references → keep manual `Load ${CLAUDE_SKILL_DIR}/references/...` instructions
+  - Conditional or large references → keep manual `Load ./references/...` instructions
 
 ## Step 5: Create Supporting Files
 
@@ -144,11 +144,11 @@ Additional guidelines:
 
 ## Step 6: Validate
 
-Run validation (see `${CLAUDE_SKILL_DIR}/references/validation-rules.md`):
+Run validation (see `./references/validation-rules.md`):
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py {skill-dir}/SKILL.md
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade {skill-dir}/SKILL.md
+python3 ./scripts/validate-skill.py {skill-dir}/SKILL.md
+python3 ./scripts/validate-skill.py --grade {skill-dir}/SKILL.md
 ```
 
 Standard tier is the default (no required fields, broad compatibility). Use `--enterprise` for full 100-point marketplace grading.
@@ -159,14 +159,14 @@ Standard tier is the default (no required fields, broad compatibility). Use `--e
 - Description: third person, what + when, keywords, length
 - Body: under 500 lines, no absolute paths, has instructions + examples
 - Tools: valid names, scoped Bash
-- Resources: all `${CLAUDE_SKILL_DIR}/` references exist
+- Resources: all `./` references exist
 - Anti-patterns: Windows paths, nested refs, hardcoded model IDs
 - Progressive disclosure: appropriate use of references/
 
 **If validation fails:** fix issues and re-run. Common fixes:
 
 - Scope Bash tools: `Bash(git:*)` not `Bash`
-- Remove absolute paths, use `${CLAUDE_SKILL_DIR}/`
+- Remove absolute paths, use `./`
 - Split long SKILL.md into references
 - Add missing sections (Overview, Prerequisites, Output)
 - Move author/version to top-level if nested in metadata
@@ -258,7 +258,7 @@ Ask for the SKILL.md path or detect from context. Common locations:
 ### Step V2: Run Validator
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade {path}/SKILL.md
+python3 ./scripts/validate-skill.py --grade {path}/SKILL.md
 ```
 
 ### Step V3: Review Grade
@@ -276,7 +276,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/validate-skill.py --grade {path}/SKILL.md
 
 Grade scale: A (90+), B (80-89), C (70-79), D (60-69), F (<60)
 
-See `${CLAUDE_SKILL_DIR}/references/validation-rules.md` for detailed sub-criteria.
+See `./references/validation-rules.md` for detailed sub-criteria.
 
 ### Step V4: Report Results
 
@@ -289,28 +289,28 @@ If the user says "fix it" or "auto-fix", apply the suggested improvements:
 1. Add missing sections (Overview, Prerequisites, Output)
 2. Add "Use when" / "Trigger with" to description
 3. Move author/version from metadata to top-level
-4. Fix path variables to `${CLAUDE_SKILL_DIR}/`
+4. Fix path variables to `./`
 5. Re-run grading to confirm improvement
 
 ## Running and Evaluating Test Cases
 
-For detailed empirical eval workflow (Steps E1-E5), read `${CLAUDE_SKILL_DIR}/references/advanced-eval-workflow.md`.
+For detailed empirical eval workflow (Steps E1-E5), read `./references/advanced-eval-workflow.md`.
 
-**Quick summary:** Spawn with-skill and baseline subagents in parallel -> draft assertions while running -> capture timing data from task notifications -> grade with `${CLAUDE_SKILL_DIR}/agents/grader.md` -> aggregate with `scripts/aggregate_benchmark.py` -> launch `eval-viewer/generate_review.py` for interactive human review -> read `feedback.json`.
+**Quick summary:** Spawn with-skill and baseline subagents in parallel -> draft assertions while running -> capture timing data from task notifications -> grade with `./agents/grader.md` -> aggregate with `scripts/aggregate_benchmark.py` -> launch `eval-viewer/generate_review.py` for interactive human review -> read `feedback.json`.
 
 ## Improving the Skill
 
-For iteration loop details, read `${CLAUDE_SKILL_DIR}/references/advanced-eval-workflow.md` (section "Improving the Skill").
+For iteration loop details, read `./references/advanced-eval-workflow.md` (section "Improving the Skill").
 
 **Key principles:** Generalize from feedback (don't overfit), keep prompts lean, explain the *why* behind rules (not just prescriptions), and bundle repeated helper scripts.
 
 ## Description Optimization (Automated)
 
-For the full pipeline (Steps D1-D4), read `${CLAUDE_SKILL_DIR}/references/advanced-eval-workflow.md` (section "Description Optimization"). Quick summary: generate 20 realistic trigger eval queries -> review with user via `${CLAUDE_SKILL_DIR}/assets/eval_review.html` -> run `python -m scripts.run_loop` (60/40 train/test, 3 runs/query, up to 5 iterations) -> apply `best_description`.
+For the full pipeline (Steps D1-D4), read `./references/advanced-eval-workflow.md` (section "Description Optimization"). Quick summary: generate 20 realistic trigger eval queries -> review with user via `./assets/eval_review.html` -> run `python -m scripts.run_loop` (60/40 train/test, 3 runs/query, up to 5 iterations) -> apply `best_description`.
 
 ## Advanced: Blind Comparison
 
-For A/B testing between skill versions, read `${CLAUDE_SKILL_DIR}/agents/comparator.md` and `${CLAUDE_SKILL_DIR}/agents/analyzer.md`. Optional; most users won't need it.
+For A/B testing between skill versions, read `./agents/comparator.md` and `./agents/analyzer.md`. Optional; most users won't need it.
 
 ## Packaging
 
@@ -318,7 +318,7 @@ For A/B testing between skill versions, read `${CLAUDE_SKILL_DIR}/agents/compara
 
 ## Platform-Specific Notes
 
-See `${CLAUDE_SKILL_DIR}/references/advanced-eval-workflow.md` (section "Platform-Specific Notes").
+See `./references/advanced-eval-workflow.md` (section "Platform-Specific Notes").
 
 - **Claude.ai**: No subagents — run tests yourself, skip benchmarking/description optimization.
 - **Cowork**: Full subagent workflow. Use `--static` for eval viewer. Generate viewer BEFORE self-evaluation.

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/source-of-truth.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/source-of-truth.md
@@ -206,7 +206,7 @@ skill-name/
 │   ├── errors.md                 # Required — troubleshooting table (error | cause | fix)
 │   ├── examples.md               # Required — real usage examples with code
 │   └── implementation.md         # Required — how the skill works internally
-├── scripts/                      # If skill uses ${CLAUDE_SKILL_DIR}/scripts/
+├── scripts/                      # If skill uses ./scripts/
 ├── config/                       # If skill needs configuration templates
 ├── templates/                    # Optional — boilerplate files for generation
 └── assets/                       # Optional — static resources (images, configs)
@@ -422,7 +422,7 @@ Enterprise-grade skills should include these 7 sections:
 | **Output** | Expected deliverables | What the skill produces |
 | **Error Handling** | Failure modes and recovery | Common errors + fixes |
 | **Examples** | Concrete input/output | At least 1, ideally 2-3 |
-| **Resources** | Links to bundled files | `${CLAUDE_SKILL_DIR}/` paths |
+| **Resources** | Links to bundled files | `./` paths |
 
 ### Content Quality
 
@@ -478,8 +478,8 @@ Session tracking: ${CLAUDE_SESSION_ID}
 
 | Scenario | Method | Why |
 |----------|--------|-----|
-| Always-needed, small (<5KB) | `` !`cat ${CLAUDE_SKILL_DIR}/references/small.md` `` | Saves a Read tool call, always available |
-| Conditional (mode-dependent) | Manual `Load ${CLAUDE_SKILL_DIR}/references/...` | Only loads when the branch executes |
+| Always-needed, small (<5KB) | `` !`cat ./references/small.md` `` | Saves a Read tool call, always available |
+| Conditional (mode-dependent) | Manual `Load ./references/...` | Only loads when the branch executes |
 | Large (>5KB) | Manual load | Avoids bloating context on every activation |
 | Dynamic state (git log, env) | `` !`git log --oneline -5` `` | Fresh data at activation time |
 
@@ -587,7 +587,7 @@ Best for: dashboards, reports, documentation sites.
 
 | Anti-Pattern | Why It's Bad | Fix |
 |-------------|-------------|-----|
-| Windows-style paths | Not portable | Use `${CLAUDE_SKILL_DIR}/` or Unix paths |
+| Windows-style paths | Not portable | Use `./` or Unix paths |
 | Too many options without defaults | Analysis paralysis | Provide sensible defaults |
 | Deeply nested references (>1 level) | Loading failures | Flatten to one level |
 | Assuming tools are installed | Runtime failures | Note requirements in description or body |

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/validation-rules.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/references/validation-rules.md
@@ -192,8 +192,8 @@ capabilities: []                  # NOTE: valid for agents ONLY, not skills
 |-------|-------|--------|
 | 7 required sections present | Error | Overview, Prerequisites, Instructions, Output, Error Handling, Examples, Resources |
 | Instructions have numbered steps | Warning | Should have numbered steps or `### Step N` headings |
-| All `${CLAUDE_SKILL_DIR}/` refs exist | Error | Referenced scripts, references, templates must exist |
-| No path escapes | Error | No `${CLAUDE_SKILL_DIR}/../` |
+| All `./` refs exist | Error | Referenced scripts, references, templates must exist |
+| No path escapes | Error | No `../` |
 | `references/` directory exists | Error | Must use `references/` (plural directory), not `reference.md` singular |
 | Word count | Warning | Over 5000 words suggests splitting to references |
 
@@ -339,7 +339,7 @@ These are invented fields that appear in no Anthropic documentation:
 | Anti-Pattern | Check | Level |
 |-------------|-------|-------|
 | Windows paths | `C:\` or backslash paths | Error |
-| Nested references | `${CLAUDE_SKILL_DIR}/references/sub/dir/file` (more than 1 level deep) | Warning |
+| Nested references | `./references/sub/dir/file` (more than 1 level deep) | Warning |
 | Hardcoded model IDs | `claude-*-20\d{6}` pattern (use `sonnet`/`haiku`/`opus` instead) | Warning |
 | Voodoo constants | Unexplained magic numbers | Info |
 | Over-verbose | >5000 words in SKILL.md body | Warning |
@@ -396,7 +396,7 @@ Skills can use `` !`command` `` syntax (Anthropic spec preprocessing) to inject 
 
 | Scenario | Method |
 |----------|--------|
-| Always-needed, small references (<5KB) | `` !`cat ${CLAUDE_SKILL_DIR}/references/small.md` `` |
+| Always-needed, small references (<5KB) | `` !`cat ./references/small.md` `` |
 | Dynamic state (git log, env vars) | `` !`git log --oneline -5` `` |
 | Conditional or large references (>5KB) | Manual `Load ...` instructions |
 
@@ -455,10 +455,10 @@ Also recognized: `${CLAUDE_SESSION_ID}` — current session identifier (Anthropi
 
 ### Resource Validation
 
-1. All `${CLAUDE_SKILL_DIR}/scripts/*` references exist
-2. All `${CLAUDE_SKILL_DIR}/references/*` references exist
-3. All `${CLAUDE_SKILL_DIR}/templates/*` references exist
-4. All `${CLAUDE_SKILL_DIR}/assets/*` references exist
+1. All `./scripts/*` references exist
+2. All `./references/*` references exist
+3. All `./templates/*` references exist
+4. All `./assets/*` references exist
 5. Relative markdown links (e.g., `ref`) point to existing files
 6. No path escape attempts (`../`)
 7. No empty (0-byte) supporting files (stub detection)
@@ -529,7 +529,7 @@ INFO-level suggestions emitted after grading. Not scored — purely advisory.
 | 10 | Progressive disclosure used (references/ for heavy content) | Progressive Disclosure Scoring | Warning |
 | 11 | No TOC in SKILL.md body (wastes tokens) | Progressive Disclosure Scoring > Has unnecessary TOC | -1 modifier |
 | 12 | Reference files >100 lines have TOC | Progressive Disclosure Scoring > Reference files TOC | +1 modifier |
-| 13 | All `${CLAUDE_SKILL_DIR}/` references resolve to existing files | Body Validation > Enterprise Tier, Resource Validation | Error |
+| 13 | All `./` references resolve to existing files | Body Validation > Enterprise Tier, Resource Validation | Error |
 | 14 | No path escapes (`../`) | Body Validation > Enterprise Tier, Resource Validation | Error |
 | 15 | Required packages and dependencies listed | Body Validation > Standard Tier > Required packages listed | Warning |
 | 16 | 7 required body sections present (Enterprise) | Body Validation > Enterprise Tier > 7 required sections | Error |

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/templates/skill-template.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/templates/skill-template.md
@@ -122,5 +122,5 @@ These patterns are deprecated but users may encounter them:
 
 ## Resources
 
-- ${CLAUDE_SKILL_DIR}/references/{{REFERENCE_1}}.md - {{REFERENCE_1_PURPOSE}}
-- ${CLAUDE_SKILL_DIR}/scripts/{{SCRIPT_1}}.py - {{SCRIPT_1_PURPOSE}}
+- ./references/{{REFERENCE_1}}.md - {{REFERENCE_1_PURPOSE}}
+- ./scripts/{{SCRIPT_1}}.py - {{SCRIPT_1_PURPOSE}}

--- a/plugins/skill-enhancers/skill-creator/templates/skill-template.md
+++ b/plugins/skill-enhancers/skill-creator/templates/skill-template.md
@@ -122,5 +122,5 @@ These patterns are deprecated but users may encounter them:
 
 ## Resources
 
-- ${CLAUDE_SKILL_DIR}/references/{{REFERENCE_1}}.md - {{REFERENCE_1_PURPOSE}}
-- ${CLAUDE_SKILL_DIR}/scripts/{{SCRIPT_1}}.py - {{SCRIPT_1_PURPOSE}}
+- ./references/{{REFERENCE_1}}.md - {{REFERENCE_1_PURPOSE}}
+- ./scripts/{{SCRIPT_1}}.py - {{SCRIPT_1_PURPOSE}}

--- a/plugins/testing/browser-compatibility-tester/package.json
+++ b/plugins/testing/browser-compatibility-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/browser-compatibility-tester",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Cross-browser testing with Playwright, BrowserStack, Sauce Labs, LambdaTest, and Kobiton - test across Chrome, Firefox, Safari, Edge on real devices",
   "keywords": [
     "testing",

--- a/plugins/testing/browser-compatibility-tester/skills/testing-browser-compatibility/SKILL.md
+++ b/plugins/testing/browser-compatibility-tester/skills/testing-browser-compatibility/SKILL.md
@@ -35,7 +35,7 @@ Test web applications across multiple browsers, rendering engines, and real devi
 ## Prerequisites
 
 - Playwright installed (`npx playwright install --with-deps`) and application running at a test URL
-- For cloud testing: provider credentials in environment variables (see `${CLAUDE_SKILL_DIR}/references/cloud-providers.md`)
+- For cloud testing: provider credentials in environment variables (see `./references/cloud-providers.md`)
 
 ## Instructions
 
@@ -66,7 +66,7 @@ Default mode. Zero cloud accounts needed.
 
 ### Mode 2: Cloud Real-Device Testing
 
-Applies when real physical devices, broader OS coverage, or carrier network conditions are required beyond what Playwright emulation can replicate. Read `${CLAUDE_SKILL_DIR}/references/cloud-providers.md` for full auth, API, and capabilities details.
+Applies when real physical devices, broader OS coverage, or carrier network conditions are required beyond what Playwright emulation can replicate. Read `./references/cloud-providers.md` for full auth, API, and capabilities details.
 
 **Provider selection:**
 
@@ -81,10 +81,10 @@ Never hardcode credentials. Set provider env vars (`BROWSERSTACK_USERNAME`/`ACCE
 
 1. Verify credentials are set for the chosen provider
 2. Query available devices/browsers via provider API
-3. Configure WebDriver or Appium capabilities (see `${CLAUDE_SKILL_DIR}/references/cloud-providers.md`)
+3. Configure WebDriver or Appium capabilities (see `./references/cloud-providers.md`)
 4. Execute tests against cloud grid
 5. Retrieve session artifacts (screenshots, video, logs, network HAR)
-6. Aggregate results into compatibility report (CI/CD patterns: `${CLAUDE_SKILL_DIR}/references/ci-cd-integration.md`)
+6. Aggregate results into compatibility report (CI/CD patterns: `./references/ci-cd-integration.md`)
 
 ### Browser-Specific Checks
 
@@ -92,7 +92,7 @@ Never hardcode credentials. Set provider env vars (`BROWSERSTACK_USERNAME`/`ACCE
 - **Firefox**: scrollbar styling, gap in flexbox, subpixel rendering, print stylesheets
 - **Mobile**: touch events, viewport meta, safe area insets, virtual keyboard resize
 
-Pre-built device matrices: `${CLAUDE_SKILL_DIR}/references/device-matrix.md` (top 10, mobile-first, enterprise, Kobiton real-device).
+Pre-built device matrices: `./references/device-matrix.md` (top 10, mobile-first, enterprise, Kobiton real-device).
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Federico Sapuppo reported via LinkedIn DM (2026-05-28) that SKILL.md files across the repo use `${CLAUDE_SKILL_DIR}/...` path references that don't resolve when browsing the GitHub source. The targeted files DO exist on disk, but a browser-visiting user can't click through or copy a working path. The example he cited was `soc2-audit-helper` but the pattern is widespread.

## The fix

Replace the variable form with relative paths everywhere it's used as a path. Works for both audiences:

- **GitHub browse view:** `./references/foo.md` is human-readable and the path resolves correctly relative to the SKILL.md file viewer.
- **Claude runtime:** when reading a SKILL.md, the working-directory context IS the skill directory, so `./references/foo.md` resolves to `<skill-dir>/references/foo.md` (canonical Anthropic spec).

## Transforms applied

| Before | After | Count |
|---|---|---|
| `${CLAUDE_SKILL_DIR}/../` | `../` | 7 |
| `${CLAUDE_SKILL_DIR}/` | `./` | 1,200 |
| bare `${CLAUDE_SKILL_DIR}` (no trailing `/`) | **preserved** — teaching-concept docs | 9 |

## What's NOT changed

Bare `${CLAUDE_SKILL_DIR}` (no trailing `/`) is preserved in 9 files where the variable is referenced as a teaching concept, not used as a path:

- `plugins/skill-enhancers/skill-creator/**` — docs that explain the path-variable spec to skill authors
- `plugins/saas-packs/claude-pack/skills/clade-reference-architecture/**` — reference architecture docs
- `plugins/crypto/market-price-tracker/skills/tracking-crypto-prices/ARD.md` — guidance about using the variable

These are documentation about Anthropic's path-variable spec itself, not unresolved paths.

## Verification

Before the change, Federico's example file rendered as:

```markdown
See `${CLAUDE_SKILL_DIR}/references/implementation.md` for the six-phase implementation guide.
```

After:

```markdown
See `./references/implementation.md` for the six-phase implementation guide.
```

Browse-view test: viewing `plugins/security/soc2-audit-helper/skills/assisting-with-soc2-audit-preparation/SKILL.md` on GitHub now shows readable relative paths a contributor can copy and trace.

## Test plan

- [ ] View any SKILL.md in `plugins/security/`, `plugins/saas-packs/`, or `plugins/skill-enhancers/` on github.com and confirm `${CLAUDE_SKILL_DIR}/` no longer appears in prose path references.
- [ ] Spot-check that bare `${CLAUDE_SKILL_DIR}` (no trailing slash) still appears in `plugins/skill-enhancers/skill-creator/skills/skill-creator/SKILL.md` where it's documenting the spec.
- [ ] Run any one of the affected skills to confirm Claude's path resolution still works (e.g., `soc2-audit-helper`).

## Scope: 266 files, 1,207 path replacements

Touches every skill pack that adopted the `${CLAUDE_SKILL_DIR}` pattern: security pack (soc2-audit-helper, etc.), saas-packs (40+ vendor packs), ai-ml, skill-enhancers, crypto, testing, productivity, governance. Generated content (`marketplace/src/data/skills-catalog.json`) is not touched because it's regenerated from source SKILL.md files at build time.

- Jeremy Longshore
intentsolutions.io