### PR TITLE
Add Xquik external skill source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1279,6 +1279,30 @@ sources:
       - '*.log'
       - 'scripts/**'
 
+  # ============================================================
+  # Xquik X/Twitter API Skill
+  # https://github.com/Xquik-dev/x-twitter-scraper
+  # ============================================================
+
+  - name: x-twitter-scraper
+    description: X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.
+    repo: Xquik-dev/x-twitter-scraper
+    branch: master
+    source_path: skills/x-twitter-scraper
+    target_path: plugins/api-development/x-twitter-scraper
+    author:
+      name: Xquik
+      github: Xquik-dev
+    license: MIT
+    category: api-development
+    verified: true
+    include:
+      - 'SKILL.md'
+      - 'references/**'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
## Summary
Adds Xquik's installable `x-twitter-scraper` skill to `sources.yaml` as an external source.

## Validation
- Parsed `sources.yaml` with PyYAML and confirmed the new entry.
- Verified `Xquik-dev/x-twitter-scraper` `master` contains `skills/x-twitter-scraper/SKILL.md` and `references/`.
- Confirmed the public source repo and docs URL return HTTP 200.
- Ran `git diff --check`.
