### PR TITLE
fix(claude-never-forgets): quote plugin paths to handle spaces on Windows

### DIFF
--- a/plugins/community/claude-never-forgets/hooks/hooks.json
+++ b/plugins/community/claude-never-forgets/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py\"",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt.py\"",
             "timeout": 3
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/tool_rejected.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/tool_rejected.py\"",
             "timeout": 3
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop_cleanup.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/stop_cleanup.py\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary

- All 4 hook commands in `claude-never-forgets/hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` unquoted
- On Windows, user profile paths commonly contain spaces (e.g. `C:\Users\ASUS ROG STRIX\...`)
- Python receives a truncated path split at the first space, causing `No such file or directory` on every hook event

## Fix

Wrapped the path argument in double quotes in all 4 commands:

```json
"command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py\""
```

## Test plan

- [ ] Verify hooks no longer error on Windows with spaces in username path
- [ ] Verify hooks still work on Linux/macOS (double quotes are valid in both shells)

Reproduced on Windows 11 with username `ASUS ROG STRIX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability for the Claude plugin by fixing path interpolation handling in hook configurations. This ensures commands execute correctly when file paths contain spaces or special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->