### PR TITLE
chore: remove Nixtla from public listings + align geepers catalog name with npm

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -5544,7 +5544,7 @@
       }
     },
     {
-      "name": "geepers",
+      "name": "geepers-agents",
       "source": "./plugins/community/geepers-agents",
       "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
       "version": "1.0.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5098,7 +5098,7 @@
       }
     },
     {
-      "name": "geepers",
+      "name": "geepers-agents",
       "source": "./plugins/community/geepers-agents",
       "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
       "version": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `fairdb-ops-manager`     | Database operations management for FairDB PostgreSQL clusters                                                                               |
 | `framecraft`             | Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos…  |
 | `gastown`                | Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software…         |
-| `geepers`                | Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built… |
 | `geepers-agents`         | Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and…      |
+| `geepers-agents`         | Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built… |
 | `jeremy-firebase`        | Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration                                                          |
 | `jeremy-firestore`       | Firestore database specialist for schema design, queries, and real-time sync                                                                |
 | `sprint`                 | Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend,…      |

--- a/marketplace/src/data/partners.json
+++ b/marketplace/src/data/partners.json
@@ -11,17 +11,6 @@
       "logoLight": "/images/partners/kobiton-light.svg",
       "logoDark": "/images/partners/kobiton-dark.svg",
       "accentColor": "#0487D9"
-    },
-    {
-      "slug": "nixtla",
-      "name": "Nixtla",
-      "url": "https://nixtla.io",
-      "wordmark": "Nixtla",
-      "tagline": "Time series forecasting & anomaly detection",
-      "logoLight": "/images/partners/nixtla-light.svg",
-      "logoDark": "/images/partners/nixtla-dark.svg",
-      "accentColor": "#000000",
-      "logoHeight": 20
     }
   ]
 }

--- a/marketplace/src/pages/sponsor.astro
+++ b/marketplace/src/pages/sponsor.astro
@@ -765,33 +765,6 @@ const seo = {
       </div>
     </section>
 
-    <!-- Current Partners -->
-    <section class="section section-alt">
-      <div class="container">
-        <div class="section-header">
-          <h2 class="section-title">Current Partners</h2>
-        </div>
-
-        <div class="pricing-grid" style="max-width: 56rem; margin: 0 auto;">
-          <!-- Nixtla -->
-          <div style="padding: 2rem; background: var(--brand-light); border: 2px solid var(--brand-orange); border-radius: 1rem;">
-            <a href="https://www.nixtla.io/" target="_blank" rel="noopener noreferrer" style="text-decoration: none;">
-              <h3 style="font-size: 1.75rem; font-weight: 700; color: var(--brand-dark); margin-bottom: 0.5rem;">Nixtla</h3>
-            </a>
-            <p style="color: var(--brand-orange); font-weight: 600; margin-bottom: 1rem;">Time Series Forecasting AI &bull; YC S21</p>
-            <p style="color: var(--brand-mid-gray); line-height: 1.6; margin-bottom: 1rem;">
-              <strong>Partner Since:</strong> November 2024<br>
-              <strong>Custom Plugins:</strong> 3 enterprise-grade solutions
-            </p>
-            <p style="font-style: italic; color: var(--brand-mid-gray); border-left: 3px solid var(--brand-orange); padding-left: 1rem;">
-              "The custom plugins have streamlined our workflow, saving our team 10+ hours weekly on routine tasks."
-            </p>
-          </div>
-
-        </div>
-      </div>
-    </section>
-
     <!-- Success Stories -->
     <section class="section">
       <div class="container">


### PR DESCRIPTION
## Two cleanups

**1. Remove Nixtla from public partner + sponsor listings.** Nixtla was a **paid sponsor whose placement lapsed (they stopped paying for advertising)** — so the unpaid ad comes off the public bar. (An earlier version of this description called them an "active client"; that was inaccurate — corrected here for the record. The squash-merge commit message retains the original wording since history is immutable.)
- `partners.json` — removed the homepage hero-bar entry (only `kobiton` remains)
- `sponsor.astro` — removed the "Current Partners" sponsor block (Nixtla was its only card)

**2. Align `geepers` catalog name with its npm package.** Catalog said `geepers` while npm + source dir are both `geepers-agents` — a download-name mismatch. Renamed the catalog entry to `geepers-agents`; regenerated marketplace.json + README via sync-marketplace.

The other 2 name mismatches (`slack-channel`→`claude-channel-slack`, `x-bug-triage`→`x-bug-triage-plugin`) are unscoped/legacy MCP names — matching them would degrade the catalog display, so they're left for a separate call.