### PR TITLE
feat(agents): elevate all 317 in-repo agents to A-grade (least-privilege tools, Trigger descriptions, real tags)

### DIFF
--- a/.claude/agents/skill-auditor.md
+++ b/.claude/agents/skill-auditor.md
@@ -1,24 +1,20 @@
 ---
 name: skill-auditor
-description: Audit and fix Claude Code SKILL.md files to meet enterprise compliance standards. Analyzes frontmatter, required sections, and style. Use when you need to validate or repair skills in a plugin directory.
+description: 'Audit and fix Claude Code SKILL.md files against enterprise compliance standards: frontmatter completeness, required body sections, and style. Use when validating or repairing skills in a plugin directory. Trigger with "audit skill", "fix skill compliance".'
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- skill
-- auditor
+  - skill-compliance
+  - frontmatter
+  - plugin-quality
 disallowedTools: []
 skills: []
 background: false
@@ -32,6 +28,7 @@ permissionMode: default
 # isolation: worktree     # run in an isolated git worktree
 # initialPrompt: "…"      # seed the agent's first turn
 ---
+
 # Skill Auditor Agent
 
 You are a specialized agent for auditing and fixing Claude Code SKILL.md files to meet enterprise compliance standards.

--- a/plugins/ai-agency/make-scenario-builder/agents/make-expert.md
+++ b/plugins/ai-agency/make-scenario-builder/agents/make-expert.md
@@ -1,24 +1,20 @@
 ---
 name: make-expert
-description: Expert Make.com scenario designer for visual automation
+description: Design and document Make.com (Integromat) visual automation scenarios with modules, routers, error handling, and cost estimates. Use when building or architecting a Make.com integration workflow. Trigger with "design a Make scenario", "build a Make workflow".
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- make
+- make-com
+- automation
+- workflow-design
+- no-code
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/n8n-workflow-designer/agents/n8n-expert.md
+++ b/plugins/ai-agency/n8n-workflow-designer/agents/n8n-expert.md
@@ -1,24 +1,20 @@
 ---
 name: n8n-expert
-description: Expert n8n workflow designer specializing in complex automation
+description: Design n8n automation workflows with node configs, JavaScript code nodes, error handling, and full importable JSON exports. Use when building complex automations or self-hosted integrations. Trigger with "design an n8n workflow", "build an n8n automation".
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
 - n8n
+- automation
+- workflow-design
+- self-hosted
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/apex.md
+++ b/plugins/ai-agency/tonone/agents/apex.md
@@ -1,15 +1,8 @@
 ---
 name: apex
-description: Engineering lead — orchestrates the team, scopes work, controls depth and budget
+description: Engineering lead that translates product briefs into scoped work, dispatches specialists, and delivers unified output. Use when you need technical architecture decisions or multi-specialist coordination. Trigger with "scope this feature", "dispatch the engineering team".
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: opus
@@ -17,8 +10,10 @@ color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- apex
+- engineering-lead
+- orchestration
+- architecture
+- multi-agent
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/atlas.md
+++ b/plugins/ai-agency/tonone/agents/atlas.md
@@ -1,24 +1,21 @@
 ---
 name: atlas
-description: Knowledge engineer — architecture docs, ADRs, API specs, system diagrams, onboarding
+description: Write architecture docs, ADRs, API specs, onboarding guides, and system diagrams using the Diátaxis model. Use when the team needs durable, accurate technical documentation. Trigger with "write an ADR", "document this architecture".
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- atlas
+- documentation
+- architecture
+- adr
+- knowledge-engineering
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/audit.md
+++ b/plugins/ai-agency/tonone/agents/audit.md
@@ -1,9 +1,8 @@
 ---
 name: audit
-description: Legal compliance audit — internal controls review, legal risk register, audit trail documentation
+description: Run internal legal compliance audits, build risk registers, and review legal controls framed as risk/probability/fix/cost-of-inaction. Use when assessing legal exposure or documenting audit trail. Trigger with "run a legal audit", "build a risk register".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,7 +13,8 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
+- legal-compliance
+- risk-management
 - audit
 disallowedTools: []
 skills: []

--- a/plugins/ai-agency/tonone/agents/axe.md
+++ b/plugins/ai-agency/tonone/agents/axe.md
@@ -1,21 +1,21 @@
 ---
 name: axe
-description: Accessibility engineering — WCAG audits, keyboard nav, screen reader testing, ARIA
+description: Audit and fix WCAG AA accessibility issues including keyboard navigation, ARIA patterns, focus management, and screen reader compatibility. Use when reviewing or remediating a UI for accessibility compliance. Trigger with "run an accessibility audit", "fix WCAG failures".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- axe
+- accessibility
+- wcag
+- aria
+- inclusive-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/bench.md
+++ b/plugins/ai-agency/tonone/agents/bench.md
@@ -1,21 +1,21 @@
 ---
 name: bench
-description: API performance benchmarking — latency profiling, throughput testing, performance regression detection
+description: Design API benchmarks, profile p50/p95/p99 latency, set up throughput tests, and detect performance regressions with k6/wrk. Use when establishing baselines or catching latency regressions in CI. Trigger with "benchmark this API", "set up a performance test".
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- bench
+- performance
+- benchmarking
+- latency
+- load-testing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/bind.md
+++ b/plugins/ai-agency/tonone/agents/bind.md
@@ -1,9 +1,8 @@
 ---
 name: bind
-description: Compliance framework implementation — SOC2, GDPR, HIPAA, ISO 27001 gap analysis and remediation plans
+description: Run compliance gap analyses for SOC2, GDPR, HIPAA, and ISO 27001, then produce stage-appropriate remediation plans and policy drafts. Use when preparing for a compliance audit or framework adoption. Trigger with "run a SOC2 gap analysis", "build a compliance remediation plan".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- bind
+- compliance
+- soc2
+- gdpr
+- regulatory
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/blue.md
+++ b/plugins/ai-agency/tonone/agents/blue.md
@@ -1,9 +1,8 @@
 ---
 name: blue
-description: Blue team operations — SOC design, detection engineering, hardening playbooks
+description: Design MITRE ATT&CK-mapped detection rules, CIS-benchmarked hardening playbooks, and SOC triage procedures to reduce attacker dwell time. Use when building defensive security controls or auditing detection coverage. Trigger with "design detection rules", "write a hardening playbook".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- blue
+- blue-team
+- detection-engineering
+- soc
+- security-hardening
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/brace.md
+++ b/plugins/ai-agency/tonone/agents/brace.md
@@ -1,24 +1,22 @@
 ---
 name: brace
-description: Support engineer -- ticket workflow design, SLA architecture, knowledge base, escalation paths, and support operations at scale
+description: Design ticket workflows, SLA tiers, knowledge-base structures, and escalation paths for stage-appropriate support operations. Use when building or auditing a support operation from triage to Tier 3. Trigger with "design a support workflow", "build a support knowledge base".
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- brace
+- customer-support
+- sla
+- knowledge-base
+- ticket-workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/brief.md
+++ b/plugins/ai-agency/tonone/agents/brief.md
@@ -1,9 +1,8 @@
 ---
 name: brief
-description: Contract & policy drafting — NDAs, MSAs, employment agreements, SLAs, vendor contracts
+description: Draft and redline contracts and policies — NDAs, MSAs, employment agreements, vendor contracts — with stage-appropriate risk framing. Use when a contract needs to be written from scratch or reviewed for risk. Trigger with "draft an NDA", "redline this contract".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- brief
+- contracts
+- legal-drafting
+- policy
+- risk-framing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/budget.md
+++ b/plugins/ai-agency/tonone/agents/budget.md
@@ -1,21 +1,21 @@
 ---
 name: budget
-description: AI cost engineering — LLM spend tracking, model cost optimization, budget alerts, token efficiency audits
+description: Audit LLM spend, identify top token consumers, design model-tiering strategies, and set up cost alerts before budgets breach. Use when AI costs are rising or untraceable. Trigger with "audit AI spend", "optimize LLM costs".
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- budget
+- llm-costs
+- token-efficiency
+- ai-operations
+- cost-optimization
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/buzz.md
+++ b/plugins/ai-agency/tonone/agents/buzz.md
@@ -1,24 +1,21 @@
 ---
 name: buzz
-description: PR & Community engineer — press pitches, social media, open source community, DevRel, and coordinated launch moments
+description: Write press pitches, HN posts, community playbooks, and coordinated launch plans that earn media instead of buying it. Use when launching a product or building developer community at any ARR stage. Trigger with "write a press pitch", "plan a Product Hunt launch".
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- buzz
+- pr
+- community
+- devrel
+- launch
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/cache.md
+++ b/plugins/ai-agency/tonone/agents/cache.md
@@ -1,21 +1,21 @@
 ---
 name: cache
-description: Caching strategy — Redis/Memcached design, cache invalidation, eviction policies, application caching patterns
+description: Design application-layer caching strategies covering Redis/Memcached patterns, key namespacing, TTL, eviction policies, and thundering-herd prevention. Use when adding or auditing caching to reduce database load. Trigger with "design a caching strategy", "audit Redis usage".
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- cache
+- caching
+- redis
+- performance
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/cast.md
+++ b/plugins/ai-agency/tonone/agents/cast.md
@@ -1,6 +1,6 @@
 ---
 name: cast
-description: Time series forecasting — demand prediction, trend analysis, seasonal decomposition
+description: "Builds time series forecasting models for demand, revenue, and usage signals. Use when you need demand prediction, trend analysis, or seasonal decomposition. Trigger with \"forecast this time series\", \"build a demand model\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,15 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- cast
+- forecasting
+- time-series
+- data-science
+- demand-planning
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/chain.md
+++ b/plugins/ai-agency/tonone/agents/chain.md
@@ -1,6 +1,6 @@
 ---
 name: chain
-description: Supply chain security — SBOM generation, dependency scanning, third-party risk, license compliance
+description: "Secures the software supply chain via SBOM generation, dependency scanning, and license compliance. Use when you need to audit transitive dependencies, detect CVEs in CI, or assess third-party vendor risk. Trigger with \"scan my dependencies\", \"generate an SBOM\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,15 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- chain
+- supply-chain-security
+- sbom
+- dependency-scanning
+- license-compliance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/change.md
+++ b/plugins/ai-agency/tonone/agents/change.md
@@ -1,21 +1,20 @@
 ---
 name: change
-description: Changelog and release communication — breaking change documentation, deprecation notices, migration guides
+description: "Writes developer-facing changelogs, deprecation notices, and migration guides so breaking changes are never a surprise. Use when you need release notes, a sunset timeline, or a step-by-step migration path. Trigger with \"write the changelog\", \"document this breaking change\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- change
+- changelog
+- release-communication
+- api-versioning
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/chaos.md
+++ b/plugins/ai-agency/tonone/agents/chaos.md
@@ -1,21 +1,20 @@
 ---
 name: chaos
-description: Chaos engineering — failure injection design, game days, resilience testing, blast radius control
+description: "Designs controlled failure experiments to expose resilience gaps before production incidents do. Use when you need a chaos experiment hypothesis, a game day plan, or a blast-radius-limited resilience audit. Trigger with \"design a chaos experiment\", \"plan a game day\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- chaos
+- chaos-engineering
+- resilience-testing
+- site-reliability
+- failure-injection
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/cite.md
+++ b/plugins/ai-agency/tonone/agents/cite.md
@@ -1,9 +1,8 @@
 ---
 name: cite
-description: Legal research — case law synthesis, statute analysis, regulatory guidance, jurisdiction comparison
+description: "Synthesizes case law, statutes, and regulatory guidance into actionable legal risk assessments sized for the company's stage. Use when you need a jurisdiction comparison, a regulatory compliance check, or a plain-language legal summary. Trigger with \"research this legal question\", \"what does this statute mean for us\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- cite
+- legal-research
+- regulatory-compliance
+- risk-assessment
+- contract-law
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/clause.md
+++ b/plugins/ai-agency/tonone/agents/clause.md
@@ -1,21 +1,20 @@
 ---
 name: clause
-description: Contract clause analysis — redlining, risk scoring, negotiation playbooks
+description: "Analyzes contracts clause-by-clause for risk, scores exposure, and generates negotiation playbooks. Use when you need a redline review, a risk-scored clause breakdown, or a playbook for a specific contract type. Trigger with \"analyze this contract\", \"build a negotiation playbook\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- clause
+- contract-analysis
+- legal
+- risk-scoring
+- negotiation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/clean.md
+++ b/plugins/ai-agency/tonone/agents/clean.md
@@ -1,21 +1,21 @@
 ---
 name: clean
-description: Data quality — deduplication, validation, outlier detection, ETL pipeline design
+description: "Designs data validation, cleaning, and quality-monitoring pipelines so models train on trustworthy data. Use when you need deduplication logic, outlier detection, or an ETL quality gate. Trigger with \"audit my data quality\", \"design a cleaning pipeline\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- clean
+- data-quality
+- etl
+- data-validation
+- data-science
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/compat.md
+++ b/plugins/ai-agency/tonone/agents/compat.md
@@ -1,21 +1,21 @@
 ---
 name: compat
-description: Backwards compatibility — breaking change detection, deprecation management, semver discipline
+description: "Detects breaking API changes before they ship and designs deprecation lifecycles that give developers time to migrate. Use when you need a semver audit, a compatibility policy, or a CI gate for API drift. Trigger with \"audit this API for breaking changes\", \"design a deprecation policy\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- compat
+- backwards-compatibility
+- api-versioning
+- semver
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/copy.md
+++ b/plugins/ai-agency/tonone/agents/copy.md
@@ -1,21 +1,20 @@
 ---
 name: copy
-description: UX writing and content design — microcopy, error messages, onboarding flows, UI content strategy
+description: "Writes and audits the words inside products — buttons, error messages, empty states, tooltips, and onboarding flows. Use when you need UX copy for a feature, a microcopy audit, or an onboarding content pass. Trigger with \"write the UX copy\", \"audit the error messages\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- copy
+- ux-writing
+- microcopy
+- content-design
+- onboarding
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/cortex.md
+++ b/plugins/ai-agency/tonone/agents/cortex.md
@@ -1,6 +1,6 @@
 ---
 name: cortex
-description: ML/AI engineer — LLM integration, prompt engineering, RAG, evals, and AI feature design for production
+description: "Designs and ships production AI features — LLM integration, prompt engineering, RAG pipelines, evals, and MLOps. Use when you need an AI architecture decision, a prompt-first vs RAG vs fine-tune call, or an eval harness for an existing feature. Trigger with \"build this AI feature\", \"design the RAG pipeline\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- cortex
+- llm-engineering
+- prompt-engineering
+- rag
+- mlops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/crest.md
+++ b/plugins/ai-agency/tonone/agents/crest.md
@@ -1,11 +1,10 @@
 ---
 name: crest
-description: Product strategist — diagnosis-first strategy, roadmap sequencing, competitive positioning, and market decisions
+description: "Produces actionable product strategy — roadmap decisions, competitive positioning, and OKRs rooted in a crisp diagnosis. Use when you need a prioritized roadmap, a where-to-play/how-to-win call, or a strategic narrative the team can execute today. Trigger with \"build the product roadmap\", \"diagnose our strategic position\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- crest
+- product-strategy
+- roadmap
+- competitive-positioning
+- market-decisions
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/cut.md
+++ b/plugins/ai-agency/tonone/agents/cut.md
@@ -1,21 +1,20 @@
 ---
 name: cut
-description: Illustration and icon design — custom assets, icon systems, SVG optimization
+description: "Designs and manages icon systems and custom illustrations that extend the brand visually. Use when you need an icon system audit, an SVG optimization pass, or an illustration style spec. Trigger with \"audit the icon system\", \"optimize these SVGs\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- cut
+- icon-design
+- illustration
+- svg
+- design-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/deal.md
+++ b/plugins/ai-agency/tonone/agents/deal.md
@@ -1,11 +1,10 @@
 ---
 name: deal
-description: Revenue & Sales engineer — B2B pipeline, deal strategy, pricing proposals, sales playbooks, and enterprise closing
+description: "Builds the B2B pipeline, writes the sales playbook, drafts the pricing proposal, and designs the closing motion. Use when you need an outbound sequence, a MEDDPICC-qualified deal strategy, or a pricing tier structure. Trigger with \"build the sales playbook\", \"design pricing for this deal\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- deal
+- sales
+- b2b-pipeline
+- pricing
+- revenue
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/deploy.md
+++ b/plugins/ai-agency/tonone/agents/deploy.md
@@ -1,21 +1,21 @@
 ---
 name: deploy
-description: Model deployment and serving — inference API design, blue/green rollouts, canary releases, rollback
+description: "Designs model serving infrastructure, blue/green rollouts, and canary release plans with explicit rollback triggers. Use when you need inference API configuration, a traffic-splitting strategy, or a deployment topology audit. Trigger with \"design the model serving setup\", \"plan a canary release\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- deploy
+- model-deployment
+- mlops
+- canary-releases
+- inference-serving
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/draft.md
+++ b/plugins/ai-agency/tonone/agents/draft.md
@@ -1,15 +1,12 @@
 ---
 name: draft
-description: UX designer — user flows, information architecture, wireframes, and interaction design
+description: "Owns the structural UX layer — user flows, information architecture, wireframes, and interaction patterns. Use when you need a job-to-be-done flow mapping, an IA decision, or a Mermaid wireframe with error and empty states. Trigger with \"map the user flow\", \"design the information architecture\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,8 +14,10 @@ color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- draft
+- ux-design
+- information-architecture
+- user-flows
+- wireframing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/drift.md
+++ b/plugins/ai-agency/tonone/agents/drift.md
@@ -1,21 +1,21 @@
 ---
 name: drift
-description: ML monitoring — data drift, concept drift, model degradation, production ML health
+description: "Detects and diagnoses ML model decay in production — data drift, concept drift, and silent degradation. Use when models may have stopped working, distributions have shifted, or monitoring needs a design. Trigger with \"audit my ML monitoring\", \"detect model drift\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- drift
+- ml-monitoring
+- data-drift
+- model-degradation
+- production-ml
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/echo.md
+++ b/plugins/ai-agency/tonone/agents/echo.md
@@ -1,24 +1,20 @@
 ---
 name: echo
-description: User researcher — interviews, personas, Jobs-to-Be-Done, and customer feedback synthesis
+description: "Synthesizes user research into actionable product signal — interviews, JTBD analysis, persona development, and feedback clustering. Use when you need to understand what users actually want, synthesize interview findings, or build evidence-based personas. Trigger with \"synthesize user research\", \"build personas from interviews\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- echo
+- user-research
+- jobs-to-be-done
+- product-discovery
+- ux-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/edge.md
+++ b/plugins/ai-agency/tonone/agents/edge.md
@@ -1,21 +1,21 @@
 ---
 name: edge
-description: Edge computing and CDN — global distribution, cache strategy, edge functions, latency optimization
+description: "Designs CDN configurations, cache strategies, and edge function deployments to minimize latency globally. Use when you need to optimize cache hit ratios, design edge routing, or deploy Cloudflare Workers/Lambda@Edge. Trigger with \"design CDN config\", \"optimize cache strategy\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- edge
+- cdn
+- edge-computing
+- caching
+- latency-optimization
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/embed.md
+++ b/plugins/ai-agency/tonone/agents/embed.md
@@ -1,21 +1,21 @@
 ---
 name: embed
-description: Embeddings and vector search — model selection, pipeline design, similarity search, production index management
+description: "Designs embedding pipelines and vector search systems — model selection, ANN index tuning, hybrid search, and index freshness monitoring. Use when building semantic search, RAG infrastructure, or diagnosing retrieval quality issues. Trigger with \"design embedding pipeline\", \"optimize vector search\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- embed
+- embeddings
+- vector-search
+- semantic-search
+- rag
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/eval.md
+++ b/plugins/ai-agency/tonone/agents/eval.md
@@ -1,21 +1,21 @@
 ---
 name: eval
-description: Experiment design — A/B testing, statistical power, experiment tracking, causal inference
+description: "Designs statistically rigorous experiments — A/B tests, power analysis, variance reduction, and causal inference frameworks. Use when designing an experiment, analyzing test results for validity, or auditing experimentation infrastructure. Trigger with \"design A/B test\", \"review experiment methodology\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- eval
+- ab-testing
+- experimentation
+- causal-inference
+- statistics
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/evals.md
+++ b/plugins/ai-agency/tonone/agents/evals.md
@@ -1,21 +1,21 @@
 ---
 name: evals
-description: LLM evaluation — eval harness design, benchmark suites, automated regression, human eval orchestration
+description: "Builds LLM eval harnesses — benchmark suites, automated regression pipelines, golden set management, and human eval orchestration. Use when measuring model quality, wiring evals into CI, or auditing benchmark validity. Trigger with \"design eval harness\", \"build LLM regression suite\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- evals
+- llm-evaluation
+- benchmarking
+- model-quality
+- ai-testing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/feat.md
+++ b/plugins/ai-agency/tonone/agents/feat.md
@@ -1,21 +1,21 @@
 ---
 name: feat
-description: Feature engineering — transformations, encodings, feature stores, pipeline design
+description: "Transforms raw data into model-ready features — leakage audits, encoding strategies, feature stores, and reproducible pipeline design. Use when building ML features, auditing for data leakage, or designing a shared feature store. Trigger with \"build feature pipeline\", \"audit features for leakage\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- feat
+- feature-engineering
+- ml-pipelines
+- data-leakage
+- feature-store
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/finop.md
+++ b/plugins/ai-agency/tonone/agents/finop.md
@@ -1,21 +1,21 @@
 ---
 name: finop
-description: Cloud cost optimization — FinOps practices, rightsizing, reservation strategy, cost attribution
+description: "Analyzes and optimizes cloud spend — rightsizing recommendations, reservation strategy, zombie resource elimination, and cost attribution via tagging. Use when cloud bills are growing, reservations need a strategy, or cost visibility is broken. Trigger with \"audit cloud spend\", \"design FinOps strategy\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- finop
+- finops
+- cloud-cost
+- cost-optimization
+- cloud-infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/fit.md
+++ b/plugins/ai-agency/tonone/agents/fit.md
@@ -1,21 +1,21 @@
 ---
 name: fit
-description: Model training — algorithm selection, hyperparameter tuning, training infrastructure
+description: "Selects algorithms, tunes hyperparameters, and builds reproducible training pipelines from baseline to production. Use when choosing a model architecture, designing a tuning strategy, or auditing training code for leakage and reproducibility. Trigger with \"design training pipeline\", \"tune model hyperparameters\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- fit
+- model-training
+- hyperparameter-tuning
+- ml-pipelines
+- algorithm-selection
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/flux.md
+++ b/plugins/ai-agency/tonone/agents/flux.md
@@ -1,6 +1,6 @@
 ---
 name: flux
-description: Data engineer — databases, migrations, pipelines, data modeling
+description: "Designs schemas, writes migrations, and builds data pipelines that model reality and evolve without pain. Use when designing a database schema, planning a zero-downtime migration, or building ETL/ELT pipelines. Trigger with \"design database schema\", \"write zero-downtime migration\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,16 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- flux
+- data-engineering
+- database-design
+- migrations
+- data-pipelines
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/folk.md
+++ b/plugins/ai-agency/tonone/agents/folk.md
@@ -1,24 +1,24 @@
 ---
 name: folk
-description: People engineer - org design, hiring pipelines, compensation frameworks, onboarding playbooks, performance management, and human-to-agent migration
+description: "Designs orgs, writes job descriptions, builds comp frameworks, and produces onboarding playbooks and migration plans that ship to the team. Use when designing headcount structure, writing a JD with comp bands, or planning human-to-agent role migration. Trigger with \"design org structure\", \"build hiring pipeline\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- folk
+- org-design
+- hiring
+- people-ops
+- compensation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/forge.md
+++ b/plugins/ai-agency/tonone/agents/forge.md
@@ -1,6 +1,6 @@
 ---
 name: forge
-description: Infrastructure engineer — cloud services, networking, IaC, cost optimization
+description: "Builds the infrastructure everything runs on — writes IaC, makes cloud provider and sizing decisions, and ships right-sized architecture for today's scale. Use when provisioning cloud resources, writing Terraform configs, or choosing compute/database architecture. Trigger with \"provision infrastructure\", \"write Terraform for this\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,16 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- forge
+- infrastructure
+- iac
+- cloud
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/form.md
+++ b/plugins/ai-agency/tonone/agents/form.md
@@ -1,24 +1,24 @@
 ---
 name: form
-description: Visual designer — brand identity, color systems, typography, UI design, and design systems
+description: "Owns the product's visual surface — brand identity, color systems, typography, SVG logos, and design token specs that bridge design to code. Use when creating a brand identity, building a design system, or auditing visual inconsistency. Trigger with \"design brand identity\", \"build design system\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- form
+- visual-design
+- brand-identity
+- design-system
+- typography
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/frame.md
+++ b/plugins/ai-agency/tonone/agents/frame.md
@@ -1,21 +1,21 @@
 ---
 name: frame
-description: Corporate governance — board resolutions, cap table hygiene, shareholder agreements, equity plan docs
+description: "Writes board resolutions, equity plan docs, and shareholder agreements with stage-appropriate legal rigor framed as risk/probability/fix/cost-of-inaction. Use when drafting corporate governance documents, surveying cap table hygiene, or reviewing equity plans. Trigger with \"draft board resolution\", \"audit corporate governance\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- frame
+- corporate-governance
+- equity
+- legal
+- startup
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/gate.md
+++ b/plugins/ai-agency/tonone/agents/gate.md
@@ -1,21 +1,21 @@
 ---
 name: gate
