### PR TITLE
test(kernel-vendor-hash): formalize V<=C<=K ordering invariant test corpus

### DIFF
--- a/.github/workflows/kernel-vendor-hash.yml
+++ b/.github/workflows/kernel-vendor-hash.yml
@@ -33,6 +33,7 @@ on:
   pull_request:
     paths:
       - 'scripts/kernel-vendor-hash.mjs'
+      - 'scripts/kernel-vendor-hash.test.mjs'
       - 'scripts/validate-skills-schema.py'
       - 'package.json'
       - 'pnpm-lock.yaml'
@@ -71,6 +72,16 @@ jobs:
       # V from node_modules in the absence of a .kernel-vendor/ snapshot.
       - name: Install root dev dependencies
         run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
+
+      # BLOCKING — the version-ordering invariant test corpus (F-MK-003). This is
+      # NOT advisory: it exercises the V <= C <= K comparator (`evaluateCoupling` +
+      # `semverCompare`) with synthetic positive/negative/staleness fixtures and the
+      # CLI advisory-vs-strict exit-code contract. Correctness of the comparator is
+      # ORTHOGONAL to the DR-049 soak (which only governs pin-bump pressure / validator
+      # authority) — a broken comparator is a real bug, so a failing corpus turns this
+      # check red. Uses node's built-in runner (zero new deps).
+      - name: Version-ordering invariant test corpus (blocking)
+        run: node --test scripts/kernel-vendor-hash.test.mjs
 
       # K (kernel latest published) is resolved from npm in CI — the read-only
       # sibling repo is not checked out here. Pass it explicitly so C <= K and the

