### PR TITLE
fix(ci): resolve all 75 actionlint/shellcheck findings across 15 workflows

### DIFF
--- a/.github/workflows/auto-bump-on-pr.yml
+++ b/.github/workflows/auto-bump-on-pr.yml
@@ -85,8 +85,7 @@ jobs:
             echo "No bumps needed."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            BUMPED=$(echo "$OUTPUT" | grep -c '^bumped:' || true)
-            COUNT=$(echo "$OUTPUT" | grep -E '→' | wc -l)
+            COUNT=$(echo "$OUTPUT" | grep -cE '→' || true)
             echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           fi
 
@@ -95,6 +94,8 @@ jobs:
         # `--no-verify` skips local pre-commit hooks (husky / lint-staged)
         # which can OOM on prettier across the staged set in CI. Same
         # pattern as `update-npm-stats.yml`.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
@@ -108,15 +109,17 @@ jobs:
           jeremy made me do it
           -claude"
 
-          git push origin HEAD:"${{ github.head_ref }}"
+          git push origin HEAD:"$HEAD_REF"
 
       - name: Summary
         if: always()
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           echo "## 🔢 Auto-bump on PR" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.bump.outputs.changed }}" = "true" ]; then
-            echo "✅ Bumped ${{ steps.bump.outputs.count }} plugin(s); commit pushed to \`${{ github.head_ref }}\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ Bumped ${{ steps.bump.outputs.count }} plugin(s); commit pushed to \`$HEAD_REF\`." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "✓ No plugin source changes that warrant a patch bump." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -96,7 +96,7 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/cli-v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "✅ Published version: $VERSION"
 
       - name: Create GitHub Release
@@ -140,15 +140,17 @@ jobs:
 
       - name: Report success
         run: |
-          echo "## 🎉 CLI Published Successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Package**: [@claude-code-plugins/ccp](https://www.npmjs.com/package/@claude-code-plugins/ccp)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Installation" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npx @claude-code-plugins/ccp@${{ steps.version.outputs.version }} doctor" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🎉 CLI Published Successfully"
+            echo ""
+            echo "**Version**: ${{ steps.version.outputs.version }}"
+            echo "**Package**: [@claude-code-plugins/ccp](https://www.npmjs.com/package/@claude-code-plugins/ccp)"
+            echo ""
+            echo "### Installation"
+            echo "\`\`\`bash"
+            echo "npx @claude-code-plugins/ccp@${{ steps.version.outputs.version }} doctor"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Post-publish verification
   verify-publish:
@@ -169,6 +171,8 @@ jobs:
 
       - name: Report
         run: |
-          echo "## ✅ Verification Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Package is live and installable from npm registry" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ✅ Verification Complete"
+            echo ""
+            echo "Package is live and installable from npm registry"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -173,8 +173,10 @@ jobs:
 
       - name: Report
         run: |
-          echo "## CLI Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Cross-platform testing complete" >> $GITHUB_STEP_SUMMARY
-          echo "- Node.js testing: ${{ needs.test-cli.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Deno testing: ${{ needs.test-deno.result }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## CLI Test Results"
+            echo ""
+            echo "✅ Cross-platform testing complete"
+            echo "- Node.js testing: ${{ needs.test-cli.result }}"
+            echo "- Deno testing: ${{ needs.test-deno.result }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/daily-skill-generator.yml
+++ b/.github/workflows/daily-skill-generator.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Find next plugin needing skills
         id: find
         run: |