-description: API quality gates — linting, style enforcement, breaking change CI, and API governance
+description: "Builds CI gates that enforce API quality before changes merge — Spectral lint rules, breaking change detection, and governance tooling for OpenAPI/GraphQL/protobuf. Use when designing API lint rulesets, integrating quality gates into CI, or auditing API governance gaps. Trigger with \"design API lint rules\", \"add API quality gate to CI\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- gate
+- api-governance
+- api-linting
+- ci-gates
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/glyph.md
+++ b/plugins/ai-agency/tonone/agents/glyph.md
@@ -1,21 +1,20 @@
 ---
 name: glyph
-description: Typography system design — font pairing, type scale, hierarchy, readability tokens
+description: "Designs type systems — font pairing, scale, hierarchy, and readability tokens for design systems. Use when setting up or auditing typography for a product or codebase. Trigger with \"design a type system\", \"audit our typography\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- glyph
+- design-systems
+- typography
+- ui-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/grid.md
+++ b/plugins/ai-agency/tonone/agents/grid.md
@@ -1,21 +1,20 @@
 ---
 name: grid
-description: Layout system design — spacing scales, responsive grids, breakpoints, layout primitives
+description: "Designs spatial foundations — spacing scales, responsive grids, breakpoints, and layout primitives for design systems. Use when creating or auditing layout systems for a product. Trigger with \"design a layout system\", \"audit our grid\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- grid
+- design-systems
+- layout
+- responsive-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/guard.md
+++ b/plugins/ai-agency/tonone/agents/guard.md
@@ -1,9 +1,8 @@
 ---
 name: guard
-description: AI safety and guardrails — input/output filters, PII detection, content moderation, runtime policy enforcement
+description: "Designs and audits AI guardrail layers — input/output filters, PII detection, content moderation, and runtime policy enforcement. Use when adding safety controls to an LLM feature or auditing existing ones. Trigger with \"design guardrails\", \"audit our AI safety controls\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- guard
+- ai-safety
+- guardrails
+- pii-detection
+- content-moderation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/guide.md
+++ b/plugins/ai-agency/tonone/agents/guide.md
@@ -1,21 +1,20 @@
 ---
 name: guide
-description: API and SDK documentation — reference docs, guides, and documentation architecture
+description: "Writes and audits API reference docs, integration guides, and SDK documentation that developers actually use. Use when documenting an API endpoint, auditing doc coverage, or writing a developer quickstart. Trigger with \"document this API\", \"audit our developer docs\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- guide
+- developer-docs
+- api-documentation
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/helm.md
+++ b/plugins/ai-agency/tonone/agents/helm.md
@@ -1,11 +1,10 @@
 ---
 name: helm
-description: Head of Product — product strategy, requirements, and engineering handoff via the Helm↔Apex interface
+description: "Head of Product — turns goals and user problems into scoped product briefs ready for engineering handoff via the Helm↔Apex interface. Use when defining what to build, prioritizing scope, or dispatching product specialists. Trigger with \"write a product brief\", \"help me scope this feature\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,9 @@ color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- helm
+- product-management
+- requirements
+- product-strategy
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/hue.md
+++ b/plugins/ai-agency/tonone/agents/hue.md
@@ -1,21 +1,20 @@
 ---
 name: hue
-description: Color palette design — semantic tokens, dark/light mode, WCAG contrast compliance
+description: "Designs color systems — semantic tokens, dark/light mode palettes, and WCAG contrast compliance for design systems. Use when building or auditing a color palette for a product. Trigger with \"design a color system\", \"audit our color tokens\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- hue
+- design-systems
+- color-tokens
+- accessibility
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/hunt.md
+++ b/plugins/ai-agency/tonone/agents/hunt.md
@@ -1,9 +1,8 @@
 ---
 name: hunt
-description: Threat hunting — hypothesis-driven hunting, compromise assessment, IOC analysis
+description: "Runs hypothesis-driven threat hunts to surface attackers that evaded automated detection — IOC enrichment, compromise assessment, and hunting playbooks. Use when proactively searching for threats or assessing potential compromise. Trigger with \"run a threat hunt\", \"assess for compromise\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,9 @@ color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- hunt
+- threat-hunting
+- security-operations
+- ioc-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/ink.md
+++ b/plugins/ai-agency/tonone/agents/ink.md
@@ -1,11 +1,10 @@
 ---
 name: ink
-description: Content Marketing engineer — blog strategy, SEO, thought leadership, developer content, case studies, and content calendar
+description: "Produces distribution-first content — blog posts, topic clusters, SEO keyword research, content calendars, and case studies that actually convert. Use when drafting content, building a topic cluster, or planning a content calendar. Trigger with \"write a blog post\", \"build a content strategy\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,9 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- ink
+- content-marketing
+- seo
+- copywriting
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/keel.md
+++ b/plugins/ai-agency/tonone/agents/keel.md
@@ -1,11 +1,10 @@
 ---
 name: keel
-description: Operations engineer — process design, vendor management, legal ops, compliance, OKR execution, and cross-functional coordination
+description: "Designs processes, SOPs, OKR cascades, vendor contracts, and compliance programs that scale with company growth. Use when documenting a business process, auditing ops posture, or managing vendor contracts. Trigger with \"write a SOP\", \"build our OKR framework\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,10 @@ color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- keel
+- operations
+- process-design
+- compliance
+- vendor-management
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/keep.md
+++ b/plugins/ai-agency/tonone/agents/keep.md
@@ -1,15 +1,13 @@
 ---
 name: keep
-description: Customer Success engineer — onboarding optimization, health scoring, expansion revenue, churn prevention, and NRR growth
+description: "Builds customer success systems — onboarding flows, health scoring models, expansion playbooks, and churn prevention sequences that drive NRR. Use when designing onboarding, modeling customer health, or building a retention playbook. Trigger with \"build an onboarding flow\", \"design a health scoring model\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,8 +15,10 @@ color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- keep
+- customer-success
+- retention
+- churn-prevention
+- onboarding
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/kube.md
+++ b/plugins/ai-agency/tonone/agents/kube.md
@@ -1,6 +1,6 @@
 ---
 name: kube
-description: Kubernetes cluster design — RBAC, networking, operators, workload configuration
+description: "Designs and audits Kubernetes cluster architectures — RBAC policies, CNI networking, workload configuration, and operators with explicit reliability tradeoffs. Use when designing a cluster, auditing RBAC, or rightsizing workloads. Trigger with \"design a Kubernetes cluster\", \"audit our RBAC\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,14 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- kube
+- kubernetes
+- infrastructure
+- cloud-native
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/lens.md
+++ b/plugins/ai-agency/tonone/agents/lens.md
@@ -1,6 +1,6 @@
 ---
 name: lens
-description: Data analytics & BI engineer — dashboards, metrics design, reporting, data storytelling
+description: "Turns raw data into actionable decisions — dashboards, metric definitions, SQL analytics, funnel and cohort analysis across BI platforms. Use when designing a dashboard, defining KPIs, or running funnel analysis. Trigger with \"design a dashboard\", \"analyze our funnel\"."
 tools:
 - Read
 - Write
@@ -9,16 +9,16 @@ tools:
 - Glob
 - Grep
 - WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- lens
+- analytics
+- business-intelligence
+- data-visualization
+- sql
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/lodge.md
+++ b/plugins/ai-agency/tonone/agents/lodge.md
@@ -1,11 +1,9 @@
 ---
 name: lodge
-description: Regulatory filings — DMCA responses, FTC disclosures, GDPR DPA agreements, government filings, state registrations
+description: "Prepares regulatory filings and disclosures from start to finish — DMCA responses, FTC disclosures, GDPR DPA agreements, government filings, and state registrations. Use when handling a required filing or surveying compliance obligations. Trigger with \"prepare a DMCA notice\", \"survey our regulatory filings\"."
 tools:
 - Read
-- Bash
 - Glob
-- Grep
 - Write
 - WebFetch
 - WebSearch
@@ -14,8 +12,9 @@ color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- lodge
+- regulatory
+- legal-ops
+- compliance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/lumen.md
+++ b/plugins/ai-agency/tonone/agents/lumen.md
@@ -1,6 +1,6 @@
 ---
 name: lumen
-description: Product analyst — metrics architecture, funnel analysis, A/B test design, retention, and growth measurement
+description: "Owns the measurement layer — North Star definition, input metrics trees, A/B test specs, funnel and cohort analysis that drive product decisions. Use when defining what to track, diagnosing a funnel, or designing an experiment. Trigger with \"define our North Star metric\", \"design an A/B test\"."
 tools:
 - Read
 - Write
@@ -9,16 +9,16 @@ tools:
 - Glob
 - Grep
 - WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- lumen
+- product-analytics
+- metrics
+- ab-testing
+- growth
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/mark.md
+++ b/plugins/ai-agency/tonone/agents/mark.md
@@ -1,21 +1,20 @@
 ---
 name: mark
-description: Brand identity design — logo usage rules, brand guidelines, visual identity systems
+description: "Designs and stewards visual identities — logo usage rules, brand guidelines, asset libraries, and visual identity systems that stay consistent across contexts. Use when creating brand guidelines or auditing existing brand assets. Trigger with \"write brand guidelines\", \"audit our brand assets\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- mark
+- brand-identity
+- visual-design
+- design-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/mesh.md
+++ b/plugins/ai-agency/tonone/agents/mesh.md
@@ -1,21 +1,20 @@
 ---
 name: mesh
-description: Service mesh design — Istio/Linkerd/Envoy, mTLS, traffic management, observability integration
+description: "Designs and audits service meshes (Istio/Linkerd/Consul) including mTLS policy, traffic management, and golden-signal observability. Use when adding a service mesh, hardening inter-service security, or auditing an existing mesh config. Trigger with \"design a service mesh\", \"audit our Istio setup\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- mesh
+- service-mesh
+- infrastructure
+- mtls
+- observability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/mint.md
+++ b/plugins/ai-agency/tonone/agents/mint.md
@@ -1,24 +1,22 @@
 ---
 name: mint
-description: Finance engineer — P&L, runway, unit economics, fundraising, board reporting, and cap table management
+description: "Builds financial models, P&L reports, runway calculations, unit economics (LTV/CAC/payback), cap tables, and board packages stage-matched to ARR. Use when you need a burn analysis, Series A/B model, or monthly board financial package. Trigger with \"calculate our runway\", \"build the financial model\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- mint
+- finance
+- unit-economics
+- fundraising
+- startup
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/mock.md
+++ b/plugins/ai-agency/tonone/agents/mock.md
@@ -1,21 +1,20 @@
 ---
 name: mock
-description: API mocking — mock server design, contract testing, API simulation for development
+description: "Designs mock servers and consumer-driven contract tests (Pact/Prism/WireMock/msw) so teams can build without depending on the live API. Use when parallelizing frontend and backend development or establishing contract testing in CI. Trigger with \"set up API mocks\", \"design contract tests\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- mock
+- api-mocking
+- contract-testing
+- developer-experience
+- testing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/move.md
+++ b/plugins/ai-agency/tonone/agents/move.md
@@ -1,21 +1,20 @@
 ---
 name: move
-description: Motion design — animation principles, transition systems, micro-interaction specs
+description: "Designs animation systems — timing tokens, easing curves, micro-interactions, and prefers-reduced-motion fallbacks — that guide attention without blocking users. Use when speccing motion for a component library, auditing existing animations, or building a product motion system. Trigger with \"design the animation system\", \"audit our animations\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- move
+- motion-design
+- animation
+- ui-ux
+- design-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/multi.md
+++ b/plugins/ai-agency/tonone/agents/multi.md
@@ -1,21 +1,20 @@
 ---
 name: multi
-description: Multi-cloud architecture — provider selection, portability strategy, lock-in avoidance, workload placement
+description: "Designs multi-cloud strategies including provider selection, workload placement, lock-in assessment, and portability roadmaps — with explicit tradeoff framing on complexity vs. benefit. Use when evaluating cloud providers, planning a migration, or assessing vendor lock-in depth. Trigger with \"design our multi-cloud strategy\", \"assess our cloud lock-in\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- multi
+- multi-cloud
+- cloud-architecture
+- vendor-lock-in
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/onboard.md
+++ b/plugins/ai-agency/tonone/agents/onboard.md
@@ -1,21 +1,20 @@
 ---
 name: onboard
-description: Developer onboarding — quickstart design, time-to-first-call optimization, onboarding funnel audit
+description: "Designs developer onboarding experiences that get engineers to their first successful API call in under 5 minutes — quickstarts, TTFC audits, and friction analysis. Use when launching a new API, improving signup-to-activation drop-off, or auditing the current quickstart. Trigger with \"improve our developer onboarding\", \"write the quickstart\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- onboard
+- developer-onboarding
+- developer-experience
+- api-docs
+- activation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/patch.md
+++ b/plugins/ai-agency/tonone/agents/patch.md
@@ -1,21 +1,21 @@
 ---
 name: patch
-description: Vulnerability management — CVE triage, CVSS prioritization, patching cadence, SLA design
+description: "Triages CVEs using CVSS + EPSS + CISA KEV, designs patch SLA programs with asset-criticality tiers, and audits existing vuln management programs. Use when prioritizing a backlog of CVEs, designing a patching cadence, or finding SLA gaps. Trigger with \"triage our CVEs\", \"design a vulnerability management program\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- patch
+- vulnerability-management
+- security-operations
+- cve-triage
+- patching
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/pave.md
+++ b/plugins/ai-agency/tonone/agents/pave.md
@@ -1,6 +1,6 @@
 ---
 name: pave
-description: Platform engineer — developer experience, golden paths, service catalogs, environment management, internal tooling. Builds what removes friction for the team that exists.
+description: "Builds golden paths, service catalogs, internal CLIs, scaffolding, and local dev environments that measurably improve DORA metrics for the current team. Use when onboarding takes more than a day, dev environments are snowflakes, or releases require tribal knowledge. Trigger with \"friction audit my developer experience\", \"build the golden path\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- pave
+- platform-engineering
+- developer-experience
+- golden-path
+- dora-metrics
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/phish.md
+++ b/plugins/ai-agency/tonone/agents/phish.md
@@ -1,21 +1,20 @@
 ---
 name: phish
-description: Security awareness — phishing simulation design, security training programs, social engineering assessment
+description: "Designs phishing simulation programs, security awareness curricula, and social engineering assessments that drive behavior change through immediate feedback and difficulty progression. Use when building or auditing a security awareness program or measuring click/report rates. Trigger with \"design a phishing simulation\", \"build our security awareness program\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- phish
+- security-awareness
+- phishing-simulation
+- social-engineering
+- security-culture
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/pitch.md
+++ b/plugins/ai-agency/tonone/agents/pitch.md
@@ -1,24 +1,22 @@
 ---
 name: pitch
-description: Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy
+description: "Runs the Dunford five-step positioning framework and writes the output — homepage copy, launch announcements, email, taglines, and GTM plans that name specific distribution channels. Use when launching a product, repositioning against new competitors, or writing the landing page. Trigger with \"position this product\", \"write the launch copy\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- pitch
+- product-marketing
+- positioning
+- copywriting
+- gtm
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/plot.md
+++ b/plugins/ai-agency/tonone/agents/plot.md
@@ -1,21 +1,20 @@
 ---
 name: plot
-description: Data visualization — chart design, visualization libraries, exploratory analysis, dashboard specs
+description: "Selects chart types and encodings, designs EDA workflows, and audits existing visualizations for misleading charts, accessibility failures, and wrong library choices. Use when choosing how to visualize a dataset, building a dashboard spec, or catching bad charts in a notebook. Trigger with \"design this visualization\", \"audit our charts\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- plot
+- data-visualization
+- exploratory-data-analysis
+- dashboards
+- charting
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/port.md
+++ b/plugins/ai-agency/tonone/agents/port.md
@@ -1,21 +1,20 @@
 ---
 name: port
-description: SDK design — multi-language SDK architecture, idiomatic patterns, and cross-language consistency
+description: "Architects multi-language SDKs with idiomatic patterns per language, typed error handling, auto-pagination, and consistent cross-language interfaces — generated and hand-polished. Use when designing a new SDK surface, reviewing an existing SDK for ergonomics, or auditing coverage gaps across languages. Trigger with \"design the SDK architecture\", \"review this SDK\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- port
+- sdk-design
+- developer-experience
+- api-design
+- multi-language
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/prism.md
+++ b/plugins/ai-agency/tonone/agents/prism.md
@@ -1,6 +1,6 @@
 ---
 name: prism
-description: Frontend & DX engineer — translates Form's design system into production UI components, pages, and internal tools
+description: "Implements design system specs into production-quality UI components, pages, and internal tools using design tokens, TDD, and full a11y — never reinterprets Form's visual decisions. Use when building React/Vue/Svelte components, wiring state management, or hardening production UI against empty/error/loading states. Trigger with \"implement this component\", \"build the UI\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- prism
+- frontend
+- ui-components
+- design-systems
+- accessibility
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/prompt.md
+++ b/plugins/ai-agency/tonone/agents/prompt.md
@@ -1,21 +1,20 @@
 ---
 name: prompt
-description: Prompt engineering — system prompt design, few-shot libraries, chain-of-thought patterns, prompt versioning
+description: "Designs versioned system prompts, few-shot libraries, and chain-of-thought patterns with A/B testing and regression coverage — treats prompts as production code. Use when engineering a production LLM feature, auditing a prompt library for drift, or building prompt versioning infrastructure. Trigger with \"design this system prompt\", \"audit our prompt library\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- prompt
+- prompt-engineering
+- llm
+- ai-operations
+- few-shot
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/proof.md
+++ b/plugins/ai-agency/tonone/agents/proof.md
@@ -1,6 +1,6 @@
 ---
 name: proof
-description: QA & testing engineer — test strategy, E2E suites, integration testing, test infrastructure, flaky test triage
+description: "Risk-maps codebases and writes the actual test code — integration tests on critical paths, Playwright E2E for user journeys, flaky test triage, and CI gating — using the testing trophy over the pyramid. Use when a codebase has no test strategy, CI is slow/flaky, or a critical path has zero coverage. Trigger with \"write the tests\", \"triage our flaky tests\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- proof
+- qa
+- testing
+- e2e
+- ci
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/queue.md
+++ b/plugins/ai-agency/tonone/agents/queue.md
@@ -1,21 +1,21 @@
 ---
 name: queue
-description: Message queuing and streaming — Kafka, SQS, RabbitMQ design, consumer group strategy, dead letter queues
+description: "Designs message queuing and event streaming architectures (Kafka, SQS, RabbitMQ) — consumer groups, DLQs, backpressure, and exactly-once semantics. Use when designing or auditing queue infrastructure. Trigger with \"design my queue architecture\", \"audit my Kafka setup\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- queue
+- message-queuing
+- event-streaming
+- distributed-systems
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/rank.md
+++ b/plugins/ai-agency/tonone/agents/rank.md
@@ -1,21 +1,21 @@
 ---
 name: rank
-description: AI ranking and relevance — retrieval reranking, relevance scoring, learning-to-rank, result quality evaluation
+description: "Designs retrieval reranking pipelines, relevance scoring systems, and learning-to-rank models with rigorous NDCG/MRR evaluation. Use when ranking quality is poor or a reranker is needed. Trigger with \"improve my search ranking\", \"design a reranking pipeline\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- rank
+- retrieval
+- ranking
+- relevance
+- ml-evaluation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/red.md
+++ b/plugins/ai-agency/tonone/agents/red.md
@@ -1,21 +1,21 @@
 ---
 name: red
-description: Red team operations — penetration testing, attack simulation, vulnerability exploitation
+description: "Plans and documents red team exercises — pen test scopes, attack path documentation, CVSS-scored finding reports, and OSINT reconnaissance plans. Use when scoping a pen test or writing a security assessment. Trigger with \"plan a pen test\", \"write a red team report\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- red
+- penetration-testing
+- red-team
+- offensive-security
+- vulnerability-assessment
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/relay.md
+++ b/plugins/ai-agency/tonone/agents/relay.md
@@ -1,6 +1,6 @@
 ---
 name: relay
-description: DevOps engineer — CI/CD, deployments, GitOps, developer experience
+description: "Builds CI/CD pipelines, deployment configs, and GitOps workflows that make shipping invisible — trunk-based development, cache strategies, rollback procedures, and platform auto-detection. Use when setting up or fixing pipelines and deployments. Trigger with \"set up CI/CD\", \"fix my deployment pipeline\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- relay
+- ci-cd
+- devops
+- gitops
+- release-engineering
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/resp.md
+++ b/plugins/ai-agency/tonone/agents/resp.md
@@ -1,21 +1,21 @@
 ---
 name: resp
-description: Incident response — playbook design, containment procedures, DFIR, post-incident review
+description: "Writes incident response playbooks, containment runbooks, and post-incident reviews following the PICERL framework — contain first, preserve evidence, never blame. Use when building IR readiness or handling an active incident. Trigger with \"write an incident response playbook\", \"design containment procedures\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- resp
+- incident-response
+- dfir
+- security-operations
+- playbook
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/sample.md
+++ b/plugins/ai-agency/tonone/agents/sample.md
@@ -1,6 +1,6 @@
 ---
 name: sample
-description: Code samples and tutorials — working examples, quickstarts, and language-specific guides
+description: "Writes runnable code samples and tutorials that get developers to first success fast — real values, error handling, expected output, language parity. Use when creating or reviewing API examples and quickstarts. Trigger with \"write a code sample\", \"create a quickstart guide\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,15 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- sample
+- developer-experience
+- code-samples
+- documentation
+- tutorials
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/sast.md
+++ b/plugins/ai-agency/tonone/agents/sast.md
@@ -1,21 +1,22 @@
 ---
 name: sast
-description: Application security — SAST/DAST scanning, code security review, secure SDLC design
+description: "Integrates SAST/DAST tooling into the SDLC — Semgrep rules, CodeQL, OWASP ZAP, and secure code review covering the full OWASP Top 10. Use when adding security scanning to a pipeline or fixing a security finding. Trigger with \"set up SAST scanning\", \"fix this security finding\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
+- application-security
 - sast
+- secure-sdlc
+- code-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/schema.md
+++ b/plugins/ai-agency/tonone/agents/schema.md
@@ -1,21 +1,21 @@
 ---
 name: schema
-description: API schema design — OpenAPI, GraphQL, gRPC schema quality, and design standards
+description: "Designs and reviews API schemas (OpenAPI 3.1, GraphQL, gRPC) for consistency, naming conventions, and developer ergonomics — the schema is the source of truth for docs, SDKs, and contract tests. Use when designing a new API or auditing an existing spec. Trigger with \"design this API schema\", \"review my OpenAPI spec\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- schema
+- api-design
+- openapi
+- graphql
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/scope.md
+++ b/plugins/ai-agency/tonone/agents/scope.md
@@ -1,11 +1,10 @@
 ---
 name: scope
-description: IP strategy — trademark clearance, patent landscape, open source license compliance, IP assignment
+description: "Clears trademarks, maps patent landscapes, and audits open source license compliance — frames every finding as risk, probability, fix, and cost of inaction. Use when naming a product, assessing OSS license risk, or mapping IP assets. Trigger with \"clear this trademark\", \"audit our open source licenses\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
 - WebFetch
 - WebSearch
@@ -14,8 +13,10 @@ color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- scope
+- intellectual-property
+- trademark
+- open-source-compliance
+- legal
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/score.md
+++ b/plugins/ai-agency/tonone/agents/score.md
@@ -1,21 +1,21 @@
 ---
 name: score
-description: Model evaluation — metrics design, statistical significance, model comparison, evaluation frameworks
+description: "Designs honest model evaluation frameworks — metric selection matched to business cost functions, statistical significance testing, calibration, and confusion analysis. Use when choosing eval metrics or comparing models. Trigger with \"design a model evaluation framework\", \"compare these models statistically\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- score
+- model-evaluation
+- ml-metrics
+- statistical-testing
+- data-science
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/serv.md
+++ b/plugins/ai-agency/tonone/agents/serv.md
@@ -1,21 +1,21 @@
 ---
 name: serv
-description: Serverless architecture — Lambda/Cloud Functions/Cloud Run design, cold start optimization, event patterns
+description: "Designs serverless architectures for Lambda, Cloud Functions, and Cloud Run — cold start mitigation, event-driven wiring, cost modeling, and IaC via SAM or Serverless Framework. Use when building or auditing serverless workloads. Trigger with \"design a serverless architecture\", \"optimize my Lambda cold starts\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- serv
+- serverless
+- lambda
+- event-driven
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/shield.md
+++ b/plugins/ai-agency/tonone/agents/shield.md
@@ -1,11 +1,10 @@
 ---
 name: shield
-description: Regulatory risk assessment — GDPR exposure, CCPA, FTC rules, financial regulation, export controls
+description: "Maps regulatory exposure across GDPR, CCPA, FTC, financial regulation, and export controls — frames every finding as risk, probability, fix, and cost of inaction. Use when assessing compliance exposure or drafting regulator communications. Trigger with \"assess my regulatory risk\", \"draft a regulatory response\"."
 tools:
 - Read
