### PR TITLE
chore(deps): bump @intentsolutions/audit-harness to 1.1.5 + fix(ci): build marketplace on Node 22

### DIFF
--- a/.github/workflows/deploy-marketplace.yml
+++ b/.github/workflows/deploy-marketplace.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
@@ -27,7 +27,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # astro@6.x requires Node >=22.12.0; the "Build with Astro" step
+          # below fails on Node 20 with "Node.js vXX is not supported by Astro!".
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -405,6 +405,20 @@ jobs:
               cd "$dir"
               tested=$((tested + 1))
 
+              # Workspace members (plugins/mcp/*, plugins/saas-packs/*-pack)
+              # get their deps from the root `pnpm install --frozen-lockfile`
+              # above. Non-workspace plugins (e.g. skill-enhancers/*) are NOT in
+              # pnpm-workspace.yaml, so the root install never populates their
+              # node_modules — `pnpm test` would otherwise resolve a tool (e.g.
+              # vitest) hoisted from the root at a DIFFERENT major than the one
+              # the plugin declares, producing spurious failures like
+              # "ReferenceError: __vite_ssr_exportName__ is not defined".
+              # Install the plugin's own declared deps in isolation first.
+              if [ "$category" != "mcp" ] && [[ "$plugin_name" != *-pack ]]; then
+                echo "  ↳ non-workspace plugin — installing its own deps (--ignore-workspace)"
+                pnpm install --ignore-workspace
+              fi
+
               if grep -q '"test:ci":' package.json; then
                 pnpm test:ci
               else

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -333,7 +333,10 @@ jobs:
         if: matrix.test-type == 'mcp-plugins'
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # astro@6.x (marketplace dep) requires Node >=22.12.0; the
+          # `pnpm build` step below builds the marketplace via astro. Node 20
+          # hard-fails with "Node.js vXX is not supported by Astro!".
+          node-version: '22'
 
       - name: Setup pnpm
         if: matrix.test-type == 'mcp-plugins'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^9.39.4",
-    "@intentsolutions/audit-harness": "^0.1.0",
+    "@intentsolutions/audit-harness": "^1.1.5",
     "@types/node": "^20.19.41",
     "archiver": "^7.0.1",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       '@intentsolutions/audit-harness':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^1.1.5
+        version: 1.1.5
       '@types/node':
         specifier: ^20.19.41
         version: 20.19.41
@@ -1740,8 +1740,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@intentsolutions/audit-harness@0.1.0':
-    resolution: {integrity: sha512-7YNrX4KLEPwJUT41yKa4w94/bqWS3Bdcvxa57GfQOEF/yUtu39Yl59t+bijx+7lO3HmWS5gc/llU1Nca1+QGtg==}
+  '@intentsolutions/audit-harness@1.1.5':
+    resolution: {integrity: sha512-VbE4gPR/wtp2czWT0/Wjo5ZEtX3SRxeWMBS5nx1LhgyxdrKdZdo+deP5/km3Cl5PMyf4XbwXtVt7pDjXi0w1mQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6463,7 +6463,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@intentsolutions/audit-harness@0.1.0': {}
+  '@intentsolutions/audit-harness@1.1.5': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
Three changes — one routine bump plus two pre-existing CI-failure fixes that were blocking the `test (mcp-plugins)` required check.

## 1. Routine harness bump
Maintenance bump of the `@intentsolutions/audit-harness` dev dependency from `^0.1.0` to `^1.1.5`, the now-published version on npm (carries sigstore provenance). Part of `/sync-testing-harness` propagation.

- `package.json`: `@intentsolutions/audit-harness` `^0.1.0` → `^1.1.5`
- `pnpm-lock.yaml`: relocked (audit-harness version + integrity hash only; no transitive churn)

Verification: `pnpm exec audit-harness --version` → `1.1.5`; `pnpm exec audit-harness verify` → `harness-hash: OK`.

## 2. Fix pre-existing marketplace-build failure (astro needs Node 22)

`test (mcp-plugins)` runs `pnpm build`, which builds the Astro marketplace site. `astro@6.4.2` (already pinned on `main`) declares `engines: { node: ">=22.12.0" }` and **hard-fails at runtime on Node 20**: `Node.js v20.x is not supported by Astro!` — failing the whole build with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` *after* every prior build step succeeds. (The `clade-common-errors` / `abridge-common-errors` lines in the log are harmless orphan-list + "first 3 skills" sample output, not the error.)

Fix — bump the two CI jobs that run the Astro build from Node 20 → 22:
- `validate-plugins.yml` → `test (mcp-plugins)` job (the failing required check)
- `deploy-marketplace.yml` → GitHub Pages build (same latent defect; would break the next marketplace push to `main`)

CLI-only build jobs (`validation-scripts`, `cli-smoke-tests`) build just `packages/cli` via `tsc`, never Astro, so they stay on Node 20. `deploy-vps.yml` already uses Node 22.

Verified: full `pnpm --filter marketplace build` completes on Node 22.21.0 — exit 0, 4172 pages built, astro `Complete!`.

## 3. Fix pre-existing plugin-test failure (wrong vitest resolved)

With the build fixed, the test step in the same required check was reached for the first time and exposed a **second** pre-existing failure: the loop ran `pnpm test` for `skill-enhancers/web-to-github-issue` against the root-hoisted `vitest@2.1.9` instead of the `vitest@^3.2.4` the plugin declares. vitest 2.1.x's SSR transform throws `ReferenceError: __vite_ssr_exportName__ is not defined`, failing all 3 test files.

Root cause: this plugin is **not** a pnpm workspace member (`pnpm-workspace.yaml` covers only `plugins/mcp/*` and `plugins/saas-packs/*-pack`), so the root `pnpm install --frozen-lockfile` never populates its `node_modules`; tool resolution falls through to the hoisted root version at the wrong major. Reproduced **identically on Node 20 and Node 22** — confirming a latent defect, not a regression from the Node bump. It was simply masked because CI previously died at the build step.

Fix — in the test loop, for any non-workspace plugin (`category != mcp` and `name != *-pack`), run `pnpm install --ignore-workspace` to install its own declared deps before `pnpm test`. Workspace members keep using the frozen-locked hoisted deps unchanged. `web-to-github-issue` is currently the only non-workspace plugin with a JS test script.

Verified: with its own `vitest@3.2.6`, all **118 tests pass** (3 files, 0 fail) on both Node 20.20.2 and Node 22.21.0.

---

No plugin disabled, skipped, or deleted; no SKILL.md changed; no build step or gate weakened.

- Jeremy Longshore
intentsolutions.io