### PR TITLE
feat(ci): per-domain lint workflows + actionlint + path-routing test (PR 2/3)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,15 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # actionlint releases a single-binary executable; downloading via the
-      # official install script is the canonical pattern. Pinned to v1.7.4
-      # (latest stable as of 2026-06-03) — bump explicitly in this file.
+      # actionlint releases a single-binary executable; the install script is
+      # fetched FROM THE v1.7.4 TAG (not main HEAD) so the script's content is
+      # immutable for this version — supply-chain hardening. Bump the tag in
+      # BOTH places (URL ref + bash arg) explicitly when updating.
       - name: Install actionlint
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/actionlint"
           curl -sSL \
-            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.4/scripts/download-actionlint.bash \
             | bash -s -- 1.7.4 "$RUNNER_TEMP/actionlint"
           "$RUNNER_TEMP/actionlint/actionlint" -version
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,46 @@
+name: Actionlint
+
+# Lints every .github/workflows/*.yml file for syntactically correct GitHub
+# Actions YAML, valid event triggers, valid if: expressions, and valid action
+# references. New gate per PR 2 of the new-track CI overhaul — the workflow
+# split adds 6+ new YAML files, and the validators themselves need a gate.
+#
+# Fires only when workflow YAML changes.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint-matcher.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # actionlint releases a single-binary executable; downloading via the
+      # official install script is the canonical pattern. Pinned to v1.7.4
+      # (latest stable as of 2026-06-03) — bump explicitly in this file.
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/actionlint"
+          curl -sSL \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
+            | bash -s -- 1.7.4 "$RUNNER_TEMP/actionlint"
+          "$RUNNER_TEMP/actionlint/actionlint" -version
+
+      # BLOCKING — no `|| true`. If a workflow YAML doesn't lint cleanly,
+      # the PR cannot merge. This gate protects the workflow split from
+      # accidental syntax breakage as PR 3 (prescreen rewrite) lands and
+      # subsequent PRs touch the workflow files.
+      - name: Run actionlint
+        run: |
+          "$RUNNER_TEMP/actionlint/actionlint" -color

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,40 @@
+name: Lint Markdown
+
+# Per-domain split of validate-plugins.yml (PR 2 of the new-track CI overhaul).
+# This workflow ONLY fires when the PR actually touches Markdown / MDX files.
+# The original markdownlint job in validate-plugins.yml continues to run on
+# every PR until the new split is proven green on 3+ PRs and the original is
+# retired in a follow-up cleanup PR.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.markdownlint-cli2.jsonc'
+      - '.github/workflows/lint-markdown.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.markdownlint-cli2.jsonc'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # BLOCKING — codebase passed baseline at PR #772 (2026-05-23).
+      # See validate-plugins.yml#markdownlint for the cleanup-arc history.
+      # .markdownlint-cli2.jsonc at repo root governs rule selection.
+      - name: Run markdownlint-cli2
+        run: |
+          npx -y markdownlint-cli2

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,60 @@
+name: Lint Python
+
+# Per-domain split of validate-plugins.yml (PR 2 of the new-track CI overhaul).
+# Fires when the PR touches Python sources, pyproject.toml, or requirements*.
+# Original ruff-check / ruff-format-check jobs in validate-plugins.yml continue
+# to run on every PR until the new split is proven green.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '**/pyproject.toml'
+      - '**/requirements*.txt'
+      - 'ruff.toml'
+      - '.ruff.toml'
+      - '.github/workflows/lint-python.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.py'
+      - '**/pyproject.toml'
+      - '**/requirements*.txt'
+
+jobs:
+  ruff-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      # BLOCKING — codebase passed baseline at PR #765 (2026-05-22, 730→0).
+      # ruff.toml at repo root governs rule selection.
+      - name: Run ruff check
+        run: ruff check plugins/ scripts/
+
+  ruff-format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      # BLOCKING — 374 files formatted at PR #765 baseline.
+      # Run `ruff format plugins/ scripts/` locally to fix before pushing.
+      - name: Check ruff formatting
+        run: ruff format --check plugins/ scripts/

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -1,0 +1,56 @@
+name: Lint Shell
+
+# Per-domain split of validate-plugins.yml (PR 2 of the new-track CI overhaul).
+# Fires when the PR touches shell scripts.
+# Original shellcheck-skills job in validate-plugins.yml continues to run on
+# every PR until the new split is proven green.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.sh'
+      - '**/*.bash'
+      - '.shellcheckrc'
+      - '.github/workflows/lint-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.sh'
+      - '**/*.bash'
+
+jobs:
+  shellcheck-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          shellcheck --version | head -2
+
+      # BLOCKING — codebase passed baseline at PR #768 (2026-05-22, 223→0).
+      # .shellcheckrc at repo root governs disable= directives.
+      # No `|| true` swallow: external PRs that introduce shellcheck warnings
+      # or errors fail this gate.
+      - name: Run shellcheck (severity=warning) across plugins/**/*.sh
+        run: |
+          set -e
+          # Build list of .sh files to check, EXCLUDING:
+          #   - node_modules
+          #   - upstream-synced plugin dirs (any dir containing .source.json
+          #     in its plugin root — those scripts are the upstream
+          #     maintainer's responsibility, and the next weekly sync will
+          #     overwrite any fixes we apply here)
+          synced_dirs=$(find plugins -maxdepth 3 -name '.source.json' -type f -exec dirname {} \;)
+          declare -a prune_args=()
+          for d in $synced_dirs; do
+            prune_args+=(-not -path "$d/*")
+          done
+          count=$(find plugins -name '*.sh' -not -path '*/node_modules/*' "${prune_args[@]}" -type f | wc -l)
+          echo "Shellchecking $count .sh files at severity=warning..."
+          echo "Excluded $(echo "$synced_dirs" | wc -l) upstream-synced plugin dirs."
+          find plugins -name '*.sh' -not -path '*/node_modules/*' "${prune_args[@]}" -type f -print0 \
+            | xargs -0 shellcheck --severity=warning --shell=bash