--- a/scripts/kernel-vendor-hash.mjs
+++ b/scripts/kernel-vendor-hash.mjs
@@ -82,7 +82,7 @@
 
 import { readFileSync, existsSync, statSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -127,8 +127,11 @@ function parseArgs(argv) {
 
 /** Minimal, dependency-free semver compare. Returns -1 / 0 / 1. Pre-release tags
  *  (e.g. "1.0.0-draft") are compared core-first, then a present pre-release sorts
- *  BEFORE the same core with no pre-release, per semver §11. */
-function semverCompare(a, b) {
+ *  BEFORE the same core with no pre-release, per semver §11.
+ *
+ *  Exported so the version-ordering test corpus can exercise the SAME comparator
+ *  the CLI uses (no logic fork). See scripts/kernel-vendor-hash.test.mjs. */
+export function semverCompare(a, b) {
   const split = (v) => {
     const [core, pre = ''] = String(v).trim().replace(/^v/, '').split('-');
     const nums = core.split('.').map((n) => parseInt(n, 10) || 0);
@@ -229,20 +232,33 @@ function ageFromIso(iso) {
   return Math.floor((Date.now() - t) / MS_PER_DAY);
 }
 
-function main() {
-  const args = parseArgs(process.argv.slice(2));
+/**
+ * PURE comparator core — the V ≤ C ≤ K ordering invariant + bounded-staleness
+ * evaluation, with no filesystem / process / clock dependency. The CLI (`main`)
+ * resolves V/C/K from disk and passes them here; the version-ordering test corpus
+ * (scripts/kernel-vendor-hash.test.mjs) drives this directly with synthetic
+ * fixtures so the SAME logic is exercised end-to-end without a fork.
+ *
+ * @param {object} input
+ * @param {string|null} input.V          vendored snapshot version (semver) or null/absent
+ * @param {string|null} input.C          CCPI-declared kernel pin (semver) or null/absent
+ * @param {string|null} input.K          kernel latest published (semver) or null/absent
+ * @param {boolean}     [input.ranged]   whether C was declared with a range operator
+ * @param {number|null} [input.kernelAgeDays] kernel publish age in days, or null if unknown
+ * @param {number}      [input.stalenessLimitDays] day bound (defaults to STALENESS_LIMIT_DAYS)
+ * @returns {{ violations: string[], warnings: string[], stale: boolean }}
+ */
+export function evaluateCoupling(input) {
+  const {
+    V = null,
+    C = null,
+    K = null,
+    ranged = false,
+    kernelAgeDays = null,
+    stalenessLimitDays = STALENESS_LIMIT_DAYS,
+  } = input ?? {};
   const warnings = [];
   const violations = [];
-
-  const vendored = resolveVendored();
-  const declared = resolveDeclared();
-  const kernel = resolveKernelLatest(args);
-  // CCPI's own validator schema version — reported for context, NOT part of V≤C≤K.
-  const ccpSchemaVersion = readCcpSchemaVersion();
-
-  const V = vendored.version;
-  const C = declared.version;
-  const K = kernel.version;
 
   // --- existence guards (loud warn, never crash) -----------------------------
   if (!V) {
@@ -257,7 +273,7 @@ function main() {
       'C (CCPI-declared kernel) UNRESOLVED: package.json has no @intentsolutions/core dependency. ' +
         'V≤C and C≤K checks SKIPPED.',
     );
-  } else if (declared.ranged) {
+  } else if (ranged) {
     warnings.push(
       `C pin "${C}" uses a RANGE operator. The kernel pin must be EXACT (no ^/~) per the ` +
         'shadow-validation pin discipline. Treating the floor as C for ordering.',
@@ -282,30 +298,55 @@ function main() {
     );
   }
 
-  // --- bounded staleness ≤ 7 days --------------------------------------------
+  // --- bounded staleness ≤ N days --------------------------------------------
   let stale = false;
   if (V && K && semverCompare(V, K) < 0) {
-    // The vendored snapshot lags the latest kernel. Only a >7-day lag is reported
+    // The vendored snapshot lags the latest kernel. Only a >N-day lag is reported
     // as staleness (per § 14.15.2). Age comes from the kernel publish timestamp.
-    if (kernel.ageDays === null) {
+    if (kernelAgeDays === null) {
       warnings.push(
         `STALENESS: V (${V}) lags K (${K}) but kernel publish age is UNKNOWN ` +
           '(pass --kernel-published <ISO> for a precise age). Not firing staleness.',
       );
-    } else if (kernel.ageDays > STALENESS_LIMIT_DAYS) {
+    } else if (kernelAgeDays > stalenessLimitDays) {
       stale = true;
       violations.push(
         `STALENESS: V (${V}) lags K (${K}) and the kernel has been published for ` +
-          `${kernel.ageDays} days (> ${STALENESS_LIMIT_DAYS}-day bound). ` +
+          `${kernelAgeDays} days (> ${stalenessLimitDays}-day bound). ` +
           'DEFERRED ACTION (post-DR-049-flip): CI would open a kernel-bump PR here.',
       );
     } else {
       warnings.push(
-        `STALENESS OK: V (${V}) lags K (${K}) by ${kernel.ageDays} day(s) ` +
-          `(within the ${STALENESS_LIMIT_DAYS}-day bound).`,
+        `STALENESS OK: V (${V}) lags K (${K}) by ${kernelAgeDays} day(s) ` +
+          `(within the ${stalenessLimitDays}-day bound).`,
       );
     }
   }
+
+  return { violations, warnings, stale };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const vendored = resolveVendored();
+  const declared = resolveDeclared();
+  const kernel = resolveKernelLatest(args);
+  // CCPI's own validator schema version — reported for context, NOT part of V≤C≤K.
+  const ccpSchemaVersion = readCcpSchemaVersion();
+
+  const V = vendored.version;
+  const C = declared.version;
+  const K = kernel.version;
+
+  const { violations, warnings, stale } = evaluateCoupling({
+    V,
+    C,
+    K,
+    ranged: declared.ranged,
+    kernelAgeDays: kernel.ageDays,
+    stalenessLimitDays: STALENESS_LIMIT_DAYS,
+  });
 
   const report = {
     schema: 'kernel-vendor-hash/v1',
@@ -391,4 +432,9 @@ function printHuman(r) {
   line('');
 }
 
-main();
+// Run main() ONLY when invoked directly as a CLI (node scripts/kernel-vendor-hash.mjs),
+// never when imported as a module (the test corpus imports evaluateCoupling +
+// semverCompare without triggering the disk-reading / process-exiting main()).
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/kernel-vendor-hash.test.mjs
+++ b/scripts/kernel-vendor-hash.test.mjs
@@ -235,8 +235,10 @@ test('ranged pin warns but still orders on the floor', () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CLI exit-code contract (end-to-end subprocess) — advisory exits 0 even when the
-// ordering is violated; --strict exits 1 on a real violation. Drives the resolved
-// V/C from this repo's disk (both 0.4.1) with K injected via --kernel-latest.
+// ordering is violated; --strict exits 1 on a real violation. The resolved V/C
+// come from this repo's disk; C is read from a baseline --json run (NOT hardcoded)
+// so a routine package.json pin bump cannot break these blocking smokes. K is
+// injected via --kernel-latest to force / clear the ordering relationship.
 // ─────────────────────────────────────────────────────────────────────────────
 function runCli(args) {
   try {
@@ -247,29 +249,46 @@ function runCli(args) {
   }
 }
 
+/** Resolve the declared kernel pin (C) from a baseline advisory --json run, so the
+ *  CLI smokes track the real package.json pin instead of a hardcoded literal. */
+function resolveDeclaredC() {
+  const baseline = JSON.parse(runCli(['--json']).stdout);
+  const c = baseline.identities?.C_ccpDeclaredKernel?.version;
+  assert.ok(c, 'baseline run must resolve C (the declared @intentsolutions/core pin)');
+  return c;
+}
+
+// A K guaranteed below any real pin → forces the C > K ordering violation
+// regardless of what C is bumped to.
+const FORCED_LOW_K = '0.0.0';
+
 test('CLI advisory: a C>K ordering violation still EXITS 0 (report-only)', () => {
-  // C resolves to 0.4.1 from package.json; K=0.1.0 forces C > K.
-  const { code, stdout } = runCli(['--kernel-latest', '0.1.0', '--json']);
+  const declaredC = resolveDeclaredC();
+  const { code, stdout } = runCli(['--kernel-latest', FORCED_LOW_K, '--json']);
   assert.equal(code, 0, 'advisory mode must exit 0 regardless of violations');
   const report = JSON.parse(stdout);
+  const expected = new RegExp(
+    `C \\(${declaredC.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\) > K \\(${FORCED_LOW_K.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\)`,
+  );
   assert.ok(
-    report.violations.some((v) => /C \(0\.4\.1\) > K \(0\.1\.0\)/.test(v)),
-    'expected the C>K ordering violation to be reported',
+    report.violations.some((v) => expected.test(v)),
+    `expected the C>K ordering violation to be reported, got: ${JSON.stringify(report.violations)}`,
   );
   assert.equal(report.advisory, true);
 });
 
 test('CLI --strict: a C>K ordering violation EXITS 1', () => {
-  const { code } = runCli(['--strict', '--kernel-latest', '0.1.0']);
+  const { code } = runCli(['--strict', '--kernel-latest', FORCED_LOW_K]);
   assert.equal(code, 1, '--strict must exit non-zero on a real ordering violation');
 });
 
 test('CLI --strict: a clean ordering (C=K) EXITS 0', () => {
-  // K=0.4.1 matches the declared pin → V=C=K → no violation.
+  // K set equal to the declared pin → V=C=K → no violation, regardless of the pin.
+  const declaredC = resolveDeclaredC();
   const { code } = runCli([
     '--strict',
     '--kernel-latest',
-    '0.4.1',
+    declaredC,
     '--kernel-published',
     new Date().toISOString(),
   ]);

--- a/scripts/kernel-vendor-hash.test.mjs
+++ b/scripts/kernel-vendor-hash.test.mjs
@@ -1,0 +1,277 @@
+/**
+ * kernel-vendor-hash.test.mjs — VERSION-ORDERING INVARIANT TEST CORPUS
+ *
+ * Closes F-MK-003 (bead: "Version ordering invariant V <= C <= K formalized in
+ * test corpus"). Formalizes the V ≤ C ≤ K ordering invariant + bounded-staleness
+ * model from plan 033 § 14.15.1 as an executable fixture corpus.
+ *
+ * The corpus drives the SAME comparator the CLI uses — `evaluateCoupling` is the
+ * pure core that `main()` in kernel-vendor-hash.mjs delegates to, so there is no
+ * logic fork between what CI runs and what these tests assert. A handful of
+ * end-to-end subprocess smokes additionally assert the CLI's advisory vs --strict
+ * EXIT CODE contract (advisory exits 0 even on a violation; --strict exits 1).
+ *
+ * Run: node --test scripts/kernel-vendor-hash.test.mjs
+ *
+ * FIXTURE SHAPE (one row per scenario)
+ *   { name, V, C, K, ranged?, kernelAgeDays?, expect: { violations, stale, ordering } }
+ *     - ordering: 'ok' (V<=C<=K holds + within staleness budget) | 'violation'
+ *     - violations: expected count of reported ordering/staleness violations
+ *     - stale: expected boolean staleness flag
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { evaluateCoupling, semverCompare } from './kernel-vendor-hash.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, 'kernel-vendor-hash.mjs');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// semverCompare — the primitive the ordering invariant is built on.
+// ─────────────────────────────────────────────────────────────────────────────
+test('semverCompare: equal cores compare to 0', () => {
+  assert.equal(semverCompare('0.4.1', '0.4.1'), 0);
+  assert.equal(semverCompare('1.0.0', '1.0.0'), 0);
+  assert.equal(semverCompare('v0.4.1', '0.4.1'), 0, 'leading v is tolerated');
+});
+
+test('semverCompare: orders by major.minor.patch', () => {
+  assert.equal(semverCompare('0.4.1', '0.4.2'), -1);
+  assert.equal(semverCompare('0.5.0', '0.4.9'), 1);
+  assert.equal(semverCompare('1.0.0', '0.99.99'), 1);
+  assert.equal(semverCompare('0.4.0', '0.4.0'), 0);
+});
+
+test('semverCompare: a pre-release sorts BEFORE the same core without one (semver §11)', () => {
+  assert.equal(semverCompare('1.0.0-draft', '1.0.0'), -1);
+  assert.equal(semverCompare('1.0.0', '1.0.0-draft'), 1);
+  assert.equal(semverCompare('1.0.0-alpha', '1.0.0-beta'), -1);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The V ≤ C ≤ K fixture corpus — POSITIVE cases (the bead's (a),(b),(c)).
+// ─────────────────────────────────────────────────────────────────────────────
+const POSITIVE_FIXTURES = [
+  {
+    // (a) canonical happy path — all three identities equal (the steady state).
+    name: '(a) vendored = CCP = kernel — canonical steady state',
+    V: '0.4.1',
+    C: '0.4.1',
+    K: '0.4.1',
+    expect: { violations: 0, stale: false, ordering: 'ok' },
+  },
+  {
+    // (b) legitimate lag within the 7-day budget — vendored < CCP = kernel, and
+    //     since V < K, staleness is evaluated against the publish age (3 days ≤ 7).
+    name: '(b) vendored < CCP = kernel within the 7-day staleness budget',
+    V: '0.4.0',
+    C: '0.4.1',
+    K: '0.4.1',
+    kernelAgeDays: 3,
+    expect: { violations: 0, stale: false, ordering: 'ok' },
+  },
+  {
+    // (c) kernel ahead, CCP not yet bumped — vendored = CCP < kernel. V < K so
+    //     staleness is evaluated; with a 2-day age it is within budget.
+    name: '(c) vendored = CCP < kernel (kernel ahead, CCP not yet bumped), fresh',
+    V: '0.4.1',
+    C: '0.4.1',
+    K: '0.5.0',
+    kernelAgeDays: 2,
+    expect: { violations: 0, stale: false, ordering: 'ok' },
+  },
+  {
+    // Variant of (b)/(c): vendored < CCP < kernel, both lags legitimate, fresh.
+    name: 'vendored < CCP < kernel, fully ordered, fresh kernel',
+    V: '0.4.0',
+    C: '0.4.1',
+    K: '0.5.0',
+    kernelAgeDays: 1,
+    expect: { violations: 0, stale: false, ordering: 'ok' },
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NEGATIVE cases — the invariant MUST report a violation (vendored>kernel,
+// vendored>CCP, CCP>kernel) and the bounded-staleness breach (>7-day lag).
+// ─────────────────────────────────────────────────────────────────────────────
+const NEGATIVE_FIXTURES = [
+  {
+    // vendored AHEAD of CCP-declared pin (V > C) — you cannot validate against a
+    // schema newer than your pin.
+    name: 'vendored > CCP — snapshot ahead of the declared pin (V > C)',
+    V: '0.5.0',
+    C: '0.4.1',
+    K: '0.5.0',
+    kernelAgeDays: 1,
+    expect: { violations: 1, stale: false, ordering: 'violation', match: /V \(0\.5\.0\) > C/ },
+  },
+  {
+    // CCP-declared pin AHEAD of latest published kernel (C > K) — you cannot pin a
+    // version that does not exist yet.
+    name: 'CCP > kernel — declared pin ahead of latest published kernel (C > K)',
+    V: '0.4.1',
+    C: '0.5.0',
+    K: '0.4.1',
+    expect: { violations: 1, stale: false, ordering: 'violation', match: /C \(0\.5\.0\) > K/ },
+  },
+  {
+    // vendored AHEAD of kernel latest (V > K) — surfaces via the V>C and/or C>K
+    // legs. Here V=0.6.0 > C=0.5.0 (V>C) AND C=0.5.0 > K=0.4.1 (C>K): two legs.
+    name: 'vendored > kernel — both ordering legs break (V > C and C > K)',
+    V: '0.6.0',
+    C: '0.5.0',
+    K: '0.4.1',
+    expect: { violations: 2, stale: false, ordering: 'violation' },
+  },
+  {
+    // bounded-staleness breach: V < K but the kernel has been published >7 days,
+    // so the vendored snapshot is STALE beyond budget.
+    name: 'staleness breach — vendored lags kernel by >7 days of publish age',
+    V: '0.4.1',
+    C: '0.4.1',
+    K: '0.5.0',
+    kernelAgeDays: 30,
+    expect: { violations: 1, stale: true, ordering: 'violation', match: /STALENESS/ },
+  },
+];
+
+for (const fx of POSITIVE_FIXTURES) {
+  test(`ordering POSITIVE: ${fx.name}`, () => {
+    const r = evaluateCoupling({
+      V: fx.V,
+      C: fx.C,
+      K: fx.K,
+      ranged: fx.ranged ?? false,
+      kernelAgeDays: fx.kernelAgeDays ?? null,
+    });
+    assert.equal(
+      r.violations.length,
+      fx.expect.violations,
+      `expected ${fx.expect.violations} violation(s), got: ${JSON.stringify(r.violations)}`,
+    );
+    assert.equal(r.stale, fx.expect.stale, 'stale flag mismatch');
+    // A positive fixture: the ordering invariant holds at the comparator level.
+    assert.ok(semverCompare(fx.V, fx.C) <= 0, 'V <= C must hold for a positive fixture');
+    assert.ok(semverCompare(fx.C, fx.K) <= 0, 'C <= K must hold for a positive fixture');
+  });
+}
+
+for (const fx of NEGATIVE_FIXTURES) {
+  test(`ordering NEGATIVE: ${fx.name}`, () => {
+    const r = evaluateCoupling({
+      V: fx.V,
+      C: fx.C,
+      K: fx.K,
+      ranged: fx.ranged ?? false,
+      kernelAgeDays: fx.kernelAgeDays ?? null,
+    });
+    assert.equal(
+      r.violations.length,
+      fx.expect.violations,
+      `expected ${fx.expect.violations} violation(s), got: ${JSON.stringify(r.violations)}`,
+    );
+    assert.ok(r.violations.length > 0, 'a negative fixture MUST report at least one violation');
+    assert.equal(r.stale, fx.expect.stale, 'stale flag mismatch');
+    if (fx.expect.match) {
+      assert.ok(
+        r.violations.some((v) => fx.expect.match.test(v)),
+        `expected a violation matching ${fx.expect.match}, got: ${JSON.stringify(r.violations)}`,
+      );
+    }
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Staleness boundary — exactly at the 7-day bound is WITHIN budget (≤ not <).
+// ─────────────────────────────────────────────────────────────────────────────
+test('staleness boundary: lag at exactly 7 days is within budget (not stale)', () => {
+  const r = evaluateCoupling({ V: '0.4.1', C: '0.4.1', K: '0.5.0', kernelAgeDays: 7 });
+  assert.equal(r.stale, false);
+  assert.equal(r.violations.length, 0);
+  assert.ok(r.warnings.some((w) => /STALENESS OK/.test(w)));
+});
+
+test('staleness boundary: lag at 8 days is OVER budget (stale)', () => {
+  const r = evaluateCoupling({ V: '0.4.1', C: '0.4.1', K: '0.5.0', kernelAgeDays: 8 });
+  assert.equal(r.stale, true);
+  assert.equal(r.violations.length, 1);
+});
+
+test('staleness with UNKNOWN kernel age does not fire (warns instead)', () => {
+  const r = evaluateCoupling({ V: '0.4.1', C: '0.4.1', K: '0.5.0', kernelAgeDays: null });
+  assert.equal(r.stale, false);
+  assert.equal(r.violations.length, 0);
+  assert.ok(r.warnings.some((w) => /publish age is UNKNOWN/.test(w)));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Existence guards — absent inputs warn + SKIP the relevant comparison, never
+// crash and never produce a violation. (The whole check is existence-guarded.)
+// ─────────────────────────────────────────────────────────────────────────────
+test('existence guard: all inputs absent → warnings only, no violations', () => {
+  const r = evaluateCoupling({ V: null, C: null, K: null });
+  assert.equal(r.violations.length, 0);
+  assert.equal(r.stale, false);
+  assert.equal(r.warnings.length, 3, 'one warning per absent identity (V, C, K)');
+});
+
+test('existence guard: missing K skips the C≤K + staleness legs', () => {
+  const r = evaluateCoupling({ V: '0.4.1', C: '0.4.1', K: null });
+  assert.equal(r.violations.length, 0);
+  assert.ok(r.warnings.some((w) => /K \(kernel latest published\) UNRESOLVED/.test(w)));
+});
+
+test('ranged pin warns but still orders on the floor', () => {
+  const r = evaluateCoupling({ V: '0.4.1', C: '0.4.1', K: '0.4.1', ranged: true });
+  assert.equal(r.violations.length, 0);
+  assert.ok(r.warnings.some((w) => /RANGE operator/.test(w)));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI exit-code contract (end-to-end subprocess) — advisory exits 0 even when the
+// ordering is violated; --strict exits 1 on a real violation. Drives the resolved
+// V/C from this repo's disk (both 0.4.1) with K injected via --kernel-latest.
+// ─────────────────────────────────────────────────────────────────────────────
+function runCli(args) {
+  try {
+    const stdout = execFileSync('node', [CLI, ...args], { encoding: 'utf8' });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status ?? 1, stdout: err.stdout?.toString() ?? '' };
+  }
+}
+
+test('CLI advisory: a C>K ordering violation still EXITS 0 (report-only)', () => {
+  // C resolves to 0.4.1 from package.json; K=0.1.0 forces C > K.
+  const { code, stdout } = runCli(['--kernel-latest', '0.1.0', '--json']);
+  assert.equal(code, 0, 'advisory mode must exit 0 regardless of violations');
+  const report = JSON.parse(stdout);
+  assert.ok(
+    report.violations.some((v) => /C \(0\.4\.1\) > K \(0\.1\.0\)/.test(v)),
+    'expected the C>K ordering violation to be reported',
+  );
+  assert.equal(report.advisory, true);
+});
+
+test('CLI --strict: a C>K ordering violation EXITS 1', () => {
+  const { code } = runCli(['--strict', '--kernel-latest', '0.1.0']);
+  assert.equal(code, 1, '--strict must exit non-zero on a real ordering violation');
+});
+
+test('CLI --strict: a clean ordering (C=K) EXITS 0', () => {
+  // K=0.4.1 matches the declared pin → V=C=K → no violation.
+  const { code } = runCli([
+    '--strict',
+    '--kernel-latest',
+    '0.4.1',
+    '--kernel-published',
+    new Date().toISOString(),
+  ]);
+  assert.equal(code, 0, '--strict must exit 0 when the invariant holds');
+});


### PR DESCRIPTION
## What

Adds an executable fixture corpus that formalizes the version-coupling ordering invariant **V ≤ C ≤ K** + bounded-staleness model (plan 033 § 14.15.1) against the existing `kernel-vendor-hash` comparator. Closes F-MK-003.

The three version identities:
- **V** vendored snapshot · **C** CCPI-declared kernel pin · **K** kernel latest published.

### Changes

- **Surgical refactor of `scripts/kernel-vendor-hash.mjs`** — extract the pure V≤C≤K + staleness evaluation into an exported `evaluateCoupling()` that `main()` now delegates to (no behavior change; CLI output verified identical before/after), export `semverCompare`, and guard the `main()` call so the module is import-safe (runs only when invoked as a CLI, never on import). This keeps the CLI and the tests on a single code path — no logic fork.
- **New `scripts/kernel-vendor-hash.test.mjs`** (node's built-in `node --test` runner, **zero new dependencies**), 20 tests:
  - **Positive fixtures** (the bead's a/b/c): (a) vendored=CCP=kernel; (b) vendored<CCP=kernel within the 7-day budget; (c) vendored=CCP<kernel (kernel ahead).
  - **Negative fixtures**: vendored>CCP, CCP>kernel, vendored>kernel (both ordering legs), and a >7-day staleness breach — each must report a violation/stale.
  - **Edge cases**: staleness boundary (7d in-budget vs 8d over), unknown kernel age, existence guards (absent V/C/K warn + skip, never crash/violate), ranged-pin warning.
  - **CLI exit-code contract** (end-to-end subprocess): advisory exits 0 even on a violation; `--strict` exits 1 on a real ordering violation; clean ordering exits 0.
- **Wire a BLOCKING test step into `.github/workflows/kernel-vendor-hash.yml`** + add the test file to the path filter.

## Why

The version-coupling check shipped advisory-only with no test corpus. Comparator **correctness** is orthogonal to the DR-049 advisory soak (which governs only pin-bump pressure / validator authority) — a broken comparator is a real bug. This pins the ordering invariant's behavior so a regression turns CI red, while the check itself stays advisory on pin-bump pressure during the soak.

## Verification

All green:
- `node --test scripts/kernel-vendor-hash.test.mjs` → **20 pass / 0 fail**
- `node scripts/kernel-vendor-hash.mjs` (advisory smoke) → exit 0
- `eslint` + `prettier` (`scripts/**`) clean
- `audit-harness verify` → `harness-hash: OK`
- Full pre-commit gate (lint-staged + harness) passed on commit

- Jeremy Longshore
intentsolutions.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a full Node test suite covering semver ordering, coupling validation, and staleness boundary behavior (including disabled/stale/warning scenarios).
  * Added end-to-end CLI checks for both advisory and strict exit-code contracts.
* **New Features**
  * Added blocking CI validation that runs the coupling test corpus before the advisory reporting step.
* **Refactor**
  * Refactored the kernel coupling evaluation to be reusable and parameterized, while keeping the existing report output behavior.
* **Chores**
  * Updated the CI workflow triggers so changes to the test corpus re-run the validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->