### PR TITLE
fix(site): dedupe newsletter signup — one site-wide footer form

### DIFF
--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -614,13 +614,13 @@ const currentPath = Astro.url.pathname;
     <footer>
         <div class="footer-inner">
             <div class="footer-signup-row">
-                <h4>Stay in the Loop</h4>
+                <h4>Agent Skills in Your Inbox</h4>
                 <form data-signup-form="footer" class="footer-signup-form">
                     <input type="email" name="email" placeholder="you@example.com" required />
                     <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0;height:0;width:0;" />
                     <button type="submit">Subscribe</button>
                 </form>
-                <p class="footer-form-note">No spam. Unsubscribe anytime.</p>
+                <p class="footer-form-note">No spam, ever. Unsubscribe with one click.</p>
             </div>
 
             <div class="footer-columns">

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1933,19 +1933,8 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         </ol>
     </section>
 
-    <!-- Email Signup -->
-    <section class="signup-section">
-        <div class="signup-inner reveal">
-            <h2 class="section-title signup-title">Agent Skills in Your Inbox</h2>
-            <p class="signup-desc">Weekly deep-dives on agent skills, new plugin drops, and workflow tips.</p>
-            <form data-signup-form="homepage" class="signup-form">
-                <input type="email" name="email" placeholder="you@example.com" required />
-                <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0;height:0;width:0;" />
-                <button type="submit">Subscribe</button>
-            </form>
-            <p class="signup-note">No spam, ever. Unsubscribe with one click.</p>
-        </div>
-    </section>
+    <!-- Newsletter signup is the site-wide footer block (BaseLayout.astro) — the
+         homepage-specific duplicate was removed to avoid two newsletter forms on one page. -->
 
     <!-- JavaScript for interactions -->
     <script is:inline>


### PR DESCRIPTION
## Why

The homepage shows **two** newsletter signups stacked together:
1. `index.astro` — a homepage-only `signup-section` ("Agent Skills in Your Inbox")
2. `BaseLayout.astro` footer — the site-wide form ("Stay in the Loop"), rendered on **every** page

Because the homepage is wrapped in `BaseLayout`, both render → it reads as a bug. Every other page correctly shows only the footer one.

## Fix (industry standard)

One newsletter, in the site-wide footer:

- **Remove** the homepage `signup-section` (`index.astro`).
- **Upgrade** the footer copy (`BaseLayout.astro`) to the better wording — heading → "Agent Skills in Your Inbox", note → "No spam, ever. Unsubscribe with one click."

Newsletter capture now exists once per page (footer), everywhere — the standard pattern.

## Safe

Forms are wired via `document.querySelectorAll('[data-signup-form]').forEach(wireSignup)` (`BaseLayout.astro:821`), so removing the homepage form leaves no dangling reference. The homepage's **other** two email forms — the killer-skill spotlight capture and the training waitlist — are unrelated and untouched. Dead `.signup-section` CSS in `index.astro` is left in place (harmless; can be swept separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate newsletter signup form from the homepage, consolidating to a single signup experience in the footer.

* **Style**
  * Updated footer signup section heading to better reflect newsletter content.
  * Refined signup messaging to emphasize transparency and simplify the unsubscribe process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->