-- Bash
-- Glob
 - Grep
+- Glob
 - Write
 - WebFetch
 - WebSearch
@@ -14,8 +13,10 @@ color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- shield
+- regulatory-compliance
+- gdpr
+- risk-assessment
+- legal
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/siem.md
+++ b/plugins/ai-agency/tonone/agents/siem.md
@@ -1,21 +1,22 @@
 ---
 name: siem
-description: SIEM engineering — log pipeline design, detection rule development, alert tuning
+description: "Builds log pipelines and SIEM detection rules — SIGMA format, MITRE mapping, retention policies, and alert tuning to keep volume within analyst capacity. Use when designing detection coverage or reducing alert fatigue. Trigger with \"write a SIEM detection rule\", \"audit my log pipeline\"."
 tools:
 - Read
 - Bash
 - Glob
 - Grep
 - Write
-- WebFetch
 - WebSearch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
 - siem
+- detection-engineering
+- log-pipeline
+- security-operations
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/spine.md
+++ b/plugins/ai-agency/tonone/agents/spine.md
@@ -1,6 +1,6 @@
 ---
 name: spine
-description: Backend engineer — APIs, system design, performance, distributed systems
+description: "Designs and implements backend systems contract-first — REST/gRPC/GraphQL APIs, distributed architecture, caching, auth, and rate limiting using boring technology that ships and stays simple. Use when designing a new API or fixing backend performance. Trigger with \"design this backend API\", \"build this service\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- spine
+- backend
+- api-design
+- distributed-systems
+- system-architecture
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/surge.md
+++ b/plugins/ai-agency/tonone/agents/surge.md
@@ -1,24 +1,23 @@
 ---
 name: surge
-description: Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy
+description: "Diagnoses growth constraints and designs compounding growth loops — retention before acquisition, PLG architecture, activation sequencing, and experiment design with kill conditions. Use when diagnosing why growth is stalling or designing a PLG motion. Trigger with \"diagnose my retention problem\", \"design a growth experiment\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- surge
+- growth-engineering
+- product-led-growth
+- retention
+- activation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/terms.md
+++ b/plugins/ai-agency/tonone/agents/terms.md
@@ -1,21 +1,21 @@
 ---
 name: terms
-description: Privacy policy and Terms of Service — GDPR-compliant privacy notices, ToS, cookie policies, data processing agreements
+description: "Drafts GDPR-compliant privacy policies, Terms of Service, cookie notices, and DPAs sized to company stage. Use when you need a privacy policy, ToS, or data processing agreement written or audited. Trigger with \"draft my privacy policy\", \"review my terms of service\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- terms
+- legal
+- privacy
+- gdpr
+- compliance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/terra.md
+++ b/plugins/ai-agency/tonone/agents/terra.md
@@ -1,6 +1,6 @@
 ---
 name: terra
-description: Terraform and IaC — module design, state management, drift detection, and IaC best practices
+description: "Designs Terraform module structures, state management strategies, drift detection workflows, and IaC best practices. Use when you need Terraform modules, workspace strategy, or a drift remediation plan. Trigger with \"design my Terraform module\", \"audit my Terraform code\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,15 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- terra
+- terraform
+- infrastructure-as-code
+- devops
+- cloud
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/token.md
+++ b/plugins/ai-agency/tonone/agents/token.md
@@ -1,21 +1,21 @@
 ---
 name: token
-description: Token and context management — context window optimization, token counting, truncation strategy, chunking design
+description: "Optimizes LLM context windows through token budgeting, chunking strategy, and truncation design. Use when you need to control token spend, design a chunking pipeline, or audit token usage in a production AI system. Trigger with \"design my token budget\", \"fix my context overflow\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- token
+- llm
+- token-management
+- rag
+- ai-ops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/tone.md
+++ b/plugins/ai-agency/tonone/agents/tone.md
@@ -1,21 +1,21 @@
 ---
 name: tone
-description: Design token engineering — token architecture, theming systems, style-dictionary pipelines
+description: "Engineers design token systems — three-tier token architecture, multi-brand theming, and style-dictionary build pipelines. Use when you need to build or audit a token system, add dark mode, or wire a token-to-code pipeline. Trigger with \"design my token architecture\", \"audit my design tokens\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- tone
+- design-system
+- design-tokens
+- theming
+- frontend
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/touch.md
+++ b/plugins/ai-agency/tonone/agents/touch.md
@@ -1,6 +1,6 @@
 ---
 name: touch
-description: Mobile engineer — native iOS/Android, cross-platform, app stores, mobile performance
+description: "Full-stack mobile engineer covering iOS, Android, React Native, and Flutter — from architecture decisions to app store submission. Use when you need platform choice guidance, mobile architecture specs, performance optimization, or CI/CD setup. Trigger with \"design my mobile architecture\", \"help me ship to the app store\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- touch
+- mobile
+- ios
+- android
+- react-native
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/trace.md
+++ b/plugins/ai-agency/tonone/agents/trace.md
@@ -1,6 +1,6 @@
 ---
 name: trace
-description: LLM observability — tracing, span capture, prompt/completion logging, cost attribution, AI debugging
+description: "Instruments LLM systems with tracing, span capture, cost attribution, and debugging tooling. Use when you need to add observability to AI pipelines, debug model behavior, or audit LLM cost attribution. Trigger with \"instrument my LLM calls\", \"debug my AI system with traces\"."
 tools:
 - Read
 - Bash
@@ -8,14 +8,15 @@ tools:
 - Grep
 - Write
 - WebFetch
-- WebSearch
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- trace
+- llm-observability
+- tracing
+- ai-ops
+- cost-attribution
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/tune.md
+++ b/plugins/ai-agency/tonone/agents/tune.md
@@ -1,9 +1,8 @@
 ---
 name: tune
-description: LLM fine-tuning — PEFT/LoRA, RLHF, instruction tuning, prompt optimization
+description: "Designs LLM fine-tuning pipelines using PEFT/LoRA, RLHF, and instruction datasets, and systematically optimizes prompts before recommending fine-tuning. Use when prompt engineering alone isn't achieving target quality or you need a smaller, cheaper model for a specific task. Trigger with \"design a fine-tuning pipeline\", \"optimize my prompts\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- tune
+- fine-tuning
+- llm
+- peft
+- prompt-optimization
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/vect.md
+++ b/plugins/ai-agency/tonone/agents/vect.md
@@ -1,9 +1,8 @@
 ---
 name: vect
-description: Embeddings and vector search — semantic search, RAG pipelines, vector database design
+description: "Designs embedding pipelines and vector search systems for semantic search, RAG, and similarity applications. Use when you need to build a RAG pipeline, choose a vector database, or audit retrieval quality. Trigger with \"design my RAG pipeline\", \"help me choose a vector database\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- vect
+- embeddings
+- vector-search
+- rag
+- semantic-search
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/vigil.md
+++ b/plugins/ai-agency/tonone/agents/vigil.md
@@ -1,6 +1,6 @@
 ---
 name: vigil
-description: Observability & reliability engineer — SLOs, alerting, instrumentation, incident response. Writes configs and runbooks, doesn't produce roadmaps.
+description: "Writes production-ready SLO definitions, alert rules, OpenTelemetry instrumentation configs, and incident runbooks from a burn-rate-first perspective. Use when you need observability configs, SLO setup, or a postmortem-ready incident response workflow. Trigger with \"set up my SLOs\", \"write my alert runbook\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- vigil
+- observability
+- slo
+- alerting
+- reliability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/volt.md
+++ b/plugins/ai-agency/tonone/agents/volt.md
@@ -1,6 +1,6 @@
 ---
 name: volt
-description: Embedded & IoT engineer — firmware architecture, microcontrollers, OTA updates, edge computing, device protocols
+description: "Designs firmware architectures, HAL boundaries, RTOS selection, and OTA rollback strategies for ESP32, STM32, nRF52, and RP2040 targets. Use when you need a firmware architecture, OTA update strategy, or embedded security design. Trigger with \"design my firmware architecture\", \"help me add OTA updates\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- volt
+- embedded
+- iot
+- firmware
+- microcontroller
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/warden.md
+++ b/plugins/ai-agency/tonone/agents/warden.md
@@ -1,6 +1,6 @@
 ---
 name: warden
-description: Security engineer — IAM, secrets, threat modeling, hardening, auth, and supply chain security
+description: "Writes threat models, IAM policies, hardening specs, and auth implementation reviews sized to actual risk — not compliance theater. Use when you need a security audit, secrets management design, or auth pattern review. Trigger with \"threat model my app\", \"audit my security posture\"."
 tools:
 - Read
 - Write
@@ -10,15 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- warden
+- security
+- iam
+- threat-modeling
+- auth
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/wire.md
+++ b/plugins/ai-agency/tonone/agents/wire.md
@@ -1,21 +1,20 @@
 ---
 name: wire
-description: Prototyping and handoff — interactive flow docs, component specs, developer handoff
+description: "Produces developer-ready handoff specs, annotated prototype flows, and component state documentation that bridges design and engineering. Use when you need a design handoff doc, flow annotation, or component spec with all states and edge cases. Trigger with \"write my handoff spec\", \"document this user flow\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
-- WebFetch
-- WebSearch
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- wire
+- design-handoff
+- prototyping
+- ux
+- design-system
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/agents/zero.md
+++ b/plugins/ai-agency/tonone/agents/zero.md
@@ -1,9 +1,8 @@
 ---
 name: zero
-description: Zero trust architecture — network segmentation, identity-based access, microsegmentation design
+description: "Designs zero trust network architectures with phased roadmaps covering identity pillars, microsegmentation, and ZTNA replacement for VPN. Use when you need a zero trust design, a network segmentation plan, or a ZT maturity assessment. Trigger with \"design my zero trust architecture\", \"audit my network for zero trust readiness\"."
 tools:
 - Read
-- Bash
 - Glob
 - Grep
 - Write
@@ -14,8 +13,10 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- zero
+- zero-trust
+- network-security
+- iam
+- microsegmentation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/full-team/agents/buzz.md
+++ b/plugins/ai-agency/tonone/bundle/full-team/agents/buzz.md
@@ -1,11 +1,10 @@
 ---
 name: buzz
-description: PR & Community engineer — press pitches, social media, open source community, DevRel, and coordinated launch moments
+description: "Writes press pitches, HN posts, community playbooks, and coordinated launch plans that generate earned media and compound developer communities. Use when you need to plan a product launch, draft a press pitch, or build a developer community strategy. Trigger with \"write my HN launch post\", \"build my community playbook\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,10 @@ color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- buzz
+- pr
+- community
+- devrel
+- launch
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/full-team/agents/deal.md
+++ b/plugins/ai-agency/tonone/bundle/full-team/agents/deal.md
@@ -1,11 +1,10 @@
 ---
 name: deal
-description: Revenue & Sales engineer — B2B pipeline, deal strategy, pricing proposals, sales playbooks, and enterprise closing
+description: "Builds B2B sales systems — outreach sequences, MEDDPICC qualification frameworks, pricing tables, and closing playbooks — stage-matched from $0-$1M to $10M-$100M ARR. Use when you need a sales playbook, a pricing proposal, or a pipeline architecture for your current stage. Trigger with \"build my sales playbook\", \"write my outreach sequence\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
@@ -17,8 +16,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- deal
+- sales
+- b2b
+- revenue
+- pricing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/full-team/agents/ink.md
+++ b/plugins/ai-agency/tonone/bundle/full-team/agents/ink.md
@@ -1,24 +1,22 @@
 ---
 name: ink
-description: Content Marketing engineer — blog strategy, SEO, thought leadership, developer content, case studies, and content calendar
+description: "Writes blog posts, topic clusters, content calendars, and case studies with SEO-first distribution plans. Use when you need compounding content strategy executed, not advised on. Trigger with \"write a blog post\", \"build a content calendar\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- ink
+- content-marketing
+- seo
+- developer-content
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/full-team/agents/keep.md
+++ b/plugins/ai-agency/tonone/bundle/full-team/agents/keep.md
@@ -1,24 +1,21 @@
 ---
 name: keep
-description: Customer Success engineer — onboarding optimization, health scoring, expansion revenue, churn prevention, and NRR growth
+description: "Builds onboarding flows, health scoring models, expansion playbooks, and churn prevention sequences that ship to production. Use when NRR is the lever and customer retention artifacts need to be made, not discussed. Trigger with \"build a health score model\", \"write an expansion playbook\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- keep
+- customer-success
+- retention
+- nrr
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/marketing-team/agents/buzz.md
+++ b/plugins/ai-agency/tonone/bundle/marketing-team/agents/buzz.md
@@ -1,24 +1,21 @@
 ---
 name: buzz
-description: PR & Community engineer — press pitches, social media, open source community, DevRel, and coordinated launch moments
+description: "Writes press pitches, HN posts, community playbooks, and coordinated launch plans that ship — not PR strategy decks. Use when earned media or developer community growth needs actual artifacts produced. Trigger with \"write a press pitch\", \"draft a HN launch post\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- buzz
+- pr
+- community
+- developer-relations
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/marketing-team/agents/ink.md
+++ b/plugins/ai-agency/tonone/bundle/marketing-team/agents/ink.md
@@ -1,24 +1,22 @@
 ---
 name: ink
-description: Content Marketing engineer — blog strategy, SEO, thought leadership, developer content, case studies, and content calendar
+description: "Writes blog posts, topic clusters, content calendars, and case studies with SEO-first distribution plans. Use when you need compounding content strategy executed, not advised on. Trigger with \"write a blog post\", \"build a content calendar\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- ink
+- content-marketing
+- seo
+- developer-content
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/marketing-team/agents/pitch.md
+++ b/plugins/ai-agency/tonone/bundle/marketing-team/agents/pitch.md
@@ -1,24 +1,21 @@
 ---
 name: pitch
-description: Product marketer — positioning, messaging, value proposition, GTM strategy, and launch copy
+description: "Produces positioning statements, messaging frameworks, landing page copy, and GTM launch plans from the Dunford framework. Use when positioning or copy needs to actually ship, not be workshopped. Trigger with \"write positioning copy\", \"build a GTM launch plan\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- pitch
+- product-marketing
+- positioning
+- gtm
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/product-team/agents/buzz.md
+++ b/plugins/ai-agency/tonone/bundle/product-team/agents/buzz.md
@@ -1,24 +1,21 @@
 ---
 name: buzz
-description: PR & Community engineer — press pitches, social media, open source community, DevRel, and coordinated launch moments
+description: "Writes press pitches, HN posts, community playbooks, and coordinated launch plans that ship — not PR strategy decks. Use when earned media or developer community growth needs actual artifacts produced. Trigger with \"write a press pitch\", \"draft a HN launch post\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- buzz
+- pr
+- community
+- developer-relations
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/product-team/agents/deal.md
+++ b/plugins/ai-agency/tonone/bundle/product-team/agents/deal.md
@@ -1,24 +1,21 @@
 ---
 name: deal
-description: Revenue & Sales engineer — B2B pipeline, deal strategy, pricing proposals, sales playbooks, and enterprise closing
+description: "Builds B2B sales pipelines, writes outbound sequences, pricing proposals, and MEDDPICC-qualified playbooks that close deals. Use when a repeatable revenue motion needs to be built or unblocked, not coached. Trigger with \"write a sales playbook\", \"draft a pricing proposal\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- deal
+- sales
+- revenue
+- b2b
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/product-team/agents/ink.md
+++ b/plugins/ai-agency/tonone/bundle/product-team/agents/ink.md
@@ -1,24 +1,22 @@
 ---
 name: ink
-description: Content Marketing engineer — blog strategy, SEO, thought leadership, developer content, case studies, and content calendar
+description: "Writes blog posts, topic clusters, content calendars, and case studies with SEO-first distribution plans. Use when you need compounding content strategy executed, not advised on. Trigger with \"write a blog post\", \"build a content calendar\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- ink
+- content-marketing
+- seo
+- developer-content
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/product-team/agents/keep.md
+++ b/plugins/ai-agency/tonone/bundle/product-team/agents/keep.md
@@ -1,24 +1,21 @@
 ---
 name: keep
-description: Customer Success engineer — onboarding optimization, health scoring, expansion revenue, churn prevention, and NRR growth
+description: "Builds onboarding flows, health scoring models, expansion playbooks, and churn prevention sequences that ship to production. Use when NRR is the lever and customer retention artifacts need to be made, not discussed. Trigger with \"build a health score model\", \"write an expansion playbook\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- keep
+- customer-success
+- retention
+- nrr
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/revenue-team/agents/deal.md
+++ b/plugins/ai-agency/tonone/bundle/revenue-team/agents/deal.md
@@ -1,24 +1,21 @@
 ---
 name: deal
-description: Revenue & Sales engineer — B2B pipeline, deal strategy, pricing proposals, sales playbooks, and enterprise closing
+description: "Builds B2B sales pipelines, writes outbound sequences, pricing proposals, and MEDDPICC-qualified playbooks that close deals. Use when a repeatable revenue motion needs to be built or unblocked, not coached. Trigger with \"write a sales playbook\", \"draft a pricing proposal\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- deal
+- sales
+- revenue
+- b2b
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/revenue-team/agents/keep.md
+++ b/plugins/ai-agency/tonone/bundle/revenue-team/agents/keep.md
@@ -1,24 +1,21 @@
 ---
 name: keep
-description: Customer Success engineer — onboarding optimization, health scoring, expansion revenue, churn prevention, and NRR growth
+description: "Builds onboarding flows, health scoring models, expansion playbooks, and churn prevention sequences that ship to production. Use when NRR is the lever and customer retention artifacts need to be made, not discussed. Trigger with \"build a health score model\", \"write an expansion playbook\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- keep
+- customer-success
+- retention
+- nrr
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-agency/tonone/bundle/revenue-team/agents/surge.md
+++ b/plugins/ai-agency/tonone/bundle/revenue-team/agents/surge.md
@@ -1,24 +1,21 @@
 ---
 name: surge
-description: Growth engineer — acquisition channels, activation funnels, retention playbooks, and PLG strategy
+description: "Diagnoses growth constraints and produces retention plans, PLG architectures, activation playbooks, and referral loop designs. Use when a growth lever needs to be identified and a specific artifact built, not a list of options generated. Trigger with \"diagnose our growth constraint\", \"design a PLG activation flow\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-agency
-- surge
+- growth
+- plg
+- activation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-ml/ai-sdk-agents/agents/multi-agent-orchestrator.md
+++ b/plugins/ai-ml/ai-sdk-agents/agents/multi-agent-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: multi-agent-orchestrator
-description: Expert coordinator for multi-agent systems - analyzes requests, routes to...
+description: "Coordinates multi-agent systems by decomposing tasks, routing to the right specialist, managing handoffs with full context, and aggregating outputs into a cohesive result. Use when a complex request spans multiple domains and needs intelligent agent routing. Trigger with \"orchestrate this task\", \"route to the right agent\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-ml
-- multi
-- orchestrator
+- multi-agent
+- orchestration
+- task-routing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-ml/jeremy-adk-orchestrator/agents/a2a-protocol-manager.md
+++ b/plugins/ai-ml/jeremy-adk-orchestrator/agents/a2a-protocol-manager.md
@@ -1,6 +1,6 @@
 ---
 name: a2a-protocol-manager
-description: Expert in Agent-to-Agent (A2A) protocol for communicating with Vertex AI ADK...
+description: "Implements A2A JSON-RPC protocol for communicating between Claude Code and Vertex AI ADK agents, including AgentCard discovery, session management, async polling, and multi-agent orchestration patterns. Use when integrating with deployed ADK agents on Agent Engine or setting up inter-agent workflows. Trigger with \"set up A2A client\", \"connect to an ADK agent\"."
 tools:
 - Read
 - Write
@@ -9,18 +9,14 @@ tools:
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-ml
-- a2a
-- protocol
-- manager
+- a2a-protocol
+- vertex-ai
+- agent-engine
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-ml/jeremy-gcp-starter-examples/agents/gcp-starter-kit-expert.md
+++ b/plugins/ai-ml/jeremy-gcp-starter-examples/agents/gcp-starter-kit-expert.md
@@ -1,6 +1,6 @@
 ---
 name: gcp-starter-kit-expert
-description: Expert in Google Cloud starter kits, ADK samples, Genkit templates, Agent...
+description: "Provides production-ready code examples from official Google Cloud repos — ADK samples, Agent Starter Pack, Genkit flows, Vertex AI fine-tuning, and Gemini function calling patterns. Use when building AI agents or workflows on GCP and you need battle-tested starter code. Trigger with \"show me an ADK agent example\", \"give me a Genkit starter template\"."
 tools:
 - Read
 - Write
@@ -10,17 +10,14 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-ml
 - gcp
-- starter
-- kit
+- adk
+- genkit
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-ml/jeremy-genkit-pro/agents/genkit-flow-architect.md
+++ b/plugins/ai-ml/jeremy-genkit-pro/agents/genkit-flow-architect.md
@@ -1,6 +1,6 @@
 ---
 name: genkit-flow-architect
-description: Expert Firebase Genkit flow architect specializing in designing...
+description: "Designs and implements production-grade Firebase Genkit flows (Node.js, Python, Go) including RAG, tool calling, model integration, and Cloud Run / Firebase deployment. Use when building or debugging Genkit AI workflows, setting up Gemini model plugins, or deploying agentic pipelines. Trigger with \"create a Genkit flow\", \"design AI workflow with Genkit\"."
 tools:
 - Read
 - Write
@@ -10,17 +10,15 @@ tools:
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-ml
 - genkit
-- flow
-- architect
+- firebase
+- ai-workflows
+- google-ai
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/ai-ml/jeremy-vertex-engine/agents/vertex-engine-inspector.md
+++ b/plugins/ai-ml/jeremy-vertex-engine/agents/vertex-engine-inspector.md
@@ -1,26 +1,22 @@
 ---
 name: vertex-engine-inspector
-description: Expert inspector for Vertex AI Agent Engine deployments. Validates runtime...
+description: "Inspects and validates Vertex AI Agent Engine deployments — runtime config, code-execution sandbox, memory bank, A2A protocol compliance, security posture, and production readiness. Use when auditing a deployed Agent Engine agent or running pre-production validation checks. Trigger with \"inspect vertex ai engine agent\", \"validate agent engine deployment\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- ai-ml
-- vertex
-- engine
-- inspector
+- vertex-ai
+- agent-engine
+- gcp-audit
+- production-readiness
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/anomaly-detector.md
+++ b/plugins/analytics/web-analytics/agents/anomaly-detector.md
@@ -1,25 +1,19 @@
 ---
 name: anomaly-detector
-description: 'Detects traffic spikes, drops, bot activity, and tracking gaps. Distinguishes real problems from data artifacts. Answers: is this a real problem or a data problem?'
+description: "Detects traffic spikes, drops, bot activity, and tracking gaps in Umami analytics data, then classifies each anomaly by severity and root-cause hypothesis. Use when investigating unexpected traffic changes or data quality issues. Trigger with \"check for anomalies\", \"why did traffic drop\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- anomaly
-- detector
+- web-analytics
+- anomaly-detection
+- data-quality
+- umami
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/audience-segmentation.md
+++ b/plugins/analytics/web-analytics/agents/audience-segmentation.md
@@ -1,25 +1,19 @@
 ---
 name: audience-segmentation
-description: 'Analyzes visitor cohorts, geographic distribution, device/platform mix, new vs returning patterns, and churn risk. Answers: who are best users, who are we losing?'
+description: "Analyzes visitor cohorts, geographic distribution, device/platform mix, and new-vs-returning patterns to identify best audience segments and churn risk. Use when profiling who visits your sites or spotting engagement decline in key cohorts. Trigger with \"analyze my audience\", \"who are my best visitors\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- audience
-- segmentation
+- web-analytics
+- audience-segmentation
+- cohort-analysis
+- umami
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/content-seo.md
+++ b/plugins/analytics/web-analytics/agents/content-seo.md
@@ -1,25 +1,19 @@
 ---
 name: content-seo
-description: 'Analyzes page-level performance, identifies content gaps, tracks topic clusters, and recommends content strategy. Answers: what content works, what to create next?'
+description: "Analyzes page-level traffic performance, classifies rising and declining content, identifies gaps, and recommends data-backed content strategy from Umami analytics. Use when evaluating which content drives results or deciding what to publish next. Trigger with \"analyze content performance\", \"what should I publish next\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- content
+- web-analytics
+- content-strategy
 - seo
+- page-performance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/conversion-funnel.md
+++ b/plugins/analytics/web-analytics/agents/conversion-funnel.md
@@ -1,25 +1,19 @@
 ---
 name: conversion-funnel
-description: 'Analyzes conversion events, goal completion, funnel drop-off, and revenue impact. Answers: where are people abandoning, what''s the revenue impact?'
+description: "Analyzes conversion events, funnel stage drop-off rates, and goal completions to quantify where visitors abandon and what the business impact is. Use when diagnosing funnel health or measuring event-driven conversions across sites. Trigger with \"analyze conversion funnel\", \"where are people dropping off\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- conversion
-- funnel
+- web-analytics
+- conversion-funnel
+- goal-tracking
+- umami
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/data-collector.md
+++ b/plugins/analytics/web-analytics/agents/data-collector.md
@@ -1,25 +1,17 @@
 ---
 name: data-collector
