### PR TITLE
docs(schema-changelog): kernel authoring/v1 CHANGELOG is canonical for kernel-tracked fields

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -69,6 +69,28 @@ from Jeremy Longshore in the issue/PR thread BEFORE the change lands.
 
 ---
 
+## Kernel changelog citation — authoring/v1 semantics are canonical upstream
+
+Standing rule (2026-06-12, changelog-observance gate per intent-eval-lab doc
+045 § 6): the contract semantics of the `authoring/v1` family — required-field
+sets, folds, field types for skill-frontmatter and the other authoring
+contracts — are **CANONICAL in the Spec Authority Kernel's changelog**:
+
+[`@intentsolutions/core` → `schemas/authoring/v1/CHANGELOG.md`](https://github.com/jeremylongshore/intent-eval-core/blob/main/schemas/authoring/v1/CHANGELOG.md)
+
+When an entry below concerns a kernel-tracked field, it **cites the matching
+kernel changelog entry instead of duplicating its rationale**. CCP entries stay
+scoped to what changed HERE (validator behavior, tier wiring, prose-spec text);
+the "why" for contract semantics lives in the kernel entry being cited.
+
+This section is additive: it does not modify, weaken, or reinterpret the
+NON-NEGOTIABLES above. The IS 8-field rubric and the errors-not-warnings tier
+semantics are unchanged — the kernel encodes that same rubric as its
+`is-overlay` schemas, and its overlay-required floor evolves under the same
+approval discipline.
+
+---
+
 ## How we got here — the 2026-04-28 schema debacle
 
 This section exists so the same mistake doesn't get re-made. The full


### PR DESCRIPTION
## What (bead: changelog-observance, CCP half)

Adversarially verified (approve). `000-docs/SCHEMA_CHANGELOG.md` gains a standing section (NON-NEGOTIABLES untouched): authoring/v1 contract semantics are canonical in the kernel's `schemas/authoring/v1/CHANGELOG.md`; CCP entries about kernel-tracked fields cite the kernel entry instead of duplicating rationale. Pairs with the kernel-side observance gate (intent-eval-core #38).

[skip auto-bump]