### PR TITLE
feat(ci): pr-classifier — deterministic file-level PR component detection

### DIFF
--- a/scripts/pr-classifier/README.md
+++ b/scripts/pr-classifier/README.md
@@ -1,0 +1,132 @@
+# pr-classifier — File-level PR component detection
+
+Given a list of files changed in a PR, emit a structured JSON object describing the contribution: which plugins, skills, agents, MCP servers, hooks, workflows, scripts, and docs are affected, plus any catalog or sources additions parsed from the diff.
+
+Deterministic. Same input → same output, always. No network, no LLM, no I/O beyond `--file` / `--diff-file` reads and stdout JSON emission.
+
+## Why this exists
+
+The previous prescreen pipeline used a coarse `awk -F/ '{print $1"/"$2"/"$3}'` extractor at depth 3, which surfaced the plugin directory of any changed file. That caused doc-only PRs touching `plugins/saas-packs/<pack>/000-docs/foo.md` to drag in every skill in the pack for validator scoring — including unrelated skills that already had pre-existing C grades, which were then incorrectly attributed to the new PR as blockers. PR #823 hit this exactly.
+
+The classifier cuts at depth 4 for skills (`plugins/<cat>/<plugin>/skills/<skill>/SKILL.md`) and only surfaces the SPECIFIC skill whose SKILL.md was modified. Pack-level changes still surface as `plugin_paths`, but the prescreen no longer fans out into every skill in the pack by default.
+
+## Usage
+
+### From stdin (typical CI)
+
+```bash
+git diff --name-only origin/main..HEAD | \
+    python3 scripts/pr-classifier/detect_components.py --stdin
+```
+
+### From a file list
+
+```bash
+python3 scripts/pr-classifier/detect_components.py --file /tmp/pr-files.txt
+```
+
+### With diff for catalog/sources detection
+
+```bash
+python3 scripts/pr-classifier/detect_components.py \
+    --stdin --diff-file /tmp/pr-diff.patch
+```
+
+### Positional
+
+```bash
+python3 scripts/pr-classifier/detect_components.py \
+    plugins/security/penetration-tester/skills/auditing-npm-dependencies/SKILL.md \
+    .github/workflows/validate-plugins.yml
+```
+
+### Pretty-print
+
+```bash
+... --pretty
+```
+
+## Output JSON shape
+
+```json
+{
+  "contribution_types": ["plugin", "skill"],
+  "plugin_paths": ["plugins/saas-packs/databricks-pack"],
+  "affected_skills": ["databricks-incident-runbook"],
+  "affected_agents": [],
+  "affected_mcp": [],
+  "affected_hooks": [],
+  "catalog_additions": [
+    { "name": "aomi", "source": "./plugins/crypto/aomi", "category": "crypto" }
+  ],
+  "sources_additions": [],
+  "file_categories": { "md": 4, "json": 2 },
+  "touches_workflows": false,
+  "touches_frontend": false,
+  "touches_scripts": false,
+  "touches_tests": false,
+  "unknown": false,
+  "unmatched": []
+}
+```
+
+All top-level lists are sorted; the dict is JSON-serializable and stable across runs.
+
+## Contribution types
+
+| Type          | Trigger                                                             |
+| ------------- | ------------------------------------------------------------------- |
+| `skill`       | A `plugins/<cat>/<plugin>/skills/<skill>/SKILL.md` file             |
+| `agent`       | A `plugins/<cat>/<plugin>/agents/<agent>.md` file                   |
+| `mcp`         | A `plugins/mcp/<name>/**` file, or `.mcp.json`, or `mcpServers/**`  |
+| `hook`        | A `plugins/<cat>/<plugin>/hooks/hooks.json` file                    |
+| `plugin`      | ANY file inside `plugins/<cat>/<plugin>/`                           |
+| `catalog`     | A touch of `.claude-plugin/marketplace.{,extended.}json`            |
+| `catalog_add` | An ADDITION to `marketplace.extended.json` (requires `--diff-file`) |
+| `sources`     | A touch of `sources.yaml`                                           |
+| `sources_add` | An ADDITION to `sources.yaml` (requires `--diff-file`)              |
+| `ci`          | A `.github/workflows/*.yml`/`.yaml` file                            |
+| `frontend`    | A `marketplace/src/**` file                                         |
+| `script`      | A `scripts/**` file                                                 |
+| `test`        | A `test_*.py` file OR anything under a `tests/` directory           |
+| `doc`         | A standalone `*.md` or `*.mdx` outside any plugin                   |
+
+A single PR can hit many types simultaneously. The output's `contribution_types` is the sorted set of types matched.
+
+## When to extend the ruleset
+
+Edit `rules.py`. Three steps:
+
+1. Add a row to `RULE_DESCRIPTIONS` describing the new rule.
+2. Add the detection logic to `classify_files()`.
+3. Add a unit test in `tests/pr-classifier/test_classifier.py`.
+
+Don't add detection logic without a corresponding rule description — the description IS the audit trail for why a file got classified.
+
+## Tests
+
+Unit + snapshot tests live at `tests/pr-classifier/test_classifier.py`. **46 tests, all deterministic.**
+
+Run from the repo root:
+
+```bash
+python3 -m pytest tests/pr-classifier/ -v
+```
+
+Snapshot regression: real PR diffs captured at `tests/pr-classifier/fixtures/pr-<num>.{files,diff,expected.json}`. To regenerate after an intentional behavior change:
+
+```bash
+python3 scripts/pr-classifier/detect_components.py \
+    --file tests/pr-classifier/fixtures/pr-823.files \
+    --diff-file tests/pr-classifier/fixtures/pr-823.diff \
+    --pretty > tests/pr-classifier/fixtures/pr-823.expected.json
+```
+
+The commit message must explain why the snapshot changed.
+
+## Downstream consumers
+
+This module is the foundation for two follow-up pieces (separate PRs):
+
+- **PR 2** — Split `validate-plugins.yml` into per-domain workflow files with native `paths:` filters. The classifier's `contribution_types` informs which checks need to fire for any given PR.
+- **PR 3** — Prescreen rewrite as single coordinator. The classifier's `affected_skills` becomes the input to the prescreen's grader, eliminating the depth-3 false-positive fan-out.

--- a/scripts/pr-classifier/__init__.py
+++ b/scripts/pr-classifier/__init__.py
@@ -1,0 +1,16 @@
+"""PR file-level component classifier.
+
+Given a list of files changed in a PR, emit a structured JSON object
+describing what kind of contribution it is — which plugins, skills,
+agents, MCP servers, hooks, workflows, scripts, docs, and catalog
+additions are affected.
+
+The classifier is deterministic. Same input → same output, always.
+Downstream consumers (the prescreen, the per-domain CI workflows)
+use this output to route per-contribution-type evaluation without
+each re-implementing the file-path-to-component mapping.
+"""
+
+from .rules import RULE_DESCRIPTIONS, classify_files
+
+__all__ = ["RULE_DESCRIPTIONS", "classify_files"]