-description: Fetches raw analytics data from Umami MCP and GA4 backends. Never interprets — only collects and structures data for specialist agents.
+description: "Fetches raw analytics data from Umami MCP across all tracked sites and returns structured datasets for specialist agents — never interprets, only collects. Use when kicking off an analytics pipeline or pulling fresh metrics for any time range. Trigger with \"collect analytics data\", \"fetch site metrics\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- data
-- collector
+- web-analytics
+- data-collection
+- umami
+- mcp-integration
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/memory-agent.md
+++ b/plugins/analytics/web-analytics/agents/memory-agent.md
@@ -1,24 +1,19 @@
 ---
 name: memory-agent
-description: Maintains rolling analytics context — baselines, historical trends, and learned patterns. Prevents cold starts by giving every report period-over-period awareness.
+description: "Maintains rolling 90-day analytics baselines, learned seasonal patterns, and anomaly history so specialist agents never start cold. Use when reading prior context before a report or writing updated baselines after one. Trigger with \"load analytics context\", \"update analytics baselines\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- memory
+- web-analytics
+- baseline-tracking
+- context-persistence
+- umami
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/reporting-narrative.md
+++ b/plugins/analytics/web-analytics/agents/reporting-narrative.md
@@ -1,25 +1,20 @@
 ---
 name: reporting-narrative
-description: Compiles specialist agent outputs into cohesive, business-grade analytics narratives. Never analyzes raw data — only synthesizes and formats.
+description: "Compiles specialist agent outputs into tiered analytics narratives (mini pulse, daily brief, full deep-dive) in an advisory business voice — never touches raw data. Use when generating a polished analytics report for console, email, or Slack. Trigger with \"generate analytics report\", \"compile analytics brief\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
+- web-analytics
 - reporting
-- narrative
+- narrative-synthesis
+- multi-site
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/traffic-intelligence.md
+++ b/plugins/analytics/web-analytics/agents/traffic-intelligence.md
@@ -1,25 +1,19 @@
 ---
 name: traffic-intelligence
-description: 'Analyzes traffic patterns, source attribution, channel performance, and AI referral trends. Answers: where is traffic from, why did it change?'
+description: "Analyzes web traffic source attribution, channel performance, AI referral trends, and redirect domain tracking to explain where visitors come from and why traffic changed. Use when diagnosing channel shifts or measuring AI-referral growth. Trigger with \"analyze traffic sources\", \"why did traffic change\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- traffic
-- intelligence
+- web-analytics
+- traffic-attribution
+- channel-analysis
+- ai-referrals
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/analytics/web-analytics/agents/verification-agent.md
+++ b/plugins/analytics/web-analytics/agents/verification-agent.md
@@ -1,24 +1,19 @@
 ---
 name: verification-agent
-description: Adversarial quality checker that catches hallucinated insights, sampling bias, unsupported claims, and logical errors in specialist agent outputs before delivery.
+description: "Adversarially verifies specialist analytics agent outputs — checks every number against raw data, flags hallucinated insights, logical contradictions, and sampling bias before the report reaches the user. Use when quality-gating an analytics pipeline before final delivery. Trigger with \"verify analytics outputs\", \"quality check the report\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- analytics
-- verification
+- web-analytics
+- quality-assurance
+- hallucination-detection
+- adversarial-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/general-legal-assistant/agents/legal-clauses.md
+++ b/plugins/business-tools/general-legal-assistant/agents/legal-clauses.md
@@ -1,25 +1,18 @@
 ---
 name: legal-clauses
-description: Extract and categorize every clause in a contract with completeness scoring
+description: "Extracts, categorizes, and scores every clause in a contract document across 20 standard categories, including gap analysis, defined terms, cross-references, and completeness scoring. Use when inventorying a contract before risk review or compliance checking. Trigger with \"extract contract clauses\", \"analyze this contract\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- legal
-- clauses
+- contract-analysis
+- clause-extraction
+- legal-review
+- compliance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/general-legal-assistant/agents/legal-compliance.md
+++ b/plugins/business-tools/general-legal-assistant/agents/legal-compliance.md
@@ -1,25 +1,18 @@
 ---
 name: legal-compliance
-description: Check contract clauses against GDPR, CCPA, employment law, and industry regulations
+description: "Checks every contract clause against applicable regulatory frameworks (GDPR, CCPA, employment law, UCC, sector-specific regulations) by jurisdiction and outputs a structured compliance checklist with enforceability assessments. Use when verifying a contract for regulatory exposure before signing. Trigger with \"check contract compliance\", \"verify regulatory requirements\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- legal
-- compliance
+- contract-compliance
+- gdpr
+- employment-law
+- regulatory-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/general-legal-assistant/agents/legal-obligations.md
+++ b/plugins/business-tools/general-legal-assistant/agents/legal-obligations.md
@@ -1,25 +1,18 @@
 ---
 name: legal-obligations
-description: Map every obligation, deadline, and financial exposure in a contract chronologically
+description: "Maps every obligation, deadline, trap, and financial exposure in a contract into a chronological obligations matrix with total exposure calculation and imbalance scoring. Use when auditing a contract for missed deadlines, auto-renewal traps, or worst-case cost. Trigger with \"map contract obligations\", \"calculate financial exposure\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- legal
-- obligations
+- contract-obligations
+- deadline-tracking
+- financial-exposure
+- legal-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/general-legal-assistant/agents/legal-recommendations.md
+++ b/plugins/business-tools/general-legal-assistant/agents/legal-recommendations.md
@@ -1,25 +1,18 @@
 ---
 name: legal-recommendations
-description: Generate prioritized recommendations with replacement clause language and negotiation scripts
+description: "Synthesizes findings from the clauses, compliance, obligations, and risks agents into a prioritized action plan with P0-P4 recommendations, exact replacement clause language, and complete negotiation scripts. Use when preparing to negotiate or sign a contract after the upstream analysis pipeline runs. Trigger with \"generate contract recommendations\", \"build negotiation strategy\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- legal
-- recommendations
+- contract-negotiation
+- legal-recommendations
+- redline-drafting
+- risk-mitigation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/general-legal-assistant/agents/legal-risks.md
+++ b/plugins/business-tools/general-legal-assistant/agents/legal-risks.md
@@ -1,25 +1,17 @@
 ---
 name: legal-risks
-description: Score every contract clause for legal and financial risk on a 1-10 scale
+description: "Scores every contract clause for legal and financial risk using a 4-factor weighted methodology, detects poison pills, and issues a SIGN/NEGOTIATE/ESCALATE/REJECT recommendation. Use when reviewing a contract before signing. Trigger with \"score this contract\", \"risk-check this agreement\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
 - legal
-- risks
+- contract-review
+- risk-scoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/openbb-terminal/agents/crypto-analyst.md
+++ b/plugins/business-tools/openbb-terminal/agents/crypto-analyst.md
@@ -1,25 +1,18 @@
 ---
 name: crypto-analyst
-description: Expert cryptocurrency analyst specializing in on-chain analysis, tokenomics,...
+description: Delivers on-chain metrics, tokenomics evaluation, and DeFi protocol analysis to produce ACCUMULATE/HOLD/REDUCE ratings with position sizing guidance. Use when researching a crypto asset or DeFi protocol. Trigger with "analyze this token", "crypto thesis for X".
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
 - crypto
-- analyst
+- on-chain-analysis
+- defi
+- investment-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/openbb-terminal/agents/equity-analyst.md
+++ b/plugins/business-tools/openbb-terminal/agents/equity-analyst.md
@@ -1,25 +1,18 @@
 ---
 name: equity-analyst
-description: Expert equity analyst specializing in stock analysis, valuation, financial...
+description: Produces institutional-quality equity research using fundamental analysis, DCF valuation, and technical analysis to issue Buy/Hold/Sell ratings with price targets. Use when analyzing a stock or building an investment thesis. Trigger with "analyze this stock", "equity research on X".
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
 - equity
-- analyst
+- stock-analysis
+- valuation
+- investment-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/openbb-terminal/agents/macro-economist.md
+++ b/plugins/business-tools/openbb-terminal/agents/macro-economist.md
@@ -1,25 +1,18 @@
 ---
 name: macro-economist
-description: Expert macroeconomist specializing in economic analysis, central bank...
+description: Translates macroeconomic data (GDP, CPI, Fed policy, yield curve) into asset-class positioning and sector rotation recommendations across business cycle phases. Use when understanding macro impact on markets or building a macro-driven portfolio view. Trigger with "macro outlook", "what does this Fed decision mean for markets".
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- macro
-- economist
+- macroeconomics
+- monetary-policy
+- asset-allocation
+- investment-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/business-tools/openbb-terminal/agents/portfolio-manager.md
+++ b/plugins/business-tools/openbb-terminal/agents/portfolio-manager.md
@@ -1,25 +1,18 @@
 ---
 name: portfolio-manager
-description: Expert portfolio manager specializing in asset allocation, risk management,...
+description: Applies Modern Portfolio Theory to construct and rebalance portfolios, calculate Sharpe/Sortino ratios, size positions via Kelly Criterion, and flag concentration or volatility threshold breaches. Use when reviewing a portfolio or planning an asset allocation. Trigger with "review my portfolio", "optimize asset allocation".
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- business-tools
-- portfolio
-- manager
+- portfolio-management
+- asset-allocation
+- risk-management
+- investment-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/contributing-clanker/skills/contribute/agents/draft-writer.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/draft-writer.md
@@ -1,15 +1,15 @@
 ---
 name: draft-writer
-description: Use this agent to draft a Design Issue body (preferred) or PR description from a working branch's diff. Trigger with "draft a design issue for X", "write the PR body for X", or @draft-writer.
+description: Drafts Design Issue bodies or PR descriptions from a working branch diff, writes them to the candidate file, and pre-fills required gate sections. Use when preparing an OSS contribution for submission. Trigger with "draft a design issue for X", "write the PR body for X".
 tools: Bash, Read
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- draft
-- writer
+- oss-contribution
+- pr-drafting
+- contributing-clanker
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/contributing-clanker/skills/contribute/agents/repo-analyzer.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/repo-analyzer.md
@@ -1,15 +1,15 @@
 ---
 name: repo-analyzer
-description: Use this agent for one-shot repo eligibility checks (CLA / activity / competing PRs / CONTRIBUTING.md). DEPRECATED — most function moved to @researcher dossiers.
+description: Runs one-shot repo eligibility checks — CLA status, maintainer activity, competing PRs, and CONTRIBUTING.md — and issues a claim/wait/skip verdict. Use when quickly qualifying a repo before committing research time. Trigger with "should I claim X", "qualify this issue".
 tools: Bash, Read
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- repo
-- analyzer
+- oss-contribution
+- repo-eligibility
+- contributing-clanker
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/contributing-clanker/skills/contribute/agents/researcher.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/researcher.md
@@ -1,14 +1,16 @@
 ---
 name: researcher
-description: Use this agent when building or refreshing per-repo dossiers (CLA/DCO, branch convention, AI policy, review bots, pet peeves). Trigger with "build/refresh dossier for X" or @researcher.
+description: Builds and refreshes per-repo dossiers capturing CLA/DCO requirements, branch conventions, AI disclosure policy, review bots, and maintainer pet peeves as the gate system's source of truth. Use when starting work on a new repo or when a dossier is stale. Trigger with "build dossier for X", "refresh dossier for X".
 tools: Bash, Read, Write, Edit, Glob, Grep
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- researcher
+- oss-contribution
+- repo-research
+- dossier
+- contributing-clanker
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/contributing-clanker/skills/contribute/agents/scout.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/scout.md
@@ -1,14 +1,15 @@
 ---
 name: scout
-description: Use this agent when discovering OSS contribution candidates ranked by star-tier brackets. Three modes — baseline, refresh, ad-hoc. Trigger with "scout for X", "find me a repo", or @scout.
-tools: Bash, Read, Write, Edit, Glob, Grep
+description: Discovers and scores OSS contribution candidates by star-tier bracket using gh search, applying profile-driven filters for language, CLA tolerance, and competition density. Use when finding new repos to contribute to or refreshing the candidate pipeline. Trigger with "scout for X", "find me a repo to contribute to".
+tools: Bash, Read, Write
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- scout
+- oss-contribution
+- candidate-discovery
+- contributing-clanker
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/contributing-clanker/skills/contribute/agents/test-runner.md
+++ b/plugins/community/contributing-clanker/skills/contribute/agents/test-runner.md
@@ -1,15 +1,15 @@
 ---
 name: test-runner
-description: Use this agent to run an upstream repo's native test suite (pnpm/yarn/npm/pytest/cargo/sbt/composer/bundle), log to ~/.contribute-system/test-logs/. Trigger with "run tests for X" or @test-runner.
+description: Runs an upstream repo's native test suite using auto-detected stack conventions (pnpm/yarn/npm/pytest/cargo/sbt/composer/bundle) and logs structured output for gate consumption. Use when verifying a contribution locally before submitting. Trigger with "run tests for X", "verify before PR".
 tools: Bash, Read
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- test
-- runner
+- oss-contribution
+- test-execution
+- contributing-clanker
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/fairdb-ops-manager/agents/fairdb-incident-responder.md
+++ b/plugins/community/fairdb-ops-manager/agents/fairdb-incident-responder.md
@@ -1,26 +1,19 @@
 ---
 name: fairdb-incident-responder
-description: Autonomous incident response agent for FairDB database emergencies
+description: Triages and resolves FairDB PostgreSQL production incidents using a P0–P3 severity protocol — diagnosing disk, connection, and performance failures, then generating incident reports and stakeholder communications. Use when a FairDB database is down or degraded. Trigger with "database is down", "FairDB incident".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
+- postgresql
+- incident-response
+- database-ops
 - fairdb
-- incident
-- responder
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/fairdb-ops-manager/agents/fairdb-ops-auditor.md
+++ b/plugins/community/fairdb-ops-manager/agents/fairdb-ops-auditor.md
@@ -1,26 +1,19 @@
 ---
 name: fairdb-ops-auditor
-description: Operations compliance auditor - verify FairDB server meets all SOP requirements
+description: Audits FairDB VPS instances at three depth levels against SOP-001 (security), SOP-002 (PostgreSQL config), and SOP-003 (backup integrity), producing a scored compliance report with remediation steps. Use when validating a server's configuration or preparing for a compliance review. Trigger with "audit this FairDB server", "run a compliance check".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
+- postgresql
+- compliance-audit
+- database-ops
 - fairdb
-- ops
-- auditor
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/fairdb-ops-manager/agents/fairdb-setup-wizard.md
+++ b/plugins/community/fairdb-ops-manager/agents/fairdb-setup-wizard.md
@@ -1,26 +1,19 @@
 ---
 name: fairdb-setup-wizard
-description: Guided setup wizard for complete FairDB VPS configuration from scratch
+description: Guides users step-by-step through three-phase FairDB provisioning — VPS hardening, PostgreSQL 16 installation, and pgBackRest backup configuration — on a fresh Ubuntu 24.04 VPS. Use when setting up a new FairDB server from scratch. Trigger with "set up FairDB", "provision a new database server".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
+- postgresql
+- vps-setup
+- database-ops
 - fairdb
-- setup
-- wizard
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/conductor_geepers.md
+++ b/plugins/community/geepers-agents/agents/conductor_geepers.md
@@ -1,25 +1,19 @@
 ---
 name: conductor-geepers
-description: Master orchestrator for coordinating geepers_* agents. Use this when you ne...
+description: Orchestrates the full geepers_* agent fleet — routing requests to the correct topic orchestrator or individual specialist, logging dispatch decisions, and synthesizing cross-agent results. Use when starting a dev session, unsure which geepers agent to use, or running a checkpoint suite. Trigger with "start my session", "coordinate the geepers agents".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- conductor
 - geepers
+- orchestration
+- multi-agent
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_a11y.md
+++ b/plugins/community/geepers-agents/agents/geepers_a11y.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-a11y
-description: Agent for accessibility audits, WCAG compliance review, assistive technol...
+description: Audits UI code for WCAG 2.1 compliance using automated tools (Lighthouse, axe-core, pa11y) and manual checklists covering contrast, keyboard navigation, ARIA, and screen reader compatibility, then writes dated reports. Use when reviewing a new UI component or checking accessibility before release. Trigger with "check accessibility", "a11y audit for X".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - geepers
-- a11y
+- accessibility
+- wcag
+- ui-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_api.md
+++ b/plugins/community/geepers-agents/agents/geepers_api.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-api
-description: Agent for API design review, REST compliance auditing, endpoint documenta...
+description: "Reviews APIs for REST compliance, naming consistency, OpenAPI coverage, and security posture. Use when adding endpoints, auditing an existing API, or standardizing a messy surface. Trigger with \"audit the API\", \"review endpoint design\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- api
+- api-design
+- rest-compliance
+- openapi
+- security-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_business_plan.md
+++ b/plugins/community/geepers-agents/agents/geepers_business_plan.md
@@ -1,26 +1,20 @@
 ---
 name: geepers-business-plan
-description: Business plan generator that creates comprehensive business models, market ...
+description: Transforms a product idea into a full business plan covering market analysis, competitive landscape, business model, GTM strategy, and financial projections. Use when validating a new idea or preparing investor documentation. Trigger with "create a business plan", "analyze market opportunity".
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
+- WebFetch
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- business
-- plan
+- business-plan
+- market-analysis
+- go-to-market
+- product-strategy
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_caddy.md
+++ b/plugins/community/geepers-agents/agents/geepers_caddy.md
@@ -1,25 +1,22 @@
 ---
 name: geepers-caddy
-description: Agent for ALL Caddy configuration changes, port allocation, and routing setup
+description: Sole authority for Caddy configuration changes — adds routes, manages port allocation, validates before reload, and creates backups. Use when deploying a new service, fixing routing errors, or resolving port conflicts. Trigger with "add a Caddy route", "fix 502 on this path".
 tools:
 - Read
-- Write
 - Edit
+- Write
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - caddy
+- reverse-proxy
+- port-management
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_canary.md
+++ b/plugins/community/geepers-agents/agents/geepers_canary.md
@@ -1,25 +1,18 @@
 ---
 name: geepers-canary
-description: Early warning system that spot-checks fragile and critical systems. Like a ...
+description: Fast early-warning health checker that pings critical services, checks disk/memory, and produces an all-clear or alert report in under 60 seconds. Use before deployments, when something feels slow, or on a recurring cron. Trigger with "run canary check", "spot-check the services".
 tools:
-- Read
-- Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: haiku
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- canary
+- health-check
+- monitoring
+- infrastructure
+- observability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_citations.md
+++ b/plugins/community/geepers-agents/agents/geepers_citations.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-citations
-description: Data validation and citation checker. Use when verifying data accuracy, che...
+description: Verifies citations and data claims by checking URL accessibility, DOI resolution, source authority, and formatting style consistency across APA, MLA, and Chicago. Use when validating academic content or auditing reference accuracy. Trigger with "check citations", "verify data sources".
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
+- Grep
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- citations
+- citation-validation
+- fact-checking
+- academic
+- data-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_code_checker.md
+++ b/plugins/community/geepers-agents/agents/geepers_code_checker.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-code-checker
-description: Multi-model code validation agent that checks code for errors using multipl...
+description: Validates code across syntax, logic, security, performance, and accessibility dimensions using multi-model synthesis, then produces a prioritized report with corrected snippets. Use after code generation or before production hand-off. Trigger with "check this code for errors", "validate the generated code".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- code
-- checker
+- code-review
+- security-scanning
+- quality-assurance
+- static-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_corpus.md
+++ b/plugins/community/geepers-agents/agents/geepers_corpus.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-corpus
-description: Agent for corpus linguistics projects, language dataset management, compu...
+description: Manages corpus linguistics datasets — acquisition, annotation, data-structure validation, and UTF-8 encoding hygiene across reference, historical, and web corpora. Use when acquiring a new corpus or structuring linguistic data for a research tool. Trigger with "set up the corpus", "validate this linguistic dataset".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- corpus
+- corpus-linguistics
+- nlp
+- dataset-management
+- language-data
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_corpus_ux.md
+++ b/plugins/community/geepers-agents/agents/geepers_corpus_ux.md
@@ -1,26 +1,20 @@
 ---
 name: geepers-corpus-ux
-description: Agent for corpus linguistics UI/UX design - KWIC displays, concordance vi...
+description: Designs linguistically-informed interfaces for corpus research tools — KWIC displays, concordance viewers, frequency charts, and genre filters following Swiss Design principles. Use when building or improving a UI for a corpus or NLP tool. Trigger with "design the concordance viewer", "improve the KWIC display".
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- corpus
-- ux
+- corpus-linguistics
+- ux-design
+- data-visualization
+- academic-tools
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_critic.md
+++ b/plugins/community/geepers-agents/agents/geepers_critic.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-critic
-description: UX and architecture critic that generates CRITIC.md documenting annoying de...
+description: Generates a CRITIC.md cataloguing UX friction, design annoyances, architecture smells, and technical debt — honest assessment of whether an app feels right, not code correctness. Use when a product feels off or before a refactor sprint. Trigger with "critique this app's UX", "audit the architecture".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Bash
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- critic
+- ux-review
+- architecture-audit
+- technical-debt
+- design-critique
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_dashboard.md
+++ b/plugins/community/geepers-agents/agents/geepers_dashboard.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-dashboard
-description: Agent for dashboard synchronization, service persistence configuration, a...
+description: Synchronizes admin dashboards, registers new services for persistence via service_manager.py, and verifies all dashboards reflect accurate system state after reboots. Use when adding a new service or verifying the system after a restart. Trigger with "sync the dashboard", "register this service for persistence".
 tools:
 - Read
 - Write
 - Edit
 - Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - dashboard
+- service-management
+- persistence
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_data.md
+++ b/plugins/community/geepers-agents/agents/geepers_data.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-data
-description: Agent for data quality auditing, validation, enrichment, and freshness mo...
+description: Audits datasets across five quality dimensions — accuracy, completeness, consistency, timeliness, and schema validity — and flags stale or malformed records against authoritative sources. Use when updating a dataset or when data feels outdated. Trigger with "audit this dataset", "check data freshness".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- data
+- data-quality
+- data-validation
+- enrichment
+- freshness-monitoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_db.md
+++ b/plugins/community/geepers-agents/agents/geepers_db.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-db
-description: Agent for database optimization, query analysis, index recommendations, a...
+description: Analyzes query plans, recommends indexes, and diagnoses N+1 patterns, lock contention, and missing pagination for SQLite and PostgreSQL databases. Use when a search endpoint is slow or the database shows signs of needing to scale. Trigger with "analyze slow queries", "optimize the database".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- db
+- database
+- query-optimization
+- indexing
+- performance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_deps.md
+++ b/plugins/community/geepers-agents/agents/geepers_deps.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-deps
-description: Agent for dependency audits, security vulnerability scanning, license com...
+description: Audits project dependencies for CVEs, outdated packages, and license compatibility using pip-audit, npm audit, and pip-licenses/license-checker. Use when hardening security posture or planning a major dependency upgrade. Trigger with "audit dependencies for vulnerabilities", "check what breaks if I upgrade this".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- deps
+- dependency-audit
+- security
+- license-compliance
+- supply-chain
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_design.md
+++ b/plugins/community/geepers-agents/agents/geepers_design.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-design
-description: Agent for visual design systems, typography, layout geometry, color palet...
+description: Applies Swiss/International Style principles — grid systems, typographic scales, 8px spacing, and WCAG AA contrast — to create clean, functional interface designs and design system recommendations. Use when building a new component or auditing a page's visual consistency. Trigger with "review the design system", "design this component".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- design
+- design-system
+- typography
+- visual-design
+- ui-components
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_diag.md
+++ b/plugins/community/geepers-agents/agents/geepers_diag.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-diag
-description: Agent for system diagnostics, error pattern detection, log analysis, and ...
+description: Performs root-cause analysis on failing services by mining logs, monitoring resource usage, correlating event timelines, and identifying patterns like OOM, connection failures, or CPU saturation. Use when a service crashes repeatedly or a health check fails. Trigger with "diagnose this crash", "find the root cause".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- diag
+- diagnostics
+- log-analysis
+- root-cause-analysis
+- system-health
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_docs.md
+++ b/plugins/community/geepers-agents/agents/geepers_docs.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-docs
-description: Documentation generator that creates user-friendly manuals, README files, a...
+description: "Generates README files, setup guides, API docs, and dependency guides from existing code. Use when a project needs end-user documentation or a fresh dev needs setup instructions. Trigger with \"document this project\", \"write the README\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: haiku
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- docs
+- documentation
+- readme
+- code-analysis
+- technical-writing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_flask.md
+++ b/plugins/community/geepers-agents/agents/geepers_flask.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-flask
-description: Flask application specialist. Use when building, reviewing, or debugging Fl...
+description: "Flask specialist for building, reviewing, and debugging Flask apps — blueprints, app factory, extensions, error handling, deployment. Use when creating a Flask API or diagnosing Flask-specific issues. Trigger with \"build a Flask app\", \"debug my Flask routes\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - flask
+- python
+- web-framework
+- api-development
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_fullstack_dev.md
+++ b/plugins/community/geepers-agents/agents/geepers_fullstack_dev.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-fullstack-dev
-description: Full-stack development agent that generates complete, working code from PRD...
+description: "Generates complete, production-ready full-stack applications (Flask/FastAPI backend, React/vanilla JS frontend, DB schema, tests, Docker) from a PRD or spec. Use when requirements are ready and you need working code. Trigger with \"build this app\", \"implement the PRD\"."
 tools:
 - Read
 - Write
