### PR TITLE
feat(sources): add mengram plugin

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1175,6 +1175,28 @@ sources:
       - '.git/**'
       - '*.log'
 
+  - name: mengram
+    description: Persistent memory for Claude Code that survives /clear, machine switches, and team handoffs. Hosted memory backend with hybrid retrieval (vector + BM25 + RRF), Ebbinghaus temporal decay, and importance weighting. Same memory available across Claude Code, Cursor, Codex, and ChatGPT.
+    repo: alibaizhanov/mengram
+    source_path: integrations/claude-code-plugin
+    target_path: plugins/productivity/mengram
+    author:
+      name: Ali Baizhanov
+      github: alibaizhanov
+      email: ali@mengram.io
+    license: Apache-2.0
+    category: productivity
+    verified: false
+    include:
+      - '.claude-plugin/**'
+      - 'skills/**'
+      - 'hooks/**'
+      - 'README.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
## Type of Change
- [x] 🔌 New plugin submission

## Description

**Summary:** Adds mengram to sources.yaml so it auto-syncs into plugins/productivity/mengram.

**Motivation:** Mengram is persistent memory for Claude Code: hosted backend, hybrid retrieval (vector + BM25 + RRF), Ebbinghaus temporal decay, and importance weighting. The plugin under `integrations/claude-code-plugin` wires SessionStart + Stop hooks, a memory skill, and an MCP server into Claude Code so context survives `/clear`, machine switches, and team handoffs.

**Related Issues:** N/A

## Plugin Details
**Plugin Name:** mengram
**Category:** productivity
**Version:** 0.1.0

**Components Included:**
- [x] Skills (skills/memory/SKILL.md)
- [x] Hooks (SessionStart, Stop)
- [x] MCP server (mengram via Streamable HTTP at mengram.io/mcp)

**Dependencies:** Hosted Mengram API (free tier at https://mengram.io, 40 adds + 200 searches/mo). API key via `MENGRAM_API_KEY` env var.

## Checklist
- [x] Plugin has valid `.claude-plugin/plugin.json` (passes `claude plugin validate`)
- [x] README.md is comprehensive (in integrations/claude-code-plugin/README.md)
- [x] LICENSE file is included (Apache-2.0, repo root)
- [x] No hardcoded secrets, API keys, or credentials
- [x] Hooks use `${CLAUDE_PLUGIN_ROOT}` for portable paths
- [x] All JSON files valid

## Testing Evidence
**Test Environment:** macOS, Claude Code 2.1.175

**Test Commands Run:**
```bash
claude plugin marketplace add alibaizhanov/mengram
claude plugin install mengram@mengram
claude plugin details mengram
```

Plugin installed successfully, status `enabled`, hooks fire on SessionStart and Stop, MCP server connects to mengram.io/mcp.

## Breaking Changes
- [x] No

## Security Considerations
- [x] No hardcoded secrets — API key read from `MENGRAM_API_KEY` env
- [x] All network calls documented in README (HTTPS to mengram.io/v1/*)
- [x] Minimal permissions

## Also submitted to
- Official Anthropic claude-plugins-community marketplace (2 days ago, pending review)
- claudemarketplaces.com (today via hi@ email)