### PR TITLE
feat(databricks-pack): v1.1.0 deprecation release ahead of v2 rebuild [skip auto-bump]

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -6584,8 +6584,8 @@
     {
       "name": "databricks-pack",
       "source": "./plugins/saas-packs/databricks-pack",
-      "description": "Complete Databricks integration skill pack with 24 skills covering Delta Lake, MLflow, notebooks, clusters, and data engineering workflows. Flagship tier vendor pack.",
-      "version": "1.0.0",
+      "description": "DEPRECATED (v1) — these 24 documentation skills are removed in v2.0.0, which rebuilds the pack as 5 live-detection skills + a shared databricks-workspace-mcp server. See the README migration map before upgrading.",
+      "version": "1.1.0",
       "category": "saas-packs",
       "keywords": [
         "databricks",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5847,8 +5847,8 @@
     {
       "name": "databricks-pack",
       "source": "./plugins/saas-packs/databricks-pack",
-      "description": "Complete Databricks integration skill pack with 24 skills covering Delta Lake, MLflow, notebooks, clusters, and data engineering workflows. Flagship tier vendor pack.",
-      "version": "1.0.0",
+      "description": "DEPRECATED (v1) — these 24 documentation skills are removed in v2.0.0, which rebuilds the pack as 5 live-detection skills + a shared databricks-workspace-mcp server. See the README migration map before upgrading.",
+      "version": "1.1.0",
       "category": "saas-packs",
       "keywords": [
         "databricks",

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `coreweave-pack`    | Claude Code skill pack for CoreWeave (24 skills)                                                                                            |
 | `cursor-pack`       | Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity…    |
 | `customerio-pack`   | Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and…    |
-| `databricks-pack`   | Complete Databricks integration skill pack with 24 skills covering Delta Lake, MLflow, notebooks, clusters, and data engineering…           |
+| `databricks-pack`   | DEPRECATED (v1) — these 24 documentation skills are removed in v2.0.0, which rebuilds the pack as 5 live-detection skills + a shared…       |
 | `deepgram-pack`     | Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio…    |
 | `documenso-pack`    | Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation.…      |
 | `elevenlabs-pack`   | Claude Code skill pack for ElevenLabs (18 skills)                                                                                           |

--- a/plugins/saas-packs/databricks-pack/CHANGELOG.md
+++ b/plugins/saas-packs/databricks-pack/CHANGELOG.md
@@ -9,6 +9,7 @@ versioning is SemVer on the `databricks-pack` marketplace slug.
 on the v2 rebuild so users on auto-update see what's coming before `2.0.0` deletes the v1 skills.
 
 ### Added
+
 - Deprecation banner at the top of all **24** v1 `SKILL.md` files. Each banner states the skill
   is removed in `2.0.0` and points to its v2 replacement (or marks it cut, with reason).
 - README **Migration: v1 → v2** section — full v1-skill → v2-destination map + the 5 v2 skills
@@ -16,9 +17,11 @@ on the v2 rebuild so users on auto-update see what's coming before `2.0.0` delet
 - README top-of-file deprecation warning.
 
 ### Changed
+
 - Nothing functional. Skill bodies are unchanged below the banner.
 
 ### Why
+
 Per [`000-docs/007-AT-ADEC-databricks-v2-cto-decision.md`](000-docs/007-AT-ADEC-databricks-v2-cto-decision.md)
 § Decision 1: Claude Code marketplace auto-update **deletes files** on upgrade. Jumping straight
 from v1 to a `2.0.0` that removes every v1 skill would break any `CLAUDE.md` referencing them with
@@ -26,11 +29,13 @@ no in-product warning. The `1.1.0` deprecation lane (2–4 weeks) + `2.0.0` tomb
 404 cliff.
 
 ## [Unreleased] — v2.0.0 (in progress)
+
 - 5 live-detection skills (`cost-leak-hunter` pilot, `cluster-forensics`, `streaming-guardian`,
   `uc-migration-pilot`, `bundle-medic`) + shared `databricks-workspace-mcp` server.
 - Tombstone stubs in the 24 removed v1 skill directories.
 - Rewritten catalog description (operational depth, not surface breadth).
 
 ## [1.0.x] — through 2026-06
+
 - The original 24-skill documentation pack (Standard / Pro / Flagship tiers). Superseded by the
   v2 rebuild; see the migration map.

--- a/plugins/saas-packs/databricks-pack/CHANGELOG.md
+++ b/plugins/saas-packs/databricks-pack/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog — databricks-pack
+
+All notable changes to this pack. Format loosely follows [Keep a Changelog](https://keepachangelog.com/);
+versioning is SemVer on the `databricks-pack` marketplace slug.
+
+## [1.1.0] — 2026-06-21 — Deprecation release
+
+**This is a signposting release. No skill behavior changes.** It starts the auto-update clock
+on the v2 rebuild so users on auto-update see what's coming before `2.0.0` deletes the v1 skills.
+
+### Added
+- Deprecation banner at the top of all **24** v1 `SKILL.md` files. Each banner states the skill
+  is removed in `2.0.0` and points to its v2 replacement (or marks it cut, with reason).
+- README **Migration: v1 → v2** section — full v1-skill → v2-destination map + the 5 v2 skills
+  and the `1.1.0 → 2.0.0 → 2.1.0` timeline.
+- README top-of-file deprecation warning.
+
+### Changed
+- Nothing functional. Skill bodies are unchanged below the banner.
+
+### Why
+Per [`000-docs/007-AT-ADEC-databricks-v2-cto-decision.md`](000-docs/007-AT-ADEC-databricks-v2-cto-decision.md)
+§ Decision 1: Claude Code marketplace auto-update **deletes files** on upgrade. Jumping straight
+from v1 to a `2.0.0` that removes every v1 skill would break any `CLAUDE.md` referencing them with
+no in-product warning. The `1.1.0` deprecation lane (2–4 weeks) + `2.0.0` tombstones close that
+404 cliff.
+
+## [Unreleased] — v2.0.0 (in progress)
+- 5 live-detection skills (`cost-leak-hunter` pilot, `cluster-forensics`, `streaming-guardian`,
+  `uc-migration-pilot`, `bundle-medic`) + shared `databricks-workspace-mcp` server.
+- Tombstone stubs in the 24 removed v1 skill directories.
+- Rewritten catalog description (operational depth, not surface breadth).
+
+## [1.0.x] — through 2026-06
+- The original 24-skill documentation pack (Standard / Pro / Flagship tiers). Superseded by the
+  v2 rebuild; see the migration map.

--- a/plugins/saas-packs/databricks-pack/README.md
+++ b/plugins/saas-packs/databricks-pack/README.md
@@ -1,6 +1,6 @@
 # Databricks Skill Pack
 
-> 24 production-ready skills for the Databricks Lakehouse Platform — Unity Catalog, Delta Lake, MLflow, Spark SQL, Asset Bundles, and the full REST API.
+24 production-ready skills for the Databricks Lakehouse Platform — Unity Catalog, Delta Lake, MLflow, Spark SQL, Asset Bundles, and the full REST API.
 
 > [!WARNING]
 > **This pack is being rebuilt — `v1.x` is deprecated.** Every v1 skill below carries a

--- a/plugins/saas-packs/databricks-pack/README.md
+++ b/plugins/saas-packs/databricks-pack/README.md
@@ -2,6 +2,14 @@
 
 > 24 production-ready skills for the Databricks Lakehouse Platform — Unity Catalog, Delta Lake, MLflow, Spark SQL, Asset Bundles, and the full REST API.
 
+> [!WARNING]
+> **This pack is being rebuilt — `v1.x` is deprecated.** Every v1 skill below carries a
+> deprecation banner and will be **removed in `databricks-pack@2.0.0`**, which replaces the
+> 24 documentation-style skills with **5 live-detection skills + a shared
+> `databricks-workspace-mcp` server** that runs against your own workspace. If you have any
+> `databricks-*` skill in your `CLAUDE.md`, read **[Migration: v1 → v2](#migration-v1--v2)**
+> before upgrading. The v2 rebuild ships on the `databricks-pack` slug (no rename).
+
 ## Installation
 
 ```bash
@@ -93,6 +101,42 @@ The two authenticate independently. Losing access to one does not disable the ot
 Full scope-boundary rationale — including the 8 → 6 endpoint cut and the auth-flow decisions — is in [`000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md`](000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md). Reference document for any "why is this skill not pulling X?" question.
 
 Thanks to [@Gingiris-1031](https://github.com/Gingiris-1031) ([#795](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/795)) for surfacing the isolation-story framing that made this section necessary.
+
+## Migration: v1 → v2
+
+`databricks-pack@2.0.0` is a ground-up rebuild. The 24 v1 skills described Databricks ops;
+the 5 v2 skills **run** them — live detection against your own workspace via a shared
+`databricks-workspace-mcp` server (control plane) composed with the Databricks managed SQL
+MCP (`system.*` reads). Rationale: [`000-docs/007-AT-ADEC-databricks-v2-cto-decision.md`](000-docs/007-AT-ADEC-databricks-v2-cto-decision.md)
+and [`000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md`](000-docs/013-AT-ADEC-epic1-mcp-scope-adjustment.md).
+
+**Timeline:** `1.1.0` (this release — deprecation banners) → `2.0.0` (5 skills + MCP, v1
+skills removed with tombstones) → `2.1.0` (tombstones cleaned up). Users on auto-update get a
+2–4 week window on `1.1.0` to read these banners before `2.0.0` lands.
+
+### Where each v1 skill goes
+
+| v1 skill | v2 destination |
+|----------|----------------|
+| `databricks-cost-tuning` | `databricks-cost-leak-hunter` |
+| `databricks-performance-tuning` | `databricks-cost-leak-hunter` + `databricks-cluster-forensics` |
+| `databricks-incident-runbook` | `databricks-cluster-forensics` + `databricks-streaming-guardian` |
+| `databricks-observability` | `databricks-streaming-guardian` |
+| `databricks-upgrade-migration` | `databricks-cluster-forensics` (DBR-upgrade triage) |
+| `databricks-debug-bundle` · `databricks-deploy-integration` · `databricks-local-dev-loop` · `databricks-ci-integration` | `databricks-bundle-medic` |
+| `databricks-migration-deep-dive` · `databricks-multi-env-setup` · `databricks-enterprise-rbac` | `databricks-uc-migration-pilot` |
+| `databricks-security-basics` | `databricks-uc-migration-pilot` + `databricks-bundle-medic` (identity/secrets) |
+| `databricks-hello-world` · `databricks-install-auth` · `databricks-sdk-patterns` · `databricks-core-workflow-a` · `databricks-core-workflow-b` · `databricks-common-errors` · `databricks-prod-checklist` · `databricks-rate-limits` · `databricks-webhooks-events` · `databricks-reference-architecture` · `databricks-data-handling` | **Cut** — no direct replacement (setup folds into the MCP `.env.sops` + each skill's `## Prerequisites`; checklists/architecture move into v2 `references/`; error catalogs ship per-skill) |
+
+### The 5 v2 skills
+
+| v2 skill | What it does (live) |
+|----------|---------------------|
+| `databricks-cost-leak-hunter` (pilot) | `$X/month wasted` audit from your own `system.billing.usage` — idle clusters, All-Purpose-vs-Jobs, instance-pool waste, DLT tier, tag-based chargeback |
+| `databricks-cluster-forensics` | Cold-start / launch-failure / Photon / DBR-upgrade triage from cluster events |
+| `databricks-streaming-guardian` | Delta + Liquid Clustering + Structured Streaming + DLT health |
+| `databricks-uc-migration-pilot` | Unity Catalog readiness + IAM/SCIM + access tracing (HMS deadline **Sept 30, 2026**) |
+| `databricks-bundle-medic` | Asset Bundles deploy diagnostics + CMK rotation + PrivateLink audit |
 
 ## Design Records
 

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.0.13",
-  "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines",
+  "version": "1.1.0",
+  "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines (v1, DEPRECATED — rebuilt as 5 live-detection skills + MCP in v2.0.0)",
   "main": "README.md",
   "type": "module",
   "files": [

--- a/plugins/saas-packs/databricks-pack/skills/databricks-ci-integration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-ci-integration/SKILL.md
@@ -24,6 +24,13 @@ tags:
 - ci-cd
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-bundle-medic` (Asset-Bundle CI diagnostics).
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks CI Integration
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-common-errors/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-common-errors/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - debugging
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Subsumed — every v2 skill carries its own error catalog in `references/`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Common Errors
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-a/SKILL.md
@@ -23,6 +23,13 @@ tags:
 - etl
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Generic ETL walkthrough — no specific pain cluster.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Core Workflow A: Delta Lake ETL
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-core-workflow-b/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - workflow
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Generic ML walkthrough — no specific pain cluster.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Core Workflow B: MLflow Training & Serving
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-tuning/SKILL.md
@@ -23,6 +23,13 @@ tags:
 - cost-optimization
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-cost-leak-hunter`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Cost Tuning
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-data-handling/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-data-handling/SKILL.md
@@ -22,6 +22,13 @@ tags:
 - databricks-data
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Too vague to map to a pain cluster — cut.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Data Handling
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-debug-bundle/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - debugging
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-bundle-medic`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Debug Bundle
 
 ## Current State

--- a/plugins/saas-packs/databricks-pack/skills/databricks-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-deploy-integration/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - deployment
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-bundle-medic`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Deploy Integration
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-enterprise-rbac/SKILL.md
@@ -22,6 +22,13 @@ tags:
 - rbac
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-uc-migration-pilot`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Enterprise RBAC
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-hello-world/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-hello-world/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - testing
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Documentation cosplay — cut, not absorbed.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Hello World
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-incident-runbook/SKILL.md
@@ -23,6 +23,13 @@ tags:
 - incident-response
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-cluster-forensics` + `databricks-streaming-guardian`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Incident Runbook
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-install-auth/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-install-auth/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - authentication
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. One-line setup, not a skill — auth now lives in the `databricks-workspace-mcp` `.env.sops` + each skill's `## Prerequisites`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Install & Auth
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-local-dev-loop/SKILL.md
@@ -23,6 +23,13 @@ tags:
 - workflow
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-bundle-medic`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Local Dev Loop
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-migration-deep-dive/SKILL.md
@@ -22,6 +22,13 @@ tags:
 - migration
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-uc-migration-pilot`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Migration Deep Dive
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-multi-env-setup/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - deployment
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-uc-migration-pilot`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Multi-Environment Setup
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-observability/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-observability/SKILL.md
@@ -25,6 +25,13 @@ tags:
 - dashboard
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-streaming-guardian`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Observability
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-performance-tuning/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - performance
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-cost-leak-hunter` + `databricks-cluster-forensics`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Performance Tuning
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-prod-checklist/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - deployment
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Checklists move into v2 `references/`, not a top-level skill.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Production Checklist
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-rate-limits/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-rate-limits/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - api
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. No corresponding pain in the v2 catalog — retry/backoff is built into the MCP server.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Rate Limits
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-reference-architecture/SKILL.md
@@ -22,6 +22,13 @@ tags:
 - databricks-reference
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. Architecture doc, not a skill — moves to shared `references/`.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Reference Architecture
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-sdk-patterns/SKILL.md
@@ -22,6 +22,13 @@ tags:
 - python
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. SDK ergonomics is library documentation, not a skill.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks SDK Patterns
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-security-basics/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-security-basics/SKILL.md
@@ -23,6 +23,13 @@ tags:
 - audit
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-uc-migration-pilot` + `databricks-bundle-medic` (identity/secrets ops).
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Security Basics
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-upgrade-migration/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - migration
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is replaced in the v2 rebuild. **Migrate to:** `databricks-cluster-forensics` (DBR-upgrade triage folds into cluster lifecycle).
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Upgrade & Migration
 
 ## Overview

--- a/plugins/saas-packs/databricks-pack/skills/databricks-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-webhooks-events/SKILL.md
@@ -21,6 +21,13 @@ tags:
 - webhooks
 compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
+
+> [!WARNING]
+> **DEPRECATED — to be removed in `databricks-pack@2.0.0`.**
+>
+> This v1 skill is being **cut** in the v2 rebuild — no direct replacement. No corresponding pain in the v2 catalog.
+> See [the pack README → Migration: v1 → v2](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/README.md#migration-v1--v2) for the full map and rationale.
+
 # Databricks Webhooks & Events
 
 ## Overview


### PR DESCRIPTION
## What

Ships **`databricks-pack@1.1.0`** — the deprecation lane for the v2 rebuild. **No skill behavior changes.** This is a signposting release that starts the auto-update clock so users see what's coming before `2.0.0` removes the v1 skills.

## Why

Per [`000-docs/007-AT-ADEC-databricks-v2-cto-decision.md`](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/blob/main/plugins/saas-packs/databricks-pack/000-docs/007-AT-ADEC-databricks-v2-cto-decision.md) § Decision 1: Claude Code marketplace auto-update **deletes files** on upgrade. Jumping straight from v1 to a `2.0.0` that removes every v1 skill would silently break any `CLAUDE.md` referencing them. The `1.1.0` banners (2–4 week window) + `2.0.0` tombstones close that 404 cliff.

## Changes

- **Deprecation banner** at the top of all **24** v1 `SKILL.md` files — each points to its v2 replacement (`cost-leak-hunter` / `cluster-forensics` / `streaming-guardian` / `uc-migration-pilot` / `bundle-medic`) or is marked **cut** with a reason.
- **README** — top-of-file deprecation warning + a **Migration: v1 → v2** section mapping every v1 skill to its v2 destination, listing the 5 v2 skills, and the `1.1.0 → 2.0.0 → 2.1.0` timeline.
- **CHANGELOG.md** added.
- `package.json` `1.0.13 → 1.1.0`; catalog entry `1.0.0 → 1.1.0` with a deprecation description; `marketplace.json` + README TOC regenerated via `sync-marketplace`.

## Validation

- Marketplace validator: all 24 skills error-free (relative-link escape fixed → canonical GitHub URLs).
- Unicode hygiene: clean.
- `sync-marketplace`: derived `marketplace.json` + TOC in sync.

`[skip auto-bump]` — versions are hand-set for the deprecation cadence.

This is the first of the v2-rebuild PR series (deprecation → MCP server → 5 skills → v2.0.0). Umbrella: #795.

- Jeremy Longshore
intentsolutions.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices across all Databricks pack skills, indicating v1 removal at v2.0.0.
  * Updated pack metadata and descriptions to reflect deprecation and upcoming v2 rebuild.
  * Added comprehensive migration guidance mapping v1 skills to v2 replacements.

* **Chores**
  * Bumped pack version to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->