### PR TITLE
docs(readme): Anthropic deep-link map + wiki section + FAQ + troubleshooting

### DIFF
--- a/.github/workflows/deploy-marketplace.yml
+++ b/.github/workflows/deploy-marketplace.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
@@ -27,7 +27,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # astro@6.x requires Node >=22.12.0; the "Build with Astro" step
+          # below fails on Node 20 with "Node.js vXX is not supported by Astro!".
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -405,6 +405,20 @@ jobs:
               cd "$dir"
               tested=$((tested + 1))
 
+              # Workspace members (plugins/mcp/*, plugins/saas-packs/*-pack)
+              # get their deps from the root `pnpm install --frozen-lockfile`
+              # above. Non-workspace plugins (e.g. skill-enhancers/*) are NOT in
+              # pnpm-workspace.yaml, so the root install never populates their
+              # node_modules — `pnpm test` would otherwise resolve a tool (e.g.
+              # vitest) hoisted from the root at a DIFFERENT major than the one
+              # the plugin declares, producing spurious failures like
+              # "ReferenceError: __vite_ssr_exportName__ is not defined".
+              # Install the plugin's own declared deps in isolation first.
+              if [ "$category" != "mcp" ] && [[ "$plugin_name" != *-pack ]]; then
+                echo "  ↳ non-workspace plugin — installing its own deps (--ignore-workspace)"
+                pnpm install --ignore-workspace
+              fi
+
               if grep -q '"test:ci":' package.json; then
                 pnpm test:ci
               else

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -333,7 +333,10 @@ jobs:
         if: matrix.test-type == 'mcp-plugins'
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # astro@6.x (marketplace dep) requires Node >=22.12.0; the
+          # `pnpm build` step below builds the marketplace via astro. Node 20
+          # hard-fails with "Node.js vXX is not supported by Astro!".
+          node-version: '22'
 
       - name: Setup pnpm
         if: matrix.test-type == 'mcp-plugins'

