### PR TITLE
Add apple-notes plugin (external source)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1145,6 +1145,31 @@ sources:
       - '.git/**'
       - '*.log'
 
+  # ============================================================
+  # Apple Notes (Conner K Ward)
+  # https://github.com/connerkward/mcp-apple-notes
+  # ============================================================
+
+  - name: apple-notes
+    description: Semantic search and connection-discovery across your own Apple Notes — hybrid search, Swanson-ABC bridges, entity threads, cited synthesis. On-device embeddings; macOS.
+    repo: connerkward/mcp-apple-notes
+    source_path: .
+    target_path: plugins/community/apple-notes
+    author:
+      name: Conner K Ward
+      github: connerkward
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - 'plugin.json'
+      - 'SKILL.md'
+      - 'README.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds an external-source entry (Path B) for the **apple-notes** plugin, maintained at [connerkward/mcp-apple-notes](https://github.com/connerkward/mcp-apple-notes). My repo stays the source of truth and the weekly sync mirrors it into `plugins/community/apple-notes`.

**What it is:** semantic search and connection-discovery across your own Apple Notes — hybrid (semantic + BM25) search, Swanson-ABC bridges, entity threads, and cited synthesis over everything you have written. Embeddings, search, clustering, and bridges run on-device; only synthesis calls an LLM (local or cloud, your choice). macOS-only, MIT licensed.

The repo ships a Claude Code plugin (`.claude-plugin/plugin.json`, plugin name `apple-notes`) bundling the `apple-notes-search` agent skill at `skills/apple-notes-search/SKILL.md`, plus a `README.md`.

**Change:** a single entry appended to `sources.yaml` under `sources:`, following the Path B format documented in CONTRIBUTING.md.

- `repo: connerkward/mcp-apple-notes`
- `source_path: .` (plugin.json and the skill live in different top-level dirs, so the include globs match by filename at any depth)
- `target_path: plugins/community/apple-notes`
- `include: [plugin.json, SKILL.md, README.md]`
- `category: community`, `verified: false`

Validated that `sources.yaml` still parses and all 49 entries load cleanly. No other files touched; the catalog and README tables regenerate via the sync workflow.