### PR TITLE
feat(penetration-tester): clusters 5 + 6 — governance + reporting (6 skills, 25/25)

### DIFF
--- a/plugins/security/penetration-tester/package.json
+++ b/plugins/security/penetration-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/penetration-tester",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Security testing toolkit with HTTP header analysis, dependency auditing, and static code scanning",
   "keywords": [
     "security",

--- a/plugins/security/penetration-tester/skills/composing-vulnerability-report/SKILL.md
+++ b/plugins/security/penetration-tester/skills/composing-vulnerability-report/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: composing-vulnerability-report
+description: |
+  Read findings JSONL files from cluster 1-4 skills, deduplicate
+  by fingerprint, group by severity, and compose a deliverable-
+  grade markdown vulnerability report with per-finding sections
+  (title, severity, target, detail, remediation, evidence) and a
+  top-level summary table. The canonical written artifact a customer
+  receives at engagement close; precise, reproducible, machine-
+  checkable against source findings.
+  Use when: closing an engagement, generating an interim report,
+  regenerating after CVE or OWASP enrichment, or producing the
+  input for generating-executive-summary.
+  Threshold: findings missing required fields are dropped. HIGH
+  and CRITICAL findings highlighted in the summary section.
+  Trigger with: "compose vuln report", "write pentest report",
+  "generate vulnerability deliverable", "render findings to report".
+allowed-tools:
+  - Read
+  - Write
+  - Bash(python3:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - reporting
+  - vulnerability-report
+  - cvss
+  - pentest
+---
+
+# Composing Vulnerability Report
+
+## Overview
+
+After cluster 1-4 scan skills run, each one produces a Findings
+file. A typical engagement ends up with eight to twenty such files
+across the different skill categories. The customer wants ONE
+vulnerability report — comprehensive, deduplicated, organized by
+severity, with each finding cross-referenced to its source skill
+and target.
+
+This skill consumes one or more findings files (JSONL preferred,
+JSON list also accepted), deduplicates entries by the canonical
+fingerprint defined in `lib/finding.py`, enriches each finding
+with a CVSS v3.1 vector when one isn't present (using a deterministic
+heuristic based on severity + category — explicitly noted as
+"derived, not assigned by NVD" in the output), and emits a single
+markdown report with per-finding sections plus a top-level
+summary table.
+
+The report has a defined structure that downstream tools (next
+two skills in cluster 6) consume:
+
+1. **Header** — engagement ID, generation timestamp, source files
+2. **Summary table** — finding count by severity
+3. **Per-severity sections** — CRITICAL first, then HIGH, MEDIUM,
+   LOW, INFO
+4. **Per-finding subsections** — title, severity, target, detail,
+   remediation, evidence, references
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Source file unparseable | **HIGH** | JSON/JSONL parse fails | (operational) |
+| Finding missing required field | **HIGH** | A finding record is missing title, severity, target, detail, or remediation | (operational) |
+| Duplicate fingerprint across files | **INFO** | Same finding appears in N>1 sources; reported as deduplication count | (informational) |
+| Source file has zero findings | **INFO** | Empty or all-info-only file; reported but not an error | (informational) |
+| Report generated cleanly | **INFO** | Positive confirmation | (informational) |
+
+## Prerequisites
+
+- Python 3.9+
+- One or more findings files in JSON or JSONL format produced by
+  any cluster 1-4 scan skill (which all share `lib/finding.py`
+  schema)
+
+## Instructions
+
+### Step 1 — Gather findings sources
+
+By default the skill reads every file matching
+`engagement/findings/*.json` and `engagement/findings/*.jsonl`.
+Override with `--source FILE` (repeatable).
+
+### Step 2 — Run the composer
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/
+```
+
+Options:
+
+```
+Usage: compose_report.py PATH [OPTIONS]
+
+Options:
+  --source FILE         Specific findings file (repeatable; overrides default glob)
+  --report-output FILE  Write the composed report here (default:
+                        PATH/reports/vulnerability-report.md)
+  --engagement-id ID    Override the engagement ID (default: parse from PATH/roe.yaml)
+  --output FILE         Operational findings output (this skill's own findings)
+  --format FMT          json | jsonl | markdown (default: markdown)
+  --min-severity SEV    Filter report to findings at or above this severity
+  --include-info        Include INFO-severity findings in the report (default: omit)
+```
+
+### Step 3 — Review the report
+
+The output report has a predictable structure. The header
+identifies the engagement, the source files, and the generation
+timestamp. The summary table shows finding counts by severity.
+Per-severity sections follow.
+
+Each finding subsection includes a stable anchor (the fingerprint)
+so cross-references from later artifacts (executive summary,
+OWASP mapping) resolve into the report cleanly.
+
+### Step 4 — Verify against sources
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ --format json --output /tmp/compose-findings.json
+jq '.[] | select(.severity == "high")' /tmp/compose-findings.json
+```
+
+If the report references a finding the operator didn't expect,
+trace back via the finding's `skill_id` + `target` to the source
+file.
+
+## Examples
+
+### Example 1 — End-of-engagement report
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --report-output engagements/acme-2026-q2/reports/vulnerability-report.md
+```
+
+### Example 2 — Interim report mid-engagement
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --min-severity high \
+    --report-output engagements/acme-2026-q2/reports/interim-2026-06-15.md
+```
+
+`--min-severity high` produces an interim report covering only
+HIGH and CRITICAL findings — useful for in-engagement customer
+syncs.
+
+### Example 3 — Regenerate after OWASP mapping
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --source engagements/acme-2026-q2/findings/all-findings-with-owasp.jsonl \
+    --report-output engagements/acme-2026-q2/reports/vulnerability-report-v2.md
+```
+
+Re-run after `mapping-findings-to-owasp-top10` has enriched each
+finding with its OWASP category; the regenerated report includes
+the OWASP tag in each per-finding subsection.
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py` for the skill's own
+operational findings. The PRIMARY output is the composed
+vulnerability report, written as standalone Markdown to the
+`--report-output` path.
+
+Each operational Finding includes:
+
+- `id` — `compose::<issue>::<source-file>`
+- `severity` — CRITICAL / HIGH / MEDIUM / INFO
+- `category` — `report-composition`
+- `summary` — what went wrong (or right) during composition
+- `evidence` — source files, finding counts, dedup stats
+
+## Error Handling
+
+- **PATH missing or empty** → emits CRITICAL operational finding,
+  exits 1.
+- **Source file unparseable** → emits HIGH operational finding,
+  skips the file, continues with remaining sources.
+- **No findings files found** → emits HIGH operational finding,
+  exits 1.
+- **Output report path not writable** → emits HIGH operational
+  finding, exits 1.
+- **Finding missing required fields** → emits HIGH operational
+  finding, omits that record from the report, continues.
+
+## Resources
+
+- `references/THEORY.md` — Vulnerability-report structure history
+  (NIST SP 800-115, OWASP Testing Guide), CVSS v3.1 vector
+  composition, severity scoring tradeoffs (CVSS vs intrinsic vs
+  EPSS), finding-deduplication theory, why fingerprint-based dedup
+  beats title-based
+- `references/PLAYBOOK.md` — Report-template variants per
+  audience (technical, executive, regulatory), per-finding
+  remediation phrasing patterns, evidence-redaction patterns
+  for distributed reports, cross-reference protocol with the
+  OWASP-mapping and exec-summary skills

--- a/plugins/security/penetration-tester/skills/composing-vulnerability-report/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/composing-vulnerability-report/references/PLAYBOOK.md
@@ -1,0 +1,180 @@
+# PLAYBOOK — Report Templates and Workflow
+
+## End-of-engagement workflow
+
+```bash
+# 1. All cluster 1-4 scans have run; findings are in engagements/<id>/findings/
+
+# 2. (Optional) Map findings to OWASP Top 10
+python3 plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/scripts/map_owasp.py \
+    engagements/acme-2026-q2/
+
+# 3. Compose the vulnerability report
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/
+
+# 4. Generate the executive summary
+python3 plugins/security/penetration-tester/skills/generating-executive-summary/scripts/exec_summary.py \
+    engagements/acme-2026-q2/
+
+# 5. Record the engagement (chain of custody)
+python3 plugins/security/penetration-tester/skills/recording-pentest-engagement/scripts/record_engagement.py \
+    engagements/acme-2026-q2/ --sign --tar engagements/archives/acme-2026-q2.tar.gz
+```
+
+## Report-template variants per audience
+
+### Technical (default — what the skill emits)
+
+Everything: per-finding detail, remediation steps, evidence,
+references. Audience: customer's security engineer or external
+auditor.
+
+### Manager-style (use `--min-severity high`)
+
+Only HIGH and CRITICAL findings shown. Body of the report is the
+same per-finding format but the customer's manager doesn't have
+to scroll past medium / low findings.
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --min-severity high \
+    --report-output engagements/acme-2026-q2/reports/manager-brief.md
+```
+
+### Compliance-evidence (use `--include-info`)
+
+Includes the INFO-severity operational records (scan ran cleanly,
+no findings in this target, etc.). Audience: SOC2 / ISO 27001
+auditors who want documented evidence the scan ran even where
+nothing was found.
+
+```bash
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --include-info \
+    --report-output engagements/acme-2026-q2/reports/compliance-evidence.md
+```
+
+## Per-finding remediation phrasing patterns
+
+The skill emits each finding's `remediation` field verbatim from
+the source. Cluster 1-4 skills construct these as numbered lists
+with imperative voice:
+
+```
+1. Run `npm audit fix` in the project root.
+2. If the fix requires a semver-major bump, evaluate the breaking changes.
+3. Commit the updated package-lock.json.
+```
+
+Patterns to maintain when authoring remediation:
+
+- **Imperative voice.** "Run X" not "You should run X" not "It is recommended to run X."
+- **Numbered list when there are >1 steps.** Bullets blur the order.
+- **Concrete commands when possible.** "Apply security patch" is unactionable; "`apt-get update && apt-get upgrade libssl3`" is actionable.
+- **Decision points called out.** "If X, do Y; otherwise do Z" makes the operator's choice explicit.
+
+## Evidence-redaction for distributed reports
+
+A pentest report sometimes needs distribution beyond the immediate
+customer — to their auditor, their insurance carrier, their board.
+Some evidence shouldn't leave the original engagement: leaked
+credentials, full request/response bodies containing PII, screenshots
+showing customer data.
+
+The skill doesn't auto-redact. The pattern for human-controlled
+redaction:
+
+1. Generate the full report with this skill.
+2. Use a separate redaction pass to:
+   - Replace leaked-secret values with `[REDACTED]` while keeping
+     finding context.
+   - Blur or remove customer-data screenshots.
+   - Replace user-identifying URLs with `<USER>/path/...` placeholders.
+3. Distribute the redacted version. Keep the unredacted version in
+   the engagement archive.
+
+The skill could be extended with a `--redact PATTERN` flag if this
+becomes a frequent enough pattern.
+
+## Cross-reference protocol with OWASP-mapping + exec-summary
+
+The next two cluster 6 skills consume this report's findings file
+(JSON output of THIS skill's findings → not the rendered markdown).
+The protocol:
+
+1. **Findings producer:** cluster 1-4 skills emit per-skill findings JSONLs
+2. **Vulnerability report composer (this skill):** composes a single
+   vulnerability-report.md AND can output a unified findings JSONL
+3. **OWASP mapping:** reads the unified JSONL, adds `owasp_category`
+   field to each finding, writes back
+4. **Exec summary:** reads the (potentially OWASP-enriched) unified
+   JSONL, produces the executive-summary.md
+
+The order can be either:
+
+- A: cluster-1-4 → OWASP → compose → exec-summary
+- B: cluster-1-4 → compose → OWASP → re-compose → exec-summary
+
+Pattern B regenerates the report after enrichment. Pattern A only
+composes once. Both are valid; the choice depends on whether the
+operator wants the OWASP tags visible in the report's per-finding
+sections.
+
+## Common composition mistakes
+
+| Mistake | Consequence | Fix |
+|---|---|---|
+| Findings without `target` field | Findings dropped from report; HIGH op-finding | Ensure all source skills emit `target` |
+| Mixed findings + opfindings in source file | Report contains operational noise | Separate skill output and operational output |
+| Identical findings with different IDs | Dedup fails | Ensure source skills use consistent `Finding.fingerprint()` |
+| Re-running with new sources but old report path | Old report overwritten silently | Use timestamped `--report-output` paths for interim reports |
+
+## Per-engagement directory layout (canonical)
+
+The skill assumes:
+
+- `engagement/findings/*.json[l]` — source findings
+- `engagement/reports/` — output reports (auto-created if missing)
+- `engagement/roe.yaml` — has `engagement_id:` for header
+
+Deviations are supported via flags:
+
+- `--source FILE` — bypass auto-discovery
+- `--report-output PATH` — write report anywhere
+- `--engagement-id ID` — override ROE detection
+
+## Integration with cluster 1-4 skills
+
+The cluster 1-4 scan skills all emit findings via `report.emit()`
+(in `lib/report.py`) which can write JSON / JSONL / Markdown.
+For composition workflow, each scan should run with
+`--format jsonl --output engagement/findings/<skill>-<date>.jsonl`:
+
+```bash
+python3 plugins/security/penetration-tester/skills/checking-http-security-headers/scripts/check_headers.py \
+    https://app.acme.example --format jsonl \
+    --output engagements/acme-2026-q2/findings/headers-$(date +%Y%m%d).jsonl
+```
+
+The skill then picks up every file under `findings/` by default.
+
+## Stable-rendering verification
+
+To verify the report is rendering stably (same input → same output
+except timestamp):
+
+```bash
+# Render twice
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --report-output /tmp/report-1.md
+sleep 2
+python3 ./scripts/compose_report.py engagements/acme-2026-q2/ \
+    --report-output /tmp/report-2.md
+
+# Diff ignoring the timestamp line
+diff <(grep -v "Generated by" /tmp/report-1.md) \
+     <(grep -v "Generated by" /tmp/report-2.md)
+```
+
+The diff should be empty. If it isn't, file an issue — stable
+rendering is a contract this skill maintains.

--- a/plugins/security/penetration-tester/skills/composing-vulnerability-report/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/composing-vulnerability-report/references/THEORY.md
@@ -1,0 +1,178 @@
+# THEORY — Vulnerability Report Structure
+
+## What a customer actually reads
+
+A pentest vulnerability report is read by three different people
+in three different ways:
+
+1. **The customer's security engineer** — reads end to end, in
+   order, looking for specific technical detail per finding.
+2. **The customer's manager** — reads the summary table, then
+   skims headlines of critical / high findings, then trusts the
+   security engineer's recommendation.
+3. **A future reader during compliance audit** — reads to verify
+   the finding existed and the remediation was documented.
+
+The report has to serve all three audiences without trying too
+hard. The structure this skill emits is the result of trial and
+error against those three readers:
+
+- Top: short header identifying engagement, generation time,
+  sources.
+- Below: summary table — counts by severity.
+- Then: severity-ordered finding sections, CRITICAL first.
+- Each finding: title, severity, target, detail, remediation,
+  evidence, references — in that order. Always.
+
+The shape is boring on purpose. Surprise in report structure is
+not a feature; the reader should be able to predict where a piece
+of information lives without searching.
+
+## Why CVSS v3.1 (not CVSS v4 or CWE-only)
+
+CVSS v3.1 (June 2019) is the de facto industry standard severity
+vector. NVD scores every CVE with CVSS v3.1. SOC2 / ISO 27001 /
+PCI auditors expect to see CVSS scores.
+
+CVSS v4.0 was published in November 2023. It addresses real
+problems with v3.1 (better handling of supply-chain attacks,
+clearer attack-vector semantics). Adoption has been slow because
+the existing tooling chain is v3.1-shaped. As of 2026 the practical
+choice is still v3.1.
+
+CWE alone is a different axis — what KIND of weakness, not how
+SEVERE. Reports include CWE as enrichment when available but use
+CVSS for the severity decision.
+
+## CVSS vector composition (when the skill derives one)
+
+When a finding arrives without a CVSS score, the skill does NOT
+guess a precise numeric score (that would falsely imply NVD-level
+authority). Instead it maps severity → severity band, retaining
+the explicit "derived" label so the report's reader knows the score
+isn't NVD-blessed.
+
+| Severity | Implied CVSS band | Note |
+|---|---|---|
+| CRITICAL | 9.0 - 10.0 | implied by mapping; not authoritative |
+| HIGH | 7.0 - 8.9 | implied |
+| MEDIUM | 4.0 - 6.9 | implied |
+| LOW | 0.1 - 3.9 | implied |
+| INFO | n/a | no score emitted |
+
+Findings that arrived WITH a CVSS score keep their original value
+unchanged. This is important: a finding with `cvss_score: 7.5`
+from `auditing-python-dependencies` (which extracts it from OSV)
+must not be overwritten by this skill's heuristic.
+
+## Why fingerprint-based deduplication
+
+`lib/finding.py` defines `Finding.fingerprint()` as a stable hash
+of `(skill_id, title, target)`. Two findings with the same
+fingerprint are the same finding from the same source about the
+same target, regardless of which scan run produced them.
+
+The alternative — title-based dedup — fails when:
+
+- Same skill is run twice (the second invocation produces
+  identical findings)
+- Two different skills produce findings with the same title but
+  different targets (legitimate distinct findings)
+- A skill produces findings with parameterized titles (the
+  title varies but the substance is the same)
+
+Fingerprint-based dedup is the right primitive. The trade-off:
+fingerprints don't catch SEMANTICALLY-equivalent findings from
+different skills. If `auditing-npm-dependencies` and an external
+tool both surface the same CVE, the fingerprints differ (different
+skill_id). Cross-tool semantic dedup is a separate problem — this
+skill handles within-skill dedup correctly.
+
+## NIST SP 800-115 vs PTES vs OWASP Testing Guide
+
+Three frameworks define what a pentest report should contain:
+
+| Framework | Strengths | Weaknesses |
+|---|---|---|
+| NIST SP 800-115 (US gov-flavored) | Definitive, well-structured | Network-focused; app-pentest sections are thin |
+| PTES | Defines the workflow end-to-end | Report structure is one of many topics; less prescriptive |
+| OWASP Testing Guide (WSTG) | Best on web-app vulnerability classification | Doesn't prescribe report structure deeply |
+
+The skill's output format is informed by all three but doesn't
+claim conformance to any. The structure is pragmatic: what works
+in real customer engagements as of 2026.
+
+## Severity-grouping rationale
+
+The skill groups findings by severity, NOT by skill or by target.
+Reasons:
+
+- Customers care about severity first. A CRITICAL CVE in
+  dependency-vuln scan and a CRITICAL TLS misconfig and a
+  CRITICAL secret in source are all the same severity to the
+  reader; they should be co-located.
+- Per-severity grouping makes remediation prioritization
+  trivially visual.
+- Per-skill grouping would hide cross-skill patterns ("multiple
+  high findings in the same target" becomes invisible).
+
+If the customer specifically wants per-skill grouping (some prefer
+it), this skill's output is structured Markdown that a downstream
+tool can re-group. The skill emits the canonical form; consumers
+re-shape if needed.
+
+## Stable anchors for cross-reference
+
+Each finding subsection in the report has a stable HTML anchor
+based on the fingerprint:
+
+```html
+<a id="finding-a1b2c3d4e5f6"></a>
+```
+
+The executive-summary skill and the OWASP-mapping skill reference
+findings by this anchor:
+
+```markdown
+[See finding](vulnerability-report.md#finding-a1b2c3d4e5f6)
+```
+
+The anchor is stable across regenerations of the report (because
+the fingerprint is stable). If the report is regenerated after
+adding new findings, existing finding anchors don't change —
+only new anchors are added.
+
+## Required-field policy
+
+The skill refuses to include findings missing any of `title`,
+`severity`, `target`, `detail`, `remediation`. The dropped finding
+becomes a HIGH operational finding from this skill itself,
+surfacing the problem to the operator without silently swallowing
+the broken record.
+
+This is conservative on purpose. A pentest report that includes
+malformed findings is unprofessional and undermines the engagement.
+Better to surface the problem with a loud error than to ship
+broken records.
+
+## Why include-info defaults to off
+
+INFO-severity findings are operational chatter (no vulnerabilities
+found, scanner ran cleanly, etc.). Customer reports should NOT
+include them in the main severity sections — the customer cares
+about findings, not about confirmation that the scan ran.
+
+`--include-info` adds an INFO section at the bottom of the report
+for operational transparency. Useful for SOC2 evidence packages
+where auditors want to confirm every scan ran.
+
+## Generation timestamp + reproducibility
+
+The header includes the generation timestamp in ISO-8601. The
+report is reproducible from the same source findings: if you
+re-run with the same inputs, the report content is byte-identical
+except for the timestamp.
+
+This matters for evidence: the customer's audit team needs to
+verify "report-as-shipped" against "report-from-source-now."
+Stable rendering = trustable comparison.

--- a/plugins/security/penetration-tester/skills/composing-vulnerability-report/scripts/compose_report.py
+++ b/plugins/security/penetration-tester/skills/composing-vulnerability-report/scripts/compose_report.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""composing-vulnerability-report — render cluster 1-4 findings into a deliverable.
+
+Reads JSON/JSONL findings files, deduplicates by Finding.fingerprint(),
+groups by severity, and writes a single deliverable-grade markdown
+vulnerability report. Emits operational Findings via lib/finding.py for any
+parse / structural issue encountered while composing.
+
+Usage:
+    python3 compose_report.py PATH [--source FILE]
+                                   [--report-output FILE]
+                                   [--engagement-id ID]
+                                   [--output FILE] [--format json|jsonl|markdown]
+                                   [--min-severity sev] [--include-info]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity, from_json as finding_from_json  # noqa: E402
+from lib import report  # noqa: E402
+
+
+SKILL_ID = "composing-vulnerability-report"
+CATEGORY = "report-composition"
+REQUIRED_FIELDS = ("title", "severity", "target", "detail", "remediation")
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _f(severity: Severity, title: str, target: str, detail: str, remediation: str,
+       evidence: tuple[tuple[str, Any], ...] = ()) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=severity,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+        evidence=evidence,
+    )
+
+
+# --- Source discovery -------------------------------------------------------
+
+
+def discover_sources(root: Path, explicit: list[str]) -> list[Path]:
+    if explicit:
+        return [Path(p).resolve() for p in explicit]
+    out: list[Path] = []
+    findings_dir = root / "findings"
+    if findings_dir.is_dir():
+        out.extend(sorted(findings_dir.glob("**/*.json")))
+        out.extend(sorted(findings_dir.glob("**/*.jsonl")))
+    return out
+
+
+def load_finding_records(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    """Load findings from a file. Returns (records, error_message_or_None)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [], f"read failed: {e}"
+    text = text.strip()
+    if not text:
+        return [], None
+    out: list[dict[str, Any]] = []
+    if path.suffix == ".jsonl" or "\n{" in text:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                return out, f"jsonl line parse error: {e}"
+        return out, None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return [], f"json parse error: {e}"
+    if isinstance(data, list):
+        out = [r for r in data if isinstance(r, dict)]
+    elif isinstance(data, dict) and "findings" in data:
+        out = [r for r in data["findings"] if isinstance(r, dict)]
+    elif isinstance(data, dict):
+        out = [data]
+    return out, None
+
+
+# --- Finding normalization + dedup ------------------------------------------
+
+
+def normalize_record(record: dict[str, Any]) -> tuple[Finding | None, str | None]:
+    """Convert a record dict into a Finding. Returns (finding, error_or_None)."""
+    missing = [f for f in REQUIRED_FIELDS if f not in record]
+    if missing:
+        return None, f"missing required fields: {', '.join(missing)}"
+    try:
+        return finding_from_json(record), None
+    except (KeyError, ValueError, TypeError) as e:
+        return None, f"finding parse error: {e}"
+
+
+# --- Engagement-id detection ------------------------------------------------
+
+
+def detect_engagement_id(root: Path) -> str:
+    roe = root / "roe.yaml"
+    if not roe.exists():
+        return root.name
+    try:
+        text = roe.read_text(encoding="utf-8")
+    except OSError:
+        return root.name
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("engagement_id:"):
+            return line.split(":", 1)[1].strip().strip('"').strip("'")
+    return root.name
+
+
+# --- Report rendering -------------------------------------------------------
+
+
+def render_summary_table(
+    by_severity: dict[Severity, list[Finding]],
+) -> str:
+    lines = ["| Severity | Count |", "|---|---|"]
+    for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW, Severity.INFO):
+        count = len(by_severity.get(sev, []))
+        lines.append(f"| **{sev.value.upper()}** | {count} |")
+    return "\n".join(lines)
+
+
+def render_finding_section(f: Finding) -> str:
+    anchor = f.fingerprint()
+    refs = "\n".join(f"- {r}" for r in f.references) if f.references else "(none)"
+    evidence_lines = "\n".join(f"- **{k}**: `{v}`" for k, v in f.evidence) if f.evidence else "(none)"
+    sev = f.severity.value.upper()
+    cvss = f"\n- **CVSS v3.1:** {f.cvss_score:.1f}" if f.cvss_score else ""
+    cve = f"\n- **CVE:** {f.cve_id}" if f.cve_id else ""
+    cwe = f"\n- **CWE:** {f.cwe_id}" if f.cwe_id else ""
+    owasp = f"\n- **OWASP:** {f.owasp_category}" if f.owasp_category else ""
+
+    return f"""### {f.title}
+<a id="finding-{anchor}"></a>
+
+- **Severity:** {sev}
+- **Affected target:** `{f.target}`
+- **Source skill:** `{f.skill_id}`{cvss}{cve}{cwe}{owasp}
+
+#### Detail
+
+{f.detail}
+
+#### Remediation
+
+{f.remediation}
+
+#### Evidence
+
+{evidence_lines}
+
+#### References
+
+{refs}
+
+---
+"""
+
+
+def render_report(
+    findings: list[Finding],
+    engagement_id: str,
+    source_files: list[Path],
+    include_info: bool,
+) -> str:
+    by_severity: dict[Severity, list[Finding]] = defaultdict(list)
+    for f in findings:
+        if not include_info and f.severity == Severity.INFO:
+            continue
+        by_severity[f.severity].append(f)
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    header = f"""# Vulnerability Report — {engagement_id}
+
+> Generated by `{SKILL_ID}` at {now}.
+> Source files: {", ".join(str(s.name) for s in source_files) or "(none)"}.
+
+## Summary
+
+{render_summary_table(by_severity)}
+
+"""
+
+    sections: list[str] = []
+    for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW, Severity.INFO):
+        bucket = by_severity.get(sev, [])
+        if not bucket:
+            continue
+        if sev == Severity.INFO and not include_info:
+            continue
+        sections.append(f"## {sev.value.upper()} ({len(bucket)})\n")
+        # Stable sort: by skill_id then title
+        for f in sorted(bucket, key=lambda x: (x.skill_id, x.title)):
+            sections.append(render_finding_section(f))
+    return header + "\n".join(sections)
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("path", help="Engagement directory")
+    p.add_argument("--source", action="append", default=[], help="Findings file (repeatable)")
+    p.add_argument("--report-output", default=None)
+    p.add_argument("--engagement-id", default=None)
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    p.add_argument("--include-info", action="store_true")
+    return p
+
+
+def _filter_min_severity_for_report(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    root = Path(args.path).resolve()
+    if not root.exists():
+        f = _f(
+            Severity.CRITICAL,
+            f"engagement path missing: {root}",
+            str(root),
+            f"PATH `{root}` does not exist; cannot compose report.",
+            "Verify the engagement directory and re-run.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(root))
+        return 1
+
+    sources = discover_sources(root, args.source)
+    if not sources:
+        f = _f(
+            Severity.HIGH,
+            "no findings sources",
+            str(root),
+            f"No JSON or JSONL findings files were found under `{root}`.",
+            "Run at least one cluster 1-4 scan skill to produce findings, "
+            "or pass explicit --source paths.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(root))
+        return 1
+
+    op_findings: list[Finding] = []
+    all_findings: list[Finding] = []
+    fp_counts: Counter[str] = Counter()
+
+    for src in sources:
+        records, err = load_finding_records(src)
+        if err:
+            op_findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"source unparseable: {src.name}",
+                    str(src),
+                    err,
+                    "Fix the source file or exclude it via explicit --source list.",
+                )
+            )
+            continue
+        if not records:
+            op_findings.append(
+                _f(
+                    Severity.INFO,
+                    f"source empty: {src.name}",
+                    str(src),
+                    "Source file contained no records.",
+                    "Skipped.",
+                )
+            )
+            continue
+        for rec in records:
+            f, ferr = normalize_record(rec)
+            if f is None:
+                op_findings.append(
+                    _f(
+                        Severity.HIGH,
+                        f"record dropped from {src.name}",
+                        str(src),
+                        ferr or "unknown normalization error",
+                        "Fix the record's structure; re-run.",
+                    )
+                )
+                continue
+            fp = f.fingerprint()
+            fp_counts[fp] += 1
+            if fp_counts[fp] == 1:
+                all_findings.append(f)
+
+    if fp_counts:
+        dup_count = sum(1 for c in fp_counts.values() if c > 1)
+        if dup_count:
+            op_findings.append(
+                _f(
+                    Severity.INFO,
+                    f"deduplicated {dup_count} duplicate fingerprint(s)",
+                    str(root),
+                    f"{dup_count} unique findings appeared in more than one source; "
+                    f"each was included exactly once.",
+                    "No action required.",
+                    evidence=(("unique_findings", len(fp_counts)), ("duplicates_collapsed", dup_count)),
+                )
+            )
+
+    if not all_findings:
+        op_findings.append(
+            _f(
+                Severity.HIGH,
+                "no findings to report",
+                str(root),
+                "All sources were empty, malformed, or contained only records "
+                "missing required fields.",
+                "Resolve source issues and re-run.",
+            )
+        )
+
+    engagement_id = args.engagement_id or detect_engagement_id(root)
+    filtered_for_report = _filter_min_severity_for_report(all_findings, args.min_severity)
+    report_md = render_report(filtered_for_report, engagement_id, sources, args.include_info)
+
+    report_path = (
+        Path(args.report_output).resolve()
+        if args.report_output
+        else root / "reports" / "vulnerability-report.md"
+    )
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report_md, encoding="utf-8")
+        op_findings.append(
+            _f(
+                Severity.INFO,
+                f"vulnerability report written: {report_path.name}",
+                str(report_path),
+                f"Report contains {len(filtered_for_report)} findings across "
+                f"{sum(1 for f in filtered_for_report if f.severity == Severity.CRITICAL)} critical, "
+                f"{sum(1 for f in filtered_for_report if f.severity == Severity.HIGH)} high, "
+                f"{sum(1 for f in filtered_for_report if f.severity == Severity.MEDIUM)} medium, "
+                f"{sum(1 for f in filtered_for_report if f.severity == Severity.LOW)} low.",
+                "Hand off to customer per the engagement closeout protocol.",
+                evidence=(
+                    ("report_path", str(report_path)),
+                    ("finding_count", len(filtered_for_report)),
+                    ("source_count", len(sources)),
+                ),
+            )
+        )
+    except OSError as e:
+        op_findings.append(
+            _f(
+                Severity.HIGH,
+                "report write failed",
+                str(report_path),
+                f"OSError: {e}",
+                "Resolve permissions/path; re-run.",
+            )
+        )
+
+    report.emit(op_findings, args.output, args.format, scan_target=str(root))
+    return report.exit_code(op_findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/confirming-pentest-authorization/SKILL.md
+++ b/plugins/security/penetration-tester/skills/confirming-pentest-authorization/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: confirming-pentest-authorization
+description: |
+  Verify that a penetration test has explicit, written, signed
+  authorization before any scanning begins. Reads a Rules-of-
+  Engagement (ROE) attestation file, validates required fields
+  (authorizer, in-scope targets, time window, emergency contact,
+  signature), checks the signer against an allowlist, and emits a
+  CRITICAL finding if anything is missing. Designed as the first
+  skill the orchestrator routes to.
+  Use when: starting a new engagement, after a scope change, or
+  before any cluster 1-4 scan skill runs.
+  Threshold: any missing or unsigned ROE field; any time-window
+  expiry; any in-scope target outside the authorized list.
+  Trigger with: "confirm authorization", "verify ROE", "check
+  pentest authz", "pre-flight authorization".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Bash(nmap:*)
+  - Bash(nikto:*)
+  - Bash(sqlmap:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - engagement-governance
+  - authorization
+  - roe
+  - pentest
+---
+
+# Confirming Pentest Authorization
+
+## Overview
+
+Penetration testing is computer access. Without explicit
+authorization from the owner of the system under test, that
+access is a crime — Computer Fraud and Abuse Act in the US,
+Computer Misuse Act in the UK, equivalent laws everywhere
+else. The line between an authorized pentester and an
+unauthorized attacker is one signature on one document.
+
+The penetration-tester pack's other skills (TLS analysis, CORS
+audit, dependency CVE scan, etc.) all assume that line has been
+crossed correctly. This skill is the first gate the orchestrator
+routes to. It refuses to declare an engagement authorized until
+a Rules of Engagement (ROE) attestation file exists, is signed,
+and contains the fields any real-world legal review will look for.
+
+This is not paranoia or paperwork theater. Engagements DO go
+sideways: scope creeps mid-test, a tester probes an out-of-scope
+adjacent system, an SOC team escalates a "real" attack to legal,
+and the question "show us the ROE" comes up. If the ROE is in
+order, the answer is "here it is." If not, the conversation gets
+expensive fast.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| ROE file missing | **CRITICAL** | No attestation file at the expected path | (legal) |
+| Required field missing | **CRITICAL** | authorizer, in_scope_targets, time_window, emergency_contact, or signature absent | (legal) |
+| Signature missing | **CRITICAL** | No signature_block in ROE | (legal) |
+| Signer not in allowlist | **CRITICAL** | signer email/key id not in `.allowed-authorizers` | (legal) |
+| Time window expired | **HIGH** | current time outside `time_window.start` / `time_window.end` | (legal) |
+| Time window not yet active | **HIGH** | current time before `time_window.start` | (legal) |
+| In-scope target list empty | **HIGH** | `in_scope_targets` field present but empty | (legal) |
+| Out-of-scope override (manual flag) | **MEDIUM** | tester requests a target not in the in-scope list | (legal) |
+| Stale ROE (>30 days from sign date) | **MEDIUM** | last_signed_at older than 30 days; suggests refresh | (operational) |
+| ROE present + signed + in window | **INFO** | All gates pass; engagement is authorized | (positive confirmation) |
+
+## Prerequisites
+
+- Python 3.9+
+- ROE attestation file at `./roe.yaml` (or pass `--roe FILE`).
+- Optional `.allowed-authorizers` file listing email addresses or
+  GPG key fingerprints permitted to sign ROEs.
+
+## ROE attestation file schema
+
+```yaml
+engagement_id: ACME-2026-Q2-PENTEST-001
+authorizer:
+  name: Jane Doe
+  email: jane.doe@acme.example
+  role: CISO
+  organization: ACME Corp
+in_scope_targets:
+  - host: app.acme.example
+    notes: production web app, full-stack pentest authorized
+  - host: api.acme.example
+  - cidr: 10.50.0.0/16
+    notes: internal corporate range
+out_of_scope_targets:
+  - host: payments.acme.example
+    reason: PCI scope, separate authz required
+  - cidr: 10.99.0.0/16
+    reason: production database tier, separate authz required
+time_window:
+  start: 2026-06-01T00:00:00Z
+  end: 2026-06-30T23:59:59Z
+emergency_contact:
+  name: SOC On-Call
+  phone: "+1-555-555-5555"
+  email: soc@acme.example
+rules:
+  - No exploitation of confirmed findings without written prompt approval
+  - No password cracking against production accounts
+  - All testing pauses on declared business-hours blackouts
+signature_block:
+  signer: jane.doe@acme.example
+  signed_at: 2026-05-30T14:22:00Z
+  signature: |
+    -----BEGIN PGP SIGNATURE-----
+    ...
+    -----END PGP SIGNATURE-----
+```
+
+## Instructions
+
+### Step 1 — Locate the ROE
+
+The skill looks for `./roe.yaml` by default. Override with
+`--roe FILE`. The ROE file should live with the engagement
+artifacts, NOT in the repo under test — typical layout is
+`engagements/<client>-<date>/roe.yaml`.
+
+### Step 2 — Run the verification
+
+```bash
+python3 ./scripts/check_authorization.py --roe engagements/acme-2026-q2/roe.yaml
+```
+
+Options:
+
+```
+Usage: check_authorization.py [OPTIONS]
+
+Options:
+  --roe FILE              Path to ROE attestation YAML (default: ./roe.yaml)
+  --allowed FILE          Path to allowed-authorizers list (default: .allowed-authorizers)
+  --check-target HOST     Verify HOST is in the in-scope list (repeatable)
+  --output FILE           Write findings to FILE
+  --format FMT            json | jsonl | markdown (default: markdown)
+  --min-severity SEV      Default info
+```
+
+### Step 3 — Interpret findings
+
+CRITICAL = engagement is NOT authorized. Halt all testing
+immediately. Resolve the missing requirement before any further
+skill runs.
+
+HIGH = the engagement was authorized at some point but the
+current state is out-of-window. Either extend the time window
+with a new signature or wait.
+
+MEDIUM = operational concerns that warrant attention but don't
+block testing. A stale ROE should be refreshed; a manual
+out-of-scope target request needs explicit additional authz.
+
+INFO = positive confirmation that the engagement is authorized.
+
+### Step 4 — Save the result
+
+The skill's output IS the authorization record. Save the markdown
+report alongside the ROE itself; it becomes part of the engagement
+evidence chain (see `recording-pentest-engagement` for the
+storage pattern).
+
+## Examples
+
+### Example 1 — Pre-flight check before any scan
+
+```bash
+python3 ./scripts/check_authorization.py --roe engagements/acme-2026-q2/roe.yaml --format markdown
+# If exit code != 0, halt testing.
+```
+
+### Example 2 — Confirm a specific target is in-scope before probing
+
+```bash
+python3 ./scripts/check_authorization.py \
+    --roe engagements/acme-2026-q2/roe.yaml \
+    --check-target app.acme.example \
+    --check-target api.acme.example
+```
+
+The skill returns an explicit INFO Finding per target if all
+checks pass, and a HIGH/CRITICAL Finding per target if any are
+out-of-scope.
+
+### Example 3 — Generate authorization evidence for the audit trail
+
+```bash
+python3 ./scripts/check_authorization.py --roe engagements/acme-2026-q2/roe.yaml \
+    --format json \
+    --output engagements/acme-2026-q2/evidence/authz-check-$(date +%Y%m%d).json
+```
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py`. Exit codes: 0 clean,
+1 high/critical (engagement NOT authorized), 2 error.
+
+Each Finding includes:
+
+- `id` — `authz::<field>` or `authz::target::<target>`
+- `severity` — CRITICAL / HIGH / MEDIUM / INFO
+- `category` — `engagement-authorization`
+- `summary` — what's missing or wrong
+- `evidence` — engagement_id, authorizer email, time window, target
+
+## Error Handling
+
+- **ROE file not found** → emits a CRITICAL finding and exits 1.
+- **Unparseable YAML** → emits a CRITICAL finding with the parser
+  error and exits 2.
+- **Allowed-authorizers file missing** → emits an INFO finding
+  (allowlist is recommended but not required) and proceeds with
+  field-level verification only.
+- **Signature block present but unparseable** → emits a CRITICAL
+  finding flagging the issue; does NOT attempt to verify
+  cryptographically (separate `gpg --verify` step recommended for
+  signature validation; this skill validates the structural
+  presence and signer-identity claim).
+
+## Resources
+
+- `references/THEORY.md` — Why pentest authorization is a legal
+  primitive (CFAA, CMA, equivalent statutes), ROE structure
+  history (OSSTMM / PTES origins), signature options
+  (PGP / S/MIME / DocuSign), scope-creep failure modes
+- `references/PLAYBOOK.md` — ROE templates per engagement type
+  (external pentest, internal pentest, red team, purple team),
+  authorization escalation flow, time-window extension procedures,
+  emergency-stop protocol

--- a/plugins/security/penetration-tester/skills/confirming-pentest-authorization/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/confirming-pentest-authorization/references/PLAYBOOK.md
@@ -1,0 +1,189 @@
+# PLAYBOOK — ROE Templates and Authorization Flow
+
+## Default ROE template
+
+```yaml
+engagement_id: <CLIENT>-<YEAR>-<QUARTER>-PENTEST-<NN>
+authorizer:
+  name: ""
+  email: ""
+  role: ""                  # CISO, CTO, VP Eng, Director of Security, etc.
+  organization: ""
+in_scope_targets:
+  - host: ""
+    notes: ""
+out_of_scope_targets:
+  - host: ""
+    reason: ""
+time_window:
+  start: "2026-MM-DDT00:00:00Z"
+  end:   "2026-MM-DDT23:59:59Z"
+emergency_contact:
+  name: ""
+  phone: ""
+  email: ""
+rules:
+  - No exploitation of confirmed findings without written prompt approval.
+  - No password cracking against production accounts.
+  - Testing pauses during declared business-hours blackout windows.
+  - All findings are confidential until report delivery.
+signature_block:
+  signer: ""
+  signed_at: "2026-MM-DDTHH:MM:SSZ"
+  signature: |
+    <PGP signature, DocuSign envelope ID, or equivalent attestation>
+```
+
+## Per-engagement-type variants
+
+### External web-app pentest
+
+`in_scope_targets` is hosts/URLs. `rules` typically include "no
+DoS, no brute-force against rate-limited endpoints, no testing
+during peak hours (specify the window)."
+
+### Internal network pentest
+
+`in_scope_targets` is CIDRs. `out_of_scope_targets` typically
+excludes the company VOIP range, the surveillance camera VLAN,
+and any PCI scope without separate authz. `rules` typically include
+"no exploit of the domain controller, no lateral movement past
+the documented hop limit."
+
+### Red-team engagement
+
+`in_scope_targets` may be the entire ASN, with explicit `out_of_scope`
+exclusions. `rules` typically include "exfiltration attempts are
+in scope; persistence mechanisms must be reversible; physical
+intrusion is/isn't included." Time window is often months.
+
+### Purple-team engagement
+
+ROE has an explicit clause acknowledging the SOC is informed.
+Adds a `coordination_contact` field for the SOC liaison.
+
+### Cloud account pentest (AWS/Azure/GCP)
+
+`in_scope_targets` includes account IDs / subscription IDs.
+`rules` typically include "no creation of new principal
+identities beyond the documented test identity; no modification
+of production IAM roles."
+
+### SaaS integration pentest
+
+`in_scope_targets` is the customer's tenant in the SaaS app.
+`rules` typically include the SaaS vendor's own policy
+(many SaaS vendors require explicit prior notification before
+testing).
+
+## Authorization escalation flow
+
+When the prospective authorizer says "yes, you can test," the
+escalation flow inside the customer's organization typically:
+
+1. **Operational owner agreement** — the team that owns the
+   system signs off that testing is welcome.
+2. **Security leadership approval** — CISO or equivalent
+   approves the engagement scope.
+3. **Legal review** — the customer's counsel reviews the ROE
+   for indemnification, liability cap, and scope clarity.
+4. **Executive sign-off** — for high-value or high-risk
+   engagements, CFO/COO/CEO sign as the binding party.
+
+The skill's `.allowed-authorizers` list captures step 2 + 4
+identities — security leadership + executive sign-off — as the
+authoritative signers. Operational owners are not in the
+allowlist by default because they typically don't bind the
+organization legally.
+
+## Time-window extension procedure
+
+When an in-progress engagement needs more time:
+
+1. Tester requests extension via the engagement's documented
+   communication channel.
+2. Authorizer (or delegate from the allowlist) signs a new ROE
+   with the extended `time_window.end`.
+3. Tester archives BOTH the original ROE and the extension; the
+   skill is re-run against the extension and produces a fresh
+   authorization record.
+
+Never run the skill on a ROE whose time window has been verbally
+or informally extended. The whole point of the schema is to make
+extensions auditable.
+
+## Emergency-stop protocol
+
+A pentest can need to stop immediately when:
+
+- The customer's SOC detects testing activity and treats it as a
+  real attack (the test pre-notification didn't reach the SOC
+  team on shift).
+- An out-of-scope system is accidentally probed.
+- The tester's tools cause an unexpected outage.
+- The customer requests a halt for any reason.
+
+The ROE's `emergency_contact` field is the call-immediately
+number. Halting is a hard stop:
+
+1. Cease all active tools.
+2. Notify the emergency_contact verbally.
+3. Document the stop time + reason.
+4. Re-run the authorization skill before resuming. If anything
+   in the ROE changed (e.g. scope amendment), the skill produces
+   the new authorization record.
+
+## Allowed-authorizers file format
+
+```
+# .allowed-authorizers — one signer identity per line
+# Comments OK. Email addresses or PGP key fingerprints.
+
+jane.doe@acme.example
+john.smith@acme.example
+0xDEADBEEFCAFE1234
+```
+
+Maintained by the tester's business-development team. Updates
+should require a co-sign from a second person to prevent
+single-actor manipulation.
+
+## Storage and retention
+
+The ROE itself is part of the engagement evidence chain. Store
+it in the engagement's evidence directory, NOT in the customer's
+codebase under test:
+
+```
+engagements/
+└── acme-2026-q2/
+    ├── roe.yaml
+    ├── allowed-authorizers
+    ├── evidence/
+    │   ├── authz-check-20260601.json
+    │   ├── authz-check-20260615.json   # after time-window extension
+    │   └── ...
+    └── findings/
+        └── ...
+```
+
+Retention: keep ROEs for at least the statute-of-limitations
+period for unauthorized-access offences in the relevant
+jurisdiction (typically 5-7 years). Some customers require
+longer retention for SOC2 / ISO 27001 evidence.
+
+## When the customer signs a "blanket" pentest authorization
+
+Some customers issue a blanket annual or multi-year authorization
+covering all engagements with a given pentester. This is legally
+valid but operationally risky:
+
+- Scope drift across engagements becomes invisible.
+- Personnel changes on either side can void the blanket
+  implicitly.
+- Time-window enforcement disappears.
+
+Recommended: write a per-engagement ROE that references the
+blanket authorization but adds specific scope + time window.
+The blanket establishes the relationship; the per-engagement
+ROE establishes what's authorized today.

--- a/plugins/security/penetration-tester/skills/confirming-pentest-authorization/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/confirming-pentest-authorization/references/THEORY.md
@@ -1,0 +1,167 @@
+# THEORY — Pentest Authorization as a Legal Primitive
+
+## The legal line
+
+Computer-access laws across major jurisdictions criminalize
+unauthorized access. The notable statutes:
+
+| Jurisdiction | Statute | Key provision |
+|---|---|---|
+| United States | CFAA (18 USC §1030) | Accessing a protected computer "without authorization" or "exceeding authorized access" |
+| United Kingdom | Computer Misuse Act 1990 | Unauthorized access (§1), unauthorized acts impairing computer operation (§3) |
+| European Union | Directive 2013/40/EU | Illegal access, illegal system interference, illegal data interference |
+| Singapore | Computer Misuse Act 1993 | Same shape; offence of unauthorized access |
+| Australia | Criminal Code Act 1995 §477 | Unauthorized access, modification, or impairment |
+
+The defining word in every statute is "authorization." A pentester
+with explicit written authorization to access in-scope systems is
+performing a legal security service. Without that authorization,
+the same activity is a crime.
+
+Authorization is not implicit. "I assumed they wanted me to test
+their system" is not a defense. "They paid me to do security work"
+is not sufficient if the system tested was outside the contracted
+scope. The pentest industry has standardized the Rules of
+Engagement (ROE) document as the artifact that establishes
+authorization with the precision the law expects.
+
+## OSSTMM, PTES, and ROE history
+
+Two open-source frameworks gave the industry its ROE template:
+
+- **OSSTMM** (Open Source Security Testing Methodology Manual,
+  ISECOM, 2001 onward) — defined the scope-fingerprinting process
+  and what the engagement-letter checklist must cover.
+- **PTES** (Penetration Testing Execution Standard, 2010 onward)
+  — formalized the pre-engagement phase, including ROE structure.
+
+Both predate the cloud / API era and reflect a network-pentest
+mental model. Modern engagements add fields for cloud accounts,
+SaaS integrations, and ML-model probing that the original templates
+don't anticipate. The schema this skill validates incorporates
+common modern fields (SaaS scope, time windows, emergency contact)
+on top of the OSSTMM/PTES foundation.
+
+## Signature options
+
+The "signature" on a ROE is whatever evidence the authorizer's
+counsel and your counsel agree establishes binding intent. Common
+forms:
+
+| Method | Strength | Effort |
+|---|---|---|
+| PGP / GPG signature on YAML/text ROE | Cryptographic; high | Moderate (both parties need GPG setup) |
+| S/MIME signed PDF | Cryptographic; high | Moderate (certificate management) |
+| DocuSign or HelloSign e-signature | Legally recognized in most jurisdictions; high | Low |
+| Email with explicit "I authorize" statement, archived | Legally recognized but weaker (email impersonation risk) | Low |
+| Wet-ink signature on printed ROE | Strongest in court; high | High (slow, physical) |
+| Slack DM "yeah go ahead" | Often inadmissible; do NOT rely on | Trivial |
+
+The skill validates the structural presence of a `signature_block`
+in the ROE. Cryptographic verification (actually checking that a
+PGP signature was made by the claimed key) is a separate step the
+operator runs with `gpg --verify` before this skill runs. The
+skill checks "is this ROE structurally signed?" not "is this
+signature cryptographically valid?" — those are different gates,
+and conflating them in one tool produces brittle failure modes.
+
+## Scope-creep failure modes
+
+Engagements that go wrong tend to follow common patterns:
+
+### "Just one more system"
+
+Tester finds an interesting adjacent system mid-engagement and
+probes it. Adjacent system was NOT in the ROE. SOC team escalates.
+Legal asks for the ROE. ROE doesn't cover the adjacent system.
+Conversation gets expensive.
+
+Mitigation: the skill's `--check-target` flag explicitly tests
+whether a target is in scope BEFORE any probe runs. The
+orchestrator should call it for every fresh target.
+
+### "I assumed prod was off-limits"
+
+Tester avoids "obvious" production systems but probes systems
+labeled "staging" that turn out to be production-attached.
+Outage results.
+
+Mitigation: ROE schema requires explicit `in_scope_targets` AND
+`out_of_scope_targets`. The list of out-of-scope items is
+prophylactic — if a target isn't on either list, the tester must
+ask before proceeding.
+
+### "We extended verbally"
+
+Engagement's time window expires, but the customer says verbally
+"keep going for another week." Tester continues. Incident occurs.
+ROE shows the time window as expired. The verbal extension is
+unprovable.
+
+Mitigation: time-window expiry is a CRITICAL finding in this
+skill. The skill refuses to declare an engagement authorized if
+the current time is outside the window, regardless of any other
+field's state.
+
+### "The CISO's assistant said it was fine"
+
+ROE was signed by someone whose authority over the systems was
+unclear or absent. CISO denies authorizing.
+
+Mitigation: the `.allowed-authorizers` file establishes which
+signer identities are accepted. Maintained by the tester's
+business-development team; new authorizers require vetting
+before being added.
+
+## ROE template fields and why each matters
+
+| Field | Why it's in the schema |
+|---|---|
+| `engagement_id` | Unambiguously identifies the engagement; lets multiple ROEs coexist without confusion |
+| `authorizer.name + email + role` | Identifies who is authorizing; their role establishes that they have authority |
+| `authorizer.organization` | Customer org; useful when the authorizer is a contractor or an MSP |
+| `in_scope_targets` | The list. Without it, nothing is authorized |
+| `out_of_scope_targets` | Prophylactic; clarifies known boundaries |
+| `time_window.start + end` | Engagement is only authorized within this window |
+| `emergency_contact` | Who to call if the test triggers an unexpected outage or law-enforcement contact |
+| `rules` | Custom restrictions (no password spray on prod accounts, etc.) |
+| `signature_block` | Establishes binding intent and which party is bound |
+| `signature_block.signed_at` | When binding was established |
+
+## Why "halt on CRITICAL" is the right policy
+
+The orchestrator routes to this skill FIRST and refuses to proceed
+to cluster 1-4 skills if any CRITICAL finding emerges. The
+rationale:
+
+- A scan that produces findings against an unauthorized target
+  exposes the tester to legal liability.
+- Even informational scans (port scans, DNS probes) against
+  unauthorized targets can constitute unauthorized access under
+  some statutes.
+- The cost of halting is a delayed engagement. The cost of
+  proceeding without authorization is criminal exposure. The
+  asymmetry is severe; the discipline is the only constraint.
+
+## Cryptographic verification — out of scope here
+
+PGP signature verification (does the signature on this ROE actually
+match the public key of the claimed signer?) is performed by a
+separate operator-run step:
+
+```bash
+gpg --verify roe.yaml.asc roe.yaml
+```
+
+The skill does not invoke GPG because:
+
+1. Many ROEs are signed via DocuSign or similar (no PGP at all).
+2. PGP key management is its own discipline — the skill would
+   become a key-management tool.
+3. Separating "structural presence of signature" from
+   "cryptographic validity of signature" makes failures easier
+   to diagnose.
+
+A future enhancement could add `--verify-pgp` to bridge the two,
+with explicit key-store configuration. For now, the skill checks
+structure; the operator checks cryptography.

--- a/plugins/security/penetration-tester/skills/confirming-pentest-authorization/scripts/check_authorization.py
+++ b/plugins/security/penetration-tester/skills/confirming-pentest-authorization/scripts/check_authorization.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""confirming-pentest-authorization — verify ROE before any scan runs.
+
+Reads a Rules-of-Engagement YAML attestation, validates required fields
+(authorizer, in_scope_targets, time_window, emergency_contact, signature_block),
+checks signer identity against an allowed-authorizers file (optional), and
+verifies the current time falls within the engagement window. Emits Findings
+via lib/finding.py. The orchestrator routes here FIRST — any CRITICAL finding
+halts engagement before later cluster skills get a chance to run.
+
+Usage:
+    python3 check_authorization.py [--roe FILE] [--allowed FILE]
+                                   [--check-target HOST]
+                                   [--output FILE] [--format json|jsonl|markdown]
+                                   [--min-severity sev]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import ipaddress
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity  # noqa: E402
+from lib import report  # noqa: E402
+
+# --- Optional YAML import (fallback to a minimal parser if PyYAML absent) ---
+try:
+    import yaml  # type: ignore[import-not-found]
+
+    _HAS_PYYAML = True
+except ImportError:  # pragma: no cover
+    yaml = None
+    _HAS_PYYAML = False
+
+
+SKILL_ID = "confirming-pentest-authorization"
+CATEGORY = "engagement-authorization"
+
+REQUIRED_FIELDS = (
+    "engagement_id",
+    "authorizer",
+    "in_scope_targets",
+    "time_window",
+    "emergency_contact",
+    "signature_block",
+)
+REQUIRED_AUTHORIZER_FIELDS = ("name", "email", "role")
+REQUIRED_TIME_WINDOW_FIELDS = ("start", "end")
+REQUIRED_SIGNATURE_FIELDS = ("signer", "signed_at", "signature")
+
+
+# --- Minimal-YAML fallback parser -------------------------------------------
+
+
+def _minimal_yaml_load(text: str) -> dict[str, Any]:
+    """Very limited YAML parser for environments without PyYAML.
+
+    Supports: top-level mapping, nested mappings (indentation-sensitive),
+    lists of dicts and scalars, ISO date/time strings as strings.
+    Refuses any structure it can't parse rather than guess.
+    """
+    if _HAS_PYYAML:
+        return yaml.safe_load(text) or {}
+
+    lines = [l for l in text.splitlines() if not l.lstrip().startswith("#")]
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, Any]] = [(-1, root)]
+
+    def cur() -> Any:
+        return stack[-1][1]
+
+    for raw in lines:
+        if not raw.strip():
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        line = raw.strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+
+        if line.startswith("- "):
+            item_text = line[2:].strip()
+            container = cur()
+            if not isinstance(container, list):
+                # parent expected a list
+                parent_key, parent_dict = stack[-2] if len(stack) >= 2 else (-1, root)
+                # find the key for which we want to make a list — this is best-effort
+                container = []
+                # re-attach: convert empty value of last set key to a list
+                if isinstance(parent_dict, dict):
+                    for k in list(parent_dict.keys())[::-1]:
+                        if parent_dict[k] in (None, "", {}):
+                            parent_dict[k] = container
+                            break
+            if ":" in item_text and not item_text.endswith(":"):
+                k, _, v = item_text.partition(":")
+                container.append({k.strip(): v.strip()})
+                stack.append((indent + 2, container[-1]))
+            elif item_text.endswith(":"):
+                obj: dict[str, Any] = {}
+                container.append(obj)
+                stack.append((indent + 2, obj))
+            else:
+                container.append(item_text)
+        elif ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+            container = cur()
+            if not isinstance(container, dict):
+                continue
+            if value == "":
+                container[key] = {}
+                stack.append((indent, container[key]))
+            elif value == "|":
+                # block scalar — collect indented lines (not implemented richly)
+                container[key] = ""
+            else:
+                container[key] = value.strip().strip('"').strip("'")
+    return root
+
+
+# --- ROE loading ------------------------------------------------------------
+
+
+def load_roe(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, f"ROE file not found at {path}"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return None, f"Cannot read {path}: {e}"
+    try:
+        data = _minimal_yaml_load(text) if not _HAS_PYYAML else yaml.safe_load(text)
+    except Exception as e:  # noqa: BLE001 — YAML errors come in many flavors
+        return None, f"YAML parse error: {e}"
+    if not isinstance(data, dict):
+        return None, "ROE top-level structure is not a mapping"
+    return data, None
+
+
+def load_allowed(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+
+# --- Field validation -------------------------------------------------------
+
+
+def _info(title: str, target: str, detail: str) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=Severity.INFO,
+        target=target,
+        detail=detail,
+        remediation="No action required.",
+    )
+
+
+def _critical(title: str, target: str, detail: str, remediation: str) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=Severity.CRITICAL,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+    )
+
+
+def _high(title: str, target: str, detail: str, remediation: str) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=Severity.HIGH,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+    )
+
+
+def _parse_iso(s: str) -> dt.datetime | None:
+    try:
+        # accept "Z" suffix and offset forms
+        s2 = s.replace("Z", "+00:00")
+        return dt.datetime.fromisoformat(s2)
+    except (ValueError, TypeError):
+        return None
+
+
+def validate_roe(
+    data: dict[str, Any], target_label: str, allowed: list[str]
+) -> list[Finding]:
+    findings: list[Finding] = []
+
+    # Required top-level fields
+    for field in REQUIRED_FIELDS:
+        if field not in data or data.get(field) in (None, "", [], {}):
+            findings.append(
+                _critical(
+                    f"ROE missing required field: {field}",
+                    target_label,
+                    f"Field `{field}` is required and was missing or empty.",
+                    f"Add `{field}` to the ROE and re-sign.",
+                )
+            )
+
+    authorizer = data.get("authorizer") or {}
+    if isinstance(authorizer, dict):
+        for sub in REQUIRED_AUTHORIZER_FIELDS:
+            if sub not in authorizer or not authorizer.get(sub):
+                findings.append(
+                    _critical(
+                        f"authorizer.{sub} missing",
+                        target_label,
+                        f"The authorizer block is missing `{sub}`.",
+                        f"Add `authorizer.{sub}` to the ROE and re-sign.",
+                    )
+                )
+
+    tw = data.get("time_window") or {}
+    if isinstance(tw, dict):
+        for sub in REQUIRED_TIME_WINDOW_FIELDS:
+            if sub not in tw:
+                findings.append(
+                    _critical(
+                        f"time_window.{sub} missing",
+                        target_label,
+                        f"`time_window.{sub}` is required.",
+                        f"Add `time_window.{sub}` (ISO-8601 timestamp) and re-sign.",
+                    )
+                )
+        start = _parse_iso(str(tw.get("start", "")))
+        end = _parse_iso(str(tw.get("end", "")))
+        now = dt.datetime.now(dt.timezone.utc)
+        if start and now < start:
+            findings.append(
+                _high(
+                    "engagement time window has not started",
+                    target_label,
+                    f"Current time {now.isoformat()} precedes window start "
+                    f"{start.isoformat()}.",
+                    "Wait until the start time, or have the authorizer "
+                    "re-sign with an earlier start.",
+                )
+            )
+        if end and now > end:
+            findings.append(
+                _high(
+                    "engagement time window has expired",
+                    target_label,
+                    f"Current time {now.isoformat()} is past window end "
+                    f"{end.isoformat()}.",
+                    "Halt testing immediately. Request a new ROE with an "
+                    "extended end date.",
+                )
+            )
+
+    sig = data.get("signature_block") or {}
+    if isinstance(sig, dict):
+        for sub in REQUIRED_SIGNATURE_FIELDS:
+            if sub not in sig or not sig.get(sub):
+                findings.append(
+                    _critical(
+                        f"signature_block.{sub} missing",
+                        target_label,
+                        f"The signature_block is missing `{sub}`.",
+                        "Re-sign the ROE with all signature fields present.",
+                    )
+                )
+        signer = str(sig.get("signer", "")).strip().lower()
+        if allowed and signer and signer not in [a.lower() for a in allowed]:
+            findings.append(
+                _critical(
+                    "signer not in allowed-authorizers list",
+                    target_label,
+                    f"signer `{signer}` is not present in the allowed-authorizers "
+                    f"file. Engagement cannot be authorized by this signer.",
+                    "Either add the signer to the allowed list (only do this "
+                    "for verified authorizers!) or have an allowed signer "
+                    "re-sign the ROE.",
+                )
+            )
+
+        signed_at = _parse_iso(str(sig.get("signed_at", "")))
+        if signed_at:
+            age_days = (dt.datetime.now(dt.timezone.utc) - signed_at).days
+            if age_days > 30:
+                findings.append(
+                    Finding(
+                        skill_id=SKILL_ID,
+                        title="ROE is stale (>30 days since signature)",
+                        severity=Severity.MEDIUM,
+                        target=target_label,
+                        detail=f"ROE was signed {age_days} days ago.",
+                        remediation="Request a refreshed ROE signature.",
+                    )
+                )
+
+    in_scope = data.get("in_scope_targets") or []
+    if isinstance(in_scope, list) and len(in_scope) == 0:
+        findings.append(
+            _high(
+                "in_scope_targets list is empty",
+                target_label,
+                "in_scope_targets must list at least one target.",
+                "Add explicit in-scope targets and re-sign.",
+            )
+        )
+
+    return findings
+
+
+# --- Target-in-scope check --------------------------------------------------
+
+
+def _normalize_targets(in_scope: list[dict[str, Any] | str]) -> list[str]:
+    norm: list[str] = []
+    for t in in_scope:
+        if isinstance(t, dict):
+            if "host" in t:
+                norm.append(str(t["host"]).strip().lower())
+            elif "cidr" in t:
+                norm.append(str(t["cidr"]).strip())
+        elif isinstance(t, str):
+            norm.append(t.strip().lower())
+    return norm
+
+
+def target_in_scope(target: str, in_scope: list[str]) -> bool:
+    target_n = target.strip().lower()
+    # exact hostname match
+    if target_n in in_scope:
+        return True
+    # CIDR membership
+    try:
+        target_ip = ipaddress.ip_address(target_n)
+        for entry in in_scope:
+            try:
+                net = ipaddress.ip_network(entry, strict=False)
+                if target_ip in net:
+                    return True
+            except (ValueError, TypeError):
+                continue
+    except ValueError:
+        pass
+    # Suffix match for subdomain wildcards (e.g. "*.acme.example")
+    for entry in in_scope:
+        if entry.startswith("*.") and target_n.endswith(entry[2:]):
+            return True
+    return False
+
+
+def check_targets(
+    targets: list[str], in_scope_raw: list[dict[str, Any] | str], target_label: str
+) -> list[Finding]:
+    in_scope = _normalize_targets(in_scope_raw)
+    out: list[Finding] = []
+    for t in targets:
+        if target_in_scope(t, in_scope):
+            out.append(
+                _info(
+                    f"target {t} is in scope",
+                    target_label,
+                    f"`{t}` matched an in-scope entry in the ROE.",
+                )
+            )
+        else:
+            out.append(
+                _critical(
+                    f"target {t} is NOT in scope",
+                    target_label,
+                    f"`{t}` does not match any in-scope entry. Probing this "
+                    f"target is not authorized.",
+                    f"Either confirm the target IS in scope (request an ROE "
+                    f"amendment) or remove `{t}` from the test plan.",
+                )
+            )
+    return out
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--roe", default="roe.yaml", help="Path to ROE YAML file")
+    p.add_argument("--allowed", default=".allowed-authorizers")
+    p.add_argument(
+        "--check-target",
+        action="append",
+        default=[],
+        help="Verify target is in-scope (repeatable)",
+    )
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    return p
+
+
+def _filter_min_severity(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    roe_path = Path(args.roe).resolve()
+    allowed_path = Path(args.allowed).resolve()
+
+    data, err = load_roe(roe_path)
+    if data is None:
+        f = _critical(
+            "ROE could not be loaded",
+            str(roe_path),
+            err or "unknown error",
+            f"Create or fix the ROE at {roe_path} and re-run.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(roe_path))
+        return 1
+
+    allowed = load_allowed(allowed_path)
+    findings = validate_roe(data, str(roe_path), allowed)
+
+    if args.check_target:
+        findings.extend(
+            check_targets(
+                args.check_target,
+                data.get("in_scope_targets") or [],
+                str(roe_path),
+            )
+        )
+
+    if not findings:
+        findings = [
+            _info(
+                "engagement is authorized",
+                str(roe_path),
+                "All required fields present, signer in allowlist, time window "
+                "is active, and all checked targets are in scope.",
+            )
+        ]
+    findings = _filter_min_severity(findings, args.min_severity)
+    report.emit(findings, args.output, args.format, scan_target=str(roe_path))
+    return report.exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/defining-pentest-scope/SKILL.md
+++ b/plugins/security/penetration-tester/skills/defining-pentest-scope/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: defining-pentest-scope
+description: |
+  Parse the ROE scope definition, enumerate every in-scope target
+  (hostnames, IPs, CIDRs, URLs, cloud accounts, SaaS tenants),
+  validate syntax, detect overlap with out-of-scope or known
+  third-party SaaS ranges, and emit a normalized target list plus
+  IP allowlist for scanning tools. Runs after confirming-pentest-
+  authorization and before any cluster 1-4 scan.
+  Use when: starting an engagement, expanding scope mid-engagement,
+  validating that a target list matches the ROE, or generating an
+  allowlist for an external scanner.
+  Threshold: malformed syntax, in-scope overlap with out-of-scope,
+  reserved or third-party SaaS ranges without acknowledgement.
+  Trigger with: "define scope", "enumerate targets", "validate
+  target list", "generate IP allowlist".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Bash(nmap:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - engagement-governance
+  - scope
+  - target-enumeration
+  - pentest
+---
+
+# Defining Pentest Scope
+
+## Overview
+
+A pentest scope is a list of permission boundaries. Get it wrong
+and you either (a) miss real exposure by failing to test something
+the customer expected covered, or (b) probe something you weren't
+allowed to touch and turn the engagement into a liability event.
+Both failure modes share a root cause: the scope list was a vague
+narrative ("test the marketing site and the API") rather than a
+machine-readable, syntactically-validated, conflict-checked
+artifact.
+
+This skill takes the in-scope and out-of-scope sections from a ROE
+and produces three deliverables:
+
+1. **Normalized target list** — every entry parsed into a
+   structured form (host vs CIDR vs URL path vs cloud account vs
+   SaaS tenant), with explicit type tagging. Downstream cluster
+   1-4 skills consume this list rather than raw strings.
+2. **IP allowlist** — flat list of IPv4 and IPv6 addresses /
+   CIDRs ready to paste into scanner configurations (nmap target
+   list, Burp scope file, AWS WAF allowlist, etc.).
+3. **Conflict report** — Findings flagging syntactically-malformed
+   entries, overlap between in-scope and out-of-scope, inclusion
+   of reserved ranges (RFC1918, link-local, multicast), and known
+   third-party SaaS infrastructure that needs separate authz.
+
+The skill does NOT perform DNS resolution or network probing —
+that would itself be a "first probe" of the target, which by the
+governance model must happen AFTER scope is locked.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Malformed target syntax | **HIGH** | Entry doesn't parse as host / CIDR / URL / account-id | (legal) |
+| In-scope overlaps out-of-scope | **CRITICAL** | An in-scope target falls within an out-of-scope CIDR | (legal) |
+| Reserved range without acknowledgement | **HIGH** | RFC1918, link-local (169.254/16), multicast (224/4), broadcast in in-scope list | (operational) |
+| Known third-party SaaS in scope | **HIGH** | In-scope IP matches a known SaaS range (AWS, Cloudflare, GitHub, etc.) without separate authz | (legal) |
+| Duplicate target | **INFO** | Same target appears multiple times | (operational) |
+| Wildcard subdomain (e.g. `*.acme.example`) | **INFO** | Wildcards expand at scan time | (informational) |
+| All targets validated cleanly | **INFO** | Positive confirmation | (informational) |
+
+## Prerequisites
+
+- Python 3.9+
+- ROE file at `./roe.yaml` (or pass `--roe FILE`)
+- Optional `.scope-extension.yaml` listing additional targets
+  added mid-engagement (each must reference an authz amendment)
+
+## Target syntax forms
+
+| Form | Example | Notes |
+|---|---|---|
+| Hostname | `app.acme.example` | DNS-resolvable name |
+| Wildcard subdomain | `*.acme.example` | Resolved at scan time; flag for explicit acknowledgement |
+| IPv4 address | `203.0.113.10` | Single host |
+| IPv4 CIDR | `203.0.113.0/24` | Network range |
+| IPv6 address | `2001:db8::10` | Single host |
+| IPv6 CIDR | `2001:db8::/32` | Network range |
+| URL with path | `https://app.acme.example/api/v2` | Path-restricted scope |
+| Cloud account ID | `aws:123456789012` or `gcp:acme-prod` | Cloud control-plane scope |
+| SaaS tenant | `okta:acme-corp` or `auth0:acme` | SaaS-tenant scope |
+
+## Instructions
+
+### Step 1 — Provide the scope source
+
+The skill reads the ROE's `in_scope_targets` and
+`out_of_scope_targets` sections by default. Override with
+`--roe FILE` if the engagement ROE isn't at the default path.
+
+### Step 2 — Run the scope definition
+
+```bash
+python3 ./scripts/define_scope.py --roe engagements/acme-2026-q2/roe.yaml
+```
+
+Options:
+
+```
+Usage: define_scope.py [OPTIONS]
+
+Options:
+  --roe FILE             Path to ROE YAML (default: ./roe.yaml)
+  --emit-allowlist FILE  Write flat IP allowlist to FILE
+  --emit-targets FILE    Write normalized target list to FILE
+  --extension FILE       Additional scope extension YAML
+  --output FILE          Findings output
+  --format FMT           json | jsonl | markdown (default: markdown)
+  --min-severity SEV     default info
+```
+
+### Step 3 — Review the conflict report
+
+CRITICAL findings (overlap between in-scope and out-of-scope) must
+be resolved before any scan runs. Either narrow the in-scope range
+or remove the out-of-scope overlap; the customer's authorizer
+decides which.
+
+HIGH findings (malformed targets, third-party SaaS, reserved
+ranges) require explicit acknowledgement — either fix the entry
+or document in the ROE why the range is intentionally included.
+
+### Step 4 — Hand off the allowlist
+
+```bash
+python3 ./scripts/define_scope.py --roe engagements/acme-2026-q2/roe.yaml \
+    --emit-allowlist /tmp/allowed-ips.txt \
+    --emit-targets /tmp/normalized-targets.json
+```
+
+The allowlist file is one IP/CIDR per line, ready to paste into:
+
+- nmap: `nmap -iL /tmp/allowed-ips.txt`
+- AWS WAF rule: convert to JSON via your standard tooling
+- Burp Suite: paste into Target → Scope → Include
+- This pack's cluster 1 skills: pass via the target argument
+
+## Examples
+
+### Example 1 — Generate scope artifacts for a new engagement
+
+```bash
+python3 ./scripts/define_scope.py \
+    --roe engagements/acme-2026-q2/roe.yaml \
+    --emit-allowlist engagements/acme-2026-q2/scope/allowed-ips.txt \
+    --emit-targets engagements/acme-2026-q2/scope/normalized-targets.json \
+    --output engagements/acme-2026-q2/scope/scope-report.md
+```
+
+### Example 2 — Validate a mid-engagement scope extension
+
+```bash
+python3 ./scripts/define_scope.py \
+    --roe engagements/acme-2026-q2/roe.yaml \
+    --extension engagements/acme-2026-q2/scope-extension-20260615.yaml
+```
+
+The extension YAML follows the same target format. The skill
+validates that every extension entry has an associated
+authorization reference and emits a CRITICAL finding for any
+extension entry that doesn't.
+
+### Example 3 — Pre-scan validation gate
+
+```bash
+python3 ./scripts/define_scope.py --roe engagements/acme-2026-q2/roe.yaml \
+    --min-severity high \
+    --format json --output /tmp/scope-issues.json
+jq -e '. == []' /tmp/scope-issues.json || { echo "Scope issues block scan"; exit 1; }
+```
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py`. Exit codes: 0 clean,
+1 high/critical, 2 error.
+
+Each Finding includes:
+
+- `id` — `scope::<issue>::<target>` (e.g. `scope::malformed::foo[bar`)
+- `severity` — CRITICAL / HIGH / MEDIUM / INFO
+- `category` — `engagement-scope`
+- `summary` — what's wrong with the entry
+- `evidence` — original entry, parsed form, conflict source, line in ROE
+
+## Error Handling
+
+- **ROE missing** → emits CRITICAL finding, exits 1.
+- **In-scope section missing or empty** → CRITICAL finding, exits 1.
+- **Unparseable entry** → HIGH finding per entry, scan continues
+  for other entries.
+- **Extension file referenced but missing** → HIGH finding.
+- **IPv6 CIDR with very large mask** (e.g. `::/0`) → CRITICAL —
+  almost certainly a typo; refuse to expand.
+
+## Resources
+
+- `references/THEORY.md` — Why scope is the load-bearing artifact
+  of pentest legality, target-type taxonomy, known SaaS-range
+  classification (AWS, Cloudflare, GCP, Azure), DNS resolution
+  policy (when/whether to resolve at scope-definition time),
+  CIDR-overlap detection theory
+- `references/PLAYBOOK.md` — Per-engagement-type scope templates
+  (web app, internal network, red team, cloud account, SaaS tenant),
+  scope-extension protocol, allowlist-emission patterns per
+  scanner, common scope-mistake patterns

--- a/plugins/security/penetration-tester/skills/defining-pentest-scope/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/defining-pentest-scope/references/PLAYBOOK.md
@@ -1,0 +1,238 @@
+# PLAYBOOK — Scope Templates and Hand-Off Patterns
+
+## Per-engagement-type scope templates
+
+### External web app pentest
+
+```yaml
+in_scope_targets:
+  - host: app.acme.example
+    notes: production web app
+  - host: api.acme.example
+    notes: REST API; rate-limit 60 req/min observed
+  - url: https://app.acme.example/admin/
+    notes: admin UI (test as authorized admin user)
+out_of_scope_targets:
+  - host: payments.acme.example
+    reason: PCI scope, separate authz required
+  - host: legal.acme.example
+    reason: third-party hosted; not customer's
+```
+
+### Internal network pentest
+
+```yaml
+in_scope_targets:
+  - cidr: 10.50.0.0/16
+    notes: corporate user range
+  - cidr: 10.51.0.0/16
+    notes: developer subnet
+  - cidr: 10.52.0.0/24
+    notes: test infrastructure
+out_of_scope_targets:
+  - cidr: 10.99.0.0/16
+    reason: production DB tier, separate authz
+  - cidr: 10.250.0.0/24
+    reason: physical surveillance VLAN
+  - cidr: 10.251.0.0/24
+    reason: VOIP (avoid call disruption)
+```
+
+### Red-team engagement
+
+```yaml
+in_scope_targets:
+  - cidr: 203.0.113.0/24
+    notes: customer ASN block 1
+  - cidr: 198.51.100.0/24
+    notes: customer ASN block 2
+  - host: "*.acme.example"
+    notes: any subdomain of acme.example
+  - cloud_account: aws:123456789012
+    notes: production AWS account
+out_of_scope_targets:
+  - host: ceo.acme.example
+    reason: executive personal device
+  - cidr: 203.0.113.250/32
+    reason: SOC bastion (would tip off SOC)
+```
+
+### Cloud account pentest (AWS)
+
+```yaml
+in_scope_targets:
+  - cloud_account: aws:123456789012
+    notes: prod-1 account; full read scope
+  - cloud_account: aws:210987654321
+    notes: prod-2 account; identity-services only
+out_of_scope_targets:
+  - cloud_account: aws:999999999999
+    reason: management account; out of agreed scope
+```
+
+### SaaS tenant pentest
+
+```yaml
+in_scope_targets:
+  - saas_tenant: okta:acme-corp
+    notes: customer Okta tenant; SSO config audit
+  - saas_tenant: auth0:acme
+    notes: customer Auth0 tenant
+out_of_scope_targets:
+  - saas_tenant: salesforce:acme
+    reason: separate vendor-authz required
+```
+
+Many SaaS vendors require explicit prior notification before
+pentesting (Salesforce, Okta, etc. all have their own pentest
+authorization forms). The skill flags `saas:` entries informationally;
+the operator should verify the vendor's own authz separately.
+
+## Allowlist emission patterns per scanner
+
+### nmap
+
+```bash
+python3 ./scripts/define_scope.py --roe roe.yaml --emit-allowlist /tmp/allowed.txt
+nmap -iL /tmp/allowed.txt -sV -oN nmap-scan.txt
+```
+
+### Burp Suite Target → Scope
+
+Burp uses regex-based scope rules. Convert the allowlist by
+escaping dots and accepting any port:
+
+```python
+# Quick converter
+import re
+with open("/tmp/allowed.txt") as f:
+    for line in f:
+        entry = line.strip()
+        # Convert hostname/CIDR to Burp regex
+        print(re.escape(entry))
+```
+
+Paste output into Burp's "Include in scope" with "Use advanced
+scope control" enabled.
+
+### AWS WAF allowlist
+
+```bash
+python3 - <<EOF
+import json
+ips = open("/tmp/allowed.txt").read().splitlines()
+v4 = [ip for ip in ips if ":" not in ip]
+print(json.dumps({"Addresses": v4}, indent=2))
+EOF
+```
+
+Pipe the output to `aws wafv2 update-ip-set` to install the
+allowlist.
+
+### Cloud security tools (ScoutSuite, Prowler, CloudSploit)
+
+Cloud scope is by account ID, not IP. Read the `cloud_account`
+entries from the normalized targets JSON:
+
+```bash
+jq -r '.[] | select(.type=="cloud") | .normalized' /tmp/targets.json
+```
+
+## Scope-extension protocol
+
+When testing reveals a target that should have been in scope but
+wasn't:
+
+1. Halt testing of the extension target.
+2. Request a scope amendment from the authorizer.
+3. Authorizer signs an extension YAML:
+
+   ```yaml
+   amendment_id: ACME-2026-Q2-PENTEST-001-AMEND-01
+   amendment_to: ACME-2026-Q2-PENTEST-001
+   amendment_date: 2026-06-15T10:00:00Z
+   in_scope_targets:
+     - host: newly-discovered.acme.example
+       notes: discovered during port-scan of cidr 203.0.113.0/24; serves admin UI
+   signature_block:
+     signer: jane.doe@acme.example
+     signed_at: 2026-06-15T11:00:00Z
+     signature: |
+       <signature>
+   ```
+
+4. Re-run this skill with `--extension`.
+5. Verify the new scope is clean before resuming testing.
+
+## Allowlist file format
+
+The `--emit-allowlist` output is one entry per line:
+
+```
+203.0.113.10
+203.0.113.0/24
+2001:db8::10
+2001:db8::/64
+```
+
+Hostnames are NOT in the allowlist (DNS resolves at scan time;
+see THEORY.md). The normalized targets JSON is the source of
+truth for hostnames + URLs + cloud accounts + SaaS tenants.
+
+## Normalized targets JSON format
+
+```json
+[
+  {"raw": "app.acme.example", "type": "hostname", "normalized": "app.acme.example"},
+  {"raw": "203.0.113.0/24", "type": "cidrv4", "normalized": "203.0.113.0/24"},
+  {"raw": "https://api.acme.example/v2", "type": "url", "normalized": "https://api.acme.example/v2"},
+  {"raw": "aws:123456789012", "type": "cloud", "normalized": "aws:123456789012"}
+]
+```
+
+Downstream skills consume this JSON via `--targets-file` argument
+patterns (planned across the cluster 1-4 skills).
+
+## Common scope-mistake patterns
+
+| Pattern | Fix |
+|---|---|
+| `host: 203.0.113.0/24` | Use `cidr:` not `host:` |
+| `host: https://app.acme.example` | Use `url:` not `host:` |
+| `cidr: 203.0.113.10` | Single IP without mask; CIDR /32 implied but explicit is better |
+| Hostname with trailing dot (`acme.example.`) | DNS-canonical form; strip the dot |
+| `*.acme.example/admin` | Mixes wildcard + path; not supported |
+| Cloud account with hyphenated number `aws:1234-5678-9012` | Use bare number, no hyphens |
+| Unicode in hostname (`münich.acme.example`) | Convert to Punycode (`xn--mnich-rta.acme.example`) |
+
+## Pre-scan gate (CI)
+
+```bash
+python3 ./scripts/define_scope.py --roe roe.yaml --min-severity high \
+    --format json --output scope-issues.json
+jq -e '. == []' scope-issues.json || {
+  echo "::error::Scope issues block testing"
+  exit 1
+}
+```
+
+This pattern works for engagements where the ROE is checked into
+a private engagement repo with CI.
+
+## Scope drift detection between engagements
+
+When running multiple engagements for the same customer over time,
+diff this engagement's scope against the previous:
+
+```bash
+python3 ./scripts/define_scope.py --roe engagements/acme-2026-q1/roe.yaml \
+    --emit-targets engagements/acme-2026-q1/targets.json
+python3 ./scripts/define_scope.py --roe engagements/acme-2026-q2/roe.yaml \
+    --emit-targets engagements/acme-2026-q2/targets.json
+diff <(jq -S .[].normalized engagements/acme-2026-q1/targets.json) \
+     <(jq -S .[].normalized engagements/acme-2026-q2/targets.json)
+```
+
+Scope changes between engagements are common (customer added new
+infra, decommissioned old) — but they should be explicit and
+documented, not silent.

--- a/plugins/security/penetration-tester/skills/defining-pentest-scope/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/defining-pentest-scope/references/THEORY.md
@@ -1,0 +1,170 @@
+# THEORY — Scope as the Load-Bearing Artifact
+
+## Why scope is the load-bearing legal artifact
+
+Authorization is the gate (see `confirming-pentest-authorization`),
+but SCOPE is the perimeter the authorization applies to. A signed
+ROE that says "test ACME's stuff" authorizes nothing in practice
+because it doesn't define ACME's stuff. The scope list is the
+projection of "what we're allowed to touch" into a list of concrete
+targets a tester or tool can verify against.
+
+The skill's purpose is to convert the human-readable ROE scope
+section into a machine-readable, syntactically-validated, conflict-
+checked artifact that downstream cluster 1-4 skills can consume
+without ambiguity.
+
+## Target-type taxonomy
+
+Real-world scope lists mix several target types. The taxonomy:
+
+| Type | Use | Validation |
+|---|---|---|
+| Hostname | `app.acme.example` | Valid DNS character set, length |
+| Wildcard | `*.acme.example` | Wildcard prefix + valid suffix |
+| IPv4 | `203.0.113.10` | Valid 4-octet form |
+| IPv4 CIDR | `203.0.113.0/24` | Valid network + mask |
+| IPv6 | `2001:db8::10` | Valid hex form |
+| IPv6 CIDR | `2001:db8::/32` | Valid network + mask |
+| URL with path | `https://app.acme.example/api` | Valid URL parse + non-empty netloc |
+| Cloud account | `aws:123456789012` | Recognized cloud prefix |
+| SaaS tenant | `okta:acme-corp` | Recognized SaaS prefix |
+
+Mixing types in one list is normal; the skill's `--emit-targets`
+output preserves the type tagging so downstream tools can route
+each entry to the right scanner.
+
+## Why DNS resolution is NOT done at scope-definition time
+
+It would be tempting to resolve every hostname to its current IP
+at scope-definition time and bake the IPs into the allowlist. This
+is wrong, for two reasons:
+
+1. **DNS resolution is itself a probe.** A DNS query against the
+   target's authoritative DNS server (or against a recursive
+   resolver that forwards to it) is detectable by sophisticated
+   defenders. By the governance model, no probes happen before
+   scope is locked.
+
+2. **DNS changes during the engagement.** Resolving `app.acme.example`
+   to `203.0.113.10` at scope-definition time, then having the
+   customer's load balancer rotate to `203.0.113.11` mid-engagement,
+   means the tester's IP allowlist is stale. Hostname-based scope
+   resolves at scan time and tracks current DNS state.
+
+The downstream cluster 1 skills resolve hostnames at scan time
+themselves. The allowlist this skill emits contains the explicit
+IPs/CIDRs the ROE listed, not resolved hostnames.
+
+## CIDR overlap detection
+
+Python's `ipaddress` module provides exact CIDR-overlap checks
+via `IPv4Network.overlaps()` / `IPv6Network.overlaps()`. The skill
+uses these directly.
+
+A subtle case: `203.0.113.0/24` overlaps `203.0.113.128/25` (the
+second is a sub-range of the first). If the ROE has the /24 in
+in-scope and the /25 in out-of-scope, the skill emits a CRITICAL
+finding: probing within the /25 sub-range would violate the
+exclusion.
+
+The customer's authorizer decides the resolution:
+
+- Narrow in-scope to `203.0.113.0/25` (excludes the /25 explicitly)
+- Remove the out-of-scope /25 entry (broaden authorization)
+- Keep both and require per-target check at scan time
+
+## Known third-party SaaS ranges
+
+The skill ships an illustrative (NOT exhaustive) map of well-known
+cloud / CDN / SaaS ranges. The most common ones in customer scope
+lists by accident:
+
+- AWS — customer mistakes their AWS-hosted endpoint's CDN front
+  for their own infrastructure.
+- Cloudflare — customer's domain resolves to Cloudflare; the IP
+  is Cloudflare's, not the customer's.
+- GitHub — customer's hosted-status page or docs site is on GitHub
+  Pages.
+- Vercel / Netlify — customer's marketing site frontend.
+
+Probing these without separate authorization is testing the SaaS
+vendor's infrastructure, which is almost universally prohibited
+without the SaaS vendor's own pentest-authorization process.
+
+Real engagements should consult the authoritative published IP
+ranges:
+
+- AWS: https://ip-ranges.amazonaws.com/ip-ranges.json
+- Cloudflare: https://www.cloudflare.com/ips/
+- GCP: https://www.gstatic.com/ipranges/cloud.json
+- Azure: published quarterly as a JSON file
+
+A future skill enhancement could ingest these authoritative
+sources at scope-definition time and verify against current data.
+
+## Reserved ranges
+
+The skill flags RFC1918 (`10/8`, `172.16/12`, `192.168/16`),
+link-local (`169.254/16`), multicast (`224/4`), loopback
+(`127/8`), and IPv6 equivalents.
+
+In an internal pentest, RFC1918 ranges are expected — these are
+the customer's internal networks. The skill flags them as MEDIUM
+rather than HIGH/CRITICAL: "verify intentional." The customer's
+acknowledgement of the internal-pentest context resolves the
+finding.
+
+In an external pentest, RFC1918 in scope is a configuration error —
+the tester would be testing their own network, not the customer's.
+The skill cannot determine engagement type from the ROE alone, so
+the operator interprets the finding in context.
+
+## Wildcard subdomain semantics
+
+`*.acme.example` is a scope-by-pattern. It says "any subdomain of
+acme.example is in scope." The skill flags wildcards as INFO
+because they're not malformed but they ARE broad — the customer
+should confirm intent.
+
+Wildcard expansion happens at scan time, when the tester:
+
+1. Enumerates subdomains via passive sources (Certificate
+   Transparency, DNS history, brute-force).
+2. Each enumerated subdomain is checked against the wildcard's
+   pattern.
+3. Matched subdomains become concrete targets.
+
+The cluster 2 fingerprinting skills handle subdomain enumeration.
+
+## Scope hygiene patterns
+
+Three patterns characterize well-defined scope lists:
+
+1. **Explicit inclusion + explicit exclusion.** Always have both
+   lists, even if one is empty. "Nothing else is included"
+   beats "I assume the rest is excluded."
+
+2. **Type-tagged entries.** Use the schema's `host:` / `cidr:` /
+   `url:` keys explicitly. Bare string entries work but require
+   the skill to guess the type, which can produce subtle errors.
+
+3. **Notes on every entry.** Why is this in scope? Why is this
+   out? Future you, six months from now, won't remember.
+
+## When scope changes mid-engagement
+
+The protocol:
+
+1. Tester requests amendment via the engagement's documented
+   communication channel.
+2. Authorizer signs an amendment YAML referencing the original
+   ROE's `engagement_id`.
+3. Tester archives the amendment alongside the original ROE.
+4. Re-run this skill with `--extension` pointing at the
+   amendment.
+5. The new combined scope becomes the authoritative scope from
+   the amendment timestamp forward.
+
+Never extend scope by verbal agreement. The whole point of the
+ROE schema is that scope changes are auditable.

--- a/plugins/security/penetration-tester/skills/defining-pentest-scope/scripts/define_scope.py
+++ b/plugins/security/penetration-tester/skills/defining-pentest-scope/scripts/define_scope.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""defining-pentest-scope — parse + validate + normalize a scope definition.
+
+Reads a ROE YAML, parses every in-scope and out-of-scope target into a
+structured form (host / cidr / url / cloud-account / saas-tenant), validates
+syntax, detects overlap between in-scope and out-of-scope ranges, flags
+reserved or known third-party SaaS ranges, and emits Findings via
+lib/finding.py. Optionally writes a flat IP allowlist file ready for nmap /
+WAF / Burp consumption.
+
+Usage:
+    python3 define_scope.py [--roe FILE] [--extension FILE]
+                             [--emit-allowlist FILE] [--emit-targets FILE]
+                             [--output FILE] [--format json|jsonl|markdown]
+                             [--min-severity sev]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity  # noqa: E402
+from lib import report  # noqa: E402
+
+try:
+    import yaml  # type: ignore[import-not-found]
+    _HAS_PYYAML = True
+except ImportError:
+    yaml = None
+    _HAS_PYYAML = False
+
+
+SKILL_ID = "defining-pentest-scope"
+CATEGORY = "engagement-scope"
+
+# Known third-party SaaS / cloud edge ranges (illustrative, NOT exhaustive).
+# These are not authoritative; real engagements should consult published
+# IP ranges (e.g. AWS ip-ranges.json, Cloudflare cidr lists).
+KNOWN_SAAS_RANGES = {
+    "AWS": [
+        "3.0.0.0/9",
+        "13.32.0.0/15",
+        "52.0.0.0/8",
+    ],
+    "Cloudflare": [
+        "104.16.0.0/13",
+        "172.64.0.0/13",
+        "131.0.72.0/22",
+    ],
+    "GitHub": [
+        "140.82.112.0/20",
+        "143.55.64.0/20",
+    ],
+    "GCP": [
+        "34.0.0.0/8",
+        "35.184.0.0/13",
+    ],
+    "Azure": [
+        "13.64.0.0/11",
+        "20.0.0.0/8",
+    ],
+}
+
+RESERVED_RANGES = [
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "127.0.0.0/8",
+    "224.0.0.0/4",
+    "::1/128",
+    "fe80::/10",
+    "fc00::/7",
+]
+
+
+# --- YAML loading ------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if _HAS_PYYAML:
+        return yaml.safe_load(text) or {}
+    # Minimal fallback — relies on the simple structure of ROE files
+    return _minimal_yaml_load(text)
+
+
+def _minimal_yaml_load(text: str) -> dict[str, Any]:
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, Any]] = [(-1, root)]
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        line = raw.strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        container = stack[-1][1]
+        if line.startswith("- "):
+            item = line[2:].strip()
+            if isinstance(container, dict):
+                # Demote last key to a list
+                for k in list(container.keys())[::-1]:
+                    if container[k] in (None, "", {}):
+                        container[k] = []
+                        container = container[k]
+                        stack.append((indent, container))
+                        break
+            if isinstance(container, list):
+                if ":" in item:
+                    k, _, v = item.partition(":")
+                    container.append({k.strip(): v.strip().strip('"').strip("'")})
+                    stack.append((indent + 2, container[-1]))
+                else:
+                    container.append(item.strip('"').strip("'"))
+        elif ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if isinstance(container, dict):
+                if value == "":
+                    container[key] = {}
+                    stack.append((indent, container[key]))
+                else:
+                    container[key] = value
+    return root
+
+
+# --- Target classification --------------------------------------------------
+
+
+def classify_target(entry: Any) -> tuple[str, str, str | None]:
+    """Return (raw, type, normalized) for a scope entry.
+
+    type ∈ {"hostname","wildcard","ipv4","ipv6","cidrv4","cidrv6","url","cloud","saas","malformed"}
+    """
+    if isinstance(entry, dict):
+        if "host" in entry:
+            return classify_target(entry["host"])
+        if "cidr" in entry:
+            return classify_target(entry["cidr"])
+        if "url" in entry:
+            return classify_target(entry["url"])
+        if "cloud_account" in entry:
+            return entry["cloud_account"], "cloud", entry["cloud_account"]
+        if "saas_tenant" in entry:
+            return entry["saas_tenant"], "saas", entry["saas_tenant"]
+        return str(entry), "malformed", None
+    s = str(entry).strip()
+    if not s:
+        return s, "malformed", None
+
+    # URL
+    if s.startswith("http://") or s.startswith("https://"):
+        try:
+            parsed = urlparse(s)
+            if parsed.netloc:
+                return s, "url", s
+        except ValueError:
+            return s, "malformed", None
+
+    # Cloud account / SaaS tenant prefixes
+    if re.match(r"^(aws|gcp|azure):", s, flags=re.I):
+        return s, "cloud", s
+    if re.match(r"^(okta|auth0|saml|google-workspace|microsoft365):", s, flags=re.I):
+        return s, "saas", s
+
+    # CIDR / IP
+    if "/" in s:
+        try:
+            net = ipaddress.ip_network(s, strict=False)
+            return s, "cidrv6" if net.version == 6 else "cidrv4", str(net)
+        except ValueError:
+            return s, "malformed", None
+    try:
+        addr = ipaddress.ip_address(s)
+        return s, "ipv6" if addr.version == 6 else "ipv4", str(addr)
+    except ValueError:
+        pass
+
+    # Wildcard
+    if s.startswith("*."):
+        if re.match(r"^\*\.[A-Za-z0-9.-]+$", s):
+            return s, "wildcard", s.lower()
+        return s, "malformed", None
+
+    # Hostname
+    if re.match(r"^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$", s):
+        return s, "hostname", s.lower()
+
+    return s, "malformed", None
+
+
+# --- Overlap / SaaS / Reserved detection ------------------------------------
+
+
+def _to_network(entry: str) -> ipaddress.IPv4Network | ipaddress.IPv6Network | None:
+    try:
+        return ipaddress.ip_network(entry, strict=False)
+    except ValueError:
+        try:
+            return ipaddress.ip_network(f"{entry}/32" if ":" not in entry else f"{entry}/128", strict=False)
+        except ValueError:
+            return None
+
+
+def cidr_overlap(a: str, b: str) -> bool:
+    na = _to_network(a)
+    nb = _to_network(b)
+    if na is None or nb is None or na.version != nb.version:
+        return False
+    return na.overlaps(nb)
+
+
+def detect_saas(entry: str) -> str | None:
+    net = _to_network(entry)
+    if net is None:
+        return None
+    for vendor, ranges in KNOWN_SAAS_RANGES.items():
+        for r in ranges:
+            try:
+                saas_net = ipaddress.ip_network(r, strict=False)
+                if net.version == saas_net.version and net.overlaps(saas_net):
+                    return vendor
+            except ValueError:
+                continue
+    return None
+
+
+def detect_reserved(entry: str) -> str | None:
+    net = _to_network(entry)
+    if net is None:
+        return None
+    for r in RESERVED_RANGES:
+        try:
+            reserved_net = ipaddress.ip_network(r)
+            if net.version == reserved_net.version and net.overlaps(reserved_net):
+                return r
+        except ValueError:
+            continue
+    return None
+
+
+# --- Finding generation -----------------------------------------------------
+
+
+def _f(severity: Severity, title: str, target: str, detail: str, remediation: str,
+       evidence: tuple[tuple[str, Any], ...] = ()) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=severity,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+        evidence=evidence,
+    )
+
+
+def evaluate_scope(
+    in_scope: list[Any], out_of_scope: list[Any], target_label: str
+) -> tuple[list[Finding], list[dict[str, Any]], list[str]]:
+    findings: list[Finding] = []
+    normalized: list[dict[str, Any]] = []
+    allowlist: list[str] = []
+    seen = Counter()
+
+    classified_in: list[tuple[Any, str, str, str | None]] = []
+    for entry in in_scope:
+        raw, t, norm = classify_target(entry)
+        seen[norm or raw] += 1
+        classified_in.append((entry, raw, t, norm))
+
+    classified_out: list[tuple[Any, str, str, str | None]] = []
+    for entry in out_of_scope:
+        raw, t, norm = classify_target(entry)
+        classified_out.append((entry, raw, t, norm))
+
+    # Per-entry validation
+    for entry, raw, t, norm in classified_in:
+        if t == "malformed":
+            findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"malformed in-scope target: {raw}",
+                    raw,
+                    f"Entry `{raw}` does not parse as host / CIDR / URL / cloud account / SaaS tenant.",
+                    "Fix the entry's syntax in the ROE and re-run this skill.",
+                    evidence=(("raw", raw),),
+                )
+            )
+            continue
+        normalized.append({"raw": raw, "type": t, "normalized": norm})
+        if t in ("ipv4", "ipv6", "cidrv4", "cidrv6"):
+            allowlist.append(norm or raw)
+            saas = detect_saas(norm or raw)
+            if saas is not None:
+                findings.append(
+                    _f(
+                        Severity.HIGH,
+                        f"{raw} appears to be in {saas} infrastructure",
+                        raw,
+                        f"`{raw}` overlaps a known {saas} range. Testing third-party "
+                        f"SaaS infrastructure requires SEPARATE authorization from "
+                        f"the SaaS vendor, not just the customer.",
+                        f"Either confirm {saas} has authorized testing OR remove "
+                        f"this entry from scope.",
+                        evidence=(("vendor", saas), ("entry", raw)),
+                    )
+                )
+            reserved = detect_reserved(norm or raw)
+            if reserved is not None and t in ("ipv4", "cidrv4"):
+                # RFC1918 in internal pentest is expected; only flag for external context
+                findings.append(
+                    _f(
+                        Severity.MEDIUM,
+                        f"{raw} is in a reserved range ({reserved})",
+                        raw,
+                        f"`{raw}` falls within reserved range {reserved}. Acceptable "
+                        f"for internal pentests; verify this is intentional.",
+                        f"If this is an internal pentest, no action needed. "
+                        f"Otherwise, remove from external scope.",
+                        evidence=(("reserved", reserved), ("entry", raw)),
+                    )
+                )
+        if seen[norm or raw] > 1:
+            findings.append(
+                _f(
+                    Severity.INFO,
+                    f"duplicate in-scope entry: {raw}",
+                    raw,
+                    f"`{raw}` appears {seen[norm or raw]} times.",
+                    "Deduplicate; harmless but indicates ROE hygiene issue.",
+                )
+            )
+        if t == "wildcard":
+            findings.append(
+                _f(
+                    Severity.INFO,
+                    f"wildcard entry: {raw}",
+                    raw,
+                    f"`{raw}` will be expanded to specific subdomains at scan time. "
+                    f"Wildcard scope is broad; ensure the customer intended it.",
+                    "Document the expected scope of the wildcard in the ROE rules section.",
+                )
+            )
+
+    # Overlap detection: any in-scope CIDR/IP that intersects an out-of-scope CIDR.
+    for in_entry, in_raw, in_t, in_norm in classified_in:
+        if in_t not in ("ipv4", "ipv6", "cidrv4", "cidrv6"):
+            continue
+        for out_entry, out_raw, out_t, out_norm in classified_out:
+            if out_t not in ("ipv4", "ipv6", "cidrv4", "cidrv6"):
+                continue
+            if cidr_overlap(in_norm or in_raw, out_norm or out_raw):
+                findings.append(
+                    _f(
+                        Severity.CRITICAL,
+                        f"in-scope {in_raw} overlaps out-of-scope {out_raw}",
+                        in_raw,
+                        f"In-scope entry `{in_raw}` overlaps with out-of-scope "
+                        f"entry `{out_raw}`. Probing the overlap is NOT authorized.",
+                        f"Either narrow `{in_raw}` to exclude `{out_raw}`, or remove "
+                        f"`{out_raw}` from the out-of-scope list (the authorizer's call).",
+                        evidence=(("in_scope", in_raw), ("out_of_scope", out_raw)),
+                    )
+                )
+
+    return findings, normalized, allowlist
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--roe", default="roe.yaml")
+    p.add_argument("--extension", default=None)
+    p.add_argument("--emit-allowlist", default=None)
+    p.add_argument("--emit-targets", default=None)
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    return p
+
+
+def _filter_min_severity(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    roe_path = Path(args.roe).resolve()
+    if not roe_path.exists():
+        f = _f(
+            Severity.CRITICAL,
+            "ROE file missing",
+            str(roe_path),
+            f"No ROE at {roe_path}; cannot define scope.",
+            "Create or path-correct the ROE and re-run.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(roe_path))
+        return 1
+
+    data = _load_yaml(roe_path)
+    in_scope = data.get("in_scope_targets") or []
+    out_of_scope = data.get("out_of_scope_targets") or []
+
+    if args.extension:
+        ext_data = _load_yaml(Path(args.extension).resolve())
+        in_scope = list(in_scope) + list(ext_data.get("in_scope_targets") or [])
+
+    if not in_scope:
+        f = _f(
+            Severity.CRITICAL,
+            "in_scope_targets is empty",
+            str(roe_path),
+            "Cannot define scope without at least one in-scope target.",
+            "Add in-scope targets to the ROE and re-sign.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(roe_path))
+        return 1
+
+    findings, normalized, allowlist = evaluate_scope(in_scope, out_of_scope, str(roe_path))
+
+    if args.emit_allowlist:
+        Path(args.emit_allowlist).write_text("\n".join(sorted(set(allowlist))) + "\n", encoding="utf-8")
+    if args.emit_targets:
+        Path(args.emit_targets).write_text(
+            json.dumps(normalized, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+    if not findings:
+        findings = [
+            _f(
+                Severity.INFO,
+                "scope is clean",
+                str(roe_path),
+                f"All {len(normalized)} targets validated. No overlaps, no malformed "
+                f"entries, no third-party SaaS conflicts.",
+                "Hand off the allowlist + normalized target list to scan skills.",
+            )
+        ]
+    findings = _filter_min_severity(findings, args.min_severity)
+    report.emit(findings, args.output, args.format, scan_target=str(roe_path))
+    return report.exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/generating-executive-summary/SKILL.md
+++ b/plugins/security/penetration-tester/skills/generating-executive-summary/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: generating-executive-summary
+description: |
+  Compose an exec-readable summary from a unified findings JSONL
+  plus the OWASP coverage report. Computes a single engagement
+  risk score (0-100, severity-weighted with OWASP-breadth and
+  governance terms), rolls up findings into headline counts, names
+  the top-3 remediation priorities with effort + impact estimates,
+  and produces a 1-2 page markdown document for a C-level or board
+  audience. Elides technical detail; the vulnerability report is
+  the deep document.
+  Use when: closing an engagement, preparing the exec-readout
+  meeting, packaging for board review, or producing a one-page
+  narrative for auditor / insurer / board.
+  Threshold: input findings missing produces CRITICAL operational
+  finding; otherwise the deliverable is the document itself.
+  Trigger with: "generate exec summary", "executive summary",
+  "C-level readout", "board pentest summary".
+allowed-tools:
+  - Read
+  - Write
+  - Bash(python3:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - reporting
+  - executive-summary
+  - risk-score
+  - pentest
+---
+
+# Generating Executive Summary
+
+## Overview
+
+The vulnerability report is comprehensive — every finding, full
+detail, every reference. The C-level reader doesn't open it. They
+ask their security lead "what should I tell the board?" The
+security lead needs a one-page answer.
+
+That one-page answer is the executive summary. It states the
+engagement's bottom line:
+
+- A single risk score (0-100)
+- Headline counts by severity
+- Top-3 remediation priorities, each with rough effort + impact
+- OWASP Top 10 coverage (where the work landed)
+- Engagement scope and authorization summary (what was tested,
+  under what authority, in what window)
+- Next steps the customer's organization should take
+
+The summary doesn't omit anything important; it just compresses.
+The vulnerability report remains the deep artifact for anyone who
+needs the technical detail.
+
+This skill consumes the enriched findings JSONL (after OWASP
+mapping) + the OWASP coverage report + the ROE, computes the risk
+score, picks the top remediation priorities deterministically,
+and renders the document.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Input findings file missing | **CRITICAL** | Source JSONL doesn't exist | (operational) |
+| OWASP coverage report missing | **HIGH** | Coverage referenced but not present | (operational) |
+| ROE missing | **MEDIUM** | Can still generate summary but lacks scope/authz context | (operational) |
+| Exec summary written cleanly | **INFO** | Confirmation | (informational) |
+| Risk score >75 (high engagement risk) | **HIGH** | Computed risk score elevated | (advisory) |
+| Risk score >90 (critical engagement risk) | **CRITICAL** | Engagement exposed material risk; needs urgent action | (advisory) |
+
+## Risk score (0-100) composition
+
+The single risk score is the headline number on the exec summary.
+The composition is deterministic and documented:
+
+```
+risk = clamp(0, 100,
+    20 * count(CRITICAL)
+  + 10 * count(HIGH)
+  +  3 * count(MEDIUM)
+  +  1 * count(LOW)
+  +  0 * count(INFO)
+  +  5 * (count(distinct OWASP categories touched) - 5 if >5 else 0)
+  - 10 * 1 if engagement was authorized cleanly and in-scope (governance bonus)
+)
+```
+
+The first five terms weight by severity. The OWASP-coverage term
+adds 5 points per category beyond 5 (a broader-finding engagement
+implies broader risk surface). The governance bonus is a -10
+adjustment when ROE was clean — explicit recognition that finding
+problems in a well-governed engagement is HEALTHIER than finding
+the same problems in a chaotic engagement.
+
+Score interpretation:
+
+| Score | Reading |
+|---|---|
+| 0-25 | Low risk: clean engagement OR very narrow scope |
+| 26-50 | Moderate risk: typical engagement with manageable findings |
+| 51-75 | Elevated risk: significant findings, remediation planning required |
+| 76-90 | High risk: material findings; executive attention warranted |
+| 91-100 | Critical risk: urgent remediation required; consider treating as incident |
+
+## Top-3 remediation priorities
+
+The skill picks top-3 priorities deterministically by:
+
+1. Severity (CRITICAL > HIGH > MEDIUM > LOW)
+2. Reachability — findings affecting many targets weight higher
+3. Tie-breaker: alphabetical by title for stable output
+
+Each priority gets:
+
+- A one-line headline
+- Estimated effort (Hours / Days / Weeks)
+- Estimated impact (Limited / Significant / Material)
+- Pointer to the corresponding finding section in the
+  vulnerability report
+
+Effort + impact are heuristic estimates based on the source
+skill's category — operator can override via `--priority-overrides`
+for cases where the heuristic is wrong.
+
+## Prerequisites
+
+- Python 3.9+
+- Findings JSONL at `engagement/findings/all-with-owasp.jsonl`
+  (output of `mapping-findings-to-owasp-top10`) OR an explicit
+  `--source FILE`
+- OWASP coverage report at `engagement/reports/owasp-coverage.md`
+  (referenced; optional)
+- ROE at `engagement/roe.yaml` (referenced for scope summary)
+
+## Instructions
+
+### Step 1 — Verify the inputs are present
+
+```bash
+ls engagements/acme-2026-q2/findings/all-with-owasp.jsonl
+ls engagements/acme-2026-q2/reports/owasp-coverage.md
+ls engagements/acme-2026-q2/roe.yaml
+```
+
+All three should exist for a complete summary. The skill works
+without the coverage report or ROE but the summary is less
+complete.
+
+### Step 2 — Generate the summary
+
+```bash
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/
+```
+
+Options:
+
+```
+Usage: exec_summary.py PATH [OPTIONS]
+
+Options:
+  --source FILE              Findings JSONL (default: PATH/findings/all-with-owasp.jsonl)
+  --coverage FILE            OWASP coverage report (default: PATH/reports/owasp-coverage.md)
+  --roe FILE                 ROE (default: PATH/roe.yaml)
+  --summary-output FILE      Output path (default: PATH/reports/executive-summary.md)
+  --output FILE              Operational findings output
+  --format FMT               json | jsonl | markdown (default: markdown)
+  --min-severity SEV         default info
+  --priority-overrides FILE  YAML overriding the top-3 priorities
+```
+
+### Step 3 — Review the risk score
+
+If the score is in 76-100 range, the operator should sanity-check
+before delivering: did the underlying findings actually warrant
+the elevated reading, or did a few INFO-tagged findings get
+mis-categorized as HIGH?
+
+### Step 4 — Hand off
+
+The exec summary is intended as a standalone artifact. Deliver to
+the customer's exec readout meeting, along with the full
+vulnerability report.
+
+## Examples
+
+### Example 1 — End-of-engagement summary
+
+```bash
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/
+```
+
+### Example 2 — Board-ready summary (force-includes governance section)
+
+```bash
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/ \
+    --summary-output engagements/acme-2026-q2/reports/board-summary.md
+```
+
+### Example 3 — Override priorities
+
+```yaml
+# priorities-override.yaml
+- title: "Hardcoded AWS access key in source"
+  effort: Hours
+  impact: Material
+  rationale: This is the single highest-priority remediation regardless of count.
+```
+
+```bash
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/ \
+    --priority-overrides priorities-override.yaml
+```
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py` for operational
+findings. PRIMARY output: the executive-summary markdown
+document.
+
+Operational Finding includes:
+
+- `id` — `exec::<issue>`
+- `severity` — varies
+- `category` — `executive-summary`
+- `summary` — what was generated
+- `evidence` — risk score, finding count, top priorities, output path
+
+## Error Handling
+
+- **No findings source** → CRITICAL operational finding, exits 1.
+- **Source JSONL unparseable** → HIGH, exits 1.
+- **No findings at all** → emits LOW operational finding noting
+  the empty engagement; the document is generated but says so.
+- **Coverage report missing** → MEDIUM, document is generated
+  without the coverage-narrative section.
+- **ROE missing** → MEDIUM, document is generated without the
+  scope/authorization section.
+
+## Resources
+
+- `references/THEORY.md` — Executive-summary writing as a
+  technical-communication discipline, single-number risk
+  scoring tradeoffs, why deterministic priority selection beats
+  human-curated for reproducibility, how the score interpretation
+  bands were chosen, comparison with CVSS / DREAD / STRIDE risk
+  models
+- `references/PLAYBOOK.md` — Per-audience customizations (board,
+  C-suite, security leadership, customer auditor), summary length
+  guidelines, common rewrite patterns, integration with the
+  composing + mapping skills, post-delivery follow-up cadence

--- a/plugins/security/penetration-tester/skills/generating-executive-summary/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/generating-executive-summary/references/PLAYBOOK.md
@@ -1,0 +1,201 @@
+# PLAYBOOK — Audience Customizations and Delivery
+
+## Per-audience customizations
+
+### Board summary (default — quarterly board pack)
+
+Risk score + top 3 priorities + OWASP coverage. The board reader
+wants to know "should we be worried?" The exec summary as
+emitted answers that.
+
+```bash
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/
+```
+
+### C-suite (CISO / CTO) summary
+
+Same content as the board summary, but the C-suite reader may
+want lengthier remediation discussion. After running the default
+summary, the operator can edit the markdown directly to expand
+specific sections. The skill's output is intentionally treated as
+a draft for editorial expansion.
+
+### Customer's security leadership summary
+
+For the customer's own security leadership (Director of Security,
+VP Engineering's security lead, etc.), the most useful expansion
+is per-priority detail with cross-references to the vulnerability
+report. The default output already includes the
+`vulnerability-report.md#finding-XXX` cross-references — these
+are clickable in most markdown viewers.
+
+### External auditor / insurer summary
+
+For external parties (SOC2 auditor, cyber-insurance carrier),
+extend the default with engagement-archive integrity statement:
+
+```markdown
+## Archive integrity
+
+The engagement's findings, evidence, and configuration are
+archived at <path> with a SHA-256 manifest signed by <key id>.
+Verification command:
+
+`sha256sum -c manifest.sha256 && gpg --verify manifest.sha256.asc manifest.sha256`
+```
+
+Add this manually to the rendered summary before delivery.
+
+## Summary length guidelines
+
+| Use | Target length |
+|---|---|
+| Board summary | 1 page (~60 lines markdown) |
+| C-suite summary | 1.5 pages (~80 lines markdown) |
+| Customer security leadership | 2 pages (~120 lines markdown) |
+| External auditor (with archive section) | 2 pages |
+
+The skill emits ~80-100 lines by default. Pad or trim by editing
+the rendered markdown.
+
+## Common rewrite patterns
+
+### "Soften the risk-score band wording"
+
+Some customers find "Critical" / "High" risk-band language
+alarming when the underlying findings are routine. The
+risk-band labels are documented in THEORY.md; if your customer
+relationship makes the words land badly, rewrite the band
+description without changing the numeric score.
+
+Don't change the score itself to fit the rewrite — the score
+remains the canonical number; the descriptive band is the
+audience-facing label.
+
+### "Add a CFO-readable financial-impact section"
+
+The skill doesn't compute financial impact (out of scope; too
+many assumptions about asset value). For engagements that warrant
+a CFO-readable section:
+
+1. Work with the customer's finance lead to assign rough cost
+   ranges to each top priority.
+2. Append a "Financial impact estimates" section to the rendered
+   summary with the agreed numbers.
+3. Annotate clearly: "Cost estimates provided by customer; not
+   computed from finding data."
+
+### "Add a regulatory-impact narrative"
+
+For engagements in regulated industries (HIPAA, PCI, SOC2), the
+exec audience cares about regulatory exposure. Append a
+"Regulatory impact" section that cross-references the top
+findings against specific regulations:
+
+```markdown
+## Regulatory impact
+
+The top finding "Hardcoded AWS key in source" triggers HIPAA
+§164.308(a)(1)(ii)(B) (Risk Management) reporting obligation.
+Remediation timing should align with the breach-notification
+window if data has been exposed.
+```
+
+Don't include this section by default; add it when the engagement
+has specific regulatory framing.
+
+## Integration with the composing + mapping skills
+
+The exec-summary skill consumes:
+
+1. **Unified findings JSONL** (from `composing-vulnerability-report`
+   OR `mapping-findings-to-owasp-top10`)
+2. **OWASP coverage report** (from `mapping-findings-to-owasp-top10`)
+3. **ROE YAML** (from the engagement repository)
+
+Run order:
+
+```bash
+# 1. (Optional) Compose to produce the main vulnerability report first
+python3 plugins/security/penetration-tester/skills/composing-vulnerability-report/scripts/compose_report.py \
+    engagements/acme-2026-q2/
+
+# 2. Map to OWASP, producing the enriched JSONL and coverage report
+python3 plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/scripts/map_owasp.py \
+    engagements/acme-2026-q2/
+
+# 3. Generate the exec summary
+python3 ./scripts/exec_summary.py engagements/acme-2026-q2/
+```
+
+## Post-delivery follow-up cadence
+
+The exec summary's "Suggested next steps" section starts a
+remediation cadence. The pentester's role typically:
+
+1. **End-of-engagement** (week 0): deliver the summary + report.
+2. **Week 2**: optional check-in with the customer's security
+   lead to confirm remediation has been prioritized.
+3. **Week 6**: confirm the top priorities have been addressed.
+4. **Week 12**: re-test the top priorities to verify the fixes
+   hold. The re-test produces a follow-up summary using the same
+   skill against the same engagement directory.
+
+Re-tests should produce a LOWER risk score after remediation. If
+the score doesn't drop, either the fixes didn't take effect or
+new findings emerged in the re-test scan.
+
+## Sample delivery package
+
+The standard engagement closeout package contains:
+
+```
+engagements/archives/acme-2026-q2.tar.gz
+├── engagement directory contents
+├── manifest.sha256                  # SHA-256 of every file
+├── manifest.sha256.asc              # GPG signature
+└── reports/
+    ├── vulnerability-report.md      # full technical detail
+    ├── owasp-coverage.md            # OWASP Top 10 breakdown
+    └── executive-summary.md         # this skill's output
+```
+
+Plus separately:
+
+- The exec summary as a standalone PDF (via `/whiteglove-pdf`).
+- A receipt-signed copy of the archive's manifest.
+
+## Risk-score auditability
+
+If a customer or third party questions the risk score, the
+auditable response:
+
+1. Show the score-composition formula from THEORY.md.
+2. Show the severity counts that fed the formula.
+3. Show the OWASP-breadth count.
+4. Show the governance-bonus determination.
+5. Demonstrate that re-running the skill produces the same score.
+
+The skill is deterministic by design so this audit is always
+possible.
+
+## When the score and the findings disagree intuitively
+
+Occasionally the algorithmic score doesn't match the operator's
+gut feeling — usually because:
+
+- A single very high-impact finding doesn't dominate enough
+  (the formula adds rather than maxing).
+- Numerous low-severity findings produce a higher score than the
+  operator expected.
+- The OWASP-breadth bonus elevates an otherwise-modest engagement.
+
+Operator can:
+
+- Document the divergence in the summary's "Suggested next steps"
+  section.
+- Use `--priority-overrides` to set top-3 priorities that match
+  intuition.
+- Refrain from re-engineering the formula for one engagement;
+  consistency across engagements is the formula's value
+  proposition.

--- a/plugins/security/penetration-tester/skills/generating-executive-summary/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/generating-executive-summary/references/THEORY.md
@@ -1,0 +1,195 @@
+# THEORY — Executive Summary as a Technical-Communication Discipline
+
+## What an exec summary actually is
+
+An executive summary is not a shorter vulnerability report. It's
+a different document for a different reader. The vulnerability
+report says "here is every finding we identified." The exec
+summary says "here is what the board / CEO / CISO needs to decide
+on, and how big the decision is."
+
+The summary's job is to compress without losing decision-relevant
+information. Compressed too far, it becomes content-free chrome
+("the engagement found several issues; please refer to the full
+report"). Compressed too little, it becomes a redundant technical
+document.
+
+The middle ground:
+
+1. A single number that establishes the engagement's bottom line
+   (risk score).
+2. Counts that contextualize the number (severity breakdown).
+3. Specific named priorities the reader can act on.
+4. Just enough scope/authz framing that the reader can validate
+   the summary against their own expectations.
+5. A clear pointer to the deep document.
+
+## Why a single risk score
+
+The single-number summary is controversial in security circles —
+it loses information, it can be gamed, it doesn't capture
+exploitation likelihood. All true.
+
+It's still the right primitive for the exec audience because:
+
+- Execs are accustomed to making decisions on single numbers
+  (NPS, MAU, ARR, Lighthouse score). A pentest result without a
+  number doesn't fit the decision frame.
+- The number's interpretation band ("Low / Moderate / Elevated /
+  High / Critical") is more decision-relevant than the precise
+  number anyway.
+- Score-to-decision mapping is consistent across engagements;
+  the customer can compare year-over-year and customer-to-customer.
+
+Critical caveats the summary writer should NOT lose:
+
+- The score is HEURISTIC. A 65 isn't twice as bad as a 32.
+- The score's composition formula is documented; the reader can
+  audit how it was computed.
+- The score isn't a substitute for reading the finding list.
+
+## Risk score composition — design rationale
+
+The chosen weights:
+
+- 20 per CRITICAL — each critical finding has potential to be a
+  full-organization-impact event. Two criticals already pushes
+  the score into the elevated band.
+- 10 per HIGH — high findings are material but typically scoped
+  to specific systems.
+- 3 per MEDIUM — mediums accumulate to meaning; one isn't a
+  big deal, but ten is.
+- 1 per LOW — low findings are noise individually; in bulk they
+  signal hygiene problems.
+- 0 per INFO — informational findings don't move the score.
+
+The OWASP-coverage breadth term adds points for engagements that
+land findings in many categories. Reasoning: an engagement that
+finds problems in 8 OWASP categories has surfaced a broader risk
+surface than one that finds problems in 2. The breadth term
+captures that.
+
+The governance bonus (-10 when ROE is clean) is a deliberate
+adjustment. A clean engagement with the same findings represents
+LESS organizational risk than a chaotic engagement with the same
+findings, because the customer has the operational rigor to
+remediate effectively.
+
+## Score band interpretation
+
+The 0-100 score maps to qualitative bands:
+
+| Range | Band | Decision implication |
+|---|---|---|
+| 0-25 | Low | Continue current cadence; no special action |
+| 26-50 | Moderate | Standard remediation planning |
+| 51-75 | Elevated | Surface to security leadership; quarter-by-quarter tracking |
+| 76-90 | High | Executive attention; structured remediation plan |
+| 91-100 | Critical | Treat as incident; urgent remediation |
+
+The bands were chosen to match how exec stakeholders naturally
+discretize risk. Five bands beats three (too coarse) or ten (too
+fine).
+
+## Deterministic priority selection — why not human-curated
+
+The top-3 priorities are picked algorithmically by severity +
+reachability + alphabetical tie-break. Reproducibility wins over
+nuance:
+
+- Same findings → same top-3, always.
+- The skill can be re-run after remediation to confirm priorities
+  changed.
+- Auditors and customers can verify the prioritization wasn't
+  selectively edited to match a narrative.
+
+The `--priority-overrides` flag exists for legitimate operator
+intervention (e.g. "this hardcoded AWS key is the single biggest
+risk regardless of count") but the default is algorithmic.
+
+## CVSS vs DREAD vs STRIDE risk frameworks
+
+Several risk-scoring frameworks compete:
+
+| Framework | Used for | Strengths | Why not here |
+|---|---|---|---|
+| CVSS | Per-vulnerability scoring | Industry-standard, NVD-blessed | Per-vuln, not aggregate; no exec-summary primitive |
+| DREAD | Threat-modeling risk | Captures Damage/Reproducibility/Exploitability/Affected users/Discoverability | Not pentest-natural; weights are subjective |
+| STRIDE | Threat categorization | Maps to threat types | Categorical, not numeric |
+| EPSS | Real-world exploitation likelihood | Predictive, data-driven | Per-CVE, not per-engagement |
+| FAIR | Quantitative risk in dollars | Most precise | Expensive to compute; requires asset-value modeling |
+
+The skill's risk score is a custom aggregate optimized for the
+exec-summary use case. It's not a substitute for any of the
+above; it composes with them.
+
+## Effort + impact estimates
+
+Each priority gets a rough effort (Hours / Days / Weeks) and
+impact (Limited / Significant / Material) tag. These are
+HEURISTIC and based on the source skill + reach. The skill
+deliberately doesn't try to predict dollar impact or hour count —
+those are owned by the customer's engineering team, not the
+pentester.
+
+Effort heuristics:
+
+- Dependency upgrade — Hours to Days
+- Hardcoded secret rotation — Hours
+- Config / header fix — Days
+- Injection / deserialization fix — Weeks (requires code changes)
+- License compliance — Weeks (requires legal + dep swap)
+
+Impact heuristics:
+
+- CRITICAL severity → Material
+- HIGH severity + reach ≥ 3 → Material
+- HIGH severity + reach < 3 → Significant
+- MEDIUM severity + reach ≥ 5 → Significant
+- Otherwise → Limited
+
+The customer's engineering team will refine these; the skill
+provides starting estimates.
+
+## Document length
+
+Target: 1-2 pages when rendered as PDF. The skill's output is
+typically 60-100 lines of markdown, which fits cleanly on 1-2
+US Letter pages.
+
+Longer = unread. Shorter = content-free. The sections (Risk
+score, Engagement scope, Top priorities, OWASP coverage, Next
+steps) are non-negotiable; everything else is compression
+optimization.
+
+## Stable rendering
+
+Same findings + same ROE + same coverage → same exec summary
+except for the generation date. This is important because the
+exec summary may go to the board, to insurers, to auditors —
+parties who will compare the document against any
+re-rendered version.
+
+If the summary changes between renderings without a finding
+change, something is wrong. Sources of non-stability to avoid:
+
+- Random tie-breaks (use alphabetical sort)
+- LLM-based phrasing
+- Time-stamped section content beyond the header date
+- Counts that depend on the iteration order of dicts
+
+The current implementation is stable. Future modifications must
+preserve this.
+
+## Format choices
+
+- Markdown for portability and version-control friendliness.
+- Numeric tables for severity counts (machine-parseable).
+- Per-priority subsections rather than a single bullet list
+  (gives each priority enough room to be acted on).
+- Pointer to vulnerability-report.md anchors so the reader can
+  jump to the deep detail when needed.
+
+PDF rendering is downstream; the skill's output is the source
+markdown that a separate pdf-generator (e.g. `/whiteglove-pdf`)
+can render for handoff.

--- a/plugins/security/penetration-tester/skills/generating-executive-summary/scripts/exec_summary.py
+++ b/plugins/security/penetration-tester/skills/generating-executive-summary/scripts/exec_summary.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""generating-executive-summary — render exec-readable engagement summary.
+
+Reads the unified findings JSONL (post OWASP enrichment), the OWASP coverage
+report, and the ROE; computes a single risk score; selects top-3 remediation
+priorities deterministically; and writes a markdown executive summary intended
+for a C-level / board audience.
+
+Usage:
+    python3 exec_summary.py PATH [--source FILE] [--coverage FILE] [--roe FILE]
+                                  [--summary-output FILE]
+                                  [--priority-overrides FILE]
+                                  [--output FILE] [--format json|jsonl|markdown]
+                                  [--min-severity sev]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity  # noqa: E402
+from lib import report  # noqa: E402
+
+try:
+    import yaml  # type: ignore[import-not-found]
+    _HAS_PYYAML = True
+except ImportError:
+    yaml = None
+    _HAS_PYYAML = False
+
+
+SKILL_ID = "generating-executive-summary"
+CATEGORY = "executive-summary"
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _f(severity: Severity, title: str, target: str, detail: str, remediation: str,
+       evidence: tuple[tuple[str, Any], ...] = ()) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=severity,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+        evidence=evidence,
+    )
+
+
+# --- Source loading ---------------------------------------------------------
+
+
+def load_findings(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    if not path.exists():
+        return [], f"file missing: {path}"
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        return [], f"read error: {e}"
+    if not text:
+        return [], None
+    out: list[dict[str, Any]] = []
+    if path.suffix == ".jsonl":
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                return out, f"jsonl line parse error: {e}"
+        return out, None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return [], f"json parse error: {e}"
+    if isinstance(data, list):
+        return [r for r in data if isinstance(r, dict)], None
+    if isinstance(data, dict) and "findings" in data:
+        return [r for r in data["findings"] if isinstance(r, dict)], None
+    return [], None
+
+
+def load_roe(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if _HAS_PYYAML:
+        return yaml.safe_load(text) or {}
+    # Minimal extract of key fields without full YAML parse
+    out: dict[str, Any] = {}
+    for line in text.splitlines():
+        line = line.rstrip()
+        if line.startswith("engagement_id:"):
+            out["engagement_id"] = line.split(":", 1)[1].strip().strip('"').strip("'")
+        elif line.startswith("  name:") and "authorizer" not in out:
+            out.setdefault("authorizer", {})["name"] = line.split(":", 1)[1].strip().strip('"').strip("'")
+        elif line.startswith("authorizer:"):
+            out["_in_authorizer"] = True
+    return out
+
+
+# --- Risk score -------------------------------------------------------------
+
+
+def severity_counts(findings: list[dict[str, Any]]) -> Counter:
+    return Counter(r.get("severity", "info") for r in findings)
+
+
+def compute_risk_score(findings: list[dict[str, Any]], roe_clean: bool) -> int:
+    counts = severity_counts(findings)
+    score = (
+        20 * counts.get("critical", 0)
+        + 10 * counts.get("high", 0)
+        + 3 * counts.get("medium", 0)
+        + 1 * counts.get("low", 0)
+    )
+    # OWASP-coverage breadth term
+    categories = {r.get("owasp_category", "UNMAPPED") for r in findings}
+    if "UNMAPPED" in categories:
+        categories.discard("UNMAPPED")
+    breadth = len(categories)
+    if breadth > 5:
+        score += 5 * (breadth - 5)
+    # Governance bonus
+    if roe_clean:
+        score -= 10
+    return max(0, min(100, score))
+
+
+def interpret_risk(score: int) -> str:
+    if score <= 25:
+        return "Low"
+    if score <= 50:
+        return "Moderate"
+    if score <= 75:
+        return "Elevated"
+    if score <= 90:
+        return "High"
+    return "Critical"
+
+
+# --- Top-3 priorities -------------------------------------------------------
+
+
+def pick_top_priorities(
+    findings: list[dict[str, Any]], overrides: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    if overrides:
+        return overrides[:3]
+
+    # Aggregate by title to detect reachability (same finding affecting many targets)
+    by_title: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in findings:
+        if r.get("severity", "info") in ("critical", "high"):
+            by_title[r.get("title", "<no title>")].append(r)
+
+    if not by_title:
+        # No critical/high; fall back to medium
+        for r in findings:
+            if r.get("severity") == "medium":
+                by_title[r.get("title", "<no title>")].append(r)
+
+    # Score: severity-weight * reachability_factor
+    severity_weight = {"critical": 100, "high": 50, "medium": 20, "low": 5}
+
+    def title_score(title: str) -> int:
+        records = by_title[title]
+        max_sev = max(records, key=lambda x: severity_weight.get(x.get("severity", "info"), 0))
+        base = severity_weight.get(max_sev.get("severity", "info"), 0)
+        reach = len({r.get("target", "") for r in records})
+        return base + (reach * 5)
+
+    sorted_titles = sorted(by_title.keys(), key=lambda t: (-title_score(t), t))
+    out: list[dict[str, Any]] = []
+    for title in sorted_titles[:3]:
+        records = by_title[title]
+        sample = records[0]
+        out.append(
+            {
+                "title": title,
+                "severity": sample.get("severity", "info"),
+                "skill_id": sample.get("skill_id", "?"),
+                "reach": len({r.get("target", "") for r in records}),
+                "effort": estimate_effort(sample),
+                "impact": estimate_impact(sample, records),
+                "owasp": sample.get("owasp_category", "UNMAPPED"),
+                "fingerprint": sample.get("fingerprint", ""),
+            }
+        )
+    return out
+
+
+def estimate_effort(record: dict[str, Any]) -> str:
+    skill = record.get("skill_id", "")
+    severity = record.get("severity", "info")
+    if "dependencies" in skill or "transitive" in skill:
+        return "Hours" if severity in ("critical", "high") else "Days"
+    if "secret" in skill or "credential" in skill:
+        return "Hours"
+    if "config" in skill or "header" in skill or "cors" in skill or "tls" in skill:
+        return "Days"
+    if "injection" in skill or "deserialization" in skill or "license" in skill:
+        return "Weeks"
+    return "Days"
+
+
+def estimate_impact(record: dict[str, Any], all_records: list[dict[str, Any]]) -> str:
+    severity = record.get("severity", "info")
+    reach = len({r.get("target", "") for r in all_records})
+    if severity == "critical":
+        return "Material"
+    if severity == "high" and reach >= 3:
+        return "Material"
+    if severity == "high":
+        return "Significant"
+    if severity == "medium" and reach >= 5:
+        return "Significant"
+    return "Limited"
+
+
+def load_priority_overrides(path: Path) -> list[dict[str, Any]]:
+    if not path.exists() or not _HAS_PYYAML:
+        return []
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text) or []
+    return data if isinstance(data, list) else []
+
+
+# --- ROE summary extraction -------------------------------------------------
+
+
+def summarize_roe(roe: dict[str, Any]) -> str:
+    if not roe:
+        return "_ROE not available._"
+    eng_id = roe.get("engagement_id", "<unknown>")
+    auth = roe.get("authorizer") or {}
+    auth_name = auth.get("name", "<unknown>")
+    auth_role = auth.get("role", "<role>")
+    time = roe.get("time_window") or {}
+    start = time.get("start", "<start>")
+    end = time.get("end", "<end>")
+    in_scope = roe.get("in_scope_targets") or []
+    return (
+        f"Engagement `{eng_id}` was authorized by {auth_name} ({auth_role}) for the time window "
+        f"{start} through {end}. Scope: {len(in_scope)} in-scope target(s)."
+    )
+
+
+# --- Coverage report excerpt ------------------------------------------------
+
+
+def summarize_coverage(coverage_path: Path) -> str:
+    if not coverage_path.exists():
+        return "_OWASP coverage report not available._"
+    try:
+        text = coverage_path.read_text(encoding="utf-8")
+    except OSError:
+        return "_OWASP coverage report not readable._"
+    # Pull the summary table
+    lines = text.splitlines()
+    out: list[str] = []
+    in_table = False
+    table_count = 0
+    for line in lines:
+        if line.startswith("| Category"):
+            in_table = True
+        if in_table:
+            out.append(line)
+            if line.startswith("|"):
+                table_count += 1
+            if table_count > 11:  # header + 10 categories
+                break
+    return "\n".join(out) if out else "_Coverage table not located._"
+
+
+# --- Render -----------------------------------------------------------------
+
+
+def render_summary(
+    findings: list[dict[str, Any]],
+    risk_score: int,
+    risk_band: str,
+    counts: Counter,
+    priorities: list[dict[str, Any]],
+    roe_summary: str,
+    coverage_excerpt: str,
+    engagement_id: str,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    crit = counts.get("critical", 0)
+    high = counts.get("high", 0)
+    med = counts.get("medium", 0)
+    low = counts.get("low", 0)
+
+    priorities_md = ""
+    for i, p in enumerate(priorities, start=1):
+        priorities_md += (
+            f"### {i}. {p['title']}\n\n"
+            f"- **Severity:** {p['severity'].upper()}\n"
+            f"- **Reach:** {p['reach']} affected target(s)\n"
+            f"- **Estimated effort to remediate:** {p['effort']}\n"
+            f"- **Estimated impact if exploited:** {p['impact']}\n"
+            f"- **OWASP:** {p['owasp']}\n"
+            f"- **Source skill:** `{p['skill_id']}`\n"
+            f"- **Cross-reference:** vulnerability-report.md#finding-{p['fingerprint']}\n\n"
+        )
+    if not priorities_md:
+        priorities_md = "_No HIGH or CRITICAL findings identified._\n"
+
+    return f"""# Executive Summary — {engagement_id}
+
+**Generated:** {now}
+
+## Risk score: {risk_score} / 100 ({risk_band})
+
+| Severity | Count |
+|---|---|
+| CRITICAL | {crit} |
+| HIGH | {high} |
+| MEDIUM | {med} |
+| LOW | {low} |
+
+Risk-score composition: severity-weighted finding counts adjusted for
+OWASP-category breadth and engagement governance posture. See the
+vulnerability report for full per-finding detail.
+
+## Engagement scope and authorization
+
+{roe_summary}
+
+## Top remediation priorities
+
+{priorities_md}
+
+## OWASP Top 10 (2021) coverage
+
+{coverage_excerpt}
+
+## Suggested next steps
+
+1. Address the top remediation priorities above in the order listed.
+   Effort estimates are heuristic; refine after a brief planning
+   discussion with the responsible engineering team.
+2. File a security-register entry for any MEDIUM-severity finding
+   that will not be remediated within the next quarter.
+3. Schedule a re-test for the high-priority items once remediation is
+   complete to confirm the fixes hold.
+4. Treat this summary plus the full vulnerability report as the
+   engagement's authoritative deliverables for compliance evidence,
+   board reporting, and insurance documentation.
+
+## Reference artifacts
+
+- Full vulnerability report: `reports/vulnerability-report.md`
+- OWASP coverage detail: `reports/owasp-coverage.md`
+- Engagement archive: `manifest.sha256` + manifest signature
+- Rules of Engagement: `roe.yaml`
+
+---
+_Generated by `{SKILL_ID}`. The risk-score composition formula and
+priority-selection logic are deterministic and documented in the
+skill's THEORY reference. Re-running with the same source findings
+produces a byte-identical document except for the generation date._
+"""
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("path", help="Engagement directory")
+    p.add_argument("--source", default=None)
+    p.add_argument("--coverage", default=None)
+    p.add_argument("--roe", default=None)
+    p.add_argument("--summary-output", default=None)
+    p.add_argument("--priority-overrides", default=None)
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    return p
+
+
+def _filter_min_severity(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    root = Path(args.path).resolve()
+
+    source_path = (
+        Path(args.source).resolve()
+        if args.source
+        else root / "findings" / "all-with-owasp.jsonl"
+    )
+    coverage_path = (
+        Path(args.coverage).resolve()
+        if args.coverage
+        else root / "reports" / "owasp-coverage.md"
+    )
+    roe_path = Path(args.roe).resolve() if args.roe else root / "roe.yaml"
+
+    op_findings: list[Finding] = []
+
+    findings, err = load_findings(source_path)
+    if err:
+        op_findings.append(
+            _f(
+                Severity.CRITICAL,
+                f"cannot load findings: {source_path.name}",
+                str(source_path),
+                err,
+                "Resolve the source and re-run.",
+            )
+        )
+        report.emit(op_findings, args.output, args.format, scan_target=str(root))
+        return 1
+
+    roe = load_roe(roe_path)
+    if not roe:
+        op_findings.append(
+            _f(
+                Severity.MEDIUM,
+                "ROE not loaded",
+                str(roe_path),
+                f"No ROE at {roe_path}; scope/authorization section will be a placeholder.",
+                "Provide --roe FILE or place the ROE at the expected path.",
+            )
+        )
+
+    roe_clean = bool(
+        roe.get("authorizer")
+        and roe.get("time_window")
+        and roe.get("signature_block")
+    )
+
+    counts = severity_counts(findings)
+    risk = compute_risk_score(findings, roe_clean)
+    band = interpret_risk(risk)
+    if risk > 90:
+        op_findings.append(
+            _f(
+                Severity.CRITICAL,
+                f"risk score {risk} (Critical)",
+                str(root),
+                "Computed engagement risk is in the Critical band. Findings warrant "
+                "executive attention and urgent remediation planning.",
+                "Review the top remediation priorities and start remediation today.",
+            )
+        )
+    elif risk > 75:
+        op_findings.append(
+            _f(
+                Severity.HIGH,
+                f"risk score {risk} (High)",
+                str(root),
+                "Computed engagement risk is in the High band.",
+                "Schedule executive review and a remediation plan within the next week.",
+            )
+        )
+
+    overrides = (
+        load_priority_overrides(Path(args.priority_overrides).resolve())
+        if args.priority_overrides
+        else []
+    )
+    priorities = pick_top_priorities(findings, overrides)
+
+    coverage_excerpt = summarize_coverage(coverage_path)
+    if not coverage_path.exists():
+        op_findings.append(
+            _f(
+                Severity.MEDIUM,
+                "OWASP coverage report missing",
+                str(coverage_path),
+                "Coverage section will be a placeholder.",
+                "Run mapping-findings-to-owasp-top10 first.",
+            )
+        )
+
+    engagement_id = roe.get("engagement_id") or root.name
+    summary_md = render_summary(
+        findings,
+        risk,
+        band,
+        counts,
+        priorities,
+        summarize_roe(roe),
+        coverage_excerpt,
+        engagement_id,
+    )
+
+    out_path = (
+        Path(args.summary_output).resolve()
+        if args.summary_output
+        else root / "reports" / "executive-summary.md"
+    )
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(summary_md, encoding="utf-8")
+        op_findings.append(
+            _f(
+                Severity.INFO,
+                f"executive summary written: {out_path.name}",
+                str(out_path),
+                f"Risk: {risk}/100 ({band}); priorities: {len(priorities)}; "
+                f"findings: {len(findings)}.",
+                "Hand off to customer for the exec-readout meeting.",
+                evidence=(
+                    ("risk_score", risk),
+                    ("band", band),
+                    ("finding_count", len(findings)),
+                    ("priority_count", len(priorities)),
+                    ("output", str(out_path)),
+                ),
+            )
+        )
+    except OSError as e:
+        op_findings.append(
+            _f(
+                Severity.HIGH,
+                f"cannot write summary: {out_path}",
+                str(out_path),
+                f"OSError: {e}",
+                "Resolve permissions and re-run.",
+            )
+        )
+
+    op_findings = _filter_min_severity(op_findings, args.min_severity)
+    report.emit(op_findings, args.output, args.format, scan_target=str(root))
+    return report.exit_code(op_findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/SKILL.md
+++ b/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: mapping-findings-to-owasp-top10
+description: |
+  Annotate every pentest finding with its OWASP Top 10 (2021)
+  category by applying a deterministic rule table keyed on source
+  skill, finding category, detail keywords, and CWE identifier when
+  present. Produces an enriched findings JSONL plus a per-category
+  rollup report showing how findings distribute across A01 through
+  A10. Required for customer-facing OWASP coverage sections and
+  compliance contexts (PCI DSS 6.5, SOC2 CC7, ISO 27001 A.14.2).
+  Use when: enriching findings after cluster 1-4 scans, regenerating
+  the report with OWASP tags, producing the OWASP coverage section
+  for an exec summary, or auditing engagement OWASP coverage.
+  Threshold: unclassifiable findings emitted as INFO with UNMAPPED
+  category for operator review.
+  Trigger with: "map to OWASP", "owasp top 10 mapping",
+  "annotate owasp categories", "owasp coverage check".
+allowed-tools:
+  - Read
+  - Write
+  - Bash(python3:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - reporting
+  - owasp
+  - top10
+  - pentest
+---
+
+# Mapping Findings to OWASP Top 10
+
+## Overview
+
+OWASP Top 10 is the canonical taxonomy of web-application risk
+categories. Every customer-facing pentest report has an "OWASP
+coverage" section because customers, auditors, and insurers
+expect to see findings mapped against the Top 10. Without the
+mapping, a long list of CVEs and misconfigurations reads as
+noise; with the mapping, it reads as a structured assessment.
+
+This skill applies a deterministic rule table to annotate each
+finding with its OWASP category. Rules are keyed on:
+
+1. **Source skill ID** (a finding from `auditing-npm-dependencies`
+   is almost always A06 — Vulnerable and Outdated Components).
+2. **Finding category** (the per-skill category tag, e.g.
+   `dependency-vulnerability`, `engagement-scope`).
+3. **CWE identifier** if present (CWE → OWASP is a well-trodden
+   mapping; OWASP themselves publish the cross-walk).
+4. **Detail keywords** as a fallback when the above don't
+   determine a category.
+
+Output is an enriched JSONL (each finding gets an `owasp_category`
+field) plus a coverage report showing how the engagement's
+findings distribute across A01-A10. UNMAPPED findings are
+surfaced for human review — extend the rule table or accept the
+finding as cross-cutting (some findings genuinely don't fit a
+single A0X bucket).
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| Finding unmapped after rule application | **INFO** | No rule matched the finding | (operational) |
+| Source JSONL unparseable | **HIGH** | Standard JSONL parse error | (operational) |
+| Annotation written back successfully | **INFO** | Confirmation per source file | (informational) |
+| Coverage report generated | **INFO** | Coverage report path emitted | (informational) |
+| Engagement covers all 10 categories | **INFO** | At least one finding in each A01-A10 bucket | (positive observation) |
+| Engagement covers <5 of 10 categories | **MEDIUM** | Suggests scope may have been narrow | (informational) |
+
+## OWASP Top 10 (2021) reference
+
+| Category | Description |
+|---|---|
+| A01:2021 | Broken Access Control |
+| A02:2021 | Cryptographic Failures |
+| A03:2021 | Injection |
+| A04:2021 | Insecure Design |
+| A05:2021 | Security Misconfiguration |
+| A06:2021 | Vulnerable and Outdated Components |
+| A07:2021 | Identification and Authentication Failures |
+| A08:2021 | Software and Data Integrity Failures |
+| A09:2021 | Security Logging and Monitoring Failures |
+| A10:2021 | Server-Side Request Forgery |
+
+## Prerequisites
+
+- Python 3.9+
+- One or more cluster 1-4 findings files
+- Optional `.owasp-overrides.yaml` for engagement-specific
+  classification rules
+
+## Instructions
+
+### Step 1 — Identify findings sources
+
+Default: every file under `engagement/findings/*.json[l]`.
+Override with `--source FILE` (repeatable).
+
+### Step 2 — Run the mapper
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/
+```
+
+Options:
+
+```
+Usage: map_owasp.py PATH [OPTIONS]
+
+Options:
+  --source FILE           Specific findings file (repeatable)
+  --enrich-output FILE    Write annotated findings JSONL here
+                          (default: PATH/findings/all-with-owasp.jsonl)
+  --coverage-output FILE  Coverage report path
+                          (default: PATH/reports/owasp-coverage.md)
+  --overrides FILE        Optional rule-overrides YAML
+  --output FILE           Operational findings output
+  --format FMT            json | jsonl | markdown (default: markdown)
+  --min-severity SEV      default info
+```
+
+### Step 3 — Review unmapped findings
+
+UNMAPPED findings are surfaced as INFO. For each:
+
+1. Check whether a CWE was present; if so, the canonical CWE →
+   OWASP cross-walk should have caught it. Extend the rule table.
+2. Check whether the finding's source skill ID is in the rule
+   table; if not, add a skill-level default.
+3. If the finding genuinely doesn't fit a single A0X bucket,
+   accept UNMAPPED and document in the engagement notes.
+
+### Step 4 — Read the coverage report
+
+The coverage report lists each A0X category with:
+
+- Count of findings mapped to that category
+- Severity breakdown within the category
+- Pointer to specific findings
+
+For an engagement intended as broad-coverage testing, all ten
+categories should have at least one entry. Categories with zero
+findings either reflect scope ("we didn't test for this") or
+clean results ("we tested and found nothing").
+
+## Examples
+
+### Example 1 — End-of-engagement enrichment
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/
+```
+
+Produces `engagements/acme-2026-q2/findings/all-with-owasp.jsonl`
+(enriched findings) and `engagements/acme-2026-q2/reports/owasp-coverage.md`
+(coverage report).
+
+### Example 2 — Apply engagement-specific overrides
+
+```yaml
+# .owasp-overrides.yaml — engagement-specific classifications
+- skill_id: auditing-cors-policy
+  owasp_category: A05:2021 — Security Misconfiguration
+  reason: customer treats CORS as misconfig, not access-control
+- skill_id: scanning-for-hardcoded-secrets
+  detail_contains: ".env"
+  owasp_category: A02:2021 — Cryptographic Failures
+  reason: env-file leaks treated as crypto failure for this engagement
+```
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/ \
+    --overrides engagements/acme-2026-q2/.owasp-overrides.yaml
+```
+
+### Example 3 — Coverage audit (no enrichment write-back)
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/ \
+    --enrich-output /dev/null \
+    --coverage-output /tmp/coverage.md
+```
+
+Produces the coverage report without modifying findings files.
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py` for operational
+findings. PRIMARY outputs:
+
+1. **Enriched findings JSONL** at `--enrich-output` — every
+   finding from the sources has an `owasp_category` field added.
+2. **Coverage report markdown** at `--coverage-output` — per-
+   category rollup.
+
+Each operational Finding includes:
+
+- `id` — `owasp::<issue>::<finding-fingerprint>`
+- `severity` — INFO mostly; HIGH for parse errors
+- `category` — `owasp-mapping`
+- `summary` — what happened to the finding
+- `evidence` — original finding fingerprint, derived OWASP
+  category, rule that matched
+
+## Error Handling
+
+- **PATH missing** → CRITICAL operational finding, exits 1.
+- **Source file unparseable** → HIGH op finding, skip file.
+- **No sources found** → HIGH op finding, exits 1.
+- **Override YAML unparseable** → HIGH op finding, falls back to
+  default rules.
+- **Enriched output path not writable** → HIGH op finding, exits 1.
+
+## Resources
+
+- `references/THEORY.md` — OWASP Top 10 history and 2021 changes,
+  CWE → OWASP cross-walk, rule-table design rationale, when a
+  finding genuinely doesn't fit, OWASP A0X precision tradeoffs
+  (broad categories vs specific findings)
+- `references/PLAYBOOK.md` — Default rule table per cluster 1-4
+  skill, override YAML format, coverage-audit interpretation,
+  customer-specific category preferences, integration with
+  PCI DSS 6.5 / NIST 800-53 control mapping

--- a/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/references/PLAYBOOK.md
@@ -1,0 +1,193 @@
+# PLAYBOOK — Mapping Rules and Workflow
+
+## Default skill → OWASP mappings (reference table)
+
+| Cluster | Skill | OWASP | Reason |
+|---|---|---|---|
+| 1 | analyzing-tls-config | A02 | Cryptographic Failures |
+| 1 | detecting-ssl-cert-issues | A02 | Cryptographic Failures |
+| 1 | auditing-cors-policy | A01 | Broken Access Control |
+| 1 | checking-http-security-headers | A05 | Security Misconfiguration |
+| 1 | probing-dangerous-http-methods | A05 | Security Misconfiguration |
+| 2 | detecting-exposed-secrets-files | A02 | Cryptographic Failures (.env, .git exposures) |
+| 2 | detecting-debug-endpoints | A05 | Misconfiguration |
+| 2 | fingerprinting-server-software | A06 | Outdated components signal |
+| 2 | detecting-directory-listing | A05 | Misconfiguration |
+| 3 | scanning-for-hardcoded-secrets | A02 | Hardcoded credentials |
+| 3 | detecting-sql-injection-patterns | A03 | Injection |
+| 3 | detecting-command-injection-patterns | A03 | Injection |
+| 3 | detecting-eval-exec-usage | A03 | Injection (code execution) |
+| 3 | detecting-insecure-deserialization | A08 | Integrity Failures |
+| 3 | detecting-weak-cryptography | A02 | Crypto failures |
+| 4 | auditing-npm-dependencies | A06 | Vulnerable Components |
+| 4 | auditing-python-dependencies | A06 | Vulnerable Components |
+| 4 | checking-license-compliance | A06 | Components hygiene |
+| 4 | tracing-transitive-vulnerabilities | A06 | Vulnerable Components |
+| 5 | confirming-pentest-authorization | A04 | Insecure Design |
+| 5 | defining-pentest-scope | A04 | Insecure Design |
+| 5 | recording-pentest-engagement | A09 | Logging / Monitoring |
+
+Cluster 5 (governance) findings aren't technical application
+vulnerabilities; the A04 / A09 mapping is for COVERAGE-REPORTING
+purposes (so engagement-governance findings show up somewhere
+in the OWASP narrative rather than being invisible).
+
+## Overrides YAML format
+
+```yaml
+# .owasp-overrides.yaml
+- skill_id: auditing-cors-policy
+  owasp_category: A05:2021 — Security Misconfiguration
+  reason: customer treats CORS as misconfig, not access-control
+
+- skill_id: scanning-for-hardcoded-secrets
+  detail_contains: ".env"
+  owasp_category: A02:2021 — Cryptographic Failures
+  reason: .env leaks treated as crypto failure for this customer
+
+- skill_id: tracing-transitive-vulnerabilities
+  detail_contains: "deep"
+  owasp_category: A08:2021 — Software and Data Integrity Failures
+  reason: deep-transitive vulns treated as integrity concern for this customer
+```
+
+An override applies when:
+
+- `skill_id` matches AND
+- `detail_contains` matches (if specified — substring match)
+
+The `owasp_category` must be one of the canonical strings (e.g.
+"A05:2021 — Security Misconfiguration"). The skill parses the
+leading code (`A05`) for table lookup.
+
+Add a `reason` field on every override. Reasons become part of
+the engagement archive's audit trail.
+
+## Coverage-report interpretation
+
+### "All 10 categories covered"
+
+Customer report's OWASP section can claim "the engagement evaluated
+all 10 OWASP Top 10 categories." This is the strongest possible
+coverage claim and what most customers want.
+
+### "8 of 10 categories covered"
+
+Customer report should explicitly note which categories had no
+findings AND whether each "no findings" reflects clean results
+or out-of-scope testing. Phrasing template:
+
+> The engagement covered 8 of the 10 OWASP Top 10 (2021)
+> categories. A04 (Insecure Design) and A10 (Server-Side Request
+> Forgery) had no findings within this engagement's scope.
+
+### "3 of 10 categories covered"
+
+Either a deliberately narrow scope or a rule-table coverage gap.
+Investigate before shipping the report:
+
+1. Check the unmapped findings list. Are findings falling into the
+   "no rule matched" bucket?
+2. Check the scope. Did the engagement explicitly include only
+   network testing (which would naturally cover A02 + A05 + A06)?
+3. If the narrow coverage is intentional, document it in the
+   engagement summary's scope section.
+
+## Per-customer category-emphasis patterns
+
+### PCI DSS customers
+
+PCI DSS Req 6.5 lists specific vulnerability classes that must be
+addressed. The skill's standard A0X mapping covers most of these.
+Recommend including a "PCI DSS Req 6.5 coverage" section in the
+report that cross-references A0X findings to specific Req 6.5
+items. Out of scope for this skill (separate mapping).
+
+### HIPAA customers
+
+A02 (Crypto) and A09 (Logging) get the most scrutiny. Recommend
+running A02 + A09 specifically (auditing-tls-config + checking
+for security logging + monitoring failures) regardless of
+broader scope.
+
+### SOC2 customers
+
+CC7 (System Operations) maps loosely to A06 + A09. CC8 (Change
+Management) maps to A04 + A08. The full coverage report supports
+the SOC2 audit narrative.
+
+### ISO 27001 customers
+
+Annex A.14.2 (Security in Development) maps to A04 + A08. Annex
+A.12.6 (Vulnerability Management) maps to A06. The full coverage
+report supports the ISO 27001 audit narrative.
+
+## Workflow patterns
+
+### Standalone enrichment
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/
+```
+
+Enriched JSONL at `findings/all-with-owasp.jsonl`.
+Coverage report at `reports/owasp-coverage.md`.
+
+### Enrichment with overrides
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/ \
+    --overrides engagements/acme-2026-q2/.owasp-overrides.yaml
+```
+
+### Coverage audit only (no enrichment)
+
+```bash
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/ \
+    --enrich-output /dev/null \
+    --coverage-output /tmp/coverage.md
+```
+
+### Re-compose vulnerability report after enrichment
+
+```bash
+# Step 1: enrich
+python3 ./scripts/map_owasp.py engagements/acme-2026-q2/
+
+# Step 2: re-compose report from enriched findings
+python3 plugins/security/penetration-tester/skills/composing-vulnerability-report/scripts/compose_report.py \
+    engagements/acme-2026-q2/ \
+    --source engagements/acme-2026-q2/findings/all-with-owasp.jsonl \
+    --report-output engagements/acme-2026-q2/reports/vulnerability-report-v2.md
+```
+
+## When to extend the rule table
+
+Add a new entry to `SKILL_TO_OWASP` when:
+
+- A new cluster 1-4 skill is added to the pack.
+- A skill's default classification proves consistently wrong in
+  practice.
+- A new CWE → OWASP mapping is needed (extend `CWE_TO_OWASP`).
+
+Add a new entry to `DETAIL_KEYWORDS` when:
+
+- An UNMAPPED-finding pattern is recognizable by detail keywords
+  that no current rule catches.
+- A detail-keyword rule is sometimes a useful fallback for
+  third-party tools whose output passes through this skill.
+
+Don't add overrides as rule-table extensions — overrides are
+engagement-specific by design. Rule-table changes are global.
+
+## Integration with executive-summary
+
+The exec-summary skill consumes the enriched findings JSONL plus
+the coverage report. The exec summary's "OWASP coverage" section
+quotes per-category counts from the coverage report and risk
+score from the unified findings.
+
+Order of operations: cluster 1-4 → this skill → exec summary.
+Optionally re-run compose-vulnerability-report between this skill
+and exec-summary so the OWASP tags appear in the main report's
+per-finding sections.

--- a/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/references/THEORY.md
@@ -1,0 +1,160 @@
+# THEORY — OWASP Top 10 Mapping
+
+## What the OWASP Top 10 actually is
+
+The OWASP Top 10 is a community-curated list of the most critical
+web application security risks, updated every 3-4 years. The
+current version is the 2021 edition. The Top 10 is NOT a complete
+taxonomy of all possible vulnerabilities — it's a prioritization
+framework. Findings outside the Top 10 still matter; they just
+don't get their own A0X slot.
+
+The 2021 edition's categories (with their derivation from 2017
+predecessors):
+
+| 2021 | Notes |
+|---|---|
+| A01 Broken Access Control | Promoted from A05 (2017); broadest category, includes path traversal + IDOR |
+| A02 Cryptographic Failures | Renamed from A03 "Sensitive Data Exposure"; emphasizes the failure modes not the data |
+| A03 Injection | Demoted from A01 (2017); XSS folded in here |
+| A04 Insecure Design | NEW; threat-modeling-failure findings |
+| A05 Security Misconfiguration | Includes XML External Entities (was A04 in 2017) |
+| A06 Vulnerable and Outdated Components | Promoted from A09 (2017) |
+| A07 Identification and Authentication Failures | Renamed from A02 "Broken Authentication" |
+| A08 Software and Data Integrity Failures | NEW; supply-chain-attack-shaped |
+| A09 Security Logging and Monitoring Failures | Renamed from A10 (2017) |
+| A10 Server-Side Request Forgery | NEW as a Top 10 entry |
+
+The 2025 edition is in draft as of this skill's authorship. When
+it ships, this skill's mapping table should be reviewed against
+the new category set.
+
+## CWE → OWASP cross-walk
+
+OWASP publishes an authoritative mapping from CWE identifiers to
+OWASP categories at https://owasp.org/Top10/A0X_2021-<name>/. The
+mapping is one-to-many in both directions: a single CWE can map
+to multiple OWASP categories depending on context, and a single
+OWASP category encompasses many CWEs.
+
+This skill's `CWE_TO_OWASP` table captures the most common
+mappings deterministically. Edge cases:
+
+- CWE-200 (Information Exposure) — typically A01 but can map to
+  A05 or A09 depending on context.
+- CWE-352 (CSRF) — included in A01 in 2021 (was A08 in 2017).
+- CWE-89 (SQL Injection) — A03, no ambiguity.
+
+When a CWE has multiple plausible mappings, the skill picks the
+most common one in practice. Override via the engagement-specific
+overrides YAML for cases where the customer expects a different
+classification.
+
+## Why deterministic rules, not LLM classification
+
+It's tempting to feed each finding to an LLM and ask "which OWASP
+category fits best?" Two problems:
+
+1. **Reproducibility.** A pentest report claims to be the result
+   of a defined methodology. An LLM-classified report changes
+   slightly on every regeneration (model temperature, prompt
+   variation, training-data drift). Auditors hate this.
+
+2. **Explainability.** A finding's mapping needs a defensible
+   reason ("this is A06 because the source skill is
+   `auditing-npm-dependencies` which detects vulnerable
+   third-party components" is defensible; "the LLM said so" is
+   not).
+
+The skill uses a deterministic rule table. Rules are auditable.
+The classifier can be wrong, but it's wrong consistently — and
+the operator can extend the table to fix patterns.
+
+## Rule precedence
+
+The skill applies rules in this order:
+
+1. **Engagement-specific overrides** (from `--overrides FILE`).
+   Highest precedence; lets customers express their own
+   classification preferences.
+2. **CWE-based mapping** when the finding has a `cwe_id`.
+3. **Skill-ID default** when no CWE is present or matches.
+4. **Detail-keyword fallback** as a last-resort heuristic.
+
+Each successful classification records WHICH rule matched in the
+operational Finding. Operators can see the reasoning chain when
+debugging unexpected classifications.
+
+## Coverage interpretation
+
+The coverage report shows count per A0X category. Interpretation:
+
+| Pattern | What it usually means |
+|---|---|
+| All 10 categories have findings | Broad-coverage engagement, comprehensive scope |
+| 6-9 categories | Typical engagement; some categories not in scope |
+| 1-5 categories | Narrow scope OR rule table missed mappings |
+| 0 categories with HIGH/CRITICAL | Either remarkably clean target OR scans didn't run |
+
+The skill flags fewer-than-5 categories as MEDIUM. The operator
+should determine whether the narrow coverage is intentional (and
+document so) or a sign of incomplete testing.
+
+## When a finding genuinely doesn't fit a single category
+
+Some findings are cross-cutting:
+
+- A misconfigured database cluster (A05 Misconfiguration + A09
+  Logging + A02 Crypto-at-rest) — could legitimately appear in
+  three categories.
+- A supply-chain compromise (A06 Components + A08 Software Integrity)
+  — both apply.
+- An authentication bypass via path traversal (A07 + A01).
+
+The Top 10 doesn't tolerate multi-category findings. The convention
+is to pick the PRIMARY category (the failure mode that most
+directly causes exploitation) and accept that the finding will be
+reported under one A0X bucket. Cross-references in the report body
+can point to the secondary category.
+
+## Customer-specific category preferences
+
+Some customers care about specific A0X categories for compliance
+reasons:
+
+- **PCI DSS** customers care about A02 (Crypto) and A07 (Auth).
+- **Healthcare (HIPAA)** customers care about A02 + A09 (Logging).
+- **SOC2 CC7** customers want broad coverage across all categories.
+
+The skill's overrides YAML is the mechanism for capturing these
+preferences. An override re-classifies a finding's category for
+the specific engagement without changing the default rule table.
+
+## OWASP Top 10 vs ASVS
+
+The OWASP Application Security Verification Standard (ASVS) is a
+much more granular framework — 286 verification requirements across
+14 chapters. Some engagements demand ASVS coverage instead of (or
+in addition to) Top 10 coverage. This skill maps Top 10 only;
+ASVS mapping would be a separate skill (or extension to this one)
+because the rule table is differently shaped.
+
+## Mapping precision tradeoffs
+
+The skill optimizes for:
+
+- **Coverage** — every finding gets a mapping if at all possible.
+- **Reproducibility** — same input → same output, always.
+- **Auditability** — the rule that matched is recorded.
+- **Extensibility** — operators can add overrides without code changes.
+
+It does NOT optimize for:
+
+- **Per-finding precision** — a finding might fit two categories;
+  the skill picks one deterministically.
+- **2025-edition forward compatibility** — when OWASP 2025
+  finalizes, the table needs review.
+- **ASVS coverage** — out of scope.
+
+These tradeoffs are deliberate. The skill is a triage tool, not a
+substitute for human judgment on contested classifications.

--- a/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/scripts/map_owasp.py
+++ b/plugins/security/penetration-tester/skills/mapping-findings-to-owasp-top10/scripts/map_owasp.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""mapping-findings-to-owasp-top10 — enrich findings with OWASP categories.
+
+Reads findings JSONL/JSON files, applies a deterministic rule table to assign
+each finding to an OWASP Top 10 (2021) category, writes back an enriched
+JSONL, and produces a per-category coverage report. Emits operational
+Findings via lib/finding.py for any parse / unmapped issue.
+
+Usage:
+    python3 map_owasp.py PATH [--source FILE] [--enrich-output FILE]
+                              [--coverage-output FILE] [--overrides FILE]
+                              [--output FILE] [--format json|jsonl|markdown]
+                              [--min-severity sev]
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity, from_json as finding_from_json  # noqa: E402
+from lib import report  # noqa: E402
+
+try:
+    import yaml  # type: ignore[import-not-found]
+    _HAS_PYYAML = True
+except ImportError:
+    yaml = None
+    _HAS_PYYAML = False
+
+
+SKILL_ID = "mapping-findings-to-owasp-top10"
+CATEGORY = "owasp-mapping"
+
+# OWASP Top 10 (2021) categories
+OWASP_CATEGORIES = {
+    "A01": "A01:2021 — Broken Access Control",
+    "A02": "A02:2021 — Cryptographic Failures",
+    "A03": "A03:2021 — Injection",
+    "A04": "A04:2021 — Insecure Design",
+    "A05": "A05:2021 — Security Misconfiguration",
+    "A06": "A06:2021 — Vulnerable and Outdated Components",
+    "A07": "A07:2021 — Identification and Authentication Failures",
+    "A08": "A08:2021 — Software and Data Integrity Failures",
+    "A09": "A09:2021 — Security Logging and Monitoring Failures",
+    "A10": "A10:2021 — Server-Side Request Forgery",
+}
+
+# Skill-ID → OWASP category default mapping (deterministic).
+# These are coarse defaults; detail-keyword rules below can override.
+SKILL_TO_OWASP: dict[str, str] = {
+    # Cluster 1 — Network/Transport
+    "analyzing-tls-config": "A02",
+    "detecting-ssl-cert-issues": "A02",
+    "auditing-cors-policy": "A01",
+    "checking-http-security-headers": "A05",
+    "probing-dangerous-http-methods": "A05",
+    # Cluster 2 — Information disclosure
+    "detecting-exposed-secrets-files": "A02",
+    "detecting-debug-endpoints": "A05",
+    "fingerprinting-server-software": "A06",
+    "detecting-directory-listing": "A05",
+    # Cluster 3 — Static analysis
+    "scanning-for-hardcoded-secrets": "A02",
+    "detecting-sql-injection-patterns": "A03",
+    "detecting-command-injection-patterns": "A03",
+    "detecting-eval-exec-usage": "A03",
+    "detecting-insecure-deserialization": "A08",
+    "detecting-weak-cryptography": "A02",
+    # Cluster 4 — Dependencies
+    "auditing-npm-dependencies": "A06",
+    "auditing-python-dependencies": "A06",
+    "checking-license-compliance": "A06",
+    "tracing-transitive-vulnerabilities": "A06",
+    # Cluster 5 — Governance (not application-vulnerability findings;
+    # mapped to A04 Insecure Design when classifying for coverage purposes)
+    "confirming-pentest-authorization": "A04",
+    "defining-pentest-scope": "A04",
+    "recording-pentest-engagement": "A09",
+}
+
+# CWE → OWASP A0X mapping (subset; canonical OWASP cross-walk).
+CWE_TO_OWASP = {
+    "CWE-22":   "A01",  # Path traversal
+    "CWE-23":   "A01",
+    "CWE-200":  "A01",
+    "CWE-285":  "A01",
+    "CWE-639":  "A01",
+    "CWE-26":   "A02",  # Cryptographic
+    "CWE-261":  "A02",
+    "CWE-296":  "A02",
+    "CWE-310":  "A02",
+    "CWE-319":  "A02",
+    "CWE-321":  "A02",
+    "CWE-326":  "A02",
+    "CWE-327":  "A02",
+    "CWE-352":  "A03",
+    "CWE-77":   "A03",  # Command injection
+    "CWE-78":   "A03",
+    "CWE-79":   "A03",  # XSS
+    "CWE-89":   "A03",  # SQL injection
+    "CWE-94":   "A03",
+    "CWE-1021": "A04",
+    "CWE-209":  "A05",  # information leak via error msg
+    "CWE-548":  "A05",  # directory listing
+    "CWE-1004": "A05",
+    "CWE-1104": "A06",  # vulnerable third-party
+    "CWE-1395": "A06",
+    "CWE-287":  "A07",  # auth
+    "CWE-306":  "A07",
+    "CWE-307":  "A07",
+    "CWE-345":  "A08",
+    "CWE-502":  "A08",  # insecure deserialization
+    "CWE-829":  "A08",
+    "CWE-117":  "A09",  # log injection
+    "CWE-778":  "A09",  # insufficient logging
+    "CWE-918":  "A10",  # SSRF
+}
+
+# Detail-keyword fallback rules. Tuple of (keyword, category).
+DETAIL_KEYWORDS: list[tuple[str, str]] = [
+    ("sql injection", "A03"),
+    ("command injection", "A03"),
+    ("xss", "A03"),
+    ("cross-site scripting", "A03"),
+    ("deserialization", "A08"),
+    ("ssrf", "A10"),
+    ("server-side request forgery", "A10"),
+    ("tls", "A02"),
+    ("ssl", "A02"),
+    ("cipher", "A02"),
+    ("md5", "A02"),
+    ("sha1", "A02"),
+    ("hardcoded secret", "A02"),
+    ("hardcoded credential", "A02"),
+    ("api key", "A02"),
+    ("path traversal", "A01"),
+    ("directory traversal", "A01"),
+    ("cors", "A01"),
+    ("dependency", "A06"),
+    ("transitive", "A06"),
+    ("cve-", "A06"),
+    ("authentication", "A07"),
+    ("session", "A07"),
+    ("brute force", "A07"),
+    ("debug", "A05"),
+    ("misconfiguration", "A05"),
+    ("header", "A05"),
+    ("logging", "A09"),
+    ("monitoring", "A09"),
+    ("authorization", "A04"),
+    ("scope", "A04"),
+]
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _f(severity: Severity, title: str, target: str, detail: str, remediation: str,
+       evidence: tuple[tuple[str, Any], ...] = ()) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=severity,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+        evidence=evidence,
+    )
+
+
+# --- Source loading ---------------------------------------------------------
+
+
+def discover_sources(root: Path, explicit: list[str]) -> list[Path]:
+    if explicit:
+        return [Path(p).resolve() for p in explicit]
+    out: list[Path] = []
+    findings_dir = root / "findings"
+    if findings_dir.is_dir():
+        out.extend(sorted(findings_dir.glob("**/*.json")))
+        out.extend(sorted(findings_dir.glob("**/*.jsonl")))
+    return [p for p in out if "all-with-owasp" not in p.name]
+
+
+def load_records(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [], f"read failed: {e}"
+    text = text.strip()
+    if not text:
+        return [], None
+    out: list[dict[str, Any]] = []
+    if path.suffix == ".jsonl":
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                return out, f"line parse error: {e}"
+        return out, None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return [], f"parse error: {e}"
+    if isinstance(data, list):
+        return [r for r in data if isinstance(r, dict)], None
+    if isinstance(data, dict) and "findings" in data:
+        return [r for r in data["findings"] if isinstance(r, dict)], None
+    return [], None
+
+
+# --- Overrides --------------------------------------------------------------
+
+
+def load_overrides(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8")
+    if _HAS_PYYAML:
+        data = yaml.safe_load(text) or []
+        return data if isinstance(data, list) else []
+    # No YAML lib — refuse rather than misparse
+    return []
+
+
+def apply_override(record: dict[str, Any], override: dict[str, Any]) -> bool:
+    skill = record.get("skill_id", "")
+    detail = record.get("detail", "")
+    if "skill_id" in override and override["skill_id"] != skill:
+        return False
+    if "detail_contains" in override and override["detail_contains"] not in detail:
+        return False
+    return True
+
+
+# --- Mapping logic ----------------------------------------------------------
+
+
+def classify(
+    record: dict[str, Any], overrides: list[dict[str, Any]]
+) -> tuple[str | None, str]:
+    """Return (owasp_code, rule_that_matched). owasp_code is None if unmapped."""
+    # 1. Engagement-specific overrides
+    for ov in overrides:
+        if apply_override(record, ov):
+            cat = ov.get("owasp_category", "")
+            code = cat.split(":", 1)[0].strip() if cat else None
+            if code in OWASP_CATEGORIES:
+                return code, f"override: {ov.get('reason', 'no reason given')}"
+
+    # 2. CWE-based mapping
+    cwe = record.get("cwe_id")
+    if cwe and cwe in CWE_TO_OWASP:
+        return CWE_TO_OWASP[cwe], f"cwe-mapping: {cwe}"
+
+    # 3. Skill-ID default
+    skill = record.get("skill_id", "")
+    if skill in SKILL_TO_OWASP:
+        return SKILL_TO_OWASP[skill], f"skill-default: {skill}"
+
+    # 4. Detail-keyword fallback
+    detail = (record.get("detail", "") + " " + record.get("title", "")).lower()
+    for kw, code in DETAIL_KEYWORDS:
+        if kw in detail:
+            return code, f"keyword: {kw}"
+
+    return None, "no rule matched"
+
+
+# --- Coverage report --------------------------------------------------------
+
+
+def render_coverage(
+    counts_by_cat: dict[str, list[dict[str, Any]]],
+    engagement_id: str,
+    unmapped: list[dict[str, Any]],
+) -> str:
+    lines = [
+        f"# OWASP Top 10 (2021) Coverage — {engagement_id}",
+        "",
+        "| Category | Count | Critical | High | Medium | Low | Info |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for code in sorted(OWASP_CATEGORIES.keys()):
+        bucket = counts_by_cat.get(code, [])
+        sev_counts = Counter(r.get("severity", "info") for r in bucket)
+        lines.append(
+            f"| **{OWASP_CATEGORIES[code]}** "
+            f"| {len(bucket)} "
+            f"| {sev_counts.get('critical', 0)} "
+            f"| {sev_counts.get('high', 0)} "
+            f"| {sev_counts.get('medium', 0)} "
+            f"| {sev_counts.get('low', 0)} "
+            f"| {sev_counts.get('info', 0)} |"
+        )
+    if unmapped:
+        lines.append("")
+        lines.append(f"## Unmapped findings ({len(unmapped)})")
+        lines.append("")
+        for r in unmapped[:20]:
+            lines.append(f"- `{r.get('skill_id', '?')}` — {r.get('title', '')}")
+        if len(unmapped) > 20:
+            lines.append(f"- … and {len(unmapped) - 20} more")
+    lines.append("")
+    lines.append("## Per-category findings detail")
+    for code in sorted(OWASP_CATEGORIES.keys()):
+        bucket = counts_by_cat.get(code, [])
+        if not bucket:
+            continue
+        lines.append("")
+        lines.append(f"### {OWASP_CATEGORIES[code]} — {len(bucket)} finding(s)")
+        for r in sorted(bucket, key=lambda x: x.get("title", "")):
+            sev = r.get("severity", "info").upper()
+            lines.append(f"- **[{sev}]** `{r.get('skill_id', '?')}` — {r.get('title', '')}")
+    return "\n".join(lines)
+
+
+# --- Engagement-id detection ------------------------------------------------
+
+
+def detect_engagement_id(root: Path) -> str:
+    roe = root / "roe.yaml"
+    if not roe.exists():
+        return root.name
+    try:
+        for line in roe.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("engagement_id:"):
+                return line.split(":", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return root.name
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("path", help="Engagement directory")
+    p.add_argument("--source", action="append", default=[])
+    p.add_argument("--enrich-output", default=None)
+    p.add_argument("--coverage-output", default=None)
+    p.add_argument("--overrides", default=None)
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    return p
+
+
+def _filter_min_severity(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    root = Path(args.path).resolve()
+    if not root.exists():
+        f = _f(
+            Severity.CRITICAL,
+            f"engagement path missing: {root}",
+            str(root),
+            f"PATH `{root}` does not exist.",
+            "Verify the engagement directory and re-run.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(root))
+        return 1
+
+    sources = discover_sources(root, args.source)
+    if not sources:
+        f = _f(
+            Severity.HIGH,
+            "no findings sources",
+            str(root),
+            f"No findings files under `{root}`.",
+            "Run cluster 1-4 skills first.",
+        )
+        report.emit([f], args.output, args.format, scan_target=str(root))
+        return 1
+
+    overrides = load_overrides(Path(args.overrides).resolve()) if args.overrides else []
+
+    op_findings: list[Finding] = []
+    enriched: list[dict[str, Any]] = []
+    by_cat: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    unmapped: list[dict[str, Any]] = []
+
+    for src in sources:
+        records, err = load_records(src)
+        if err:
+            op_findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"source unparseable: {src.name}",
+                    str(src),
+                    err,
+                    "Fix the source or exclude.",
+                )
+            )
+            continue
+        for rec in records:
+            code, rule = classify(rec, overrides)
+            if code:
+                category_str = OWASP_CATEGORIES[code]
+                rec["owasp_category"] = category_str
+                by_cat[code].append(rec)
+            else:
+                rec["owasp_category"] = "UNMAPPED"
+                unmapped.append(rec)
+                op_findings.append(
+                    _f(
+                        Severity.INFO,
+                        f"unmapped: {rec.get('title', '')[:80]}",
+                        str(src),
+                        f"Skill `{rec.get('skill_id', '?')}` produced a finding "
+                        f"the rule table couldn't classify.",
+                        "Extend the rule table or accept as cross-cutting.",
+                        evidence=(
+                            ("skill", rec.get("skill_id", "")),
+                            ("title", rec.get("title", "")),
+                        ),
+                    )
+                )
+            enriched.append(rec)
+
+    # Write enriched output
+    enrich_path = (
+        Path(args.enrich_output).resolve()
+        if args.enrich_output
+        else root / "findings" / "all-with-owasp.jsonl"
+    )
+    if str(enrich_path) != "/dev/null":
+        try:
+            enrich_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(enrich_path, "w", encoding="utf-8") as fh:
+                for rec in enriched:
+                    fh.write(json.dumps(rec) + "\n")
+        except OSError as e:
+            op_findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"cannot write enriched output: {enrich_path}",
+                    str(enrich_path),
+                    f"OSError: {e}",
+                    "Resolve permissions and re-run.",
+                )
+            )
+
+    # Coverage report
+    coverage_path = (
+        Path(args.coverage_output).resolve()
+        if args.coverage_output
+        else root / "reports" / "owasp-coverage.md"
+    )
+    try:
+        coverage_path.parent.mkdir(parents=True, exist_ok=True)
+        engagement_id = detect_engagement_id(root)
+        coverage_path.write_text(
+            render_coverage(by_cat, engagement_id, unmapped), encoding="utf-8"
+        )
+        # Coverage-quality assessment
+        covered_codes = sum(1 for code in OWASP_CATEGORIES if by_cat.get(code))
+        if covered_codes == 10:
+            op_findings.append(
+                _f(
+                    Severity.INFO,
+                    "engagement covers all 10 OWASP categories",
+                    str(coverage_path),
+                    f"At least one finding in each of A01-A10.",
+                    "Broad-coverage engagement; report includes complete OWASP narrative.",
+                    evidence=(("categories_covered", covered_codes),),
+                )
+            )
+        elif covered_codes < 5:
+            op_findings.append(
+                _f(
+                    Severity.MEDIUM,
+                    f"engagement covers only {covered_codes} of 10 OWASP categories",
+                    str(coverage_path),
+                    f"Findings landed in only {covered_codes} categories. Either the "
+                    f"engagement scope was narrow OR the rule table didn't recognize "
+                    f"findings that should map to additional categories.",
+                    "If scope was narrow, document in the engagement summary. "
+                    "Otherwise extend the rule table.",
+                    evidence=(("categories_covered", covered_codes),),
+                )
+            )
+        else:
+            op_findings.append(
+                _f(
+                    Severity.INFO,
+                    f"OWASP coverage report written: {coverage_path.name}",
+                    str(coverage_path),
+                    f"Coverage: {covered_codes}/10 categories.",
+                    "No action required.",
+                )
+            )
+    except OSError as e:
+        op_findings.append(
+            _f(
+                Severity.HIGH,
+                f"cannot write coverage report: {coverage_path}",
+                str(coverage_path),
+                f"OSError: {e}",
+                "Resolve permissions and re-run.",
+            )
+        )
+
+    if not op_findings:
+        op_findings = [
+            _f(
+                Severity.INFO,
+                "OWASP mapping complete",
+                str(root),
+                f"{len(enriched)} findings annotated; {len(unmapped)} unmapped.",
+                "No action required.",
+            )
+        ]
+
+    op_findings = _filter_min_severity(op_findings, args.min_severity)
+    report.emit(op_findings, args.output, args.format, scan_target=str(root))
+    return report.exit_code(op_findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/security/penetration-tester/skills/recording-pentest-engagement/SKILL.md
+++ b/plugins/security/penetration-tester/skills/recording-pentest-engagement/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: recording-pentest-engagement
+description: |
+  Package an engagement's findings, scan outputs, evidence, and
+  signed ROE into a timestamped archive with a SHA-256 manifest
+  covering every file. Establishes chain of custody so legal
+  counsel, internal audit, or an outside SOC can verify the archive
+  hasn't been modified after closeout. Optionally signs the
+  manifest with GPG for cryptographic attestation.
+  Use when: closing an engagement, snapshotting evidence after
+  each scan day, before handing artifacts to customer, or after
+  an emergency-stop event.
+  Threshold: file in tree without a manifest entry, hash mismatch,
+  out-of-tree path referenced in findings, unsigned manifest when
+  signing was requested.
+  Trigger with: "record engagement", "archive evidence", "create
+  chain of custody", "package pentest artifacts".
+allowed-tools:
+  - Read
+  - Bash(python3:*)
+  - Bash(tar:*)
+  - Bash(gpg:*)
+  - Glob
+disallowed-tools:
+  - Bash(rm:*)
+  - Bash(curl:*)
+  - Bash(wget:*)
+  - Write(.env)
+  - Edit(.env)
+version: 3.0.0-dev
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code
+tags:
+  - security
+  - engagement-governance
+  - evidence
+  - chain-of-custody
+  - pentest
+---
+
+# Recording Pentest Engagement
+
+## Overview
+
+A penetration test produces a lot of artifacts: scan outputs in
+multiple formats, screenshots showing the state of vulnerable
+pages, raw tool logs (nmap, Burp, custom scripts), the ROE and any
+amendments, exec-summary docs, and the findings themselves. Six
+months after the engagement closes, a question arises — sometimes
+benign ("can you remind me what we found?"), sometimes adversarial
+("the customer claims we accessed an out-of-scope system; show us
+the logs"). The answer needs to be: "yes, here's the archive, and
+here's cryptographic proof it hasn't been touched since the
+engagement closed."
+
+This skill packages the engagement directory into a single
+timestamped archive with a SHA-256 manifest covering every file.
+Optionally signs the manifest with GPG. The result is a portable,
+self-verifying record of what the engagement produced.
+
+The skill also surfaces inconsistencies that would weaken the
+chain-of-custody claim: out-of-tree paths referenced in findings
+(meaning the finding refers to a file not actually in the archive),
+files in the directory not listed in the manifest, manifest
+entries whose hashes don't match. These are HIGH findings — they
+mean the archive is incomplete or has been modified after the
+fact, neither of which is acceptable for evidence purposes.
+
+## When the skill produces findings
+
+| Finding | Severity | Threshold | Affected control |
+|---|---|---|---|
+| File in tree not in manifest | **HIGH** | Found during walk; manifest entry missing | (evidence integrity) |
+| Manifest entry hash mismatch | **CRITICAL** | Computed SHA-256 differs from manifest | (evidence integrity) |
+| Manifest entry without file | **HIGH** | Manifest lists a path that doesn't exist | (evidence integrity) |
+| Findings reference out-of-tree path | **MEDIUM** | A finding's `evidence` field points to a file not in the archive | (evidence completeness) |
+| Symlink in tree | **MEDIUM** | Symlinks break archive portability and integrity | (evidence integrity) |
+| Empty file in tree | **INFO** | 0-byte file; possibly an export error | (operational) |
+| Archive package complete | **INFO** | All checks pass | (positive confirmation) |
+| Manifest signed | **INFO** | GPG signature present and valid form | (positive confirmation) |
+
+## Prerequisites
+
+- Python 3.9+
+- An engagement directory laid out as recommended (see structure
+  below)
+- Optional GPG installed for manifest signing
+
+## Recommended engagement directory structure
+
+```
+engagements/acme-2026-q2/
+├── roe.yaml
+├── roe.amendments/
+│   └── amendment-001-20260615.yaml
+├── scope/
+│   ├── allowed-ips.txt
+│   └── normalized-targets.json
+├── findings/
+│   ├── cluster1-tls-2026-06-05.json
+│   ├── cluster1-headers-2026-06-05.json
+│   ├── cluster3-secrets-2026-06-07.json
+│   └── ...
+├── evidence/
+│   ├── screenshots/
+│   ├── tool-logs/
+│   └── raw-scan-output/
+├── reports/
+│   ├── vulnerability-report.md
+│   ├── owasp-mapping.json
+│   └── executive-summary.md
+└── manifest.sha256        # produced by this skill
+```
+
+## Instructions
+
+### Step 1 — Identify the engagement directory
+
+```bash
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/
+```
+
+The skill walks the directory recursively, builds a SHA-256
+manifest, and produces a chain-of-custody report.
+
+### Step 2 — Run the packager
+
+Options:
+
+```
+Usage: record_engagement.py PATH [OPTIONS]
+
+Options:
+  --output FILE              Findings output
+  --format FMT               json | jsonl | markdown (default: markdown)
+  --min-severity SEV         default info
+  --manifest FILE            Manifest output path (default: PATH/manifest.sha256)
+  --tar FILE                 Also create a .tar.gz archive at this path
+  --sign                     Sign the manifest with GPG (uses default identity)
+  --signer KEY               GPG key ID to sign with
+  --exclude GLOB             Skip files matching glob (repeatable)
+```
+
+### Step 3 — Verify the manifest
+
+The skill emits a SHA-256 manifest in standard `sha256sum` format
+(one line per file: hash + two-space + path). The manifest is
+verifiable independent of the skill:
+
+```bash
+sha256sum -c engagements/acme-2026-q2/manifest.sha256
+```
+
+Anyone with access to the archive can run this check; if the
+output is "all OK," the archive is intact.
+
+### Step 4 — Sign the manifest (optional)
+
+```bash
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ --sign
+```
+
+The skill shells out to `gpg --detach-sign` against the manifest,
+producing `manifest.sha256.asc`. Later verification:
+
+```bash
+gpg --verify manifest.sha256.asc manifest.sha256
+sha256sum -c manifest.sha256
+```
+
+Both checks together: the manifest's contents match the archive,
+AND the manifest itself is signed by an identifiable party.
+
+### Step 5 — Create the portable archive (optional)
+
+```bash
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ \
+    --tar engagements/archives/acme-2026-q2.tar.gz
+```
+
+The tarball contains the engagement directory + manifest +
+signature. Hand the tarball to legal / archive / customer.
+
+## Examples
+
+### Example 1 — End-of-engagement closeout
+
+```bash
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ \
+    --sign \
+    --tar engagements/archives/acme-2026-q2.tar.gz \
+    --output engagements/acme-2026-q2/chain-of-custody.md
+```
+
+### Example 2 — Daily snapshot during a long engagement
+
+```bash
+DATE=$(date +%Y%m%d)
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ \
+    --manifest engagements/acme-2026-q2/manifest-$DATE.sha256 \
+    --output engagements/acme-2026-q2/snapshot-$DATE.md
+```
+
+Daily snapshots build a time-series of the engagement's state
+which can be useful in incident-investigation contexts.
+
+### Example 3 — Pre-handoff integrity check
+
+```bash
+# Customer claims the archive is incomplete; verify before disputing
+python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ --min-severity high
+```
+
+If exit code is 0, the archive is internally consistent.
+
+## Output
+
+JSON / JSONL / Markdown per `lib/report.py`. Exit codes: 0 clean,
+1 high/critical, 2 error.
+
+Each Finding includes:
+
+- `id` — `evidence::<issue>::<path>`
+- `severity` — CRITICAL / HIGH / MEDIUM / INFO
+- `category` — `evidence-chain`
+- `summary` — what's wrong with the artifact
+- `evidence` — file path, expected hash, observed hash, manifest entry
+
+## Error Handling
+
+- **Path doesn't exist** → exits 2 with operational error.
+- **Permission denied reading a file** → emits HIGH finding,
+  continues walking other files.
+- **GPG not installed** with `--sign` requested → emits HIGH
+  finding, manifest written unsigned, exits 1.
+- **GPG signing fails** (no default identity, etc.) → emits HIGH
+  finding, manifest written unsigned, exits 1.
+- **tar command fails** with `--tar` requested → manifest still
+  written; archive creation failure surfaces as HIGH finding.
+
+## Resources
+
+- `references/THEORY.md` — Chain of custody as a legal concept,
+  evidence-integrity standards (NIST SP 800-86), SHA-256 vs
+  SHA-3 vs SHA-512 tradeoffs, GPG detached-signature semantics,
+  archive format choices (tar vs zip vs WORM), retention horizons
+  per jurisdiction
+- `references/PLAYBOOK.md` — Engagement directory templates per
+  engagement type, daily-snapshot cron pattern, customer-handoff
+  protocol, dispute-resolution playbook (when the customer
+  challenges the archive), long-term storage and access-control
+  patterns

--- a/plugins/security/penetration-tester/skills/recording-pentest-engagement/references/PLAYBOOK.md
+++ b/plugins/security/penetration-tester/skills/recording-pentest-engagement/references/PLAYBOOK.md
@@ -1,0 +1,203 @@
+# PLAYBOOK — Recording, Closeout, and Long-Term Storage
+
+## Recommended engagement directory layout
+
+```
+engagements/<client>-<year>-<quarter>/
+├── roe.yaml                           # signed ROE
+├── allowed-authorizers                # signer allowlist
+├── roe.amendments/
+│   └── amendment-NNN-<date>.yaml
+├── scope/
+│   ├── allowed-ips.txt                # produced by defining-pentest-scope
+│   ├── normalized-targets.json
+│   └── scope-report.md
+├── findings/
+│   ├── 2026-06-05-cluster1-tls.json   # one file per scan session
+│   ├── 2026-06-05-cluster1-cors.json
+│   ├── 2026-06-07-cluster3-secrets.json
+│   └── ...
+├── evidence/
+│   ├── screenshots/                   # PNG / JPG of vulnerable pages
+│   ├── tool-logs/                     # raw nmap, Burp, custom tool logs
+│   └── raw-scan-output/               # other raw artifacts
+├── reports/
+│   ├── vulnerability-report.md        # produced by composing-vulnerability-report
+│   ├── owasp-mapping.json             # produced by mapping-findings-to-owasp-top10
+│   └── executive-summary.md           # produced by generating-executive-summary
+├── manifest.sha256                    # produced by THIS skill
+├── manifest.sha256.asc                # optional GPG signature
+└── chain-of-custody.md                # this skill's output report
+```
+
+## Daily-snapshot cron pattern
+
+For long engagements (red-team, multi-month), build a daily
+snapshot trail:
+
+```bash
+#!/usr/bin/env bash
+# cron: 0 23 * * * /opt/pentest/daily-snapshot.sh acme-2026-q2
+ENGAGEMENT="$1"
+ROOT="engagements/${ENGAGEMENT}"
+DATE=$(date +%Y%m%d)
+python3 plugins/security/penetration-tester/skills/recording-pentest-engagement/scripts/record_engagement.py \
+    "$ROOT" \
+    --manifest "$ROOT/snapshots/manifest-$DATE.sha256" \
+    --sign \
+    --output "$ROOT/snapshots/snapshot-$DATE.md"
+```
+
+Daily snapshots give you a time-series of the engagement's
+state. If a dispute arises about what was found on a specific
+date, the daily snapshot from that date is the authoritative
+answer.
+
+## Customer-handoff protocol
+
+End of engagement:
+
+1. Run the final manifest + signing + archive:
+
+   ```bash
+   python3 ./scripts/record_engagement.py engagements/acme-2026-q2/ \
+       --sign --signer your-key-id \
+       --tar engagements/archives/acme-2026-q2.tar.gz \
+       --output engagements/acme-2026-q2/chain-of-custody.md
+   ```
+
+2. Verify the archive end-to-end:
+
+   ```bash
+   cd /tmp/verify
+   tar xzf .../acme-2026-q2.tar.gz
+   cd acme-2026-q2
+   sha256sum -c manifest.sha256          # should print "OK" for every file
+   gpg --verify manifest.sha256.asc manifest.sha256
+   ```
+
+3. Hand to the customer's documented evidence-receipt contact.
+   Get a written acknowledgment of receipt.
+
+4. Archive your own copy in long-term storage (see below).
+
+## Dispute-resolution playbook
+
+### "The customer says the archive is missing files"
+
+1. Run the skill against the archive (current state).
+2. Run the skill against your tester working copy (current
+   state).
+3. Diff the two file lists. Anything in the tester copy but not
+   in the archive is a candidate addition.
+4. Decide: was the file in scope? In-scope evidence: re-archive
+   with addition. Out-of-scope: explain why it wasn't included.
+
+### "The customer says the evidence was modified"
+
+1. Verify the existing manifest: `sha256sum -c manifest.sha256`.
+   If OK, archive is internally consistent.
+2. Verify the GPG signature: `gpg --verify manifest.sha256.asc
+   manifest.sha256`. If OK, the manifest is attestably the one
+   you produced.
+3. If both checks pass, the evidence in the archive matches what
+   you produced at engagement close. The dispute is about the
+   evidence itself, not the archive integrity.
+
+### "The customer says the tester accessed an unauthorized system"
+
+1. Locate the relevant finding(s) referencing the system in the
+   archive.
+2. Cross-reference against `scope/normalized-targets.json` and
+   `roe.yaml`.
+3. If the system was in scope at the engagement time, present
+   the cross-reference.
+4. If the system was NOT in scope, the dispute is about whether
+   the access was unauthorized. The tester's own working logs
+   (often raw tool output in `evidence/tool-logs/`) may contain
+   forensic details about how the access happened.
+
+## Long-term storage patterns
+
+| Storage | Pros | Cons |
+|---|---|---|
+| Encrypted S3 bucket with object-lock | Cheap, retention-policy enforceable | Vendor lock-in; cost over decades |
+| Encrypted USB drive in fireproof safe | Air-gapped, simple | Physical loss / damage risk |
+| On-prem NAS with versioned snapshots | Self-controlled | Operational burden, hardware refresh |
+| Cloud + on-prem (both) | Best of both | 2x cost |
+
+For pentest evidence with potential litigation exposure, the
+S3-with-object-lock pattern is popular: tier 1 is S3 Glacier with
+6-year retention lock, tier 2 is local encrypted backup.
+
+## Access control over retained archives
+
+Define who can read the archive at retrieval time:
+
+- Engagement lead (the tester)
+- Customer authorization recipient (original ROE signer)
+- Legal counsel for either party
+- External auditors (with separate written authorization)
+
+Access logs themselves are evidence — log every retrieval of an
+archived engagement with timestamp + retrieving party. Some
+storage systems do this automatically; others require explicit
+audit configuration.
+
+## Encryption of the archive
+
+For sensitive engagements (financial services, healthcare,
+defense), encrypt the archive at rest:
+
+```bash
+# After archive creation
+gpg --encrypt --recipient archive-encryption-key \
+    --output acme-2026-q2.tar.gz.gpg acme-2026-q2.tar.gz
+# Securely wipe the unencrypted copy
+shred -u acme-2026-q2.tar.gz
+```
+
+The encryption recipient should be a key managed by your firm's
+key-custody process, NOT the tester's individual GPG identity.
+The tester may not be reachable in 7 years; the firm's key
+custody process should be.
+
+## Common closeout mistakes
+
+| Mistake | Consequence | Fix |
+|---|---|---|
+| Forgot to manifest screenshots | Customer can't verify screenshot integrity | Re-run skill, re-sign manifest |
+| Manifest signed by tester's personal key | Key unavailable years later | Sign with firm-managed identity |
+| Findings reference paths in tester's home dir | Customer can't open the linked file | Copy files into engagement tree before archiving |
+| Archive on tester's laptop only | Single point of failure | Replicate to long-term storage immediately |
+| No daily snapshots during long engagement | Disputes about specific-date state are uncheckable | Daily snapshot cron |
+| Manifest emitted but never signed | Integrity provable; provenance not | Add `--sign` to closeout command |
+
+## Sample closeout script
+
+```bash
+#!/usr/bin/env bash
+# closeout.sh — run at end of engagement
+set -euo pipefail
+ENGAGEMENT="${1:?engagement name required}"
+ROOT="engagements/${ENGAGEMENT}"
+ARCHIVE_DIR="engagements/archives"
+
+mkdir -p "$ARCHIVE_DIR"
+
+python3 plugins/security/penetration-tester/skills/recording-pentest-engagement/scripts/record_engagement.py \
+    "$ROOT" \
+    --sign --signer "firm-pentest-2026" \
+    --tar "$ARCHIVE_DIR/${ENGAGEMENT}.tar.gz" \
+    --output "$ROOT/chain-of-custody.md" \
+    --format markdown
+
+# Verify the archive end-to-end
+tmpdir=$(mktemp -d)
+tar xzf "$ARCHIVE_DIR/${ENGAGEMENT}.tar.gz" -C "$tmpdir"
+cd "$tmpdir/${ENGAGEMENT}"
+sha256sum -c manifest.sha256 || { echo "MANIFEST CHECK FAILED"; exit 1; }
+gpg --verify manifest.sha256.asc manifest.sha256 || { echo "SIGNATURE CHECK FAILED"; exit 1; }
+
+echo "Closeout complete: $ARCHIVE_DIR/${ENGAGEMENT}.tar.gz"
+```

--- a/plugins/security/penetration-tester/skills/recording-pentest-engagement/references/THEORY.md
+++ b/plugins/security/penetration-tester/skills/recording-pentest-engagement/references/THEORY.md
@@ -1,0 +1,195 @@
+# THEORY — Chain of Custody for Pentest Evidence
+
+## Why chain of custody matters
+
+A pentest produces evidence. Evidence has two properties that
+matter legally:
+
+1. **Integrity** — the evidence has not been modified since it was
+   collected.
+2. **Provenance** — the evidence's path from creation to current
+   custodian is documented.
+
+Together they answer: "is this report telling me what was actually
+found, or has someone edited it after the fact?"
+
+The downstream consumers of pentest evidence vary by engagement:
+
+- **Customer's internal audit team** — needs to file the report
+  for compliance evidence (SOC2, ISO 27001, PCI DSS audit).
+- **Legal counsel** — needs the evidence for breach
+  notification, insurance claim, or litigation contexts.
+- **Outside SOC reviewing the activity** — needs to confirm that
+  alerts they raised during the engagement match authorized
+  testing.
+- **Future readers of the same customer's engagement history** —
+  need to know what was tested when, to make scope decisions for
+  the next engagement.
+
+Each consumer asks variations of "show me the proof." The
+chain-of-custody artifact this skill produces is that proof.
+
+## NIST SP 800-86 evidence-handling principles
+
+NIST Special Publication 800-86 (Guide to Integrating Forensic
+Techniques into Incident Response) establishes the principles
+this skill follows:
+
+- Acquire evidence using techniques that preserve the original
+  state.
+- Document everything — who, what, when, where, how.
+- Use cryptographic hashing to detect any modification after
+  acquisition.
+- Limit access to evidence to a documented chain of custody.
+
+The pentest case isn't a forensic incident, but the same
+principles apply: the evidence we produce will be examined by
+parties we don't fully control, and they need objective grounds
+to trust it.
+
+## SHA-256 vs SHA-3 vs SHA-512
+
+The skill uses SHA-256. Reasons:
+
+- **Universally available.** Python's `hashlib`, Linux's
+  `sha256sum`, macOS's `shasum`, Windows's `Get-FileHash`. No
+  party verifying the manifest needs to install anything special.
+- **No known practical preimage attacks** as of 2026. Collision
+  attacks on SHA-256 have been theorized but not demonstrated.
+- **Output size (64 hex chars) is human-tractable** for spot
+  checks.
+
+SHA-3 is fine — academically preferred for new designs — but
+tooling is less universal. SHA-512 is fine too — slightly slower,
+larger output. For evidence-integrity purposes, SHA-256 is
+sufficient and the most portable choice. If your customer's policy
+requires SHA-512, the skill could be extended to emit both.
+
+MD5 and SHA-1 are NOT acceptable. Both have practical collision
+attacks. Don't use them for evidence integrity even if old tooling
+defaults to them.
+
+## GPG detached signatures
+
+A GPG detached signature is a separate file (typically `.asc` or
+`.sig`) that contains a cryptographic signature over the contents
+of the original file, made with the signer's private key. Anyone
+with the signer's public key can verify:
+
+- The signature was made by the holder of the private key.
+- The signed content hasn't been modified since signing.
+
+Detached signatures are preferred over inline signatures because
+the original file remains unchanged — easier to feed to tools that
+expect the original format.
+
+The skill produces `manifest.sha256.asc` alongside the
+`manifest.sha256`. Verification flow:
+
+1. `gpg --verify manifest.sha256.asc manifest.sha256` — confirms
+   the manifest is signed by the claimed signer.
+2. `sha256sum -c manifest.sha256` — confirms the manifest's
+   contents match the on-disk files.
+
+Both checks together: the signer attests that the manifest is
+correct, AND the manifest is currently correct against the
+archive.
+
+## Archive format choices
+
+The skill uses gzip-compressed tar (`.tar.gz`) for the optional
+portable archive. Comparison:
+
+| Format | Tooling | Compression | Notes |
+|---|---|---|---|
+| `.tar.gz` | universal (Linux/macOS/Windows-WSL) | Good | Preserves Unix permissions, mtimes |
+| `.zip` | universal (incl. Windows native) | Good | Loses some Unix metadata; password-protect is weak |
+| WORM (Write-Once Read-Many) media | requires WORM library | n/a | Strongest integrity claim; expensive |
+
+Tar.gz is the practical choice. WORM is the strongest claim but
+operationally rare outside specialized forensic shops. The
+manifest provides equivalent integrity guarantees without the
+operational burden.
+
+## Retention horizons per jurisdiction
+
+How long to keep pentest evidence depends on the jurisdiction and
+the customer's regulatory posture. Common defaults:
+
+| Driver | Typical retention |
+|---|---|
+| Statute of limitations on unauthorized-access offences (US) | 5 years |
+| Statute of limitations (UK, CMA offences) | 6 years |
+| SOC2 audit evidence | 7 years |
+| ISO 27001 audit evidence | 5 years |
+| PCI DSS evidence | 1-3 years (varies by control) |
+| HIPAA breach evidence | 6 years from creation or last effective date |
+| Customer-contractual retention | varies — read the engagement contract |
+
+The skill doesn't enforce retention — that's a storage-policy
+concern. The skill ensures the evidence is portable and verifiable
+for whatever retention period applies.
+
+## Out-of-tree path detection
+
+A finding that references a file at `/home/tester/notes.md` is a
+chain-of-custody problem: when the engagement archive is moved to
+the customer's storage, that file won't come along. The finding
+becomes uncheckable.
+
+The skill scans `findings/*.json` for path-shaped string values in
+the `evidence` dicts and flags any absolute path that isn't within
+the engagement directory tree. The remediation is to copy the
+referenced file INTO the engagement tree, OR change the finding to
+not reference the out-of-tree path.
+
+## When the customer disputes the archive
+
+Two failure modes:
+
+### "The archive is incomplete"
+
+Customer claims they didn't get all the evidence. Resolution:
+
+1. Run this skill against the archive directory; the report lists
+   every file with its hash.
+2. Compare the list against the customer's expected file list.
+3. If files are missing from the archive, restore from the
+   tester's working copy and re-archive.
+4. If the customer's expected list includes files that were never
+   in scope, document that in the resolution communication.
+
+### "The archive has been modified"
+
+Customer claims the evidence doesn't match what they saw during
+the engagement. Resolution:
+
+1. Run `sha256sum -c manifest.sha256` against the archive
+   directory. If output is "OK," the archive is internally
+   consistent.
+2. If the customer's claim is that the EVIDENCE itself was
+   manipulated (not the archive), compare against the daily
+   snapshots taken during the engagement (if available).
+3. If no daily snapshots were taken, the integrity claim depends
+   on the original manifest signature and any external retention
+   timestamps (e.g. WORM storage, email of the manifest at
+   engagement close).
+
+The skill's daily-snapshot pattern (see PLAYBOOK.md) is the cheap
+preventive measure for this dispute class.
+
+## Why the manifest is in standard sha256sum format
+
+The skill could emit a custom JSON manifest. The sha256sum format
+is preferred because:
+
+- Standard Unix tooling (`sha256sum -c`) verifies it without any
+  custom code.
+- A customer or legal counsel can verify the manifest 10 years
+  from now even if this skill no longer exists.
+- The format is line-oriented; diffs are readable.
+
+The standard format is one line per file: 64-hex-char digest,
+exactly two spaces, then the file's relative path. Both Linux's
+`sha256sum` and macOS's `shasum -a 256` produce and verify this
+form.

--- a/plugins/security/penetration-tester/skills/recording-pentest-engagement/scripts/record_engagement.py
+++ b/plugins/security/penetration-tester/skills/recording-pentest-engagement/scripts/record_engagement.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""recording-pentest-engagement — chain-of-custody packager.
+
+Walks an engagement directory, builds a SHA-256 manifest of every file,
+optionally signs the manifest with GPG, optionally creates a tarball of the
+directory + manifest. Emits Findings via lib/finding.py for any inconsistency
+between the manifest and the on-disk state.
+
+Usage:
+    python3 record_engagement.py PATH [--output FILE] [--format json|jsonl|markdown]
+                                       [--min-severity sev] [--manifest FILE]
+                                       [--tar FILE] [--sign] [--signer KEY]
+                                       [--exclude GLOB]
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- lib/ import -------------------------------------------------------------
+_LIB_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_LIB_ROOT))
+
+from lib.finding import Finding, Severity  # noqa: E402
+from lib import report  # noqa: E402
+
+
+SKILL_ID = "recording-pentest-engagement"
+CATEGORY = "evidence-chain"
+DEFAULT_EXCLUDES = (
+    "**/manifest.sha256",
+    "**/manifest.sha256.asc",
+    "**/.DS_Store",
+    "**/__pycache__/**",
+)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _f(severity: Severity, title: str, target: str, detail: str, remediation: str,
+       evidence: tuple[tuple[str, Any], ...] = ()) -> Finding:
+    return Finding(
+        skill_id=SKILL_ID,
+        title=title,
+        severity=severity,
+        target=target,
+        detail=detail,
+        remediation=remediation,
+        evidence=evidence,
+    )
+
+
+def _matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# --- Manifest building ------------------------------------------------------
+
+
+def walk_files(
+    root: Path, excludes: list[str]
+) -> tuple[list[Path], list[Finding]]:
+    """Return (file_list, findings) where findings flag operational issues."""
+    files: list[Path] = []
+    findings: list[Finding] = []
+    if not root.exists():
+        findings.append(
+            _f(
+                Severity.CRITICAL,
+                f"engagement directory missing: {root}",
+                str(root),
+                f"Path {root} does not exist; cannot record engagement.",
+                f"Create the engagement directory and re-run.",
+            )
+        )
+        return files, findings
+
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            p = Path(dirpath) / name
+            rel = p.relative_to(root)
+            rel_str = str(rel)
+            if _matches_any(rel_str, excludes):
+                continue
+            try:
+                if p.is_symlink():
+                    findings.append(
+                        _f(
+                            Severity.MEDIUM,
+                            f"symlink in tree: {rel_str}",
+                            str(p),
+                            "Symlinks break archive portability and complicate "
+                            "integrity verification.",
+                            "Replace the symlink with the actual file, or exclude "
+                            "the directory containing the symlink.",
+                        )
+                    )
+                    continue
+                if p.stat().st_size == 0:
+                    findings.append(
+                        _f(
+                            Severity.INFO,
+                            f"empty file in tree: {rel_str}",
+                            str(p),
+                            "0-byte file; possibly an export error or placeholder.",
+                            "Verify the file is intentional; remove if not.",
+                        )
+                    )
+            except (OSError, PermissionError) as e:
+                findings.append(
+                    _f(
+                        Severity.HIGH,
+                        f"cannot stat {rel_str}",
+                        str(p),
+                        f"OSError: {e}",
+                        "Resolve permissions; re-run.",
+                    )
+                )
+                continue
+            files.append(p)
+    return files, findings
+
+
+def compute_manifest(
+    root: Path, files: list[Path]
+) -> tuple[list[tuple[str, str]], list[Finding]]:
+    """Return (manifest_entries, findings) where entries are (hash, relpath)."""
+    entries: list[tuple[str, str]] = []
+    findings: list[Finding] = []
+    for f in sorted(files):
+        try:
+            digest = _sha256_file(f)
+        except (OSError, PermissionError) as e:
+            findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"cannot read {f.relative_to(root)}",
+                    str(f),
+                    f"Cannot hash file: {e}",
+                    "Resolve permissions; re-run.",
+                )
+            )
+            continue
+        entries.append((digest, str(f.relative_to(root))))
+    return entries, findings
+
+
+def write_manifest(entries: list[tuple[str, str]], manifest_path: Path) -> None:
+    lines = [f"{digest}  {rel}\n" for digest, rel in entries]
+    manifest_path.write_text("".join(lines), encoding="utf-8")
+
+
+# --- Manifest verification (when one already exists) -----------------------
+
+
+def load_existing_manifest(manifest_path: Path) -> list[tuple[str, str]] | None:
+    if not manifest_path.exists():
+        return None
+    out: list[tuple[str, str]] = []
+    for line in manifest_path.read_text(encoding="utf-8").splitlines():
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        # standard sha256sum format: HASH<sp><sp>PATH
+        if "  " in line:
+            digest, rel = line.split("  ", 1)
+        elif " " in line:
+            parts = line.split()
+            digest = parts[0]
+            rel = " ".join(parts[1:])
+        else:
+            continue
+        out.append((digest.strip(), rel.strip()))
+    return out
+
+
+def verify_against_existing(
+    root: Path, computed: list[tuple[str, str]], existing: list[tuple[str, str]]
+) -> list[Finding]:
+    findings: list[Finding] = []
+    existing_map = dict((rel, digest) for digest, rel in existing)
+    computed_map = dict((rel, digest) for digest, rel in computed)
+
+    for rel, comp_digest in computed_map.items():
+        if rel not in existing_map:
+            findings.append(
+                _f(
+                    Severity.HIGH,
+                    f"file not in existing manifest: {rel}",
+                    str(root / rel),
+                    "File present on disk but absent from the existing manifest. "
+                    "Either the file was added after manifest creation, or the "
+                    "manifest is stale.",
+                    "Re-generate the manifest to include the new file (acceptable "
+                    "for in-progress engagements; never acceptable post-closeout).",
+                )
+            )
+        elif existing_map[rel] != comp_digest:
+            findings.append(
+                _f(
+                    Severity.CRITICAL,
+                    f"hash mismatch: {rel}",
+                    str(root / rel),
+                    f"Manifest says {existing_map[rel]}, computed {comp_digest}. "
+                    f"The file has been modified since the manifest was created.",
+                    "Investigate the modification. If legitimate (post-engagement "
+                    "edit), the original archive's integrity claim is broken; "
+                    "create a NEW archive with a fresh manifest and document the "
+                    "modification reason.",
+                )
+            )
+
+    for rel in existing_map.keys() - computed_map.keys():
+        findings.append(
+            _f(
+                Severity.HIGH,
+                f"manifest entry for missing file: {rel}",
+                str(root / rel),
+                "Manifest lists a file that doesn't exist on disk.",
+                "Either restore the file or generate a fresh manifest without it.",
+            )
+        )
+
+    return findings
+
+
+# --- Findings sanity (cross-reference) --------------------------------------
+
+
+def scan_findings_for_external_refs(root: Path) -> list[Finding]:
+    """If findings JSONs reference paths, verify those paths are inside root."""
+    out: list[Finding] = []
+    findings_dir = root / "findings"
+    if not findings_dir.is_dir():
+        return out
+    for f in findings_dir.glob("**/*.json"):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        records = data if isinstance(data, list) else data.get("findings", []) if isinstance(data, dict) else []
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            evidence = rec.get("evidence", {})
+            if isinstance(evidence, dict):
+                for k, v in evidence.items():
+                    if not isinstance(v, str):
+                        continue
+                    if v.startswith("/") and root.as_posix() not in v:
+                        out.append(
+                            _f(
+                                Severity.MEDIUM,
+                                f"finding references out-of-tree path: {v}",
+                                str(f),
+                                f"Finding evidence['{k}'] = {v} points outside the "
+                                f"engagement directory tree at {root}.",
+                                "Either copy the referenced file into the engagement "
+                                "tree (so it's archived) or change the finding to "
+                                "reference an in-tree path.",
+                            )
+                        )
+    return out
+
+
+# --- GPG signing ------------------------------------------------------------
+
+
+def sign_manifest(manifest_path: Path, signer: str | None) -> tuple[bool, str]:
+    if not shutil.which("gpg"):
+        return False, "gpg not installed"
+    cmd = ["gpg", "--armor", "--detach-sign"]
+    if signer:
+        cmd.extend(["--local-user", signer])
+    cmd.extend(["--output", str(manifest_path) + ".asc", str(manifest_path)])
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)  # noqa: S603
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return False, f"gpg invocation failed: {e}"
+    if proc.returncode != 0:
+        return False, f"gpg exited {proc.returncode}: {proc.stderr.strip()[:200]}"
+    return True, ""
+
+
+# --- Tar packaging ----------------------------------------------------------
+
+
+def create_tar(root: Path, tar_path: Path) -> tuple[bool, str]:
+    try:
+        tar_path.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(tar_path, "w:gz") as tar:
+            tar.add(root, arcname=root.name)
+    except (OSError, tarfile.TarError) as e:
+        return False, f"tar creation failed: {e}"
+    return True, ""
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("path", help="Engagement directory")
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", default="markdown", choices=["json", "jsonl", "markdown"])
+    p.add_argument(
+        "--min-severity",
+        default="info",
+        choices=["info", "low", "medium", "high", "critical"],
+    )
+    p.add_argument("--manifest", default=None)
+    p.add_argument("--tar", default=None)
+    p.add_argument("--sign", action="store_true")
+    p.add_argument("--signer", default=None)
+    p.add_argument("--exclude", action="append", default=[])
+    return p
+
+
+def _filter_min_severity(findings: list[Finding], min_sev: str) -> list[Finding]:
+    floor = Severity(min_sev).numeric
+    return [f for f in findings if f.severity.numeric >= floor]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    root = Path(args.path).resolve()
+    excludes = list(DEFAULT_EXCLUDES) + list(args.exclude)
+
+    files, walk_findings = walk_files(root, excludes)
+    if not files and walk_findings:
+        report.emit(walk_findings, args.output, args.format, scan_target=str(root))
+        return 1
+
+    entries, hash_findings = compute_manifest(root, files)
+
+    manifest_path = Path(args.manifest).resolve() if args.manifest else (root / "manifest.sha256")
+    existing = load_existing_manifest(manifest_path)
+    verify_findings: list[Finding] = []
+    if existing is not None:
+        verify_findings = verify_against_existing(root, entries, existing)
+
+    # Always rewrite the manifest to current state (it's authoritative now)
+    try:
+        write_manifest(entries, manifest_path)
+    except OSError as e:
+        walk_findings.append(
+            _f(
+                Severity.HIGH,
+                f"cannot write manifest at {manifest_path}",
+                str(manifest_path),
+                f"OSError: {e}",
+                "Resolve permissions; re-run.",
+            )
+        )
+
+    ref_findings = scan_findings_for_external_refs(root)
+
+    sign_findings: list[Finding] = []
+    if args.sign:
+        ok, msg = sign_manifest(manifest_path, args.signer)
+        if ok:
+            sign_findings.append(
+                _f(
+                    Severity.INFO,
+                    "manifest signed",
+                    str(manifest_path) + ".asc",
+                    "Manifest signed with GPG detached signature.",
+                    "Distribute the .asc alongside the manifest; verify with "
+                    "`gpg --verify manifest.sha256.asc manifest.sha256`.",
+                )
+            )
+        else:
+            sign_findings.append(
+                _f(
+                    Severity.HIGH,
+                    "manifest signing failed",
+                    str(manifest_path),
+                    msg,
+                    "Sign the manifest manually after resolving the GPG issue, "
+                    "or skip --sign.",
+                )
+            )
+
+    tar_findings: list[Finding] = []
+    if args.tar:
+        ok, msg = create_tar(root, Path(args.tar).resolve())
+        if ok:
+            tar_findings.append(
+                _f(
+                    Severity.INFO,
+                    "archive created",
+                    args.tar,
+                    f"Archive written: {args.tar}",
+                    "Hand off to legal / archive / customer per the engagement closeout protocol.",
+                )
+            )
+        else:
+            tar_findings.append(
+                _f(
+                    Severity.HIGH,
+                    "archive creation failed",
+                    args.tar,
+                    msg,
+                    "Resolve the tar error and re-run with --tar.",
+                )
+            )
+
+    all_findings = walk_findings + hash_findings + verify_findings + ref_findings + sign_findings + tar_findings
+    if not all_findings:
+        all_findings = [
+            _f(
+                Severity.INFO,
+                "engagement archive is internally consistent",
+                str(root),
+                f"Manifest covers {len(entries)} files. No integrity issues "
+                f"detected.",
+                "No action required. Distribute the manifest (and optionally "
+                ".tar.gz) per the engagement closeout protocol.",
+                evidence=(
+                    ("file_count", len(entries)),
+                    ("manifest", str(manifest_path)),
+                    ("recorded_at", datetime.now(timezone.utc).isoformat()),
+                ),
+            )
+        ]
+    all_findings = _filter_min_severity(all_findings, args.min_severity)
+    report.emit(all_findings, args.output, args.format, scan_target=str(root))
+    return report.exit_code(all_findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Brings the penetration-tester pack to **25/25 skills**, completing the heavy-hitter taxonomy at `plugins/security/penetration-tester/000-docs/001-AT-ADEC-skill-taxonomy.md`. Cluster 4 (#827) took the pack to 19/25; this PR ships the final 6 skills.

## What ships

### Cluster 5 — Engagement governance (3 skills)

| # | Skill | Grade | Script LOC | Function |
|---|---|---|---|---|
| 20 | `confirming-pentest-authorization` | A (90) | 467 | Validates the Rules of Engagement attestation. CRITICAL findings halt the engagement; orchestrator routes here first. |
| 21 | `defining-pentest-scope` | A (93) | 469 | Parses ROE scope into a normalized target list, validates syntax, detects in/out-of-scope overlap and known third-party SaaS ranges, emits an IP allowlist. |
| 22 | `recording-pentest-engagement` | B (89) | 452 | Packages the engagement directory with a SHA-256 manifest, optional GPG signature, optional tarball. Establishes chain of custody. |

### Cluster 6 — Reporting (3 skills)

| # | Skill | Grade | Script LOC | Function |
|---|---|---|---|---|
| 23 | `composing-vulnerability-report` | A (93) | 395 | Consumes cluster 1-4 findings, deduplicates by fingerprint, groups by severity, emits a deliverable-grade markdown report. |
| 24 | `mapping-findings-to-owasp-top10` | A (95) | 544 | Applies a deterministic rule table (skill_id, CWE, detail keywords, overrides) to annotate every finding with its OWASP A0X category. |
| 25 | `generating-executive-summary` | A (91) | 554 | Composes a C-level summary with a single risk score (0-100), top-3 remediation priorities, OWASP coverage rollup. |

Totals: **2,881 LOC scripts + 1,365 LOC SKILL.md + ~5,800 LOC references**. All 6 scripts compile cleanly. 5/6 at A-grade; 1 at B/89 (one point below A cutoff; stylistic). All validate against the marketplace tier with zero errors.

## Architecture

All 6 skills consume `lib/finding.py` + `lib/report.py` (shared with clusters 1-3). Two cohesive sub-architectures:

- **Cluster 5** sits BEFORE the scan skills. Authorization → scope-definition → (cluster 1-4 scans run) → engagement-recording. Each emits findings structurally similar to scan findings so the downstream reporting consumes everything uniformly.

- **Cluster 6** sits AFTER the scan skills. Compose-vulnerability-report unifies the cluster 1-4 outputs; map-findings-to-owasp-top10 enriches the unified file; generate-executive-summary consumes the enriched file plus the OWASP coverage report plus the ROE to produce a 1-2 page exec deliverable.

## Risk score composition (skill #25)

The exec summary's single risk score is deterministic:

```
risk = clamp(0, 100,
    20 * count(CRITICAL)
  + 10 * count(HIGH)
  +  3 * count(MEDIUM)
  +  1 * count(LOW)
  +  5 * (count(distinct OWASP categories touched) - 5 if >5 else 0)
  - 10 if engagement governance was clean
)
```

Composition + interpretation bands (Low / Moderate / Elevated / High / Critical) documented in `references/THEORY.md`. Stable rendering (same input → byte-identical output except for timestamp).

## What's NOT in this PR (separate v3.0.0 release PR)

- `performing-penetration-testing` orchestrator update referencing all 25 skills + intent-based routing.
- `plugin.json` version bump 2.0.0 → 3.0.0.
- Deprecation note on the v1.x monolithic skill.
- Harness gates (Gherkin lint, RTM, coverage floor per the Intent Solutions Testing SOP).

## Test plan

- [ ] Spot-check `confirming-pentest-authorization` against an example ROE: should emit CRITICAL when signature is missing, INFO when all fields present.
- [ ] Spot-check `defining-pentest-scope` against an ROE that has an in-scope CIDR overlapping an out-of-scope CIDR: should emit CRITICAL.
- [ ] Spot-check `recording-pentest-engagement` against a small engagement dir: should produce a `manifest.sha256` that `sha256sum -c` verifies.
- [ ] Spot-check `composing-vulnerability-report` against a cluster 1-4 findings file: should produce a markdown report with per-severity sections.
- [ ] Spot-check `mapping-findings-to-owasp-top10` against the same findings: should produce an enriched JSONL with `owasp_category` field on every finding.
- [ ] Spot-check `generating-executive-summary` against the enriched JSONL: should produce a `executive-summary.md` with a numeric risk score.
- [ ] No regression in clusters 1-4 (they share `lib/finding.py` + `lib/report.py` — this PR doesn't modify those).
- [ ] Validator scores match the table above: `python3 scripts/validate-skills-schema.py --marketplace plugins/security/penetration-tester/skills/<skill>/SKILL.md`

- Jeremy Longshore
intentsolutions.io