### PR TITLE
feat(sources): list governed-second-brain (local-first MCP second brain)

### DIFF
--- a/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
+++ b/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
@@ -157,4 +157,3 @@ The legacy single-key fallback stays for back-compat: an existing `TEAMKB_API_KE
 - [Green CI Proves Nothing: Why Your Tests Gate Zero Calls](/posts/when-green-ci-proves-nothing/)
 - [Honor the Gate When the Verdict Is Inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/)
 - [When --cap-drop ALL Broke the Gate Socket](/posts/cap-drop-all-broke-the-gate-socket/)
-

--- a/sources.yaml
+++ b/sources.yaml
@@ -708,6 +708,36 @@ sources:
       - 'tests/**'
       - 'bun.lock'
       - '**/.gitkeep'
+
+  # ============================================================
+  # Governed Second Brain (Jeremy Longshore / Intent Solutions)
+  # https://github.com/jeremylongshore/governed-second-brain-plugin
+  # ============================================================
+
+  - name: governed-second-brain
+    description: Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident, hash-chained audit trail. Install via `npx governed-second-brain init <folder>`.
+    repo: jeremylongshore/governed-second-brain-plugin
+    source_path: .
+    target_path: plugins/mcp/governed-second-brain
+    author:
+      name: Jeremy Longshore
+      github: jeremylongshore
+      email: jeremy@intentsolutions.io
+    license: Apache-2.0
+    category: productivity
+    verified: true
+    include:
+      - '.claude-plugin/**'
+      - '.mcp.json'
+      - 'skills/**'
+      - 'plugin-runtime/**'
+      - 'README.md'
+      - 'LICENSE'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
   - name: skyvern
     description: AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins
     repo: Skyvern-AI/skyvern


### PR DESCRIPTION
Adds **governed-second-brain** to `sources.yaml` for the daily external sync.

- **Repo:** [jeremylongshore/governed-second-brain-plugin](https://github.com/jeremylongshore/governed-second-brain-plugin) (Apache-2.0, [npm](https://www.npmjs.com/package/governed-second-brain) — SLSA-provenanced)
- **Home:** `plugins/mcp/governed-second-brain` (MCP plugin — same `source_path: .` pattern as pr-to-spec / slack-channel / x-bug-triage)
- **What it is:** a local-first **governed second brain** — turn your own files into **cited (`qmd://`) memory** with **deterministic governance** (dedupe → policy → promote) and a **tamper-evident, SHA-256 hash-chained audit trail** with an external anchor. In-process stdio MCP; no daemon, no network for retrieval.
- **Install:** `npx governed-second-brain init <folder>` (the installer builds the native store + registers the MCP). The runtime degrades to a clear actionable message on file-copy installs, so marketplace discovery is safe.

Only `sources.yaml` is touched — the generated `marketplace.json`/`marketplace.extended.json` are left to the sync, per repo policy.

- Jeremy Longshore
intentsolutions.io