--- a/.github/workflows/lint-skill-codeblocks.yml
+++ b/.github/workflows/lint-skill-codeblocks.yml
@@ -1,0 +1,43 @@
+name: Lint Skill Code Blocks
+
+# Per-domain split of validate-plugins.yml (PR 2 of the new-track CI overhaul).
+# Fires when the PR touches plugin-internal SKILL.md or README.md files.
+# Original skill-codeblock-syntax job in validate-plugins.yml continues to run
+# on every PR until the new split is proven green.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'plugins/**/SKILL.md'
+      - 'plugins/**/README.md'
+      - 'scripts/lint-skill-codeblocks.py'
+      - '.github/workflows/lint-skill-codeblocks.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/**/SKILL.md'
+      - 'plugins/**/README.md'
+
+jobs:
+  skill-codeblock-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Setup Node.js (for js codeblock syntax checks)
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # BLOCKING — codebase passed baseline at PR #771 (2026-05-23).
+      # 5,991 of 16,298 fenced code blocks checked (only python/bash/sh/
+      # javascript get syntax-checked per scripts/lint-skill-codeblocks.py).
+      - name: Lint fenced code blocks in SKILL.md / README.md
+        run: |
+          python3 scripts/lint-skill-codeblocks.py --root plugins

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -1,0 +1,93 @@
+name: Lint TypeScript
+
+# Per-domain split of validate-plugins.yml (PR 2 of the new-track CI overhaul).
+# Fires when the PR touches TS/JS sources, tsconfig files, or package.json.
+# Original jobs in validate-plugins.yml continue to run on every PR until the
+# new split is proven green and the original is retired in a follow-up.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '**/tsconfig*.json'
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - '.eslintrc*'
+      - 'eslint.config.*'
+      - '.prettierrc*'
+      - 'prettier.config.*'
+      - '.github/workflows/lint-typescript.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/tsconfig*.json'
+      - '**/package.json'
+
+jobs:
+  eslint-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install root dev dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+
+      # BLOCKING — codebase passed baseline at PR #764 (2026-05-22).
+      - name: Run eslint
+        run: pnpm lint:root
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install root dev dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+
+      # BLOCKING — 5 files autofixed on PR #764 baseline (2026-05-22).
+      # Run `pnpm format` locally to fix before pushing.
+      - name: Check prettier formatting
+        run: pnpm format:check
+
+  typescript-coverage-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # BLOCKING — codebase passed baseline at PR #769 (2026-05-23).
+      # All 142 .ts files in plugins/ covered by a typecheck script in their
+      # enclosing package.json. Audit excludes **/assets/** and **/.vitepress/**.
+      - name: Audit TypeScript files for typecheck coverage
+        run: |
+          python3 scripts/audit-typescript-coverage.py --root plugins

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -30,6 +30,8 @@ on:
       - '**/*.tsx'
       - '**/*.js'
       - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
       - '**/tsconfig*.json'
       - '**/package.json'
 

--- a/scripts/ci/check_path_routing.py
+++ b/scripts/ci/check_path_routing.py
@@ -128,11 +128,7 @@ def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
 
             if in_pr_paths_ignore:
                 m = re.match(r"^(\s*)-\s*(.+?)\s*$", stripped)
-                if (
-                    m
-                    and pr_paths_ignore_indent is not None
-                    and len(m.group(1)) > pr_paths_ignore_indent
-                ):
+                if m and pr_paths_ignore_indent is not None and len(m.group(1)) > pr_paths_ignore_indent:
                     item = m.group(2).strip('"').strip("'")
                     paths_ignore.append(item)
                     continue
@@ -218,7 +214,7 @@ def run_routing(changed_files: list[str]) -> dict[str, Any]:
         workflows.append(extract_workflow_metadata(wf))
 
     result: dict[str, Any] = {
-        "_no_filter": [],   # workflows that fire on every PR (no paths / paths-ignore)
+        "_no_filter": [],  # workflows that fire on every PR (no paths / paths-ignore)
         "_changed_files": sorted(changed_files),
     }
 
@@ -230,13 +226,9 @@ def run_routing(changed_files: list[str]) -> dict[str, Any]:
         if not workflow_fires_for(changed_files, wf["paths"], wf["paths_ignore"]):
             continue
         if wf["paths"]:
-            matched = sorted(
-                [f for f in changed_files if path_matches_filter(f, wf["paths"])]
-            )
+            matched = sorted([f for f in changed_files if path_matches_filter(f, wf["paths"])])
         else:
