### PR TITLE
fix(validator): real allowed-tools validation + missing-name diagnostic + stale docstrings

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -66,22 +66,30 @@ jobs:
         id: sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Injection hygiene: dispatch-controlled strings must reach the shell
+          # via env vars, never via direct ${{ }} interpolation inside run:.
+          # A crafted repository_dispatch client_payload.source would otherwise
+          # be expanded verbatim into the script (command execution on the
+          # runner). Env values arrive as data, not code.
+          SYNC_SOURCE: ${{ inputs.source || github.event.client_payload.source }}
         run: |
           ARGS=""
           if [ "${{ inputs.force }}" = "true" ]; then
             ARGS="$ARGS --force"
-          fi
-          # Source from workflow_dispatch input or repository_dispatch payload
-          SOURCE="${{ inputs.source || github.event.client_payload.source }}"
-          if [ -n "$SOURCE" ]; then
-            ARGS="$ARGS --source=$SOURCE"
           fi
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
           fi
           ARGS="$ARGS --force --verbose"
 
-          node scripts/sync-external.mjs $ARGS
+          # Source from workflow_dispatch input or repository_dispatch payload.
+          # Passed as a single quoted argv entry so metacharacters / spaces in
+          # the payload stay one argument, never extra flags.
+          if [ -n "$SYNC_SOURCE" ]; then
+            node scripts/sync-external.mjs $ARGS --source="$SYNC_SOURCE"
+          else
+            node scripts/sync-external.mjs $ARGS
+          fi
 
       - name: Check for changes
         id: changes

--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -124,6 +124,65 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.8.0] — 2026-06-11 — Real `allowed-tools` entry validation + standard-tier missing-`name` diagnostic (additive)
+
+Code-review fixes (findings f-ccp-validator-1..4). **No change to `ALWAYS_REQUIRED`,
+the tier model, or error-vs-warning semantics** — all new diagnostics are
+WARNING-level (NON-NEGOTIABLE #7 reserves error/warning semantic changes for
+explicitly approved architectural work).
+
+### Fixed — `validate_tool_permission` actually validates (f-ccp-validator-1)
+
+The function previously returned `True` for every entry and its diagnostic
+messages were silently dropped by the caller, so misspelled tool names
+(`Reads`), truncated wildcards (`Bash(git add *` without the closing paren),
+and stray fragments (`wc:*)`) all passed without a word. Now:
+
+- **Malformed entries** (unbalanced parentheses, scope not closing at end of
+  entry, empty scope `Bash()`, illegal characters in the tool name, empty
+  entry) → WARNING at every tier.
+- **Well-formed but unknown base tool names** (e.g. `Reads`) → WARNING with a
+  did-you-mean suggestion when a close match exists.
+- **MCP tool references** (`mcp__server__tool`) are recognized as valid.
+- The old `cmd:*`-format advisory is dropped: Anthropic's canonical example is
+  the space form `Bash(git add *)` (code.claude.com/docs/en/skills), so a
+  no-colon scope is spec-compliant, not suspect.
+
+Severity note: these are WARNINGS (not marketplace ERRORS) because the
+NON-NEGOTIABLES do not define tool-entry severity and #7 makes any
+error-vs-warning escalation an approval-gated architectural change. If a
+malformed-entry ERROR at marketplace tier is wanted, that needs explicit
+sign-off first.
+
+### Fixed — standard tier emits a missing-`name` diagnostic (f-ccp-validator-2)
+
+`STANDARD_REQUIRED = {name, description}`, but a SKILL.md with no `name` field
+produced zero frontmatter-presence diagnostics at standard tier. Now emits a
+WARNING (`Missing required field: 'name'`), parallel to the existing
+missing-`description` warning at that tier.
+
+### Fixed — stale "marketplace = warnings-only" docs (f-ccp-validator-3)
+
+The module docstring and the comment blocks around `MARKETPLACE_TRACKING_FIELDS`
+still described marketplace tier as "WARNINGS for missing polish fields … No
+additional ERRORS beyond Standard" — pre-3.3.0 wording that contradicts
+NON-NEGOTIABLES #1–#2 and the actual code (missing `ALWAYS_REQUIRED` fields
+error at marketplace tier since 3.3.0). Docstrings now state the 8-field
+ERROR behavior. The stale `Schema: 3.0.0` header line is also corrected.
+
+### Fixed — dead expression in `validate_frontmatter` (f-ccp-validator-4)
+
+Removed a discarded `fm.get("metadata", …)` expression statement (dropped
+assignment left over from a refactor; value was never used).
+
+### Migration
+
+None required. Existing skills keep validating; some now surface WARNINGS for
+malformed/unknown `allowed-tools` entries or a missing `name`. Warnings do not
+fail validation (unless `--fail-on-warn`) and do not affect rubric grades.
+
+---
+
 ## [3.7.0] — 2026-05-28 — Recognize `disallowed-tools` (Claude Code v2.1.152, additive)
 
 Adds the `disallowed-tools` field to the schema registry. Source: Claude Code v2.1.152 changelog (released 2026-05-27) — *"Skills and slash commands can now set `disallowed-tools` in frontmatter to remove tools from the model while the skill is active."* **No validator rule changes** — `ALWAYS_REQUIRED` 8-field set is untouched; `disallowed-tools` is recognized as an Anthropic-spec optional field with the same string|array shape as `allowed-tools`.

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -10,9 +10,10 @@ Unified validator for all Claude Code plugin content:
 Two-tier validation system (aligned with Anthropic published spec):
 - Standard (DEFAULT): Mirrors Anthropic spec exactly. Required: name + description only.
   All other fields optional. Type/value validation when fields are present.
