### PR TITLE
fix(plane-sync): HTML-escape issue body before description_html injection

### DIFF
--- a/.github/workflows/plane-sync.yml
+++ b/.github/workflows/plane-sync.yml
@@ -36,8 +36,12 @@ jobs:
           BACKLOG: ${{ steps.state.outputs.backlog }}
         run: |
           set -euo pipefail
+          # HTML-escape the body (& first, then < >) so angle-bracket placeholders
+          # like mcp__<server>__<tool> survive Plane's HTML renderer; <pre> preserves
+          # line breaks that the old <p> collapsed.
           HTML=$(jq -n --arg body "${BODY:-<no description>}" --arg url "$GH_URL" \
-            '"<p>" + $body + "</p><hr><p>Mirrored from <a href=\"" + $url + "\">" + $url + "</a></p>"')
+            '($body | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $escaped
+             | "<pre>" + $escaped + "</pre><hr><p>Mirrored from <a href=\"" + $url + "\">" + $url + "</a></p>"')
           PAYLOAD=$(jq -n --arg name "$TITLE" --argjson html "$HTML" --arg state "$BACKLOG" \
             '{name:$name, description_html:$html, state:$state}')
           RESP=$(curl -fsSL -H "X-API-Key: $PLANE_API_KEY" -H "Content-Type: application/json" \


### PR DESCRIPTION
Fixes #845. The `gh-issue-to-plane` job injected the raw issue body into `description_html` unescaped, so angle-bracket placeholders (`mcp__<server>__<tool>`, `<udid>`, `<sessionId>`) were parsed as HTML tags by Plane and stripped.

**Fix:** escape `&`/`<`/`>` (ampersand first to avoid double-escaping) and wrap in `<pre>` to preserve the line breaks the old `<p>` collapsed.

Verified locally: a body of `Call mcp__<server>__<tool> & check <udid>` renders as `<pre>Call mcp__&lt;server&gt;__&lt;tool&gt; &amp; check &lt;udid&gt;</pre>` — placeholders survive.

Per the issue acceptance criteria, existing CCP mirrors are not retroactively edited.

[skip auto-bump]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of mirrored issue content to properly preserve line breaks and handle special characters during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->