-            matched = sorted(
-                [f for f in changed_files if not path_matches_filter(f, wf["paths_ignore"])]
-            )
+            matched = sorted([f for f in changed_files if not path_matches_filter(f, wf["paths_ignore"])])
         entry: dict[str, Any] = {
             "file": wf["file"],
             "matched_files": matched,
@@ -273,11 +265,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.changed_files:
-        files = [
-            l.strip()
-            for l in Path(args.changed_files).read_text(encoding="utf-8").splitlines()
-            if l.strip()
-        ]
+        files = [l.strip() for l in Path(args.changed_files).read_text(encoding="utf-8").splitlines() if l.strip()]
     elif args.stdin:
         files = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
     else:

--- a/scripts/ci/check_path_routing.py
+++ b/scripts/ci/check_path_routing.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Workflow paths-filter dry-run / verifier.
+
+Reads every .github/workflows/*.yml file, extracts its `pull_request.paths`
+filter (if any), and reports which workflows would fire for a given list of
+changed files.
+
+Used as a regression gate for the workflow split (PR 2 of the new-track CI
+overhaul). If a future PR breaks the paths routing — e.g., a typo in a glob
+or a renamed file pattern that no workflow catches — the test_path_routing
+pytest detects it before merge.
+
+Usage:
+    # Standalone (interactive):
+    python3 scripts/ci/check_path_routing.py --changed-files /tmp/files.txt
+
+    # With stdin:
+    git diff --name-only origin/main..HEAD | \\
+        python3 scripts/ci/check_path_routing.py --stdin
+
+    # Pretty JSON output:
+    ... --pretty
+
+The output JSON is keyed by workflow name; each value is a list of files that
+match that workflow's paths filter. Workflows with NO paths filter (fire on
+every PR) are listed under the "_no_filter" key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+
+# --- Minimal YAML extraction --------------------------------------------------
+#
+# We don't depend on PyYAML — the runtime CI doesn't always have it. We need
+# just two things: the workflow `name:` and the `pull_request.paths:` list.
+# A bespoke line-oriented parser is sufficient for the well-known shape of
+# our workflow files.
+
+
+def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
+    """Return {name, paths} for one workflow file.
+
+    name: the top-level `name:` value (string) or the filename stem.
+    paths: list of pull_request `paths:` globs (empty list = no filter).
+    """
+    text = yaml_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    workflow_name: str | None = None
+    paths: list[str] = []
+
+    in_pull_request = False
+    in_pr_paths = False
+    pr_paths_indent: int | None = None
+
+    for line in lines:
+        stripped = line.rstrip()
+        if not stripped or stripped.lstrip().startswith("#"):
+            continue
+
+        # Top-level workflow name
+        m = re.match(r"^name:\s*(.+?)\s*$", stripped)
+        if m and workflow_name is None:
+            workflow_name = m.group(1).strip('"').strip("'")
+            continue
+
+        # Detect `pull_request:` (top-level under `on:` — leading whitespace = 2)
+        m = re.match(r"^(\s*)pull_request:\s*$", stripped)
+        if m and len(m.group(1)) <= 2:
+            in_pull_request = True
+            in_pr_paths = False
+            continue
+
+        if in_pull_request:
+            # Leaving pull_request when we hit a sibling top-level event
+            # (e.g. `push:`) at the same indent
+            m = re.match(r"^(\s*)([a-z_]+):\s*$", stripped)
+            if m and len(m.group(1)) <= 2 and m.group(2) != "pull_request":
+                in_pull_request = False
+                in_pr_paths = False
+                continue
+
+            # Detect `paths:` inside pull_request
+            m = re.match(r"^(\s*)paths:\s*$", stripped)
+            if m:
+                in_pr_paths = True
+                pr_paths_indent = len(m.group(1))
+                continue
+
+            if in_pr_paths:
+                # Continue collecting list items until we leave the indent block
+                m = re.match(r"^(\s*)-\s*(.+?)\s*$", stripped)
+                if m and pr_paths_indent is not None and len(m.group(1)) > pr_paths_indent:
+                    item = m.group(2).strip('"').strip("'")
+                    paths.append(item)
+                    continue
+                # Non-list-item line → we've left the paths block
+                # but might still be inside pull_request
+                if stripped.lstrip() and not stripped.lstrip().startswith("-"):
+                    in_pr_paths = False
+
+    return {
+        "name": workflow_name or yaml_path.stem,
+        "file": str(yaml_path.relative_to(_REPO_ROOT)),
+        "paths": paths,
+    }
+
+
+# --- Glob matching ----------------------------------------------------------
+
+
+def path_matches_filter(path: str, glob_patterns: list[str]) -> bool:
+    """GitHub paths filter behavior: a file matches if ANY pattern matches.
+
+    Uses fnmatch with GitHub's `**` extension. fnmatch's bare `*` already
+    matches across `/`, but we explicitly normalize `**/<pat>` → `*<pat>`
+    for clarity.
+    """
+    for pattern in glob_patterns:
+        # GitHub's **/<x> matches "x at any depth"; fnmatch's * already does this.
+        # Strip the leading "**/" if present.
+        norm = pattern
+        if norm.startswith("**/"):
+            norm = norm[3:]
+        if fnmatch.fnmatch(path, norm):
+            return True
+        # Also try matching with the original pattern (fnmatch handles "**" OK
+        # in some cases via collapsed star semantics).
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+
+# --- Routing dry-run --------------------------------------------------------
+
+
+def run_routing(changed_files: list[str]) -> dict[str, Any]:
+    """Apply each workflow's paths filter to the changed-file list."""
+    workflows: list[dict[str, Any]] = []
+    for wf in sorted(_WORKFLOWS_DIR.glob("*.yml")):
+        workflows.append(extract_workflow_metadata(wf))
+
+    result: dict[str, Any] = {
+        "_no_filter": [],   # workflows that fire on every PR
+        "_changed_files": sorted(changed_files),
+    }
+
+    for wf in workflows:
+        wf_name = wf["name"]
+        if not wf["paths"]:
+            result["_no_filter"].append(wf_name)
+            continue
+        matched = sorted([f for f in changed_files if path_matches_filter(f, wf["paths"])])
+        if matched:
+            result[wf_name] = {
+                "file": wf["file"],
+                "matched_files": matched,
+            }
+
+    return result
+
+
+def list_all_workflows() -> list[dict[str, Any]]:
+    return [extract_workflow_metadata(wf) for wf in sorted(_WORKFLOWS_DIR.glob("*.yml"))]
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--changed-files", default=None, help="File containing changed-file list (one per line)")
+    p.add_argument("--stdin", action="store_true", help="Read changed files from stdin")
+    p.add_argument("--pretty", action="store_true")
+    p.add_argument("--list-workflows", action="store_true", help="List all workflows + their paths filters")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    if args.list_workflows:
+        wfs = list_all_workflows()
+        print(json.dumps(wfs, indent=2 if args.pretty else None))
+        return 0
+
+    if args.changed_files:
+        files = [
+            l.strip()
+            for l in Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+            if l.strip()
+        ]
+    elif args.stdin:
+        files = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
+    else:
+        print("error: provide --changed-files FILE or --stdin", file=sys.stderr)
+        return 2
+
+    result = run_routing(files)
+    print(json.dumps(result, indent=2 if args.pretty else None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_path_routing.py
+++ b/scripts/ci/check_path_routing.py
@@ -49,20 +49,27 @@ _WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
 
 
 def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
-    """Return {name, paths} for one workflow file.
+    """Return {name, file, paths, paths_ignore, uses_paths_ignore} for one workflow.
 
-    name: the top-level `name:` value (string) or the filename stem.
-    paths: list of pull_request `paths:` globs (empty list = no filter).
+    name:               the top-level `name:` value (string) or the filename stem.
+    paths:              list of pull_request `paths:` globs (empty list = no filter).
+    paths_ignore:       list of pull_request `paths-ignore:` globs (empty list = none).
+    uses_paths_ignore:  True if the workflow uses `paths-ignore:` instead of (or
+                        in addition to) `paths:`. Routing semantics flip when
+                        paths-ignore is used (fires for everything EXCEPT matches).
     """
     text = yaml_path.read_text(encoding="utf-8")
     lines = text.splitlines()
 
     workflow_name: str | None = None
     paths: list[str] = []
+    paths_ignore: list[str] = []
 
     in_pull_request = False
     in_pr_paths = False
+    in_pr_paths_ignore = False
     pr_paths_indent: int | None = None
+    pr_paths_ignore_indent: int | None = None
 
     for line in lines:
         stripped = line.rstrip()
@@ -80,6 +87,7 @@ def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
         if m and len(m.group(1)) <= 2:
             in_pull_request = True
             in_pr_paths = False
+            in_pr_paths_ignore = False
             continue
 
         if in_pull_request:
@@ -89,31 +97,61 @@ def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
             if m and len(m.group(1)) <= 2 and m.group(2) != "pull_request":
                 in_pull_request = False
                 in_pr_paths = False
+                in_pr_paths_ignore = False
                 continue
 
             # Detect `paths:` inside pull_request
             m = re.match(r"^(\s*)paths:\s*$", stripped)
             if m:
                 in_pr_paths = True
+                in_pr_paths_ignore = False
                 pr_paths_indent = len(m.group(1))
                 continue
 
+            # Detect `paths-ignore:` inside pull_request
+            m = re.match(r"^(\s*)paths-ignore:\s*$", stripped)
+            if m:
+                in_pr_paths_ignore = True
+                in_pr_paths = False
+                pr_paths_ignore_indent = len(m.group(1))
+                continue
+
             if in_pr_paths:
-                # Continue collecting list items until we leave the indent block
                 m = re.match(r"^(\s*)-\s*(.+?)\s*$", stripped)
                 if m and pr_paths_indent is not None and len(m.group(1)) > pr_paths_indent:
                     item = m.group(2).strip('"').strip("'")
                     paths.append(item)
                     continue
                 # Non-list-item line → we've left the paths block
-                # but might still be inside pull_request
                 if stripped.lstrip() and not stripped.lstrip().startswith("-"):
                     in_pr_paths = False
 
+            if in_pr_paths_ignore:
+                m = re.match(r"^(\s*)-\s*(.+?)\s*$", stripped)
+                if (
+                    m
+                    and pr_paths_ignore_indent is not None
+                    and len(m.group(1)) > pr_paths_ignore_indent
+                ):
+                    item = m.group(2).strip('"').strip("'")
+                    paths_ignore.append(item)
+                    continue
+                if stripped.lstrip() and not stripped.lstrip().startswith("-"):
+                    in_pr_paths_ignore = False
+
+    # Try to produce a repo-relative path; if the file is outside the repo
+    # (e.g. a tmp file in tests) fall back to the absolute path.
+    try:
+        file_str = str(yaml_path.relative_to(_REPO_ROOT))
+    except ValueError:
+        file_str = str(yaml_path)
+
     return {
         "name": workflow_name or yaml_path.stem,
-        "file": str(yaml_path.relative_to(_REPO_ROOT)),
+        "file": file_str,
         "paths": paths,
+        "paths_ignore": paths_ignore,
+        "uses_paths_ignore": bool(paths_ignore),
     }
 
 
@@ -123,50 +161,89 @@ def extract_workflow_metadata(yaml_path: Path) -> dict[str, Any]:
 def path_matches_filter(path: str, glob_patterns: list[str]) -> bool:
     """GitHub paths filter behavior: a file matches if ANY pattern matches.
 
-    Uses fnmatch with GitHub's `**` extension. fnmatch's bare `*` already
-    matches across `/`, but we explicitly normalize `**/<pat>` → `*<pat>`
-    for clarity.
+    Python's fnmatch treats `*` and `**` identically (both compile to `.*`
+    and cross `/` boundaries), which handles mid-path `**` (e.g.
+    `plugins/**/SKILL.md`) correctly. The ONE gap vs GitHub's minimatch:
+    a leading `**/<x>` pattern is supposed to also match `<x>` at the
+    repo root, but fnmatch's `*` requires non-empty content followed by
+    `/`. We patch that specifically by also trying the pattern with the
+    leading `**/` stripped.
+
+    Edge cases where this approximation diverges from GitHub minimatch:
+      - Patterns starting with `!` (negation) — NOT SUPPORTED here. Use
+        paths_ignore in the workflow instead.
+      - Brace expansion `{a,b}` — NOT SUPPORTED here. List each as a
+        separate path entry.
     """
     for pattern in glob_patterns:
-        # GitHub's **/<x> matches "x at any depth"; fnmatch's * already does this.
-        # Strip the leading "**/" if present.
-        norm = pattern
-        if norm.startswith("**/"):
-            norm = norm[3:]
-        if fnmatch.fnmatch(path, norm):
-            return True
-        # Also try matching with the original pattern (fnmatch handles "**" OK
-        # in some cases via collapsed star semantics).
         if fnmatch.fnmatch(path, pattern):
             return True
+        # GitHub: `**/<x>` matches `<x>` at the repo root too. fnmatch
+        # treats `**/<x>` as requiring `<something>/<x>`, so we explicitly
+        # also try the stripped form for the root-file case.
+        if pattern.startswith("**/") and fnmatch.fnmatch(path, pattern[3:]):
+            return True
     return False
+
+
+def workflow_fires_for(
+    files: list[str],
+    paths: list[str],
+    paths_ignore: list[str],
+) -> bool:
+    """Apply GitHub's combined paths / paths-ignore semantics.
+
+    Per GitHub docs: a workflow with `paths-ignore` runs unless ALL the
+    changed files match the ignore patterns. A workflow with `paths` runs if
+    ANY file matches. When BOTH are specified, GitHub treats them as
+    independent — `paths` wins precedence in this implementation.
+
+    Empty paths AND empty paths_ignore → fires unconditionally.
+    """
+    if paths:
+        return any(path_matches_filter(f, paths) for f in files)
+    if paths_ignore:
+        # Fires if ANY file does NOT match ignore patterns
+        return any(not path_matches_filter(f, paths_ignore) for f in files)
+    return True
 
 
 # --- Routing dry-run --------------------------------------------------------
 
 
 def run_routing(changed_files: list[str]) -> dict[str, Any]:
-    """Apply each workflow's paths filter to the changed-file list."""
+    """Apply each workflow's paths / paths-ignore filter to the changed-file list."""
     workflows: list[dict[str, Any]] = []
     for wf in sorted(_WORKFLOWS_DIR.glob("*.yml")):
         workflows.append(extract_workflow_metadata(wf))
 
     result: dict[str, Any] = {
-        "_no_filter": [],   # workflows that fire on every PR
+        "_no_filter": [],   # workflows that fire on every PR (no paths / paths-ignore)
         "_changed_files": sorted(changed_files),
     }
 
     for wf in workflows:
         wf_name = wf["name"]
-        if not wf["paths"]:
+        if not wf["paths"] and not wf["paths_ignore"]:
             result["_no_filter"].append(wf_name)
             continue
-        matched = sorted([f for f in changed_files if path_matches_filter(f, wf["paths"])])
-        if matched:
-            result[wf_name] = {
-                "file": wf["file"],
-                "matched_files": matched,
-            }
+        if not workflow_fires_for(changed_files, wf["paths"], wf["paths_ignore"]):
+            continue
+        if wf["paths"]:
+            matched = sorted(
+                [f for f in changed_files if path_matches_filter(f, wf["paths"])]
+            )
+        else:
+            matched = sorted(
+                [f for f in changed_files if not path_matches_filter(f, wf["paths_ignore"])]
+            )
+        entry: dict[str, Any] = {
+            "file": wf["file"],
+            "matched_files": matched,
+        }
+        if wf["uses_paths_ignore"]:
+            entry["uses_paths_ignore"] = True
+        result[wf_name] = entry
 
     return result
 

--- a/tests/ci/test_path_routing.py
+++ b/tests/ci/test_path_routing.py
@@ -1,0 +1,252 @@
+"""Path-routing dry-run tests for the new-track workflow split.
+
+Pin which workflows fire for synthetic PR diffs. Catches:
+    - Glob typos in a workflow's `paths:` filter
+    - Renamed file patterns that no workflow catches
+    - Workflows that should fire NEVER firing
+    - Workflows that should NOT fire firing erroneously
+
+Tests document the intended routing as concrete assertions. Changes to the
+routing require updating the test + an accompanying commit message
+explaining why.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "ci" / "check_path_routing.py"
+_spec = importlib.util.spec_from_file_location("check_path_routing", _SCRIPT_PATH)
+_routing = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_routing)
+
+run_routing = _routing.run_routing
+list_all_workflows = _routing.list_all_workflows
+path_matches_filter = _routing.path_matches_filter
+extract_workflow_metadata = _routing.extract_workflow_metadata
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def fires_for(files: list[str]) -> set[str]:
+    """Return the set of workflow names that match for a given file list,
+    EXCLUDING workflows that fire on every PR (no paths filter)."""
+    result = run_routing(files)
+    return {k for k in result.keys() if not k.startswith("_")}
+
+
+# =============================================================================
+# Per-domain routing tests
+# =============================================================================
+
+
+class TestMarkdownRouting:
+    def test_pure_markdown_change_fires_lint_markdown(self):
+        fired = fires_for(["README.md"])
+        assert "Lint Markdown" in fired
+
+    def test_plugin_skill_md_fires_both_markdown_and_skill_codeblocks(self):
+        fired = fires_for([
+            "plugins/security/penetration-tester/skills/x/SKILL.md",
+        ])
+        assert "Lint Markdown" in fired
+        assert "Lint Skill Code Blocks" in fired
+
+    def test_doc_only_change_does_not_fire_python_or_typescript(self):
+        fired = fires_for(["000-docs/some-doc.md"])
+        assert "Lint Markdown" in fired
+        assert "Lint Python" not in fired
+        assert "Lint TypeScript" not in fired
+        assert "Lint Shell" not in fired
+
+
+class TestPythonRouting:
+    def test_python_source_fires_lint_python(self):
+        fired = fires_for(["scripts/foo.py"])
+        assert "Lint Python" in fired
+
+    def test_python_source_does_not_fire_typescript_lint(self):
+        fired = fires_for(["scripts/foo.py"])
+        assert "Lint TypeScript" not in fired
+
+    def test_pyproject_change_fires_lint_python(self):
+        fired = fires_for(["plugins/security/penetration-tester/pyproject.toml"])
+        assert "Lint Python" in fired
+
+    def test_requirements_change_fires_lint_python(self):
+        fired = fires_for(["plugins/x/requirements.txt"])
+        assert "Lint Python" in fired
+
+
+class TestTypeScriptRouting:
+    def test_ts_source_fires_lint_typescript(self):
+        fired = fires_for(["packages/cli/src/index.ts"])
+        assert "Lint TypeScript" in fired
+
+    def test_js_source_fires_lint_typescript(self):
+        fired = fires_for(["scripts/sync-marketplace.cjs"])
+        assert "Lint TypeScript" in fired
+
+    def test_tsconfig_change_fires_lint_typescript(self):
+        fired = fires_for(["packages/cli/tsconfig.json"])
+        assert "Lint TypeScript" in fired
+
+    def test_package_json_fires_lint_typescript(self):
+        fired = fires_for(["package.json"])
+        assert "Lint TypeScript" in fired
+
+
+class TestShellRouting:
+    def test_shell_script_fires_lint_shell(self):
+        fired = fires_for(["scripts/quick-test.sh"])
+        assert "Lint Shell" in fired
+
+    def test_shell_script_does_not_fire_python_lint(self):
+        fired = fires_for(["scripts/quick-test.sh"])
+        assert "Lint Python" not in fired
+
+
+class TestSkillCodeblocksRouting:
+    def test_skill_md_fires_skill_codeblocks(self):
+        fired = fires_for([
+            "plugins/security/penetration-tester/skills/x/SKILL.md",
+        ])
+        assert "Lint Skill Code Blocks" in fired
+
+    def test_plugin_readme_fires_skill_codeblocks(self):
+        fired = fires_for(["plugins/security/penetration-tester/README.md"])
+        assert "Lint Skill Code Blocks" in fired
+
+    def test_top_level_readme_does_not_fire_skill_codeblocks(self):
+        """README.md at repo root is NOT a plugin SKILL.md / README.md."""
+        fired = fires_for(["README.md"])
+        assert "Lint Skill Code Blocks" not in fired
+
+
+class TestActionlintRouting:
+    def test_workflow_change_fires_actionlint(self):
+        fired = fires_for([".github/workflows/some-workflow.yml"])
+        assert "Actionlint" in fired
+
+    def test_non_workflow_change_does_not_fire_actionlint(self):
+        fired = fires_for(["README.md"])
+        assert "Actionlint" not in fired
+
+
+# =============================================================================
+# Multi-file routing
+# =============================================================================
+
+
+class TestMultiFileRouting:
+    def test_mixed_python_and_typescript_fires_both(self):
+        fired = fires_for([
+            "scripts/foo.py",
+            "packages/cli/src/x.ts",
+        ])
+        assert "Lint Python" in fired
+        assert "Lint TypeScript" in fired
+
+    def test_doc_only_pr_fires_only_markdown_workflows(self):
+        """The PR #823 failure mode: doc-only edit should fire ONLY markdown
+        workflows. The plugin-structure required check (which still runs
+        unfiltered from validate-plugins.yml) is not in this set because
+        it has no paths filter."""
+        fired = fires_for([
+            "plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md",
+            "plugins/saas-packs/databricks-pack/000-docs/014-spec.md",
+        ])
+        assert "Lint Markdown" in fired
+        # NO python, TS, shell, actionlint
+        assert "Lint Python" not in fired
+        assert "Lint TypeScript" not in fired
+        assert "Lint Shell" not in fired
+        assert "Actionlint" not in fired
+
+
+# =============================================================================
+# Each new workflow has a paths filter
+# =============================================================================
+
+
+class TestEveryNewWorkflowHasPathsFilter:
+    """The point of PR 2's split is that each new workflow has a paths filter.
+    If a new workflow gains a `paths:` filter only by accident (e.g. fires
+    on every PR), this test catches it."""
+
+    EXPECTED_FILTERED_WORKFLOWS = {
+        "Lint Markdown",
+        "Lint TypeScript",
+        "Lint Python",
+        "Lint Shell",
+        "Lint Skill Code Blocks",
+        "Actionlint",
+    }
+
+    def test_all_new_workflows_have_paths_filters(self):
+        all_wfs = list_all_workflows()
+        for wf in all_wfs:
+            if wf["name"] in self.EXPECTED_FILTERED_WORKFLOWS:
+                assert wf["paths"], (
+                    f"workflow '{wf['name']}' ({wf['file']}) should have a "
+                    f"paths: filter but does not"
+                )
+
+
+# =============================================================================
+# Glob-matching unit tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "path, patterns, expected",
+    [
+        ("README.md", ["**/*.md"], True),
+        ("scripts/foo.py", ["**/*.py"], True),
+        ("scripts/foo.py", ["**/*.ts"], False),
+        ("packages/cli/tsconfig.json", ["**/tsconfig*.json"], True),
+        ("plugins/x/y/SKILL.md", ["plugins/**/SKILL.md"], True),
+        (".github/workflows/test.yml", [".github/workflows/**"], True),
+        ("README.md", ["**/*.py", "**/*.md"], True),
+        ("README.md", ["**/*.py", "**/*.ts"], False),
+    ],
+)
+def test_path_matches_filter(path, patterns, expected):
+    assert path_matches_filter(path, patterns) is expected
+
+
+# =============================================================================
+# Workflow metadata extraction smoke test
+# =============================================================================
+
+
+class TestWorkflowMetadataExtraction:
+    def test_extracts_workflow_name(self):
+        wf = extract_workflow_metadata(
+            _REPO_ROOT / ".github" / "workflows" / "lint-markdown.yml"
+        )
+        assert wf["name"] == "Lint Markdown"
+
+    def test_extracts_paths_filter(self):
+        wf = extract_workflow_metadata(
+            _REPO_ROOT / ".github" / "workflows" / "lint-python.yml"
+        )
+        assert "**/*.py" in wf["paths"]
+        assert "**/pyproject.toml" in wf["paths"]
+
+    def test_workflow_without_filter_returns_empty_paths(self):
+        """validate-plugins.yml has no paths: filter (transition baseline)."""
+        wf = extract_workflow_metadata(
+            _REPO_ROOT / ".github" / "workflows" / "validate-plugins.yml"
+        )
+        assert wf["paths"] == []

--- a/tests/ci/test_path_routing.py
+++ b/tests/ci/test_path_routing.py
@@ -31,6 +31,7 @@ run_routing = _routing.run_routing
 list_all_workflows = _routing.list_all_workflows
 path_matches_filter = _routing.path_matches_filter
 extract_workflow_metadata = _routing.extract_workflow_metadata
+workflow_fires_for = _routing.workflow_fires_for
 
 
 # =============================================================================
@@ -219,10 +220,170 @@ class TestEveryNewWorkflowHasPathsFilter:
         (".github/workflows/test.yml", [".github/workflows/**"], True),
         ("README.md", ["**/*.py", "**/*.md"], True),
         ("README.md", ["**/*.py", "**/*.ts"], False),
+        # Mid-path ** (the reviewer flagged this — the strip-leading-** branch
+        # used to be dead-weight; verify the simple fnmatch path still works)
+        ("plugins/security/x/skills/y/SKILL.md", ["plugins/**/SKILL.md"], True),
+        ("plugins/a/b/c/d/e/f/SKILL.md", ["plugins/**/SKILL.md"], True),
+        ("scripts/x.py", ["plugins/**/SKILL.md"], False),
+        # Trailing ** (directory recursion)
+        (".github/workflows/foo.yml", [".github/workflows/**"], True),
+        (".github/actions/x.yml", [".github/workflows/**"], False),
+        # Edge: zero patterns means no match
+        ("README.md", [], False),
     ],
 )
 def test_path_matches_filter(path, patterns, expected):
     assert path_matches_filter(path, patterns) is expected
+
+
+# =============================================================================
+# paths-ignore semantics
+# =============================================================================
+
+
+class TestPathsIgnoreSemantics:
+    def test_workflow_fires_when_no_filter(self):
+        assert workflow_fires_for(["README.md"], paths=[], paths_ignore=[]) is True
+
+    def test_workflow_fires_when_paths_matches(self):
+        assert workflow_fires_for(["scripts/x.py"], paths=["**/*.py"], paths_ignore=[]) is True
+
+    def test_workflow_skips_when_paths_does_not_match(self):
+        assert workflow_fires_for(["README.md"], paths=["**/*.py"], paths_ignore=[]) is False
+
+    def test_paths_ignore_skips_when_all_files_match_ignore(self):
+        """A `paths-ignore: ['**/*.md']` workflow should NOT fire for a doc-only PR."""
+        fires = workflow_fires_for(
+            ["docs/a.md", "docs/b.md"],
+            paths=[],
+            paths_ignore=["**/*.md"],
+        )
+        assert fires is False
+
+    def test_paths_ignore_fires_when_any_file_not_ignored(self):
+        """`paths-ignore: ['**/*.md']` fires if ANY file isn't a markdown."""
+        fires = workflow_fires_for(
+            ["docs/a.md", "scripts/x.py"],
+            paths=[],
+            paths_ignore=["**/*.md"],
+        )
+        assert fires is True
+
+
+# =============================================================================
+# Zero-match / gap detection
+# =============================================================================
+
+
+class TestZeroMatchGapDetection:
+    def test_file_matching_no_workflow_appears_nowhere(self):
+        """A file pattern that no workflow currently catches should be visible
+        as belonging only to the always-on workflows."""
+        result = run_routing(["random-experimental-dir/foo.xyz"])
+        # The file shouldn't appear in any path-filtered workflow's matched_files
+        filtered_workflows = {
+            k: v for k, v in result.items() if not k.startswith("_") and isinstance(v, dict)
+        }
+        for wf_name, entry in filtered_workflows.items():
+            assert "random-experimental-dir/foo.xyz" not in entry["matched_files"], (
+                f"unexpected match in {wf_name}"
+            )
+
+    def test_validate_plugins_in_no_filter_set(self):
+        """validate-plugins.yml is the transition baseline — must NOT have a filter."""
+        result = run_routing(["README.md"])
+        assert "Validate Plugins" in result["_no_filter"]
+
+
+# =============================================================================
+# YAML extraction edge cases
+# =============================================================================
+
+
+class TestYamlExtractionEdgeCases:
+    def test_paths_ignore_field_extracted(self, tmp_path):
+        """If a workflow uses paths-ignore, our parser should surface it."""
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "name: Test Ignore\n"
+            "on:\n"
+            "  pull_request:\n"
+            "    paths-ignore:\n"
+            "      - '**/*.md'\n"
+            "      - 'docs/**'\n"
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n",
+            encoding="utf-8",
+        )
+        wf_path = wf  # absolute; extract_workflow_metadata uses relative_to(_REPO_ROOT)
+        # Can't use the real extractor because it relative_to's against repo root.
+        # Just test via temp parse: simulate by reading lines + calling extractor's
+        # logic. Easiest: skip relative_to via monkey-patch.
+        from importlib import reload
+        # Direct functional test via the existing module
+        original = _routing._WORKFLOWS_DIR  # noqa: SLF001
+        try:
+            _routing._WORKFLOWS_DIR = tmp_path  # noqa: SLF001
+            meta = _routing.extract_workflow_metadata(wf_path)
+        finally:
+            _routing._WORKFLOWS_DIR = original  # noqa: SLF001
+        assert meta["paths_ignore"] == ["**/*.md", "docs/**"]
+        assert meta["uses_paths_ignore"] is True
+        assert meta["paths"] == []
+
+    def test_unquoted_glob_in_paths(self, tmp_path):
+        """Unquoted globs in YAML must extract without the surrounding quote
+        characters (this is the most common shape in practice)."""
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "name: Test Unquoted\n"
+            "on:\n"
+            "  pull_request:\n"
+            "    paths:\n"
+            "      - '**/*.md'\n"
+            '      - "**/*.py"\n'
+            "      - scripts/**\n"   # unquoted
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n",
+            encoding="utf-8",
+        )
+        original = _routing._WORKFLOWS_DIR  # noqa: SLF001
+        try:
+            _routing._WORKFLOWS_DIR = tmp_path  # noqa: SLF001
+            meta = _routing.extract_workflow_metadata(wf)
+        finally:
+            _routing._WORKFLOWS_DIR = original  # noqa: SLF001
+        assert meta["paths"] == ["**/*.md", "**/*.py", "scripts/**"]
+
+    def test_workflow_dispatch_only_returns_empty_paths(self, tmp_path):
+        """A workflow with no pull_request trigger at all should report no filter."""
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "name: Test Dispatch Only\n"
+            "on:\n"
+            "  workflow_dispatch:\n"
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n",
+            encoding="utf-8",
+        )
+        original = _routing._WORKFLOWS_DIR  # noqa: SLF001
+        try:
+            _routing._WORKFLOWS_DIR = tmp_path  # noqa: SLF001
+            meta = _routing.extract_workflow_metadata(wf)
+        finally:
+            _routing._WORKFLOWS_DIR = original  # noqa: SLF001
+        assert meta["paths"] == []
+        assert meta["paths_ignore"] == []
+        assert meta["uses_paths_ignore"] is False
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR 2 of the 3-PR new-track CI overhaul. Adds 5 per-domain lint workflows + an actionlint gate + a path-routing dry-run test. Each new workflow has a native `paths:` filter so it only fires when the PR touches relevant files.

**`validate-plugins.yml` is UNCHANGED in this PR** — the original monolithic workflow continues to run on every PR. The new workflows shadow the originals for a transition period. A follow-up PR will retire the original after the new ones prove green on 3+ PRs.

This split avoids the "10 Expected forever" stuck-PR class documented at the top of `validate-plugins.yml` (originally triggered by PR #778).

## New workflows

| File | Fires on | Jobs (copied verbatim from validate-plugins.yml) |
|---|---|---|
| `lint-markdown.yml` | `**/*.md`, `**/*.mdx`, `.markdownlint-cli2.jsonc` | `markdownlint` |
| `lint-typescript.yml` | `**/*.{ts,tsx,js,jsx,mjs,cjs}`, `tsconfig*.json`, `package.json`, `pnpm-lock.yaml` | `eslint-check`, `format-check`, `typescript-coverage-audit` |
| `lint-python.yml` | `**/*.py`, `pyproject.toml`, `requirements*.txt`, `ruff.toml` | `ruff-check`, `ruff-format-check` |
| `lint-shell.yml` | `**/*.sh`, `**/*.bash`, `.shellcheckrc` | `shellcheck-skills` |
| `lint-skill-codeblocks.yml` | `plugins/**/SKILL.md`, `plugins/**/README.md` | `skill-codeblock-syntax` |
| **`actionlint.yml`** | `.github/workflows/**` | `actionlint` — **NEW gate** lints workflow YAML on every workflow-file change |

Each new workflow is a verbatim copy of the relevant job from `validate-plugins.yml` (preserving baseline comments + history references), with only the trigger `paths:` added at the workflow level.

## Path-routing tooling

- **`scripts/ci/check_path_routing.py`** — extracts each workflow's `pull_request.paths` filter from the YAML, applies the filter to a given list of changed files, and reports which workflows would fire. Standalone (no PyYAML dependency — works in the CI's minimal environment).
- **`tests/ci/test_path_routing.py`** — **32 deterministic tests** pinning the routing. Catches glob typos, renamed patterns no workflow catches, workflows that should fire firing erroneously.

The PR #823 doc-only case is explicitly tested: should fire ONLY `Lint Markdown` among the new workflows, NOT Python / TS / shell / actionlint / skill-codeblocks.

## Path-routing dry-run example

```bash
$ echo -e "plugins/saas-packs/databricks-pack/000-docs/000-INDEX.md\nplugins/saas-packs/databricks-pack/000-docs/014-spec.md" | \
    python3 scripts/ci/check_path_routing.py --stdin --pretty
{
  "_no_filter": ["Validate Plugins", "PR Pre-screen", ...],
  "Lint Markdown": {"matched_files": [...]},
  "Check Markdown Links": {"matched_files": [...]}
  // Lint Python, Lint TypeScript, Lint Shell, Actionlint, Lint Skill Code Blocks
  // are NOT in the output — correct.
}
```

## What's NOT in this PR (deliberately deferred)

- **`validate-plugins.yml` retirement.** Original stays as transition baseline until the new workflows prove green on 3+ PRs. Separate cleanup PR.
- **`validate` / `marketplace-validation` split.** Those are the only REQUIRED branch-protection checks. Splitting them needs coordinated branch-protection migration; doing it in this PR would risk a stuck-PR class.
- **Branch-protection updates.** The plan calls for removing `eslint-check`, `ruff-check`, `ruff-format-check`, `shellcheck-skills`, `skill-codeblock-syntax`, `markdownlint`, `typescript-coverage-audit`, `format-check` from required-status-checks once the new workflows have proven coverage. This requires direct API access to the repo settings; documented for execution but not auto-applied.
- **Daily branch-protection drift detection workflow.** Adds operational complexity; lands when branch-protection updates do.

## Branch-protection update (for Jeremy to run post-merge once new workflows are proven)

After 3+ PRs show the new workflows firing correctly:

```bash
# Read current required checks
gh api repos/jeremylongshore/claude-code-plugins-plus-skills/branches/main/protection \
  --jq '.required_status_checks.contexts'

# Update — keep validate + marketplace-validation, add new ones once proven
gh api -X PATCH repos/jeremylongshore/claude-code-plugins-plus-skills/branches/main/protection/required_status_checks \
  -F 'contexts[]=validate' \
  -F 'contexts[]=marketplace-validation' \
  -F 'contexts[]=Lint Markdown / markdownlint' \
  -F 'contexts[]=Lint Python / ruff-check' \
  -F 'contexts[]=Lint Python / ruff-format-check' \
  -F 'contexts[]=Lint TypeScript / eslint-check' \
  -F 'contexts[]=Lint TypeScript / format-check' \
  -F 'contexts[]=Lint TypeScript / typescript-coverage-audit' \
  -F 'contexts[]=Lint Shell / shellcheck-skills' \
  -F 'contexts[]=Lint Skill Code Blocks / skill-codeblock-syntax' \
  -F 'contexts[]=Actionlint / actionlint' \
  -F 'strict=true'
```

## Stacking

Sits alongside PR #838 (pr-classifier — PR 1 of the same overhaul). Either order of merge works; this PR doesn't import from pr-classifier yet. PR 3 (prescreen rewrite + public grading) will consume both.

## Test plan

- [ ] `python3 -m pytest tests/ci/ -v` passes locally (32/32 tests).
- [ ] After merge, open a doc-only PR — Lint Markdown fires, Lint Python / Shell / TypeScript do NOT.
- [ ] After merge, open a Python-only PR — Lint Python fires, Lint Markdown does NOT.
- [ ] After merge, open a workflow-touching PR — Actionlint fires.
- [ ] No regression in `Validate Plugins` (still fires unfiltered on every PR).
- [ ] Branch-protection required checks continue to pass on PRs that touch the relevant files.

- Jeremy Longshore
intentsolutions.io