@@ -8,19 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - fullstack
-- dev
+- code-generation
+- flask
+- react
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_game.md
+++ b/plugins/community/geepers-agents/agents/geepers_game.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-game
-description: Agent for gamification design - reward systems, engagement loops, progres...
+description: "Applies game-design principles to non-game apps — XP systems, streaks, leaderboards, achievement badges, and feedback loops. Use when a product needs higher engagement or motivation mechanics. Trigger with \"add gamification\", \"make this more engaging\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- game
+- gamification
+- engagement
+- ux-design
+- reward-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_gamedev.md
+++ b/plugins/community/geepers-agents/agents/geepers_gamedev.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-gamedev
-description: Agent for video game development expertise - gameplay mechanics, level de...
+description: "Video game design expert covering core loops, difficulty curves, player psychology, genre-specific patterns (platformers, roguelikes, strategy), and game feel. Use when designing a new game or improving player retention. Trigger with \"design the game loop\", \"my game feels bad\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- gamedev
+- game-development
+- game-design
+- player-experience
+- interactive-entertainment
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_godot.md
+++ b/plugins/community/geepers-agents/agents/geepers_godot.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-godot
-description: Agent for Godot Engine development - GDScript, scene architecture, node p...
+description: "Godot Engine 4.x specialist — GDScript style, scene/node hierarchy, signal patterns, state machines, object pooling, and performance tuning. Use when building or debugging a Godot project. Trigger with \"help with my Godot game\", \"design this Godot scene\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - godot
+- gdscript
+- game-engine
+- game-development
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_intern_pool.md
+++ b/plugins/community/geepers-agents/agents/geepers_intern_pool.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-intern-pool
-description: Cost-effective multi-model code generation agent. Uses a pool of smaller/ch...
+description: "Cost-optimized code generator using tiered model routing — cheap models for boilerplate, mid-tier for logic, high-tier only for security-critical paths. Use when generating bulk code on a budget. Trigger with \"generate code cheaply\", \"draft the implementation\"."
 tools:
 - Read
 - Write
@@ -8,19 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: haiku
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- intern
-- pool
+- code-generation
+- cost-optimization
+- multi-model
+- scaffolding
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_janitor.md
+++ b/plugins/community/geepers-agents/agents/geepers_janitor.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-janitor
-description: Aggressive cleanup and maintenance agent. Use when projects have accumulate...
+description: "Hunts and eliminates project cruft — auto-removes cache/build artifacts, archives unused files with a manifest, flags dead code and stale dependencies. Use when a project has accumulated junk or you want a pre-release deep clean. Trigger with \"clean up this project\", \"run the janitor\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- janitor
+- cleanup
+- maintenance
+- dead-code
+- project-hygiene
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_links.md
+++ b/plugins/community/geepers-agents/agents/geepers_links.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-links
-description: Agent for link validation, broken link detection, URL enrichment, and res...
+description: "Validates URLs, detects broken links, updates redirects to final destinations, and enriches resource collections with accurate descriptions. Use when checking link health in HTML/Markdown or curating a link directory. Trigger with \"check the links\", \"fix broken URLs\"."
 tools:
 - Read
 - Write
@@ -9,17 +9,15 @@ tools:
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- links
+- link-validation
+- url-hygiene
+- content-quality
+- broken-links
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_checkpoint.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_checkpoint.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-checkpoint
-description: Checkpoint orchestrator that coordinates session maintenance agents - scout...
+description: "Coordinates the session-end hygiene suite — scout, repo cleanup, status logging, and snippet harvesting — to leave a codebase clean and documented between sessions. Use when wrapping up a session or reaching a milestone. Trigger with \"checkpoint\", \"I'm done for today\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- checkpoint
+- orchestration
+- session-management
+- project-hygiene
+- maintenance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_corpus.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_corpus.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-corpus
-description: Corpus orchestrator that coordinates linguistics agents - corpus, corpus_ux...
+description: "Coordinates corpus linguistics agents (linguistics expert, KWIC/concordance UI, database performance) for building and optimizing language corpus tools. Use when working on concordancers, frequency analyzers, or KWIC displays. Trigger with \"build a corpus feature\", \"optimize corpus queries\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- corpus
+- orchestration
+- corpus-linguistics
+- nlp
+- concordance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_deploy.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_deploy.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-deploy
-description: Deployment orchestrator that coordinates infrastructure agents - validator,...
+description: "Orchestrates safe service deployments by sequencing pre-validation, Caddy route configuration, service lifecycle management, and post-deploy health checks with rollback on failure. Use when deploying a new service or changing infrastructure routing. Trigger with \"deploy this service\", \"add a Caddy route\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- deploy
+- orchestration
+- deployment
+- infrastructure
+- caddy
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_fullstack.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_fullstack.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-fullstack
-description: Full-stack engineering orchestrator that coordinates backend-to-frontend de...
+description: "Coordinates the full engineering team (API design, database, React frontend, accessibility, deployment) to deliver cohesive backend-to-frontend features with enforced layer contracts. Use when building a feature that spans database, API, and UI. Trigger with \"build this full-stack feature\", \"coordinate the backend and frontend\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
+- orchestration
 - fullstack
+- api-design
+- frontend-backend
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_games.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_games.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-games
-description: Games orchestrator that coordinates game development agents - gamedev, game...
+description: "Coordinates game development agents (design, gamification, React/web or Godot implementation) to build or enhance interactive games and gamification features. Use when creating a new game or adding achievement systems to an app. Trigger with \"build a game\", \"add gamification to this app\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- games
+- orchestration
+- game-development
+- gamification
+- interactive-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_product.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_product.md
@@ -1,15 +1,12 @@
 ---
 name: geepers-orchestrator-product
-description: Product development orchestrator that coordinates agents for complete produ...
+description: "Runs the full product pipeline from raw idea to validated code — business plan, PRD, full-stack or cost-optimized code generation, and final code review. Use when taking an idea through to a working implementation. Trigger with \"build this product idea\", \"take this from idea to code\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -17,10 +14,10 @@ color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- product
+- orchestration
+- product-development
+- idea-to-code
+- pipeline
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_python.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_python.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-orchestrator-python
-description: Python project orchestrator that coordinates agents for Python development ...
+description: "Coordinates specialized sub-agents to audit, build, or refactor Python projects (Flask apps, CLI tools, libraries, scripts). Use when starting or reviewing a Python codebase and needing end-to-end coverage. Trigger with \"audit this Python project\", \"build a Python tool\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
+- Write
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
 - python
+- orchestration
+- code-review
+- project-structure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_quality.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_quality.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-orchestrator-quality
-description: Quality orchestrator that coordinates audit agents - a11y, perf, api, and d...
+description: "Coordinates accessibility, performance, API design, and dependency audit agents in parallel to produce a scored quality report. Use when running a pre-release gate or investigating multi-domain quality issues. Trigger with \"run a quality audit\", \"check this app for quality issues\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
+- Write
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- quality
+- quality-assurance
+- orchestration
+- accessibility
+- performance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_research.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_research.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-orchestrator-research
-description: Research orchestrator that coordinates data gathering agents in swarm-style...
+description: "Coordinates swarm-style parallel data gathering across APIs, websites, and system sources, then aggregates findings into a structured research report. Use when pulling data from multiple sources or validating link collections. Trigger with \"gather data from these APIs\", \"research and synthesize this topic\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
 - research
+- orchestration
+- data-gathering
+- web-search
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_orchestrator_web.md
+++ b/plugins/community/geepers-agents/agents/geepers_orchestrator_web.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-orchestrator-web
-description: Web application orchestrator that coordinates agents for building and revie...
+description: "Coordinates backend (Flask/API/DB), frontend (React/design/a11y), and quality agents to build or audit full-stack web applications. Use when building a new web app end-to-end or running a comprehensive web audit. Trigger with \"build this web application\", \"audit my web app\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
-- TodoWrite
+- Write
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- orchestrator
-- web
+- web-development
+- orchestration
+- full-stack
+- flask
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_perf.md
+++ b/plugins/community/geepers-agents/agents/geepers_perf.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-perf
-description: Agent for performance profiling, bottleneck identification, resource anal...
+description: "Profiles applications, identifies bottlenecks (DB, I/O, memory, CPU), and produces optimization recommendations with benchmarked metrics. Use when an app is slow, traffic is scaling, or you need a pre-release performance baseline. Trigger with \"profile this service\", \"find performance bottlenecks\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- perf
+- performance
+- profiling
+- bottleneck-analysis
+- optimization
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_prd.md
+++ b/plugins/community/geepers-agents/agents/geepers_prd.md
@@ -1,25 +1,19 @@
 ---
 name: geepers-prd
-description: Product Requirements Document generator that creates detailed PRDs based on...
+description: "Transforms ideas and business plans into detailed PRDs with user personas, prioritized user stories, functional requirements, and acceptance criteria developers can build from. Use when starting a new product or feature and needing structured technical requirements. Trigger with \"write a PRD for this\", \"turn this idea into requirements\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- prd
+- product-requirements
+- documentation
+- user-stories
+- planning
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_pycli.md
+++ b/plugins/community/geepers-agents/agents/geepers_pycli.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-pycli
-description: Python CLI tool specialist. Use when building command-line applications wit...
+description: "Designs and implements Python CLI tools using Click, Typer, or argparse — covering argument parsing, output formatting, exit codes, shell completion, and PyPI packaging. Use when building or improving a command-line application in Python. Trigger with \"build a Python CLI tool\", \"improve this CLI UX\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- pycli
+- python
+- cli
+- click
+- developer-tools
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_react.md
+++ b/plugins/community/geepers-agents/agents/geepers_react.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-react
-description: Agent for React development expertise - component architecture, hooks, st...
+description: "Implements and reviews React components using modern hooks, state management, and performance patterns (memoization, virtualization, code splitting) with TypeScript. Use when architecting components, debugging re-renders, or choosing a state strategy. Trigger with \"build this React component\", \"review my React code\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
 - react
+- frontend
+- typescript
+- component-architecture
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_repo.md
+++ b/plugins/community/geepers-agents/agents/geepers_repo.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-repo
-description: Agent for git hygiene, repository cleanup, and commit organization
+description: "Cleans up repositories by auditing git state, fixing .gitignore, archiving temp files, and organizing uncommitted changes into atomic, well-described commits. Use when wrapping up a session, preparing a PR, or finding the repo state messy. Trigger with \"clean up this repo\", \"organize my uncommitted changes\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- repo
+- git
+- repo-hygiene
+- commit-organization
+- cleanup
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_scalpel.md
+++ b/plugins/community/geepers-agents/agents/geepers_scalpel.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-scalpel
-description: Agent for precise, surgical code modifications in complex or large files
+description: "Makes minimal, surgical edits to complex or large files with zero collateral damage — mapping dependencies, preserving invariants, and verifying syntax after each atomic change. Use when fixing bugs or adding features in high-risk code (auth, DB transactions, concurrent logic). Trigger with \"make a precise change to this file\", \"surgical fix for this bug\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- scalpel
+- code-editing
+- surgical-precision
+- refactoring
+- bug-fix
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_scout.md
+++ b/plugins/community/geepers-agents/agents/geepers_scout.md
@@ -1,6 +1,6 @@
 ---
 name: geepers-scout
-description: Agent for project reconnaissance, quick fixes, and generating improvement...
+description: "Systematically scans a project for issues, applies safe non-breaking quick fixes (typos, whitespace, unused imports), and generates a prioritized improvement report with HTML output. Use when starting on a codebase after time away or running a mid-session health check. Trigger with \"scout this project\", \"scan for quick wins\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- scout
+- code-review
+- reconnaissance
+- quick-fix
+- code-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_services.md
+++ b/plugins/community/geepers-agents/agents/geepers_services.md
@@ -1,25 +1,19 @@
 ---
 name: geepers-services
-description: Agent for service lifecycle management - starting, stopping, restarting s...
+description: "Manages Linux service lifecycle (start, stop, restart, health check, crash investigation) via systemd and the sm service manager, delegating all routing changes to geepers_caddy. Use when a service is down, crashing, or needs deployment. Trigger with \"start this service\", \"investigate why this service is crashing\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- services
+- service-management
+- linux
+- systemd
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_snippets.md
+++ b/plugins/community/geepers-agents/agents/geepers_snippets.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-snippets
-description: Use this agent to harvest reusable code patterns, maintain the snippet libr...
+description: "Harvests reusable code patterns from projects into a categorized snippet library, deduplicates existing entries, and updates the searchable JSON index and HTML GUI. Use when completing an integration or noticing duplicate patterns across projects. Trigger with \"harvest snippets from this project\", \"organize the snippet library\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- snippets
+- snippet-library
+- code-reuse
+- pattern-extraction
+- knowledge-management
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_status.md
+++ b/plugins/community/geepers-agents/agents/geepers_status.md
@@ -1,25 +1,20 @@
 ---
 name: geepers-status
-description: Use this agent to log work accomplishments and maintain the project status ...
+description: "Logs work accomplishments by analyzing git commits and agent reports, then regenerates the HTML status dashboard and JSON data file with cross-project activity tracking. Use when ending a work session or checking recent progress across projects. Trigger with \"log today's work\", \"update the status dashboard\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- status
+- status-tracking
+- work-logging
+- dashboard
+- productivity
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_swarm_research.md
+++ b/plugins/community/geepers-agents/agents/geepers_swarm_research.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-swarm-research
-description: Multi-tier research agent that scales from quick queries to comprehensive m...
+description: "Scales research depth from Quick (3-5 sources) to Swarm (10-20 multi-domain) to Hive (25+ via 5 decomposed sub-investigations), saving APA-cited reports. Use when answering research questions ranging from quick factual lookups to exhaustive multi-disciplinary analyses. Trigger with \"research this topic\", \"do a deep dive on this\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
 - Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- swarm
 - research
+- web-search
+- multi-agent
+- knowledge-synthesis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_system_diag.md
+++ b/plugins/community/geepers-agents/agents/geepers_system_diag.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-system-diag
-description: Comprehensive dr.eamer.dev system diagnostic. Checks all services, Caddy ro...
+description: "Full-depth infrastructure health check for dr.eamer.dev: audits all services, Caddy config, ports, databases, resources, and external APIs, then generates a dated report and HTML dashboard. Use when something feels wrong or before major changes. Trigger with \"run system diagnostic\", \"full infrastructure audit\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- system
-- diag
+- system-diagnostics
+- infrastructure-health
+- server-monitoring
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_system_help.md
+++ b/plugins/community/geepers-agents/agents/geepers_system_help.md
@@ -1,26 +1,18 @@
 ---
 name: geepers-system-help
-description: Reference guide for all geepers agents. Use when unsure which agent to use,...
+description: Reference guide for the complete geepers agent suite — maps every agent to its purpose and generates an HTML index. Use when unsure which agent to use or to regenerate documentation. Trigger with "which geepers agent", "show me all agents".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: haiku
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- system
-- help
+- agent-discovery
+- documentation
+- developer-onboarding
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_system_onboard.md
+++ b/plugins/community/geepers-agents/agents/geepers_system_onboard.md
@@ -1,26 +1,21 @@
 ---
 name: geepers-system-onboard
-description: Project understanding agent for getting up to speed on unfamiliar codebases...
+description: Reads an unfamiliar codebase and produces a structured ONBOARD.md covering purpose, stack, architecture, data flow, and key files. Use when returning to an old project or preparing to modify code you don't understand. Trigger with "onboard me to this project", "explain this codebase".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- system
-- onboard
+- codebase-understanding
+- developer-onboarding
+- documentation
+- architecture
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/geepers-agents/agents/geepers_validator.md
+++ b/plugins/community/geepers-agents/agents/geepers_validator.md
@@ -1,25 +1,21 @@
 ---
 name: geepers-validator
-description: Agent for comprehensive project validation - checking configurations, pat...
+description: Validates all aspects of a project before deployment — config files, paths, permissions, ports, service status, and cross-service integration — then produces a categorized report with actionable fixes. Use when preparing to deploy or debugging mysterious failures. Trigger with "validate project", "pre-deploy check".
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Write
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- geepers
-- validator
+- project-validation
+- pre-deploy
+- config-audit
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/jeremy-firestore/agents/firebase-operations-agent.md
+++ b/plugins/community/jeremy-firestore/agents/firebase-operations-agent.md
@@ -1,6 +1,6 @@
 ---
 name: firebase-operations-agent
-description: Expert Firestore operations agent for CRUD, queries, batch processing, and...
+description: Performs production-safe Firestore CRUD, batch writes, complex queries, transactions, and cost optimizations using the Firebase Admin SDK with full error handling. Use when reading, writing, or restructuring Firestore data. Trigger with "run Firestore operation", "batch update collection".
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
+- firestore
 - firebase
-- operations
+- database-operations
+- google-cloud
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/jeremy-firestore/agents/firestore-security-agent.md
+++ b/plugins/community/jeremy-firestore/agents/firestore-security-agent.md
@@ -1,6 +1,6 @@
 ---
 name: firestore-security-agent
-description: Expert Firestore security rules generation, validation, and A2A agent access...
+description: Generates and validates production-grade Firestore security rules for user auth, role-based access, A2A service accounts, and data validation patterns, with emulator-ready unit tests. Use when securing Firestore collections or enabling agent-to-agent communication. Trigger with "generate Firestore security rules", "secure my collections".
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - firestore
-- security
+- security-rules
+- firebase-auth
+- a2a-security
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/allpurpose-agent.md
+++ b/plugins/community/sprint/agents/allpurpose-agent.md
@@ -1,6 +1,6 @@
 ---
 name: allpurpose-agent
-description: General-purpose implementation agent. Adapts to any technology stack based...
+description: Implements code for any technology stack strictly from sprint spec files, then returns a structured IMPLEMENTATION REPORT with conformity status and deviations. Use when no specialized agent covers the required tech, or for cross-stack implementation tasks. Trigger with "implement sprint task", "build from specs".
 tools:
 - Read
 - Write
@@ -8,17 +8,14 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- allpurpose
+- implementation
+- polyglot
+- sprint-workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/cicd-agent.md
+++ b/plugins/community/sprint/agents/cicd-agent.md
@@ -1,6 +1,6 @@
 ---
 name: cicd-agent
-description: Set up and maintain CI/CD pipelines. Configure builds, tests, deployments,...
+description: Designs and maintains CI/CD pipelines (GitHub Actions, GitLab CI, CircleCI) including builds, tests, quality gates, secrets management, and deployment strategies, then reports conformity with sprint specs. Use when setting up or fixing CI/CD for a project. Trigger with "set up CI/CD", "fix pipeline".
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - cicd
+- pipeline
+- devops
+- automation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/nextjs-dev.md
+++ b/plugins/community/sprint/agents/nextjs-dev.md
@@ -1,6 +1,6 @@
 ---
 name: nextjs-dev
-description: Build Next.js 16 frontend. Server/Client Components, TypeScript,...
+description: Implements Next.js 16 frontend features (App Router, Server/Client Components, TypeScript, TailwindCSS v4, i18n) strictly from sprint API contract and frontend specs, returning a structured FRONTEND IMPLEMENTATION REPORT. Use when building or updating Next.js pages and components in a sprint. Trigger with "implement frontend sprint", "build Next.js feature".
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - nextjs
-- dev
+- react
+- typescript
+- frontend
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/nextjs-diagnostics-agent.md
+++ b/plugins/community/sprint/agents/nextjs-diagnostics-agent.md
@@ -1,25 +1,17 @@
 ---
 name: nextjs-diagnostics-agent
-description: (Optional, Next.js only) Monitor Next.js runtime errors and diagnostics...
+description: Monitors a running Next.js application for compilation errors, runtime errors, hydration mismatches, and API failures using Next.js DevTools MCP — runs in parallel with ui-test-agent. Use when testing a Next.js project and need server-side error visibility. Trigger with "monitor Next.js errors", "run Next.js diagnostics".
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - nextjs
-- diagnostics
+- runtime-diagnostics
+- error-monitoring
+- testing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/project-architect.md
+++ b/plugins/community/sprint/agents/project-architect.md
@@ -1,25 +1,21 @@
 ---
 name: project-architect
-description: Plan and coordinate sprints. Break down high-level goals into tasks for...
+description: Analyzes requirements, creates API contracts and sprint specs, coordinates implementation by issuing SPAWN REQUEST blocks to the orchestrator, and iterates through QA until finalization. Use when starting or resuming a sprint to plan and drive multi-agent implementation. Trigger with "start sprint", "plan this feature".
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- project
-- architect
+- sprint-orchestration
+- architecture
+- planning
+- multi-agent
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/python-dev.md
+++ b/plugins/community/sprint/agents/python-dev.md
@@ -1,6 +1,6 @@
 ---
 name: python-dev
-description: Build Python backend with FastAPI. Implement async patterns, APIs, database...
+description: Implements production-grade Python/FastAPI backends with async patterns, PostgreSQL/Alembic migrations, auth, and LLM integrations strictly from sprint API contract and backend specs, returning a BACKEND IMPLEMENTATION REPORT. Use when building or updating Python API services in a sprint. Trigger with "implement backend sprint", "build FastAPI endpoint".
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - python
-- dev
+- fastapi
+- backend
+- async
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/qa-test-agent.md
+++ b/plugins/community/sprint/agents/qa-test-agent.md
@@ -1,6 +1,6 @@
 ---
 name: qa-test-agent
-description: Maintain and run a coherent automated test suite. Validate features and API...
+description: Maintains and runs an automated API and unit test suite (pytest, Jest, Vitest) against the sprint API contract, reports coverage gaps and failures in a structured QA REPORT. Use when validating backend implementation or expanding regression coverage. Trigger with "run QA tests", "validate API contract".
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
 - qa
-- test
+- automated-testing
+- api-validation
+- sprint-workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/ui-test-agent.md
+++ b/plugins/community/sprint/agents/ui-test-agent.md
@@ -1,25 +1,17 @@
 ---
 name: ui-test-agent
-description: Automate critical UI testing using Chrome browser. Run smoke tests, happy...
+description: Automates end-to-end UI tests on a running frontend using Chrome browser MCP tools — executes smoke tests, happy paths, form validation, and CRUD flows, then returns a structured UI TEST REPORT. Use when validating a deployed frontend after implementation or running manual browser sessions. Trigger with "run UI tests", "test the frontend".
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- ui
-- test
+- ui-testing
+- e2e
+- browser-automation
+- sprint-workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/community/sprint/agents/website-designer.md
+++ b/plugins/community/sprint/agents/website-designer.md
@@ -1,25 +1,21 @@
 ---
 name: website-designer
-description: Design static marketing websites for GitHub Pages. Focus on SEO, conversion...
+description: Designs conversion-focused static marketing websites from sprint specs — applies SEO best practices, clear CTAs, mobile-first responsive layouts, and WCAG accessibility, then returns a concise IMPLEMENTATION REPORT. Use when building or redesigning a product landing page or GitHub Pages site. Trigger with "design website", "build landing page".
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: opus
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- community
-- website
-- designer
+- static-site
+- marketing
+- seo
+- web-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/crypto/cross-chain-bridge-monitor/agents/bridge-monitor-agent.md
+++ b/plugins/crypto/cross-chain-bridge-monitor/agents/bridge-monitor-agent.md
@@ -1,25 +1,19 @@
 ---
 name: bridge-monitor-agent
-description: Cross-chain bridge monitoring and security analysis specialist
+description: "Monitor cross-chain bridge activity, analyze security models, detect exploits, and compare route fees across Wormhole, Stargate, Hop, and canonical L2 bridges. Use when tracking a pending bridge transfer, assessing TVL risk, or investigating unusual bridge behavior. Trigger with \"monitor bridge\", \"analyze bridge security\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
 - Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- crypto
-- bridge
-- monitor
+- cross-chain
+- bridge-security
+- defi
+- exploit-detection
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/crypto/crypto-derivatives-tracker/agents/derivatives-agent.md
+++ b/plugins/crypto/crypto-derivatives-tracker/agents/derivatives-agent.md
@@ -1,24 +1,19 @@
 ---
 name: derivatives-agent
-description: Crypto derivatives specialist for futures, options, and perpetuals analysis
+description: "Track and analyze crypto derivatives markets — funding rates, open interest, liquidation heatmaps, implied volatility, and options flow across Binance, Bybit, Deribit, and DEX perps. Use when researching perpetual positioning, basis-trade opportunities, or options sentiment. Trigger with \"analyze derivatives\", \"funding rates\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- crypto
 - derivatives
+- perpetuals
+- options
+- funding-rates
+- defi
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/crypto/flash-loan-simulator/agents/flashloan-agent.md
+++ b/plugins/crypto/flash-loan-simulator/agents/flashloan-agent.md
@@ -1,24 +1,18 @@
 ---
 name: flashloan-agent
