### PR TITLE
docs(CLAUDE.md): refresh to schema 3.11.0 + kernel-strict agent gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,11 @@ pnpm test && pnpm typecheck
 pnpm lint
 pnpm run verify                   # Full pipeline — what CI's `verify` job runs
 
-# Validator (schema 3.6.0 — see 000-docs/SCHEMA_CHANGELOG.md)
+# Validator (schema 3.11.0 — see 000-docs/SCHEMA_CHANGELOG.md)
 python3 scripts/validate-skills-schema.py --verbose
 python3 scripts/validate-skills-schema.py --marketplace --verbose
 python3 scripts/validate-skills-schema.py --marketplace --populate-db freshie/inventory.sqlite
+python3 scripts/validate-skills-schema.py --agents-only --verbose   # agents only (kernel-strict gate)
 
 # Unicode hygiene gate — Trapdoor / Trojan Source defense for SKILL.md /
 # plugin.json / agent / command files. Default mode blocks on tag chars
@@ -120,6 +121,8 @@ Beyond the 8 required fields, schema 3.5.0+ adds optional visibility-gating fiel
 `compatible-with` is deprecated. Migrate with: `python3 scripts/batch-remediate.py --migrate-compatible-with`
 
 **Agents use `disallowedTools` (camelCase denylist).** Skills use `allowed-tools` (allowlist) AND optionally `disallowed-tools` (kebab-case denylist, schema 3.7.0+). The two field names are intentionally different — do NOT use camelCase on skills or kebab-case on agents; the validator rejects either mismatch. Agent-only fields: `effort`, `maxTurns`.
+
+**Agent gate is kernel-strict (schema 3.10.0, NOT tier-gated).** Every authored agent must carry the kernel-floor 8 (`name, description, tools, model, color, version, author, tags`) plus the enterprise live set (`disallowedTools`, `skills`, `background`; + `hooks`, `mcpServers`, `permissionMode` on standalone agents) — all **errors** at every tier. Banned fields (`capabilities`, `expertise_level`, `activation_priority`, `type`, `category`, `compatible-with`, `when_to_use`) are errors; `fable` is an accepted model. All 317 in-repo agents are at **A-grade** (least-privilege `tools`, Trigger-bearing descriptions, real tags). **Schema 3.11.0** added a body-vs-allowlist check: an agent whose body invokes `mcp__server__tool` not in its `tools` allowlist is an error (it would runtime-block). Validate with `--agents-only`.
 
 ### Optional frontmatter (schema 3.5.0 / 3.6.0 / 3.7.0 — all default to off)
 


### PR DESCRIPTION
Brings the repo CLAUDE.md current with this session's landed work: validator schema reference 3.6.0 → 3.11.0, the `--agents-only` command, the kernel-strict agent gate (3.10.0, not tier-gated), the 317-agent A-grade fleet, and the 3.11.0 body-vs-allowlist check.

Docs-only.

[skip auto-bump]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validator schema documentation to version 3.11.0
  * Introduced new `--agents-only` validation command option for agent-specific validation
  * Enhanced agent authoring requirements documentation with kernel specifications and field requirements
  * Added MCP tool invocation validation to ensure tool usage is covered by agent tools allowlist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->