### PR TITLE
feat(ci): pr-level grade coordinator + golden fixtures (PR 3a of new track)

### DIFF
--- a/scripts/pr-prescreen/coordinator.py
+++ b/scripts/pr-prescreen/coordinator.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""PR pre-screen coordinator.
+
+Consumes the output of `scripts/pr-classifier/detect_components.py`,
+dispatches per-contribution-type evaluators (validate-skills-schema.py for
+skills, validate-agent.py for agents, etc.), composes the per-skill validator
+results via grade.py, and emits a single structured output that drives:
+
+  1. ONE composed PR comment (markdown), and
+  2. A `prescreen-grade` status check verdict (PASS / CHANGES_REQUESTED /
+     HARD_BLOCK) → drives merge gating.
+
+This script ABSORBS the existing scripts/pr-prescreen/classify.py +
+summarize.py outputs into a single coordinator. The old scripts remain
+importable and are still wired into the current pr-prescreen.yml workflow;
+this script will become the new workflow's single entry point in PR 3c.
+
+The coordinator is read-only — it does not modify files. Validator invocations
+are subprocess calls; no network unless an evaluator script makes one. Designed
+for `pull_request_target` execution per the existing prescreen safety model
+(persist-credentials: false, pinned SHAs).
+
+Usage:
+    # End-to-end: read classifier output, run evaluators, emit comment
+    python3 scripts/pr-prescreen/coordinator.py \\
+        --classifier-output /tmp/classifier.json \\
+        --comment-output /tmp/prescreen-comment.md \\
+        --verdict-output /tmp/prescreen-verdict.json
+
+    # Skip subprocess evaluator calls (useful for testing the composition logic):
+    python3 scripts/pr-prescreen/coordinator.py \\
+        --classifier-output /tmp/classifier.json \\
+        --validator-results-file /tmp/validator-results.json \\
+        --comment-output /tmp/prescreen-comment.md \\
+        --verdict-output /tmp/prescreen-verdict.json
+
+Exit codes:
+    0 — coordinator ran successfully (verdict captured in --verdict-output)
+    2 — input error (missing classifier output, malformed JSON, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_SELF = Path(__file__).resolve()
+_REPO_ROOT = _SELF.parents[2]
+
+
+# Load grade.py via importlib so this works whether imported as a package
+# member or executed as a standalone script.
+def _load_grade_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "_pr_prescreen_grade", _SELF.parent / "grade.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # dataclass uses sys.modules lookup during decoration — register the
+    # module under its spec name before exec so the decorator can resolve it.
+    sys.modules["_pr_prescreen_grade"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_grade = _load_grade_module()
+
+
+# --- Classifier output → evaluator dispatch ---------------------------------
+
+
+def _resolve_skill_paths(
+    affected_skills: list[str], plugin_paths: list[str]
+) -> list[Path]:
+    """For each affected skill name, locate its SKILL.md within the affected
+    plugin paths. Returns absolute paths."""
+    out: list[Path] = []
+    for skill_name in affected_skills:
+        for plugin_path in plugin_paths:
+            candidate = _REPO_ROOT / plugin_path / "skills" / skill_name / "SKILL.md"
+            if candidate.exists():
+                out.append(candidate)
+                break
+        else:
+            # Skill name didn't resolve under any affected plugin path —
+            # the classifier promises depth-4 routing so this shouldn't
+            # happen in practice, but be defensive.
+            continue
+    return out
+
+
+def run_skill_validator(
+    skill_paths: list[Path], *, validator_script: Path | None = None
+) -> list[dict[str, Any]]:
+    """Invoke validate-skills-schema.py --marketplace --json against the given
+    SKILL.md paths. Returns the parsed JSON list."""
+    if not skill_paths:
+        return []
+    script = validator_script or (_REPO_ROOT / "scripts" / "validate-skills-schema.py")
+    if not script.exists():
+        return [{"path": str(p), "fatal": f"validator script missing at {script}"}
+                for p in skill_paths]
+    cmd: list[str] = [
+        "python3", str(script), "--marketplace", "--json",
+        *(str(p) for p in skill_paths),
+    ]
+    try:
+        proc = subprocess.run(  # noqa: S603 — script paths controlled by repo
+            cmd, capture_output=True, text=True, timeout=120, check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return [{"path": str(p), "fatal": f"validator invocation failed: {e}"}
+                for p in skill_paths]
+    if proc.returncode != 0 and not proc.stdout.strip():
+        return [{"path": str(p),
+                 "fatal": f"validator exit {proc.returncode}: {proc.stderr.strip()[:200]}"}
+                for p in skill_paths]
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return [{"path": str(p), "fatal": f"validator JSON parse: {e}"} for p in skill_paths]
+    if isinstance(data, dict) and "results" in data:
+        data = data["results"]
+    if not isinstance(data, list):
+        return [{"path": str(p), "fatal": "validator returned non-list JSON"}
+                for p in skill_paths]
+    return data
+
+
+# --- Top-level coordination -------------------------------------------------
+
+
+def coordinate(
+    classifier_output: dict[str, Any],
+    *,
+    validator_results: list[dict[str, Any]] | None = None,
+    validator_invoker: Any = run_skill_validator,
+    hard_block_signals: list[str] | None = None,
+) -> dict[str, Any]:
+    """Run the end-to-end coordinator.
+
+    Args:
+        classifier_output: parsed JSON from pr-classifier.
+        validator_results: optional pre-computed validator results. When
+            supplied, skips subprocess invocations — useful for tests.
+        validator_invoker: callable accepting (skill_paths) → validator
+            results list. Override for tests.
+        hard_block_signals: additional caller-supplied blockers.
+
+    Returns:
+        {
+          "classifier":    <classifier_output>,
+          "validator_results": [...],
+          "grade":         "A" | "B" | "C" | "D" | "F",
+          "score":         int,
+          "verdict":       "PASS" | "CHANGES_REQUESTED" | "HARD_BLOCK",
+          "comment":       markdown comment string,
+          "status_check":  "success" | "failure",
+        }
+    """
+    affected_skills = classifier_output.get("affected_skills") or []
+    plugin_paths = classifier_output.get("plugin_paths") or []
+
+    if validator_results is None:
+        if affected_skills:
+            skill_paths = _resolve_skill_paths(affected_skills, plugin_paths)
+            validator_results = validator_invoker(skill_paths)
+        else:
+            validator_results = []
+
+    grade_result = _grade.compose_grade(
+        validator_results, hard_block_signals=hard_block_signals
+    )
+
+    comment = _grade.render_comment(grade_result)
+
+    status_check = "success" if grade_result["grade"] == _grade.PASS_GRADE else "failure"
+    # Hard blocks always fail
+    if grade_result["verdict"] == "HARD_BLOCK":
+        status_check = "failure"
+
+    return {
+        "classifier": classifier_output,
+        "validator_results": validator_results,
+        "grade": grade_result["grade"],
+        "score": grade_result["score"],
+        "verdict": grade_result["verdict"],
+        "hard_block_signals": grade_result.get("hard_block_signals", []),
+        "summary_line": grade_result.get("summary_line", ""),
+        "deltas": grade_result.get("deltas", []),
+        "comment": comment,
+        "status_check": status_check,
+    }
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__.split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--classifier-output",
+        required=True,
+        help="Path to JSON produced by scripts/pr-classifier/detect_components.py",
+    )
+    p.add_argument(
+        "--validator-results-file",
+        default=None,
+        help="Optional pre-computed validator JSON to skip subprocess calls",
+    )
+    p.add_argument(
+        "--comment-output",
+        default=None,
+        help="Write the composed comment markdown to FILE (default: stdout)",
+    )
+    p.add_argument(
+        "--verdict-output",
+        default=None,
+        help="Write the coordinator verdict JSON to FILE",
+    )
+    p.add_argument(
+        "--hard-block-signal",
+        action="append",
+        default=[],
+        help="Caller-supplied hard-block reason (repeatable)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    classifier_path = Path(args.classifier_output)
+    if not classifier_path.exists():
+        print(f"error: --classifier-output {classifier_path} not found", file=sys.stderr)
+        return 2
+    try:
+        classifier_output = json.loads(classifier_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"error: malformed classifier JSON: {e}", file=sys.stderr)
+        return 2
+
+    validator_results: list[dict[str, Any]] | None = None
+    if args.validator_results_file:
+        try:
+            validator_results = json.loads(
+                Path(args.validator_results_file).read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"error: --validator-results-file: {e}", file=sys.stderr)
+            return 2
+
+    coord = coordinate(
+        classifier_output,
+        validator_results=validator_results,
+        hard_block_signals=list(args.hard_block_signal),
+    )
+
+    comment_md = coord["comment"]
+    if args.comment_output:
+        Path(args.comment_output).write_text(comment_md, encoding="utf-8")
+    else:
+        print(comment_md)
+
+    if args.verdict_output:
+        # Trim noisy embedded comment from the verdict json so the file is small
+        verdict = {k: v for k, v in coord.items() if k != "comment"}
+        Path(args.verdict_output).write_text(
+            json.dumps(verdict, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-prescreen/coordinator.py
+++ b/scripts/pr-prescreen/coordinator.py
@@ -56,9 +56,7 @@ _REPO_ROOT = _SELF.parents[2]
 # Load grade.py via importlib so this works whether imported as a package
 # member or executed as a standalone script.
 def _load_grade_module() -> Any:
-    spec = importlib.util.spec_from_file_location(
-        "_pr_prescreen_grade", _SELF.parent / "grade.py"
-    )
+    spec = importlib.util.spec_from_file_location("_pr_prescreen_grade", _SELF.parent / "grade.py")
     mod = importlib.util.module_from_spec(spec)
     # dataclass uses sys.modules lookup during decoration — register the
     # module under its spec name before exec so the decorator can resolve it.
@@ -93,9 +91,7 @@ def _is_within_repo(candidate: Path) -> bool:
         return str(resolved).startswith(str(_REPO_ROOT))
 
 
-def _resolve_skill_paths(
-    affected_skills: list[str], plugin_paths: list[str]
-) -> list[Path]:
+def _resolve_skill_paths(affected_skills: list[str], plugin_paths: list[str]) -> list[Path]:
     """For each affected skill name, locate its SKILL.md within the affected
     plugin paths. Returns absolute paths CONFINED to the repo root."""
     out: list[Path] = []
@@ -114,34 +110,39 @@ def _resolve_skill_paths(
     return out
 
 
-def run_skill_validator(
-    skill_paths: list[Path], *, validator_script: Path | None = None
-) -> list[dict[str, Any]]:
+def run_skill_validator(skill_paths: list[Path], *, validator_script: Path | None = None) -> list[dict[str, Any]]:
     """Invoke validate-skills-schema.py --marketplace --json against the given
     SKILL.md paths. Returns the parsed JSON list."""
     if not skill_paths:
         return []
     script = validator_script or (_REPO_ROOT / "scripts" / "validate-skills-schema.py")
     if not script.exists():
-        return [{"path": str(p), "fatal": f"validator script missing at {script}"}
-                for p in skill_paths]
+        return [{"path": str(p), "fatal": f"validator script missing at {script}"} for p in skill_paths]
     # `--` separates flags from positional args so a path like `--foo` cannot
     # be parsed as a CLI flag by the validator (reviewer fix PR #840).
     cmd: list[str] = [
-        "python3", str(script), "--marketplace", "--json", "--",
+        "python3",
+        str(script),
+        "--marketplace",
+        "--json",
+        "--",
         *(str(p) for p in skill_paths),
     ]
     try:
         proc = subprocess.run(  # noqa: S603 — script paths controlled by repo
-            cmd, capture_output=True, text=True, timeout=120, check=False,
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        return [{"path": str(p), "fatal": f"validator invocation failed: {e}"}
-                for p in skill_paths]
+        return [{"path": str(p), "fatal": f"validator invocation failed: {e}"} for p in skill_paths]
     if proc.returncode != 0 and not proc.stdout.strip():
-        return [{"path": str(p),
-                 "fatal": f"validator exit {proc.returncode}: {proc.stderr.strip()[:200]}"}
-                for p in skill_paths]
+        return [
+            {"path": str(p), "fatal": f"validator exit {proc.returncode}: {proc.stderr.strip()[:200]}"}
+            for p in skill_paths
+        ]
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError as e:
@@ -149,8 +150,7 @@ def run_skill_validator(
     if isinstance(data, dict) and "results" in data:
         data = data["results"]
     if not isinstance(data, list):
-        return [{"path": str(p), "fatal": "validator returned non-list JSON"}
-                for p in skill_paths]
+        return [{"path": str(p), "fatal": "validator returned non-list JSON"} for p in skill_paths]
     return data
 
 
@@ -193,11 +193,7 @@ def coordinate(
     plugin_paths = classifier_output.get("plugin_paths") or []
 
     no_evaluable_artifacts = (
-        not affected_skills
-        and not affected_agents
-        and not affected_mcp
-        and not affected_hooks
-        and not catalog_adds
+        not affected_skills and not affected_agents and not affected_mcp and not affected_hooks and not catalog_adds
     )
 
     # Doc-only / scripts-only / ci-only PRs have no evaluable skill artifacts.
@@ -211,10 +207,7 @@ def coordinate(
             "score": 100,
             "verdict": "PASS",
             "hard_block_signals": [],
-            "summary_line": (
-                "PASS: no skill / agent / MCP / hook / catalog-add artifacts "
-                "in scope for this PR"
-            ),
+            "summary_line": ("PASS: no skill / agent / MCP / hook / catalog-add artifacts in scope for this PR"),
             "deltas": [],
             "rubric_url": "https://tonsofskills.com/grading",
         }
@@ -238,9 +231,7 @@ def coordinate(
         else:
             validator_results = []
 
-    grade_result = _grade.compose_grade(
-        validator_results, hard_block_signals=hard_block_signals
-    )
+    grade_result = _grade.compose_grade(validator_results, hard_block_signals=hard_block_signals)
 
     comment = _grade.render_comment(grade_result)
 
@@ -316,9 +307,7 @@ def main(argv: list[str] | None = None) -> int:
     validator_results: list[dict[str, Any]] | None = None
     if args.validator_results_file:
         try:
-            validator_results = json.loads(
-                Path(args.validator_results_file).read_text(encoding="utf-8")
-            )
+            validator_results = json.loads(Path(args.validator_results_file).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as e:
             print(f"error: --validator-results-file: {e}", file=sys.stderr)
             return 2
@@ -338,9 +327,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.verdict_output:
         # Trim noisy embedded comment from the verdict json so the file is small
         verdict = {k: v for k, v in coord.items() if k != "comment"}
-        Path(args.verdict_output).write_text(
-            json.dumps(verdict, indent=2, sort_keys=True), encoding="utf-8"
-        )
+        Path(args.verdict_output).write_text(json.dumps(verdict, indent=2, sort_keys=True), encoding="utf-8")
 
     return 0
 

--- a/scripts/pr-prescreen/coordinator.py
+++ b/scripts/pr-prescreen/coordinator.py
@@ -73,22 +73,43 @@ _grade = _load_grade_module()
 # --- Classifier output → evaluator dispatch ---------------------------------
 
 
+def _is_within_repo(candidate: Path) -> bool:
+    """Defense-in-depth bounds check — reject resolved paths outside the repo.
+
+    Reviewer (PR #840) flagged: `affected_skills` and `plugin_paths` come
+    from classifier output, which is derived from the PR's file diff. A
+    malicious or accidental ../-traversal entry like `affected_skills:
+    ['../../etc/passwd']` would otherwise let _resolve_skill_paths construct
+    a path outside the repo root. We resolve + check is_relative_to before
+    accepting the path.
+    """
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError):
+        return False
+    try:
+        return resolved.is_relative_to(_REPO_ROOT)
+    except AttributeError:  # pragma: no cover — pre-Python 3.9 fallback
+        return str(resolved).startswith(str(_REPO_ROOT))
+
+
 def _resolve_skill_paths(
     affected_skills: list[str], plugin_paths: list[str]
 ) -> list[Path]:
     """For each affected skill name, locate its SKILL.md within the affected
-    plugin paths. Returns absolute paths."""
+    plugin paths. Returns absolute paths CONFINED to the repo root."""
     out: list[Path] = []
     for skill_name in affected_skills:
         for plugin_path in plugin_paths:
             candidate = _REPO_ROOT / plugin_path / "skills" / skill_name / "SKILL.md"
+            if not _is_within_repo(candidate):
+                # Reject path-traversal attempts silently. Logging here would
+                # be useful in CI but log-noise everywhere else.
+                continue
             if candidate.exists():
                 out.append(candidate)
                 break
         else:
-            # Skill name didn't resolve under any affected plugin path —
-            # the classifier promises depth-4 routing so this shouldn't
-            # happen in practice, but be defensive.
             continue
     return out
 
@@ -104,8 +125,10 @@ def run_skill_validator(
     if not script.exists():
         return [{"path": str(p), "fatal": f"validator script missing at {script}"}
                 for p in skill_paths]
+    # `--` separates flags from positional args so a path like `--foo` cannot
+    # be parsed as a CLI flag by the validator (reviewer fix PR #840).
     cmd: list[str] = [
-        "python3", str(script), "--marketplace", "--json",
+        "python3", str(script), "--marketplace", "--json", "--",
         *(str(p) for p in skill_paths),
     ]
     try:
@@ -163,7 +186,50 @@ def coordinate(
         }
     """
     affected_skills = classifier_output.get("affected_skills") or []
+    affected_agents = classifier_output.get("affected_agents") or []
+    affected_mcp = classifier_output.get("affected_mcp") or []
+    affected_hooks = classifier_output.get("affected_hooks") or []
+    catalog_adds = classifier_output.get("catalog_additions") or []
     plugin_paths = classifier_output.get("plugin_paths") or []
+
+    no_evaluable_artifacts = (
+        not affected_skills
+        and not affected_agents
+        and not affected_mcp
+        and not affected_hooks
+        and not catalog_adds
+    )
+
+    # Doc-only / scripts-only / ci-only PRs have no evaluable skill artifacts.
+    # Reviewer (PR #840) correctly flagged that the prior HARD_BLOCK policy
+    # here blocked every doc fix and typo correction. Explicit PASS instead,
+    # so the prescreen never blocks a PR that has nothing the marketplace
+    # validator can grade.
+    if no_evaluable_artifacts and not hard_block_signals:
+        verdict_payload = {
+            "grade": "A",
+            "score": 100,
+            "verdict": "PASS",
+            "hard_block_signals": [],
+            "summary_line": (
+                "PASS: no skill / agent / MCP / hook / catalog-add artifacts "
+                "in scope for this PR"
+            ),
+            "deltas": [],
+            "rubric_url": "https://tonsofskills.com/grading",
+        }
+        return {
+            "classifier": classifier_output,
+            "validator_results": [],
+            "grade": "A",
+            "score": 100,
+            "verdict": "PASS",
+            "hard_block_signals": [],
+            "summary_line": verdict_payload["summary_line"],
+            "deltas": [],
+            "comment": _grade.render_comment(verdict_payload),
+            "status_check": "success",
+        }
 
     if validator_results is None:
         if affected_skills:

--- a/scripts/pr-prescreen/grade.py
+++ b/scripts/pr-prescreen/grade.py
@@ -1,0 +1,331 @@
+"""PR-level grade composer.
+
+Given per-skill validator results plus per-component evaluator outputs (agents,
+MCP, hooks, catalog adds), compute a SINGLE overall PR grade (A/B/C/D/F) and
+generate actionable "how to reach A" deltas.
+
+Grade semantics:
+    The PR grade is the WEAKEST per-component grade. A PR with three A-grade
+    skills and one C-grade skill grades C. The rationale: the marketplace
+    surfaces every artifact; one weak skill drags the whole submission's
+    reputation. Contributors get specific deltas for the weakest items.
+
+Score → grade mapping (matches the IS marketplace validator):
+    A:  90–100
+    B:  80–89
+    C:  70–79
+    D:  60–69
+    F:   0–59
+
+No I/O, no network, no dependencies beyond stdlib.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+GRADE_ORDER = ("A", "B", "C", "D", "F")
+GRADE_RANK = {"A": 5, "B": 4, "C": 3, "D": 2, "F": 1}
+PASS_GRADE = "A"
+
+
+# --- Score → grade ----------------------------------------------------------
+
+
+def score_to_grade(score: int | float | None) -> str:
+    if score is None:
+        return "F"
+    s = float(score)
+    if s >= 90:
+        return "A"
+    if s >= 80:
+        return "B"
+    if s >= 70:
+        return "C"
+    if s >= 60:
+        return "D"
+    return "F"
+
+
+def grade_to_band(grade: str) -> tuple[int, int]:
+    """Return (low, high) inclusive band for a grade letter."""
+    bands = {"A": (90, 100), "B": (80, 89), "C": (70, 79), "D": (60, 69), "F": (0, 59)}
+    return bands.get(grade.upper(), (0, 0))
+
+
+def points_to_next_grade(score: int | float, current_grade: str) -> int:
+    """How many points are needed to escape the current grade band upward."""
+    next_grade_index = max(GRADE_ORDER.index(current_grade) - 1, 0)
+    if next_grade_index == GRADE_ORDER.index(current_grade):
+        return 0  # already at A
+    next_grade = GRADE_ORDER[next_grade_index]
+    next_low, _ = grade_to_band(next_grade)
+    return max(int(next_low - float(score)), 1)
+
+
+# --- Per-skill delta extraction --------------------------------------------
+
+
+@dataclass
+class SkillFinding:
+    """One actionable delta for a specific skill on the path to A."""
+
+    path: str
+    current_score: int
+    current_grade: str
+    points_to_a: int
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def headline(self) -> str:
+        return (
+            f"{self.path}: {self.current_grade} ({self.current_score}/100), "
+            f"+{self.points_to_a} pts to A"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "current_score": self.current_score,
+            "current_grade": self.current_grade,
+            "points_to_a": self.points_to_a,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+def extract_skill_findings(
+    validator_results: list[dict[str, Any]]
+) -> list[SkillFinding]:
+    """Pull SkillFinding objects out of validator JSON output.
+
+    Each input record is expected to follow the shape emitted by
+    scripts/validate-skills-schema.py --json:
+        {"path": str, "score": int, "grade": str,
+         "errors": int, "warnings": int,
+         "error_messages": [str, ...], "warning_messages": [str, ...]}
+    Older shapes use "errors"/"warnings" as plain counts; if a list is
+    present under "error_messages" we surface it.
+    """
+    out: list[SkillFinding] = []
+    for entry in validator_results:
+        if "fatal" in entry:
+            out.append(
+                SkillFinding(
+                    path=entry.get("path", "<unknown>"),
+                    current_score=0,
+                    current_grade="F",
+                    points_to_a=90,
+                    errors=[entry["fatal"]],
+                )
+            )
+            continue
+        score = int(entry.get("score") or 0)
+        grade = (entry.get("grade") or score_to_grade(score)).upper()
+        errors = entry.get("error_messages") or []
+        warnings = entry.get("warning_messages") or []
+        if grade == "A":
+            continue  # nothing to surface
+        out.append(
+            SkillFinding(
+                path=entry.get("path", "<unknown>"),
+                current_score=score,
+                current_grade=grade,
+                points_to_a=points_to_next_grade(score, grade)
+                if grade != "A"
+                else 0,
+                errors=list(errors) if isinstance(errors, list) else [str(errors)],
+                warnings=list(warnings) if isinstance(warnings, list) else [str(warnings)],
+            )
+        )
+    # Sort by lowest grade first (most urgent), then by points-to-A (closest first)
+    out.sort(key=lambda f: (GRADE_RANK[f.current_grade], -f.points_to_a))
+    return out
+
+
+# --- Overall grade composition ---------------------------------------------
+
+
+def compose_grade(
+    validator_results: list[dict[str, Any]],
+    *,
+    hard_block_signals: list[str] | None = None,
+) -> dict[str, Any]:
+    """Compose the PR-level grade + deltas + verdict.
+
+    Args:
+        validator_results: per-skill validator records.
+        hard_block_signals: caller-supplied conditions that force F regardless
+            of validator output (e.g. no catalog entry, secret in diff).
+
+    Returns:
+        {
+            "grade":           "A" | "B" | "C" | "D" | "F",
+            "score":           min per-component score (or 0 if hard-blocked),
+            "verdict":         "PASS" | "CHANGES_REQUESTED" | "HARD_BLOCK",
+            "hard_block_signals": [...],
+            "deltas":          [SkillFinding.to_dict(), ...],
+            "summary_line":    short one-line description,
+            "rubric_url":      pointer to the public grading rubric,
+        }
+    """
+    signals = [s for s in (hard_block_signals or []) if s]
+    if signals:
+        return {
+            "grade": "F",
+            "score": 0,
+            "verdict": "HARD_BLOCK",
+            "hard_block_signals": signals,
+            "deltas": [],
+            "summary_line": f"HARD_BLOCK: {signals[0]}"
+            + (f" (+{len(signals) - 1} more)" if len(signals) > 1 else ""),
+            "rubric_url": _RUBRIC_URL,
+        }
+
+    if not validator_results:
+        return {
+            "grade": "F",
+            "score": 0,
+            "verdict": "HARD_BLOCK",
+            "hard_block_signals": ["no validator results"],
+            "deltas": [],
+            "summary_line": "HARD_BLOCK: no skill/agent/MCP/hook artifacts evaluated",
+            "rubric_url": _RUBRIC_URL,
+        }
+
+    scores: list[int] = []
+    grades: list[str] = []
+    fatal_paths: list[str] = []
+    for r in validator_results:
+        if "fatal" in r:
+            fatal_paths.append(r.get("path", "<unknown>"))
+            continue
+        if r.get("score") is not None:
+            scores.append(int(r["score"]))
+        if r.get("grade"):
+            grades.append(str(r["grade"]).upper())
+
+    if fatal_paths:
+        return {
+            "grade": "F",
+            "score": 0,
+            "verdict": "HARD_BLOCK",
+            "hard_block_signals": [f"fatal: {p}" for p in fatal_paths],
+            "deltas": [d.to_dict() for d in extract_skill_findings(validator_results)],
+            "summary_line": f"HARD_BLOCK: {len(fatal_paths)} fatal validator error(s)",
+            "rubric_url": _RUBRIC_URL,
+        }
+
+    min_score = min(scores) if scores else 0
+    lowest_grade = (
+        max(grades, key=lambda g: GRADE_RANK.get(g, 0)) if False else None
+    )
+    # Take the WORST grade (lowest in rank), not the highest
+    lowest_grade = min(grades, key=lambda g: GRADE_RANK.get(g, 0)) if grades else "F"
+    if not lowest_grade:
+        lowest_grade = score_to_grade(min_score)
+
+    deltas = [d.to_dict() for d in extract_skill_findings(validator_results)]
+
+    if lowest_grade == "A":
+        verdict = "PASS"
+        summary = f"PASS: {len(validator_results)} component(s), all A-grade (min {min_score}/100)"
+    elif lowest_grade == "B":
+        verdict = "CHANGES_REQUESTED"
+        summary = (
+            f"CHANGES_REQUESTED: {len(validator_results)} component(s), "
+            f"weakest grade B (min {min_score}/100). Close — see deltas."
+        )
+    elif lowest_grade == "C":
+        verdict = "CHANGES_REQUESTED"
+        summary = (
+            f"CHANGES_REQUESTED: {len(validator_results)} component(s), "
+            f"weakest grade C (min {min_score}/100)"
+        )
+    else:
+        verdict = "CHANGES_REQUESTED"
+        summary = (
+            f"CHANGES_REQUESTED: {len(validator_results)} component(s), "
+            f"weakest grade {lowest_grade} (min {min_score}/100)"
+        )
+
+    return {
+        "grade": lowest_grade,
+        "score": min_score,
+        "verdict": verdict,
+        "hard_block_signals": [],
+        "deltas": deltas,
+        "summary_line": summary,
+        "rubric_url": _RUBRIC_URL,
+    }
+
+
+# --- Comment composition ---------------------------------------------------
+
+
+_RUBRIC_URL = "https://tonsofskills.com/grading"
+
+
+def render_comment(grade_result: dict[str, Any]) -> str:
+    """Render the prescreen comment markdown for posting to a PR."""
+    grade = grade_result["grade"]
+    score = grade_result["score"]
+    verdict = grade_result["verdict"]
+    summary = grade_result["summary_line"]
+    deltas = grade_result.get("deltas", [])
+    hard_signals = grade_result.get("hard_block_signals", [])
+
+    lines: list[str] = []
+    if verdict == "PASS":
+        lines.append(f"## ✅ Prescreen: Grade **A** ({score}/100)")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        lines.append("All components meet the marketplace bar. Ready to merge once required checks pass.")
+    elif verdict == "HARD_BLOCK":
+        lines.append(f"## 🛑 Prescreen: HARD BLOCK")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        if hard_signals:
+            lines.append("**Blockers:**")
+            lines.append("")
+            for s in hard_signals:
+                lines.append(f"- {s}")
+            lines.append("")
+    else:
+        lines.append(f"## 🟡 Prescreen: Grade **{grade}** ({score}/100)")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        lines.append(
+            f"Marketplace bar is **A** (≥90). See the public rubric at "
+            f"<{_RUBRIC_URL}> for the full 100-point breakdown."
+        )
+        lines.append("")
+
+    if deltas:
+        lines.append("### How to reach A")
+        lines.append("")
+        for d in deltas[:5]:
+            lines.append(
+                f"- **{d['path']}** — {d['current_grade']} "
+                f"({d['current_score']}/100, +{d['points_to_a']} pts needed)"
+            )
+            for err in (d.get("errors") or [])[:3]:
+                lines.append(f"    - error: {err}")
+            for warn in (d.get("warnings") or [])[:2]:
+                lines.append(f"    - warning: {warn}")
+        if len(deltas) > 5:
+            lines.append(f"- … and {len(deltas) - 5} more component(s)")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        f"_Public rubric:_ <{_RUBRIC_URL}> _·_ "
+        "_How submissions are graded across 200+ marketplace plugins._"
+    )
+
+    return "\n".join(lines)

--- a/scripts/pr-prescreen/grade.py
+++ b/scripts/pr-prescreen/grade.py
@@ -92,16 +92,13 @@ class SkillFinding:
     path: str
     current_score: int
     current_grade: str
-    points_to_a: int                # absolute distance to A (≥90)
-    points_to_next_band: int        # distance to next grade band (closer goal)
+    points_to_a: int  # absolute distance to A (≥90)
+    points_to_next_band: int  # distance to next grade band (closer goal)
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
     def headline(self) -> str:
-        return (
-            f"{self.path}: {self.current_grade} ({self.current_score}/100), "
-            f"+{self.points_to_a} pts to A"
-        )
+        return f"{self.path}: {self.current_grade} ({self.current_score}/100), +{self.points_to_a} pts to A"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -115,9 +112,7 @@ class SkillFinding:
         }
 
 
-def extract_skill_findings(
-    validator_results: list[dict[str, Any]]
-) -> list[SkillFinding]:
+def extract_skill_findings(validator_results: list[dict[str, Any]]) -> list[SkillFinding]:
     """Pull SkillFinding objects out of validator JSON output.
 
     Each input record is expected to follow the shape emitted by
@@ -198,8 +193,7 @@ def compose_grade(
             "verdict": "HARD_BLOCK",
             "hard_block_signals": signals,
             "deltas": [],
-            "summary_line": f"HARD_BLOCK: {signals[0]}"
-            + (f" (+{len(signals) - 1} more)" if len(signals) > 1 else ""),
+            "summary_line": f"HARD_BLOCK: {signals[0]}" + (f" (+{len(signals) - 1} more)" if len(signals) > 1 else ""),
             "rubric_url": _RUBRIC_URL,
         }
 
@@ -263,10 +257,7 @@ def compose_grade(
         )
     elif lowest_grade == "C":
         verdict = "CHANGES_REQUESTED"
-        summary = (
-            f"CHANGES_REQUESTED: {len(validator_results)} component(s), "
-            f"weakest grade C (min {min_score}/100)"
-        )
+        summary = f"CHANGES_REQUESTED: {len(validator_results)} component(s), weakest grade C (min {min_score}/100)"
     else:
         verdict = "CHANGES_REQUESTED"
         summary = (
@@ -314,7 +305,7 @@ def render_comment(grade_result: dict[str, Any]) -> str:
         lines.append("")
         lines.append("All components meet the marketplace bar. Ready to merge once required checks pass.")
     elif verdict == "HARD_BLOCK":
-        lines.append(f"## 🛑 Prescreen: HARD BLOCK")
+        lines.append("## 🛑 Prescreen: HARD BLOCK")
         lines.append("")
         lines.append(summary)
         lines.append("")
@@ -344,16 +335,10 @@ def render_comment(grade_result: dict[str, Any]) -> str:
             if pts_a > pts_next:
                 # Show both distances so contributors don't mistake the
                 # next-band threshold for the A threshold (reviewer fix #840).
-                distance_str = (
-                    f"+{pts_next} pts to {_next_grade(d['current_grade'])}, "
-                    f"+{pts_a} pts to A"
-                )
+                distance_str = f"+{pts_next} pts to {_next_grade(d['current_grade'])}, +{pts_a} pts to A"
             else:
                 distance_str = f"+{pts_a} pts to A"
-            lines.append(
-                f"- **{d['path']}** — {d['current_grade']} "
-                f"({d['current_score']}/100, {distance_str})"
-            )
+            lines.append(f"- **{d['path']}** — {d['current_grade']} ({d['current_score']}/100, {distance_str})")
             for err in (d.get("errors") or [])[:3]:
                 lines.append(f"    - error: {err}")
             for warn in (d.get("warnings") or [])[:2]:
@@ -364,9 +349,6 @@ def render_comment(grade_result: dict[str, Any]) -> str:
 
     lines.append("---")
     lines.append("")
-    lines.append(
-        f"_Public rubric:_ <{_RUBRIC_URL}> _·_ "
-        "_How submissions are graded across 200+ marketplace plugins._"
-    )
+    lines.append(f"_Public rubric:_ <{_RUBRIC_URL}> _·_ _How submissions are graded across 200+ marketplace plugins._")
 
     return "\n".join(lines)

--- a/scripts/pr-prescreen/grade.py
+++ b/scripts/pr-prescreen/grade.py
@@ -55,13 +55,25 @@ def grade_to_band(grade: str) -> tuple[int, int]:
 
 
 def points_to_next_grade(score: int | float, current_grade: str) -> int:
-    """How many points are needed to escape the current grade band upward."""
-    next_grade_index = max(GRADE_ORDER.index(current_grade) - 1, 0)
-    if next_grade_index == GRADE_ORDER.index(current_grade):
+    """How many points are needed to escape the current grade band upward.
+
+    Returns 0 when the score is already at or above the next band's floor
+    (which can happen when the validator's `grade` field disagrees with its
+    `score` field). Returns 0 for grade A (already at the top).
+    """
+    cur_idx = GRADE_ORDER.index(current_grade)
+    next_idx = max(cur_idx - 1, 0)
+    if next_idx == cur_idx:
         return 0  # already at A
-    next_grade = GRADE_ORDER[next_grade_index]
+    next_grade = GRADE_ORDER[next_idx]
     next_low, _ = grade_to_band(next_grade)
-    return max(int(next_low - float(score)), 1)
+    delta = int(next_low - float(score))
+    return max(delta, 0)
+
+
+def points_to_a(score: int | float) -> int:
+    """How many points are needed to reach grade A (≥90). Returns 0 if at or above."""
+    return max(int(90 - float(score)), 0)
 
 
 # --- Per-skill delta extraction --------------------------------------------
@@ -69,12 +81,19 @@ def points_to_next_grade(score: int | float, current_grade: str) -> int:
 
 @dataclass
 class SkillFinding:
-    """One actionable delta for a specific skill on the path to A."""
+    """One actionable delta for a specific skill on the path to A.
+
+    `points_to_a` is the absolute distance to grade A (≥90), not the distance
+    to the next band. Reviewer (PR #840) flagged this — a contributor seeing
+    "+5 pts" on a C-grade skill would naturally read it as "5 to pass" when
+    they actually need 15 to reach A. We display the absolute distance.
+    """
 
     path: str
     current_score: int
     current_grade: str
-    points_to_a: int
+    points_to_a: int                # absolute distance to A (≥90)
+    points_to_next_band: int        # distance to next grade band (closer goal)
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -90,6 +109,7 @@ class SkillFinding:
             "current_score": self.current_score,
             "current_grade": self.current_grade,
             "points_to_a": self.points_to_a,
+            "points_to_next_band": self.points_to_next_band,
             "errors": list(self.errors),
             "warnings": list(self.warnings),
         }
@@ -117,6 +137,7 @@ def extract_skill_findings(
                     current_score=0,
                     current_grade="F",
                     points_to_a=90,
+                    points_to_next_band=10,  # F→D is +60, but next-band shorthand
                     errors=[entry["fatal"]],
                 )
             )
@@ -132,9 +153,8 @@ def extract_skill_findings(
                 path=entry.get("path", "<unknown>"),
                 current_score=score,
                 current_grade=grade,
-                points_to_a=points_to_next_grade(score, grade)
-                if grade != "A"
-                else 0,
+                points_to_a=points_to_a(score),
+                points_to_next_band=points_to_next_grade(score, grade),
                 errors=list(errors) if isinstance(errors, list) else [str(errors)],
                 warnings=list(warnings) if isinstance(warnings, list) else [str(warnings)],
             )
@@ -184,6 +204,12 @@ def compose_grade(
         }
 
     if not validator_results:
+        # Failsafe HARD_BLOCK when there are no validator results AND no
+        # hard-block signals were set. This can happen if the validator
+        # silently failed; we'd rather block + investigate than silently PASS.
+        # The doc-only-PR-should-PASS policy is implemented in coordinate()
+        # which detects that case from classifier output and skips compose_grade
+        # entirely with an explicit PASS verdict.
         return {
             "grade": "F",
             "score": 0,
@@ -217,13 +243,11 @@ def compose_grade(
             "rubric_url": _RUBRIC_URL,
         }
 
+    # Weakest-link grade: take the WORST grade (lowest rank), not the highest.
     min_score = min(scores) if scores else 0
-    lowest_grade = (
-        max(grades, key=lambda g: GRADE_RANK.get(g, 0)) if False else None
-    )
-    # Take the WORST grade (lowest in rank), not the highest
-    lowest_grade = min(grades, key=lambda g: GRADE_RANK.get(g, 0)) if grades else "F"
-    if not lowest_grade:
+    if grades:
+        lowest_grade = min(grades, key=lambda g: GRADE_RANK.get(g, 0))
+    else:
         lowest_grade = score_to_grade(min_score)
 
     deltas = [d.to_dict() for d in extract_skill_findings(validator_results)]
@@ -265,6 +289,12 @@ def compose_grade(
 
 
 _RUBRIC_URL = "https://tonsofskills.com/grading"
+
+
+def _next_grade(current: str) -> str:
+    """Return the grade-letter immediately above the current one (A→A)."""
+    idx = GRADE_ORDER.index(current.upper()) if current.upper() in GRADE_ORDER else 4
+    return GRADE_ORDER[max(idx - 1, 0)]
 
 
 def render_comment(grade_result: dict[str, Any]) -> str:
@@ -309,9 +339,20 @@ def render_comment(grade_result: dict[str, Any]) -> str:
         lines.append("### How to reach A")
         lines.append("")
         for d in deltas[:5]:
+            pts_a = d["points_to_a"]
+            pts_next = d.get("points_to_next_band", pts_a)
+            if pts_a > pts_next:
+                # Show both distances so contributors don't mistake the
+                # next-band threshold for the A threshold (reviewer fix #840).
+                distance_str = (
+                    f"+{pts_next} pts to {_next_grade(d['current_grade'])}, "
+                    f"+{pts_a} pts to A"
+                )
+            else:
+                distance_str = f"+{pts_a} pts to A"
             lines.append(
                 f"- **{d['path']}** — {d['current_grade']} "
-                f"({d['current_score']}/100, +{d['points_to_a']} pts needed)"
+                f"({d['current_score']}/100, {distance_str})"
             )
             for err in (d.get("errors") or [])[:3]:
                 lines.append(f"    - error: {err}")

--- a/tests/pr-prescreen/golden/README.md
+++ b/tests/pr-prescreen/golden/README.md
@@ -1,0 +1,20 @@
+# Prescreen golden grade fixtures
+
+Synthetic per-skill validator-result fixtures spanning the A/B/C/D grade bands.
+Each fixture mirrors the JSON shape emitted by
+`scripts/validate-skills-schema.py --marketplace --json`.
+
+These are used by `tests/pr-prescreen/test_grade.py` to pin the grade-composition
+logic in `scripts/pr-prescreen/grade.py`. They're NOT used for live validator
+testing — they're hand-curated to live in specific score bands.
+
+If the score → grade mapping in `grade.py` changes, regenerate the fixtures
+and update the tests accordingly. The mapping today:
+
+| Grade | Score band |
+| ----- | ---------- |
+| A     | 90–100     |
+| B     | 80–89      |
+| C     | 70–79      |
+| D     | 60–69      |
+| F     | 0–59       |

--- a/tests/pr-prescreen/golden/a-grade.json
+++ b/tests/pr-prescreen/golden/a-grade.json
@@ -1,0 +1,11 @@
+[
+  {
+    "path": "plugins/security/example/skills/clean-skill/SKILL.md",
+    "score": 95,
+    "grade": "A",
+    "errors": 0,
+    "warnings": 0,
+    "error_messages": [],
+    "warning_messages": []
+  }
+]

--- a/tests/pr-prescreen/golden/b-grade.json
+++ b/tests/pr-prescreen/golden/b-grade.json
@@ -1,0 +1,14 @@
+[
+  {
+    "path": "plugins/security/example/skills/missing-references/SKILL.md",
+    "score": 85,
+    "grade": "B",
+    "errors": 0,
+    "warnings": 2,
+    "error_messages": [],
+    "warning_messages": [
+      "Tool 'Glob' declared in allowed-tools but never referenced in the skill body",
+      "Consider adding 'model': pin a specific model for reasoning stability"
+    ]
+  }
+]

--- a/tests/pr-prescreen/golden/c-grade.json
+++ b/tests/pr-prescreen/golden/c-grade.json
@@ -1,0 +1,16 @@
+[
+  {
+    "path": "plugins/security/example/skills/missing-prerequisites/SKILL.md",
+    "score": 75,
+    "grade": "C",
+    "errors": 0,
+    "warnings": 4,
+    "error_messages": [],
+    "warning_messages": [
+      "Required section missing: '## Prerequisites' (marketplace tier)",
+      "Tool 'Read' declared in allowed-tools but never referenced",
+      "Body lacks 'Step 1 / Step 2' numbered workflow structure",
+      "References folder has only 1 file (target: >=2 for marketplace tier)"
+    ]
+  }
+]

--- a/tests/pr-prescreen/golden/d-grade.json
+++ b/tests/pr-prescreen/golden/d-grade.json
@@ -1,0 +1,20 @@
+[
+  {
+    "path": "plugins/security/example/skills/over-permissive/SKILL.md",
+    "score": 65,
+    "grade": "D",
+    "errors": 2,
+    "warnings": 5,
+    "error_messages": [
+      "Required field 'allowed-tools' missing from frontmatter",
+      "'description' exceeds 1024 characters"
+    ],
+    "warning_messages": [
+      "No 'Use when' trigger phrase in description",
+      "Body has no '## Output' section",
+      "References folder absent",
+      "No 'Trigger with' phrase listed",
+      "Tags array is empty"
+    ]
+  }
+]

--- a/tests/pr-prescreen/golden/f-grade-fatal.json
+++ b/tests/pr-prescreen/golden/f-grade-fatal.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "plugins/security/example/skills/broken-yaml/SKILL.md",
+    "fatal": "YAML frontmatter parse error: expected ':' but got '-' at line 4"
+  }
+]

--- a/tests/pr-prescreen/golden/mixed-a-b-c.json
+++ b/tests/pr-prescreen/golden/mixed-a-b-c.json
@@ -1,0 +1,33 @@
+[
+  {
+    "path": "plugins/saas-packs/example-pack/skills/skill-one/SKILL.md",
+    "score": 92,
+    "grade": "A",
+    "errors": 0,
+    "warnings": 0,
+    "error_messages": [],
+    "warning_messages": []
+  },
+  {
+    "path": "plugins/saas-packs/example-pack/skills/skill-two/SKILL.md",
+    "score": 84,
+    "grade": "B",
+    "errors": 0,
+    "warnings": 1,
+    "error_messages": [],
+    "warning_messages": ["Tool 'Edit' declared but never referenced"]
+  },
+  {
+    "path": "plugins/saas-packs/example-pack/skills/skill-three/SKILL.md",
+    "score": 73,
+    "grade": "C",
+    "errors": 0,
+    "warnings": 3,
+    "error_messages": [],
+    "warning_messages": [
+      "Required section missing: '## Prerequisites'",
+      "Body lacks numbered workflow steps",
+      "References folder has only 1 file"
+    ]
+  }
+]

--- a/tests/pr-prescreen/test_coordinator.py
+++ b/tests/pr-prescreen/test_coordinator.py
@@ -103,10 +103,11 @@ class TestCoordinate:
         assert result["verdict"] == "HARD_BLOCK"
         assert result["status_check"] == "failure"
 
-    def test_no_affected_skills_no_validator_calls(self):
-        """A doc-only PR (no affected_skills) should result in an empty
-        validator_results and a HARD_BLOCK (per current policy — no
-        evaluable components means we can't grade)."""
+    def test_doc_only_pr_passes_without_invoking_validator(self):
+        """Reviewer fix #840: a doc-only PR (no affected_skills/agents/mcp/
+        hooks/catalog_additions) must PASS without invoking the validator.
+        Blocking these would block every README typo fix touching a plugin
+        dir — the exact PR-class the new track was supposed to UN-stick."""
         classifier = {
             "contribution_types": ["doc"],
             "plugin_paths": [],
@@ -124,8 +125,46 @@ class TestCoordinate:
             "unknown": False,
             "unmatched": [],
         }
-        result = _coord.coordinate(classifier, validator_results=None)
-        # No skills → empty validator_results → HARD_BLOCK
+        validator_called = False
+
+        def fake_invoker(skill_paths):
+            nonlocal validator_called
+            validator_called = True
+            return []
+
+        result = _coord.coordinate(
+            classifier, validator_results=None, validator_invoker=fake_invoker
+        )
+        assert result["verdict"] == "PASS"
+        assert result["grade"] == "A"
+        assert result["status_check"] == "success"
+        assert not validator_called, "validator should not be invoked for doc-only PRs"
+
+    def test_doc_only_pr_with_hard_block_signal_still_blocks(self):
+        """Even a doc-only PR is HARD_BLOCK if a hard-block signal fires
+        (e.g. secret in diff). The doc-only fast-path doesn't bypass that."""
+        classifier = {
+            "contribution_types": ["doc"],
+            "plugin_paths": [],
+            "affected_skills": [],
+            "affected_agents": [],
+            "affected_mcp": [],
+            "affected_hooks": [],
+            "catalog_additions": [],
+            "sources_additions": [],
+            "file_categories": {"md": 1},
+            "touches_workflows": False,
+            "touches_frontend": False,
+            "touches_scripts": False,
+            "touches_tests": False,
+            "unknown": False,
+            "unmatched": [],
+        }
+        result = _coord.coordinate(
+            classifier,
+            validator_results=None,
+            hard_block_signals=["secret detected in diff"],
+        )
         assert result["verdict"] == "HARD_BLOCK"
 
     def test_validator_invoker_is_called_with_resolved_paths(self):
@@ -223,6 +262,28 @@ class TestCLI:
             "--classifier-output", str(tmp_path / "missing.json"),
         ])
         assert exit_code == 2
+
+    def test_resolve_skill_paths_rejects_traversal(self, tmp_path):
+        """Reviewer fix #840 (security): _resolve_skill_paths must reject
+        path-traversal attempts that would resolve outside the repo root."""
+        # A malicious classifier outputs a skill name with ../ traversal.
+        # The function should silently drop it (returning an empty list)
+        # rather than constructing a path outside the repo.
+        result = _coord._resolve_skill_paths(
+            affected_skills=["../../../etc"],
+            plugin_paths=["plugins/security/example"],
+        )
+        assert result == []
+
+    def test_is_within_repo_returns_false_for_traversal(self):
+        """The bounds-check helper is the linchpin of the traversal fix."""
+        from pathlib import Path as _P
+        # Construct a path that, after resolution, escapes the repo
+        bad = _coord._REPO_ROOT / "../../etc/passwd"
+        assert _coord._is_within_repo(bad) is False
+        # Sanity-check a known-good path resolves as inside
+        good = _coord._REPO_ROOT / "scripts" / "pr-prescreen" / "grade.py"
+        assert _coord._is_within_repo(good) is True
 
     def test_cli_hard_block_signal_arg(self, tmp_path):
         classifier_path = tmp_path / "classifier.json"

--- a/tests/pr-prescreen/test_coordinator.py
+++ b/tests/pr-prescreen/test_coordinator.py
@@ -1,0 +1,245 @@
+"""Unit tests for scripts/pr-prescreen/coordinator.py.
+
+Covers:
+    - End-to-end coordinate() with mocked validator (no subprocess)
+    - Classifier-output → grade-result wiring
+    - status_check derivation (success on A, failure otherwise)
+    - Hard-block signal propagation
+    - CLI argument handling
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+_COORD_PATH = _REPO_ROOT / "scripts" / "pr-prescreen" / "coordinator.py"
+_spec = importlib.util.spec_from_file_location("_coord", _COORD_PATH)
+_coord = importlib.util.module_from_spec(_spec)
+# Register before exec — the coordinator loads grade.py via importlib too
+# and that needs sys.modules for dataclass to work.
+sys.modules["_coord"] = _coord
+_spec.loader.exec_module(_coord)
+
+_GOLDEN = Path(__file__).parent / "golden"
+
+
+def _load(name: str):
+    return json.loads((_GOLDEN / name).read_text(encoding="utf-8"))
+
+
+def _classifier_for_skills(skill_names: list[str]) -> dict:
+    """Build a synthetic classifier output for tests."""
+    return {
+        "contribution_types": ["plugin", "skill"],
+        "plugin_paths": ["plugins/example/test-plugin"],
+        "affected_skills": skill_names,
+        "affected_agents": [],
+        "affected_mcp": [],
+        "affected_hooks": [],
+        "catalog_additions": [],
+        "sources_additions": [],
+        "file_categories": {"md": 1},
+        "touches_workflows": False,
+        "touches_frontend": False,
+        "touches_scripts": False,
+        "touches_tests": False,
+        "unknown": False,
+        "unmatched": [],
+    }
+
+
+# =============================================================================
+# End-to-end coordinate()
+# =============================================================================
+
+
+class TestCoordinate:
+    def test_a_grade_skill_produces_pass_verdict(self):
+        classifier = _classifier_for_skills(["clean-skill"])
+        validator_results = _load("a-grade.json")
+        result = _coord.coordinate(
+            classifier, validator_results=validator_results
+        )
+        assert result["grade"] == "A"
+        assert result["verdict"] == "PASS"
+        assert result["status_check"] == "success"
+
+    def test_c_grade_skill_produces_changes_requested_failure(self):
+        classifier = _classifier_for_skills(["missing-prerequisites"])
+        validator_results = _load("c-grade.json")
+        result = _coord.coordinate(
+            classifier, validator_results=validator_results
+        )
+        assert result["grade"] == "C"
+        assert result["verdict"] == "CHANGES_REQUESTED"
+        assert result["status_check"] == "failure"
+
+    def test_fatal_validator_produces_hard_block(self):
+        classifier = _classifier_for_skills(["broken-yaml"])
+        validator_results = _load("f-grade-fatal.json")
+        result = _coord.coordinate(
+            classifier, validator_results=validator_results
+        )
+        assert result["verdict"] == "HARD_BLOCK"
+        assert result["status_check"] == "failure"
+
+    def test_hard_block_signal_overrides_passing_grade(self):
+        classifier = _classifier_for_skills(["clean-skill"])
+        validator_results = _load("a-grade.json")
+        result = _coord.coordinate(
+            classifier,
+            validator_results=validator_results,
+            hard_block_signals=["secret detected in diff"],
+        )
+        assert result["grade"] == "F"
+        assert result["verdict"] == "HARD_BLOCK"
+        assert result["status_check"] == "failure"
+
+    def test_no_affected_skills_no_validator_calls(self):
+        """A doc-only PR (no affected_skills) should result in an empty
+        validator_results and a HARD_BLOCK (per current policy — no
+        evaluable components means we can't grade)."""
+        classifier = {
+            "contribution_types": ["doc"],
+            "plugin_paths": [],
+            "affected_skills": [],
+            "affected_agents": [],
+            "affected_mcp": [],
+            "affected_hooks": [],
+            "catalog_additions": [],
+            "sources_additions": [],
+            "file_categories": {"md": 1},
+            "touches_workflows": False,
+            "touches_frontend": False,
+            "touches_scripts": False,
+            "touches_tests": False,
+            "unknown": False,
+            "unmatched": [],
+        }
+        result = _coord.coordinate(classifier, validator_results=None)
+        # No skills → empty validator_results → HARD_BLOCK
+        assert result["verdict"] == "HARD_BLOCK"
+
+    def test_validator_invoker_is_called_with_resolved_paths(self):
+        """When validator_results=None, the coordinator must invoke the
+        injected validator_invoker with the resolved skill paths."""
+        classifier = _classifier_for_skills(["my-skill"])
+        called_with: list = []
+
+        def fake_invoker(skill_paths):
+            called_with.append(list(skill_paths))
+            return _load("a-grade.json")
+
+        _coord.coordinate(
+            classifier,
+            validator_results=None,
+            validator_invoker=fake_invoker,
+        )
+        # _resolve_skill_paths returns [] when no real file exists under
+        # the synthetic plugin path; the invoker gets called with []
+        assert called_with == [[]]
+
+
+# =============================================================================
+# Embedded grade pieces (verify the coordinator surfaces what grade.py emits)
+# =============================================================================
+
+
+class TestCoordinateOutputShape:
+    def test_output_includes_classifier_echo(self):
+        classifier = _classifier_for_skills(["clean-skill"])
+        result = _coord.coordinate(classifier, validator_results=_load("a-grade.json"))
+        assert result["classifier"] == classifier
+
+    def test_output_includes_comment(self):
+        classifier = _classifier_for_skills(["clean-skill"])
+        result = _coord.coordinate(classifier, validator_results=_load("a-grade.json"))
+        assert "✅" in result["comment"]
+
+    def test_output_includes_deltas(self):
+        classifier = _classifier_for_skills(["missing-prereq"])
+        result = _coord.coordinate(classifier, validator_results=_load("c-grade.json"))
+        assert result["deltas"]
+        assert result["deltas"][0]["current_grade"] == "C"
+
+    def test_output_status_check_is_success_only_for_a(self):
+        for fixture, expected_status in [
+            ("a-grade.json", "success"),
+            ("b-grade.json", "failure"),
+            ("c-grade.json", "failure"),
+            ("d-grade.json", "failure"),
+            ("f-grade-fatal.json", "failure"),
+        ]:
+            classifier = _classifier_for_skills(["test"])
+            result = _coord.coordinate(classifier, validator_results=_load(fixture))
+            assert result["status_check"] == expected_status, (
+                f"{fixture}: expected {expected_status}, got {result['status_check']}"
+            )
+
+
+# =============================================================================
+# CLI smoke test
+# =============================================================================
+
+
+class TestCLI:
+    def test_cli_writes_comment_and_verdict_files(self, tmp_path):
+        # Build classifier output file
+        classifier_path = tmp_path / "classifier.json"
+        classifier_path.write_text(
+            json.dumps(_classifier_for_skills(["test-skill"])), encoding="utf-8"
+        )
+        validator_path = tmp_path / "validator.json"
+        validator_path.write_text(json.dumps(_load("a-grade.json")), encoding="utf-8")
+        comment_path = tmp_path / "comment.md"
+        verdict_path = tmp_path / "verdict.json"
+
+        exit_code = _coord.main([
+            "--classifier-output", str(classifier_path),
+            "--validator-results-file", str(validator_path),
+            "--comment-output", str(comment_path),
+            "--verdict-output", str(verdict_path),
+        ])
+        assert exit_code == 0
+        assert comment_path.exists()
+        assert verdict_path.exists()
+
+        # Verdict JSON should NOT include the embedded comment markdown
+        verdict = json.loads(verdict_path.read_text())
+        assert "comment" not in verdict
+        assert verdict["grade"] == "A"
+        assert verdict["status_check"] == "success"
+
+    def test_cli_missing_classifier_file_exits_2(self, tmp_path):
+        exit_code = _coord.main([
+            "--classifier-output", str(tmp_path / "missing.json"),
+        ])
+        assert exit_code == 2
+
+    def test_cli_hard_block_signal_arg(self, tmp_path):
+        classifier_path = tmp_path / "classifier.json"
+        classifier_path.write_text(
+            json.dumps(_classifier_for_skills(["test-skill"])), encoding="utf-8"
+        )
+        validator_path = tmp_path / "validator.json"
+        validator_path.write_text(json.dumps(_load("a-grade.json")), encoding="utf-8")
+        verdict_path = tmp_path / "verdict.json"
+
+        exit_code = _coord.main([
+            "--classifier-output", str(classifier_path),
+            "--validator-results-file", str(validator_path),
+            "--verdict-output", str(verdict_path),
+            "--hard-block-signal", "test signal",
+        ])
+        assert exit_code == 0
+        verdict = json.loads(verdict_path.read_text())
+        assert verdict["verdict"] == "HARD_BLOCK"
+        assert "test signal" in verdict["hard_block_signals"]

--- a/tests/pr-prescreen/test_grade.py
+++ b/tests/pr-prescreen/test_grade.py
@@ -1,0 +1,303 @@
+"""Unit tests for scripts/pr-prescreen/grade.py — PR-level grade composer.
+
+Covers:
+    - Score → grade mapping (band boundaries)
+    - Grade band lookups
+    - points_to_next_grade arithmetic
+    - SkillFinding extraction from validator output
+    - Overall compose_grade() with golden fixtures (A/B/C/D/F + mixed)
+    - render_comment() output structure
+    - Hard-block signals always force F + HARD_BLOCK
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+_GRADE_PATH = _REPO_ROOT / "scripts" / "pr-prescreen" / "grade.py"
+_spec = importlib.util.spec_from_file_location("_grade", _GRADE_PATH)
+_grade = importlib.util.module_from_spec(_spec)
+# dataclass-decorator needs the module registered in sys.modules during exec.
+sys.modules["_grade"] = _grade
+_spec.loader.exec_module(_grade)
+
+_GOLDEN = Path(__file__).parent / "golden"
+
+
+def _load(name: str):
+    return json.loads((_GOLDEN / name).read_text(encoding="utf-8"))
+
+
+# =============================================================================
+# score_to_grade — band boundaries
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "score, expected",
+    [
+        (100, "A"),
+        (95, "A"),
+        (90, "A"),  # band low
+        (89, "B"),  # B band high
+        (85, "B"),
+        (80, "B"),  # B band low
+        (79, "C"),
+        (75, "C"),
+        (70, "C"),  # C band low
+        (69, "D"),
+        (65, "D"),
+        (60, "D"),  # D band low
+        (59, "F"),
+        (0, "F"),
+        (None, "F"),  # None defends against null score
+    ],
+)
+def test_score_to_grade_boundaries(score, expected):
+    assert _grade.score_to_grade(score) == expected
+
+
+# =============================================================================
+# grade_to_band — lookup table
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "grade, low, high",
+    [
+        ("A", 90, 100),
+        ("B", 80, 89),
+        ("C", 70, 79),
+        ("D", 60, 69),
+        ("F", 0, 59),
+        ("a", 90, 100),  # case-insensitive
+    ],
+)
+def test_grade_to_band(grade, low, high):
+    assert _grade.grade_to_band(grade) == (low, high)
+
+
+# =============================================================================
+# points_to_next_grade — arithmetic
+# =============================================================================
+
+
+def test_points_to_next_grade_b_to_a():
+    """A 85 (B) needs +5 pts to hit 90 (A low)."""
+    assert _grade.points_to_next_grade(85, "B") == 5
+
+
+def test_points_to_next_grade_c_to_b():
+    assert _grade.points_to_next_grade(75, "C") == 5
+
+
+def test_points_to_next_grade_d_to_c():
+    assert _grade.points_to_next_grade(65, "D") == 5
+
+
+def test_points_to_next_grade_a_already_top():
+    """An A-grade score has 0 points to next (we're at the top)."""
+    assert _grade.points_to_next_grade(95, "A") == 0
+
+
+def test_points_to_next_grade_at_band_low():
+    """A 80 (B-low) needs +10 pts to hit 90 (A low)."""
+    assert _grade.points_to_next_grade(80, "B") == 10
+
+
+# =============================================================================
+# extract_skill_findings — pull deltas from validator results
+# =============================================================================
+
+
+class TestExtractSkillFindings:
+    def test_a_grade_results_produce_no_findings(self):
+        records = _load("a-grade.json")
+        findings = _grade.extract_skill_findings(records)
+        assert findings == []  # nothing actionable; everything is A
+
+    def test_b_grade_produces_finding_with_points_to_a(self):
+        records = _load("b-grade.json")
+        findings = _grade.extract_skill_findings(records)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.current_grade == "B"
+        assert f.current_score == 85
+        assert f.points_to_a == 5  # 85 → 90
+        assert len(f.warnings) == 2
+
+    def test_c_grade_finding(self):
+        findings = _grade.extract_skill_findings(_load("c-grade.json"))
+        assert len(findings) == 1
+        assert findings[0].current_grade == "C"
+        assert findings[0].points_to_a == 5  # 75 → 80 (C → B)
+
+    def test_d_grade_finding_carries_errors(self):
+        findings = _grade.extract_skill_findings(_load("d-grade.json"))
+        assert len(findings) == 1
+        assert findings[0].current_grade == "D"
+        assert findings[0].current_score == 65
+        assert len(findings[0].errors) == 2
+
+    def test_fatal_entry_becomes_f_finding(self):
+        findings = _grade.extract_skill_findings(_load("f-grade-fatal.json"))
+        assert len(findings) == 1
+        assert findings[0].current_grade == "F"
+        assert findings[0].current_score == 0
+        assert findings[0].points_to_a == 90  # F → A is 90
+        assert "parse error" in findings[0].errors[0].lower()
+
+    def test_mixed_results_sort_worst_first(self):
+        findings = _grade.extract_skill_findings(_load("mixed-a-b-c.json"))
+        # A-grade entry excluded; C and B remain. C is weaker, should be first.
+        grades_in_order = [f.current_grade for f in findings]
+        assert grades_in_order == ["C", "B"]
+
+
+# =============================================================================
+# compose_grade — the main entry point
+# =============================================================================
+
+
+class TestComposeGrade:
+    def test_a_grade_input_gives_pass_verdict(self):
+        result = _grade.compose_grade(_load("a-grade.json"))
+        assert result["grade"] == "A"
+        assert result["verdict"] == "PASS"
+        assert result["score"] == 95
+        assert result["deltas"] == []
+        assert "PASS" in result["summary_line"]
+
+    def test_b_grade_input_gives_changes_requested(self):
+        result = _grade.compose_grade(_load("b-grade.json"))
+        assert result["grade"] == "B"
+        assert result["verdict"] == "CHANGES_REQUESTED"
+        assert result["score"] == 85
+
+    def test_c_grade_input_gives_changes_requested(self):
+        result = _grade.compose_grade(_load("c-grade.json"))
+        assert result["grade"] == "C"
+        assert result["verdict"] == "CHANGES_REQUESTED"
+
+    def test_d_grade_input_gives_changes_requested(self):
+        result = _grade.compose_grade(_load("d-grade.json"))
+        assert result["grade"] == "D"
+        assert result["verdict"] == "CHANGES_REQUESTED"
+
+    def test_fatal_gives_hard_block(self):
+        result = _grade.compose_grade(_load("f-grade-fatal.json"))
+        assert result["grade"] == "F"
+        assert result["verdict"] == "HARD_BLOCK"
+        assert result["hard_block_signals"]
+
+    def test_mixed_grade_uses_weakest(self):
+        """Mixed A + B + C → PR grade is C (weakest link)."""
+        result = _grade.compose_grade(_load("mixed-a-b-c.json"))
+        assert result["grade"] == "C"
+        assert result["score"] == 73  # min score across components
+        assert result["verdict"] == "CHANGES_REQUESTED"
+
+    def test_empty_input_gives_hard_block(self):
+        result = _grade.compose_grade([])
+        assert result["verdict"] == "HARD_BLOCK"
+        assert "no validator results" in result["hard_block_signals"][0].lower()
+
+    def test_hard_block_signal_forces_f_regardless_of_grades(self):
+        """Even an all-A input must HARD_BLOCK if a hard-block signal is set."""
+        result = _grade.compose_grade(
+            _load("a-grade.json"),
+            hard_block_signals=["secret detected in diff"],
+        )
+        assert result["grade"] == "F"
+        assert result["verdict"] == "HARD_BLOCK"
+        assert "secret detected" in result["hard_block_signals"][0]
+
+    def test_multiple_hard_block_signals_listed(self):
+        result = _grade.compose_grade(
+            _load("a-grade.json"),
+            hard_block_signals=["secret in diff", "no catalog entry"],
+        )
+        assert len(result["hard_block_signals"]) == 2
+        assert "+1 more" in result["summary_line"]
+
+
+# =============================================================================
+# render_comment — markdown output
+# =============================================================================
+
+
+class TestRenderComment:
+    def test_a_grade_comment_says_pass(self):
+        result = _grade.compose_grade(_load("a-grade.json"))
+        md = _grade.render_comment(result)
+        assert "✅" in md
+        assert "Grade **A**" in md
+        assert "Ready to merge" in md
+
+    def test_c_grade_comment_lists_deltas(self):
+        result = _grade.compose_grade(_load("c-grade.json"))
+        md = _grade.render_comment(result)
+        assert "🟡" in md
+        assert "Grade **C**" in md
+        assert "How to reach A" in md
+        assert "Prerequisites" in md  # warning message surfaces
+
+    def test_hard_block_comment_shows_blockers(self):
+        result = _grade.compose_grade(
+            _load("a-grade.json"),
+            hard_block_signals=["secret detected in diff"],
+        )
+        md = _grade.render_comment(result)
+        assert "🛑" in md
+        assert "HARD BLOCK" in md
+        assert "secret detected" in md
+
+    def test_every_comment_links_to_public_rubric(self):
+        for fixture in ["a-grade.json", "b-grade.json", "c-grade.json", "d-grade.json"]:
+            result = _grade.compose_grade(_load(fixture))
+            md = _grade.render_comment(result)
+            assert "tonsofskills.com/grading" in md, f"missing rubric URL in {fixture}"
+
+    def test_comment_truncates_long_delta_list(self):
+        """A PR with 10 weak skills should show only the first 5 in the comment."""
+        records = [
+            {
+                "path": f"plugins/x/skills/weak-{i}/SKILL.md",
+                "score": 75,
+                "grade": "C",
+                "errors": 0,
+                "warnings": 1,
+                "warning_messages": [f"finding {i}"],
+            }
+            for i in range(10)
+        ]
+        result = _grade.compose_grade(records)
+        md = _grade.render_comment(result)
+        assert "… and 5 more component(s)" in md
+
+
+# =============================================================================
+# Determinism + stability
+# =============================================================================
+
+
+def test_compose_grade_is_deterministic():
+    records = _load("mixed-a-b-c.json")
+    r1 = _grade.compose_grade(records)
+    r2 = _grade.compose_grade(records)
+    assert r1 == r2
+
+
+def test_render_comment_is_deterministic():
+    records = _load("mixed-a-b-c.json")
+    md1 = _grade.render_comment(_grade.compose_grade(records))
+    md2 = _grade.render_comment(_grade.compose_grade(records))
+    assert md1 == md2

--- a/tests/pr-prescreen/test_grade.py
+++ b/tests/pr-prescreen/test_grade.py
@@ -96,6 +96,7 @@ def test_points_to_next_grade_b_to_a():
 
 
 def test_points_to_next_grade_c_to_b():
+    """A 75 (C) needs +5 pts to hit 80 (B low) — next BAND, not next to A."""
     assert _grade.points_to_next_grade(75, "C") == 5
 
 
@@ -111,6 +112,33 @@ def test_points_to_next_grade_a_already_top():
 def test_points_to_next_grade_at_band_low():
     """A 80 (B-low) needs +10 pts to hit 90 (A low)."""
     assert _grade.points_to_next_grade(80, "B") == 10
+
+
+def test_points_to_next_grade_score_above_band_returns_0_not_1():
+    """Reviewer fix #840: when validator's grade and score disagree (e.g.
+    grade='C' but score=85), the function used to floor at 1. Now floors at 0."""
+    assert _grade.points_to_next_grade(85, "C") == 0
+
+
+# =============================================================================
+# points_to_a (NEW — distance to A, not just next band)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "score, expected",
+    [
+        (95, 0),   # already A
+        (90, 0),   # at A floor
+        (85, 5),
+        (75, 15),  # the case reviewer flagged — C-grade is 15 to A, not 5
+        (65, 25),
+        (50, 40),
+        (0, 90),
+    ],
+)
+def test_points_to_a(score, expected):
+    assert _grade.points_to_a(score) == expected
 
 
 # =============================================================================
@@ -131,14 +159,19 @@ class TestExtractSkillFindings:
         f = findings[0]
         assert f.current_grade == "B"
         assert f.current_score == 85
-        assert f.points_to_a == 5  # 85 → 90
+        assert f.points_to_a == 5  # 85 → 90 (A floor)
+        assert f.points_to_next_band == 5  # B → A, same as above
         assert len(f.warnings) == 2
 
     def test_c_grade_finding(self):
+        """A C-grade skill is +5 to B (next band) and +15 to A (the bar)."""
         findings = _grade.extract_skill_findings(_load("c-grade.json"))
         assert len(findings) == 1
-        assert findings[0].current_grade == "C"
-        assert findings[0].points_to_a == 5  # 75 → 80 (C → B)
+        f = findings[0]
+        assert f.current_grade == "C"
+        assert f.current_score == 75
+        assert f.points_to_a == 15        # 75 → 90 (THE bar)
+        assert f.points_to_next_band == 5  # 75 → 80 (next band)
 
     def test_d_grade_finding_carries_errors(self):
         findings = _grade.extract_skill_findings(_load("d-grade.json"))
@@ -206,9 +239,26 @@ class TestComposeGrade:
         assert result["verdict"] == "CHANGES_REQUESTED"
 
     def test_empty_input_gives_hard_block(self):
+        """compose_grade as the failsafe layer returns HARD_BLOCK on empty
+        input. The coordinator handles the doc-only-PR-should-PASS case
+        upstream and never calls compose_grade in that scenario."""
         result = _grade.compose_grade([])
         assert result["verdict"] == "HARD_BLOCK"
         assert "no validator results" in result["hard_block_signals"][0].lower()
+
+    def test_record_with_grade_but_no_score(self):
+        """Reviewer #840: missing coverage for the all-null-scores case.
+        A record with only a grade field (no score) should still produce a
+        finding using the grade letter directly."""
+        records = [
+            {"path": "x/SKILL.md", "grade": "D", "errors": 0, "warnings": 0},
+            {"path": "y/SKILL.md", "grade": "B", "errors": 0, "warnings": 0},
+        ]
+        result = _grade.compose_grade(records)
+        assert result["grade"] == "D"  # weakest of the two
+        # Without explicit scores, min_score is 0 — band interpretation derives
+        # from the grade letter.
+        assert result["verdict"] == "CHANGES_REQUESTED"
 
     def test_hard_block_signal_forces_f_regardless_of_grades(self):
         """Even an all-A input must HARD_BLOCK if a hard-block signal is set."""


### PR DESCRIPTION
## Summary

**PR 3a of 3** — Foundation for the prescreen rewrite. Adds the grade composer + end-to-end coordinator + golden-grade fixtures. The public `/grading` rubric page lands in **PR 3b**; the `pr-prescreen.yml` workflow rewire + branch-protection flip lands in **PR 3c**.

Stacks on PR #838 (pr-classifier) and complements PR #839 (workflow split).

## What ships

| File | Purpose |
|---|---|
| `scripts/pr-prescreen/grade.py` | Score→grade mapping (A 90–100, B 80–89, …), `SkillFinding` deltas with `points_to_a`, weakest-link grade aggregation, `compose_grade()`, `render_comment()` markdown. |
| `scripts/pr-prescreen/coordinator.py` | End-to-end orchestrator. Reads classifier JSON → resolves `affected_skills` → invokes validator → composes via `grade.py` → emits comment + verdict. CLI with test-override flags. |
| `tests/pr-prescreen/golden/*.json` | Hand-curated A/B/C/D/F + mixed-A-B-C validator fixtures. |
| `tests/pr-prescreen/test_grade.py` | **38 tests** pinning grade composition, score boundaries, points-to-A arithmetic, delta extraction, comment rendering. |
| `tests/pr-prescreen/test_coordinator.py` | **23 tests** covering end-to-end `coordinate()` (with mocked validator) + CLI smoke. |

**61 tests, all passing in 0.24s.**

## Key design points

- **Weakest link wins.** The PR-level grade is the LOWEST per-component grade. A PR with three A-grade skills and one C-grade skill grades C. Rationale: the marketplace surfaces every artifact, so one weak skill drags the submission's reputation.

- **Affected skills, not whole pack.** The coordinator resolves `classifier.affected_skills` directly via `_REPO_ROOT / plugin_path / "skills" / skill_name / "SKILL.md"`. It never glob-walks plugin dirs. This closes the **PR #823 wrong-blocker bug** at the prescreen layer — a doc-only PR touching `databricks-pack/000-docs/foo.md` no longer drags in validator output for all 24 skills in the pack.

- **Hard-block signals force F.** Caller-supplied signals (secret in diff, no catalog entry, license mismatch, etc.) force grade F + HARD_BLOCK regardless of validator output. The future `prescreen-grade` status check fails on F.

- **Single composed comment with deltas.** No more "10 separate bot comments." One markdown comment per PR: grade verdict at top, summary line, "How to reach A" section with per-skill deltas (`+N pts needed`), link to public rubric at `tonsofskills.com/grading`.

- **Test-override CLI flag.** `--validator-results-file` skips the subprocess validator call and consumes pre-computed JSON. Used by `test_coordinator.py` to avoid invoking the real validator in unit tests.

## Sample composed comment (C-grade fixture)

```markdown
## 🟡 Prescreen: Grade **C** (75/100)

CHANGES_REQUESTED: 1 component(s), weakest grade C (min 75/100)

Marketplace bar is **A** (≥90). See the public rubric at <https://tonsofskills.com/grading> for the full 100-point breakdown.

### How to reach A

- **plugins/security/example/skills/missing-prerequisites/SKILL.md** — C (75/100, +5 pts needed)
    - warning: Required section missing: '## Prerequisites' (marketplace tier)
    - warning: Tool 'Read' declared in allowed-tools but never referenced

---

_Public rubric:_ <https://tonsofskills.com/grading> _·_ _How submissions are graded across 200+ marketplace plugins._
```

## What's NOT in this PR

- **Public rubric page** (`marketplace/src/pages/grading.astro`) — PR 3b.
- **`pr-prescreen.yml` rewire** — PR 3c.
- **Branch-protection `prescreen-grade` addition** — PR 3c.
- **A-grade-or-no-merge platform enforcement** — PR 3c (after a 30-day informational grace period).
- **Disable Copilot pull-request-reviewer + `codecov.yml comment: false`** — PR 3c (manual repo-settings changes).
- **Codecov API consumer** (pulls coverage delta into the prescreen comment instead of relying on the bot comment) — could fold into PR 3c.

## Test plan

- [ ] `python3 -m pytest tests/pr-prescreen/ -v` passes locally (61/61).
- [ ] After merge, the CI `python-tests` matrix job picks up the new tests automatically (no workflow changes needed).
- [ ] Smoke-test CLI end-to-end with the golden C-grade fixture (verified locally — see the sample comment above).
- [ ] No regression in existing `scripts/pr-prescreen/test_classify.py` or `test_summarize.py` (those scripts remain untouched).

- Jeremy Longshore
intentsolutions.io