-description: Flash loan strategy simulator and DeFi protocol arbitrage specialist
+description: "Simulate flash loan strategies across Aave, dYdX, and Balancer — model DEX arbitrage, liquidation, and collateral-swap transactions with full fee, gas, and slippage breakdowns. Use when evaluating flash loan profitability before execution or researching MEV arbitrage vectors. Trigger with \"simulate flash loan\", \"flash loan arbitrage\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- crypto
-- flashloan
+- flash-loan
+- defi-arbitrage
+- mev
+- simulation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/crypto/mempool-analyzer/agents/mempool-agent.md
+++ b/plugins/crypto/mempool-analyzer/agents/mempool-agent.md
@@ -1,24 +1,18 @@
 ---
 name: mempool-agent
-description: Mempool analysis specialist for MEV detection and transaction monitoring
+description: "Analyze blockchain mempools for MEV opportunities, sandwich attack patterns, pending large transfers, and gas price optimization across Ethereum, BSC, and Arbitrum. Use when detecting front-running risk, profiling pending transactions, or researching block builder behavior. Trigger with \"analyze mempool\", \"detect MEV\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- crypto
 - mempool
+- mev
+- gas-optimization
+- blockchain-monitoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/crypto/token-launch-tracker/agents/launch-tracker-agent.md
+++ b/plugins/crypto/token-launch-tracker/agents/launch-tracker-agent.md
@@ -1,25 +1,18 @@
 ---
 name: launch-tracker-agent
-description: New token launch monitoring and rugpull detection specialist
+description: "Monitor new token launches on Ethereum, BSC, and Polygon — score rugpull risk by checking honeypot functions, liquidity lock status, ownership, mint capabilities, and social presence. Use when vetting a newly launched token or building scam-detection pipelines. Trigger with \"analyze new token\", \"rugpull check\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- crypto
-- launch
-- tracker
+- token-launch
+- rugpull-detection
+- smart-contract-security
+- defi
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/data-validation-engine/agents/validation-agent.md
+++ b/plugins/database/data-validation-engine/agents/validation-agent.md
@@ -1,24 +1,20 @@
 ---
 name: validation-agent
-description: Implement data validation rules
+description: "Implement comprehensive data validation at database and application layers — type, range, format, referential integrity, and custom business-rule checks. Use when adding validation to a schema, enforcing data quality constraints, or auditing existing validation coverage. Trigger with \"add data validation\", \"implement validation rules\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
+- data-validation
 - database
-- validation
+- data-quality
+- schema-enforcement
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/freshie-inventory-manager/agents/anomaly-detector.md
+++ b/plugins/database/freshie-inventory-manager/agents/anomaly-detector.md
@@ -1,25 +1,17 @@
 ---
 name: anomaly-detector
-description: Detect data quality issues, stubs, orphan plugins, and outliers in the freshie inventory database
+description: "Detect data quality issues, stubs, orphan plugins, duplicate files, and score outliers in the freshie inventory SQLite database using a structured six-check sweep. Use when auditing inventory health after a discovery run or investigating anomalous compliance grades. Trigger with \"scan for anomalies\", \"detect inventory issues\"."
 tools:
-- Read
-- Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
-- anomaly
-- detector
+- data-quality
+- anomaly-detection
+- inventory-management
+- sqlite
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/freshie-inventory-manager/agents/compliance-validator.md
+++ b/plugins/database/freshie-inventory-manager/agents/compliance-validator.md
@@ -1,25 +1,17 @@
 ---
 name: compliance-validator
-description: Run enterprise compliance validation against the freshie DB and produce grade summary with worst offenders
+description: "Run enterprise-tier skill compliance validation, populate the freshie SQLite database, and report grade distribution, average score, worst offenders, and B-grade upgrade candidates. Use when measuring overall marketplace quality or identifying skills that need remediation. Trigger with \"run compliance validation\", \"grade the inventory\"."
 tools:
-- Read
-- Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
 - compliance
-- validator
+- skill-validation
+- inventory-management
+- grading
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/freshie-inventory-manager/agents/discovery-scanner.md
+++ b/plugins/database/freshie-inventory-manager/agents/discovery-scanner.md
@@ -1,25 +1,17 @@
 ---
 name: discovery-scanner
-description: Run freshie discovery scans — full repo scan via rebuild-inventory.py with delta reporting against previous run
+description: "Run a full freshie ecosystem discovery scan via rebuild-inventory.py and report plugin, skill, and pack delta against the previous run stored in the SQLite inventory database. Use when refreshing the inventory after adding plugins or tracking ecosystem growth over time. Trigger with \"run discovery scan\", \"scan the inventory\"."
 tools:
-- Read
-- Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
 - discovery
-- scanner
+- inventory-management
+- plugin-ecosystem
+- sqlite
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/nosql-data-modeler/agents/nosql-agent.md
+++ b/plugins/database/nosql-data-modeler/agents/nosql-agent.md
@@ -1,24 +1,18 @@
 ---
 name: nosql-agent
-description: Design NoSQL data models
+description: "Design efficient NoSQL data models for MongoDB, DynamoDB, and Cassandra — applying embed-vs-reference, access-pattern-first, sharding key, and index strategies. Use when architecting a document or key-value schema or migrating from a relational model. Trigger with \"design NoSQL schema\", \"model for MongoDB\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
 - nosql
+- data-modeling
+- mongodb
+- schema-design
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/orm-code-generator/agents/orm-agent.md
+++ b/plugins/database/orm-code-generator/agents/orm-agent.md
@@ -1,24 +1,20 @@
 ---
 name: orm-agent
-description: Generate ORM models and schemas
+description: "Generate ORM entity classes, migration files, and relationship definitions for TypeORM, Prisma, SQLAlchemy, Django ORM, Hibernate, and more from database schemas or requirements. Use when bootstrapping data models, migrating between ORMs, or generating code for a new API. Trigger with \"generate ORM models\", \"create entity classes\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
 - orm
+- code-generation
+- database
+- schema-migration
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/database/query-performance-analyzer/agents/performance-agent.md
+++ b/plugins/database/query-performance-analyzer/agents/performance-agent.md
@@ -1,24 +1,19 @@
 ---
 name: performance-agent
-description: Analyze and optimize query performance
+description: "Interpret EXPLAIN plans and query execution metrics to identify bottlenecks — sequential scans, missing indexes, inefficient joins, N+1 patterns — and deliver specific index and rewrite recommendations with expected impact. Use when investigating slow queries or tuning a database under load. Trigger with \"analyze query performance\", \"review EXPLAIN plan\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- database
-- performance
+- query-optimization
+- database-performance
+- explain-plan
+- indexing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/devops/fairdb-operations-kit/agents/fairdb-automation-agent.md
+++ b/plugins/devops/fairdb-operations-kit/agents/fairdb-automation-agent.md
@@ -1,25 +1,19 @@
 ---
 name: fairdb-automation-agent
-description: Intelligent automation agent for FairDB PostgreSQL operations
+description: "Automate FairDB PostgreSQL-as-a-Service operations — proactive monitoring, incident response, customer onboarding, backup verification, query optimization, and capacity planning with a human-escalation decision framework. Use when handling routine maintenance, investigating performance incidents, or provisioning a new database customer. Trigger with \"fairdb operations\", \"run health check\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- devops
-- fairdb
+- postgresql
+- database-operations
 - automation
+- incident-response
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/devops/jeremy-github-actions-gcp/agents/gh-actions-gcp-expert.md
+++ b/plugins/devops/jeremy-github-actions-gcp/agents/gh-actions-gcp-expert.md
@@ -1,26 +1,22 @@
 ---
 name: gh-actions-gcp-expert
-description: Expert in GitHub Actions with Google Cloud deployments using Workload...
+description: "Author and validate GitHub Actions CI/CD pipelines for Google Cloud — covering Workload Identity Federation (keyless auth), Vertex AI Agent Engine deployment, Cloud Run, post-deployment validation scripts, and security best practices. Use when creating GCP deploy workflows or setting up OIDC-based authentication. Trigger with \"create GCP workflow\", \"set up Workload Identity Federation\"."
 tools:
 - Read
 - Write
 - Edit
 - Bash
-- Glob
-- Grep
 - WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- devops
-- gh
-- actions
+- github-actions
 - gcp
+- workload-identity-federation
+- ci-cd
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/devops/sugar/agents/quality-guardian.md
+++ b/plugins/devops/sugar/agents/quality-guardian.md
@@ -1,25 +1,19 @@
 ---
 name: quality-guardian
-description: Code quality, testing, and validation enforcement specialist
+description: "Enforce code quality, test coverage, security (OWASP Top 10), and documentation standards in Sugar's autonomous dev system — running linters, coverage tools, and security scanners then issuing PASS/CONDITIONAL/FAIL verdicts with actionable findings. Use when a task is marked done, a PR is created, or a manual quality gate is requested. Trigger with \"review code quality\", \"run quality check\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
-- Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- devops
-- quality
-- guardian
+- code-quality
+- testing
+- security-review
+- ci-enforcement
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/devops/sugar/agents/sugar-orchestrator.md
+++ b/plugins/devops/sugar/agents/sugar-orchestrator.md
@@ -1,15 +1,10 @@
 ---
 name: sugar-orchestrator
-description: Coordinates Sugar's autonomous development workflows with strategic oversight
+description: "Orchestrates Sugar's autonomous development pipeline: analyzes tasks, assigns specialized agents, monitors execution, and validates completion. Use when managing a complex multi-agent dev workflow. Trigger with \"orchestrate this task\", \"coordinate the agents\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
 - Task
 - TodoWrite
 model: sonnet
@@ -18,8 +13,9 @@ version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
 - devops
-- sugar
-- orchestrator
+- orchestration
+- multi-agent
+- workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/devops/sugar/agents/task-planner.md
+++ b/plugins/devops/sugar/agents/task-planner.md
@@ -1,16 +1,10 @@
 ---
 name: task-planner
-description: Strategic task planning and breakdown specialist for complex development work
+description: "Decomposes complex development requests into subtasks with effort estimates, dependency graphs, risk assessment, and SMART success criteria. Use when planning a feature, bug fix, or refactor sprint. Trigger with \"plan this feature\", \"break this down\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
 - TodoWrite
 model: sonnet
 color: red
@@ -18,8 +12,9 @@ version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
 - devops
-- task
-- planner
+- task-planning
+- estimation
+- risk-assessment
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/examples/security-agent/agents/security-reviewer.md
+++ b/plugins/examples/security-agent/agents/security-reviewer.md
@@ -1,25 +1,18 @@
 ---
 name: security-reviewer
-description: Security code review specialist
+description: Scans code for security vulnerabilities (OWASP Top 10, injection, auth flaws, insecure dependencies) and delivers severity-ranked findings with remediation guidance. Use when reviewing authentication logic, APIs, or any security-sensitive code. Trigger with "security review", "audit this code".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- examples
 - security
-- reviewer
+- code-review
+- vulnerability-detection
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/mcp/conversational-api-debugger/agents/api-expert.md
+++ b/plugins/mcp/conversational-api-debugger/agents/api-expert.md
@@ -1,24 +1,20 @@
 ---
 name: api-expert
-description: API debugging specialist - analyzes failures and suggests solutions
+description: Diagnoses REST API failures by comparing HTTP logs against OpenAPI specs, identifies root cause by status code category, and generates working cURL repro commands. Use when an API call returns unexpected errors or status codes. Trigger with "why is my API failing", "debug this API error".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- api
+- api-debugging
+- rest
+- http
+- openapi
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/mcp/project-health-auditor/agents/reviewer.md
+++ b/plugins/mcp/project-health-auditor/agents/reviewer.md
@@ -1,24 +1,20 @@
 ---
 name: reviewer
-description: Code health reviewer specialist - suggests high-impact refactors based on...
+description: Scores codebase health by combining cyclomatic complexity, git churn, and test coverage metrics, then ranks refactoring candidates by business impact. Use when prioritizing technical debt or planning a refactor sprint. Trigger with "analyze code health", "what should I refactor".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Bash
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- reviewer
+- code-quality
+- technical-debt
+- refactoring
+- metrics
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/mcp/x-bug-triage/agents/bug-clusterer.md
+++ b/plugins/mcp/x-bug-triage/agents/bug-clusterer.md
@@ -1,15 +1,16 @@
 ---
 name: bug-clusterer
-description: Parse, classify, redact PII, score reliability, and cluster bug candidates by family and signal layers. Use when processing raw X/Twitter posts into structured bug clusters.
+description: Normalizes raw X/Twitter posts into 33-field BugCandidates with PII redaction, reliability scoring, and deterministic clustering by bug family and signature. Use when processing a triage run's raw social posts into structured clusters. Trigger with "cluster these posts", "run bug clustering".
 tools: Read,Glob,Grep,triage:fetch_mentions,triage:search_recent,triage:fetch_conversation
 model: inherit
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- bug
-- clusterer
+- bug-triage
+- clustering
+- pii-redaction
+- social-signals
 disallowedTools: []
 skills:
 - bug-clustering

--- a/plugins/mcp/x-bug-triage/agents/owner-router.md
+++ b/plugins/mcp/x-bug-triage/agents/owner-router.md
@@ -1,15 +1,16 @@
 ---
 name: owner-router
-description: Recommend likely bug owners using strict 6-level routing precedence with staleness detection and override memory. Use when routing clustered bugs to teams after evidence gathering.
+description: Routes bug clusters to the most likely owning team using strict 6-level precedence (service owner → on-call → CODEOWNERS → recent assignees → committers → fallback) with staleness flagging and override memory. Use when assigning ownership after the repo-scanner step. Trigger with "route these bugs", "assign bug owners".
 tools: Read,Glob,Grep,triage:lookup_service_owner,triage:lookup_oncall,triage:parse_codeowners,triage:lookup_recent_assignees,triage:lookup_recent_committers
 model: inherit
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- owner
-- router
+- bug-triage
+- ownership-routing
+- oncall
+- codeowners
 disallowedTools: []
 skills:
 - owner-routing

--- a/plugins/mcp/x-bug-triage/agents/repo-scanner.md
+++ b/plugins/mcp/x-bug-triage/agents/repo-scanner.md
@@ -1,15 +1,16 @@
 ---
 name: repo-scanner
-description: Scan mapped GitHub repos for issue matches, recent commits, affected paths, and deploy changes. Use when gathering evidence for bug clusters after clustering step.
+description: Gathers triage-quality evidence for bug clusters by scanning up to 3 mapped GitHub repos for matching issues, suspicious recent commits, affected paths, and deploy timing. Use when building the evidence record between clustering and routing steps. Trigger with "gather repo evidence", "scan repos for this cluster".
 tools: Read,Glob,Grep,triage:search_issues,triage:inspect_recent_commits,triage:inspect_code_paths,triage:check_recent_deploys
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- repo
-- scanner
+- bug-triage
+- repo-scanning
+- evidence-gathering
+- github
 disallowedTools: []
 skills:
 - repo-scanning

--- a/plugins/mcp/x-bug-triage/agents/triage-summarizer.md
+++ b/plugins/mcp/x-bug-triage/agents/triage-summarizer.md
@@ -1,15 +1,15 @@
 ---
 name: triage-summarizer
-description: Format triage results for terminal display and parse review commands. Use when presenting clustered bug results to the user after routing and severity computation.
+description: Renders fully-processed bug clusters as concise, scannable terminal markdown ordered by severity, and parses interactive review commands for the orchestrator. Use when presenting final triage results to the engineer. Trigger with "show triage results", "summarize the bug clusters".
 tools: Read,Glob,Grep,triage:parse_review_command
 model: inherit
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- mcp
-- triage
-- summarizer
+- bug-triage
+- reporting
+- terminal-output
 disallowedTools: []
 skills:
 - triage-display

--- a/plugins/packages/ai-ml-engineering-pack/plugins/01-prompt-engineering/agents/prompt-architect.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/01-prompt-engineering/agents/prompt-architect.md
@@ -1,25 +1,19 @@
 ---
 name: prompt-architect
-description: Expert in prompt engineering patterns, techniques, and optimization
+description: Designs, patterns, and debugs LLM prompts using CoT, few-shot, zero-shot, and meta-prompting techniques, with structured templates and token-efficiency guidance. Use when authoring a new prompt or diagnosing why an existing one produces poor output. Trigger with "design a prompt", "help me write a prompt".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- prompt
-- architect
+- prompt-engineering
+- llm
+- few-shot
+- chain-of-thought
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/01-prompt-engineering/agents/prompt-optimizer.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/01-prompt-engineering/agents/prompt-optimizer.md
@@ -1,25 +1,19 @@
 ---
 name: prompt-optimizer
-description: Optimizes prompts for cost, latency, and quality trade-offs
+description: Reduces LLM API costs 50-90% by compressing prompts, selecting the right model tier, and applying caching and batching strategies with measurable ROI calculations. Use when an LLM workflow is too expensive or slow and you need data-driven optimization. Trigger with "optimize this prompt", "reduce my LLM costs".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- prompt
-- optimizer
+- prompt-engineering
+- cost-optimization
+- llm
+- token-efficiency
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/02-llm-integration/agents/llm-integration-expert.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/02-llm-integration/agents/llm-integration-expert.md
@@ -1,25 +1,20 @@
 ---
 name: llm-integration-expert
-description: Expert in LLM API integration, error handling, and production patterns
+description: Delivers production-ready LLM API integration patterns including retry/backoff, rate limiting, multi-provider fallback, streaming, and cost tracking across OpenAI, Anthropic, and Google. Use when wiring an LLM into a production service for the first time or hardening an existing integration. Trigger with "integrate an LLM API", "production LLM setup".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
 - llm
-- integration
+- api-integration
+- production-patterns
+- error-handling
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/02-llm-integration/agents/model-selector.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/02-llm-integration/agents/model-selector.md
@@ -1,25 +1,20 @@
 ---
 name: model-selector
-description: Helps select the optimal LLM model for specific tasks and requirements
+description: Recommends the right LLM model for any task by weighing quality, latency, cost, and context-window requirements across OpenAI, Anthropic, Google, and open-source options. Use when choosing a model for a new feature or reducing spend without sacrificing quality. Trigger with "which model should I use", "pick the best LLM for this".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- model
-- selector
+- llm
+- model-selection
+- cost-optimization
+- benchmarking
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/03-rag-systems/agents/rag-architect.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/03-rag-systems/agents/rag-architect.md
@@ -1,25 +1,20 @@
 ---
 name: rag-architect
-description: Expert in RAG system design, chunking strategies, and retrieval optimization
+description: Designs production RAG pipelines covering chunking strategy, embedding selection, retrieval patterns (basic, reranked, hybrid, multi-query), and evaluation metrics. Use when building a knowledge-grounded Q&A system or improving retrieval accuracy. Trigger with "design a RAG system", "help me build a knowledge base".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
 - rag
-- architect
+- retrieval
+- embeddings
+- llm
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/03-rag-systems/agents/vector-db-expert.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/03-rag-systems/agents/vector-db-expert.md
@@ -1,25 +1,20 @@
 ---
 name: vector-db-expert
-description: Expert in vector database selection, optimization, and production deployment
+description: Selects and configures the right vector database (Pinecone, Qdrant, Weaviate, pgvector, Milvus, ChromaDB) based on scale, budget, latency, and query patterns, with HNSW tuning and migration guidance. Use when choosing or optimizing a vector store for a RAG or semantic search system. Trigger with "which vector database should I use", "optimize my vector DB".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
 - WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- vector
-- db
+- vector-database
+- rag
+- semantic-search
+- embeddings
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/04-ai-safety/agents/ai-safety-expert.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/04-ai-safety/agents/ai-safety-expert.md
@@ -1,25 +1,21 @@
 ---
 name: ai-safety-expert
-description: Expert in content filtering, PII detection, bias mitigation, and LLM safety
+description: "Audits and implements AI safety layers including content filtering, PII detection, bias mitigation, and LLM guardrails. Use when securing an LLM application, reviewing safety architecture, or adding compliance controls. Trigger with \"audit ai safety\", \"add safety guardrails\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- ai
-- safety
+- ai-safety
+- pii-detection
+- content-moderation
+- llm-security
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/ai-ml-engineering-pack/plugins/04-ai-safety/agents/prompt-injection-defender.md
+++ b/plugins/packages/ai-ml-engineering-pack/plugins/04-ai-safety/agents/prompt-injection-defender.md
@@ -1,26 +1,21 @@
 ---
 name: prompt-injection-defender
-description: Expert in detecting and preventing prompt injection attacks
+description: "Detects and mitigates prompt injection, jailbreaks, and adversarial input attacks against LLM applications. Use when hardening a system prompt, reviewing LLM input handling, or implementing injection defenses. Trigger with \"defend against prompt injection\", \"harden llm inputs\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore
 tags:
-- packages
-- prompt
-- injection
-- defender
+- prompt-injection
+- llm-security
+- adversarial-defense
+- input-sanitization
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/content-strategy/distribution-automator/agents/distribution.md
+++ b/plugins/packages/creator-studio-pack/plugins/content-strategy/distribution-automator/agents/distribution.md
@@ -1,24 +1,19 @@
 ---
 name: distribution
-description: Automatically publish and distribute content across YouTube, TikTok,...
+description: "Plans and generates multi-platform content distribution strategies with platform-specific metadata, timing, and cross-promotion linking. Use when publishing a video across YouTube, TikTok, LinkedIn, and more. Trigger with \"distribute my content\", \"plan multi-platform release\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- distribution
+- content-distribution
+- multi-platform
+- social-media
+- creator-workflow
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/content-strategy/viral-idea-generator/agents/idea-generator.md
+++ b/plugins/packages/creator-studio-pack/plugins/content-strategy/viral-idea-generator/agents/idea-generator.md
@@ -1,25 +1,19 @@
 ---
 name: idea-generator
-description: Generate viral video ideas from your builds, trending topics, and audience...
+description: "Transforms technical builds and projects into ranked viral video ideas with titles, hooks, thumbnail concepts, and audience targeting. Use when deciding what to film next from your recent work. Trigger with \"generate video ideas\", \"what should I make next\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- idea
-- generator
+- content-ideation
+- viral-video
+- creator-strategy
+- tech-content
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/project-documentation/build-logger-agent/agents/build-logger.md
+++ b/plugins/packages/creator-studio-pack/plugins/project-documentation/build-logger-agent/agents/build-logger.md
@@ -1,6 +1,6 @@
 ---
 name: build-logger
-description: Automatically document your entire build process by analyzing git commits,...
+description: "Analyzes git commit history to produce structured build logs, flag hero moments worth filming, and generate video script outlines from real development work. Use when turning a coding session into content. Trigger with \"log my build\", \"extract content from my commits\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- build
-- logger
+- build-logging
+- git-analysis
+- content-extraction
+- developer-documentation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/project-documentation/code-explainer-video/agents/code-explainer.md
+++ b/plugins/packages/creator-studio-pack/plugins/project-documentation/code-explainer-video/agents/code-explainer.md
@@ -1,25 +1,21 @@
 ---
 name: code-explainer
-description: Generate video scripts that explain your code for non-technical and...
+description: "Converts code implementations into full video scripts with conversational narration, timestamped shot lists, and b-roll suggestions for educational content. Use when turning code into a tutorial video. Trigger with \"explain this code for video\", \"write a code tutorial script\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- code
-- explainer
+- code-explainer
+- video-scripting
+- developer-education
+- content-creation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/project-documentation/demo-video-generator/agents/demo-generator.md
+++ b/plugins/packages/creator-studio-pack/plugins/project-documentation/demo-video-generator/agents/demo-generator.md
@@ -1,25 +1,19 @@
 ---
 name: demo-generator
-description: Create product demo videos automatically with user journey scripts and shot...
+description: "Creates product demo video scripts with user journey narratives, feature walkthroughs, shot lists, and CTA copy designed to convert viewers to users. Use when building a launch or onboarding video for a product. Trigger with \"create demo video\", \"generate product walkthrough script\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- demo
-- generator
+- demo-video
+- product-marketing
+- video-scripting
+- conversion
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/video-production/audio-mixer-assistant/agents/audio-mixer.md
+++ b/plugins/packages/creator-studio-pack/plugins/video-production/audio-mixer-assistant/agents/audio-mixer.md
@@ -1,25 +1,20 @@
 ---
 name: audio-mixer
-description: AI-powered audio mixing that balances voice, music, and effects...
+description: "Analyzes audio tracks and prescribes a complete mixing workflow — EQ, compression, noise reduction, sidechain ducking, and platform-specific loudness targets — for broadcast-quality results. Use when mixing tutorial or vlog audio. Trigger with \"mix my audio\", \"fix my voice track\"."
 tools:
 - Read
 - Write
 - Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- audio
-- mixer
+- audio-mixing
+- post-production
+- voice-processing
+- broadcast-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/video-production/video-editor-ai/agents/video-editor.md
+++ b/plugins/packages/creator-studio-pack/plugins/video-production/video-editor-ai/agents/video-editor.md
@@ -1,25 +1,20 @@
 ---
 name: video-editor
-description: AI-assisted video editing via DaVinci Resolve API with automatic cuts, color...
+description: "Automates video editing workflows — silence removal, pacing optimization, color grading, subtitle generation, and multi-platform export — via DaVinci Resolve scripting or FFmpeg. Use when editing raw screen recordings into polished uploads. Trigger with \"edit my recording\", \"automate video editing\"."
 tools:
 - Read
 - Write
 - Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- video
-- editor
+- video-editing
+- post-production
+- davinci-resolve
+- automation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/workflow-optimization/batch-recording-scheduler/agents/batch-scheduler.md
+++ b/plugins/packages/creator-studio-pack/plugins/workflow-optimization/batch-recording-scheduler/agents/batch-scheduler.md
@@ -1,25 +1,19 @@
 ---
 name: batch-scheduler
