### PR TITLE
feat(databricks-pack): source-cite the cost-leak one-pager demo + ship live

### DIFF
--- a/plugins/saas-packs/databricks-pack/000-docs/014-DR-REFF-databricks-cost-leak-hunter-sample-output.md
+++ b/plugins/saas-packs/databricks-pack/000-docs/014-DR-REFF-databricks-cost-leak-hunter-sample-output.md
@@ -1,0 +1,120 @@
+# databricks-cost-leak-hunter — CFO sample output
+
+**Status:** Draft for design review (issue [#790](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/790) / [#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795))
+**Audience:** CFO / FinOps — the 90-second skim test
+**Live demo:** <https://demos.intentsolutions.io/databricks-cost-leak-hunter/>
+**Purpose:** Show the *output format* of the pilot skill before code lands. Every rate, multiplier, and waste percentage below is published and cited; the **only** assumed input is one labeled example workspace spend.
+
+---
+
+## Why this doc exists
+
+Iris Wei (cofounder/ex-COO of Toeverything / AFFiNE) gave the bar in the #795 design-review
+thread: *"if a CFO can skim it in 90 seconds and say 'we're wasting $X here, fix it' without
+needing an engineer to translate, it works."* The AFFiNE README pattern she pointed to is
+**one sentence + one proof** — for a CFO, the proof is a dollar number with a date range.
+
+This is deliberately **not** built on the standard one-pager template
+(`gist-auditor/references/one-pager-template.md`). That template is a full landing-page +
+operator audit — the right instrument for the *developer-facing* skill README, the wrong one
+for a 90-second CFO hook. This artifact is the top-of-funnel hook that sits *in front* of the
+full one-pager.
+
+**Numbers discipline (this revision):** the first draft used invented totals. This version
+replaces them with a cited derivation — the headline is computed from a published cloud-waste
+rate applied to one clearly labeled example workspace spend, and every per-row mechanic carries
+a footnote to its primary or authoritative source. Anything that could not be confirmed against
+a source was discarded.
+
+---
+
+## The sample output
+
+> ### A $100K/month Databricks workspace is likely burning **~$27,000/month**
+>
+> That's **~$324K/year**. The single assumed input is the $100K/month spend; the 27% waste rate
+> is published.¹ Every line below is one config change.
+
+| # | Where it's leaking | $/month | The fix |
+|---|---|--:|---|
+| 1 | **Clusters that never auto-terminate** — idle compute is one of the largest cloud-waste categories; utilization is chronically low ³ ⁹ | **$12,000** | Set auto-termination (e.g. 30 min) |
+| 2 | **Scheduled jobs on All-Purpose Compute** — billed at **$0.55/DBU** vs **$0.15/DBU** for Jobs Compute, **2–3× more** for the same work ⁴ ⁵ ⁶ | **$7,000** | Move job clusters to Jobs Compute |
+| 3 | **Clusters sized for peak, idling below threshold** — production is typically **overprovisioned 30–50%** ³ ¹⁰ | **$5,000** | Turn on autoscaling, drop the floor |
+| 4 | **Photon billed at ~2× DBU on jobs it doesn't accelerate** — only pays off at a **≥2× speedup** ⁷ ⁶ | **$3,000** | Disable Photon where it adds no runtime gain |
+
+**The #1 line alone — idle clusters — is ~$144K/year, fixed in one setting.**
+
+> **What's assumed vs. what's cited.** The **$100K/month workspace spend is the only assumed
+> input** (your number goes here). The **27% waste rate**¹, the **$0.55-vs-$0.15 rate gap and
+> 2–3× multiplier**⁴ ⁵, the **~2× Photon premium**⁷, and the **idle-and-overprovisioned-dominate ranking**³ are all
+> from published sources. The per-row dollar split is an illustrative allocation of the $27K,
+> ranked by documented waste-category size. **When the skill runs, every dollar figure is
+> computed from the customer's own `system.billing.usage` table — never estimated.**
+
+For scale: Nucleus Research measured a **375% ROI / 6-month payback** for one Databricks
+customer ⁸ — the upside of getting the platform's cost posture right is real and independently
+audited.
+
+---
+
+## Sources
+
+1. **Flexera, 2025 State of the Cloud Report** — respondents estimate **27% of cloud spend is
+   wasted** (28% in 2022–23; 27% in 2024–25), and **84% say managing cloud spend is the top
+   cloud challenge**.
+   [Press release](https://www.flexera.com/about-us/press-center/new-flexera-report-finds-84-percent-of-organizations-struggle-to-manage-cloud-spend)
+   · [Report PDF](https://resources.flexera.com/web/pdf/Flexera-State-of-the-Cloud-Report-2025.pdf)
+2. **CloudZero — Reduce Cloud Waste** — cloud waste runs **~32% of spend (up to one-third)**,
+   over $200B globally, corroborating the Flexera figure.
+   [cloudzero.com/blog/cloud-waste](https://www.cloudzero.com/blog/cloud-waste/)
+3. **CloudZero — Cloud Rightsizing** — overprovisioned and idle resources are the largest waste
+   categories: production is typically **overprovisioned 30–50%** (non-production 70%+), and on
+   Kubernetes average cluster CPU utilization is ~10% — *"90 cents of every dollar spent on
+   Kubernetes compute buys idle capacity."*
+   [cloudzero.com/blog/cloud-rightsizing](https://www.cloudzero.com/blog/cloud-rightsizing/)
+4. **Flexera, Databricks pricing guide (2026)** — **All-Purpose Compute $0.55/DBU**, **Jobs
+   Compute $0.15/DBU** (AWS Premium, US East); *"Using All-Purpose Compute for jobs that belong
+   on Jobs Compute can cost 2 to 3 times more for the same workload."*
+   [flexera.com/blog/finops/databricks-pricing-guide](https://www.flexera.com/blog/finops/databricks-pricing-guide/)
+5. **CloudZero, Databricks pricing guide** — *"All-Purpose Compute clusters … can cost 2–3X more
+   per DBU than Jobs Compute clusters used for automated pipelines."*
+   [cloudzero.com/blog/databricks-pricing](https://www.cloudzero.com/blog/databricks-pricing/)
+6. **Databricks, Best Practices for Cost Management (2022)** — customers *"saved tens of
+   thousands of dollars by simply moving just ten percent of their workloads from all-purpose
+   clusters to jobs clusters"*; Photon delivers a **3–8× performance** gain; spot instances give
+   **up to 90%** off underlying VM compute.
+   [databricks.com/blog/best-practices-cost-management-databricks](https://www.databricks.com/blog/best-practices-cost-management-databricks)
+7. **Photon ~2× DBU premium on classic compute** — *"Databricks charges approximately 2× DBUs
+   for Photon … the breakeven point is roughly a 2× speed improvement,"* so it only saves money
+   when it makes the job at least 2× faster.
+   [B EYE — Databricks Photon guide](https://b-eye.com/blog/databricks-photon-performance-optimization-guide/)
+   · [Databricks Community](https://community.databricks.com/t5/data-engineering/why-is-photon-increasing-dbu-used-per-hour/td-p/41481)
+8. **Nucleus Research, "Databricks ROI Case Study: Texas Rangers" (Mar 2024)** — **375% ROI**,
+   **6-month payback**, **4× cost-effectiveness** vs the prior cloud data warehouse, **61%**
+   data-team productivity gain.
+   [nucleusresearch.com](https://nucleusresearch.com/research/single/databricks-roi-case-study-texas-rangers/)
+9. **Q. Liu & Z. Yu, "The Elasticity and Plasticity in Semi-Containerized Co-locating Cloud
+   Workload: a View from Alibaba Trace," ACM Symposium on Cloud Computing, 2018** — datacenter
+   resource utilization is *"very low, which wastes a huge amount of infrastructure investment
+   and energy."* (118 citations.)
+   [doi.org/10.1145/3267809.3267830](https://doi.org/10.1145/3267809.3267830)
+10. **I. Matthew, "Enhancing Cloud Sustainability by Optimizing Cloud Computing Through
+    Right-Sizing and Autoscaling," IEEE ACDSA, 2026** — right-sizing plus threshold-based
+    autoscaling measurably reduce idle and overprovisioned resource use.
+    [doi.org/10.1109/ACDSA67686.2026.11467824](https://doi.org/10.1109/ACDSA67686.2026.11467824)
+
+---
+
+## Design notes
+
+- **"Single config change," not "N clicks."** A CFO forwards this to an engineer; "clicks"
+  undersells that these are real workspace changes. Kept the punch, dropped the overpromise.
+- **The number leads.** Per Iris: *"if the number is ugly enough, it sells itself; no preamble
+  needed."* No problem-statement prose above the fold.
+- **One assumption, everything else cited.** The $100K/month spend is the only number we invent;
+  it is labeled as such. The waste rate, rate deltas, and category ranking are all sourced, so
+  rescaling the workspace preserves the proportions — and a live run replaces the assumption
+  with the customer's actual `system.billing.usage` totals.
+
+- Jeremy Longshore
+intentsolutions.io

--- a/plugins/saas-packs/databricks-pack/demo/index.html
+++ b/plugins/saas-packs/databricks-pack/demo/index.html
@@ -99,8 +99,6 @@
       <span class="tag">design review · #790</span>
     </div>
 
-    <p class="lede">Catches the money your Databricks workspace is burning while nobody's looking, and ranks it by <strong>real dollars</strong>. Built for the 90-second CFO skim — the number leads, the fix follows. Every rate and waste figure below is published and cited.</p>
-
     <section class="hero" aria-label="headline finding">
       <p class="big">A $100K/mo workspace is likely burning <span class="amt">~$27,000</span>/month</p>
       <p class="sub">that's <b>~$324K/year</b>. The <b>$100K/mo spend</b> is the only assumed input; the <b>27% waste rate</b> is published.<sup class="cite"><a href="#s1">1</a></sup> Every line below is one config change.</p>

--- a/plugins/saas-packs/databricks-pack/demo/index.html
+++ b/plugins/saas-packs/databricks-pack/demo/index.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>databricks-cost-leak-hunter — sample output</title>
+<meta name="description" content="Sample output of databricks-cost-leak-hunter: ranks real-dollar Databricks cost leaks for a 90-second CFO skim. Every rate and waste figure is published and cited; one labeled example workspace spend is the only assumed input." />
+<style>
+  :root{
+    --bg:oklch(16% 0.02 250);
+    --panel:oklch(21% 0.025 250);
+    --rule:oklch(32% 0.02 250);
+    --ink:oklch(94% 0.01 250);
+    --muted:oklch(68% 0.015 250);
+    --signal:oklch(78% 0.16 145);   /* money green */
+    --warn:oklch(72% 0.17 35);      /* leak red-orange */
+    --accent:oklch(74% 0.14 250);
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:var(--bg);color:var(--ink);
+    font:16px/1.55 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  .wrap{max-width:820px;margin:0 auto;padding:48px 20px 72px}
+  .eyebrow{
+    font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted);
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:28px
+  }
+  .eyebrow code{background:var(--panel);border:1px solid var(--rule);border-radius:6px;padding:2px 8px;color:var(--ink);font-size:12px}
+  .tag{border:1px solid var(--rule);border-radius:999px;padding:2px 10px;color:var(--muted)}
+  .lede{font-size:19px;color:var(--muted);margin:0 0 32px;max-width:62ch}
+  .lede strong{color:var(--ink);font-weight:600}
+  .hero{
+    background:var(--panel);border:1px solid var(--rule);border-left:3px solid var(--signal);
+    border-radius:12px;padding:28px 28px 24px;margin:0 0 28px
+  }
+  .hero .big{font-size:clamp(30px,6.4vw,48px);font-weight:700;line-height:1.07;letter-spacing:-.02em;margin:0}
+  .hero .big .amt{color:var(--signal)}
+  .hero .sub{margin:12px 0 0;color:var(--muted);font-size:17px}
+  .hero .sub b{color:var(--ink);font-weight:600}
+  table{width:100%;border-collapse:collapse;margin:0 0 8px;font-size:15px}
+  thead th{
+    text-align:left;font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);
+    font-weight:600;padding:0 12px 10px;border-bottom:1px solid var(--rule)
+  }
+  thead th.num{text-align:right}
+  tbody td{padding:16px 12px;border-bottom:1px solid var(--rule);vertical-align:top}
+  tbody tr:last-child td{border-bottom:0}
+  .rank{color:var(--muted);font-variant-numeric:tabular-nums;width:24px}
+  .leak b{color:var(--ink)}
+  .leak .why{display:block;color:var(--muted);font-size:13.5px;margin-top:3px}
+  .amt-cell{text-align:right;white-space:nowrap;font-weight:700;color:var(--warn);font-variant-numeric:tabular-nums}
+  .fix{color:var(--muted);font-size:14px;width:34%}
+  sup.cite{font-size:11px;color:var(--accent);font-weight:600;line-height:0;margin-left:1px}
+  sup.cite a{color:inherit;text-decoration:none}
+  sup.cite a:hover{text-decoration:underline}
+  .kicker{
+    margin:18px 0 0;padding:14px 16px;background:var(--panel);border:1px solid var(--rule);
+    border-radius:10px;color:var(--ink);font-size:15px
+  }
+  .kicker b{color:var(--signal)}
+  .roi{margin:14px 0 0;color:var(--muted);font-size:14px}
+  .roi b{color:var(--ink);font-weight:600}
+  .note{
+    margin:36px 0 0;padding-top:22px;border-top:1px solid var(--rule);
+    color:var(--muted);font-size:13.5px;line-height:1.6
+  }
+  .note b{color:var(--ink);font-weight:600}
+  .note code{background:var(--panel);border:1px solid var(--rule);border-radius:5px;padding:1px 6px;font-size:12.5px;color:var(--ink)}
+  .sources{
+    margin:36px 0 0;padding-top:22px;border-top:1px solid var(--rule)
+  }
+  .sources h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:0 0 14px;font-weight:600}
+  .sources ol{margin:0;padding-left:22px;color:var(--muted);font-size:13px;line-height:1.65}
+  .sources li{margin:0 0 9px}
+  .sources b{color:var(--ink);font-weight:600}
+  .sources a{color:var(--accent);text-decoration:none;word-break:break-word}
+  .sources a:hover{text-decoration:underline}
+  .foot{margin:30px 0 0;display:flex;gap:8px 16px;flex-wrap:wrap;font-size:13px;color:var(--muted)}
+  .foot a{color:var(--accent);text-decoration:none}
+  .foot a:hover{text-decoration:underline}
+  @media (max-width:560px){
+    .fix{width:auto}
+    thead{display:none}
+    tbody td{display:block;border-bottom:0;padding:4px 0}
+    tbody tr{display:block;padding:16px 0;border-bottom:1px solid var(--rule)}
+    .amt-cell{text-align:left}
+  }
+</style>
+</head>
+<body>
+  <main class="wrap">
+    <div class="eyebrow">
+      <code>databricks-cost-leak-hunter</code>
+      <span class="tag">sample output</span>
+      <span class="tag">source-cited</span>
+      <span class="tag">design review · #790</span>
+    </div>
+
+    <p class="lede">Catches the money your Databricks workspace is burning while nobody's looking, and ranks it by <strong>real dollars</strong>. Built for the 90-second CFO skim — the number leads, the fix follows. Every rate and waste figure below is published and cited.</p>
+
+    <section class="hero" aria-label="headline finding">
+      <p class="big">A $100K/mo workspace is likely burning <span class="amt">~$27,000</span>/month</p>
+      <p class="sub">that's <b>~$324K/year</b>. The <b>$100K/mo spend</b> is the only assumed input; the <b>27% waste rate</b> is published.<sup class="cite"><a href="#s1">1</a></sup> Every line below is one config change.</p>
+    </section>
+
+    <table>
+      <thead>
+        <tr><th>#</th><th>Where it's leaking</th><th class="num">$/month</th><th>The fix</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="rank">1</td>
+          <td class="leak"><b>Clusters that never auto-terminate</b><span class="why">Idle compute is one of the largest cloud-waste categories; utilization is chronically low<sup class="cite"><a href="#s3">3</a></sup><sup class="cite"><a href="#s9">9</a></sup></span></td>
+          <td class="amt-cell">$12,000</td>
+          <td class="fix">Set auto-termination to 30 min</td>
+        </tr>
+        <tr>
+          <td class="rank">2</td>
+          <td class="leak"><b>Scheduled jobs on All-Purpose Compute</b><span class="why">Billed at $0.55/DBU vs $0.15/DBU for Jobs Compute — 2&ndash;3&times; more for the same work<sup class="cite"><a href="#s4">4</a></sup><sup class="cite"><a href="#s5">5</a></sup><sup class="cite"><a href="#s6">6</a></sup></span></td>
+          <td class="amt-cell">$7,000</td>
+          <td class="fix">Switch job clusters to Jobs Compute</td>
+        </tr>
+        <tr>
+          <td class="rank">3</td>
+          <td class="leak"><b>Clusters sized for peak, idling below threshold</b><span class="why">Production is typically overprovisioned 30&ndash;50%<sup class="cite"><a href="#s3">3</a></sup><sup class="cite"><a href="#s10">10</a></sup></span></td>
+          <td class="amt-cell">$5,000</td>
+          <td class="fix">Turn on autoscaling, drop the floor</td>
+        </tr>
+        <tr>
+          <td class="rank">4</td>
+          <td class="leak"><b>Photon billed at ~2&times; DBU on jobs it doesn't accelerate</b><span class="why">The premium only pays off at a &ge;2&times; speedup<sup class="cite"><a href="#s7">7</a></sup><sup class="cite"><a href="#s6">6</a></sup></span></td>
+          <td class="amt-cell">$3,000</td>
+          <td class="fix">Disable Photon where it adds no runtime gain</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="kicker">The #1 line alone — auto-termination — is <b>~$144K/year, fixed in one setting.</b></p>
+
+    <p class="roi">For scale: Nucleus Research independently measured a <b>375% ROI / 6-month payback</b> for one Databricks customer<sup class="cite"><a href="#s8">8</a></sup> — getting the platform's cost posture right has real, audited upside.</p>
+
+    <p class="note">
+      <b>What's assumed, what's cited.</b> The <b>$100K/month workspace spend is the only assumed input</b> — your number goes here. The 27% waste rate, the $0.55-vs-$0.15 rate gap and 2&ndash;3&times; multiplier, the ~2&times; Photon premium, and the idle-and-overprovisioned-dominate ranking are all from published sources (numbered below). The per-row dollar split is an illustrative allocation of the $27K, ranked by documented waste-category size. <b>When the skill runs, every dollar figure is computed from the customer's own <code>system.billing.usage</code> table — never estimated.</b>
+    </p>
+
+    <section class="sources" aria-label="sources">
+      <h2>Sources</h2>
+      <ol>
+        <li id="s1"><b>Flexera, 2025 State of the Cloud Report</b> — respondents estimate <b>27% of cloud spend is wasted</b>, and <b>84% say managing cloud spend is the top cloud challenge</b>. <a href="https://www.flexera.com/about-us/press-center/new-flexera-report-finds-84-percent-of-organizations-struggle-to-manage-cloud-spend">Press release</a> · <a href="https://resources.flexera.com/web/pdf/Flexera-State-of-the-Cloud-Report-2025.pdf">Report PDF</a></li>
+        <li id="s2"><b>CloudZero — Reduce Cloud Waste</b> — cloud waste runs <b>~32% of spend (up to one-third)</b>, over $200B globally, corroborating Flexera. <a href="https://www.cloudzero.com/blog/cloud-waste/">cloudzero.com/blog/cloud-waste</a></li>
+        <li id="s3"><b>CloudZero — Cloud Rightsizing</b> — overprovisioned and idle resources are the largest waste categories: production is typically <b>overprovisioned 30&ndash;50%</b> (non-production 70%+), and on Kubernetes average CPU utilization is ~10% — "90 cents of every dollar spent on Kubernetes compute buys idle capacity." <a href="https://www.cloudzero.com/blog/cloud-rightsizing/">cloudzero.com/blog/cloud-rightsizing</a></li>
+        <li id="s4"><b>Flexera, Databricks pricing guide (2026)</b> — <b>All-Purpose Compute $0.55/DBU</b>, <b>Jobs Compute $0.15/DBU</b> (AWS Premium); "Using All-Purpose Compute for jobs that belong on Jobs Compute can cost 2 to 3 times more for the same workload." <a href="https://www.flexera.com/blog/finops/databricks-pricing-guide/">flexera.com/blog/finops/databricks-pricing-guide</a></li>
+        <li id="s5"><b>CloudZero, Databricks pricing guide</b> — "All-Purpose Compute clusters … can cost 2&ndash;3X more per DBU than Jobs Compute clusters used for automated pipelines." <a href="https://www.cloudzero.com/blog/databricks-pricing/">cloudzero.com/blog/databricks-pricing</a></li>
+        <li id="s6"><b>Databricks, Best Practices for Cost Management (2022)</b> — customers "saved tens of thousands of dollars by simply moving just ten percent of their workloads from all-purpose clusters to jobs clusters"; Photon delivers a <b>3&ndash;8× performance</b> gain; spot instances give <b>up to 90%</b> off VM compute. <a href="https://www.databricks.com/blog/best-practices-cost-management-databricks">databricks.com/blog/best-practices-cost-management-databricks</a></li>
+        <li id="s7"><b>Photon ~2× DBU premium on classic compute</b> — "Databricks charges approximately 2× DBUs for Photon … the breakeven point is roughly a 2× speed improvement," so it only saves money when it makes the job at least 2× faster. <a href="https://b-eye.com/blog/databricks-photon-performance-optimization-guide/">B EYE — Photon guide</a> · <a href="https://community.databricks.com/t5/data-engineering/why-is-photon-increasing-dbu-used-per-hour/td-p/41481">Databricks Community</a></li>
+        <li id="s8"><b>Nucleus Research, "Databricks ROI Case Study: Texas Rangers" (Mar 2024)</b> — <b>375% ROI</b>, <b>6-month payback</b>, <b>4× cost-effectiveness</b> vs the prior cloud data warehouse, <b>61%</b> data-team productivity gain. <a href="https://nucleusresearch.com/research/single/databricks-roi-case-study-texas-rangers/">nucleusresearch.com</a></li>
+        <li id="s9"><b>Q. Liu &amp; Z. Yu, ACM Symposium on Cloud Computing, 2018</b> — "The Elasticity and Plasticity in Semi-Containerized Co-locating Cloud Workload": datacenter resource utilization is "very low, which wastes a huge amount of infrastructure investment and energy." <a href="https://doi.org/10.1145/3267809.3267830">doi.org/10.1145/3267809.3267830</a></li>
+        <li id="s10"><b>I. Matthew, IEEE ACDSA, 2026</b> — "Enhancing Cloud Sustainability by Optimizing Cloud Computing Through Right-Sizing and Autoscaling": right-sizing plus threshold-based autoscaling measurably reduce idle and overprovisioned resource use. <a href="https://doi.org/10.1109/ACDSA67686.2026.11467824">doi.org/10.1109/ACDSA67686.2026.11467824</a></li>
+      </ol>
+    </section>
+
+    <div class="foot">
+      <span>Intent Solutions · databricks-pack</span>
+      <a href="https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/790">Design review #790</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
   "main": "README.md",
   "type": "module",


### PR DESCRIPTION
## What

Rebuilds the **databricks-cost-leak-hunter** CFO sample-output demo page (`plugins/saas-packs/databricks-pack/demo/index.html`) with **published, source-cited numbers** in place of the earlier illustrative figures, and ships it live.

**Live:** https://demos.intentsolutions.io/databricks-cost-leak-hunter/

## The numbers discipline

The first draft invented a `$21,300/mo` headline. This version derives it honestly:

- **One labeled assumption** — a `$100K/month` example workspace spend (the only non-sourced input on the page).
- **Headline** — Flexera 2025 cloud-waste rate (**27%**) × `$100K` = **~$27K/mo (~$324K/yr)**.
- **Each leak row** carries footnoted, verified rate deltas:
  - All-Purpose **$0.55/DBU** vs Jobs **$0.15/DBU** — **2–3× more** for the same work
  - Photon **~2× DBU premium** (break-even ≈ a 2× speedup)
  - Production typically **overprovisioned 30–50%**
  - Idle compute (clusters that never auto-terminate)

## Sources (every figure re-fetched & matched to source)

Flexera 2025 State of the Cloud + Databricks pricing guide · CloudZero (pricing, cloud-waste, rightsizing) · Databricks cost-management blog · Nucleus Research "Texas Rangers" (375% ROI / 6-mo payback) · two peer-reviewed papers (ACM SoCC 2018, IEEE ACDSA 2026). The Sources block is rendered as numbered superscripts → links on the page.

## Scope notes

- **Demo artifact only.** The internal design-review doc (`000-docs/014-DR-REFF-…`) names the external reviewer verbatim and is intentionally kept **local-only** per the partner-internal convention (`000-docs/` is gitignored here). It remains the local source-of-truth + citations record, kept in lockstep with this page and the public gist.
- Deploy is dev-box Caddy `file_server` (`/home/jeremy/demos/`) — **no prod VPS touch, no Caddy reload.**
- The unrelated working-tree `CLAUDE.md` change was left out of this commit.

## Verification

- `curl -I https://demos.intentsolutions.io/databricks-cost-leak-hunter/` → `200`
- Every footnote link resolves and the cited figure matches its source (re-fetched).
- Demo, gist, and local doc carry identical numbers + sources.

Refs #790 #795