### PR TITLE
fix: restore main after the #875 external sync (validate + markdownlint + marketplace-validation)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -144,6 +144,7 @@
     "plugins/design/wondelai-ux-heuristics/**",
     "plugins/design/wondelai-web-typography/**",
     "plugins/devops/sugar/**",
+    "plugins/mcp/governed-second-brain/**",
     "plugins/mcp/pr-to-spec/**",
     "plugins/mcp/slack-channel/**",
     "plugins/mcp/x-bug-triage/**",

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -232,7 +232,7 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
                   <a href={`/skills/${skill.slug}/`} class="gist-view-link">View full skill &rarr;</a>
                 </div>
                 <div class="gist-body">
-                  <p class="gist-description">{skill.description?.split('.')[0]}.</p>
+                  <p class="gist-description">{typeof skill.description === 'string' ? skill.description.split('.')[0] + '.' : ''}</p>
                   {cleanTools(skill.allowedTools || []).length > 0 && (
                     <div class="gist-tools">
                       {cleanTools(skill.allowedTools).map((tool: string) => (

--- a/marketplace/src/pages/skills/[slug].astro
+++ b/marketplace/src/pages/skills/[slug].astro
@@ -680,7 +680,7 @@ const cleanTools = (tools: string[]) =>
           {relatedSkills.map((related: any) => (
             <a href={`/skills/${related.slug}/`} class="related-skill-card">
               <h3 class="related-skill-title">{related.name}</h3>
-              <p class="related-skill-description">{related.description?.split('.')[0]}.</p>
+              <p class="related-skill-description">{typeof related.description === 'string' ? related.description.split('.')[0] + '.' : ''}</p>
               {cleanTools(related.allowedTools || []).length > 0 && (
                 <div class="related-skill-tools">
                   {cleanTools(related.allowedTools).slice(0, 3).map((tool: string) => (

--- a/plugins/mcp/governed-second-brain/package.json
+++ b/plugins/mcp/governed-second-brain/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@intentsolutionsio/governed-second-brain",
+  "version": "0.1.5",
+  "description": "A local-first governed second brain for Claude Code — turn your own files into cited (qmd://) memory, with every write run through deterministic governance and recorded in a tamper-evident, SHA-256 ha",
+  "keywords": [
+    "memory",
+    "knowledge",
+    "governance",
+    "qmd",
+    "brain",
+    "citations",
+    "local-first",
+    "second-brain",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/mcp/governed-second-brain"
+  },
+  "homepage": "https://tonsofskills.com/plugins/governed-second-brain",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install governed-second-brain\\\\n  or /plugin install governed-second-brain@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}


### PR DESCRIPTION
The bulk **#875** external sync left `main` red on three checks (it's mine — I admin-merged #875). Surgical, no revert:

1. **`validate`** — generated the missing `plugins/mcp/governed-second-brain/package.json` (`scripts/generate-plugin-package-jsons.mjs`).
2. **`markdownlint`** — added `plugins/mcp/governed-second-brain/**` to the ignore glob, the same convention every other synced plugin follows.
3. **`marketplace-validation`** (the exit-1 build-killer) — the Astro prerender (`plugins/[name].astro`, `skills/[slug].astro`) did `description?.split('.')` and TypeError'd on any skill whose description isn't a string (`marketplace/dist/.prerender/.../[name]:646`). **Guarded the type** so one malformed third-party description can't crash the whole build — durable (survives re-sync), unlike editing the synced frontmatter.

Unblocks #869 and the rest of the approved sequence once `main` is green again.

- Jeremy Longshore
intentsolutions.io