-description: Schedule and execute batch recording sessions to create multiple videos...
+description: "Plans efficient batch recording sessions that group multiple videos by topic, manage energy and breaks, and produce detailed run-of-show schedules to maximize output per recording day. Use when scheduling a recording block. Trigger with \"plan batch recording session\", \"schedule my recording day\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- batch
-- scheduler
+- batch-recording
+- creator-workflow
+- production-planning
+- time-management
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/workflow-optimization/collaboration-manager/agents/collaboration.md
+++ b/plugins/packages/creator-studio-pack/plugins/workflow-optimization/collaboration-manager/agents/collaboration.md
@@ -1,24 +1,19 @@
 ---
 name: collaboration
-description: Manage collaborations, guest appearances, and creator partnerships for...
+description: "Identifies compatible creator partners, drafts outreach pitches, and produces detailed collaboration project plans with timelines, responsibilities, and cross-promotion strategies. Use when planning a collab or guest appearance. Trigger with \"find collaboration partners\", \"plan a creator collab\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- collaboration
+- creator-collaboration
+- partnership
+- growth-strategy
+- outreach
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/creator-studio-pack/plugins/workflow-optimization/content-calendar-ai/agents/calendar.md
+++ b/plugins/packages/creator-studio-pack/plugins/workflow-optimization/content-calendar-ai/agents/calendar.md
@@ -1,24 +1,19 @@
 ---
 name: calendar
-description: AI-powered content calendar that strategically plans video releases, batch...
+description: "Generates strategic 30-day content calendars with release timing, platform mix, batch recording days, and content diversity targets to grow a creator channel consistently. Use when planning a month of content. Trigger with \"build my content calendar\", \"plan my posting schedule\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- calendar
+- content-calendar
+- scheduling
+- creator-workflow
+- growth-strategy
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/devops-automation-pack/plugins/02-ci-cd/agents/ci-cd-expert.md
+++ b/plugins/packages/devops-automation-pack/plugins/02-ci-cd/agents/ci-cd-expert.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-expert
-description: CI/CD pipeline design and optimization specialist
+description: "Designs, optimizes, and troubleshoots CI/CD pipelines across GitHub Actions, GitLab CI, CircleCI, and Jenkins with production-ready YAML and setup instructions. Use when building or fixing a pipeline. Trigger with \"set up ci/cd\", \"optimize my pipeline\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- ci
-- cd
+- ci-cd
+- github-actions
+- pipeline-design
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/devops-automation-pack/plugins/03-docker/agents/docker-specialist.md
+++ b/plugins/packages/devops-automation-pack/plugins/03-docker/agents/docker-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: docker-specialist
-description: Docker optimization and containerization expert
+description: "Analyzes Dockerfiles and produces optimized multi-stage builds, .dockerignore files, and docker-compose configs that shrink image size by 80-90% and enforce security best practices. Use when optimizing container builds or starting a new Dockerfile. Trigger with \"optimize my dockerfile\", \"reduce docker image size\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - docker
+- containerization
+- image-optimization
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/devops-automation-pack/plugins/04-kubernetes/agents/kubernetes-expert.md
+++ b/plugins/packages/devops-automation-pack/plugins/04-kubernetes/agents/kubernetes-expert.md
@@ -1,6 +1,6 @@
 ---
 name: kubernetes-expert
-description: Kubernetes orchestration and troubleshooting expert
+description: "Generates production-ready Kubernetes manifests with security contexts, resource limits, probes, HPA, and Ingress, plus kubectl troubleshooting commands for pod failures and networking issues. Use when deploying to K8s or debugging cluster problems. Trigger with \"deploy to kubernetes\", \"debug failing pods\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - kubernetes
+- container-orchestration
+- helm
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/devops-automation-pack/plugins/05-terraform/agents/terraform-architect.md
+++ b/plugins/packages/devops-automation-pack/plugins/05-terraform/agents/terraform-architect.md
@@ -1,6 +1,6 @@
 ---
 name: terraform-architect
-description: Terraform infrastructure as code expert
+description: "Terraform IaC expert covering modules, multi-cloud resources, remote state backends, and workspace management. Use when building or refactoring .tf configs, designing module hierarchies, or planning multi-environment infrastructure. Trigger with \"terraform help\", \"IaC setup\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - terraform
-- architect
+- infrastructure-as-code
+- multi-cloud
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/devops-automation-pack/plugins/06-deployment/agents/deployment-specialist.md
+++ b/plugins/packages/devops-automation-pack/plugins/06-deployment/agents/deployment-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-specialist
-description: Deployment strategy and release management expert
+description: "Deployment strategy and release management expert covering blue/green, canary, rolling, and recreate patterns across Kubernetes, AWS ECS, GCP, and Azure. Use when planning a production rollout, choosing a deployment strategy, or designing rollback procedures. Trigger with \"deployment strategy\", \"zero-downtime deploy\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - deployment
+- release-management
+- blue-green
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/api-builder.md
+++ b/plugins/packages/fullstack-starter-pack/agents/api-builder.md
@@ -1,25 +1,21 @@
 ---
 name: api-builder
-description: Use this agent when designing RESTful or GraphQL APIs, reviewing endpoint schemas, implementing API versioning strategies, defining authentication flows, or generating OpenAPI documentation.
+description: "REST and GraphQL API design expert covering resource modeling, authentication flows, rate limiting, versioning, and OpenAPI spec generation. Use when designing API endpoints, implementing JWT/API-key auth, or writing OpenAPI docs. Trigger with \"design an API\", \"API endpoint help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- api
-- builder
+- api-design
+- rest
+- graphql
+- authentication
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/backend-architect.md
+++ b/plugins/packages/fullstack-starter-pack/agents/backend-architect.md
@@ -1,25 +1,21 @@
 ---
 name: backend-architect
-description: Use this agent when designing scalable backend systems, choosing monolithic vs microservices, planning distributed systems, or reviewing system-level architecture decisions.
+description: "Scalable backend system design expert covering monolith vs microservices trade-offs, caching strategies, message queues, gRPC, and containerized infrastructure patterns. Use when choosing an architecture pattern, designing for scale, or solving distributed system challenges. Trigger with \"backend architecture\", \"system design help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - backend
-- architect
+- system-design
+- microservices
+- scalability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/database-designer.md
+++ b/plugins/packages/fullstack-starter-pack/agents/database-designer.md
@@ -1,25 +1,21 @@
 ---
 name: database-designer
-description: Use this agent when designing database schemas, choosing between SQL and NoSQL datastores, modeling entity relationships, planning indexes, or optimizing data-access patterns for specific workloads.
+description: "Database schema design expert for SQL and NoSQL covering normalization, indexing strategies, migration patterns, and query optimization. Use when designing schemas, picking between PostgreSQL and MongoDB, or fixing slow queries. Trigger with \"database schema\", \"data model help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - database
-- designer
+- schema-design
+- sql
+- nosql
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/deployment-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/agents/deployment-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-specialist
-description: Use this agent when setting up CI/CD pipelines, writing Dockerfiles, planning cloud deployment (AWS/GCP/Azure), or implementing zero-downtime release patterns.
+description: "CI/CD and containerization expert covering Dockerfiles, GitHub Actions pipelines, cloud deployment (AWS ECS, GCP Cloud Run, Vercel), and zero-downtime strategies. Use when setting up a deploy pipeline, writing production Dockerfiles, or configuring blue/green rollouts. Trigger with \"set up CI/CD\", \"Dockerfile help\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- deployment
+- cicd
+- docker
+- cloud-deployment
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/react-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/agents/react-specialist.md
@@ -1,24 +1,21 @@
 ---
 name: react-specialist
-description: Use this agent when building React 18+ apps, reviewing component architecture, implementing server components, or optimizing hook-based performance and concurrent features.
+description: "React 18+ expert covering hooks, concurrent features, server components, state management (Zustand/Redux Toolkit), and performance optimization. Use when building React components, debugging re-renders, or migrating to the Next.js App Router. Trigger with \"React component help\", \"hook optimization\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - react
+- frontend
+- hooks
+- performance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/agents/ui-ux-expert.md
+++ b/plugins/packages/fullstack-starter-pack/agents/ui-ux-expert.md
@@ -1,25 +1,21 @@
 ---
 name: ui-ux-expert
-description: Use this agent when designing user interfaces, auditing accessibility against WCAG 2.1, reviewing responsive layouts across breakpoints, or optimizing user experience flows in web applications.
+description: "UI/UX expert covering WCAG 2.1 accessibility audits, mobile-first responsive design, design system tokens, and component API consistency. Use when auditing a UI for accessibility issues, designing a component library, or fixing responsive layout problems. Trigger with \"accessibility review\", \"UI design help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- ui
-- ux
+- ui-ux
+- accessibility
+- responsive-design
+- design-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/react-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/react-specialist.md
@@ -1,24 +1,21 @@
 ---
 name: react-specialist
-description: Use this agent when building React 18+ apps, reviewing component architecture, implementing server components, or optimizing hook-based performance and concurrent features.
+description: "React 18+ expert covering hooks, concurrent features, server components, state management (Zustand/Redux Toolkit), and performance optimization. Use when building React components, debugging re-renders, or migrating to the Next.js App Router. Trigger with \"React component help\", \"hook optimization\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - react
+- frontend
+- hooks
+- performance
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/ui-ux-expert.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/01-frontend/agents/ui-ux-expert.md
@@ -1,25 +1,21 @@
 ---
 name: ui-ux-expert
-description: Use this agent when designing user interfaces, auditing accessibility against WCAG 2.1, reviewing responsive layouts across breakpoints, or optimizing user experience flows in web applications.
+description: "UI/UX expert covering WCAG 2.1 accessibility audits, mobile-first responsive design, design system tokens, and component API consistency. Use when auditing a UI for accessibility issues, designing a component library, or fixing responsive layout problems. Trigger with \"accessibility review\", \"UI design help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- ui
-- ux
+- ui-ux
+- accessibility
+- responsive-design
+- design-systems
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/api-builder.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/api-builder.md
@@ -1,25 +1,21 @@
 ---
 name: api-builder
-description: Use this agent when designing RESTful or GraphQL APIs, reviewing endpoint schemas, implementing API versioning strategies, defining authentication flows, or generating OpenAPI documentation.
+description: "REST and GraphQL API design expert covering resource modeling, authentication flows, rate limiting, versioning, and OpenAPI spec generation. Use when designing API endpoints, implementing JWT/API-key auth, or writing OpenAPI docs. Trigger with \"design an API\", \"API endpoint help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- api
-- builder
+- api-design
+- rest
+- graphql
+- authentication
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/backend-architect.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/02-backend/agents/backend-architect.md
@@ -1,25 +1,21 @@
 ---
 name: backend-architect
-description: Use this agent when designing scalable backend systems, choosing monolithic vs microservices, planning distributed systems, or reviewing system-level architecture decisions.
+description: "Scalable backend system design expert covering monolith vs microservices trade-offs, caching strategies, message queues, gRPC, and containerized infrastructure patterns. Use when choosing an architecture pattern, designing for scale, or solving distributed system challenges. Trigger with \"backend architecture\", \"system design help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - backend
-- architect
+- system-design
+- microservices
+- scalability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/03-database/agents/database-designer.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/03-database/agents/database-designer.md
@@ -1,25 +1,21 @@
 ---
 name: database-designer
-description: Use this agent when designing database schemas, choosing between SQL and NoSQL datastores, modeling entity relationships, planning indexes, or optimizing data-access patterns for specific workloads.
+description: "Database schema design expert for SQL and NoSQL covering normalization, indexing strategies, migration patterns, and query optimization. Use when designing schemas, picking between PostgreSQL and MongoDB, or fixing slow queries. Trigger with \"database schema\", \"data model help\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - database
-- designer
+- schema-design
+- sql
+- nosql
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/fullstack-starter-pack/plugins/04-integration/agents/deployment-specialist.md
+++ b/plugins/packages/fullstack-starter-pack/plugins/04-integration/agents/deployment-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-specialist
-description: Use this agent when setting up CI/CD pipelines, writing Dockerfiles, planning cloud deployment (AWS/GCP/Azure), or implementing zero-downtime release patterns.
+description: "CI/CD and containerization expert covering Dockerfiles, GitHub Actions pipelines, cloud deployment (AWS ECS, GCP Cloud Run, Vercel), and zero-downtime strategies. Use when setting up a deploy pipeline, writing production Dockerfiles, or configuring blue/green rollouts. Trigger with \"set up CI/CD\", \"Dockerfile help\"."
 tools:
 - Read
 - Write
@@ -8,17 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- deployment
+- cicd
+- docker
+- cloud-deployment
+- devops
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/security-pro-pack/plugins/01-core-security/agents/penetration-tester.md
+++ b/plugins/packages/security-pro-pack/plugins/01-core-security/agents/penetration-tester.md
@@ -1,25 +1,20 @@
 ---
 name: penetration-tester
-description: Ethical hacking and penetration testing specialist for security assessment
+description: "Ethical hacking specialist covering MITRE ATT&CK phases, web/API/network penetration testing, and exploit chain documentation. Use when running an authorized pen test, simulating attack scenarios, or writing a findings report with proof-of-concept exploits. Trigger with \"pen test this\", \"red team assessment\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
-- Glob
 - Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- penetration
-- tester
+- penetration-testing
+- ethical-hacking
+- red-team
+- security
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/security-pro-pack/plugins/01-core-security/agents/security-auditor-expert.md
+++ b/plugins/packages/security-pro-pack/plugins/01-core-security/agents/security-auditor-expert.md
@@ -1,25 +1,20 @@
 ---
 name: security-auditor-expert
-description: OWASP Top 10 vulnerability detection and security code review specialist
+description: "OWASP Top 10 vulnerability scanner and security code reviewer that identifies injection flaws, auth failures, misconfigurations, and crypto weaknesses with CWE-mapped findings and remediation code. Use when you need a security audit, vulnerability scan, or code review for security issues. Trigger with \"security audit\", \"scan for vulnerabilities\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - security
-- auditor
+- owasp
+- vulnerability-scanning
+- code-review
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/security-pro-pack/plugins/02-compliance/agents/compliance-checker.md
+++ b/plugins/packages/security-pro-pack/plugins/02-compliance/agents/compliance-checker.md
@@ -1,25 +1,19 @@
 ---
 name: compliance-checker
-description: Regulatory compliance specialist for HIPAA, PCI DSS, GDPR, and SOC 2
+description: "Regulatory compliance specialist that assesses HIPAA, PCI DSS, GDPR, and SOC 2 gaps, produces framework-specific remediation roadmaps with regulation citations and cost estimates. Use when you need a compliance assessment, audit prep, or gap analysis. Trigger with \"compliance check\", \"HIPAA gap analysis\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
 - compliance
-- checker
+- regulatory
+- hipaa
+- gdpr
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/security-pro-pack/plugins/03-cryptography/agents/crypto-expert.md
+++ b/plugins/packages/security-pro-pack/plugins/03-cryptography/agents/crypto-expert.md
@@ -1,24 +1,19 @@
 ---
 name: crypto-expert
-description: Cryptography and encryption specialist for secure data protection
+description: "Cryptography implementation specialist that reviews cipher selection, key management, hashing algorithms, and TLS config — catches ECB mode, IV reuse, weak keys, and missing AEAD with secure code examples. Use when you need crypto guidance or a cryptographic code review. Trigger with \"review my crypto\", \"how should I encrypt this\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- crypto
+- cryptography
+- encryption
+- key-management
+- security
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/packages/security-pro-pack/plugins/04-infrastructure-security/agents/threat-modeler.md
+++ b/plugins/packages/security-pro-pack/plugins/04-infrastructure-security/agents/threat-modeler.md
@@ -1,25 +1,19 @@
 ---
 name: threat-modeler
-description: Threat modeling specialist using STRIDE and attack surface analysis
+description: "Security threat modeling specialist that applies STRIDE to system architectures, identifies trust boundary risks, and produces prioritized mitigation plans with risk scores. Use when designing a new system, reviewing architecture for security threats, or reducing attack surface. Trigger with \"threat model\", \"security design review\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- packages
-- threat
-- modeler
+- threat-modeling
+- stride
+- security-architecture
+- risk-assessment
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/obsidian-project-documentation/agents/manager.md
+++ b/plugins/productivity/obsidian-project-documentation/agents/manager.md
@@ -1,14 +1,16 @@
 ---
 name: manager
-description: Use this agent when the user requests an action that should trigger 'documentation' behavior. This agent is usually triggered by the obsidian-project-documentation skill.
+description: "Obsidian project documentation manager that creates/updates vault notes, extracts session decisions, syncs CLAUDE.md, and manages git commit/push after each working session. Use when you want to document a project session into Obsidian, update AI context files, or capture progress. Trigger with \"document this session\", \"update project notes\"."
 tools: Read, Write, Edit, Bash, TodoWrite, AskUserQuestion, Glob, Grep
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- manager
+- obsidian
+- documentation
+- knowledge-management
+- project-notes
 disallowedTools: []
 skills: []
 background: true

--- a/plugins/productivity/over-50s-health/agents/advisor.md
+++ b/plugins/productivity/over-50s-health/agents/advisor.md
@@ -1,14 +1,16 @@
 ---
 name: advisor
-description: Use this agent when the User asks for health, fitness, nutrition, or longevity guidance tailored to adults 50+, or when they describe physical symptoms, fatigue, lab results, metabolic markers, joint pain, or sleep issues — even without explicitly asking for health advice.
+description: "Evidence-based health advisor for adults 50+ covering fitness, nutrition, metabolic health, sleep, and longevity — maintains persistent context files and generates clinician-ready reports. Use when you need age-appropriate health guidance, want to track lab results, or prepare for a doctor appointment. Trigger with \"health advice\", \"prepare clinician report\"."
 tools: Read, Write, WebSearch, WebFetch
 model: opus
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- advisor
+- health
+- longevity
+- nutrition
+- fitness
 disallowedTools:
 - Bash
 - Edit

--- a/plugins/productivity/overnight-dev/agents/overnight-dev-coach.md
+++ b/plugins/productivity/overnight-dev/agents/overnight-dev-coach.md
@@ -1,26 +1,20 @@
 ---
 name: overnight-dev-coach
-description: Expert coach for autonomous overnight development sessions with TDD
+description: "Autonomous overnight development coach that enforces TDD, runs Git hook–gated sessions, debugs failing tests iteratively, and delivers a morning handoff report when all tests are green. Use when you want to run an unattended overnight coding session or set up TDD workflows. Trigger with \"overnight session\", \"autonomous TDD run\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
 - TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
+- tdd
+- autonomous-dev
+- testing
 - overnight
-- dev
-- coach
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/pair-programmer/agents/coach.md
+++ b/plugins/productivity/pair-programmer/agents/coach.md
@@ -1,14 +1,16 @@
 ---
 name: coach
-description: Use this agent when the user requests coding assistance with a declared assistance level (1-4) or mentions graduated assistance, pair programming, or preventing skill atrophy.
+description: "Graduated pair programming coach that enforces four assistance levels (advise-only → scaffold → alternate → generate+explain-back) to develop coding skills without dependency on AI generation. Use when you want to pair program while maintaining skill development or prevent skill atrophy from AI over-reliance. Trigger with \"pair program with me\", \"Level 2: scaffold this\"."
 tools: Read, Glob, Grep, Bash
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- coach
+- pair-programming
+- skill-development
+- tdd
+- coaching
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/plane/skills/plane/agents/plane-analyst.md
+++ b/plugins/productivity/plane/skills/plane/agents/plane-analyst.md
@@ -1,37 +1,17 @@
 ---
 name: plane-analyst
-description: 'Plane behavioral synthesis agent. Orchestrates the five compound commands
-
-  (cycle-velocity, stale-tickets, reviewer-gate-strength, priority-drift,
-
-  cross-project-load) by calling mcp__plane endpoints in sequence, applying
-
-  the JOIN + scoring logic, and rendering the output tables per the NOI.
-
-  Use when the user asks behavioral questions about a team''s Plane workspace
-
-  — cycle health, stuck work, review bottlenecks, planning vs. reality,
-
-  workload distribution.'
+description: "Plane behavioral synthesis agent that orchestrates compound commands (cycle-velocity, stale-tickets, reviewer-gate-strength, priority-drift, cross-project-load) via mcp__plane endpoints and renders scored behavioral-signal tables. Use when you need behavioral insights about a team's Plane workspace — cycle health, stuck work, or workload distribution. Trigger with \"cycle velocity\", \"show stale tickets\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
 - plane
-- analyst
+- project-management
+- team-analytics
+- behavioral-insights
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/plane/skills/plane/agents/plane-expert.md
+++ b/plugins/productivity/plane/skills/plane/agents/plane-expert.md
@@ -1,32 +1,16 @@
 ---
 name: plane-expert
-description: 'Plane API surface specialist. Answers "how do I query X in Plane" / "what endpoint
-
-  does Y" / "what is the response shape for Z" without firing live API calls.
-
-  Reads from the parent skill''s references/api-surface.md as ground truth. Use when
-
-  the user wants to understand the API surface before running a compound command,
-
-  or when debugging an unexpected response shape from mcp__plane.'
+description: "Plane API surface specialist that answers endpoint discovery, response shape, and pagination questions from api-surface.md without firing live API calls — suggests compound commands when a behavioral pattern is detected. Use when you want to understand the Plane API before running a query or debug an unexpected mcp__plane response. Trigger with \"what endpoint does X\", \"response shape for get_cycle\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
 - plane
+- project-management
+- api-reference
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/travel-assistant/agents/budget-calculator.md
+++ b/plugins/productivity/travel-assistant/agents/budget-calculator.md
@@ -1,25 +1,18 @@
 ---
 name: budget-calculator
-description: Financial planning expert for travel budgeting, cost optimization, and...
+description: "Travel financial planner that produces destination-specific budget breakdowns by accommodation, food, activities, and transport tiers, with currency optimization and hidden-cost identification. Use when you need a travel budget estimate, cost breakdown, or money-saving strategies for a trip. Trigger with \"travel budget\", \"how much will this trip cost\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
+- WebFetch
+- Write
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- budget
-- calculator
+- travel
+- budgeting
+- financial-planning
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/travel-assistant/agents/local-expert.md
+++ b/plugins/productivity/travel-assistant/agents/local-expert.md
@@ -1,24 +1,17 @@
 ---
 name: local-expert
-description: Cultural guide providing insider tips, customs, hidden gems, and authentic...
+description: "Local cultural expert that surfaces destination customs, etiquette, hidden gems, authentic dining, safety/scam awareness, and essential language phrases for any location worldwide. Use when you want insider local knowledge, cultural guidance, or want to avoid tourist traps. Trigger with \"local tips for\", \"cultural customs in\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
+- WebFetch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- local
+- travel
+- cultural-guidance
+- local-knowledge
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/travel-assistant/agents/travel-planner.md
+++ b/plugins/productivity/travel-assistant/agents/travel-planner.md
@@ -1,25 +1,20 @@
 ---
 name: travel-planner
-description: Master travel orchestrator coordinating weather, budget, itinerary, and...
+description: "Master travel orchestrator that coordinates weather analysis, budget calculation, and local expertise into a day-by-day itinerary with packing list and cultural tips. Use when you want a complete trip plan or need multi-specialist coordination for complex travel. Trigger with \"plan my trip\", \"create a travel itinerary\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
 - WebSearch
+- WebFetch
+- Write
 - Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
 - travel
-- planner
+- itinerary
+- trip-planning
+- orchestration
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/travel-assistant/agents/weather-analyst.md
+++ b/plugins/productivity/travel-assistant/agents/weather-analyst.md
@@ -1,25 +1,17 @@
 ---
 name: weather-analyst
-description: Weather forecasting expert analyzing patterns, seasonal trends, and travel...
+description: "Meteorological travel analyst that fetches and interprets 7–14 day forecasts, identifies seasonal patterns, flags extreme conditions, and matches weather windows to planned activities. Use when you need weather-optimized travel timing or activity scheduling for a destination. Trigger with \"weather for my trip\", \"best days for outdoor activities in\"."
 tools:
-- Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
 - WebSearch
-- Task
-- TodoWrite
+- WebFetch
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
+- travel
 - weather
-- analyst
+- seasonal-planning
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/vibe-guide/agents/explainer.md
+++ b/plugins/productivity/vibe-guide/agents/explainer.md
@@ -1,25 +1,16 @@
 ---
 name: vibe-explainer
-description: User-facing voice that presents progress in plain language without jargon. ...
+description: "User-facing progress translator that reads .vibe/status.json and renders structured, jargon-free summaries of what changed, what was verified, what's next, and any required user actions — with a dedicated error mode for failures. Use when technical progress needs to be communicated in plain language or when checking vibe-guide session status. Trigger with \"vibe status\", \"/vibe-guide:status\"."
 tools:
 - Read
-- Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 tags:
-- productivity
-- vibe
-- explainer
+- communication
+- plain-language
+- progress-reporting
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/vibe-guide/agents/explorer.md
+++ b/plugins/productivity/vibe-guide/agents/explorer.md
@@ -1,25 +1,18 @@
 ---
 name: vibe-explorer