--- a/scripts/pr-classifier/detect_components.py
+++ b/scripts/pr-classifier/detect_components.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""PR component classifier — CLI entry point.
+
+Reads a list of changed-file paths (from stdin, --file, or positional args),
+optionally reads a unified diff (from --diff-file) for catalog/sources entry
+parsing, applies the deterministic ruleset in rules.py, and emits the
+classification JSON to stdout.
+
+Typical CI invocation:
+
+    git diff --name-only origin/main..HEAD | \\
+        python3 scripts/pr-classifier/detect_components.py --stdin
+
+With diff for catalog detection:
+
+    python3 scripts/pr-classifier/detect_components.py \\
+        --stdin \\
+        --diff-file /tmp/pr-diff.patch
+
+Exit codes:
+    0 — classification produced (even if unknown=true)
+    2 — input error (no files supplied, file not readable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Resolve the package import whether invoked as `python3 detect_components.py`
+# or via `python3 -m scripts.pr-classifier.detect_components`.
+_SELF = Path(__file__).resolve()
+sys.path.insert(0, str(_SELF.parents[1]))
+
+try:
+    from pr_classifier.rules import classify_files, to_json  # type: ignore[import-not-found]
+except ImportError:
+    # Fallback for hyphenated dir name — load rules.py as a sibling module.
+    import importlib.util as _ilu
+
+    _rules_path = _SELF.parent / "rules.py"
+    _spec = _ilu.spec_from_file_location("pr_classifier_rules", _rules_path)
+    _rules = _ilu.module_from_spec(_spec)
+    _spec.loader.exec_module(_rules)
+    classify_files = _rules.classify_files
+    to_json = _rules.to_json
+
+
+def _read_files_from(args: argparse.Namespace) -> list[str]:
+    if args.file:
+        try:
+            text = Path(args.file).read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"error: cannot read --file {args.file}: {e}", file=sys.stderr)
+            sys.exit(2)
+        return [l.strip() for l in text.splitlines() if l.strip()]
+
+    if args.stdin:
+        return [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
+
+    if args.files:
+        return list(args.files)
+
+    print(
+        "error: no input. Provide --stdin, --file FILE, or positional file paths.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _read_diff(diff_file: str | None) -> str | None:
+    if not diff_file:
+        return None
+    try:
+        return Path(diff_file).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"error: cannot read --diff-file {diff_file}: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Changed file paths (positional). Mutually exclusive with --stdin/--file.",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read file paths from stdin, one per line.",
+    )
+    parser.add_argument(
+        "--file",
+        default=None,
+        help="Read file paths from FILE, one per line.",
+    )
+    parser.add_argument(
+        "--diff-file",
+        default=None,
+        help="Read unified-diff text from FILE for catalog/sources detection.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the output JSON (default: compact one-line).",
+    )
+
+    args = parser.parse_args(argv)
+    files = _read_files_from(args)
+    diff_text = _read_diff(args.diff_file)
+
+    result = classify_files(files, diff_text=diff_text)
+    print(to_json(result, pretty=args.pretty))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-classifier/rules.py
+++ b/scripts/pr-classifier/rules.py
@@ -96,6 +96,40 @@ _CATALOG_ENTRY_OBJECT = re.compile(
 )
 
 
+def _count_unquoted_braces(text: str) -> tuple[int, int]:
+    """Count `{` and `}` in text, ignoring braces inside string literals.
+
+    Reviewer flagged (PR #838 review): naive `text.count("{")` is broken when
+    a string value contains literal braces — e.g. a `"description"` field with
+    template placeholders like `"Uses {amazing} things"` (balanced, OK) or
+    `"Uses {foo {bar} patterns"` (unbalanced, drives depth counter wrong and
+    silently drops the entire catalog entry). Walk the string char-by-char
+    with quote-state tracking so braces inside `"..."` literals don't count.
+    Honors `\"` escape so `"a\"b"` is one continuous string.
+    """
+    opens = 0
+    closes = 0
+    in_string = False
+    escape_next = False
+    for ch in text:
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            opens += 1
+        elif ch == "}":
+            closes += 1
+    return opens, closes
+
+
 def parse_catalog_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
     """Extract added catalog entries from a unified-diff text.
 
@@ -137,14 +171,17 @@ def parse_catalog_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
 
         added_content = line[1:].strip()
 
-        if "{" in added_content and not in_added_block:
+        # Count braces OUTSIDE string literals only (reviewer fix PR #838).
+        line_opens, line_closes = _count_unquoted_braces(added_content)
+
+        if line_opens > 0 and not in_added_block:
             in_added_block = True
-            open_brace_depth = added_content.count("{") - added_content.count("}")
+            open_brace_depth = line_opens - line_closes
             current = {}
             continue
 
         if in_added_block:
-            open_brace_depth += added_content.count("{") - added_content.count("}")
+            open_brace_depth += line_opens - line_closes
             for field in ("name", "source", "category", "version"):
                 m = re.match(rf'^"{field}"\s*:\s*"([^"]+)"', added_content)
                 if m:
@@ -159,12 +196,16 @@ def parse_catalog_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
 
 
 def parse_sources_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
-    """Extract added entries from sources.yaml diff text.
+    """Extract added entries from the ROOT-LEVEL sources.yaml diff text.
 
     Captures top-level YAML entries that look like `- name: foo` or
-    `- repo: foo/bar` additions.
+    `- repo: foo/bar` additions. Restricted to the root-level `sources.yaml`
+    to match the touch-detection rule in classify_files (reviewer fix PR #838:
+    `config/sources.yaml` or other non-root files should NOT fire sources_add).
     """
-    if "sources.yaml" not in diff_text:
+    # Match diff header that targets root-level sources.yaml — `a/sources.yaml`
+    # or `b/sources.yaml` (no intermediate directories).
+    if not re.search(r"diff --git a/sources\.yaml b/sources\.yaml", diff_text):
         return []
 
     out: list[dict[str, str]] = []
@@ -178,12 +219,14 @@ def parse_sources_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
             current = {}
 
     for line in diff_text.splitlines():
-        if line.startswith("diff --git ") and "sources.yaml" in line:
-            in_sources_diff = True
-            continue
-        if line.startswith("diff --git ") and "sources.yaml" not in line:
-            in_sources_diff = False
-            flush()
+        if line.startswith("diff --git "):
+            # Strict root-level match — `a/sources.yaml b/sources.yaml`. Reject
+            # `a/config/sources.yaml` and similar non-root paths.
+            if re.search(r"a/sources\.yaml\s+b/sources\.yaml", line):
+                in_sources_diff = True
+            else:
+                in_sources_diff = False
+                flush()
             continue
         if not in_sources_diff:
             continue
@@ -248,22 +291,30 @@ def classify_files(
             contribution_types.add("plugin")
             matched = True
 
-            # depth-4 skill: plugins/<cat>/<name>/skills/<skill>/SKILL.md
+            # Skill match: <plugin-root>/skills/<skill>/SKILL.md at ANY depth.
+            # Reviewer fix PR #838: the prior depth-4-only check missed
+            # sub-vendored layouts like
+            # plugins/saas-packs/<vendor>/<sub>/skills/<x>/SKILL.md.
+            # Walk the tail of the path for the `skills/<name>/SKILL.md`
+            # signature instead of hardcoding parts[3].
             if (
-                len(path.parts) >= 6
-                and path.parts[3] == "skills"
+                len(path.parts) >= 3
                 and path.parts[-1] == "SKILL.md"
+                and len(path.parts) >= 3
+                and path.parts[-3] == "skills"
             ):
-                affected_skills.add(path.parts[4])
+                affected_skills.add(path.parts[-2])
                 contribution_types.add("skill")
 
-            # plugins/<cat>/<name>/agents/<agent>.md
+            # Agent match: <plugin-root>/agents/<agent>.md at ANY depth
+            # (same depth-flex fix as skills above).
             elif (
-                len(path.parts) == 5
-                and path.parts[3] == "agents"
+                len(path.parts) >= 2
                 and ext == "md"
+                and len(path.parts) >= 3
+                and path.parts[-2] == "agents"
             ):
-                affected_agents.add(path.parts[4].rsplit(".", 1)[0])
+                affected_agents.add(path.parts[-1].rsplit(".", 1)[0])
                 contribution_types.add("agent")
 
             # MCP — either plugins/mcp/<name>/** or .mcp.json or mcpServers
@@ -381,6 +432,10 @@ def classify_files(
         if sources_additions:
             contribution_types.add("sources_add")
 
+    # file_categories sorted for determinism — reviewer fix PR #838. Counter
+    # preserves insertion order, which depends on the input file-list ordering.
+    # to_json(..., sort_keys=True) hides this at serialization, but the
+    # in-memory dict was non-deterministic. Sort by key for both surfaces.
     return {
         "contribution_types": sorted(contribution_types),
         "plugin_paths": sorted(plugin_paths),
@@ -390,7 +445,7 @@ def classify_files(
         "affected_hooks": sorted(affected_hooks),
         "catalog_additions": catalog_additions,
         "sources_additions": sources_additions,
-        "file_categories": dict(file_categories),
+        "file_categories": dict(sorted(file_categories.items())),
         "touches_workflows": touches_workflows,
         "touches_frontend": touches_frontend,
         "touches_scripts": touches_scripts,

--- a/scripts/pr-classifier/rules.py
+++ b/scripts/pr-classifier/rules.py
@@ -24,47 +24,50 @@ from typing import Any
 
 
 RULE_DESCRIPTIONS: tuple[tuple[str, str], ...] = (
-    ("skill",
-     "Matches plugins/<category>/<plugin>/skills/<skill-name>/SKILL.md "
-     "(depth-4 file under skills/). Each match adds <skill-name> to "
-     "affected_skills."),
-    ("agent",
-     "Matches plugins/<category>/<plugin>/agents/<agent>.md. Each match "
-     "adds <agent> to affected_agents."),
-    ("mcp",
-     "Matches plugins/mcp/<name>/** OR plugins/<category>/<plugin>/.mcp.json "
-     "OR plugins/<category>/<plugin>/mcpServers/**. Each match adds the "
-     "MCP server identifier to affected_mcp."),
-    ("hook",
-     "Matches plugins/<category>/<plugin>/hooks/hooks.json. Each match "
-     "adds the plugin to affected_hooks."),
-    ("plugin",
-     "ANY change inside plugins/<category>/<plugin>/ — adds the plugin path "
-     "to plugin_paths. Subset markers (skill/agent/mcp/hook) are independent."),
-    ("catalog_add",
-     "Catches additions to .claude-plugin/marketplace.extended.json that "
-     "introduce new top-level plugin entries — parsed from the diff to "
-     "capture name + source + category."),
-    ("sources_add",
-     "Catches additions to sources.yaml that introduce new entries for "
-     "external source synchronization."),
-    ("ci",
-     "Touches .github/workflows/*.yml or .github/workflows/*.yaml. Marks "
-     "touches_workflows: true."),
-    ("frontend",
-     "Touches marketplace/src/** — Astro frontend. Marks touches_frontend: true."),
-    ("script",
-     "Touches scripts/** — repo-level Python or Node scripts. Marks "
-     "touches_scripts: true."),
-    ("doc",
-     "Touches *.md or *.mdx files OUTSIDE any plugin directory (top-level "
-     "docs, contributing guides, README, etc.). Plugin-internal docs are "
-     "captured under the plugin marker, not as standalone doc."),
-    ("test",
-     "Touches tests/** or **/tests/** or test_*.py — test-only changes."),
-    ("unknown",
-     "Set to true when at least one file in the input list matched no rule. "
-     "Surfaces unrecognized patterns for ruleset extension."),
+    (
+        "skill",
+        "Matches plugins/<category>/<plugin>/skills/<skill-name>/SKILL.md "
+        "(depth-4 file under skills/). Each match adds <skill-name> to "
+        "affected_skills.",
+    ),
+    ("agent", "Matches plugins/<category>/<plugin>/agents/<agent>.md. Each match adds <agent> to affected_agents."),
+    (
+        "mcp",
+        "Matches plugins/mcp/<name>/** OR plugins/<category>/<plugin>/.mcp.json "
+        "OR plugins/<category>/<plugin>/mcpServers/**. Each match adds the "
+        "MCP server identifier to affected_mcp.",
+    ),
+    ("hook", "Matches plugins/<category>/<plugin>/hooks/hooks.json. Each match adds the plugin to affected_hooks."),
+    (
+        "plugin",
+        "ANY change inside plugins/<category>/<plugin>/ — adds the plugin path "
+        "to plugin_paths. Subset markers (skill/agent/mcp/hook) are independent.",
+    ),
+    (
+        "catalog_add",
+        "Catches additions to .claude-plugin/marketplace.extended.json that "
+        "introduce new top-level plugin entries — parsed from the diff to "
+        "capture name + source + category.",
+    ),
+    (
+        "sources_add",
+        "Catches additions to sources.yaml that introduce new entries for external source synchronization.",
+    ),
+    ("ci", "Touches .github/workflows/*.yml or .github/workflows/*.yaml. Marks touches_workflows: true."),
+    ("frontend", "Touches marketplace/src/** — Astro frontend. Marks touches_frontend: true."),
+    ("script", "Touches scripts/** — repo-level Python or Node scripts. Marks touches_scripts: true."),
+    (
+        "doc",
+        "Touches *.md or *.mdx files OUTSIDE any plugin directory (top-level "
+        "docs, contributing guides, README, etc.). Plugin-internal docs are "
+        "captured under the plugin marker, not as standalone doc.",
+    ),
+    ("test", "Touches tests/** or **/tests/** or test_*.py — test-only changes."),
+    (
+        "unknown",
+        "Set to true when at least one file in the input list matched no rule. "
+        "Surfaces unrecognized patterns for ruleset extension.",
+    ),
 )
 
 
@@ -91,9 +94,7 @@ def _file_extension(path: PurePosixPath) -> str:
 # --- Catalog diff parsing ---------------------------------------------------
 
 
-_CATALOG_ENTRY_OBJECT = re.compile(
-    r'^\+\s*\{\s*$|^\+\s*\{\s*"name"\s*:\s*"(?P<inline_name>[^"]+)"', re.M
-)
+_CATALOG_ENTRY_OBJECT = re.compile(r'^\+\s*\{\s*$|^\+\s*\{\s*"name"\s*:\s*"(?P<inline_name>[^"]+)"', re.M)
 
 
 def _count_unquoted_braces(text: str) -> tuple[int, int]:
@@ -250,9 +251,7 @@ def parse_sources_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
 # --- Main classifier --------------------------------------------------------
 
 
-def classify_files(
-    files: list[str], diff_text: str | None = None
-) -> dict[str, Any]:
+def classify_files(files: list[str], diff_text: str | None = None) -> dict[str, Any]:
     """Apply the ruleset to a list of changed files.
 
     Args:
@@ -308,12 +307,7 @@ def classify_files(
 
             # Agent match: <plugin-root>/agents/<agent>.md at ANY depth
             # (same depth-flex fix as skills above).
-            elif (
-                len(path.parts) >= 2
-                and ext == "md"
-                and len(path.parts) >= 3
-                and path.parts[-2] == "agents"
-            ):
+            elif len(path.parts) >= 2 and ext == "md" and len(path.parts) >= 3 and path.parts[-2] == "agents":
                 affected_agents.add(path.parts[-1].rsplit(".", 1)[0])
                 contribution_types.add("agent")
 
@@ -324,29 +318,18 @@ def classify_files(
             elif path.name == ".mcp.json":
                 affected_mcp.add(plugin_root.split("/")[-1])
                 contribution_types.add("mcp")
-            elif (
-                len(path.parts) >= 5
-                and path.parts[3] == "mcpServers"
-            ):
+            elif len(path.parts) >= 5 and path.parts[3] == "mcpServers":
                 affected_mcp.add(plugin_root.split("/")[-1])
                 contribution_types.add("mcp")
 
             # Hooks
-            if (
-                len(path.parts) >= 5
-                and path.parts[3] == "hooks"
-                and path.name == "hooks.json"
-            ):
+            if len(path.parts) >= 5 and path.parts[3] == "hooks" and path.name == "hooks.json":
                 affected_hooks.add(plugin_root.split("/")[-1])
                 contribution_types.add("hook")
 
         # --- Non-plugin matches ---
         if path.parts and path.parts[0] == ".github":
-            if (
-                len(path.parts) >= 3
-                and path.parts[1] == "workflows"
-                and ext in ("yml", "yaml")
-            ):
+            if len(path.parts) >= 3 and path.parts[1] == "workflows" and ext in ("yml", "yaml"):
                 touches_workflows = True
                 contribution_types.add("ci")
                 matched = True
@@ -363,14 +346,7 @@ def classify_files(
             matched = True
 
         # Tests
-        if (
-            path.parts
-            and (
-                path.parts[0] == "tests"
-                or "tests" in path.parts
-                or path.name.startswith("test_")
-            )
-        ):
+        if path.parts and (path.parts[0] == "tests" or "tests" in path.parts or path.name.startswith("test_")):
             touches_tests = True
             contribution_types.add("test")
             matched = True
@@ -378,10 +354,7 @@ def classify_files(
         # Standalone docs (md/mdx outside any plugin)
         if ext in ("md", "mdx") and plugin_root is None:
             is_frontend_doc = (
-                path.parts
-                and path.parts[0] == "marketplace"
-                and len(path.parts) >= 2
-                and path.parts[1] == "src"
+                path.parts and path.parts[0] == "marketplace" and len(path.parts) >= 2 and path.parts[1] == "src"
             )
             if path.parts and path.parts[0] in ("000-docs", "docs"):
                 contribution_types.add("doc")
@@ -412,9 +385,7 @@ def classify_files(
             matched = True
 
         # sources.yaml touch
-        if path.parts == ("sources.yaml",) or (
-            len(path.parts) == 1 and path.name == "sources.yaml"
-        ):
+        if path.parts == ("sources.yaml",) or (len(path.parts) == 1 and path.name == "sources.yaml"):
             contribution_types.add("sources")
             matched = True
 

--- a/scripts/pr-classifier/rules.py
+++ b/scripts/pr-classifier/rules.py
@@ -1,0 +1,407 @@
+"""Deterministic file-path → component-type classification rules.
+
+This module is the entire ruleset. The classifier is just the
+application of these rules over a file list.
+
+Adding a new contribution type means:
+    1. Add a row to RULE_DESCRIPTIONS describing the rule.
+    2. Add the detection logic to classify_files().
+    3. Add a unit test in tests/pr-classifier/test_classifier.py.
+
+Don't add detection logic without a corresponding rule description —
+the description IS the audit trail for why a file got classified.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import PurePosixPath
+from typing import Any
+
+# --- Rule descriptions ------------------------------------------------------
+
+
+RULE_DESCRIPTIONS: tuple[tuple[str, str], ...] = (
+    ("skill",
+     "Matches plugins/<category>/<plugin>/skills/<skill-name>/SKILL.md "
+     "(depth-4 file under skills/). Each match adds <skill-name> to "
+     "affected_skills."),
+    ("agent",
+     "Matches plugins/<category>/<plugin>/agents/<agent>.md. Each match "
+     "adds <agent> to affected_agents."),
+    ("mcp",
+     "Matches plugins/mcp/<name>/** OR plugins/<category>/<plugin>/.mcp.json "
+     "OR plugins/<category>/<plugin>/mcpServers/**. Each match adds the "
+     "MCP server identifier to affected_mcp."),
+    ("hook",
+     "Matches plugins/<category>/<plugin>/hooks/hooks.json. Each match "
+     "adds the plugin to affected_hooks."),
+    ("plugin",
+     "ANY change inside plugins/<category>/<plugin>/ — adds the plugin path "
+     "to plugin_paths. Subset markers (skill/agent/mcp/hook) are independent."),
+    ("catalog_add",
+     "Catches additions to .claude-plugin/marketplace.extended.json that "
+     "introduce new top-level plugin entries — parsed from the diff to "
+     "capture name + source + category."),
+    ("sources_add",
+     "Catches additions to sources.yaml that introduce new entries for "
+     "external source synchronization."),
+    ("ci",
+     "Touches .github/workflows/*.yml or .github/workflows/*.yaml. Marks "
+     "touches_workflows: true."),
+    ("frontend",
+     "Touches marketplace/src/** — Astro frontend. Marks touches_frontend: true."),
+    ("script",
+     "Touches scripts/** — repo-level Python or Node scripts. Marks "
+     "touches_scripts: true."),
+    ("doc",
+     "Touches *.md or *.mdx files OUTSIDE any plugin directory (top-level "
+     "docs, contributing guides, README, etc.). Plugin-internal docs are "
+     "captured under the plugin marker, not as standalone doc."),
+    ("test",
+     "Touches tests/** or **/tests/** or test_*.py — test-only changes."),
+    ("unknown",
+     "Set to true when at least one file in the input list matched no rule. "
+     "Surfaces unrecognized patterns for ruleset extension."),
+)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _is_plugin_path(path: PurePosixPath) -> bool:
+    """plugins/<cat>/<name>/... — at least 3 parts under plugins/"""
+    return len(path.parts) >= 3 and path.parts[0] == "plugins"
+
+
+def _plugin_root(path: PurePosixPath) -> str | None:
+    """Return 'plugins/<cat>/<name>' for a file under that tree, else None."""
+    if not _is_plugin_path(path):
+        return None
+    return "/".join(path.parts[:3])
+
+
+def _file_extension(path: PurePosixPath) -> str:
+    suffix = path.suffix.lower().lstrip(".")
+    return suffix or "(none)"
+
+
+# --- Catalog diff parsing ---------------------------------------------------
+
+
+_CATALOG_ENTRY_OBJECT = re.compile(
+    r'^\+\s*\{\s*$|^\+\s*\{\s*"name"\s*:\s*"(?P<inline_name>[^"]+)"', re.M
+)
+
+
+def parse_catalog_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
+    """Extract added catalog entries from a unified-diff text.
+
+    Looks for added object blocks within `.claude-plugin/marketplace.extended.json`
+    diff chunks. Captures `name`, `source`, and `category` when present.
+
+    Returns one dict per added entry. Order matches diff order.
+    """
+    if "marketplace.extended.json" not in diff_text:
+        return []
+
+    out: list[dict[str, str]] = []
+    in_catalog_diff = False
+    current: dict[str, str] = {}
+    open_brace_depth = 0
+    in_added_block = False
+
+    for line in diff_text.splitlines():
+        # Track when we're inside a catalog file's diff hunk
+        if line.startswith("diff --git ") and "marketplace.extended.json" in line:
+            in_catalog_diff = True
+            continue
+        if line.startswith("diff --git ") and "marketplace.extended.json" not in line:
+            in_catalog_diff = False
+            continue
+        if not in_catalog_diff:
+            continue
+
+        # Only consider added lines
+        if not line.startswith("+") or line.startswith("+++"):
+            # Closing brace ends an added block we were tracking
+            if in_added_block and line.startswith(" ") and "}" in line:
+                if current:
+                    out.append(dict(current))
+                current = {}
+                in_added_block = False
+                open_brace_depth = 0
+            continue
+
+        added_content = line[1:].strip()
+
+        if "{" in added_content and not in_added_block:
+            in_added_block = True
+            open_brace_depth = added_content.count("{") - added_content.count("}")
+            current = {}
+            continue
+
+        if in_added_block:
+            open_brace_depth += added_content.count("{") - added_content.count("}")
+            for field in ("name", "source", "category", "version"):
+                m = re.match(rf'^"{field}"\s*:\s*"([^"]+)"', added_content)
+                if m:
+                    current[field] = m.group(1)
+            if open_brace_depth <= 0:
+                if current:
+                    out.append(dict(current))
+                current = {}
+                in_added_block = False
+
+    return out
+
+
+def parse_sources_additions_from_diff(diff_text: str) -> list[dict[str, str]]:
+    """Extract added entries from sources.yaml diff text.
+
+    Captures top-level YAML entries that look like `- name: foo` or
+    `- repo: foo/bar` additions.
+    """
+    if "sources.yaml" not in diff_text:
+        return []
+
+    out: list[dict[str, str]] = []
+    in_sources_diff = False
+    current: dict[str, str] = {}
+
+    def flush() -> None:
+        nonlocal current
+        if current:
+            out.append(dict(current))
+            current = {}
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git ") and "sources.yaml" in line:
+            in_sources_diff = True
+            continue
+        if line.startswith("diff --git ") and "sources.yaml" not in line:
+            in_sources_diff = False
+            flush()
+            continue
+        if not in_sources_diff:
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        content = line[1:]
+        if content.startswith("- "):
+            flush()
+            kv = content[2:].strip()
+            if ":" in kv:
+                k, _, v = kv.partition(":")
+                current[k.strip()] = v.strip().strip('"').strip("'")
+        elif content.startswith("  ") and ":" in content:
+            kv = content.strip()
+            k, _, v = kv.partition(":")
+            current[k.strip()] = v.strip().strip('"').strip("'")
+    flush()
+    return out
+
+
+# --- Main classifier --------------------------------------------------------
+
+
+def classify_files(
+    files: list[str], diff_text: str | None = None
+) -> dict[str, Any]:
+    """Apply the ruleset to a list of changed files.
+
+    Args:
+        files: list of repo-relative file paths (forward-slash).
+        diff_text: optional unified diff text; required for catalog/sources
+            additions to be detected. Without it, catalog_additions and
+            sources_additions will always be empty.
+
+    Returns the structured classification dict described in RULE_DESCRIPTIONS.
+    """
+    contribution_types: set[str] = set()
+    plugin_paths: set[str] = set()
+    affected_skills: set[str] = set()
+    affected_agents: set[str] = set()
+    affected_mcp: set[str] = set()
+    affected_hooks: set[str] = set()
+    file_categories: Counter[str] = Counter()
+    touches_workflows = False
+    touches_frontend = False
+    touches_scripts = False
+    touches_tests = False
+    unmatched: list[str] = []
+
+    for raw in files:
+        if not raw:
+            continue
+        path = PurePosixPath(raw)
+        matched = False
+        ext = _file_extension(path)
+        file_categories[ext] += 1
+
+        # --- Plugin-internal matches ---
+        plugin_root = _plugin_root(path)
+        if plugin_root is not None:
+            plugin_paths.add(plugin_root)
+            contribution_types.add("plugin")
+            matched = True
+
+            # depth-4 skill: plugins/<cat>/<name>/skills/<skill>/SKILL.md
+            if (
+                len(path.parts) >= 6
+                and path.parts[3] == "skills"
+                and path.parts[-1] == "SKILL.md"
+            ):
+                affected_skills.add(path.parts[4])
+                contribution_types.add("skill")
+
+            # plugins/<cat>/<name>/agents/<agent>.md
+            elif (
+                len(path.parts) == 5
+                and path.parts[3] == "agents"
+                and ext == "md"
+            ):
+                affected_agents.add(path.parts[4].rsplit(".", 1)[0])
+                contribution_types.add("agent")
+
+            # MCP — either plugins/mcp/<name>/** or .mcp.json or mcpServers
+            if path.parts[1] == "mcp":
+                affected_mcp.add(path.parts[2])
+                contribution_types.add("mcp")
+            elif path.name == ".mcp.json":
+                affected_mcp.add(plugin_root.split("/")[-1])
+                contribution_types.add("mcp")
+            elif (
+                len(path.parts) >= 5
+                and path.parts[3] == "mcpServers"
+            ):
+                affected_mcp.add(plugin_root.split("/")[-1])
+                contribution_types.add("mcp")
+
+            # Hooks
+            if (
+                len(path.parts) >= 5
+                and path.parts[3] == "hooks"
+                and path.name == "hooks.json"
+            ):
+                affected_hooks.add(plugin_root.split("/")[-1])
+                contribution_types.add("hook")
+
+        # --- Non-plugin matches ---
+        if path.parts and path.parts[0] == ".github":
+            if (
+                len(path.parts) >= 3
+                and path.parts[1] == "workflows"
+                and ext in ("yml", "yaml")
+            ):
+                touches_workflows = True
+                contribution_types.add("ci")
+                matched = True
+
+        if path.parts and path.parts[0] == "marketplace":
+            if len(path.parts) >= 3 and path.parts[1] == "src":
+                touches_frontend = True
+                contribution_types.add("frontend")
+                matched = True
+
+        if path.parts and path.parts[0] == "scripts":
+            touches_scripts = True
+            contribution_types.add("script")
+            matched = True
+
+        # Tests
+        if (
+            path.parts
+            and (
+                path.parts[0] == "tests"
+                or "tests" in path.parts
+                or path.name.startswith("test_")
+            )
+        ):
+            touches_tests = True
+            contribution_types.add("test")
+            matched = True
+
+        # Standalone docs (md/mdx outside any plugin)
+        if ext in ("md", "mdx") and plugin_root is None:
+            is_frontend_doc = (
+                path.parts
+                and path.parts[0] == "marketplace"
+                and len(path.parts) >= 2
+                and path.parts[1] == "src"
+            )
+            if path.parts and path.parts[0] in ("000-docs", "docs"):
+                contribution_types.add("doc")
+                matched = True
+            elif len(path.parts) == 1:
+                contribution_types.add("doc")
+                matched = True
+            elif path.parts[0] in (".github", "scripts", "tests"):
+                # CI / script / test docs stay under their own category
+                pass
+            elif is_frontend_doc:
+                # marketplace/src/**.md is content under the frontend route tree;
+                # the frontend marker already fired so don't double-classify.
+                pass
+            else:
+                # marketplace/<not src>/**.md and any other top-level dir's docs
+                contribution_types.add("doc")
+                matched = True
+
+        # Catalog file itself (without being a catalog-add: we detect that
+        # via diff parsing, but a touch is still classified).
+        if (
+            len(path.parts) >= 2
+            and path.parts[0] == ".claude-plugin"
+            and path.name in ("marketplace.extended.json", "marketplace.json")
+        ):
+            contribution_types.add("catalog")
+            matched = True
+
+        # sources.yaml touch
+        if path.parts == ("sources.yaml",) or (
+            len(path.parts) == 1 and path.name == "sources.yaml"
+        ):
+            contribution_types.add("sources")
+            matched = True
+
+        if not matched:
+            unmatched.append(raw)
+
+    # --- Catalog + sources diff parsing ---
+    catalog_additions: list[dict[str, str]] = []
+    sources_additions: list[dict[str, str]] = []
+    if diff_text:
+        catalog_additions = parse_catalog_additions_from_diff(diff_text)
+        sources_additions = parse_sources_additions_from_diff(diff_text)
+        if catalog_additions:
+            contribution_types.add("catalog_add")
+        if sources_additions:
+            contribution_types.add("sources_add")
+
+    return {
+        "contribution_types": sorted(contribution_types),
+        "plugin_paths": sorted(plugin_paths),
+        "affected_skills": sorted(affected_skills),
+        "affected_agents": sorted(affected_agents),
+        "affected_mcp": sorted(affected_mcp),
+        "affected_hooks": sorted(affected_hooks),
+        "catalog_additions": catalog_additions,
+        "sources_additions": sources_additions,
+        "file_categories": dict(file_categories),
+        "touches_workflows": touches_workflows,
+        "touches_frontend": touches_frontend,
+        "touches_scripts": touches_scripts,
+        "touches_tests": touches_tests,
+        "unknown": len(unmatched) > 0,
+        "unmatched": sorted(unmatched),
+    }
+
+
+def to_json(result: dict[str, Any], pretty: bool = False) -> str:
+    """Render a classify_files() result as JSON."""
+    if pretty:
+        return json.dumps(result, indent=2, sort_keys=True)
+    return json.dumps(result, sort_keys=True)

--- a/tests/pr-classifier/fixtures/pr-823.diff
+++ b/tests/pr-classifier/fixtures/pr-823.diff
@@ -1,0 +1,599 @@
+diff --git a/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md b/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
+index 10018395c..2fa36bab3 100644
+--- a/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
++++ b/plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
+@@ -1,8 +1,8 @@
+ # 000-docs Index — databricks-pack
+ 
+ **Filing standard:** Document Filing System v4.3
+-**Last updated:** 2026-05-27 (added 010-013 — MCP landscape research + Epic 1 scope adjustment; Claude Code changelog impact moved to repo-root 000-docs as repo-wide AT-ADEC)
+-**Total docs:** 13
++**Last updated:** 2026-06-03 (added 014 — cost-leak CFO output spec draft for Yipei Wei review)
++**Total docs:** 14
+ 
+ ---
+ 
+@@ -41,6 +41,12 @@
+ | 008 | `008-RA-REVW-pack-handling-pressure-test.md` | Adversarial review of pack-handling decision — MODIFY verdict (add deprecation lane + tombstones) |
+ | 009 | `009-RA-REVW-pilot-timing-pressure-test.md` | Adversarial review of pilot/timing decision — MODIFY verdict (cut scope to 3 pains, MCP first, drop opus eval) |
+ 
++## DR — Design Records
++
++| # | File | Description |
++|---|---|---|
++| 014 | `014-DR-DRFT-cost-leak-cfo-output-spec.md` | DRAFT: cost-leak-hunter CFO-grokkable output format spec. 4 detection categories, headline + evidence structure, rendering order, rounding rules. Pending review by @Gingiris-1031 ([#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795)). Becomes binding output contract once approved. |
++
+ ---
+ 
+ ## Quick reference — doc codes used
+@@ -51,3 +57,4 @@
+ | RL | Research & Learning | RSRC | Research resource |
+ | AT | Architecture & Technical | ADEC | Architecture decision |
+ | RA | Reports & Analysis | REVW | Review / critique |
++| DR | Design Records | DRFT | Draft pending review |
+diff --git a/plugins/saas-packs/databricks-pack/000-docs/014-DR-DRFT-cost-leak-cfo-output-spec.md b/plugins/saas-packs/databricks-pack/000-docs/014-DR-DRFT-cost-leak-cfo-output-spec.md
+new file mode 100644
+index 000000000..98c366068
+--- /dev/null
++++ b/plugins/saas-packs/databricks-pack/000-docs/014-DR-DRFT-cost-leak-cfo-output-spec.md
+@@ -0,0 +1,219 @@
++# 014-DR-DRFT — Cost-leak output spec for CFO audience (draft for @Gingiris-1031 review)
++
++> Status: **DRAFT** — pending review by Yipei Wei ([#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795) thread).
++> If she signs off, this becomes the binding output contract for `databricks-cost-leak-hunter` and code shipping starts. If she doesn't, redesign before code.
++>
++> Related: [#790](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/790) (skill issue), [`007-AT-ADEC § Decision 2`](007-AT-ADEC-databricks-v2-cto-decision.md) (pilot pick rationale), [`009-RA-REVW`](009-RA-REVW-pilot-timing-pressure-test.md) (pilot timing).
++
++## The bar (Yipei's framing, verbatim)
++
++> "If a CFO can skim it in 90 seconds and say 'we're wasting $X here, fix it' without needing an engineer to translate."
++
++## The structure (Yipei's AFFiNE-derived model)
++
++> "One sentence of what this does + one visual proof it works — for a CFO audience swap the visual for a dollar number with a date range."
++
++For each detected leak category, the output is **one row** following this template:
++
++```
++$X,XXX/month wasted on N <unit>, week of <YYYY-MM-DD>, fix in Y <atomic action>.
++```
++
++Below that one row, an evidence collapse: itemized list with names + per-item dollar figure + the math. The CFO skims rows. The engineer expands evidence when they go to act.
++
++## What gets cut (cannot appear in CFO output)
++
++- Cluster topology diagrams
++- DBU efficiency ratios, utilization percentages
++- Spark UI execution plans
++- Bytes-shuffled, partition counts, Photon stats
++- Any term that requires "what's a DLT pipeline?" context
++- Skill version, runtime version, SDK version
++
++Engineers get those via a separate `--engineer` flag. CFO output is the default.
++
++## The four categories — format + worked example
++
++Each category headline is **one sentence**. CFO reads four headlines + one summary. Time-to-comprehension ≤ 90 seconds.
++
++### 1. All-purpose vs job cluster overspend
++
++**Pain source:** [`002-RL-RSRC § D07`](002-RL-RSRC-databricks-compute-pain-research.md) — production batch workloads on interactive clusters at the 2-4x DBU premium.
++
++**Headline format:**
++```
++$X,XXX/month wasted on N production jobs running on interactive clusters, week of <date>, fix in 3 clicks per job (change cluster type in Jobs UI).
++```
++
++**Worked example:**
++```
++$2,840/month wasted on 7 production jobs running on interactive clusters, week of 2026-05-26, fix in 3 clicks per job (Jobs > [job] > Compute > switch to Job cluster).
++```
++
++**Evidence block (expand for engineer use):**
++
++| Job name | Runs/week | Current DBU/run | Job-cluster DBU/run | Monthly waste |
++|---|---|---|---|---|
++| `bronze-ingest-orders` | 168 | 4.2 (all-purpose) | 1.6 (job) | $1,092 |
++| `gold-attribution-rollup` | 42 | 8.4 | 3.0 | $680 |
++| `feature-store-refresh` | 168 | 2.1 | 0.8 | $546 |
++| `mlflow-experiment-cleanup` | 7 | 12.0 | 4.5 | $315 |
++| `cdc-replication-warehouse` | 168 | 1.4 | 0.5 | $151 |
++| `ds-notebook-orchestrator` | 30 | 3.5 | 1.3 | $33 |
++| `dlt-state-snapshot` | 7 | 6.0 | 2.3 | $23 |
++
++Sum row: $2,840/month total. 7 fixable items.
++
++### 2. Instance pool `min_idle` dual-billing trap
++
++**Pain source:** [`002-RL-RSRC § D09`](002-RL-RSRC-databricks-compute-pain-research.md) — the most-cursed leak in the dataset. Databricks UI shows $0 DBU while the cloud provider bills the underlying VMs 24/7. Invisible until the cloud bill arrives.
++
++**Headline format:**
++```
++$X,XXX/month wasted on N instance pools billing cloud VMs while showing $0 DBU, week of <date>, fix in 1 click per pool (set min_idle = 0).
++```
++
++**Worked example:**
++```
++$1,920/month wasted on 3 instance pools billing cloud VMs while showing $0 DBU, week of 2026-05-26, fix in 1 click per pool (Compute > Pools > [pool] > Min idle instances = 0).
++```
++
++**Evidence block:**
++
++| Pool name | min_idle | Hours idle/week | Cloud VM rate | Monthly waste |
++|---|---|---|---|---|
++| `prod-i3-2xlarge-pool` | 4 | 168 | $0.624/hr | $1,680 |
++| `staging-r5-xlarge-pool` | 2 | 168 | $0.252/hr | $168 |
++| `dev-m5-large-pool` | 1 | 132 | $0.096/hr | $51 |
++
++Sum row: $1,899/month total. 3 fixable items. (The $1,920 in the headline rounds up to the nearest $20 for skim-readability — see "rounding rules" below.)
++
++### 3. DLT serverless misuse
++
++**Pain source:** [`003-RL-RSRC § D08, D11`](003-RL-RSRC-databricks-delta-streaming-research.md) — DLT pipelines on serverless when their usage pattern (steady, predictable, multi-hour) fits classic compute at lower cost. The serverless premium is justified for spiky/short workloads — these aren't those.
++
++**Headline format:**
++```
++$X,XXX/month wasted on N DLT pipelines on serverless that fit classic compute better, week of <date>, fix in 2 clicks per pipeline (toggle serverless off).
++```
++
++**Worked example:**
++```
++$3,400/month wasted on 4 DLT pipelines on serverless that fit classic compute better, week of 2026-05-26, fix in 2 clicks per pipeline (DLT > [pipeline] > Settings > Serverless: off).
++```
++
++**Evidence block:**
++
++| Pipeline | Runtime/week | Pattern | Serverless premium | Monthly waste |
++|---|---|---|---|---|
++| `cdc-ingestion-bronze` | 168h | Steady (24/7) | 1.7x | $1,680 |
++| `silver-dedupe-rollup` | 96h | Steady business hours | 1.7x | $1,008 |
++| `gold-attribution-streaming` | 80h | Predictable peaks | 1.5x | $560 |
++| `feature-store-stream` | 40h | Predictable | 1.5x | $152 |
++
++Sum row: $3,400/month total. 4 fixable items.
++
++**The "fits classic compute better" test:** runtime ≥ 20 hours/week AND coefficient-of-variation in hourly compute load ≤ 0.4 (i.e., not spiky). Pipelines that fail either test stay on serverless and aren't reported.
++
++### 4. Idle SQL warehouse
++
++**Pain source:** [`002-RL-RSRC § D11`](002-RL-RSRC-databricks-compute-pain-research.md) — warehouses left running with auto-stop > 10 min, racking up DBU on idle time.
++
++**Headline format:**
++```
++$X,XXX/month wasted on N SQL warehouses idle but not auto-stopped, week of <date>, fix in 2 clicks per warehouse (set auto-stop = 10 min).
++```
++
++**Worked example:**
++```
++$960/month wasted on 2 SQL warehouses idle but not auto-stopped, week of 2026-05-26, fix in 2 clicks per warehouse (SQL > Warehouses > [warehouse] > Auto stop = 10 min).
++```
++
++**Evidence block:**
++
++| Warehouse | Size | Auto-stop | Idle hours/week | DBU/hour | Monthly waste |
++|---|---|---|---|---|---|
++| `analytics-large` | Large | 60 min | 42h | $4.20 | $740 |
++| `bi-dashboards-small` | Small | None | 28h | $2.10 | $244 |
++
++Sum row: $984/month total. 2 fixable items.
++
++## The summary row (sits at top of output)
++
++**Rollup format:**
++```
++$X,XXX/month total waste across N fixable items, week of <date>, ~Z min to fix all.
++```
++
++**Worked example (using all four sections above):**
++```
++$9,120/month total waste across 16 fixable items, week of 2026-05-26, ~30 min to fix all.
++```
++
++## Rendering order in the actual skill output
++
++```
++$9,120/month total waste across 16 fixable items, week of 2026-05-26, ~30 min to fix all.
++
++  $3,400/mo — 4 DLT pipelines on serverless that fit classic compute better
++  $2,840/mo — 7 production jobs running on interactive clusters
++  $1,920/mo — 3 instance pools billing cloud VMs while showing $0 DBU
++  $  960/mo — 2 SQL warehouses idle but not auto-stopped
++
++Expand any line above for the per-item evidence + the click path to fix.
++```
++
++Headline at top (the conversion moment). Four rows sorted highest waste → lowest (the CFO reads top-down and stops where the dollars stop being interesting). Single literal instruction at the bottom (the engineer trigger).
++
++## Rounding rules
++
++- Sum rows: round to **nearest $20** for skim-readability.
++- Per-item evidence: report exact (no rounding) — engineer trusts it precisely.
++- The headline number is always the rounded sum; the evidence-block sum is exact. Footnote IF the two differ by more than $40 (rare; happens only when many items round same direction).
++
++## Date range semantics
++
++- "Week of \<date>" = the 7-day window ending the last completed calendar week (Sunday).
++- Data source: `system.billing.usage` rows for that window.
++- We never extrapolate. We never project. We report observed waste in the window — extrapolated to monthly via `× 4.33`.
++- Multi-week consistency: if the same leak appears 3+ weeks running, the next iteration of this skill (out of scope for v1) starts surfacing trend annotations. v1 ships the single-week view only.
++
++## What we are NOT shipping in v1
++
++- Trend / longitudinal analysis (≥3 week pattern detection)
++- Comparison-to-peer or industry-benchmark numbers
++- Predicted-savings simulation (changes are reported as observed waste, not projected)
++- Multi-workspace rollup (single workspace per invocation; teams with N workspaces run N times)
++- Cost attribution to teams / projects / cost-centers (Databricks tags exist; using them is its own design problem)
++
++If any of these matter to the CFO test, surface in the review and we cut differently.
++
++## Questions back at Yipei
++
++1. **Headline word count.** Each headline is ~16-22 words. AFFiNE's "one sentence" — does a 22-word sentence still pass the skim test, or does it need to be shorter? Sample shortest version of #2 above: *"$1,920/month wasted on 3 idle instance pools, week of 2026-05-26, 1 click each to fix"* — 18 words. Worth it, or does losing "dual-billing trap" lose the WHY a CFO needs?
++
++2. **Rounding readability.** Is rounding to $20 the right granularity for skim, or does $100 work better? My instinct said $20; user-testing might prefer $100 for round-number cognitive load.
++
++3. **Click count semantics.** "fix in 3 clicks" is literal-clicks-in-the-Databricks-UI. Should that be navigation-clicks only, or include the confirm-dialog click? My count includes the confirm because it's part of the fix; some readers might expect "3 navigation steps + a confirm."
++
++4. **Sort order.** Currently sorted highest waste → lowest. Alternative: sort by "easiest to fix first" (the `min_idle = 0` single-click row would lead, even though it's not the biggest dollar number). Adoption thesis: do CFOs want biggest-impact-first, or do they want fastest-quick-wins-first to build momentum?
++
++5. **Anything missing from the four categories.** These four came out of the pain research ([`002`](002-RL-RSRC-databricks-compute-pain-research.md), [`003`](003-RL-RSRC-databricks-delta-streaming-research.md)) being most-cursed AND most-detectable from `system.billing.usage` + control-plane reads. Other categories exist (DBU-per-query tuning, Photon-without-vectorized-operators, etc.) but require deeper sampling. If you've seen a fifth category that beats one of these on the 90-second test, swap recommendation welcome.
++
++## Sign-off block
++
++When this draft passes your review, mark below:
++
++- [ ] @Gingiris-1031 — headline format + structure approved
++- [ ] @Gingiris-1031 — four categories cover the right surface
++- [ ] @Gingiris-1031 — open questions answered (or accepted as-is)
++- [ ] Jeremy — code work greenlit, bead `claude-0co4` closes, skill build proceeds against this spec
++
++If you redline anywhere above, send the redline however works (here on the issue, on `claude-0co4`, voice memo). Spec becomes the binding output contract once all four boxes check.
++
++---
++
++**File status:** draft — superseded only by a successor `014-AT-ADEC-cost-leak-output-contract.md` once approved.
++**Author:** Jeremy Longshore (Intent Solutions)
++**Reviewer:** Iris Wei ([@Gingiris-1031](https://github.com/Gingiris-1031))
++**Created:** 2026-06-03
+diff --git a/plugins/saas-packs/databricks-pack/package.json b/plugins/saas-packs/databricks-pack/package.json
+index 64e92ef5d..a69a7b7d9 100644
+--- a/plugins/saas-packs/databricks-pack/package.json
++++ b/plugins/saas-packs/databricks-pack/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "@intentsolutionsio/databricks-pack",
+-  "version": "1.0.5",
++  "version": "1.0.7",
+   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
+   "main": "README.md",
+   "type": "module",
+diff --git a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
+index 20b638943..d8e7e1e60 100644
+--- a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
++++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
+@@ -12,8 +12,9 @@ description: 'Execute Databricks incident response procedures with triage, mitig
+   "databricks down", "databricks on-call", "databricks emergency", "job failed".
+ 
+   '
+-allowed-tools: Read, Grep, Bash(databricks:*), Bash(curl:*)
+-version: 1.0.0
++allowed-tools: Bash(databricks:*), Bash(curl:*), Bash(jq:*)
++argument-hint: '[severity] [job_id?]'
++version: 1.0.1
+ license: MIT
+ author: Jeremy Longshore <jeremy@intentsolutions.io>
+ tags:
+@@ -37,6 +38,22 @@ Rapid incident response for Databricks: triage script, decision tree, immediate
+ | P3 | Non-critical issues | < 4 hours | Dev cluster issues, non-critical job delays |
+ | P4 | No user impact | Next business day | Monitoring gaps, cleanup needed |
+ 
++## Prerequisites
++
++Before this runbook runs, the responder must have:
++
++- **Databricks CLI v2** installed and on PATH (`databricks --version` returns ≥ 0.200.0). Install: `pip install databricks-cli` or `brew install databricks/tap/databricks-cli`.
++- **Authentication** to the affected workspace via one of:
++  - **PAT** (Personal Access Token) — `databricks configure --token`, paste a token from the workspace User Settings → Developer → Access Tokens page. Fastest for on-call; OK for short-lived incident sessions.
++  - **OAuth U2M** — `databricks auth login --host https://<workspace>.cloud.databricks.com` for human-in-the-loop sessions with auto-refresh.
++  - **OAuth M2M** — service principal client-credentials grant, for automated incident bots; env vars `DATABRICKS_CLIENT_ID` + `DATABRICKS_CLIENT_SECRET`.
++- **`jq`** on PATH (used to parse JSON from CLI output and status APIs). Install: `apt install jq` or `brew install jq`.
++- **`curl`** on PATH (used to hit `status.databricks.com` and internal status pages). Comes standard on every modern Linux/macOS install.
++- **Read permission** on the workspace's job runs + cluster events (granted by default to anyone with workspace access; not all workspaces enable strict RBAC). Without it the triage script returns empty `runs[]` arrays even when failures exist.
++- **Workspace URL + workspace ID** known and recorded in the incident ticket — needed for the comms templates in `## Examples`.
++
++If any of these is missing, fix it before starting triage. Running this skill without auth produces misleading output ("API: UNREACHABLE") that wastes early-incident minutes.
++
+ ## Instructions
+ 
+ ### Step 1: Quick Triage (Run First)
+@@ -132,7 +149,7 @@ databricks runs get --run-id $RUN_ID | jq '{
+ # Get task output for failed tasks
+ databricks runs get-output --run-id $RUN_ID | jq '{
+   error: .error,
+-  trace: (.error_trace // "" | .[0:1000])
++  trace: (.error_trace // "" | .[0:1000])  # cap trace at 1000 chars so the postmortem payload stays under Slack's 4KB block limit and Datadog's 8KB event limit
+ }'
+ 
+ # Repair failed tasks only (skip successful ones)
+@@ -178,88 +195,15 @@ databricks permissions update jobs --job-id $JOB_ID --json '{
+ 
+ ### Step 4: Communication
+ 
+-#### Internal (Slack)
+-
+-```
+-:red_circle: **P1 INCIDENT: [Brief Description]**
+-
+-**Status:** INVESTIGATING
+-**Impact:** [What data/users are affected]
+-**Started:** [Time UTC]
+-**Current Action:** [What you're doing now]
+-**Next Update:** [+30 min]
+-
+-**IC:** @[your-name]
+-```
+-
+-#### External (Status Page)
+-
+-```
+-**Data Pipeline Delay**
+-We are experiencing delays in data processing.
+-Dashboard data may be up to [X] hours stale.
+-Started: [Time] UTC
+-Status: Actively investigating
+-Next update: [Time] UTC
+-```
++Post the internal Slack and external status-page updates. **Templates with cadence rules + executive-escalation form** are in [`references/communication-templates.md`](references/communication-templates.md). Copy the bracketed-field versions; consistency matters more than artistry under incident pressure.
+ 
+ ### Step 5: Evidence Collection
+ 
+-```bash
+-#!/bin/bash
+-INCIDENT_ID=$1
+-RUN_ID=$2
+-CLUSTER_ID=$3
+-
+-mkdir -p "incident-$INCIDENT_ID"
+-
+-# Collect everything
+-databricks runs get --run-id $RUN_ID --output json > "incident-$INCIDENT_ID/run.json" 2>&1
+-databricks runs get-output --run-id $RUN_ID --output json > "incident-$INCIDENT_ID/output.json" 2>&1
+-
+-if [ -n "$CLUSTER_ID" ]; then
+-    databricks clusters get --cluster-id $CLUSTER_ID --output json > "incident-$INCIDENT_ID/cluster.json" 2>&1
+-    databricks clusters events --cluster-id $CLUSTER_ID --limit 50 --output json > "incident-$INCIDENT_ID/events.json" 2>&1
+-fi
+-
+-tar -czf "incident-$INCIDENT_ID.tar.gz" "incident-$INCIDENT_ID"
+-echo "Evidence: incident-$INCIDENT_ID.tar.gz"
+-```
+-
+-### Step 6: Postmortem Template
+-
+-```markdown
+-## Incident: [Title]
+-
+-**Date:** YYYY-MM-DD | **Duration:** Xh Ym | **Severity:** P[1-4]
+-**IC:** [Name]
+-
+-### Summary
+-[1-2 sentences: what happened and what was the impact]
++Run the evidence-collection script to bundle `run.json` + `output.json` + (if cluster-side failure) `cluster.json` + `events.json` into a tarball for the postmortem. **Script + per-artifact reference** in [`references/evidence-collection.md`](references/evidence-collection.md).
+ 
+-### Timeline (UTC)
+-| Time | Event |
+-|------|-------|
+-| HH:MM | Alert fired / issue detected |
+-| HH:MM | Investigation started |
+-| HH:MM | Root cause identified |
+-| HH:MM | Mitigation applied |
+-| HH:MM | Resolved |
++### Step 6: Postmortem
+ 
+-### Root Cause
+-[Technical explanation]
+-
+-### Impact
+-- Tables affected: [list]
+-- Data staleness: [hours]
+-- Users affected: [count/teams]
+-
+-### Action Items
+-| Priority | Action | Owner | Due |
+-|----------|--------|-------|-----|
+-| P1 | [Preventive fix] | [Name] | [Date] |
+-| P2 | [Monitoring gap] | [Name] | [Date] |
+-```
++Fill in the postmortem template within 48 hours of resolution. Archive to your team's incident-archive at `/incidents/<YYYY-MM-DD>-<slug>.md`. **Template + blameless-doc rules** in [`references/postmortem-template.md`](references/postmortem-template.md).
+ 
+ ## Output
+ 
+@@ -302,4 +246,8 @@ databricks runs list --job-id $JID --active-only | jq -r '.runs[].run_id' | \
+ 
+ ## Next Steps
+ 
+-For data handling and compliance, see `databricks-data-handling`.
++- **For data handling + compliance** (GDPR deletion, PII masking, retention) post-incident: see `databricks-data-handling`.
++- **For root-cause analysis on cluster-side failures** (OOM, cold starts, spot interruptions): see `databricks-cluster-forensics` once that skill ships in v2.
++- **For cost-impact accounting** of the incident window (job-cluster restarts, all-purpose-cluster fallbacks during the outage): see `databricks-cost-leak-hunter` (pilot v2 skill).
++- **For permanent observability** so the next incident gets caught earlier: see `databricks-observability` for system-table alerting + Prometheus integration.
++- **Postmortem template** is `## Output` § 4 above; archive completed postmortems to the team's incident-archive tag in the workspace (`/incidents/<YYYY-MM-DD>-<slug>.md`).
+diff --git a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/communication-templates.md b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/communication-templates.md
+new file mode 100644
+index 000000000..b1c593d98
+--- /dev/null
++++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/communication-templates.md
+@@ -0,0 +1,50 @@
++# Communication templates
++
++Copy-paste these. Fill in the bracketed fields. Don't customize beyond the brackets unless you've run an incident before — consistency across responders matters more than artistry.
++
++## Internal — Slack
++
++```
++:red_circle: **P1 INCIDENT: [Brief Description]**
++
++**Status:** INVESTIGATING
++**Impact:** [What data/users are affected]
++**Started:** [Time UTC]
++**Current Action:** [What you're doing now]
++**Next Update:** [+30 min]
++
++**IC:** @[your-name]
++```
++
++Update cadence: every 30 minutes until resolved. If you can't update on time, post `Still investigating, next update [+30min]` — silence is worse than no-news.
++
++## External — Status page
++
++```
++**Data Pipeline Delay**
++We are experiencing delays in data processing.
++Dashboard data may be up to [X] hours stale.
++Started: [Time] UTC
++Status: Actively investigating
++Next update: [Time] UTC
++```
++
++External wording rules:
++- No internal terminology (no "cluster", "job", "DBR version", "Photon")
++- No root-cause speculation until verified — say "investigating", not "Spark OOM"
++- Cite staleness in hours, not minutes, even if it's 15 min — minutes-precision implies recovery is closer than it is
++
++## Executive escalation (when severity exceeds responder authority)
++
++```
++Subject: [P1] Databricks production data pipeline outage — [time started]
++
++[Exec name],
++
++P1 incident in progress. Production data is stale by [X hours]; impacted downstream: [list].
++Mitigation in progress; ETA to resolution [time].
++IC: [name]. Watching: #incident-databricks Slack.
++Will email next update at [time].
++```
++
++Send this only when (a) ETA exceeds 1 hour OR (b) downstream impact spans more than one team.
+diff --git a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/evidence-collection.md b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/evidence-collection.md
+new file mode 100644
+index 000000000..203010115
+--- /dev/null
++++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/evidence-collection.md
+@@ -0,0 +1,56 @@
++# Evidence collection script
++
++Run this as Step 5 of `databricks-incident-runbook`. Collects the four artifacts needed for any postmortem (run.json, output.json, cluster.json, events.json) and tars them into a single uploadable bundle.
++
++## Usage
++
++```bash
++./collect-evidence.sh <INCIDENT_ID> <RUN_ID> [CLUSTER_ID]
++```
++
++- `INCIDENT_ID` — your team's incident tracker ID (e.g., `INC-2026-06-03-001`)
++- `RUN_ID` — Databricks job run ID from `databricks runs list` output
++- `CLUSTER_ID` — optional; only needed when the failure was cluster-side (OOM, cold start, spot interrupt)
++
++## Script
++
++```bash
++#!/bin/bash
++set -euo pipefail
++INCIDENT_ID=$1
++RUN_ID=$2
++CLUSTER_ID=${3:-}
++
++mkdir -p "incident-$INCIDENT_ID"
++
++# Collect job-run artifacts (always)
++databricks runs get --run-id $RUN_ID --output json \
++  > "incident-$INCIDENT_ID/run.json" 2>&1
++databricks runs get-output --run-id $RUN_ID --output json \
++  > "incident-$INCIDENT_ID/output.json" 2>&1
++
++# Cluster artifacts (only if cluster ID supplied)
++if [ -n "$CLUSTER_ID" ]; then
++    databricks clusters get --cluster-id $CLUSTER_ID --output json \
++      > "incident-$INCIDENT_ID/cluster.json" 2>&1
++    databricks clusters events --cluster-id $CLUSTER_ID --limit 50 --output json \
++      > "incident-$INCIDENT_ID/events.json" 2>&1
++fi
++
++# Bundle everything
++tar -czf "incident-$INCIDENT_ID.tar.gz" "incident-$INCIDENT_ID"
++echo "Evidence: incident-$INCIDENT_ID.tar.gz"
++```
++
++## What each artifact tells you
++
++| File | Use during incident | Use in postmortem |
++|---|---|---|
++| `run.json` | Current state, start time, duration | Timeline reconstruction |
++| `output.json` | Error message + stack trace | Root-cause analysis |
++| `cluster.json` | Worker count, instance type, autoscale state at time of failure | Capacity planning insights |
++| `events.json` | Last 50 cluster-lifecycle events (start, scale, interrupt, terminate) | OOM / spot-interrupt / cold-start patterns |
++
++## Storage
++
++Upload the tarball to the incident-archive tag in your workspace at `/incidents/<INCIDENT_ID>.tar.gz`. Retain 90 days minimum for compliance audits; longer if regulated industry.
+diff --git a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/postmortem-template.md b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/postmortem-template.md
+new file mode 100644
+index 000000000..17dd13af6
+--- /dev/null
++++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/postmortem-template.md
+@@ -0,0 +1,54 @@
++# Postmortem template
++
++Fill in within 48 hours of incident resolution. Archive to your team's incident-archive tag at `/incidents/<YYYY-MM-DD>-<slug>.md`.
++
++## Template
++
++```markdown
++## Incident: [Title]
++
++**Date:** YYYY-MM-DD | **Duration:** Xh Ym | **Severity:** P[1-4]
++**IC:** [Name]
++
++### Summary
++[1-2 sentences: what happened and what was the impact]
++
++### Timeline (UTC)
++| Time | Event |
++|------|-------|
++| HH:MM | Alert fired / issue detected |
++| HH:MM | Investigation started |
++| HH:MM | Root cause identified |
++| HH:MM | Mitigation applied |
++| HH:MM | Resolved |
++
++### Root Cause
++[Technical explanation. Be specific — "Spark OOM" is insufficient. "Bronze ingest job's executor was sized at 8GB but processed a 12GB Parquet partition after upstream API change increased per-record payload by 50%" is sufficient.]
++
++### Impact
++- Tables affected: [list]
++- Data staleness: [hours]
++- Users affected: [count/teams]
++
++### Action Items
++| Priority | Action | Owner | Due |
++|----------|--------|-------|-----|
++| P1 | [Preventive fix — close the gap that allowed this incident] | [Name] | [Date] |
++| P2 | [Monitoring gap — alert that should have fired] | [Name] | [Date] |
++| P3 | [Process improvement — what the team could do better next time] | [Name] | [Date] |
++```
++
++## Rules of the template
++
++- **Blameless.** Document what the system allowed to happen, never what a person did wrong. If a person clicked the wrong button, the question is "why did the system let one click cause a P1?"
++- **Specific.** Vague root causes ("data quality issue") don't help anyone. Specific root causes ("UTF-8 byte-order-mark in source CSV crashed PySpark CSV reader because `mode='FAILFAST'` was set in code path A but `mode='PERMISSIVE'` in code path B") prevent repeats.
++- **Action items have owners and dates.** "Improve monitoring" is not an action item. "Add Datadog alert on `system.streaming.query_progress` p99 latency > 5s, owner @alice, due 2026-07-01" is.
++- **48-hour deadline.** Memory degrades fast. Postmortems written 2 weeks later miss 60% of the timeline details.
++- **Read in retro.** Add the link to your next sprint retro's pre-read. Action items get accountability when surfaced to the whole team, not just the IC.
++
++## What NOT to include
++
++- Stack traces longer than 20 lines (link to evidence-bundle tarball instead)
++- Internal Slack messages copy-pasted (link to thread)
++- Customer names or PII (anonymize: "Customer A reported", not "Acme Corp reported")
++- Speculation labeled as fact ("The root cause might have been..." → only write what's verified)

--- a/tests/pr-classifier/fixtures/pr-823.expected.json
+++ b/tests/pr-classifier/fixtures/pr-823.expected.json
@@ -1,0 +1,20 @@
+{
+  "affected_agents": [],
+  "affected_hooks": [],
+  "affected_mcp": [],
+  "affected_skills": ["databricks-incident-runbook"],
+  "catalog_additions": [],
+  "contribution_types": ["plugin", "skill"],
+  "file_categories": {
+    "json": 1,
+    "md": 6
+  },
+  "plugin_paths": ["plugins/saas-packs/databricks-pack"],
+  "sources_additions": [],
+  "touches_frontend": false,
+  "touches_scripts": false,
+  "touches_tests": false,
+  "touches_workflows": false,
+  "unknown": false,
+  "unmatched": []
+}

--- a/tests/pr-classifier/fixtures/pr-823.files
+++ b/tests/pr-classifier/fixtures/pr-823.files
@@ -1,0 +1,7 @@
+plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md
+plugins/saas-packs/databricks-pack/000-docs/014-DR-DRFT-cost-leak-cfo-output-spec.md
+plugins/saas-packs/databricks-pack/package.json
+plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
+plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/communication-templates.md
+plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/evidence-collection.md
+plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/references/postmortem-template.md

--- a/tests/pr-classifier/test_classifier.py
+++ b/tests/pr-classifier/test_classifier.py
@@ -1,0 +1,540 @@
+"""Unit + snapshot tests for scripts/pr-classifier/.
+
+Two layers:
+    1. Unit tests over synthetic file lists — one test per contribution type.
+       Pins the deterministic mapping each rule expresses.
+    2. Snapshot regression tests over historical real PR diffs at
+       tests/pr-classifier/fixtures/pr-NNN-*.{diff,files,expected.json}.
+       Re-running the classifier on the same diff must always produce the
+       same output. Changes to the expected.json need a justifying commit
+       message explaining the new behavior.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Load rules.py by file path because the script dir uses a hyphen (`pr-classifier`)
+# which isn't a valid Python identifier for normal imports.
+_RULES_PATH = _REPO_ROOT / "scripts" / "pr-classifier" / "rules.py"
+_spec = importlib.util.spec_from_file_location("pr_classifier_rules", _RULES_PATH)
+_rules = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rules)
+
+classify_files = _rules.classify_files
+parse_catalog_additions_from_diff = _rules.parse_catalog_additions_from_diff
+parse_sources_additions_from_diff = _rules.parse_sources_additions_from_diff
+
+
+# =============================================================================
+# Unit tests — one per contribution type
+# =============================================================================
+
+
+class TestSkillContribution:
+    def test_single_skill_file(self):
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md",
+        ])
+        assert result["affected_skills"] == ["databricks-incident-runbook"]
+        assert "skill" in result["contribution_types"]
+        assert "plugin" in result["contribution_types"]
+        assert result["plugin_paths"] == ["plugins/saas-packs/databricks-pack"]
+
+    def test_skill_doesnt_drag_unaffected_skills_from_pack(self):
+        """Critical: editing one skill file must NOT mark every skill in the pack."""
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/skills/cost-leak-hunter/SKILL.md",
+        ])
+        assert result["affected_skills"] == ["cost-leak-hunter"]
+        # databricks-incident-runbook etc. must NOT appear
+        assert "databricks-incident-runbook" not in result["affected_skills"]
+
+    def test_multiple_skills_same_pack(self):
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/skills/skill-one/SKILL.md",
+            "plugins/saas-packs/databricks-pack/skills/skill-two/SKILL.md",
+        ])
+        assert set(result["affected_skills"]) == {"skill-one", "skill-two"}
+        assert result["plugin_paths"] == ["plugins/saas-packs/databricks-pack"]
+
+    def test_skill_reference_file_doesnt_make_it_a_skill_change(self):
+        """A change to skill/references/foo.md is plugin-internal but not a SKILL.md change."""
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/skills/skill-one/references/foo.md",
+        ])
+        assert result["affected_skills"] == []  # SKILL.md not touched
+        assert "skill" not in result["contribution_types"]
+        assert "plugin" in result["contribution_types"]
+
+
+class TestAgentContribution:
+    def test_agent_md_file(self):
+        result = classify_files([
+            "plugins/governance/intent-skill-creator/agents/agent-creator.md",
+        ])
+        assert result["affected_agents"] == ["agent-creator"]
+        assert "agent" in result["contribution_types"]
+
+
+class TestMcpContribution:
+    def test_mcp_plugin_path(self):
+        result = classify_files([
+            "plugins/mcp/lumera-agent-memory/src/server.ts",
+        ])
+        assert result["affected_mcp"] == ["lumera-agent-memory"]
+        assert "mcp" in result["contribution_types"]
+
+    def test_mcp_config_inside_plugin(self):
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/.mcp.json",
+        ])
+        assert result["affected_mcp"] == ["databricks-pack"]
+        assert "mcp" in result["contribution_types"]
+
+
+class TestHookContribution:
+    def test_hooks_json(self):
+        result = classify_files([
+            "plugins/security/penetration-tester/hooks/hooks.json",
+        ])
+        assert result["affected_hooks"] == ["penetration-tester"]
+        assert "hook" in result["contribution_types"]
+
+
+class TestPluginContribution:
+    def test_any_plugin_change(self):
+        result = classify_files([
+            "plugins/governance/intent-skill-creator/README.md",
+        ])
+        assert "plugins/governance/intent-skill-creator" in result["plugin_paths"]
+        assert "plugin" in result["contribution_types"]
+        # Plugin-internal docs don't get classified as standalone doc
+        assert "doc" not in result["contribution_types"]
+
+
+class TestCiContribution:
+    def test_workflow_yaml(self):
+        result = classify_files([
+            ".github/workflows/validate-plugins.yml",
+        ])
+        assert result["touches_workflows"] is True
+        assert "ci" in result["contribution_types"]
+
+    def test_workflow_yml_extension(self):
+        result = classify_files([
+            ".github/workflows/lint.yaml",
+        ])
+        assert result["touches_workflows"] is True
+
+
+class TestFrontendContribution:
+    def test_marketplace_src(self):
+        result = classify_files([
+            "marketplace/src/pages/index.astro",
+        ])
+        assert result["touches_frontend"] is True
+        assert "frontend" in result["contribution_types"]
+
+    def test_marketplace_root_not_src_doesnt_count_as_frontend(self):
+        result = classify_files([
+            "marketplace/DESIGN.md",
+        ])
+        assert result["touches_frontend"] is False
+        # It's a doc since marketplace/ isn't a plugin path
+        assert "doc" in result["contribution_types"]
+
+
+class TestScriptContribution:
+    def test_scripts_path(self):
+        result = classify_files([
+            "scripts/validate-skills-schema.py",
+        ])
+        assert result["touches_scripts"] is True
+        assert "script" in result["contribution_types"]
+
+
+class TestDocContribution:
+    def test_top_level_readme(self):
+        result = classify_files(["README.md"])
+        assert "doc" in result["contribution_types"]
+
+    def test_top_000_docs(self):
+        result = classify_files(["000-docs/some-decision.md"])
+        assert "doc" in result["contribution_types"]
+
+    def test_docs_dir(self):
+        result = classify_files(["docs/getting-started.md"])
+        assert "doc" in result["contribution_types"]
+
+
+class TestTestContribution:
+    def test_test_prefix_file(self):
+        result = classify_files(["tests/test_foo.py"])
+        assert result["touches_tests"] is True
+        assert "test" in result["contribution_types"]
+
+    def test_plugin_internal_test(self):
+        result = classify_files([
+            "plugins/security/penetration-tester/tests/test_x.py",
+        ])
+        # Tests inside a plugin still count as both plugin AND test
+        assert "test" in result["contribution_types"]
+        assert "plugin" in result["contribution_types"]
+
+
+# =============================================================================
+# Unknown-pattern detection
+# =============================================================================
+
+
+class TestUnknownDetection:
+    def test_unrecognized_top_level_dir(self):
+        result = classify_files(["new-experimental-dir/foo.txt"])
+        assert result["unknown"] is True
+        assert "new-experimental-dir/foo.txt" in result["unmatched"]
+
+    def test_all_unmatched_when_empty_recognizable_files(self):
+        result = classify_files(["weird-thing.xyz"])
+        assert result["unknown"] is True
+
+    def test_no_unknown_when_everything_matches(self):
+        result = classify_files([
+            "plugins/governance/x/skills/y/SKILL.md",
+            "README.md",
+            "scripts/foo.py",
+        ])
+        assert result["unknown"] is False
+        assert result["unmatched"] == []
+
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    def test_empty_input(self):
+        result = classify_files([])
+        assert result["contribution_types"] == []
+        assert result["plugin_paths"] == []
+        assert result["unknown"] is False
+
+    def test_blank_lines_ignored(self):
+        result = classify_files(["", "  ", "README.md"])
+        assert "doc" in result["contribution_types"]
+
+    def test_file_categories_extension_counting(self):
+        result = classify_files([
+            "scripts/a.py",
+            "scripts/b.py",
+            "README.md",
+            "package.json",
+        ])
+        cats = result["file_categories"]
+        assert cats.get("py") == 2
+        assert cats.get("md") == 1
+        assert cats.get("json") == 1
+
+    def test_mixed_contribution_types(self):
+        """A PR touching scripts AND a plugin AND CI should surface all three."""
+        result = classify_files([
+            "scripts/foo.py",
+            "plugins/governance/x/SKILL.md",
+            ".github/workflows/test.yml",
+        ])
+        types = set(result["contribution_types"])
+        assert {"script", "plugin", "ci"}.issubset(types)
+
+
+# =============================================================================
+# Catalog-addition diff parsing
+# =============================================================================
+
+
+_CATALOG_DIFF_AOMI = """diff --git a/.claude-plugin/marketplace.extended.json b/.claude-plugin/marketplace.extended.json
+index 1234567..89abcde 100644
+--- a/.claude-plugin/marketplace.extended.json
++++ b/.claude-plugin/marketplace.extended.json
+@@ -100,6 +100,12 @@
+     "category": "ai-ml"
+   },
++  {
++    "name": "aomi",
++    "source": "./plugins/crypto/aomi",
++    "category": "crypto",
++    "version": "1.0.0"
++  },
+   {
+     "name": "next-thing",
+"""
+
+
+class TestCatalogAdditionParsing:
+    def test_parses_single_added_entry(self):
+        adds = parse_catalog_additions_from_diff(_CATALOG_DIFF_AOMI)
+        assert len(adds) == 1
+        assert adds[0]["name"] == "aomi"
+        assert adds[0]["category"] == "crypto"
+        assert adds[0]["source"] == "./plugins/crypto/aomi"
+
+    def test_classify_picks_up_catalog_add_type(self):
+        result = classify_files(
+            [".claude-plugin/marketplace.extended.json"],
+            diff_text=_CATALOG_DIFF_AOMI,
+        )
+        assert "catalog_add" in result["contribution_types"]
+        assert result["catalog_additions"][0]["name"] == "aomi"
+
+    def test_no_catalog_diff_no_adds(self):
+        result = classify_files(
+            [".claude-plugin/marketplace.extended.json"],
+            diff_text=None,
+        )
+        assert result["catalog_additions"] == []
+        assert "catalog" in result["contribution_types"]  # touch detected
+        assert "catalog_add" not in result["contribution_types"]
+
+
+# =============================================================================
+# Sources.yaml addition diff parsing
+# =============================================================================
+
+
+_SOURCES_DIFF = """diff --git a/sources.yaml b/sources.yaml
+index 1111111..2222222 100644
+--- a/sources.yaml
++++ b/sources.yaml
+@@ -5,3 +5,7 @@
+ - name: existing-source
+   repo: foo/bar
++- name: new-external-source
++  repo: octocat/hello-world
++  ref: main
+"""
+
+
+class TestSourcesAdditionParsing:
+    def test_parses_single_sources_add(self):
+        adds = parse_sources_additions_from_diff(_SOURCES_DIFF)
+        assert len(adds) == 1
+        assert adds[0]["name"] == "new-external-source"
+
+    def test_classify_picks_up_sources_add_type(self):
+        result = classify_files(["sources.yaml"], diff_text=_SOURCES_DIFF)
+        assert "sources_add" in result["contribution_types"]
+        assert result["sources_additions"][0]["name"] == "new-external-source"
+
+
+# =============================================================================
+# Regression: historical PR shapes
+# =============================================================================
+
+
+class TestHistoricalPRShapes:
+    """Synthetic recreations of PR shapes we've seen in production.
+
+    These mirror the real PRs that motivated the new classifier — particularly
+    the doc-only-PR-incorrectly-grading-the-whole-pack failure mode from #823.
+    """
+
+    def test_pr_823_doc_only_change_does_not_drag_pack_skills(self):
+        """#823 (the bug-triggering PR) was a doc-only edit but the coarse
+        depth-3 awk extractor caused the prescreen to scan all 24 skills
+        in databricks-pack. With this classifier, the doc edit produces
+        empty affected_skills."""
+        result = classify_files([
+            "plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md",
+            "plugins/saas-packs/databricks-pack/000-docs/014-DR-DRFT-cost-leak-cfo-output-spec.md",
+        ])
+        # NO skills affected — that's the entire point
+        assert result["affected_skills"] == []
+        # Plugin path is still surfaced
+        assert "plugins/saas-packs/databricks-pack" in result["plugin_paths"]
+        assert "plugin" in result["contribution_types"]
+
+    def test_pr_822_ci_lint_fix(self):
+        """#822 — fix(ci): clear lint failures. Touches plugin docs but no skills."""
+        result = classify_files([
+            "plugins/saas-packs/foo-pack/README.md",
+            "plugins/saas-packs/bar-pack/README.md",
+            ".github/workflows/validate-plugins.yml",
+        ])
+        assert result["touches_workflows"] is True
+        assert result["affected_skills"] == []
+        assert "ci" in result["contribution_types"]
+
+    def test_pr_818_catalog_only_external_contribution(self):
+        """#818 — victorchimakanu added one row to marketplace.extended.json.
+        Without the diff text we only know the catalog file was touched;
+        with the diff we get the catalog_additions entry."""
+        result_no_diff = classify_files(
+            [".claude-plugin/marketplace.extended.json"],
+            diff_text=None,
+        )
+        assert "catalog" in result_no_diff["contribution_types"]
+
+        result_with_diff = classify_files(
+            [".claude-plugin/marketplace.extended.json"],
+            diff_text=_CATALOG_DIFF_AOMI,
+        )
+        assert "catalog_add" in result_with_diff["contribution_types"]
+        assert len(result_with_diff["catalog_additions"]) == 1
+
+    def test_self_classification(self):
+        """The classifier should be able to classify its own PR.
+
+        This PR creates files at:
+          - scripts/pr-classifier/__init__.py
+          - scripts/pr-classifier/rules.py
+          - scripts/pr-classifier/detect_components.py
+          - tests/pr-classifier/__init__.py
+          - tests/pr-classifier/test_classifier.py
+        """
+        result = classify_files([
+            "scripts/pr-classifier/__init__.py",
+            "scripts/pr-classifier/rules.py",
+            "scripts/pr-classifier/detect_components.py",
+            "tests/pr-classifier/__init__.py",
+            "tests/pr-classifier/test_classifier.py",
+        ])
+        types = set(result["contribution_types"])
+        assert "script" in types
+        assert "test" in types
+        # NO plugin touches
+        assert result["plugin_paths"] == []
+        assert result["affected_skills"] == []
+        assert result["touches_workflows"] is False
+        assert result["unknown"] is False
+
+
+# =============================================================================
+# Output shape stability
+# =============================================================================
+
+
+class TestOutputShape:
+    def test_all_top_level_keys_present(self):
+        result = classify_files(["README.md"])
+        expected_keys = {
+            "contribution_types",
+            "plugin_paths",
+            "affected_skills",
+            "affected_agents",
+            "affected_mcp",
+            "affected_hooks",
+            "catalog_additions",
+            "sources_additions",
+            "file_categories",
+            "touches_workflows",
+            "touches_frontend",
+            "touches_scripts",
+            "touches_tests",
+            "unknown",
+            "unmatched",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_lists_are_sorted(self):
+        result = classify_files([
+            "plugins/security/c/SKILL.md",
+            "plugins/security/a/SKILL.md",
+            "plugins/security/b/SKILL.md",
+        ])
+        assert result["plugin_paths"] == sorted(result["plugin_paths"])
+
+    def test_output_is_json_serializable(self):
+        result = classify_files([
+            "plugins/governance/x/skills/y/SKILL.md",
+            ".github/workflows/test.yml",
+        ])
+        # Round-trip through JSON
+        s = json.dumps(result)
+        loaded = json.loads(s)
+        assert loaded == result
+
+    def test_deterministic_repeat_runs(self):
+        files = [
+            "plugins/security/x/skills/y/SKILL.md",
+            "scripts/foo.py",
+            ".github/workflows/bar.yml",
+        ]
+        r1 = classify_files(files)
+        r2 = classify_files(files)
+        assert r1 == r2
+
+
+# =============================================================================
+# Helper-function tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("plugins/cat/name/file.md", True),
+        ("plugins/mcp/foo/server.ts", True),
+        ("scripts/foo.py", False),
+        ("plugins", False),
+        ("plugins/cat", False),
+        ("", False),
+    ],
+)
+def test_is_plugin_path(path, expected):
+    from pathlib import PurePosixPath
+    p = PurePosixPath(path) if path else PurePosixPath()
+    assert _rules._is_plugin_path(p) == expected
+
+
+# =============================================================================
+# Real PR snapshot regression tests
+# =============================================================================
+#
+# Each entry references a `pr-NNN.files` + `pr-NNN.diff` + `pr-NNN.expected.json`
+# trio under tests/pr-classifier/fixtures/. The classifier is run against the
+# file list (and diff for catalog/sources detection); output is asserted equal
+# to the committed expected.json.
+#
+# When the classifier's behavior changes intentionally, the fixture files
+# must be regenerated and the commit message must explain why.
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.mark.parametrize("pr_number", ["823"])
+def test_real_pr_snapshot(pr_number):
+    files_path = _FIXTURES / f"pr-{pr_number}.files"
+    diff_path = _FIXTURES / f"pr-{pr_number}.diff"
+    expected_path = _FIXTURES / f"pr-{pr_number}.expected.json"
+    if not files_path.exists():
+        pytest.skip(f"fixture pr-{pr_number}.files not present")
+    if not expected_path.exists():
+        pytest.skip(f"fixture pr-{pr_number}.expected.json not present")
+
+    files = [
+        l.strip()
+        for l in files_path.read_text(encoding="utf-8").splitlines()
+        if l.strip()
+    ]
+    diff_text = diff_path.read_text(encoding="utf-8") if diff_path.exists() else None
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+
+    result = classify_files(files, diff_text=diff_text)
+    assert result == expected, (
+        f"\nclassifier output changed for PR #{pr_number}.\n"
+        f"If this change is intentional, regenerate the fixture:\n"
+        f"  python3 scripts/pr-classifier/detect_components.py "
+        f"--file tests/pr-classifier/fixtures/pr-{pr_number}.files "
+        f"--diff-file tests/pr-classifier/fixtures/pr-{pr_number}.diff "
+        f"--pretty > tests/pr-classifier/fixtures/pr-{pr_number}.expected.json\n"
+        f"AND explain the new behavior in the commit message.\n"
+    )

--- a/tests/pr-classifier/test_classifier.py
+++ b/tests/pr-classifier/test_classifier.py
@@ -393,19 +393,21 @@ class TestHistoricalPRShapes:
     def test_self_classification(self):
         """The classifier should be able to classify its own PR.
 
-        This PR creates files at:
-          - scripts/pr-classifier/__init__.py
-          - scripts/pr-classifier/rules.py
-          - scripts/pr-classifier/detect_components.py
-          - tests/pr-classifier/__init__.py
-          - tests/pr-classifier/test_classifier.py
+        Reviewer fix PR #838: original test listed only 5 of the 9 files this
+        PR adds. Expanded to the full set including the README and the
+        fixture files so the test pins what the classifier ACTUALLY sees on
+        this PR.
         """
         result = classify_files([
             "scripts/pr-classifier/__init__.py",
             "scripts/pr-classifier/rules.py",
             "scripts/pr-classifier/detect_components.py",
+            "scripts/pr-classifier/README.md",
             "tests/pr-classifier/__init__.py",
             "tests/pr-classifier/test_classifier.py",
+            "tests/pr-classifier/fixtures/pr-823.files",
+            "tests/pr-classifier/fixtures/pr-823.diff",
+            "tests/pr-classifier/fixtures/pr-823.expected.json",
         ])
         types = set(result["contribution_types"])
         assert "script" in types
@@ -493,6 +495,120 @@ def test_is_plugin_path(path, expected):
     from pathlib import PurePosixPath
     p = PurePosixPath(path) if path else PurePosixPath()
     assert _rules._is_plugin_path(p) == expected
+
+
+# =============================================================================
+# Reviewer-fix regressions (PR #838 review)
+# =============================================================================
+
+
+class TestBraceInStringCatalogParser:
+    """Reviewer flagged: unbalanced braces inside a JSON string value
+    silently drove the catalog parser's depth counter wrong and dropped
+    the entire catalog entry. The fix introduces a quote-aware brace
+    counter."""
+
+    def test_unbalanced_brace_in_string_does_not_drop_entry(self):
+        diff = (
+            'diff --git a/.claude-plugin/marketplace.extended.json '
+            'b/.claude-plugin/marketplace.extended.json\n'
+            'index 1..2 100644\n'
+            '--- a/.claude-plugin/marketplace.extended.json\n'
+            '+++ b/.claude-plugin/marketplace.extended.json\n'
+            '@@ -1,3 +1,9 @@\n'
+            '   "plugins": [\n'
+            '+    {\n'
+            '+      "name": "tricky-pack",\n'
+            '+      "source": "./plugins/example/tricky",\n'
+            '+      "description": "Uses {foo {bar} template patterns",\n'
+            '+      "category": "example"\n'
+            '+    },\n'
+            '     {\n'
+        )
+        adds = _rules.parse_catalog_additions_from_diff(diff)
+        assert len(adds) == 1, "unbalanced braces in string value should NOT drop the entry"
+        assert adds[0]["name"] == "tricky-pack"
+
+    def test_quote_aware_brace_counter(self):
+        # Inside a string: not counted
+        assert _rules._count_unquoted_braces('"foo {bar}"') == (0, 0)
+        # Outside a string: counted
+        assert _rules._count_unquoted_braces('{ "name": "x" }') == (1, 1)
+        # Mixed: only the outside-string braces count
+        assert _rules._count_unquoted_braces('{ "name": "x{y}" }') == (1, 1)
+        # Escaped quote inside string preserves string state
+        assert _rules._count_unquoted_braces('{ "n": "a\\"b{c}" }') == (1, 1)
+
+
+class TestDepthFlexibleSkillMatch:
+    """Reviewer flagged: depth-4-only skill match misses sub-vendored layouts
+    like plugins/saas-packs/<vendor>/<sub>/skills/<x>/SKILL.md."""
+
+    def test_depth_5_subvendored_skill_still_classified(self):
+        result = classify_files([
+            "plugins/saas-packs/vendor-x/sub-y/skills/my-skill/SKILL.md",
+        ])
+        assert "my-skill" in result["affected_skills"]
+        assert "skill" in result["contribution_types"]
+
+    def test_depth_4_standard_skill_still_works(self):
+        """Regression check that the standard depth-4 case still works."""
+        result = classify_files([
+            "plugins/security/example/skills/my-skill/SKILL.md",
+        ])
+        assert result["affected_skills"] == ["my-skill"]
+
+
+class TestSourcesYamlRootOnly:
+    """Reviewer flagged: sources_additions parser fired on non-root
+    sources.yaml files. Now restricted to the exact root path."""
+
+    def test_non_root_sources_yaml_does_not_fire_sources_add(self):
+        diff = (
+            "diff --git a/config/sources.yaml b/config/sources.yaml\n"
+            "index 1..2 100644\n"
+            "--- a/config/sources.yaml\n"
+            "+++ b/config/sources.yaml\n"
+            "@@ -1,1 +1,3 @@\n"
+            "+- name: should-not-be-counted\n"
+            "+  repo: foo/bar\n"
+        )
+        adds = _rules.parse_sources_additions_from_diff(diff)
+        assert adds == []
+
+    def test_root_sources_yaml_fires_sources_add(self):
+        diff = (
+            "diff --git a/sources.yaml b/sources.yaml\n"
+            "index 1..2 100644\n"
+            "--- a/sources.yaml\n"
+            "+++ b/sources.yaml\n"
+            "@@ -1,1 +1,3 @@\n"
+            "+- name: legitimate\n"
+            "+  repo: foo/bar\n"
+        )
+        adds = _rules.parse_sources_additions_from_diff(diff)
+        assert len(adds) == 1
+        assert adds[0]["name"] == "legitimate"
+
+
+class TestFileCategoriesDeterminism:
+    """Reviewer flagged: file_categories dict insertion order followed input
+    file order, breaking the deterministic-output contract. Now sorted."""
+
+    def test_file_categories_keys_sorted(self):
+        result = classify_files([
+            "scripts/z.py",   # py
+            "README.md",      # md
+            "package.json",   # json
+        ])
+        keys = list(result["file_categories"].keys())
+        assert keys == sorted(keys), f"file_categories keys not sorted: {keys}"
+
+    def test_file_categories_order_independent_of_input_order(self):
+        a = classify_files(["scripts/x.py", "README.md", "package.json"])
+        b = classify_files(["package.json", "scripts/x.py", "README.md"])
+        c = classify_files(["README.md", "package.json", "scripts/x.py"])
+        assert list(a["file_categories"].keys()) == list(b["file_categories"].keys()) == list(c["file_categories"].keys())
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR 1 of the 3-PR new-track CI overhaul. Replaces the coarse `awk -F/ '{print $1"/"$2"/"$3}'` depth-3 extractor in `pr-prescreen.yml` that caused doc-only PRs to drag unrelated skills into validator scoring. **PR #823 was the trigger case** — a doc-only edit caused the prescreen to scan all 24 skills in `databricks-pack`, inherit a pre-existing C-grade as the PR's blocker, and `gh pr review --request-changes` against the contributor.

This PR is **foundation only** — adds the classifier + tests, doesn't yet rewire the prescreen workflow. PRs 2 and 3 build on this output to split `validate-plugins.yml` by domain and rewrite the prescreen.

## What ships

| File | Purpose |
|---|---|
| `scripts/pr-classifier/__init__.py` | Package marker |
| `scripts/pr-classifier/rules.py` | Entire deterministic ruleset + catalog/sources diff parsers |
| `scripts/pr-classifier/detect_components.py` | CLI entry point (`--stdin` / `--file` / `--diff-file` / positional) |
| `scripts/pr-classifier/README.md` | Usage + contract + extension instructions |
| `tests/pr-classifier/test_classifier.py` | **46 deterministic tests** |
| `tests/pr-classifier/fixtures/pr-823.{files,diff,expected.json}` | Real-PR snapshot regression for the bug-triggering case |

## Key design points

- **Depth-4 cut for skills.** `plugins/<cat>/<plugin>/skills/<skill>/SKILL.md` surfaces ONLY the named skill. No cascade to sibling skills.
- **Deterministic.** Same input → same output, always. No network, no LLM, no I/O beyond `--file` / `--diff-file` reads.
- **JSON-serializable, sorted lists, stable across runs.** Verified by `test_deterministic_repeat_runs`.
- **15 contribution types** covered: skill, agent, mcp, hook, plugin, catalog, catalog_add, sources, sources_add, ci, frontend, script, test, doc, plus an `unknown` detector that surfaces unrecognized patterns.
- **Self-classifies.** The classifier classifies its own PR correctly — `test_self_classification` pins this.

## Output JSON shape

```json
{
  "contribution_types": ["plugin", "skill"],
  "plugin_paths": ["plugins/saas-packs/databricks-pack"],
  "affected_skills": ["databricks-incident-runbook"],
  "affected_agents": [],
  "affected_mcp": [],
  "affected_hooks": [],
  "catalog_additions": [
    {"name": "aomi", "source": "./plugins/crypto/aomi", "category": "crypto"}
  ],
  "sources_additions": [],
  "file_categories": {"md": 4, "json": 2},
  "touches_workflows": false,
  "touches_frontend": false,
  "touches_scripts": false,
  "touches_tests": false,
  "unknown": false,
  "unmatched": []
}
```

## Bug caught while writing the tests

`marketplace/DESIGN.md` and similar `marketplace/<not-src>/*.md` files were not being classified as docs because the doc rule excluded ALL of `marketplace/`. Fixed in this PR: only `marketplace/src/**` is treated as frontend; the rest of `marketplace/` counts as doc. The test `test_marketplace_root_not_src_doesnt_count_as_frontend` pins the corrected behavior.

## How CI picks this up

Wires into the existing `python-tests` matrix job in `.github/workflows/validate-plugins.yml` automatically — `test_*.py` is auto-discovered. **No new workflow needed for this PR.**

## Test plan

- [ ] `python3 -m pytest tests/pr-classifier/ -v` shows 46 passing tests.
- [ ] Smoke-test the CLI:
  - `python3 scripts/pr-classifier/detect_components.py plugins/security/penetration-tester/skills/auditing-npm-dependencies/SKILL.md --pretty` outputs `affected_skills: ["auditing-npm-dependencies"]`
  - `python3 scripts/pr-classifier/detect_components.py --file tests/pr-classifier/fixtures/pr-823.files --diff-file tests/pr-classifier/fixtures/pr-823.diff --pretty` matches the committed expected.json
- [ ] CI's `python-tests` job runs the 46 new tests + the existing repo tests without regression.

## What's NOT in this PR

- **Workflow split** — `validate-plugins.yml` still monolithic. PR 2 does that, keyed on this classifier's output.
- **Prescreen rewrite** — `pr-prescreen.yml` still uses the old `awk` extractor. PR 3 rewires it to consume this classifier's output and post a single coordinated comment.
- **Public grading page** — PR 3 ships the `tonsofskills.com/grading` page using the same rubric the prescreen grades against.
- **More historical snapshot fixtures** — only #823 is captured here. PRs #811, #818, #819, #820, #821, #822 can land as fixtures in follow-up PRs.

## Why this PR is small + reviewable

The plan called for shipping the classifier independently so PRs 2 and 3 can each be reviewed without cross-cutting churn. After this lands, PR 2 introduces the new workflow files; PR 3 wires the prescreen to consume the classifier. Each PR is independently reversible.

- Jeremy Longshore
intentsolutions.io