### PR TITLE
feat(validator): agent body-vs-allowlist consistency check (schema 3.11.0)

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,45 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.11.0] — 2026-06-18 — Agent body-vs-allowlist consistency check (additive, issue #843)
+
+**Additive MINOR — no change to any required-field set, tier model, or
+error-vs-warning semantics for those fields.** `validate_agent()` now inspects
+the agent BODY (previously it read only frontmatter) and cross-checks it against
+the `tools` allowlist, which is a runtime gate (tools not listed are blocked at
+runtime). Closes the defect class where an agent's body invokes an MCP tool it
+never declares and silently runtime-blocks every call (surfaced on
+`kobiton/automate#67` by the customer, not our validator).
+
+New checks in `check_agent_body_vs_allowlist()`:
+
+- **CHECK 1 (ERROR):** body contains a fully-qualified `mcp__<server>__<tool>`
+  that is not in the declared allowlist (partial-coverage case).
+- **CHECK 3 (ERROR):** the allowlist declares zero `mcp__*` tools but the body
+  references fully-qualified MCP tools — highest-confidence form; every call
+  would block.
+- **CHECK 2 (WARN):** body backtick-mentions a verbCamelCase short name
+  (`listDevices`, `getSession`, …) with no matching declared `mcp__*__<name>`.
+  Heuristic; gated to MCP-oriented agents only (declares an mcp tool or has a
+  FQ ref) to avoid flagging plain code prose like `getStaticProps`.
+- **WARN (over-declared):** a declared `mcp__*__<tool>` whose suffix never
+  appears in the body — privilege drift.
+
+Fenced code blocks are stripped before matching so documented examples don't
+trip the FQ checks. Errors are agent-level (agents are not tier-gated).
+
+**Corpus impact:** run against all 317 in-repo agents — caught one genuine
+pre-existing defect (`plugins/analytics/web-analytics/agents/data-collector.md`
+invoked six `mcp__umami__*` tools with only `Read` declared), fixed in the same
+change by declaring the six tools. Zero false-positive errors elsewhere.
+
+Tests: `tests/test_validate_skills_schema_frontmatter.py` (9 `843` cases —
+CHECK 1/2/3, over-declared, fenced-code exemption, non-MCP suppression, and an
+end-to-end `validate_agent` fixture). `validate-agent` skill SKILL.md updated to
+reference the validator-side check (the shell heuristic becomes a fallback).
+
+---
+
 ## [3.10.0] — 2026-06-17 — AGENT gate flipped to kernel-strict + enterprise-fleshed (required-field-set change, **approved**)
 
 **This is an architectural change to the AGENT required-field set** (NON-NEGOTIABLE

--- a/plugins/analytics/web-analytics/agents/data-collector.md
+++ b/plugins/analytics/web-analytics/agents/data-collector.md
@@ -3,6 +3,12 @@ name: data-collector
 description: "Fetches raw analytics data from Umami MCP across all tracked sites and returns structured datasets for specialist agents — never interprets, only collects. Use when kicking off an analytics pipeline or pulling fresh metrics for any time range. Trigger with \"collect analytics data\", \"fetch site metrics\"."
 tools:
 - Read
+- mcp__umami__get_websites
+- mcp__umami__get_active
+- mcp__umami__get_stats
+- mcp__umami__get_pageviews
+- mcp__umami__get_metrics
+- mcp__umami__get_events
 model: sonnet
 color: yellow
 version: 1.0.0

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -126,7 +126,7 @@ except ImportError:
 #                       200 → 1536 (kernel disclosureMarkers cap). No change to the
 #                       SKILL ALWAYS_REQUIRED set or skill tier semantics.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.10.0"
+SCHEMA_VERSION = "3.11.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -1631,6 +1631,104 @@ def validate_plugin_json(path: Path) -> Dict[str, Any]:
     return {"errors": errors, "warnings": warnings}
 
 
+_MCP_VERB_PREFIXES = (
+    "list", "get", "create", "delete", "update", "reserve",
+    "terminate", "confirm", "upload", "fetch", "cancel", "start", "stop",
+)
+# Fully-qualified MCP tool reference: mcp__<server>__<tool>
+_RE_MCP_FQ = re.compile(r"mcp__[a-zA-Z0-9]+__[a-zA-Z0-9_]+")
+# Backtick-quoted verbCamelCase short names commonly tool-call-shaped.
+_RE_BACKTICK_VERB = re.compile(r"`([a-z][a-zA-Z0-9_]*)`")
+
+
+def _agent_declared_tools(fm: Dict[str, Any]) -> List[str]:
+    """Normalize the agent `tools` field (string|array) to a list of names."""
+    val = fm.get("tools")
+    if isinstance(val, list):
+        return [str(t).strip() for t in val if str(t).strip()]
+    if isinstance(val, str):
+        return [t.strip() for t in re.split(r"[,\s]+", val) if t.strip()]
+    return []
+
+
+def check_agent_body_vs_allowlist(fm: Dict[str, Any], body: str) -> Tuple[List[str], List[str]]:
+    """Cross-check the agent body against its `tools` allowlist (issue #843).
+
+    The `tools` frontmatter is a runtime allowlist — tools not listed are
+    blocked. An agent whose body invokes an MCP tool it never declares will
+    runtime-block every call (caught downstream, not by the old validator).
+
+    CHECK 1 (ERROR): body contains a fully-qualified mcp__server__tool that is
+                     not in the declared allowlist (and some MCP tools ARE
+                     declared — the partial-coverage case).
+    CHECK 3 (ERROR): the allowlist declares ZERO mcp__* tools but the body
+                     contains fully-qualified mcp__ references — the highest-
+                     confidence form of the defect; every call would block.
+    CHECK 2 (WARN):  body backtick-mentions a verbCamelCase short name
+                     (listDevices, getSession, …) with no matching declared
+                     mcp__*__<name>. Heuristic — short names are ambiguous.
+    WARN (over-declared): a declared mcp__*__<tool> whose suffix never appears
+                     in the body (FQ or short) — privilege drift.
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    declared = _agent_declared_tools(fm)
+    declared_mcp = [t for t in declared if t.startswith("mcp__")]
+    declared_set = set(declared)
+    declared_suffixes = {t.rsplit("__", 1)[-1] for t in declared_mcp if "__" in t}
+
+    # Strip fenced code blocks from the body so syntax/examples inside ``` … ```
+    # don't trip the FQ-reference checks (they document, not invoke).
+    body_no_fences = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+
+    fq_refs = sorted(set(_RE_MCP_FQ.findall(body_no_fences)))
+
+    if fq_refs and not declared_mcp:
+        # CHECK 3 — zero MCP tools declared, body references MCP tools.
+        errors.append(
+            "[agent] body references MCP tools "
+            f"({', '.join(fq_refs[:5])}{'…' if len(fq_refs) > 5 else ''}) "
+            "but the `tools` allowlist declares no mcp__* tools — every call would be runtime-blocked (#843 CHECK 3)"
+        )
+    else:
+        # CHECK 1 — specific FQ ref present in body but not in allowlist.
+        for ref in fq_refs:
+            if ref not in declared_set:
+                errors.append(
+                    f"[agent] body invokes '{ref}' but it is not in the `tools` allowlist — "
+                    "this call would be runtime-blocked (#843 CHECK 1)"
+                )
+
+    # CHECK 2 — heuristic short-name mentions with no matching declared MCP tool.
+    # Only meaningful when the agent is demonstrably MCP-oriented (declares an
+    # mcp tool or the body already has a fully-qualified ref); otherwise a
+    # backtick `getStaticProps` / `getServerSideProps` in a code-focused agent
+    # is plain prose, not a tool call. Gating here cuts the false positives the
+    # short-name heuristic is known to produce (#843 acknowledges the ambiguity).
+    short_mentions = {
+        w for w in _RE_BACKTICK_VERB.findall(body_no_fences)
+        if w.startswith(_MCP_VERB_PREFIXES) and any(c.isupper() for c in w)
+    } if (declared_mcp or fq_refs) else set()
+    for name in sorted(short_mentions):
+        if name not in declared_suffixes:
+            warnings.append(
+                f"[agent] body mentions `{name}` (tool-call-shaped) but no declared "
+                "mcp__*__"f"{name} matches — verify it isn't a runtime-blocked call (#843 CHECK 2)"
+            )
+
+    # WARN — over-declared MCP tool never referenced in the body.
+    for t in declared_mcp:
+        suffix = t.rsplit("__", 1)[-1]
+        if t not in fq_refs and suffix not in short_mentions:
+            warnings.append(
+                f"[agent] declares MCP tool '{t}' but the body never references it — "
+                "over-declared privilege / spec drift (#843)"
+            )
+
+    return errors, warnings
+
+
 def validate_agent(path: Path) -> Dict[str, Any]:
     """Validate an agent markdown file against Anthropic 2026 spec."""
     try:
@@ -1752,6 +1850,14 @@ def validate_agent(path: Path) -> Dict[str, Any]:
         for i, tag in enumerate(fm["tags"]):
             if not isinstance(tag, str):
                 errors.append(f"[agent] 'tags[{i}]' must be a string")
+
+    # Body-vs-allowlist consistency (issue #843). The allowlist is a runtime
+    # gate: tools not declared are blocked. So the body and `tools` must agree.
+    # RE_FRONTMATTER group(2) is the post-frontmatter body.
+    body = m.group(2) or ""
+    be, bw = check_agent_body_vs_allowlist(fm, body)
+    errors.extend(be)
+    warnings.extend(bw)
 
     return {"errors": errors, "warnings": warnings, "type": "agent"}
 

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -1632,8 +1632,19 @@ def validate_plugin_json(path: Path) -> Dict[str, Any]:
 
 
 _MCP_VERB_PREFIXES = (
-    "list", "get", "create", "delete", "update", "reserve",
-    "terminate", "confirm", "upload", "fetch", "cancel", "start", "stop",
+    "list",
+    "get",
+    "create",
+    "delete",
+    "update",
+    "reserve",
+    "terminate",
+    "confirm",
+    "upload",
+    "fetch",
+    "cancel",
+    "start",
+    "stop",
 )
 # Fully-qualified MCP tool reference: mcp__<server>__<tool>
 _RE_MCP_FQ = re.compile(r"mcp__[a-zA-Z0-9]+__[a-zA-Z0-9_]+")
@@ -1706,15 +1717,21 @@ def check_agent_body_vs_allowlist(fm: Dict[str, Any], body: str) -> Tuple[List[s
     # backtick `getStaticProps` / `getServerSideProps` in a code-focused agent
     # is plain prose, not a tool call. Gating here cuts the false positives the
     # short-name heuristic is known to produce (#843 acknowledges the ambiguity).
-    short_mentions = {
-        w for w in _RE_BACKTICK_VERB.findall(body_no_fences)
-        if w.startswith(_MCP_VERB_PREFIXES) and any(c.isupper() for c in w)
-    } if (declared_mcp or fq_refs) else set()
+    short_mentions = (
+        {
+            w
+            for w in _RE_BACKTICK_VERB.findall(body_no_fences)
+            if w.startswith(_MCP_VERB_PREFIXES) and any(c.isupper() for c in w)
+        }
+        if (declared_mcp or fq_refs)
+        else set()
+    )
     for name in sorted(short_mentions):
         if name not in declared_suffixes:
             warnings.append(
                 f"[agent] body mentions `{name}` (tool-call-shaped) but no declared "
-                "mcp__*__"f"{name} matches — verify it isn't a runtime-blocked call (#843 CHECK 2)"
+                "mcp__*__"
+                f"{name} matches — verify it isn't a runtime-blocked call (#843 CHECK 2)"
             )
 
     # WARN — over-declared MCP tool never referenced in the body.

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -236,7 +236,7 @@ def test_843_no_mcp_anywhere_is_silent():
 
 def test_843_fenced_code_examples_do_not_trigger_errors():
     # FQ refs inside ``` fences are documentation, not invocations.
-    body = "Here is the config shape:\n\n```json\n{\"tool\": \"mcp__foo__bar\"}\n```\n"
+    body = 'Here is the config shape:\n\n```json\n{"tool": "mcp__foo__bar"}\n```\n'
     errors, _ = _body_check(["Read"], body)
     assert errors == [], errors
 

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -180,3 +180,116 @@ def test_always_required_is_the_is_enterprise_8_field_set():
         "compatibility",
         "tags",
     }
+
+
+# =========================================================================
+# Issue #843 — agent body-vs-allowlist consistency checks.
+# The `tools` frontmatter is a runtime allowlist; a body that invokes an MCP
+# tool it never declares runtime-blocks every call. CHECK 1/3 = errors,
+# CHECK 2 + over-declared = warnings.
+# =========================================================================
+
+
+def _body_check(tools, body):
+    return validator.check_agent_body_vs_allowlist({"tools": tools}, body)
+
+
+def test_843_check1_fq_mcp_not_in_allowlist_is_error():
+    # Some MCP declared, but the body invokes a different (undeclared) one.
+    errors, _ = _body_check(
+        ["Read", "mcp__kobiton__getSession"],
+        "First call `mcp__kobiton__listDevices` to enumerate, then inspect.",
+    )
+    assert any("CHECK 1" in e and "mcp__kobiton__listDevices" in e for e in errors), errors
+
+
+def test_843_check3_zero_mcp_declared_with_body_ref_is_error():
+    # The highest-confidence defect: no mcp__* declared at all, body uses one.
+    errors, _ = _body_check(
+        ["Read", "Bash(node:*)"],
+        "Use `mcp__kobiton__getSession` to fetch the live session.",
+    )
+    assert any("CHECK 3" in e for e in errors), errors
+    # CHECK 1 must NOT double-fire in the zero-declared case.
+    assert not any("CHECK 1" in e for e in errors), errors
+
+
+def test_843_clean_allowlist_matches_body_no_errors():
+    errors, warnings = _body_check(
+        ["Read", "mcp__kobiton__listDevices"],
+        "Call `mcp__kobiton__listDevices` to enumerate devices.",
+    )
+    assert errors == [], errors
+    # Declared tool IS referenced -> no over-declared warning either.
+    assert not any("over-declared" in w for w in warnings), warnings
+
+
+def test_843_no_mcp_anywhere_is_silent():
+    # The common in-repo agent: no MCP tools, prose has no FQ mcp refs.
+    errors, warnings = _body_check(
+        ["Read", "Grep", "Glob"],
+        "Analyze the repository structure and report findings. Read the configs.",
+    )
+    assert errors == []
+    assert warnings == []
+
+
+def test_843_fenced_code_examples_do_not_trigger_errors():
+    # FQ refs inside ``` fences are documentation, not invocations.
+    body = "Here is the config shape:\n\n```json\n{\"tool\": \"mcp__foo__bar\"}\n```\n"
+    errors, _ = _body_check(["Read"], body)
+    assert errors == [], errors
+
+
+def test_843_overdeclared_mcp_tool_warns():
+    errors, warnings = _body_check(
+        ["Read", "mcp__kobiton__terminateSession"],
+        "Inspect the session state and summarize. No teardown here.",
+    )
+    assert errors == []
+    assert any("over-declared" in w for w in warnings), warnings
+
+
+def test_843_check2_shortname_mention_warns_not_errors():
+    # CHECK 2 only fires for MCP-oriented agents (declares an mcp tool here),
+    # so a backtick short name it never declared is flagged as a heuristic warn.
+    errors, warnings = _body_check(
+        ["Read", "mcp__kobiton__getSession"],
+        "First `getSession`, then if the device is busy call `reserveDevice` and retry.",
+    )
+    assert not any("CHECK 1" in e or "CHECK 3" in e for e in errors), errors
+    assert any("CHECK 2" in w and "reserveDevice" in w for w in warnings), warnings
+
+
+def test_843_check2_suppressed_for_non_mcp_agent():
+    # A code-focused agent with no MCP involvement: backtick `getStaticProps`
+    # is prose, not a tool call — must not warn (the known-FP guard).
+    errors, warnings = _body_check(
+        ["Read", "Grep"],
+        "Flag components using `getStaticProps` that should migrate to app router.",
+    )
+    assert errors == []
+    assert not any("CHECK 2" in w for w in warnings), warnings
+
+
+def test_843_end_to_end_validate_agent_surfaces_check3(tmp_path):
+    # Full plugin-agent fixture (all required fields present) so the only
+    # error is the #843 body-vs-allowlist one.
+    agent = tmp_path / "plugins" / "x" / "agents" / "defective.md"
+    agent.parent.mkdir(parents=True)
+    (tmp_path / "plugins" / "x" / ".claude-plugin").mkdir(parents=True)
+    (tmp_path / "plugins" / "x" / ".claude-plugin" / "plugin.json").write_text('{"name":"x"}')
+    agent.write_text(
+        "---\n"
+        "name: defective\n"
+        "description: Drives a Kobiton device session for automated UI testing flows end to end.\n"
+        "tools:\n  - Read\n  - Bash\n"
+        "model: sonnet\ncolor: blue\nversion: 1.0.0\n"
+        "author: T <t@example.com>\n"
+        "tags:\n  - testing\n  - mobile\n"
+        "disallowedTools: []\nskills: []\nbackground: false\n"
+        "---\n\n"
+        "Call `mcp__kobiton__getSession` then `mcp__kobiton__getSessionArtifacts`.\n"
+    )
+    result = validator.validate_agent(agent)
+    assert any("CHECK 3" in e for e in result["errors"]), result["errors"]


### PR DESCRIPTION
Closes #843.

`validate_agent()` previously read only frontmatter, so it could not see that an agent body invokes an MCP tool absent from its `tools` allowlist — a runtime allowlist that **blocks undeclared tools**. That defect class shipped past the validator (surfaced on `kobiton/automate#67` by the customer, not us).

## New checks (`check_agent_body_vs_allowlist`)
| Check | Severity | Catches |
|---|---|---|
| CHECK 1 | ERROR | body invokes `mcp__server__tool` not in allowlist (partial coverage) |
| CHECK 3 | ERROR | zero `mcp__*` declared but body references MCP tools (every call blocks) |
| CHECK 2 | WARN | verbCamelCase short-name mention with no matching declared MCP tool — gated to MCP-oriented agents to avoid false positives like `getStaticProps` |
| over-declared | WARN | declared `mcp__*__tool` never used in body (privilege drift) |

Fenced code blocks are stripped before matching so documented examples don't trip the FQ checks. Agents are not tier-gated, so these are agent-level errors.

## Corpus impact (ran against all 317 in-repo agents)
Caught **one genuine pre-existing defect**: `plugins/analytics/web-analytics/agents/data-collector.md` invoked six `mcp__umami__*` tools with only `Read` declared — it literally could not collect data. **Fixed in this PR** by declaring the six tools (documented scope extension per the CI-alert-in-unmodified-code rule). Zero false-positive errors elsewhere.

## Tests
9 new `843` cases in `tests/test_validate_skills_schema_frontmatter.py`: CHECK 1/2/3, over-declared, fenced-code exemption, non-MCP suppression, and an end-to-end `validate_agent` fixture. Full frontmatter suite: 26 passed.

Additive MINOR — no required-field-set / tier / error-vs-warning-semantics change (NON-NEGOTIABLES untouched). SCHEMA_VERSION 3.10.0 → 3.11.0; changelog entry added.

[skip auto-bump]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced agent schema validation now compares agent body MCP tool references against the declared tools allowlist, reporting mismatches and suspicious short-name mentions while ignoring fenced code examples.
* **Bug Fixes**
  * Prevents runtime-blocked MCP tool calls by catching configuration issues earlier, and improves Umami analytics tool declarations.
* **Documentation**
  * Updated the schema changelog for version 3.11.0.
* **Tests**
  * Added regression coverage for the new body-vs-allowlist consistency checks, including end-to-end validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->