-description: Educational micro-explanations for learning mode - explains tiny concepts w...
+description: Delivers single-concept micro-explanations using everyday analogies when learning mode is active. Use when a learner wants to understand one technical concept at a time in plain language. Trigger with "explain this", "what is that".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: purple
 version: 1.0.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 tags:
-- productivity
-- vibe
-- explorer
+- learning
+- education
+- vibe-guide
+- developer-experience
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/vibe-guide/agents/worker.md
+++ b/plugins/productivity/vibe-guide/agents/worker.md
@@ -1,25 +1,19 @@
 ---
 name: vibe-worker
-description: Background worker that executes tasks in tiny steps, writing progress to .v...
+description: Executes vibe-guide sessions one atomic step at a time, updating .vibe/status.json and changelog after every action. Use when running or continuing a vibe-guide session. Trigger with "vibe continue", "next step".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 tags:
-- productivity
-- vibe
-- worker
+- workflow-automation
+- step-execution
+- vibe-guide
+- progress-tracking
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/youtube-strategy/agents/channel-analyzer.md
+++ b/plugins/productivity/youtube-strategy/agents/channel-analyzer.md
@@ -1,15 +1,16 @@
 ---
 name: channel-analyzer
-description: Analyze a batch of YouTube channels for competitive intelligence. Produces structured competitive analysis per channel.
-tools: Read, Write, Bash, WebSearch, Grep
+description: Analyzes YouTube channels for competitive intelligence — engagement rates, content gaps, and steal-worthy patterns. Use when researching competitor channels or building a content strategy. Trigger with "analyze channels", "competitive channel research".
+tools: Read, Write, WebSearch, Grep
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- channel
-- analyzer
+- youtube
+- competitive-intelligence
+- content-strategy
+- channel-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/youtube-strategy/agents/idea-validator.md
+++ b/plugins/productivity/youtube-strategy/agents/idea-validator.md
@@ -1,15 +1,16 @@
 ---
 name: idea-validator
-description: Validate batches of YouTube video ideas against search demand, competition, and audience fit. Returns scored assessments.
-tools: Read, Write, Bash, WebSearch, Grep
+description: Scores YouTube video ideas against search demand, competition level, trend direction, and audience fit to produce ranked opportunity assessments. Use when deciding which video ideas to prioritize. Trigger with "validate video ideas", "score content ideas".
+tools: Read, Write, WebSearch
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- idea
-- validator
+- youtube
+- content-strategy
+- idea-validation
+- demand-research
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/productivity/youtube-strategy/agents/yt-scraper.md
+++ b/plugins/productivity/youtube-strategy/agents/yt-scraper.md
@@ -1,15 +1,16 @@
 ---
 name: yt-scraper
-description: Orchestrate YouTube scraping via Apify actors. Triggers channel/video/search scraping, fetches datasets, and persists results as JSON.
+description: Orchestrates YouTube data extraction via Apify actors — channel metadata, video details, search results — polling until complete and saving all datasets to disk. Use when collecting raw YouTube data for strategy analysis. Trigger with "scrape youtube channels", "fetch youtube data".
 tools: Read, Write, Bash
 model: sonnet
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- productivity
-- yt
-- scraper
+- youtube
+- data-extraction
+- apify
+- web-scraping
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/security/severity1-marketplace/agents/severity-triage.md
+++ b/plugins/security/severity1-marketplace/agents/severity-triage.md
@@ -1,25 +1,20 @@
 ---
 name: severity-triage
-description: Automated severity triage agent for issues and vulnerabilities
+description: Classifies incoming issues, bug reports, and vulnerability findings using the S1-S4 severity framework with blast-radius analysis and escalation routing. Use when triaging bugs or security findings that need consistent prioritization. Trigger with "triage this issue", "classify severity".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
 - security
-- severity
-- triage
+- incident-response
+- bug-triage
+- vulnerability-management
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/analyzer.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/analyzer.md
@@ -1,24 +1,18 @@
 ---
 name: analyzer
-description: Analyze blind comparison results to understand why the winner won and generate improvement suggestions
+description: Post-hoc analysis agent that unblids skill comparison results, identifies why the winner outperformed, and produces ranked improvement suggestions for the losing skill. Use when you need actionable insights after a blind eval run. Trigger with "analyze comparison results", "explain why winner won".
 tools:
 - Read
 - Write
-- Edit
-- Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- skill-enhancers
-- analyzer
+- skill-evaluation
+- benchmark-analysis
+- quality-improvement
+- llm-eval
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/comparator.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/comparator.md
@@ -1,24 +1,19 @@
 ---
 name: comparator
-description: Compare two outputs blindly without knowing which skill produced them
+description: Blind-judges two agent outputs against a rubric without knowing which skill produced them, producing scored comparisons and a declared winner. Use when running A/B eval runs to compare skill versions. Trigger with "compare outputs", "blind eval comparison".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- skill-enhancers
-- comparator
+- skill-evaluation
+- blind-comparison
+- llm-eval
+- output-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/grader.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/agents/grader.md
@@ -1,24 +1,19 @@
 ---
 name: grader
-description: Evaluate expectations against execution transcripts and outputs
+description: Grades each eval expectation against an execution transcript and output files, produces a structured pass/fail report, and flags weak assertions. Use when scoring a skill run against predefined expectations. Trigger with "grade eval run", "score expectations".
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- skill-enhancers
-- grader
+- skill-evaluation
+- grading
+- llm-eval
+- assertion-testing
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/api-test-automation/agents/api-tester.md
+++ b/plugins/testing/api-test-automation/agents/api-tester.md
@@ -1,25 +1,21 @@
 ---
 name: api-tester
-description: Specialized agent for automated API endpoint testing and validation
+description: Generates and executes REST and GraphQL API test suites covering happy paths, auth scenarios, edge cases, and contract validation, then reports results with coverage metrics. Use when automating endpoint regression testing or building a new test suite. Trigger with "test this API", "generate API tests".
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- api
-- tester
+- api-testing
+- rest
+- graphql
+- test-automation
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/chaos-engineering-toolkit/agents/chaos-engineer.md
+++ b/plugins/testing/chaos-engineering-toolkit/agents/chaos-engineer.md
@@ -1,25 +1,19 @@
 ---
 name: chaos-engineer
-description: Chaos engineering specialist for system resilience testing
+description: Designs and executes controlled chaos experiments — failure injection, latency simulation, resource exhaustion — following the scientific method with defined abort conditions and recovery validation. Use when hardening a system against cascading failures or preparing for GameDays. Trigger with "design chaos experiment", "test system resilience".
 tools:
 - Read
 - Write
-- Edit
 - Bash
-- Glob
-- Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- chaos
-- engineer
+- chaos-engineering
+- resilience-testing
+- fault-injection
+- infrastructure
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/cli-ux-tester/agents/cli-ux-tester.md
+++ b/plugins/testing/cli-ux-tester/agents/cli-ux-tester.md
@@ -1,16 +1,16 @@
 ---
 name: cli-ux-tester
-description: Expert UX evaluator for CLIs and developer APIs. Synthesizes pre-collected test data into an 11-criteria evaluation and writes artifacts to a timestamped directory. Launched by the cli-ux-tester skill.
+description: Evaluates CLI usability across 11 criteria — discoverability, naming, error messages, help, consistency, visual design, performance, accessibility, integration, security, and onboarding — then produces a scored report, remediation plan, metrics JSON, and regression test script. Use when auditing a CLI tool for developer experience quality. Trigger with "evaluate CLI UX", "audit developer tool usability".
 tools: Bash, Read, Grep, Glob, Write
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- cli
-- ux
-- tester
+- cli-testing
+- developer-experience
+- ux-evaluation
+- usability
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/async-pattern-fixer.md
+++ b/plugins/testing/code-cleanup/agents/async-pattern-fixer.md
@@ -1,26 +1,20 @@
 ---
 name: async-pattern-fixer
-description: Use this agent when scanning for floating promises, async forEach antipatterns, missing await, unhandled rejections, and mixed async styles.
+description: Scans a codebase for dangerous async patterns — floating promises, async forEach, missing await, unhandled rejections, and mixed styles — with confidence scoring and remediation guidance. Never auto-applies fixes. Use when auditing Node.js or TypeScript code for async safety issues. Trigger with "find async issues", "scan for floating promises".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Bash
 model: inherit
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- async
-- pattern
-- fixer
+- async-patterns
+- code-quality
+- javascript
+- static-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/circular-dep-untangler.md
+++ b/plugins/testing/code-cleanup/agents/circular-dep-untangler.md
@@ -1,26 +1,20 @@
 ---
 name: circular-dep-untangler
-description: Use this agent when detecting and resolving circular module dependencies that cause initialization order issues, bundle bloat, and test difficulty.
+description: Detects circular module dependencies using madge/dependency-cruiser, classifies each cycle as runtime-critical or type-only, and proposes minimal-blast-radius resolution strategies. Never auto-applies fixes. Use when debugging mysterious initialization failures or reducing bundle size. Trigger with "find circular dependencies", "untangle module cycles".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Bash
 model: inherit
 color: yellow
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- circular
-- dep
-- untangler
+- circular-dependencies
+- module-architecture
+- static-analysis
+- code-quality
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/dead-code-hunter.md
+++ b/plugins/testing/code-cleanup/agents/dead-code-hunter.md
@@ -1,26 +1,21 @@
 ---
 name: dead-code-hunter
-description: Use this agent when scanning for unreachable code, unused exports/imports/variables, and dead feature flags. Includes confidence scoring and build verification.
+description: Scans for unused exports, dead imports, unreachable code, and stale feature flags using knip/vulture/deadcode, auto-removes high-confidence findings after build verification, and flags the rest for manual review. Use when cleaning up a codebase before a refactor or release. Trigger with "find dead code", "remove unused exports".
 tools:
 - Read
-- Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
+- Bash
+- Edit
 model: inherit
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- dead
-- code
-- hunter
+- dead-code
+- code-cleanup
+- static-analysis
+- refactoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/defensive-code-cleaner.md
+++ b/plugins/testing/code-cleanup/agents/defensive-code-cleaner.md
@@ -1,26 +1,20 @@
 ---
 name: defensive-code-cleaner
-description: Use this agent when identifying unnecessary null checks, impossible error handling, redundant validation, and dead catch blocks.
+description: "Scans TypeScript/JavaScript for unnecessary null checks, impossible try/catch blocks, redundant validation, and dead catch blocks — tracing data flow to prove each defense is unneeded before flagging. Use when you want to clean up defensive-programming noise after strictNullChecks is on. Trigger with \"find unnecessary null checks\", \"audit defensive code\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- defensive
-- code
-- cleaner
+- code-quality
+- defensive-programming
+- static-analysis
+- typescript
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/dry-deduplicator.md
+++ b/plugins/testing/code-cleanup/agents/dry-deduplicator.md
@@ -1,25 +1,20 @@
 ---
 name: dry-deduplicator
-description: Use this agent when detecting copy-pasted code blocks, duplicated logic across files, and repeated patterns that should be abstracted.
+description: "Detects copy-pasted code blocks (10+ lines), near-clones, and repeated patterns that warrant abstraction — using jscpd and grep-based analysis, with a hard bias against premature extraction. Use when you suspect significant code duplication is inflating maintenance burden. Trigger with \"find duplicate code\", \"DRY audit\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- dry
-- deduplicator
+- code-quality
+- dry-principle
+- duplication-detection
+- refactoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/legacy-code-remover.md
+++ b/plugins/testing/code-cleanup/agents/legacy-code-remover.md
@@ -1,6 +1,6 @@
 ---
 name: legacy-code-remover
-description: Use this agent when modernizing deprecated API usage, old syntax patterns, compatibility shims, and unnecessary polyfills.
+description: "Modernizes deprecated API usage, old syntax patterns (var, prototype, XMLHttpRequest), unnecessary polyfills, and compatibility shims — always checking platform targets first to avoid over-modernizing. Use when upgrading a codebase to current Node/browser targets or removing old Babel polyfills. Trigger with \"remove legacy code\", \"modernize deprecated APIs\"."
 tools:
 - Read
 - Write
@@ -8,19 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: cyan
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- legacy
-- code
-- remover
+- code-modernization
+- legacy-removal
+- polyfills
+- deprecated-apis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/performance-optimizer.md
+++ b/plugins/testing/code-cleanup/agents/performance-optimizer.md
@@ -1,25 +1,20 @@
 ---
 name: performance-optimizer
-description: Use this agent when scanning for N+1 queries, blocking I/O, bundle bloat, unnecessary re-renders, and inefficient algorithms.
+description: "Scans codebases for N+1 queries, blocking I/O in async handlers, bundle bloat, unnecessary React re-renders, and O(n²) algorithm patterns — classifying findings by impact before flagging for human review. Use when profiling reveals hot paths or before a performance-focused sprint. Trigger with \"find performance issues\", \"audit N+1 queries\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: purple
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
 - performance
-- optimizer
+- n-plus-one
+- bundle-optimization
+- static-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/security-scanner.md
+++ b/plugins/testing/code-cleanup/agents/security-scanner.md
@@ -1,25 +1,20 @@
 ---
 name: security-scanner
-description: Use this agent when scanning for hardcoded secrets, weak cryptography, SQL/command injection vectors, and insecure defaults.
+description: "Scans source code for hardcoded secrets, SQL/command injection vectors, weak cryptography, and insecure defaults — using gitleaks, bandit, and pattern-based grep when tools are unavailable, with severity-rated findings and remediation guidance. Use when preparing for a security review or after a new dependency is added. Trigger with \"security scan\", \"find hardcoded secrets\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
 - security
-- scanner
+- secret-detection
+- injection-vectors
+- vulnerability-scanning
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/slop-remover.md
+++ b/plugins/testing/code-cleanup/agents/slop-remover.md
@@ -1,25 +1,21 @@
 ---
 name: slop-remover
-description: Use this agent when scanning for AI-generated comment noise, low-value JSDoc, and filler text that restates obvious code.
+description: "Identifies and removes AI-generated comment noise — restating comments, obvious JSDoc, filler section markers, and preamble boilerplate — while preserving every comment that explains why, documents a workaround, or captures business logic. Use when a codebase has been heavily AI-assisted and comment quality has degraded. Trigger with \"remove slop comments\", \"clean up AI-generated comments\"."
 tools:
 - Read
 - Write
 - Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- slop
-- remover
+- code-quality
+- comment-hygiene
+- ai-slop
+- jsdoc-cleanup
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/type-consolidator.md
+++ b/plugins/testing/code-cleanup/agents/type-consolidator.md
@@ -1,6 +1,6 @@
 ---
 name: type-consolidator
-description: Use this agent when merging duplicate type definitions, consolidating overlapping interfaces, and leveraging Pick/Omit/Partial.
+description: "Finds duplicate and near-duplicate TypeScript type/interface definitions across a codebase, consolidates them into a shared module using Pick/Omit/Partial utility types, updates all import sites, and verifies with tsc --noEmit. Use when type definitions have proliferated across modules with heavy overlap. Trigger with \"consolidate types\", \"find duplicate interfaces\"."
 tools:
 - Read
 - Write
@@ -8,18 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- type
-- consolidator
+- typescript
+- type-system
+- refactoring
+- dry-principle
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/code-cleanup/agents/weak-type-eliminator.md
+++ b/plugins/testing/code-cleanup/agents/weak-type-eliminator.md
@@ -1,6 +1,6 @@
 ---
 name: weak-type-eliminator
-description: Use this agent when replacing any, unknown, and overly broad generics with precise, compiler-verified types.
+description: "Replaces explicit any, implicit any, overly broad object/{} types, and unconstrained unknowns with precise compiler-verified types — inferring the correct type from usage patterns and verifying every change via tsc --noEmit. Use when enabling noImplicitAny or tightening an existing TypeScript codebase. Trigger with \"eliminate any types\", \"strengthen TypeScript types\"."
 tools:
 - Read
 - Write
@@ -8,19 +8,15 @@ tools:
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: inherit
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- weak
-- type
-- eliminator
+- typescript
+- type-safety
+- strict-mode
+- refactoring
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/mutation-test-runner/agents/mutation-tester.md
+++ b/plugins/testing/mutation-test-runner/agents/mutation-tester.md
@@ -1,25 +1,20 @@
 ---
 name: mutation-tester
-description: Validate test quality through mutation testing
+description: "Validates test suite quality by running mutation testing tools (Stryker, mutmut, PITest) and analyzing survived mutants to identify under-tested logic paths — outputting kill rates and targeted recommendations for filling gaps. Use when code coverage looks healthy but test confidence is still low. Trigger with \"run mutation tests\", \"find test gaps with mutation testing\"."
 tools:
 - Read
-- Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: orange
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- mutation
-- tester
+- mutation-testing
+- test-quality
+- stryker
+- coverage-gaps
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/performance-test-suite/agents/performance-tester.md
+++ b/plugins/testing/performance-test-suite/agents/performance-tester.md
@@ -1,25 +1,21 @@
 ---
 name: performance-tester
-description: Specialized agent for load testing, performance benchmarking, and bottleneck...
+description: "Designs and executes load, stress, spike, and soak test scripts (k6, Locust, JMeter, Artillery) then analyzes P50/P95/P99 response times, throughput, and resource utilization to identify bottlenecks and produce actionable recommendations. Use when validating scalability before launch or diagnosing latency regressions. Trigger with \"run load test\", \"benchmark API performance\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- performance
-- tester
+- performance-testing
+- load-testing
+- benchmarking
+- bottleneck-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/security-test-scanner/agents/security-scanner.md
+++ b/plugins/testing/security-test-scanner/agents/security-scanner.md
@@ -1,25 +1,21 @@
 ---
 name: security-scanner
-description: Specialized agent for security vulnerability testing and OWASP compliance...
+description: "Performs OWASP Top 10 security assessments and generates security test cases covering SQL injection, XSS, IDOR, auth bypass, CSRF, and misconfiguration — producing severity-rated findings with proof-of-concept payloads and fix guidance. Use when preparing a penetration testing checklist or validating security controls before release. Trigger with \"security test scan\", \"OWASP vulnerability assessment\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: blue
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- security
-- scanner
+- security-testing
+- owasp
+- penetration-testing
+- vulnerability-assessment
 disallowedTools: []
 skills: []
 background: false

--- a/plugins/testing/test-data-generator/agents/data-generator.md
+++ b/plugins/testing/test-data-generator/agents/data-generator.md
@@ -1,25 +1,21 @@
 ---
 name: data-generator
-description: Generate realistic test data for comprehensive testing
+description: "Generates realistic, locale-aware test data (users, products, orders, custom schemas) using Faker.js, Factory Boy, or json-schema-faker — producing factory functions, database seed scripts, and fixture files ready for immediate use. Use when setting up a test environment or populating a dev database with production-scale data. Trigger with \"generate test data\", \"create seed data factories\"."
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- testing
-- data
-- generator
+- test-data
+- fixtures
+- faker
+- database-seeding
 disallowedTools: []
 skills: []
 background: false

--- a/workspace/lab/schema-optimization/agents/phase_1.md
+++ b/workspace/lab/schema-optimization/agents/phase_1.md
@@ -1,26 +1,20 @@
 ---
 name: phase-1-schema-analysis
-description: 'Phase 1 of BigQuery schema optimization pipeline: reads schema exports and produces initial analysis report with table counts, field types, naming patterns, and flagged issues. Outputs strict JSON for phase 2.'
+description: "Phase 1 of the BigQuery schema optimization pipeline — parses schema export files to count tables and fields, detect naming patterns and type inconsistencies, flag duplicate or nullable issues, and write a markdown analysis report plus strict JSON for phase 2. Use when starting a BigQuery schema audit from raw exports. Trigger with \"run schema phase 1\", \"analyze BigQuery schema\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- phase
-- '1'
-- schema
-- analysis
+- bigquery
+- schema-analysis
+- data-quality
+- pipeline
 disallowedTools: []
 skills: []
 background: false

--- a/workspace/lab/schema-optimization/agents/phase_2.md
+++ b/workspace/lab/schema-optimization/agents/phase_2.md
@@ -1,26 +1,20 @@
 ---
 name: phase-2-field-utilization
-description: 'Phase 2 of BigQuery schema optimization pipeline: analyzes field usage patterns to identify unused or low-utilization fields. Reads phase 1 output and produces utilization report as strict JSON for phase 3.'
+description: "Phase 2 of the BigQuery schema optimization pipeline — reads the phase 1 report and schema exports to identify fields with >90% null rates, detect never-queried columns, and produce ranked removal and archival recommendations as a markdown report plus strict JSON for phase 3. Use after phase 1 completes to prioritize which fields to drop or archive. Trigger with \"run schema phase 2\", \"analyze field utilization\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: pink
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- phase
-- '2'
-- field
-- utilization
+- bigquery
+- field-utilization
+- schema-optimization
+- pipeline
 disallowedTools: []
 skills: []
 background: false

--- a/workspace/lab/schema-optimization/agents/phase_3.md
+++ b/workspace/lab/schema-optimization/agents/phase_3.md
@@ -1,26 +1,20 @@
 ---
 name: phase-3-impact-assessment
-description: 'Phase 3 of BigQuery schema optimization pipeline: evaluates the impact of proposed schema changes on systems, queries, and costs. Reads phase 1-2 outputs and produces impact assessment as strict JSON for phase 4.'
+description: "Phase 3 of the BigQuery schema optimization pipeline — evaluates proposed schema changes from phases 1-2 against dependent queries and systems, categorizes each change by risk level, estimates storage and cost savings, and produces an impact matrix as a markdown report plus strict JSON for phase 4. Use when deciding which field removals are safe to execute. Trigger with \"run schema phase 3\", \"assess schema change impact\"."
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: green
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- phase
-- '3'
-- impact
-- assessment
+- bigquery
+- impact-assessment
+- schema-optimization
+- cost-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/workspace/lab/schema-optimization/agents/phase_4.md
+++ b/workspace/lab/schema-optimization/agents/phase_4.md
@@ -1,25 +1,21 @@
 ---
 name: phase-4-verification
-description: 'Phase 4 of BigQuery schema optimization pipeline: runs automated verification scripts to validate phase 2-3 conclusions with empirical data. Outputs verification results as strict JSON for phase 5.'
+description: 'Runs BigQuery field-utilization shell scripts to empirically validate phase 2-3 conclusions, reconciles manual vs. script findings, and writes a verification report. Use when phase 3 analysis is complete and you need script-backed evidence. Trigger with "run verification", "validate phase 3 findings".'
 tools:
 - Read
 - Write
-- Edit
 - Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- phase
-- '4'
+- bigquery
+- schema-optimization
 - verification
+- data-analysis
 disallowedTools: []
 skills: []
 background: false

--- a/workspace/lab/schema-optimization/agents/phase_5.md
+++ b/workspace/lab/schema-optimization/agents/phase_5.md
@@ -1,25 +1,20 @@
 ---
 name: phase-5-recommendations
-description: 'Phase 5 of BigQuery schema optimization pipeline: synthesizes all phase outputs into actionable recommendations with implementation plans. Produces final recommendations report.'
+description: 'Synthesizes BigQuery schema optimization findings from all prior phases into a prioritized implementation plan with rollback procedures, timelines, and success metrics. Use when all previous phase reports are complete. Trigger with "generate recommendations", "finalize schema optimization plan".'
 tools:
 - Read
 - Write
-- Edit
-- Bash
 - Glob
 - Grep
-- WebFetch
-- WebSearch
-- Task
-- TodoWrite
 model: sonnet
 color: red
 version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:
-- phase
-- '5'
+- bigquery
+- schema-optimization
 - recommendations
+- implementation-planning
 disallowedTools: []
 skills: []
 background: false


### PR DESCRIPTION
## What

Stacks on #878 (kernel-strict agent gate). Brings every in-repo agent from the **green floor** (validator-passing) to **A-grade**, across all 317 agents.

Per agent, three frontmatter fields improved:
- **`description`** — capability lead + `Use when …` clause + `Trigger with "…", "…"` (concrete invocation phrases). 100% now carry a Trigger clause (was 0).
- **`tools`** — narrowed from the full-canonical inherit-all set to **least privilege**, per-agent, justified by what each body actually exercises. Median ~5 tools; **0 agents retain the full 10-tool set** (down from 311 inheriting all). Distribution: 1→9, 2→22, 3→38, 4→61, 5→79, 6→68, 7→17, 8→16, 9→7.
- **`tags`** — real lowercase topic tags (≥2 each), replacing the scaffolded single-category placeholders.

## Surgical guarantee

Only `description` / `tools` / `tags` changed. **Bodies and every other frontmatter field are byte-identical** across all 317 (machine-verified: 0 body changes, 0 other-field changes, 0 parse errors).

## Verification

- `python3 scripts/validate-skills-schema.py --agents-only` → **all 317 agents `(agent) - OK`**, 0 agent-level errors.
- Scope re-checked post-edit: only the three allowed fields differ on every file.
- `mcp__*` / specialized tools preserved where bodies use them (keeps the body-vs-allowlist invariant intact ahead of #843).

## How

Workflow fan-out: 22 disjoint batches (~15 agents each), one Sonnet subagent per batch reading each agent body, narrowing tools to least-privilege, writing Trigger descriptions + real tags, self-validating to agent-OK. A targeted second pass re-narrowed the 8 agents that initially kept all 10 tools.

Epic: `claude-jc4d`. Foundation: #878.

[skip auto-bump]