-          # Get all plugins
-          PLUGINS=$(jq -r '.plugins[].name' .claude-plugin/marketplace.json)
-
           # Find first plugin WITHOUT agent-skills keyword
           NEXT_PLUGIN=$(jq -r '.plugins[] |
             select((.keywords[]? == "agent-skills") | not) |
@@ -35,10 +32,12 @@ jobs:
           PLUGIN_DESC=$(jq -r ".plugins[] | select(.name == \"$NEXT_PLUGIN\") | .description" .claude-plugin/marketplace.json)
           PLUGIN_CAT=$(jq -r ".plugins[] | select(.name == \"$NEXT_PLUGIN\") | .category" .claude-plugin/marketplace.json)
 
-          echo "plugin_name=$NEXT_PLUGIN" >> $GITHUB_OUTPUT
-          echo "plugin_path=$PLUGIN_PATH" >> $GITHUB_OUTPUT
-          echo "plugin_desc=$PLUGIN_DESC" >> $GITHUB_OUTPUT
-          echo "plugin_category=$PLUGIN_CAT" >> $GITHUB_OUTPUT
+          {
+            echo "plugin_name=$NEXT_PLUGIN"
+            echo "plugin_path=$PLUGIN_PATH"
+            echo "plugin_desc=$PLUGIN_DESC"
+            echo "plugin_category=$PLUGIN_CAT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create issue for Claude Code
         if: steps.find.outputs.plugin_name != ''

--- a/.github/workflows/plane-sync.yml
+++ b/.github/workflows/plane-sync.yml
@@ -78,7 +78,7 @@ jobs:
             "$PLANE_HOST/api/v1/workspaces/$PLANE_WORKSPACE/projects/$PLANE_PROJECT_ID/issues/")
           while read -r CODE; do
             [ -n "$CODE" ] || continue
-            SEQ=${CODE#${PLANE_IDENTIFIER}-}
+            SEQ=${CODE#"${PLANE_IDENTIFIER}"-}
             UUID=$(echo "$ISSUES" | jq -r --arg seq "$SEQ" '.results[] | select(.sequence_id==($seq | tonumber)) | .id')
             if [ -z "$UUID" ]; then echo "::warning::$CODE not found in Plane"; continue; fi
             curl -fsSL -o /dev/null -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \

--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -56,11 +56,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}")
-          echo "head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
-          echo "author=$(echo "$PR_DATA" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
-          echo "title<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$PR_DATA" | jq -r '.title' >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')"
+            echo "author=$(echo "$PR_DATA" | jq -r '.user.login')"
+            echo "title<<EOF"
+            echo "$PR_DATA" | jq -r '.title'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       # Check out the BASE (main) first — we run the validator and classifier
       # FROM main, not from the PR. The PR's content is checked out into a

--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -93,9 +93,9 @@ jobs:
           PY
 
           COUNT=$(jq length /tmp/packages.json)
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           # Emit as JSON string (jq -c ensures single line)
-          echo "packages_json=$(jq -c . /tmp/packages.json)" >> $GITHUB_OUTPUT
+          echo "packages_json=$(jq -c . /tmp/packages.json)" >> "$GITHUB_OUTPUT"
           echo "Found $COUNT publishable @intentsolutionsio/* packages"
           # Use jq slice instead of `| head -20` — SIGPIPE under `set -o pipefail`
           # was aborting the whole step even though the listing succeeded.

--- a/.github/workflows/publish-changed-packages.yml
+++ b/.github/workflows/publish-changed-packages.yml
@@ -88,8 +88,8 @@ jobs:
           PY
 
           COUNT=$(jq length /tmp/packages.json)
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
-          echo "packages_json=$(jq -c . /tmp/packages.json)" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "packages_json=$(jq -c . /tmp/packages.json)" >> "$GITHUB_OUTPUT"
           echo "Publish candidates: $COUNT"
           jq -r '.[] | "  \(.name)@\(.version)"' /tmp/packages.json
 
@@ -172,6 +172,7 @@ jobs:
               # Build the notes via printf to avoid multi-line YAML literal
               # block scalar issues (blank-line-then-unindented breaks YAML
               # parsing).
+              # shellcheck disable=SC2016  # backticks are literal markdown code spans
               REL_NOTES=$(printf 'Released by `publish-changed-packages.yml` on push to `main`.\n\n**npm:** https://www.npmjs.com/package/%s/v/%s\n**Source:** `%s`\n**Install:** `pnpm add %s@%s` (or `/plugin install` via Claude Code marketplace)' "$NAME" "$VERSION" "$DIR" "$NAME" "$VERSION")
               gh release create "$TAG" \
                 --title "$TAG" \

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -46,9 +46,9 @@ jobs:
         id: check
         run: |
           if [ "${{ inputs.server }}" = "all" ] || [ "${{ inputs.server }}" = "${{ matrix.server }}" ] || [ -z "${{ inputs.server }}" ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         id: current_version
         run: |
           VERSION=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
-          echo "current=$VERSION" >> $GITHUB_OUTPUT
+          echo "current=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Current version: $VERSION"
 
       - name: Calculate new version
@@ -90,7 +90,7 @@ jobs:
           esac
 
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "New version: $NEW_VERSION"
 
       - name: Update version in marketplace.json
@@ -100,7 +100,7 @@ jobs:
           mv tmp.json .claude-plugin/marketplace.json
 
           echo "Updated marketplace.json to version $NEW_VERSION"
-          cat .claude-plugin/marketplace.json | jq '.metadata.version'
+          jq '.metadata.version' .claude-plugin/marketplace.json
 
       - name: Update version in README
         run: |
@@ -179,11 +179,13 @@ jobs:
       - name: Summary
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
-          echo "## Release v$NEW_VERSION Complete! " >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "-  Version bumped: ${{ steps.current_version.outputs.current }} → $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "-  Git tag created: v$NEW_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "-  GitHub release published" >> $GITHUB_STEP_SUMMARY
-          echo "-  Announcement issue created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v$NEW_VERSION)" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release v$NEW_VERSION Complete! "
+            echo ""
+            echo "-  Version bumped: ${{ steps.current_version.outputs.current }} → $NEW_VERSION"
+            echo "-  Git tag created: v$NEW_VERSION"
+            echo "-  GitHub release published"
+            echo "-  Announcement issue created"
+            echo ""
+            echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v$NEW_VERSION)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/slack-daily-downloads.yml
+++ b/.github/workflows/slack-daily-downloads.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [ -z "${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}" ]; then
             echo "SLACK_OPERATION_HIRED_WEBHOOK_URL not set; skipping. Configure the repo secret to enable."
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Slack payload
@@ -83,7 +83,7 @@ jobs:
             echo "payload<<EOF"
             echo "$PAYLOAD"
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post to Slack
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -67,29 +67,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARGS=""
+          ARGS=()
           if [ "${{ inputs.force }}" = "true" ]; then
-            ARGS="$ARGS --force"
+            ARGS+=(--force)
           fi
           # Source from workflow_dispatch input or repository_dispatch payload
           SOURCE="${{ inputs.source || github.event.client_payload.source }}"
           if [ -n "$SOURCE" ]; then
-            ARGS="$ARGS --source=$SOURCE"
+            ARGS+=("--source=$SOURCE")
           fi
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+            ARGS+=(--dry-run)
           fi
-          ARGS="$ARGS --force --verbose"
+          ARGS+=(--force --verbose)
 
-          node scripts/sync-external.mjs $ARGS
+          node scripts/sync-external.mjs "${ARGS[@]}"
 
       - name: Check for changes
         id: changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Sync marketplace catalog
@@ -161,10 +161,10 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## 🔄 External Plugin Sync Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 🔄 External Plugin Sync Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.changes.outputs.has_changes }}" = "true" ]; then
-            echo "✅ Changes detected and PR created" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Changes detected and PR created" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✓ All sources are up to date" >> $GITHUB_STEP_SUMMARY
+            echo "✓ All sources are up to date" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -147,8 +147,8 @@ jobs:
           # This excludes nested sub-plugin manifests inside synced plugins like
           # tonone, where each skill subdirectory has its own plugin.json from
           # upstream. Those aren't separate marketplace plugins.
-          find plugins/ -maxdepth 4 -name "plugin.json" -path "*/.claude-plugin/plugin.json" | while read plugin_json; do
-            plugin=$(dirname $(dirname "$plugin_json"))
+          find plugins/ -maxdepth 4 -name "plugin.json" -path "*/.claude-plugin/plugin.json" | while read -r plugin_json; do
+            plugin=$(dirname "$(dirname "$plugin_json")")
             echo "Validating $plugin"
 
             # Check for README
@@ -159,7 +159,7 @@ jobs:
 
             # Check scripts are executable
             if [ -d "$plugin/scripts" ]; then
-              find "$plugin/scripts" -type f -name "*.sh" | while read script; do
+              find "$plugin/scripts" -type f -name "*.sh" | while read -r script; do
                 if [ ! -x "$script" ]; then
                   echo "Script not executable: $script"
                   exit 1
@@ -174,7 +174,7 @@ jobs:
           jq empty .claude-plugin/marketplace.json
 
           # Check all plugin sources exist
-          jq -r '.plugins[].source' .claude-plugin/marketplace.json | while read source; do
+          jq -r '.plugins[].source' .claude-plugin/marketplace.json | while read -r source; do
             if [[ "$source" == ./* ]]; then
               if [ ! -d "$source" ]; then
                 echo "Plugin source not found: $source"
@@ -190,6 +190,7 @@ jobs:
         # for reviewer attention. Never blocks CI — gitleaks owns blocking.
         run: |
           echo "Scanning for credential-shaped strings (informational)..."
+          # shellcheck disable=SC2016  # the grep -v '\$(' pattern is a literal regex, not an expansion
           MATCHES=$(grep -r -E "(password|secret|api_key|token)(\s*)=(\s*)['\"]" plugins/ 2>/dev/null | \
             grep -v '= "\*\*\*"' | \
             grep -v "= '\*\*\*'" | \
@@ -420,16 +421,16 @@ jobs:
               fi
 
               if grep -q '"test:ci":' package.json; then
-                pnpm test:ci
+                TEST_CMD=(pnpm test:ci)
               else
-                pnpm test -- --run
+                TEST_CMD=(pnpm test -- --run)
               fi
-              if [ $? -ne 0 ]; then
+              if "${TEST_CMD[@]}"; then
+                echo "✅ Tests passed for $category/$plugin_name"
+              else
                 fail=1
                 failed_plugins+=("$category/$plugin_name")
                 echo "::error::$category/$plugin_name tests failed"
-              else
-                echo "✅ Tests passed for $category/$plugin_name"
               fi
 
               cd - > /dev/null
@@ -478,7 +479,7 @@ jobs:
           fi
 
           # Install dependencies from plugin requirements.txt files
-          find plugins/ -name "requirements.txt" | while read req; do
+          find plugins/ -name "requirements.txt" | while read -r req; do
             echo "Installing deps from $req"
             pip install -r "$req" || true
           done
@@ -750,8 +751,7 @@ jobs:
       - name: Test CLI --help
         run: |
           cd packages/cli
-          node dist/index.js --help
-          if [ $? -eq 0 ]; then
+          if node dist/index.js --help; then
             echo "✅ CLI --help works"
           else
             echo "❌ CLI --help failed"
@@ -761,8 +761,7 @@ jobs:
       - name: Test CLI --version
         run: |
           cd packages/cli
-          node dist/index.js --version
-          if [ $? -eq 0 ]; then
+          if node dist/index.js --version; then
             echo "✅ CLI --version works"
           else
             echo "❌ CLI --version failed"
@@ -772,8 +771,7 @@ jobs:
       - name: Test CLI doctor command
         run: |
           cd packages/cli
-          node dist/index.js doctor --help
-          if [ $? -eq 0 ]; then
+          if node dist/index.js doctor --help; then
             echo "✅ CLI doctor --help works"
           else
             echo "❌ CLI doctor --help failed"
@@ -783,8 +781,7 @@ jobs:
       - name: Test CLI validate command
         run: |
           cd packages/cli
-          node dist/index.js validate --help
-          if [ $? -eq 0 ]; then
+          if node dist/index.js validate --help; then
             echo "✅ CLI validate --help works"
           else
             echo "❌ CLI validate --help failed"
@@ -794,8 +791,7 @@ jobs:
       - name: Test CLI install command options
         run: |
           cd packages/cli
-          node dist/index.js install --help
-          if [ $? -eq 0 ]; then
+          if node dist/index.js install --help; then
             echo "✅ CLI install --help works"
           else
             echo "❌ CLI install --help failed"
@@ -813,10 +809,9 @@ jobs:
       - name: Test npm pack
         run: |
           cd packages/cli
-          npm pack
-          if [ $? -eq 0 ]; then
+          if npm pack; then
             echo "✅ npm pack works"
-            ls -lh *.tgz
+            ls -lh ./*.tgz
           else
             echo "❌ npm pack failed"
             exit 1

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -570,7 +570,7 @@ jobs:
         if: matrix.test-type == 'python-tests' && always()
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: python
           fail_ci_if_error: false
 


### PR DESCRIPTION
## What

Mechanical, behavior-preserving shellcheck cleanup so the Actionlint check can go green repo-wide — it has been red on every workflow-touching PR (75 findings: SC2086 ×47 unquoted vars, SC2181 ×7 `$?` checks, SC2129 ×6 redirect groups, SC2162 ×4 `read -r`, SC2034 ×2 unused vars, SC2016/SC2002/SC2035/SC2046/SC2126/SC2295, plus 2 `github.head_ref` expression findings and the deprecated codecov `file` input).

One commit per workflow file (14 commits). Verified locally with actionlint v1.7.12 + shellcheck: **0 findings** (was 75 on origin/main).

From the 2026-06-11 umbrella review (run wf_fd40cbff-045); surfaced when PR #858 triggered Actionlint.

[skip auto-bump]