--- a/000-docs/688-AA-AACR-2026-06-04-wiki-audit.md
+++ b/000-docs/688-AA-AACR-2026-06-04-wiki-audit.md
@@ -1,0 +1,196 @@
+# Wiki Audit — `jeremylongshore/claude-code-plugins-plus-skills.wiki`
+
+**Audited**: 2026-06-04
+**Source**: `/tmp/claude-code-plugins-wiki/` (mirror of the GitHub wiki)
+**Auditor**: Claude (read-only — no wiki edits performed)
+**Scope**: 54 markdown files (52 content pages + `_Sidebar.md` + `_Footer.md`); plus one stray `.pr_agent_accepted_suggestions.md` (PR-bot dump, doesn't belong as a page).
+
+---
+
+## 1. Executive Summary
+
+The wiki is a 52-page, ~8.3 K-line reference covering installation, the SKILL.md spec, plugin structure, validation, 11 production playbooks, 5 Learning Lab pages, catalog architecture, and a Plugin/Skill inventory. Content quality is generally solid and the information architecture (sidebar grouping) is clean. The two inventory pages (`Plugin-Inventory.md`, `Skill-Inventory.md`) and `Changelog.md` are auto-generated and stale (last refresh 2026-03-12; repo is now at v4.30.0). The three biggest issues to fix:
+
+1. **Internal spec inconsistency on required-field count.** `SKILL-md-Specification.md` / `FAQ.md` / `Glossary.md` / `Troubleshooting.md` all say 8 required marketplace-tier frontmatter fields; `Lab-Architecture.md` says 6; `Tool-Permissions-Guide.md` says `allowed-tools` MUST be CSV string (spec says CSV or YAML list, both valid per schema 3.6.0). Same wiki, contradictory rules.
+2. **Zero deep-links to Anthropic / Claude Code docs.** 32 pages mention Claude Code / Claude / SDK / "AgentSkills.io spec / Anthropic best practices" in prose, but the wiki contains no `https://code.claude.com/docs/en/...`, no `docs.anthropic.com`, no `claude.ai`, no `github.com/anthropics/*` URLs at all. The "Anthropic Best Practices" the spec page leans on is uncited. This is the biggest reader-facing gap.
+3. **Stale facts.** `Installation.md` requires Node 18 (repo CLAUDE.md says Node 20+ minimum); `CI-CD-Pipeline.md` cites CLI version 4.17.0 and says deploy is "GitHub Pages" (repo now at 4.30.0; production deploy is VPS rsync per the VPS-as-the-home program); `Data-Flow.md` describes a 5-stage build pipeline (repo CLAUDE.md describes 7 stages including `enrich-jrig-data` and `extract-readme-sections`); plugin/skill counts drift across pages (340 / 343 / 427; 2,747 vs current marketplace state).
+
+Overall status: **content is reusable but needs a deep-link sweep + a "single source of truth" reconciliation pass on the spec / counts / build pipeline / deploy target.**
+
+---
+
+## 2. Page-by-Page Inventory
+
+Status legend: `current` = factually accurate and reusable, `stale` = needs fact-update, `needs-restructure` = content OK but layout/format issue, `candidate-for-deletion` = should not exist on the wiki.
+
+| Page | Size | Category | Status | Notes |
+|---|---|---|---|---|
+| `Home.md` | 2.5 K | structural | stale | "By the Numbers" table says 343 plugins / 2,747 skills / v4.30.0 — other pages say 427/340. Reconcile numbers against `marketplace.extended.json` in one pass. |
+| `_Sidebar.md` | 2.4 K | structural | current | Navigation is well-organized into 9 sections; mirrors actual page set. No Anthropic deep-link section (missing). |
+| `_Footer.md` | 330 B | structural | stale | Hardcodes `v4.30.0` — drifts on every release. |
+| `Installation.md` | 3.1 K | getting-started | stale | Requires Node `>= 18`; the repo's own CLAUDE.md mandates `>= 20.0.0`. Step 2 install slug is correct (legacy slug `jeremylongshore/claude-code-plugins` per repo CLAUDE.md "Do Not Normalize" section). |
+| `CLI-Quick-Reference.md` | 2.4 K | getting-started | current | Solid command table. Could deep-link Claude Code's plugin CLI docs. |
+| `Your-First-Plugin.md` | 7.8 K | getting-started | current | Walkthrough is concrete and complete (code-review-toolkit). |
+| `Your-First-Skill.md` | 9.0 K | getting-started | current | test-file-generator walkthrough; coherent end-to-end. |
+| `Browsing-the-Marketplace.md` | 2.7 K | reference | current | Describes the tonsofskills.com browse UX. |
+| `How-Skills-Work.md` | 7.0 K | reference | stale | "Compatibility: Node.js >= 18" example in optional fields table (line 120) — should be `>= 20`. Spec says "Required fields" but lists only 6 in the codeblock (name, description, allowed-tools, version, author, license) — contradicts the 8-field marketplace rule cited on every other page. |
+| `Frontmatter-Reference.md` | 6.2 K | reference | needs-restructure | Has TWO `compatibility` subsections — one (line 58) says "replaces deprecated compatible-with", another (line 122) describes it as "Environment requirements... `Node.js >= 18`". Confusing — merge into one entry; mark `compatible-with` deprecated unambiguously. Also still lists `compatible-with` as a primary field in "Recommended Field Order" code block. |
+| `Tool-Permissions-Guide.md` | 4.0 K | reference | stale | Line 11 says `allowed-tools` "must be a comma-separated string, not a YAML array" — directly contradicts the spec page and `FAQ.md`/`Glossary.md`/`Frontmatter-Reference.md` which all say CSV or YAML list, both valid per schema 3.6.0. Fix before any new contributor reads it. |
+| `Templates-and-Examples.md` | 3.8 K | reference | current | Points correctly at `templates/` dir and the Skill-Creator skill. |
+| `Validation-and-Grading.md` | 5.1 K | reference | current | 100-point rubric + Two-Tier model are accurate. Could deep-link the AgentSkills.io spec at the heading rather than just in-text. |
+| `MCP-Server-Plugins.md` | 5.1 K | reference | current | Clear MCP-plugin author walkthrough. No deep-link to MCP spec or the Claude Code MCP integration docs (`code.claude.com/docs/en/mcp`) — should add. |
+| `Plugin-Structure.md` | 4.3 K | reference | current | Plugin.json field table is accurate. Could deep-link Claude Code plugins reference. |
+| `SKILL-md-Specification.md` | 21 K | reference | needs-restructure | Most authoritative wiki page. Contradiction: lists `compatible-with` in the canonical template (line 65) AND says "compatible-with is deprecated as of schema 3.4.0" (line 98). Heading "Anthropic Best Practices" (line 7) is uncited — link to the actual Claude Code skills doc and the AgentSkills.io spec. The "Recommended Field Order" code block (line 155) keeps `compatible-with` as the recommendation. |
+| `Skill-Template.md` | 3.8 K | reference | stale | Template ships with `compatible-with: claude-code, codex, openclaw` — newly-authored skills using this template will be flagged by the schema 3.4.0+ validator. Replace with `compatibility: Designed for Claude Code`. |
+| `Skill-Creator.md` | 23 K | reference | current | Comprehensive walkthrough of `/skill-creator` v5.0.0. Points correctly at the gist source-of-truth. |
+| `Glossary.md` | 7.9 K | reference | current | Definitions are accurate; says 8 required fields (consistent with FAQ + Spec page). |
+| `FAQ.md` | 6.4 K | reference | current | Consistent on 8 required fields and CSV-or-YAML-list. |
+| `Troubleshooting.md` | 6.1 K | reference | current | Solid common-issues guide; "Missing required field" hint says 8 (consistent). |
+| `Security.md` | 6.7 K | reference | current | Threat model, trust levels, MCP guidance. |
+| `Cowork-Bundles.md` | 2.9 K | reference | current | Accurate per the auto-cowork contract in repo CLAUDE.md. |
+| `Installing-Plugin-Packs.md` | 2.6 K | reference | current | Stripe/Firebase examples + SaaS pack count (42, 1,086 skills). |
+| `Two-Catalog-System.md` | 3.2 K | reference | current | Matches the repo's "Two Catalog System — Critical" section in CLAUDE.md. |
+| `Data-Flow.md` | 5.2 K | reference | stale | Build pipeline described as 5 stages (`discover-skills` → `sync-catalog` → `generate-unified-search` → `build-cowork-zips` → `astro build`). Repo CLAUDE.md describes 7 sequential steps via `scripts/build.mjs` including `extract-readme-sections` and `enrich-jrig-data`. Also says "Deploy to GitHub Pages" — production deploy is VPS rsync (force-command SSH) per the VPS-as-the-home runbook. |
+| `Repository-Structure.md` | 6.3 K | reference | current | Accurate top-level dir tree; correctly flags pnpm/npm split. |
+| `CI-CD-Pipeline.md` | 4.6 K | reference | stale | "Reports the expected version (currently 4.17.0)" — repo is at 4.30.0+. "CI deploys the marketplace build output to GitHub Pages" — production deploy is now VPS via Tailscale OIDC + rsync. Five-jobs summary doesn't include the dedicated `cowork:validate` step now wired in. |
+| `External-Plugin-Sync.md` | 2.8 K | reference | current | Accurate `sources.yaml` description. |
+| `Quality-Standards.md` | 4.2 K | reference | current | Style + grading rubric. Consistent with Validation-and-Grading. |
+| `PR-Process.md` | 3.4 K | reference | stale | Says "five parallel jobs" — the actual workflow runs six (matches `CI-CD-Pipeline.md` body which lists six). Internal contradiction. |
+| `Contributing.md` | 5.0 K | reference | current | Submission workflow accurate. References a `templates/command-plugin` template that should be checked against the real `templates/` dir (the wiki Templates page says `command`, not `command-plugin`). |
+| `Plugin-Categories.md` | 44 K | inventory | stale | Says 427 plugins / 18 categories, but the summary table lists 26 categories totaling >330. Auto-regenerate or rewrite to match `marketplace.extended.json`. |
+| `Plugin-Inventory.md` | 49 K | inventory | stale | Header says "340 plugins" / "Marketplace version 1.6.0" — other pages say 427/v4.30.0. Auto-generated; needs the regen workflow re-run (`scripts/generate-wiki-inventory.py` per the footer). |
+| `Skill-Inventory.md` | 6.4 K | inventory | stale | Auto-generated 2026-03-12; lists 29 global skills with several missing version/description fields (e.g. `airtable`, `contacts`, `frontend-slides`). Re-run the inventory script. |
+| `Glossary.md` (duplicate row, already listed) | | | | (skip) |
+| `Changelog.md` | 4.9 K | reference | stale | Last entry `4.17.0 — 2026-03-11`; repo is at v4.30.0. Either auto-sync or link out to `CHANGELOG.md`. |
+| `Playbook-Index.md` | 3.9 K | playbook | current | TOC for 11 playbooks; each row links to the wiki summary and tonsofskills.com full version. |
+| `Playbook-01-Multi-Agent-Rate-Limits.md` | 3.3 K | playbook | current | Anthropic rate-limit tier breakdown is solid. No deep-link to Anthropic's rate-limits doc — should add. |
+| `Playbook-02-Cost-Caps.md` | 3.0 K | playbook | current | Token-budget patterns. |
+| `Playbook-03-MCP-Reliability.md` | 3.3 K | playbook | current | Circuit-breaker + healthcheck patterns. |
+| `Playbook-04-Ollama-Migration.md` | 3.3 K | playbook | current | Self-hosted LLM migration overview. |
+| `Playbook-05-Incident-Debugging.md` | 3.7 K | playbook | current | SEV taxonomy + RCA process. |
+| `Playbook-06-Self-Hosted-Stack.md` | 3.5 K | playbook | current | Docker/K8s deploy. |
+| `Playbook-07-Compliance-Audit.md` | 3.9 K | playbook | current | SOC2/GDPR/HIPAA. |
+| `Playbook-08-Team-Presets.md` | 3.9 K | playbook | current | Bundle + onboarding. |
+| `Playbook-09-Cost-Attribution.md` | 3.9 K | playbook | current | Chargeback model. |
+| `Playbook-10-Progressive-Enhancement.md` | 4.0 K | playbook | current | Feature flags + canary. |
+| `Playbook-11-Advanced-Tool-Use.md` | 2.4 K | playbook | needs-restructure | Marked "Coming Soon" — either ship content or remove from sidebar until ready. Mentions "Anthropic's three beta features" without linking the Anthropic blog/docs. |
+| `Learning-Lab.md` | 4.9 K | lab | current | TOC for 3 tracks (Skills/Plugins/Orchestration) with Colab + Wiki links. |
+| `Lab-Mental-Model.md` | 6.3 K | lab | current | Test-harness orchestrator pattern. |
+| `Lab-Architecture.md` | 7.7 K | lab | stale | **Says "Required Fields (6)"** — every other reference page says 8. Cites `https://example.com/install.sh` as a sample (line 176) — fine as illustrative but worth marking explicitly. Otherwise solid SKILL.md deep-dive. |
+| `Lab-Build-Your-Own.md` | 8.1 K | lab | current | Hands-on skill+plugin walkthrough. |
+| `Lab-Debugging.md` | 7.6 K | lab | current | Validation + advanced patterns. |
+| `Lab-Orchestration.md` | 8.2 K | lab | current | Subagent + verification pattern. |
+| `.pr_agent_accepted_suggestions.md` | 18 K | — | candidate-for-deletion | PR-agent bot dump, not a wiki page. Doesn't appear in `_Sidebar.md`. Should be removed from the wiki repo entirely (move to a gist or repo-side docs if useful). |
+
+**Counts**: 52 content pages + sidebar + footer = 54 tracked. Of those: 1 candidate-for-deletion, 6 needs-restructure-or-stale (Plugin-Categories, Plugin-Inventory, Skill-Inventory, Changelog, Frontmatter-Reference, SKILL-md-Specification), ~10 stale-fact-only, rest current.
+
+---
+
+## 3. Top-Level Anthropic Deep-Link Audit
+
+**Bottom line: the wiki contains ZERO top-level Anthropic, claude.ai, docs.anthropic.com, code.claude.com, or github.com/anthropics URLs.** The "Anthropic Best Practices" referenced in `SKILL-md-Specification.md` and the "Anthropic Claude API rate limits" referenced in `Playbook-01` are uncited. The user's premise was "we have top-level URLs to fix" — what we actually have is "we have zero deep-links where deep-links are warranted." Same fix surface, different framing.
+
+Per-page recommended deep-links (additive — no top-level URL exists today to swap out):
+
+| File | Current state | Recommended deep-link to add |
+|---|---|---|
+| `Home.md` | Mentions "Claude Code, Cursor, Codex" in line 3; no link | Add a "Built on" line linking → https://code.claude.com/docs/en/ |
+| `_Sidebar.md` | No external-docs section | Add a new "Anthropic Docs" section with: Skills → https://code.claude.com/docs/en/skills, Plugins → https://code.claude.com/docs/en/plugins, MCP → https://code.claude.com/docs/en/mcp, Hooks → https://code.claude.com/docs/en/hooks |
+| `Installation.md` | "Claude Code" in prereq table, no link | Link "Claude Code" → https://code.claude.com/docs/en/ |
+| `How-Skills-Work.md` | "Claude Code Agent Skills" in headline, "Skill meta-tool" in body | Link the headline → https://code.claude.com/docs/en/skills; cite the Skill meta-tool to the same doc |
+| `SKILL-md-Specification.md` | Line 6-8: "Anthropic Best Practices" / "Claude Code Extensions" uncited | Replace "Anthropic Best Practices (progressive disclosure, degrees of freedom)" with a link → https://code.claude.com/docs/en/skills, and "Claude Code Extensions" → https://code.claude.com/docs/en/skills |
+| `Frontmatter-Reference.md` | `AgentSkills.io` is linked, but Claude-Code-specific fields (`model`, `context: fork`, `agent`, `argument-hint`, `user-invocable`, `disable-model-invocation`, `hooks`) are uncited | Add a header note: "Claude Code extension fields are documented at → https://code.claude.com/docs/en/skills" |
+| `Tool-Permissions-Guide.md` | `allowed-tools` rules sourced from nowhere | Add a "Reference" footer: → https://code.claude.com/docs/en/skills + https://code.claude.com/docs/en/settings |
+| `MCP-Server-Plugins.md` | Mentions MCP SDK + `@modelcontextprotocol/sdk` but no Anthropic doc link | Add "See also: → https://code.claude.com/docs/en/mcp" at top |
+| `Plugin-Structure.md` | Mentions `.claude-plugin/plugin.json` schema rules, uncited | Add reference → https://code.claude.com/docs/en/plugins and (for the marketplace catalog rules) → https://code.claude.com/docs/en/plugin-marketplaces |
+| `Two-Catalog-System.md` | Describes the marketplace.json schema | Add → https://code.claude.com/docs/en/plugin-marketplaces in Related Pages |
+| `Lab-Architecture.md` | Deep-dive into SKILL.md; cites no Anthropic source | Add → https://code.claude.com/docs/en/skills at top |
+| `Lab-Mental-Model.md` | Discusses skill/subagent meta-tool concept | Add → https://code.claude.com/docs/en/sub-agents |
+| `Lab-Orchestration.md` | Subagent delegation patterns | Add → https://code.claude.com/docs/en/sub-agents |
+| `Lab-Debugging.md` | Validation + skill discovery debugging | Add → https://code.claude.com/docs/en/skills |
+| `Lab-Build-Your-Own.md` | Hands-on skill + plugin build | Add → https://code.claude.com/docs/en/skills and → https://code.claude.com/docs/en/plugins |
+| `Glossary.md` | "Claude Code — Anthropic's official CLI for Claude" (line 17), no link; "MCP" (line 33), no link | Link "Claude Code" → https://code.claude.com/docs/en/; link "MCP" → https://code.claude.com/docs/en/mcp |
+| `FAQ.md` | "Anthropic" implicit throughout | Add a "Reference docs" Q: "Where do I read Anthropic's official Claude Code docs?" → list the canonical hub + skills/plugins/mcp/hooks deep-links |
+| `Troubleshooting.md` | No upstream-docs pointer | Add a "Reference" link in "Getting Help" → https://code.claude.com/docs/en/ |
+| `Playbook-01-Multi-Agent-Rate-Limits.md` | Cites "Anthropic rate limit tiers" + `anthropic-ratelimit-*` headers without links | Cite → https://docs.anthropic.com/en/api/rate-limits (Anthropic API docs) at the headers paragraph. (Note: the canonical map you gave is the Claude Code subset; this playbook is API-side, so the docs.anthropic.com root is appropriate here — flag for explicit approval.) |
+| `Playbook-11-Advanced-Tool-Use.md` | Cites "Anthropic's three beta features" without links | Cite Anthropic's tool-use blog/changelog (TBD; user picks). Pattern same as Playbook-01 — Anthropic API-side, not Claude Code-side. |
+| `Contributing.md` | No upstream-docs pointer | Add a "Reference" note: "For the canonical Claude Code skill + plugin spec see → https://code.claude.com/docs/en/skills + https://code.claude.com/docs/en/plugins" |
+| `MCP-Server-Plugins.md` | (Listed above; also worth adding AgentSkills.io for `mcp__` tool-name convention reference if user wants) | n/a |
+
+**Summary**: zero existing Anthropic URLs to replace; ~20 pages where a deep-link should be added. The user's framing ("we have top-level URLs to fix") may have been off — the actual gap is "we have un-cited references to Anthropic concepts and zero outbound deep-links." The fix list is still the canonical map given.
+
+---
+
+## 4. Stale-Link / Pattern-Only Findings
+
+No live HTTP checks performed; these are pattern-detected stale or misleading references.
+
+| File | Issue | Recommended fix |
+|---|---|---|
+| `Home.md` (line 39) | Links to repo via canonical slug `jeremylongshore/claude-code-plugins-plus-skills` — correct per "Do Not Normalize" rule. ✓ no fix. | — |
+| `Installation.md` (line 55, 126), `CLI-Quick-Reference.md` (line 33), `Troubleshooting.md` (line 73) | Use legacy slug `jeremylongshore/claude-code-plugins` for `/plugin marketplace add` — correct per "Do Not Normalize" (legacy slug is the public install slug). ✓ no fix needed. | — |
+| `Installation.md` (line 13) | Node `>= 18` requirement — stale (repo CLAUDE.md mandates `>= 20.0.0`; Node 18 causes silent workspace-resolution failures). | Bump table + nvm example to `>= 20`. |
+| `How-Skills-Work.md` (line 120), `Frontmatter-Reference.md` (line 126), `SKILL-md-Specification.md` (line 128) | `compatibility: "Node.js >= 18"` cited as example — stale Node value. | Change example to `Node.js >= 20`. |
+| `CI-CD-Pipeline.md` (line 85, 93) | CLI version "4.17.0" + "GitHub Pages" deploy — both stale. | Drop hardcoded version (link to `package.json`); change "GitHub Pages" → "VPS via Tailscale OIDC + rsync" (per VPS-as-the-home program) OR drop the deploy detail and link to `intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md`. |
+| `Data-Flow.md` (lines 38-42, 73, 107) | 5-stage build pipeline + GitHub Pages — both stale. | Update to 7-stage pipeline per repo CLAUDE.md ("discover-skills → extract-readme-sections → sync-catalog → enrich-jrig-data → generate-unified-search → build-cowork-zips → astro build") and rewrite "Deploy to GitHub Pages" → "Deploy to VPS via force-command SSH". |
+| `_Footer.md` (line 2), `Home.md` (line 13), `Repository-Structure.md` (line 3) | Hardcode `v4.30.0` — will go stale on next release. | Either auto-sync from `package.json` (regen script), or change to "current release" without a number. |
+| `Plugin-Inventory.md` (line 3) | "Marketplace version 1.6.0" — stale (matches an old marketplace version, not the current 4.30.0). | Re-run `scripts/generate-wiki-inventory.py`. |
+| `Skill-Inventory.md` (line 91), `Plugin-Inventory.md` footer, `Changelog.md` (line 111) | "Auto-generated... Last updated: 2026-03-12" — 12 weeks stale. | Re-run the inventory + changelog regen scripts as part of release cadence. |
+| `Plugin-Categories.md` (line 3) | "Browse all 427 plugins across 18 categories" but the table below lists 26 categories. Internal contradiction inside the same page. | Re-run regen; either prune empty categories or fix the headline number. |
+| `Lab-Architecture.md` (line 38) | "Cannot contain 'claude' or 'anthropic'" — verify against current validator (not flagged in `SKILL-md-Specification.md`). May be stale rule. | Cross-check with `scripts/validate-skills-schema.py`; update if rule was removed. |
+| `Tool-Permissions-Guide.md` (line 11-21) | Says `allowed-tools` MUST be CSV string, must NOT be YAML list. Wrong per schema 3.6.0. | Change to "Either CSV string OR YAML list (both valid per schema 3.6.0)" — matches `SKILL-md-Specification.md` and `FAQ.md`. |
+| `Lab-Architecture.md` (line 29) | "Required Fields (6)" — contradicts 8-field rule everywhere else. | Update to 8 (name, description, allowed-tools, version, author, license, compatibility, tags). |
+| `Skill-Template.md` (line 11) + `SKILL-md-Specification.md` (line 65, 155, 491) | Templates ship `compatible-with: claude-code, codex, openclaw` — deprecated since schema 3.4.0. | Replace with `compatibility: Designed for Claude Code` and a `tags:` list. |
+| `Frontmatter-Reference.md` (lines 62-66, 122-126) | Two `compatibility` headings — one current, one duplicate; also keeps the deprecated `compatible-with` as if recommended in field-order block. | Consolidate to a single `compatibility` section with `compatible-with` clearly marked deprecated + migration command. |
+| `PR-Process.md` (line 24) | "five parallel jobs" — `CI-CD-Pipeline.md` lists six. | Reconcile to "six". |
+| `Contributing.md` (line 44) | References `templates/command-plugin` — `Templates-and-Examples.md` (line 12) and `Plugin-Structure.md` (line 87) call it `templates/command`. | Verify the actual `templates/` dir layout and pick one name. |
+| `.pr_agent_accepted_suggestions.md` | PR-bot dump that's tracking specific PR-511 comments — doesn't belong as a wiki page. | Delete from the wiki repo. |
+| `Cowork-Bundles.md` (line 47) | Says "step 4 of the 5-step marketplace build pipeline" — pipeline is 7 steps per repo CLAUDE.md. | Update step number + total. |
+
+---
+
+## 5. Recommended "Project Wiki" Section for the Main Repo README
+
+Wiki page URL pattern: `https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/<PageName>`
+
+Suggested README block, organized by reader intent (11 pages — keeps it under the 12-page budget):
+
+**Getting started** — onboard from zero to first plugin/skill in under 30 minutes
+- [Installation](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Installation) — CLI install + marketplace setup
+- [Your First Plugin](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Your-First-Plugin) — build, validate, publish
+- [Your First Skill](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Your-First-Skill) — author a SKILL.md from scratch
+
+**Reference** — the spec + frontmatter + validation rules
+- [SKILL.md Specification](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/SKILL-md-Specification) — the canonical Intent Solutions skill standard
+- [Frontmatter Reference](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Frontmatter-Reference) — every YAML field explained
+- [Validation and Grading](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Validation-and-Grading) — the 100-point rubric + validator commands
+- [Plugin Structure](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Plugin-Structure) — directory layout + plugin.json
+
+**Playbooks** — production patterns for operating Claude Code at scale
+- [Playbook Index](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-Index) — all 11 production playbooks
+- [Multi-Agent Rate Limits](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-01-Multi-Agent-Rate-Limits) — token bucket + backpressure
+- [Incident Debugging](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-05-Incident-Debugging) — SEV protocols + RCA
+
+**Labs** — interactive Jupyter-notebook walkthroughs (Colab links inside each)
+- [Learning Lab Index](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Learning-Lab) — Skills / Plugins / Orchestration tracks
+
+If a 12th slot is wanted, add either `Troubleshooting` (reference tier) or `Lab-Orchestration` (labs tier, for the subagent-pattern reader).
+
+---
+
+## 6. Out of Scope This Round
+
+Explicitly do NOT do (defer to a follow-up after the user reviews this audit):
+
+1. **No wiki edits.** This is audit-only. Do not push to the wiki, do not edit any of the 54 files.
+2. **No structural restructuring.** Keep the existing sidebar grouping (Getting Started / User Guides / Building / Playbooks / Lab / Architecture / Contributing / Inventory / Reference). The only structural recommendation is `_Sidebar.md` getting a new "Anthropic Docs" deep-link block at the bottom, which is additive.
+3. **No new wiki pages.** All recommendations above are field/link/fact edits to existing pages.
+4. **No migrations.** Don't move content out of the wiki to `000-docs/`, don't fold playbooks back into the marketplace site, don't merge `Plugin-Inventory.md` and `Plugin-Categories.md`.
+5. **No live link-checking.** Stale-link findings in §4 are pattern-detected only (e.g., `tonsofskills.com/playbooks/01-…` — these may or may not redirect; flagged without HTTP probes).
+6. **No regen of auto-generated pages.** `Plugin-Categories.md`, `Plugin-Inventory.md`, `Skill-Inventory.md`, `Changelog.md` need their generators re-run, but that's a separate workflow — flagged here, not executed.
+7. **No `.pr_agent_accepted_suggestions.md` deletion.** Flagged as candidate-for-deletion; user decides whether to remove or archive.
+8. **No README edits.** §5 is a recommendation for the future README PR; do not modify `README.md` as part of this audit pass.
+
+---
+
+*End of audit. Next step is user review → targeted wiki-edit PR(s) scoped to the §3 deep-link adds, the §4 stale-fact fixes, and (separately) a regen run of the four auto-generated pages.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tons of Skills — Claude Code Plugins Marketplace
 
+> **Built for [Claude Code](https://code.claude.com/docs/en/).** Every plugin and skill in this catalog targets Anthropic's official CLI.
+
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/releases/tag/v4.33.0)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
 [![Plugins](https://img.shields.io/badge/plugins-431-blue)](https://tonsofskills.com/explore)
@@ -10,6 +12,14 @@
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
 432 plugins, 2,769 skills, 297 agents, 30 community contributors — validated and ready to install.
+
+## Why this repo
+
+- **One canonical catalog** — every plugin in `marketplace.extended.json` is the same `marketplace.json` the Claude Code CLI reads. No registries to reconcile, no manual sync step.
+- **Spec-correct or it doesn't ship** — every PR runs the [Intent Solutions validator](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/tree/main/scripts) against the [AgentSkills.io](https://agentskills.io/specification) open standard plus Claude Code's [skill](https://code.claude.com/docs/en/skills) and [plugin](https://code.claude.com/docs/en/plugins) references. C-grade rejects merge.
+- **8-field marketplace frontmatter is enforced**, not aspirational — `name / description / allowed-tools / version / author / license / compatibility / tags`. The [100-point rubric](https://tonsofskills.com/grading) is public.
+- **Forge-generated and hand-authored, both first-class** — `/skill-creator --forge <api-name>` builds production-grade plugins from any REST API with an audit trail; hand-authored plugins use the same templates and validators.
+- **Production-tested patterns** — the [Learning Lab](#learning-lab), [11 production playbooks](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-Index), and a [public wiki](#project-wiki) cover the failure modes that show up at scale (rate limits, MCP reliability, multi-agent cost caps, incident debugging).
 
 ```bash
 pnpm add -g @intentsolutionsio/ccpi    # Install the CLI
@@ -943,12 +953,57 @@ Community contributors make this marketplace better. Newest first.
 
 ## Resources
 
-### Official Anthropic
+### Built on the Anthropic stack
 
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code/)
-- [Agent Skills Guide](https://docs.anthropic.com/en/docs/claude-code/skills)
-- [Plugin Reference](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)
+This catalog targets Claude Code as its only first-class harness. Every reference page in the SKILL.md spec, plugin structure, MCP integration, hooks, and subagents work in this repo is grounded in the deep references below — not the top-level docs.
+
+**Claude Code documentation**
+
+- [Documentation hub](https://code.claude.com/docs/en/) — landing page for every Claude Code surface
+- [Skills reference](https://code.claude.com/docs/en/skills) — frontmatter spec, dynamic-context-injection model, control-who-invokes mechanism, subagent execution semantics
+- [Plugins reference](https://code.claude.com/docs/en/plugins) — plugin.json schema, the four component types, install paths
+- [Plugin marketplaces spec](https://code.claude.com/docs/en/plugin-marketplaces) — the `marketplace.json` schema this repo publishes
+- [Subagents reference](https://code.claude.com/docs/en/sub-agents) — agent.md frontmatter, `disallowedTools` denylist, `effort` / `maxTurns` controls
+- [Hooks reference](https://code.claude.com/docs/en/hooks) — 30+ lifecycle events, PreToolUse blocking, matcher patterns
+- [MCP integration](https://code.claude.com/docs/en/mcp) — stdio / HTTP / SSE / WebSocket transports, env-var handling, server lifecycle
+- [Settings reference](https://code.claude.com/docs/en/settings) — `~/.claude/settings.json`, permission modes, attribution config
+
+**Anthropic SDKs and code**
+
+- [Claude Code CLI source](https://github.com/anthropics/claude-code) — the official CLI repo
+- [Anthropic cookbook](https://github.com/anthropics/anthropic-cookbook) — production patterns, tool-use examples, RAG recipes
+- [Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python) — `pip install anthropic`, async + streaming + tool-use APIs
+
+**Open standards**
+
+- [AgentSkills.io specification](https://agentskills.io/specification) — the open SKILL.md standard Claude Code follows; this repo's enterprise rubric sits on top of it
+
+### Project Wiki
+
+The [GitHub wiki](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki) hosts deeper reference content than this README — 50+ pages covering installation, the full SKILL.md spec, plugin structure, validation, 11 production playbooks, and the Learning Lab walkthroughs.
+
+**Getting started** — zero-to-first-plugin in under 30 minutes
+
+- [Installation](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Installation) — CLI install + marketplace setup
+- [Your First Plugin](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Your-First-Plugin) — build, validate, publish
+- [Your First Skill](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Your-First-Skill) — author a SKILL.md from scratch
+
+**Reference** — the spec, frontmatter, and validation rules
+
+- [SKILL.md Specification](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/SKILL-md-Specification) — the canonical Intent Solutions skill standard
+- [Frontmatter Reference](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Frontmatter-Reference) — every YAML field explained
+- [Validation and Grading](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Validation-and-Grading) — the 100-point rubric + validator commands
+- [Plugin Structure](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Plugin-Structure) — directory layout + plugin.json
+
+**Playbooks** — production patterns for operating Claude Code at scale
+
+- [Playbook Index](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-Index) — all 11 production playbooks
+- [Multi-Agent Rate Limits](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-01-Multi-Agent-Rate-Limits) — token-bucket + backpressure
+- [Incident Debugging](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Playbook-05-Incident-Debugging) — SEV protocols + RCA
+
+**Labs** — interactive walkthroughs
+
+- [Learning Lab Index](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Learning-Lab) — Skills / Plugins / Orchestration tracks
 
 ### Technical Deep Dives
 
@@ -993,6 +1048,38 @@ Community contributors make this marketplace better. Newest first.
 - [Full Index](000-docs/206-DR-SOPS-readme.md)
 
 </details>
+
+---
+
+## FAQ
+
+**What is this?** A Claude Code plugin marketplace: 432 plugins, 2,769 skills, 297 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
+
+**How do I install a plugin?** Use the CLI (`ccpi install <name>`) or Claude Code's built-in `/plugin marketplace add jeremylongshore/claude-code-plugins` followed by `/plugin install <name>@claude-code-plugins-plus`. The [Quick Start](#quick-start) covers both paths.
+
+**Plugin vs skill — what's the difference?** A plugin is the distribution unit (folder with `plugin.json` + components); a skill is one component type inside a plugin (a `SKILL.md` file). One plugin can ship many skills, commands, agents, hooks, and MCP servers. The [Plugin Structure wiki page](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Plugin-Structure) is the deeper explanation.
+
+**Where do I browse the catalog?** [tonsofskills.com](https://tonsofskills.com) is the search-and-browse surface. The [`plugins/`](./plugins/) directory is the source of truth on GitHub.
+
+**Where do I get support?** Open an [issue](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues) for bugs, a [discussion](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions) for ideas, or email **jeremy@intentsolutions.io**. For the underlying CLI itself, see [Anthropic's Claude Code docs](https://code.claude.com/docs/en/) first.
+
+---
+
+## Troubleshooting
+
+Common install + author paths:
+
+- **Plugin install fails or doesn't activate** — see the [Troubleshooting wiki page](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Troubleshooting) for the common "missing required field" / "frontmatter wrong shape" / "marketplace not reachable" cases.
+- **Marketplace add fails** — verify slug with `/plugin marketplace list`; the public slug is `jeremylongshore/claude-code-plugins` (GitHub 301-redirects to the canonical `-plus-skills` repo).
+- **MCP server doesn't connect** — the [MCP-Server-Plugins wiki page](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/MCP-Server-Plugins) covers transport selection and the most common transport-mismatch errors. Anthropic's [MCP integration reference](https://code.claude.com/docs/en/mcp) is the upstream source.
+- **Validator says my skill is C-grade** — see [Validation and Grading](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/wiki/Validation-and-Grading) for the 100-point breakdown and the public [/grading rubric page](https://tonsofskills.com/grading) for worked examples.
+- **Compatibility field deprecation** — `compatible-with` was deprecated in schema 3.4.0. Migrate with `python3 scripts/batch-remediate.py --migrate-compatible-with`.
+
+---
+
+## Star history
+
+[![Star history chart](https://api.star-history.com/svg?repos=jeremylongshore/claude-code-plugins-plus-skills&type=Date)](https://star-history.com/#jeremylongshore/claude-code-plugins-plus-skills&Date)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^9.39.4",
-    "@intentsolutions/audit-harness": "^0.1.0",
+    "@intentsolutions/audit-harness": "^1.1.5",
     "@types/node": "^20.19.41",
     "archiver": "^7.0.1",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       '@intentsolutions/audit-harness':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^1.1.5
+        version: 1.1.5
       '@types/node':
         specifier: ^20.19.41
         version: 20.19.41
@@ -1740,8 +1740,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@intentsolutions/audit-harness@0.1.0':
-    resolution: {integrity: sha512-7YNrX4KLEPwJUT41yKa4w94/bqWS3Bdcvxa57GfQOEF/yUtu39Yl59t+bijx+7lO3HmWS5gc/llU1Nca1+QGtg==}
+  '@intentsolutions/audit-harness@1.1.5':
+    resolution: {integrity: sha512-VbE4gPR/wtp2czWT0/Wjo5ZEtX3SRxeWMBS5nx1LhgyxdrKdZdo+deP5/km3Cl5PMyf4XbwXtVt7pDjXi0w1mQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6463,7 +6463,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@intentsolutions/audit-harness@0.1.0': {}
+  '@intentsolutions/audit-harness@1.1.5': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
## Summary

Track N1 (README enhancement) and Track N2 (wiki audit) of the rolling marketplace plan (beads `claude-h8hd`).

**README enhancement** — partner-program-aware additions that position this repo as Claude-Code-first and surface the rest of the documentation:
- "Built for Claude Code" subtitle under the H1.
- "Why this repo" 5-bullet intro above the install snippet — canonical catalog, spec-correct-or-no-merge, 8-field frontmatter enforced, forge-generated + hand-authored, production-tested patterns.
- "Built on the Anthropic stack" Resources subsection with 12 **deep** links into code.claude.com (skills/plugins/marketplaces/subagents/hooks/mcp/settings), Anthropic cookbook, Python SDK, and the AgentSkills.io spec — replacing the prior 4-line "Official Anthropic" stub that only pointed at top-level URLs.
- "Project Wiki" section with 11 deep-links into the 50+ page wiki, organized by reader intent (Getting started / Reference / Playbooks / Labs). Surfaces wiki content that was previously hard to discover from the README.
- New FAQ + Troubleshooting + Star History sections before the existing "Important Notes."

**Wiki audit** — `000-docs/688-AA-AACR-2026-06-04-wiki-audit.md`:
- 54 pages inventoried (52 content + `_Sidebar` + `_Footer`; one `.pr_agent_*` dump flagged for deletion).
- Page-by-page status table — 6 needs-restructure-or-stale, ~10 stale-fact-only, rest current.
- Anthropic deep-link audit — wiki contains **zero** top-level Anthropic URLs today (different than the original premise); ~20 pages where prose references Claude Code / SDK / "Anthropic best practices" without citation. Per-page deep-link recommendations included.
- Pattern-detected stale facts — Node 18 vs 20+, CLI v4.17.0 → 4.30.0+, "GitHub Pages" deploy claim (production is VPS rsync), 5-stage build pipeline (actually 7), `compatible-with` deprecation drift, plugin count drift (340/343/427 across pages).
- Recommended README cross-references match the Project Wiki section shipped in this PR.

This PR does **not** edit the wiki itself — wiki edits are a separate follow-up PR after audit review.

## Out of scope

- Wiki page edits (separate PR — `claude-h8hd` Track N2 follow-up).
- Other tracks of the rolling plan (N3 learning-page audit, N4 marketplace sweep, A public /grading page, etc.) — separate PRs.

## Test plan

- [x] `pnpm run sync-marketplace` — clean
- [x] All AUTO-TOC / KILLER-SKILL / NPM-STATS markers preserved
- [x] No new anchor collisions (verified `## ` heading list)
- [ ] CI verifies link-check, markdown-lint, harness gates
- [ ] Visual smoke check after merge: README renders correctly on tonsofskills.com homepage hero card (if the marketplace site pulls README sections)

Beads: `claude-h8hd` (epic) → `claude-22w8` (Track A) + future N1/N2 sub-beads being created in parallel.

- Jeremy Longshore
intentsolutions.io