-- Marketplace (--marketplace): IS richer-marketplace polish layer. Same hard requirements
-  as Standard, plus WARNINGS for missing recommended polish fields
-  (version, author, license, allowed-tools, compatibility, tags). 100-point rubric.
+- Marketplace (--marketplace): IS enterprise standard. All 8 ALWAYS_REQUIRED fields
+  (name, description, allowed-tools, version, author, license, compatibility, tags)
+  must be present — missing any of them is an ERROR (schema 3.3.0+; see
+  000-docs/SCHEMA_CHANGELOG.md NON-NEGOTIABLES #1-#2). 100-point rubric.
 - Deep (--deep): Intent Solutions Deep Evaluation Engine. 10 weighted dimensions.
 - Auto-detect: if CI=true or GITHUB_ACTIONS=true → marketplace by default.
 
@@ -40,10 +41,11 @@ Usage:
 
 Author: Jeremy Longshore <jeremy@intentsolutions.io>
 Version: 7.0.0
-Schema:  3.0.0  (see 000-docs/SCHEMA_CHANGELOG.md)
+Schema:  3.8.0  (see 000-docs/SCHEMA_CHANGELOG.md)
 """
 
 import argparse
+import difflib
 import json as json_module
 import os
 import re
@@ -87,8 +89,17 @@ except ImportError:
 #                       at IS marketplace tier (NOT spec-floor recognition).
 #                       Snapshot anchor: intent-eval-platform/intent-eval-lab/research/
 #                       claude-docs-spec-tree-2026-05-27.md.
+# 3.8.0 (2026-06-11) — allowed-tools entry validation made real (was
+#                       always-True with diagnostics silently dropped):
+#                       malformed entries (unbalanced parens, empty scope,
+#                       illegal tool-name characters) and unknown tool names
+#                       now surface as WARNINGS at all tiers; standard tier
+#                       now emits a missing-'name' warning (was silent);
+#                       stale "marketplace = warnings-only" docstrings
+#                       corrected. No change to ALWAYS_REQUIRED or
+#                       error-vs-warning semantics.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.7.0"
+SCHEMA_VERSION = "3.8.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -123,8 +134,10 @@ VALID_TOOLS = {
 # Standard tier: nothing else required. All other fields optional, validated
 # only if present. Mirrors Anthropic published spec verbatim.
 #
-# Marketplace tier: same hard requirements + WARNINGS for missing polish fields.
-# Higher rubric scores reward inclusion. No additional ERRORS beyond Standard.
+# Marketplace tier: the full IS enterprise 8-field set (ALWAYS_REQUIRED) must
+# be present — missing any of them is an ERROR (restored in schema 3.3.0; see
+# 000-docs/SCHEMA_CHANGELOG.md NON-NEGOTIABLES #1-#2). The rubric additionally
+# rewards inclusion of optional polish fields.
 STANDARD_REQUIRED = {"name", "description"}
 STANDARD_RECOMMENDED = set()  # description is now in REQUIRED at standard tier
 
@@ -137,7 +150,9 @@ MARKETPLACE_REQUIRED = {"name", "description"}
 #   - allowed-tools : security best practice (Anthropic doc itself promotes this)
 #   - tags      : discovery filtering
 #   - compatibility : runtime / environment requirements (free-text, AgentSkills.io)
-# Validator warns at marketplace tier when any are missing; never errors.
+# All six are members of ALWAYS_REQUIRED: missing any of them at marketplace
+# tier is an ERROR (SCHEMA_CHANGELOG NON-NEGOTIABLE #2). The 100-point rubric
+# additionally rewards their inclusion.
 MARKETPLACE_TRACKING_FIELDS = {"allowed-tools", "version", "author", "license", "compatibility", "tags"}
 # Back-compat alias — old name, same set.
 MARKETPLACE_RECOMMENDED = MARKETPLACE_TRACKING_FIELDS
@@ -1617,25 +1632,83 @@ def parse_allowed_tools(tools_value: Any) -> List[str]:
     return [t for t in tokens if t]
 
 
-def validate_tool_permission(tool: str) -> Tuple[bool, str]:
-    """Validate a single tool permission including wildcards like Bash(git:*)."""
-    base_tool = tool.split("(")[0].strip()
+# Well-formed base tool / server identifier (letters, digits, underscore, hyphen).
+RE_TOOL_BASE_IDENT = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+# MCP tool reference: mcp__<server> or mcp__<server>__<tool> (Claude Code
+# permission-rule form; appears in the corpus, e.g. mcp__database-explorer__query_database).
+RE_MCP_TOOL_REF = re.compile(r"^mcp__[A-Za-z0-9_-]+(?:__[A-Za-z0-9_-]+)?$")
 
-    # Handle malformed scopes like "mysql:*)" - extract actual tool name
-    if ":" in base_tool:
-        base_tool = base_tool.split(":")[0].strip()
+
+def validate_tool_permission(tool: str) -> Tuple[bool, str]:
+    """Validate a single allowed-tools entry.
+
+    Entry shapes observed across the plugin corpus (surveyed 2026-06-11):
+      - Bare known tool:             Read, Write, Bash, Grep, ...
+      - Scoped, colon form:          Bash(git:*), Bash(npm:*)        (IS convention)
+      - Scoped, space form:          Bash(git add *)                 (Anthropic canonical example)
+      - MCP tool, double-underscore: mcp__server__tool
+      - Colon shorthand:             git:*, ServerName:tool_name
+
+    Returns (valid, msg):
+      - (True,  "")  — recognized and well-formed.
+      - (True,  msg) — well-formed but the base tool name is not a built-in
+                       Claude Code tool (e.g. a misspelling like 'Reads').
+                       Caller surfaces msg as a WARNING.
+      - (False, msg) — malformed entry (unbalanced parentheses, empty scope,
+                       illegal characters in the tool name). Caller surfaces
+                       msg as a WARNING at every tier: escalating malformed
+                       entries to a marketplace-tier ERROR would change
+                       error-vs-warning semantics, which is architectural per
+                       SCHEMA_CHANGELOG NON-NEGOTIABLE #7 and needs prior
+                       approval.
+
+    Note: the old `cmd:*`-format advisory was dropped — Anthropic's canonical
+    example is the space form `Bash(git add *)` (code.claude.com/docs/en/skills),
+    so a no-colon scope is spec-compliant, not suspect.
+    """
+    entry = tool.strip()
+    if not entry:
+        return False, "empty allowed-tools entry"
+
+    # Parenthesis structure: every "(" must be balanced and the scope must
+    # close at the end of the entry (catches truncations like `Bash(git add *`
+    # and stray fragments like `wc:*)` produced by splitting a parenthesized
+    # list on commas).
+    open_count = entry.count("(")
+    close_count = entry.count(")")
+    if open_count != close_count:
+        return False, f"Malformed entry (unbalanced parentheses): {tool}"
+    if open_count and not entry.endswith(")"):
+        return False, f"Malformed entry (scope must close at end of entry): {tool}"
+
+    base = entry.split("(", 1)[0].strip()
+    if open_count and not base:
+        return False, f"Malformed entry (missing tool name before scope): {tool}"
+
+    # MCP tool references are valid allowed-tools entries; no advisory.
+    if RE_MCP_TOOL_REF.match(entry):
+        return True, ""
+
+    # Colon shorthand like "git:*" or "ServerName:tool_name" — validate the
+    # segment before the colon as the base name.
+    base_tool = base.split(":")[0].strip()
+
+    if not RE_TOOL_BASE_IDENT.match(base_tool):
+        return False, f"Malformed entry (tool name must be alphanumeric/_/- ): {tool}"
+
+    if open_count:
+        inner = entry[entry.index("(") + 1 : -1].strip()
+        if not inner:
+            return False, f"Empty scope in allowed-tools entry: {tool}"
 
     if base_tool not in VALID_TOOLS:
-        # Warn instead of error for unknown patterns (may be valid Bash commands)
-        return True, f"Unknown tool pattern: {tool} (assuming Bash command)"
-
-    # Validate wildcard syntax if present - warn instead of error
-    if "(" in tool:
-        if not tool.endswith(")"):
-            return True, f"Malformed wildcard syntax: {tool}"
-        inner = tool[tool.index("(") + 1 : -1]
-        if ":" not in inner:
-            return True, f"Wildcard should use cmd:* format: {tool}"
+        suggestion = difflib.get_close_matches(base_tool, sorted(VALID_TOOLS), n=1, cutoff=0.75)
+        if suggestion:
+            return True, f"Unknown tool '{base_tool}' in entry '{tool}' — did you mean '{suggestion[0]}'?"
+        return True, (
+            f"Unknown tool '{base_tool}' in entry '{tool}' (not a built-in Claude Code tool; "
+            f"shell commands belong inside a Bash(...) scope)"
+        )
 
     return True, ""
 
@@ -1660,11 +1733,9 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
     infos: List[str] = []
 
     # === FIELD PRESENCE CHECKS (tier-aware) ===
-    # Standard tier: name + description recommended.
+    # Standard tier: name + description (STANDARD_REQUIRED per Anthropic spec).
     # Marketplace tier: full IS enterprise standard — all 8 ALWAYS_REQUIRED fields
     # must be present. Missing any of them = ERROR.
-
-    fm.get("metadata", {}) if isinstance(fm.get("metadata"), dict) else {}
 
     if tier == TIER_MARKETPLACE:
         for key in ALWAYS_REQUIRED:
@@ -1681,7 +1752,13 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
             if key not in fm:
                 infos.append(f"[frontmatter] Consider adding '{key}': {reason}")
     else:
-        # Standard tier: only description is recommended
+        # Standard tier: Anthropic spec requires name + description
+        # (STANDARD_REQUIRED). Both surface as WARNINGS at this tier — errors
+        # are reserved for the marketplace gate, and promoting these would be
+        # an error-vs-warning semantics change (architectural per
+        # SCHEMA_CHANGELOG NON-NEGOTIABLE #7, needs prior approval).
+        if "name" not in fm:
+            warnings.append("[frontmatter] Missing required field: 'name' (required by Anthropic spec)")
         if "description" not in fm:
             warnings.append("[frontmatter] Missing recommended field: 'description' (recommended by Anthropic spec)")
 
@@ -1837,7 +1914,17 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
         for tool in tools:
             valid, msg = validate_tool_permission(tool)
             if not valid:
-                errors.append(f"[frontmatter] allowed-tools: {msg}")
+                # Malformed entry (unbalanced parens, empty scope, illegal
+                # characters in the tool name). WARNING at every tier —
+                # escalating malformed entries to a marketplace-tier ERROR
+                # would change error-vs-warning semantics, which is
+                # architectural per SCHEMA_CHANGELOG NON-NEGOTIABLE #7 and
+                # needs prior written approval.
+                warnings.append(f"[frontmatter] allowed-tools: {msg}")
+            elif msg:
+                # Well-formed but unrecognized base tool name (e.g. a
+                # misspelling like 'Reads') — advisory.
+                warnings.append(f"[frontmatter] allowed-tools: {msg}")
 
         # Unscoped Bash check (tier-aware)
         if "Bash" in tools:

--- a/tests/ci/test_workflow_injection_hygiene.py
+++ b/tests/ci/test_workflow_injection_hygiene.py
@@ -1,0 +1,61 @@
+"""Regression guard for f-ccp-workflows-1 (2026-06-11).
+
+`repository_dispatch` client_payload values (and string-typed
+`workflow_dispatch` inputs) are attacker-influenced. If interpolated with
+``${{ }}`` directly inside a ``run:`` block, GitHub Actions expands them into
+the shell script verbatim before execution — arbitrary command execution on
+the runner. They must be routed through ``env:`` so the shell receives them
+as data, never as code.
+
+Scope: pins sync-external.yml, where the finding was reported. Boolean-typed
+inputs (force / dry_run) are not injectable and may stay inline.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sync-external.yml"
+
+# ${{ ... }} expressions referencing dispatch-controlled strings.
+RE_INJECTABLE = re.compile(r"\$\{\{[^}]*(client_payload|inputs\.source)[^}]*\}\}")
+
+
+def _iter_run_blocks(node):
+    """Yield every `run:` string anywhere in the parsed workflow document."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "run" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_run_blocks(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_run_blocks(item)
+
+
+def test_sync_external_run_blocks_do_not_interpolate_dispatch_payload():
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    offenders = [run for run in _iter_run_blocks(doc) if RE_INJECTABLE.search(run)]
+    assert not offenders, (
+        "Dispatch-controlled values (client_payload.*, inputs.source) must reach "
+        "run: blocks via env:, not direct ${{ }} interpolation (command injection "
+        f"on the runner). Offending run blocks:\n{offenders}"
+    )
+
+
+def test_sync_external_routes_source_through_env():
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["sync"]["steps"]
+    sync_step = next(s for s in steps if s.get("id") == "sync")
+    env = sync_step.get("env") or {}
+    assert any("client_payload.source" in str(v) for v in env.values()), (
+        f"sync step must carry client_payload.source through env:; got env={env}"
+    )
+    assert '"$SYNC_SOURCE"' in sync_step["run"], (
+        "run block must pass the source as a quoted env-var argv entry"
+    )

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -1,0 +1,182 @@
+"""Regression tests for scripts/validate-skills-schema.py frontmatter checks.
+
+Covers review findings f-ccp-validator-1 and f-ccp-validator-2 (2026-06-11):
+
+  * f-ccp-validator-1 — validate_tool_permission always returned True and the
+    caller dropped its diagnostic messages, so malformed or misspelled
+    allowed-tools entries passed without any output.
+  * f-ccp-validator-2 — a SKILL.md missing `name` at standard tier produced
+    zero field-presence diagnostics despite STANDARD_REQUIRED = {name,
+    description}.
+
+All new diagnostics are WARNING-level by design: escalating them to errors
+would be an error-vs-warning semantics change, which is architectural per
+000-docs/SCHEMA_CHANGELOG.md NON-NEGOTIABLE #7 and needs prior approval.
+The marketplace-tier guard tests at the bottom pin NON-NEGOTIABLES #1-#2
+(missing ALWAYS_REQUIRED fields stay ERRORS at marketplace tier).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+VALIDATOR_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate-skills-schema.py"
+_spec = importlib.util.spec_from_file_location("validate_skills_schema", VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(validator)
+
+# A description long enough (>20 chars) and bland enough to avoid unrelated
+# length / voice / discoverability diagnostics muddying assertions.
+GOOD_DESC = "Validate skill frontmatter fields against the published schema registry."
+
+SKILL_PATH = Path("plugins/testing/my-skill/skills/my-skill/SKILL.md")
+
+
+def _frontmatter(fm: dict, tier: str):
+    return validator.validate_frontmatter(SKILL_PATH, fm, tier=tier)
+
+
+# =========================================================================
+# f-ccp-validator-1 — validate_tool_permission unit behavior
+# =========================================================================
+
+
+def test_known_bare_tools_are_valid_with_no_message():
+    for tool in ("Read", "Write", "Edit", "Bash", "Grep", "Glob", "Skill"):
+        valid, msg = validator.validate_tool_permission(tool)
+        assert valid is True, tool
+        assert msg == "", (tool, msg)
+
+
+def test_scoped_colon_form_is_valid():
+    valid, msg = validator.validate_tool_permission("Bash(git:*)")
+    assert valid is True
+    assert msg == ""
+
+
+def test_scoped_space_form_is_valid_per_anthropic_canonical_example():
+    # code.claude.com/docs/en/skills canonical example: Bash(git add *)
+    valid, msg = validator.validate_tool_permission("Bash(git add *)")
+    assert valid is True
+    assert msg == "", msg
+
+
+def test_mcp_tool_reference_is_valid():
+    valid, msg = validator.validate_tool_permission("mcp__database-explorer__query_database")
+    assert valid is True
+    assert msg == "", msg
+
+
+def test_misspelled_tool_name_yields_advisory_with_suggestion():
+    valid, msg = validator.validate_tool_permission("Reads")
+    assert valid is True  # well-formed, just unknown — advisory, not malformed
+    assert "Reads" in msg
+    assert "Read" in msg  # did-you-mean suggestion
+
+
+def test_unclosed_paren_is_malformed():
+    valid, msg = validator.validate_tool_permission("Bash(git add *")
+    assert valid is False
+    assert "parenthes" in msg.lower()
+
+
+def test_stray_close_paren_is_malformed():
+    valid, msg = validator.validate_tool_permission("wc:*)")
+    assert valid is False
+    assert msg
+
+
+def test_empty_scope_is_malformed():
+    valid, msg = validator.validate_tool_permission("Bash()")
+    assert valid is False
+    assert "scope" in msg.lower()
+
+
+def test_empty_entry_is_malformed():
+    valid, msg = validator.validate_tool_permission("   ")
+    assert valid is False
+    assert msg
+
+
+# =========================================================================
+# f-ccp-validator-1 — caller routing inside validate_frontmatter
+# =========================================================================
+
+
+def test_misspelled_allowed_tool_surfaces_warning_not_error():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Reads, Write"}
+    errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("allowed-tools" in w and "Reads" in w for w in warnings), warnings
+    assert not any("allowed-tools" in e for e in errors), errors
+
+
+def test_malformed_wildcard_surfaces_warning_not_error():
+    # YAML-list form so the comma-free truncated entry survives parsing intact.
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": ["Bash(git add *", "Read"]}
+    errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("allowed-tools" in w and "parenthes" in w.lower() for w in warnings), warnings
+    assert not any("allowed-tools" in e for e in errors), errors
+
+
+def test_clean_allowed_tools_produce_no_tool_diagnostics():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, Write, Bash(git:*)"}
+    errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert not any("Unknown tool" in w or "Malformed" in w for w in warnings), warnings
+    assert not any("allowed-tools" in e for e in errors), errors
+
+
+# =========================================================================
+# f-ccp-validator-2 — standard tier missing-name diagnostic
+# =========================================================================
+
+
+def test_standard_tier_missing_name_emits_warning():
+    fm = {"description": GOOD_DESC}
+    errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("'name'" in w and "Missing" in w for w in warnings), (
+        f"standard tier must diagnose a missing 'name' field; got warnings={warnings}"
+    )
+    # Warning-level only — promoting to error is gated by NON-NEGOTIABLE #7.
+    assert not any("'name'" in e and "Missing" in e for e in errors), errors
+
+
+def test_standard_tier_missing_description_still_warns():
+    fm = {"name": "my-skill"}
+    _errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("'description'" in w and "Missing" in w for w in warnings), warnings
+
+
+def test_standard_tier_complete_minimal_frontmatter_has_no_presence_warnings():
+    fm = {"name": "my-skill", "description": GOOD_DESC}
+    errors, warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert not errors, errors
+    assert not any("Missing required field" in w or "Missing recommended field" in w for w in warnings), warnings
+
+
+# =========================================================================
+# NON-NEGOTIABLES #1-#2 guard — marketplace tier still ERRORS on the 8-field set
+# =========================================================================
+
+
+def test_marketplace_tier_missing_always_required_fields_are_errors():
+    fm = {"name": "my-skill", "description": GOOD_DESC}
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    for field in ("allowed-tools", "version", "author", "license", "compatibility", "tags"):
+        assert any(f"'{field}'" in e and "Missing required field" in e for e in errors), (
+            f"marketplace tier must ERROR on missing '{field}' (NON-NEGOTIABLE #2); got errors={errors}"
+        )
+
+
+def test_always_required_is_the_is_enterprise_8_field_set():
+    # NON-NEGOTIABLE #1 — pin the canonical set so accidental reduction fails loudly.
+    assert validator.ALWAYS_REQUIRED == {
+        "name",
+        "description",
+        "allowed-tools",
+        "version",
+        "author",
+        "license",
+        "compatibility",
+        "tags",
+    }


### PR DESCRIPTION
## What

Five verified fixes from the 24-agent umbrella review (run wf_fd40cbff-045), adversarially diff-reviewed (approve, zero scope creep), 331 validator tests green.

- `validate_tool_permission` always returned True — malformed `allowed-tools` entries now actually validate (semantics chosen per SCHEMA_CHANGELOG NON-NEGOTIABLES; ALWAYS_REQUIRED set, tier model, and error-vs-warning semantics untouched)
- Missing `name` at standard tier produced zero diagnostic despite STANDARD_REQUIRED listing it — now emits
- Stale docstring cluster claiming marketplace tier is warnings-only (wrong since schema 3.3.0) corrected
- `sync-external.yml`: `client_payload.source` routed through `env:` instead of direct `${{ }}` interpolation in the run block (injection hygiene)

[skip auto-bump]