### PR TITLE
feat(databricks-workspace-mcp): register control-plane MCP plugin in catalog

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -10310,6 +10310,31 @@
       "homepage": "https://github.com/rohithzr/claudebase",
       "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
+    },
+    {
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT",
+      "mcpTools": 8
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8741,6 +8741,30 @@
       "homepage": "https://github.com/rohithzr/claudebase",
       "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
+    },
+    {
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | 🎨  | [Design](#design)                                  |       7 |
 | 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      36 |
 | 📚  | [Examples & Templates](#examples--templates)       |       5 |
-| 🧩  | [MCP Servers](#mcp-servers)                        |      12 |
+| 🧩  | [MCP Servers](#mcp-servers)                        |      13 |
 | 📦  | [Packages](#packages)                              |       5 |
 | ⚡  | [Performance](#performance)                        |      25 |
 | ✅  | [Productivity](#productivity)                      |      27 |
@@ -443,12 +443,13 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 
 ### MCP Servers
 
-🧩 **12 plugins** · category slug: `mcp`
+🧩 **13 plugins** · category slug: `mcp`
 
 | Plugin                        | Description                                                                                                                                |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ai-experiment-logger`        | Track and analyze AI experiments with a web dashboard and MCP tools                                                                        |
 | `conversational-api-debugger` | Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation                                 |
+| `databricks-workspace-mcp`    | MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity… |
 | `design-to-code`              | Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility                                           |
 | `domain-memory-agent`         | Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required                                      |
 | `governed-second-brain`       | Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident,…        |

--- a/plugins/mcp/databricks-workspace-mcp/.claude-plugin/plugin.json
+++ b/plugins/mcp/databricks-workspace-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "databricks-workspace-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://intentsolutions.io"
+  },
+  "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+  "homepage": "https://tonsofskills.com/learn/databricks/",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "databricks",
+    "lakehouse",
+    "unity-catalog",
+    "clusters",
+    "dlt",
+    "finops",
+    "claude-code"
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/.env.example
+++ b/plugins/mcp/databricks-workspace-mcp/.env.example
@@ -1,0 +1,28 @@
+# databricks-workspace-mcp — environment template
+#
+# Copy to .env (gitignored) and fill in. The server starts and lists its 8 tools even
+# unconfigured; a tool *call* returns a structured auth error until a host + credential are set.
+# Pick exactly ONE credential flow.
+
+# --- Required: workspace host ---------------------------------------------------------
+# Your workspace URL. DATABRICKS_WORKSPACE_HOST is accepted as an alias.
+DATABRICKS_HOST=https://dbc-xxxxxxxx-xxxx.cloud.databricks.com
+
+# --- Credential flow A: Personal Access Token (CLI mode only) -------------------------
+# Simplest for laptop / CI. NOT supported in Databricks App deployment mode.
+DATABRICKS_TOKEN=dapi________________________________
+
+# --- Credential flow B: OAuth U2M (CLI mode) -----------------------------------------
+# A user token from `databricks auth login`. Mutually exclusive with the PAT above.
+# DATABRICKS_OAUTH_TOKEN=
+
+# --- Credential flow C: OAuth M2M (service principal; required in App mode) -----------
+# The ONLY flow accepted when the server runs as a Databricks App. The service principal
+# needs workspace access.
+# DATABRICKS_CLIENT_ID=
+# DATABRICKS_CLIENT_SECRET=
+
+# --- Deployment mode (optional) -------------------------------------------------------
+# Auto-detected as "app" when DATABRICKS_APP_PORT / DATABRICKS_APP_URL are present.
+# Force it explicitly with: DATABRICKS_WORKSPACE_MCP_MODE=app
+# DATABRICKS_WORKSPACE_MCP_MODE=cli

--- a/plugins/mcp/databricks-workspace-mcp/.gitignore
+++ b/plugins/mcp/databricks-workspace-mcp/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+coverage/
+.DS_Store

--- a/plugins/mcp/databricks-workspace-mcp/.npmignore
+++ b/plugins/mcp/databricks-workspace-mcp/.npmignore
@@ -1,0 +1,11 @@
+src/
+tests/
+.claude-plugin/
+commands/
+*.tsbuildinfo
+tsconfig.json
+vitest.config.ts
+.gitignore
+.mcp.json
+server.json
+.env

--- a/plugins/mcp/databricks-workspace-mcp/LICENSE
+++ b/plugins/mcp/databricks-workspace-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jeremy Longshore / Intent Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/mcp/databricks-workspace-mcp/README.md
+++ b/plugins/mcp/databricks-workspace-mcp/README.md
@@ -1,0 +1,100 @@
+<h1 align="center">databricks-workspace-mcp</h1>
+
+<p align="center">
+  An MCP server for the Databricks <strong>control plane</strong> — cluster forensics, instance-pool
+  waste, DLT pipeline event logs, and Unity Catalog storage governance.<br>
+  The 8 read-only tools no managed Databricks MCP exposes. Pairs with the managed SQL MCP for
+  <code>system.*</code> reads.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/License-MIT-10b981?style=flat-square" alt="License: MIT">
+  <img src="https://img.shields.io/badge/MCP-stdio%20%2B%20HTTP-8b5cf6?style=flat-square" alt="MCP stdio + HTTP">
+  <img src="https://img.shields.io/badge/access-read--only-0ea5e9?style=flat-square" alt="read-only">
+</p>
+
+---
+
+## Why this server exists
+
+Databricks ships five managed MCP servers (Genie, Genie Space, Vector Search, Databricks SQL, Unity
+Catalog Functions) — **all data plane**. None of them expose live control-plane state: cluster event
+timelines, instance-pool idle stats, DLT pipeline event logs, or the Unity Catalog external-location /
+storage-credential wiring. That's the gap this server fills.
+
+The split is deliberate. A consuming skill calls **this** server for typed control-plane state, and the
+**managed Databricks SQL MCP** (`/api/2.0/mcp/sql`) for everything in `system.*` (billing, audit,
+information_schema) — OAuth- and UC-governed on Databricks' side. Two MCPs, one diagnostic picture; no
+skill should ever have to shell out to the `databricks` CLI to fill a gap.
+
+Everything here is **read-only** — no create/edit/terminate. It inventories and diagnoses; it does not
+mutate your workspace.
+
+## Tool surface (8)
+
+| Tool | Endpoint | What it does |
+|---|---|---|
+| `clusters_list` | `GET /api/2.0/clusters/list` | Inventory all clusters — state, autotermination, autoscale, node types, creator. Find never-auto-terminating clusters. |
+| `clusters_get` | `GET /api/2.0/clusters/get` | Full config + state of one cluster — DBR version, Photon vs standard, autoscale bounds, `state_message`. |
+| `clusters_events` | `POST /api/2.0/clusters/events` | The event timeline (CREATING → STARTING → RUNNING → RESIZING → TERMINATING, init-script events). THE source for cold-start / launch-failure forensics. |
+| `instance_pools_list` | `GET /api/2.0/instance-pools/list` | All instance pools with live used/idle/pending stats — find pools holding warm idle VMs that bill cloud compute. |
+| `pipelines_get` | `GET /api/2.0/pipelines/{id}` | A DLT pipeline's definition + latest state — edition, channel, serverless flag, continuous vs triggered, `latest_updates`. |
+| `pipelines_get_event_log` | `GET /api/2.0/pipelines/{id}/events` | Page the structured event log (flow/update/maintenance progress, data-quality expectations, backpressure). Supports a filter expression. |
+| `external_locations_list` | `GET /api/2.1/unity-catalog/external-locations` | UC external locations — each binds a storage URL (s3/abfss/gs) to a credential, with owner + read-only + binding mode. |
+| `storage_credentials_list` | `GET /api/2.1/unity-catalog/storage-credentials` | UC storage credentials — the cloud-IAM principals UC assumes for storage access. Trace the IAM wiring behind external locations. |
+
+## Auth — three flows
+
+Resolution is lazy: the server starts and `tools/list` succeeds even with no credentials, so a consuming
+skill can detect "MCP present but unauthenticated" and degrade cleanly. Set `DATABRICKS_HOST` plus **one**
+credential:
+
+| Flow | Env | Mode |
+|---|---|---|
+| **PAT** | `DATABRICKS_TOKEN` | CLI only (not supported in App mode) |
+| **OAuth U2M** | `DATABRICKS_OAUTH_TOKEN` (from `databricks auth login`) | CLI |
+| **OAuth M2M** | `DATABRICKS_CLIENT_ID` + `DATABRICKS_CLIENT_SECRET` | CLI **and** the only flow accepted in Databricks App mode |
+
+See [`.env.example`](./.env.example) for the full template.
+
+## Install
+
+### A) Claude Code / any `.mcp.json` consumer (stdio)
+
+```jsonc
+{
+  "mcpServers": {
+    "databricks-workspace": {
+      "command": "npx",
+      "args": ["-y", "@intentsolutions/databricks-workspace-mcp"],
+      "env": {
+        "DATABRICKS_HOST": "https://dbc-xxxx.cloud.databricks.com",
+        "DATABRICKS_TOKEN": "dapi..."
+      }
+    }
+  }
+}
+```
+
+### B) Databricks App (HTTP, OAuth M2M)
+
+The same codebase serves over Streamable HTTP for deployment as a custom Databricks App, which makes the
+control-plane tools discoverable by the Mosaic AI Agent Framework and the AI Playground in addition to
+Claude Code. PAT is unsupported in this mode — use a service principal (`DATABRICKS_CLIENT_ID` /
+`DATABRICKS_CLIENT_SECRET`).
+
+## Develop
+
+```bash
+pnpm install
+pnpm build        # tsc → dist/, chmods dist/index.js executable
+pnpm check        # typecheck + vitest (run against recorded fixtures, no live workspace)
+pnpm dev          # tsc --watch
+```
+
+Tests run entirely against recorded JSON fixtures in `tests/fixtures/` — no Databricks workspace or
+credentials required to run the suite.
+
+## License
+
+MIT © [Jeremy Longshore](https://intentsolutions.io) / Intent Solutions

--- a/plugins/mcp/databricks-workspace-mcp/package.json
+++ b/plugins/mcp/databricks-workspace-mcp/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@intentsolutions/databricks-workspace-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for the Databricks control plane — cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The 6 endpoint families no managed Databricks MCP exposes. Pairs with the Databricks managed SQL MCP for system.* reads.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "bin": {
+    "databricks-workspace-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE",
+    ".env.example"
+  ],
+  "scripts": {
+    "build": "tsc && node -e \"import('node:fs').then(fs=>fs.chmodSync('dist/index.js',0o755))\"",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "pnpm typecheck && pnpm test",
+    "prepublishOnly": "pnpm build"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "databricks",
+    "lakehouse",
+    "unity-catalog",
+    "clusters",
+    "dlt",
+    "finops",
+    "claude-code"
+  ],
+  "author": {
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://intentsolutions.io"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/mcp/databricks-workspace-mcp"
+  },
+  "homepage": "https://tonsofskills.com/learn/databricks/",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3",
+    "zod-to-json-schema": "^3.25.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.19",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/plugins/mcp/databricks-workspace-mcp/pnpm-lock.yaml
+++ b/plugins/mcp/databricks-workspace-mcp/pnpm-lock.yaml
@@ -1,0 +1,1545 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.19
+        version: 22.20.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.9(@types/node@22.20.0)(vite@8.0.16(@types/node@22.20.0))
+
+packages:
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.14:
+    resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@22.20.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@22.20.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  assertion-error@2.0.1: {}
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@6.2.2: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
+  expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.26: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.14: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  obug@2.1.3: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.14
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  toidentifier@1.0.1: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite@8.0.16(@types/node@22.20.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      fsevents: 2.3.3
+
+  vitest@4.1.9(@types/node@22.20.0)(vite@8.0.16(@types/node@22.20.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.20.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@22.20.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+    transitivePeerDependencies:
+      - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/plugins/mcp/databricks-workspace-mcp/src/app.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/app.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * databricks-workspace-mcp — Databricks App entry (T13).
+ *
+ * Same tool set, served over Streamable HTTP so the server can be deployed as a Databricks App
+ * (`mcp-databricks-workspace`), making it discoverable by the Mosaic AI Agent Framework + AI
+ * Playground in addition to Claude Code. Deployment mode is forced to "app", which means OAuth
+ * M2M only — PAT is rejected at auth resolution (013-AT-ADEC Finding 5).
+ *
+ * Run with: `node dist/app.js` (Databricks App start command). Binds DATABRICKS_APP_PORT.
+ */
+
+import http from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createServer, SERVER_NAME, SERVER_VERSION } from "./server.js";
+import { makeClientProvider, probeAuth } from "./runtime.js";
+
+const PORT = Number(process.env.DATABRICKS_APP_PORT ?? process.env.PORT ?? 8000);
+const MCP_PATH = "/mcp";
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve(undefined);
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+export function createHttpServer(): http.Server {
+  // Force App deployment mode -> OAuth M2M only.
+  const getClient = makeClientProvider({ deployment: "app" });
+
+  return http.createServer(async (req, res) => {
+    try {
+      const path = (req.url ?? "").split("?")[0];
+
+      if (req.method === "GET" && (path === "/healthz" || path === "/")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok", server: SERVER_NAME, version: SERVER_VERSION }));
+        return;
+      }
+
+      if (path !== MCP_PATH) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: `Not found. MCP endpoint is ${MCP_PATH}` }));
+        return;
+      }
+
+      const body = req.method === "POST" ? await readBody(req) : undefined;
+
+      // Stateless: a fresh transport + server per request avoids cross-request id collisions.
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      const server = createServer(getClient);
+      res.on("close", () => {
+        void transport.close();
+        void server.close();
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (err) {
+      if (!res.headersSent) res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+    }
+  });
+}
+
+function main(): void {
+  const httpServer = createHttpServer();
+  httpServer.listen(PORT, () => {
+    const auth = probeAuth({ deployment: "app" });
+    console.error(
+      `${SERVER_NAME} v${SERVER_VERSION} (App mode) on :${PORT}${MCP_PATH} — ${
+        auth ? `${auth.provider.mode} auth -> ${auth.host}` : "UNCONFIGURED (set DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET)"
+      }`,
+    );
+  });
+}
+
+// Only auto-start when run directly (not when imported by tests).
+if (process.argv[1] && process.argv[1].endsWith("app.js")) {
+  main();
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/auth.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/auth.ts
@@ -1,0 +1,217 @@
+/**
+ * Authentication for the Databricks control-plane MCP server.
+ *
+ * Three flows, one decision tree (per 013-AT-ADEC § "Three auth flows"):
+ *
+ *   1. PAT          — `DATABRICKS_TOKEN`. CLI mode only.
+ *   2. OAuth U2M    — a user access token minted out-of-band by `databricks auth login`
+ *                     (browser flow), supplied as `DATABRICKS_OAUTH_TOKEN`, optionally with a
+ *                     refresh token. CLI mode.
+ *   3. OAuth M2M    — service-principal client-credentials grant
+ *                     (`DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`). The ONLY flow
+ *                     supported when running as a Databricks App (PAT is explicitly rejected
+ *                     there — Finding 5 in 013-AT-ADEC).
+ *
+ * Deployment mode is detected at startup; App mode rejects PAT cleanly rather than failing
+ * mid-request. All three flows resolve to a single `TokenProvider.getToken()` so the REST
+ * client never has to know which flow produced the bearer.
+ */
+
+import { DatabricksError } from "./errors.js";
+
+export type AuthMode = "pat" | "u2m" | "m2m";
+export type DeploymentMode = "cli" | "app";
+
+export type FetchLike = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface TokenProvider {
+  readonly mode: AuthMode;
+  getToken(): Promise<string>;
+}
+
+export interface ResolvedAuth {
+  /** Normalized workspace base URL, e.g. https://dbc-abc.cloud.databricks.com (no trailing slash). */
+  host: string;
+  deployment: DeploymentMode;
+  provider: TokenProvider;
+}
+
+export interface ResolveAuthOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Injectable fetch for testing the OAuth token endpoint without a network. */
+  fetchImpl?: FetchLike;
+  /** Force a deployment mode (otherwise auto-detected from env). */
+  deployment?: DeploymentMode;
+  /** Clock injection for token-expiry testing. */
+  now?: () => number;
+}
+
+/** Normalize a workspace host into `https://<host>` with no trailing slash. */
+export function normalizeHost(raw: string): string {
+  let h = raw.trim();
+  if (!h) throw new DatabricksError({ kind: "config", message: "Empty Databricks host" });
+  if (!/^https?:\/\//i.test(h)) h = `https://${h}`;
+  return h.replace(/\/+$/, "");
+}
+
+/** Detect whether we are running inside a Databricks App (HTTP transport, OAuth-only). */
+export function detectDeployment(env: NodeJS.ProcessEnv): DeploymentMode {
+  // Databricks Apps run the server over HTTP and inject app-runtime env. We treat an explicit
+  // mode override, or the presence of the App HTTP port, as the App signal.
+  if (env.DATABRICKS_WORKSPACE_MCP_MODE === "app") return "app";
+  if (env.DATABRICKS_APP_PORT || env.DATABRICKS_APP_URL) return "app";
+  return "cli";
+}
+
+class PatTokenProvider implements TokenProvider {
+  readonly mode = "pat" as const;
+  constructor(private readonly token: string) {}
+  async getToken(): Promise<string> {
+    return this.token;
+  }
+}
+
+class StaticOAuthTokenProvider implements TokenProvider {
+  readonly mode = "u2m" as const;
+  constructor(private readonly token: string) {}
+  async getToken(): Promise<string> {
+    return this.token;
+  }
+}
+
+/**
+ * Client-credentials (M2M) provider. Fetches and caches a short-lived access token from the
+ * workspace OIDC token endpoint, refreshing ~60s before expiry.
+ */
+class M2mTokenProvider implements TokenProvider {
+  readonly mode = "m2m" as const;
+  private cached?: { token: string; expiresAt: number };
+
+  constructor(
+    private readonly host: string,
+    private readonly clientId: string,
+    private readonly clientSecret: string,
+    private readonly fetchImpl: FetchLike,
+    private readonly now: () => number,
+  ) {}
+
+  async getToken(): Promise<string> {
+    if (this.cached && this.cached.expiresAt - 60_000 > this.now()) {
+      return this.cached.token;
+    }
+    const url = `${this.host}/oidc/v1/token`;
+    const basic = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64");
+    let resp: Response;
+    try {
+      resp = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${basic}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "grant_type=client_credentials&scope=all-apis",
+      });
+    } catch (err) {
+      throw new DatabricksError({
+        kind: "network",
+        message: `OAuth token request failed: ${err instanceof Error ? err.message : String(err)}`,
+        endpoint: "/oidc/v1/token",
+        retriable: true,
+      });
+    }
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      throw new DatabricksError({
+        kind: "auth",
+        message: `OAuth M2M token exchange failed (${resp.status}). Check DATABRICKS_CLIENT_ID/SECRET and that the service principal has workspace access. ${text}`.trim(),
+        status: resp.status,
+        endpoint: "/oidc/v1/token",
+      });
+    }
+    const json = (await resp.json()) as { access_token?: string; expires_in?: number };
+    if (!json.access_token) {
+      throw new DatabricksError({
+        kind: "auth",
+        message: "OAuth M2M token response missing access_token",
+        endpoint: "/oidc/v1/token",
+      });
+    }
+    const ttlMs = (json.expires_in ?? 3600) * 1000;
+    this.cached = { token: json.access_token, expiresAt: this.now() + ttlMs };
+    return json.access_token;
+  }
+}
+
+/**
+ * Resolve credentials from the environment into a host + token provider.
+ * Throws a structured `DatabricksError` (kind=auth/config) on any misconfiguration.
+ */
+export function resolveAuth(opts: ResolveAuthOptions = {}): ResolvedAuth {
+  const env = opts.env ?? process.env;
+  const fetchImpl = opts.fetchImpl ?? (globalThis.fetch as FetchLike);
+  const now = opts.now ?? Date.now;
+  const deployment = opts.deployment ?? detectDeployment(env);
+
+  const rawHost = env.DATABRICKS_HOST ?? env.DATABRICKS_WORKSPACE_HOST;
+  if (!rawHost) {
+    throw new DatabricksError({
+      kind: "config",
+      message:
+        "No workspace host. Set DATABRICKS_HOST (or DATABRICKS_WORKSPACE_HOST) to your workspace URL, e.g. https://dbc-xxxx.cloud.databricks.com",
+    });
+  }
+  const host = normalizeHost(rawHost);
+
+  const pat = env.DATABRICKS_TOKEN;
+  const oauthToken = env.DATABRICKS_OAUTH_TOKEN;
+  const clientId = env.DATABRICKS_CLIENT_ID;
+  const clientSecret = env.DATABRICKS_CLIENT_SECRET;
+  const hasM2m = Boolean(clientId && clientSecret);
+
+  if (deployment === "app") {
+    // Databricks Apps: OAuth M2M only. PAT is explicitly unsupported.
+    if (pat && !hasM2m) {
+      throw new DatabricksError({
+        kind: "auth",
+        message:
+          "PAT auth (DATABRICKS_TOKEN) is not supported in Databricks App deployment mode. Provide a service principal via DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET (OAuth M2M).",
+      });
+    }
+    if (!hasM2m) {
+      throw new DatabricksError({
+        kind: "auth",
+        message:
+          "Databricks App mode requires OAuth M2M: set DATABRICKS_CLIENT_ID and DATABRICKS_CLIENT_SECRET.",
+      });
+    }
+    return {
+      host,
+      deployment,
+      provider: new M2mTokenProvider(host, clientId!, clientSecret!, fetchImpl, now),
+    };
+  }
+
+  // CLI mode precedence: PAT > U2M token > M2M.
+  if (pat) {
+    return { host, deployment, provider: new PatTokenProvider(pat) };
+  }
+  if (oauthToken) {
+    return { host, deployment, provider: new StaticOAuthTokenProvider(oauthToken) };
+  }
+  if (hasM2m) {
+    return {
+      host,
+      deployment,
+      provider: new M2mTokenProvider(host, clientId!, clientSecret!, fetchImpl, now),
+    };
+  }
+
+  throw new DatabricksError({
+    kind: "auth",
+    message:
+      "No credentials. Provide one of: DATABRICKS_TOKEN (PAT), DATABRICKS_OAUTH_TOKEN (from `databricks auth login`), or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET (OAuth M2M).",
+  });
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/client.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/client.ts
@@ -1,0 +1,183 @@
+/**
+ * Databricks control-plane REST client.
+ *
+ * Wraps the workspace REST API with the three cross-cutting concerns Epic 1 T10 calls for:
+ *   - per-family token-bucket rate limiting (ratelimit.ts)
+ *   - exponential-backoff retry on 429 / 5xx, honoring `Retry-After`
+ *   - normalization of every failure into a StructuredError (errors.ts)
+ *
+ * Everything time/network/random is injectable so the whole client is exercised offline with
+ * recorded fixtures and a fake clock.
+ */
+
+import type { FetchLike, ResolvedAuth } from "./auth.js";
+import { DatabricksError, errorFromResponse, type StructuredError } from "./errors.js";
+import { FamilyRateLimiters } from "./ratelimit.js";
+
+export interface DatabricksClientOptions {
+  auth: ResolvedAuth;
+  fetchImpl?: FetchLike;
+  rateLimiters?: FamilyRateLimiters;
+  /** Total attempts = maxRetries + 1. Default 4 retries. */
+  maxRetries?: number;
+  /** Base backoff in ms (doubled each attempt). Default 250ms. */
+  backoffBaseMs?: number;
+  /** Cap on a single backoff wait. Default 20s. */
+  backoffMaxMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Jitter source in [0,1). Default Math.random. */
+  rng?: () => number;
+}
+
+export interface RequestSpec {
+  method: "GET" | "POST";
+  /** Path beginning with `/api/...`. */
+  path: string;
+  /** Endpoint family for rate limiting (e.g. "clusters", "pipelines"). */
+  family: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+}
+
+export class DatabricksClient {
+  private readonly auth: ResolvedAuth;
+  private readonly fetchImpl: FetchLike;
+  private readonly limiters: FamilyRateLimiters;
+  private readonly maxRetries: number;
+  private readonly backoffBaseMs: number;
+  private readonly backoffMaxMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly rng: () => number;
+
+  constructor(opts: DatabricksClientOptions) {
+    this.auth = opts.auth;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as FetchLike);
+    this.limiters = opts.rateLimiters ?? new FamilyRateLimiters();
+    this.maxRetries = opts.maxRetries ?? 4;
+    this.backoffBaseMs = opts.backoffBaseMs ?? 250;
+    this.backoffMaxMs = opts.backoffMaxMs ?? 20_000;
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.rng = opts.rng ?? Math.random;
+  }
+
+  get host(): string {
+    return this.auth.host;
+  }
+
+  private buildUrl(path: string, query?: RequestSpec["query"]): string {
+    const url = new URL(this.auth.host + path);
+    if (query) {
+      for (const [k, v] of Object.entries(query)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+    return url.toString();
+  }
+
+  private backoffMs(attempt: number, retryAfterSec?: number): number {
+    if (retryAfterSec && retryAfterSec > 0) return Math.min(retryAfterSec * 1000, this.backoffMaxMs);
+    const exp = this.backoffBaseMs * 2 ** attempt;
+    const jitter = exp * 0.25 * this.rng();
+    return Math.min(exp + jitter, this.backoffMaxMs);
+  }
+
+  async request<T = unknown>(spec: RequestSpec): Promise<T> {
+    await this.limiters.acquire(spec.family);
+    const url = this.buildUrl(spec.path, spec.query);
+
+    let lastError: DatabricksError | undefined;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      let token: string;
+      try {
+        token = await this.auth.provider.getToken();
+      } catch (err) {
+        // Auth resolution failures are not retriable.
+        throw err instanceof DatabricksError
+          ? err
+          : new DatabricksError({ kind: "auth", message: String(err), endpoint: spec.path });
+      }
+
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": "databricks-workspace-mcp/0.1.0",
+      };
+      const init: RequestInit = { method: spec.method, headers };
+      if (spec.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+        init.body = JSON.stringify(spec.body);
+      }
+
+      let resp: Response;
+      try {
+        resp = await this.fetchImpl(url, init);
+      } catch (err) {
+        lastError = new DatabricksError({
+          kind: "network",
+          message: `Network error calling ${spec.path}: ${err instanceof Error ? err.message : String(err)}`,
+          endpoint: spec.path,
+          retriable: true,
+        });
+        if (attempt < this.maxRetries) {
+          await this.sleep(this.backoffMs(attempt));
+          continue;
+        }
+        throw lastError;
+      }
+
+      const requestId = resp.headers.get("x-request-id") ?? undefined;
+
+      if (resp.ok) {
+        // 200 with empty body (some control-plane ops) → {}.
+        const text = await resp.text();
+        if (!text) return {} as T;
+        try {
+          return JSON.parse(text) as T;
+        } catch {
+          throw new DatabricksError({
+            kind: "api",
+            message: `Non-JSON success body from ${spec.path}`,
+            status: resp.status,
+            endpoint: spec.path,
+            requestId,
+          });
+        }
+      }
+
+      // Error path.
+      const bodyText = await resp.text().catch(() => "");
+      let parsed: unknown = bodyText;
+      try {
+        parsed = bodyText ? JSON.parse(bodyText) : undefined;
+      } catch {
+        /* keep raw text */
+      }
+      const apiErr = errorFromResponse(resp.status, spec.path, parsed, requestId);
+      lastError = apiErr;
+
+      if (apiErr.retriable && attempt < this.maxRetries) {
+        const retryAfter = Number(resp.headers.get("retry-after") ?? "");
+        await this.sleep(this.backoffMs(attempt, Number.isFinite(retryAfter) ? retryAfter : undefined));
+        continue;
+      }
+      throw apiErr;
+    }
+
+    // Exhausted retries.
+    throw (
+      lastError ??
+      new DatabricksError({ kind: "unknown", message: "Request failed", endpoint: spec.path })
+    );
+  }
+
+  get<T = unknown>(path: string, family: string, query?: RequestSpec["query"]): Promise<T> {
+    return this.request<T>({ method: "GET", path, family, query });
+  }
+
+  post<T = unknown>(path: string, family: string, body?: unknown): Promise<T> {
+    return this.request<T>({ method: "POST", path, family, body });
+  }
+}
+
+export type { StructuredError };

--- a/plugins/mcp/databricks-workspace-mcp/src/errors.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/errors.ts
@@ -1,0 +1,110 @@
+/**
+ * Structured error types for the Databricks control-plane MCP server.
+ *
+ * Databricks REST APIs return errors as JSON `{ error_code, message }`. We normalize
+ * every failure — transport, auth, rate-limit, and API — into one shape so the MCP tool
+ * layer can return a predictable `isError` payload that the calling agent can reason about
+ * (rather than a raw stack trace).
+ */
+
+export type DatabricksErrorKind =
+  | "auth" // credentials missing / rejected / wrong mode
+  | "config" // server misconfiguration (no host, etc.)
+  | "rate_limit" // 429 after retries exhausted
+  | "api" // a 4xx/5xx from the Databricks REST API
+  | "network" // fetch threw (DNS, TLS, timeout)
+  | "unknown";
+
+export interface StructuredError {
+  kind: DatabricksErrorKind;
+  /** Databricks `error_code` when present (e.g. PERMISSION_DENIED, RESOURCE_DOES_NOT_EXIST). */
+  errorCode?: string;
+  message: string;
+  /** HTTP status when the failure came from a response. */
+  status?: number;
+  /** The control-plane endpoint that was called, for triage. */
+  endpoint?: string;
+  /** Databricks request id (`x-request-id`) when present — give this to Databricks support. */
+  requestId?: string;
+  /** True when a retry could plausibly succeed (429 / 5xx / network). */
+  retriable?: boolean;
+}
+
+export class DatabricksError extends Error {
+  readonly kind: DatabricksErrorKind;
+  readonly errorCode?: string;
+  readonly status?: number;
+  readonly endpoint?: string;
+  readonly requestId?: string;
+  readonly retriable: boolean;
+
+  constructor(e: StructuredError) {
+    super(e.message);
+    this.name = "DatabricksError";
+    this.kind = e.kind;
+    this.errorCode = e.errorCode;
+    this.status = e.status;
+    this.endpoint = e.endpoint;
+    this.requestId = e.requestId;
+    this.retriable = e.retriable ?? false;
+  }
+
+  toStructured(): StructuredError {
+    return {
+      kind: this.kind,
+      errorCode: this.errorCode,
+      message: this.message,
+      status: this.status,
+      endpoint: this.endpoint,
+      requestId: this.requestId,
+      retriable: this.retriable,
+    };
+  }
+}
+
+/** Map an HTTP status + parsed Databricks error body into a StructuredError. */
+export function errorFromResponse(
+  status: number,
+  endpoint: string,
+  body: unknown,
+  requestId?: string,
+): DatabricksError {
+  let errorCode: string | undefined;
+  let message = `Databricks API returned ${status} for ${endpoint}`;
+  if (body && typeof body === "object") {
+    const b = body as Record<string, unknown>;
+    if (typeof b.error_code === "string") errorCode = b.error_code;
+    if (typeof b.message === "string" && b.message.length > 0) message = b.message;
+    // Some surfaces return a bare `{ error: "..." }`.
+    else if (typeof b.error === "string" && b.error.length > 0) message = b.error;
+  } else if (typeof body === "string" && body.length > 0) {
+    message = body;
+  }
+  const retriable = status === 429 || status >= 500;
+  const kind: DatabricksErrorKind =
+    status === 401 || status === 403 ? "auth" : status === 429 ? "rate_limit" : "api";
+  return new DatabricksError({
+    kind,
+    errorCode,
+    message,
+    status,
+    endpoint,
+    requestId,
+    retriable,
+  });
+}
+
+/** Render any thrown value as a StructuredError for the MCP isError payload. */
+export function toStructuredError(err: unknown, endpoint?: string): StructuredError {
+  if (err instanceof DatabricksError) return err.toStructured();
+  if (err instanceof Error) {
+    // A thrown fetch is almost always a transport problem.
+    return {
+      kind: "network",
+      message: err.message,
+      endpoint,
+      retriable: true,
+    };
+  }
+  return { kind: "unknown", message: String(err), endpoint };
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/index.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/index.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * databricks-workspace-mcp — stdio entry (CLI / `.mcp.json` consumption).
+ *
+ * Resolves Databricks credentials from the environment (PAT / OAuth U2M token / OAuth M2M),
+ * builds a lazy client provider, and serves the control-plane tools over stdio. Credentials are
+ * resolved lazily: the server starts and lists tools even when unconfigured, and only a tool
+ * *call* returns a structured auth error — so the consuming skill can detect "MCP present but
+ * not authenticated" and degrade cleanly.
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createServer, SERVER_NAME, SERVER_VERSION } from "./server.js";
+import { makeClientProvider, probeAuth } from "./runtime.js";
+
+async function main(): Promise<void> {
+  const getClient = makeClientProvider();
+  const server = createServer(getClient);
+  await server.connect(new StdioServerTransport());
+
+  const auth = probeAuth();
+  if (auth) {
+    console.error(
+      `${SERVER_NAME} v${SERVER_VERSION} running (${auth.deployment} mode, ${auth.provider.mode} auth) -> ${auth.host}`,
+    );
+  } else {
+    console.error(
+      `${SERVER_NAME} v${SERVER_VERSION} running UNAUTHENTICATED — set DATABRICKS_HOST + a credential (DATABRICKS_TOKEN / DATABRICKS_OAUTH_TOKEN / DATABRICKS_CLIENT_ID+SECRET). tools/list works; tools/call will return an auth error until configured.`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(`[${SERVER_NAME}] fatal:`, err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/plugins/mcp/databricks-workspace-mcp/src/ratelimit.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/ratelimit.ts
@@ -1,0 +1,77 @@
+/**
+ * Token-bucket rate limiter, applied per endpoint family so a burst of cluster-events calls
+ * can't starve a pipelines call (and vice-versa). Databricks rate limits are per-endpoint, so
+ * one bucket per family mirrors the server's own accounting.
+ *
+ * Clock and sleep are injectable so tests run instantly and deterministically.
+ */
+
+export interface RateLimiterOptions {
+  /** Max tokens in the bucket (burst size). */
+  capacity: number;
+  /** Tokens refilled per second. */
+  refillPerSec: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class RateLimiter {
+  private tokens: number;
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private last: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(opts: RateLimiterOptions) {
+    this.capacity = opts.capacity;
+    this.refillPerSec = opts.refillPerSec;
+    this.tokens = opts.capacity;
+    this.now = opts.now ?? Date.now;
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.last = this.now();
+  }
+
+  private refill(): void {
+    const t = this.now();
+    const elapsedSec = (t - this.last) / 1000;
+    if (elapsedSec > 0) {
+      this.tokens = Math.min(this.capacity, this.tokens + elapsedSec * this.refillPerSec);
+      this.last = t;
+    }
+  }
+
+  /** Block until a token is available, then consume it. */
+  async acquire(): Promise<void> {
+    // Loop guards against the wake-up racing another acquirer.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      this.refill();
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+      const deficit = 1 - this.tokens;
+      const waitMs = Math.ceil((deficit / this.refillPerSec) * 1000);
+      await this.sleep(waitMs);
+    }
+  }
+}
+
+/** Registry of per-family limiters with sensible Databricks-friendly defaults. */
+export class FamilyRateLimiters {
+  private readonly limiters = new Map<string, RateLimiter>();
+  constructor(
+    private readonly factory: (family: string) => RateLimiter = () =>
+      new RateLimiter({ capacity: 10, refillPerSec: 5 }),
+  ) {}
+
+  async acquire(family: string): Promise<void> {
+    let l = this.limiters.get(family);
+    if (!l) {
+      l = this.factory(family);
+      this.limiters.set(family, l);
+    }
+    await l.acquire();
+  }
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/runtime.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/runtime.ts
@@ -1,0 +1,31 @@
+/**
+ * Wiring between auth resolution and the server's lazy client provider. The provider memoizes a
+ * single client and re-throws the structured auth error on every call when credentials are
+ * absent — so `tools/list` still works and only `tools/call` surfaces the misconfiguration.
+ */
+
+import { resolveAuth, type ResolveAuthOptions, type ResolvedAuth } from "./auth.js";
+import { DatabricksClient, type DatabricksClientOptions } from "./client.js";
+import type { ClientProvider } from "./server.js";
+
+export function makeClientProvider(
+  authOpts: ResolveAuthOptions = {},
+  clientOpts: Partial<DatabricksClientOptions> = {},
+): ClientProvider {
+  let cached: DatabricksClient | null = null;
+  return () => {
+    if (cached) return cached;
+    const auth: ResolvedAuth = resolveAuth(authOpts); // throws DatabricksError if unconfigured
+    cached = new DatabricksClient({ auth, ...clientOpts });
+    return cached;
+  };
+}
+
+/** Best-effort auth probe for a startup log line. Returns null instead of throwing. */
+export function probeAuth(authOpts: ResolveAuthOptions = {}): ResolvedAuth | null {
+  try {
+    return resolveAuth(authOpts);
+  } catch {
+    return null;
+  }
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/server.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/server.ts
@@ -1,0 +1,106 @@
+/**
+ * MCP server factory. Registers all control-plane tools on a low-level `Server` (the same
+ * pattern the repo's design-to-code MCP uses) so the identical instance can be driven by either
+ * the stdio transport (CLI) or the Streamable HTTP transport (Databricks App mode).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { DatabricksClient } from "./client.js";
+import { toStructuredError } from "./errors.js";
+import { allTools, toolsByName } from "./tools/index.js";
+
+export const SERVER_NAME = "databricks-workspace-mcp";
+export const SERVER_VERSION = "0.1.0";
+
+export interface ToolCallResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * A client provider. Returns a ready client or throws a structured `DatabricksError` (e.g. when
+ * credentials are missing). Resolving lazily lets `tools/list` succeed even on an unconfigured
+ * workspace — the agent sees the 8 tools and gets a clean auth error only when it actually calls
+ * one (013-AT-ADEC: "report cleanly rather than failing mid-flow").
+ */
+export type ClientProvider = () => DatabricksClient;
+
+/**
+ * Pure tool-dispatch: resolve the client, validate args against the tool's zod schema, run the
+ * handler, and return the MCP content envelope. Exposed separately so tests exercise the full
+ * call path (auth → validation → handler → error normalization) without standing up a transport.
+ */
+export async function callTool(
+  getClient: ClientProvider,
+  name: string,
+  args: unknown,
+): Promise<ToolCallResult> {
+  const tool = toolsByName.get(name);
+  if (!tool) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ error: { kind: "config", message: `Unknown tool: ${name}` } }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+  const parsed = tool.schema.safeParse(args ?? {});
+  if (!parsed.success) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { error: { kind: "config", message: "Invalid arguments", issues: parsed.error.issues } },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+  try {
+    const client = getClient();
+    const result = await tool.handler(client, parsed.data);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ error: toStructuredError(err) }, null, 2) }],
+      isError: true,
+    };
+  }
+}
+
+export function createServer(getClient: ClientProvider): Server {
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: allTools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      // zod-to-json-schema's types target zod 3; we run zod 4. Cast at this single boundary.
+      inputSchema: zodToJsonSchema(t.schema as never, { target: "jsonSchema7" }) as Tool["inputSchema"],
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    // ToolCallResult is a structural CallToolResult; cast past the SDK's task-augmented union.
+    return (await callTool(getClient, name, args)) as never;
+  });
+
+  return server;
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/clusters.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/clusters.ts
@@ -1,0 +1,61 @@
+/**
+ * Cluster lifecycle tools (013-AT-ADEC T3 — KEEP). Powers cluster-forensics + the idle-cluster
+ * line of cost-leak-hunter. The managed SQL MCP cannot reach `clusters.events`; this is exactly
+ * the control-plane gap this server exists to fill.
+ */
+
+import { z } from "zod";
+import { defineTool } from "./types.js";
+
+const FAMILY = "clusters";
+
+export const clustersList = defineTool({
+  name: "clusters_list",
+  description:
+    "List all clusters in the workspace with their config and current state (RUNNING/TERMINATED/PENDING), autotermination, autoscale, node types, and creator. Use to inventory compute, find never-auto-terminating clusters, or pick All-Purpose clusters running scheduled jobs. Read-only. GET /api/2.0/clusters/list.",
+  schema: z.object({}).strict(),
+  family: FAMILY,
+  handler: (client) => client.get("/api/2.0/clusters/list", FAMILY),
+});
+
+export const clustersGet = defineTool({
+  name: "clusters_get",
+  description:
+    "Get the full configuration and current state of one cluster by id — autotermination_minutes, autoscale bounds, spark_version (DBR), node_type_id, runtime_engine (Photon vs standard), and state_message. Use for single-cluster forensics. Read-only. GET /api/2.0/clusters/get.",
+  schema: z.object({ cluster_id: z.string().min(1).describe("The cluster id, e.g. 0123-456789-abcde123") }).strict(),
+  family: FAMILY,
+  handler: (client, args) => client.get("/api/2.0/clusters/get", FAMILY, { cluster_id: args.cluster_id }),
+});
+
+export const clustersEvents = defineTool({
+  name: "clusters_events",
+  description:
+    "Retrieve the event timeline for a cluster (CREATING, STARTING, RUNNING, RESIZING, UPSCALE_COMPLETED, DRIVER_HEALTHY, TERMINATING, INIT_SCRIPTS_*, etc.) with timestamps and details. This is THE source for cold-start / launch-failure / resize forensics — managed MCP has no equivalent. Read-only. POST /api/2.0/clusters/events.",
+  schema: z
+    .object({
+      cluster_id: z.string().min(1).describe("The cluster id to fetch events for"),
+      start_time: z.number().int().optional().describe("Epoch millis lower bound (inclusive)"),
+      end_time: z.number().int().optional().describe("Epoch millis upper bound (inclusive)"),
+      event_types: z
+        .array(z.string())
+        .optional()
+        .describe("Filter to specific event types, e.g. ['STARTING','TERMINATING','INIT_SCRIPTS_FINISHED']"),
+      order: z.enum(["ASC", "DESC"]).optional().describe("Sort order by timestamp (default DESC)"),
+      limit: z.number().int().min(1).max(500).optional().describe("Max events per page (default 50)"),
+      offset: z.number().int().min(0).optional().describe("Page offset"),
+    })
+    .strict(),
+  family: FAMILY,
+  handler: (client, args) =>
+    client.post("/api/2.0/clusters/events", FAMILY, {
+      cluster_id: args.cluster_id,
+      start_time: args.start_time,
+      end_time: args.end_time,
+      event_types: args.event_types,
+      order: args.order,
+      limit: args.limit,
+      offset: args.offset,
+    }),
+});
+
+export const clusterTools = [clustersList, clustersGet, clustersEvents];

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/index.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/index.ts
@@ -1,0 +1,24 @@
+/**
+ * The full control-plane tool set this server exposes — 8 tools across the 6 endpoint families
+ * (clusters · instance pools · pipelines · UC external-locations · UC storage-credentials) that
+ * no managed Databricks MCP serves (013-AT-ADEC). Everything is read-only.
+ */
+
+import { clusterTools } from "./clusters.js";
+import { instancePoolTools } from "./instance-pools.js";
+import { pipelineTools } from "./pipelines.js";
+import { unityCatalogTools } from "./unity-catalog.js";
+import type { ToolDef } from "./types.js";
+
+export const allTools: ToolDef[] = [
+  ...clusterTools,
+  ...instancePoolTools,
+  ...pipelineTools,
+  ...unityCatalogTools,
+];
+
+export const toolsByName: ReadonlyMap<string, ToolDef> = new Map(
+  allTools.map((t) => [t.name, t]),
+);
+
+export type { ToolDef } from "./types.js";

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/instance-pools.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/instance-pools.ts
@@ -1,0 +1,21 @@
+/**
+ * Instance pool tools (013-AT-ADEC T6 — KEEP). Idle-pool waste is one of the cost-leak-hunter
+ * pillars (D09): pools hold warm VMs at `min_idle_instances` you pay the cloud provider for even
+ * when nothing schedules onto them. Managed MCP does not expose pool config.
+ */
+
+import { z } from "zod";
+import { defineTool } from "./types.js";
+
+const FAMILY = "instance_pools";
+
+export const instancePoolsList = defineTool({
+  name: "instance_pools_list",
+  description:
+    "List all instance pools with their config and live stats — min_idle_instances, max_capacity, node_type_id, idle_instance_autotermination_minutes, and stats (used/idle/pending counts). Use to find pools holding warm idle VMs (min_idle_instances > 0 with low utilization) that bill the underlying cloud compute. Read-only. GET /api/2.0/instance-pools/list.",
+  schema: z.object({}).strict(),
+  family: FAMILY,
+  handler: (client) => client.get("/api/2.0/instance-pools/list", FAMILY),
+});
+
+export const instancePoolTools = [instancePoolsList];

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/pipelines.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/pipelines.ts
@@ -1,0 +1,51 @@
+/**
+ * DLT pipeline tools (013-AT-ADEC T7 — KEEP). The pipeline event log is the diagnostic spine for
+ * streaming-guardian (DLT health) and the DLT-tier line of cost-leak-hunter. Managed MCP exposes
+ * `system.*` reads but not the pipeline definition or its structured event log.
+ */
+
+import { z } from "zod";
+import { defineTool } from "./types.js";
+
+const FAMILY = "pipelines";
+
+export const pipelinesGet = defineTool({
+  name: "pipelines_get",
+  description:
+    "Get a DLT pipeline's definition and latest state — name, edition (CORE/PRO/ADVANCED), channel, photon flag, serverless flag, clusters/autoscale config, continuous vs triggered, and latest_updates. Use to read the cost-relevant tier (edition + serverless) and the configured compute. Read-only. GET /api/2.0/pipelines/{pipeline_id}.",
+  schema: z
+    .object({ pipeline_id: z.string().min(1).describe("The DLT pipeline id (UUID)") })
+    .strict(),
+  family: FAMILY,
+  handler: (client, args) => client.get(`/api/2.0/pipelines/${encodeURIComponent(args.pipeline_id)}`, FAMILY),
+});
+
+export const pipelinesGetEventLog = defineTool({
+  name: "pipelines_get_event_log",
+  description:
+    "Page through a DLT pipeline's structured event log (flow_progress, update_progress, maintenance_progress, user_action, cluster events) with timestamps, levels, and details — including data-quality expectation metrics and backpressure signals. Use for streaming/DLT health forensics. Read-only. GET /api/2.0/pipelines/{pipeline_id}/events.",
+  schema: z
+    .object({
+      pipeline_id: z.string().min(1).describe("The DLT pipeline id (UUID)"),
+      max_results: z.number().int().min(1).max(250).optional().describe("Page size (default 25)"),
+      order: z.enum(["ASC", "DESC"]).optional().describe("Sort by timestamp (default DESC)"),
+      filter: z
+        .string()
+        .optional()
+        .describe(
+          "Optional event-log filter expression, e.g. \"level = 'ERROR'\" or \"timestamp > '2026-06-01T00:00:00Z'\"",
+        ),
+      page_token: z.string().optional().describe("Opaque token from a prior response's next_page_token"),
+    })
+    .strict(),
+  family: FAMILY,
+  handler: (client, args) =>
+    client.get(`/api/2.0/pipelines/${encodeURIComponent(args.pipeline_id)}/events`, FAMILY, {
+      max_results: args.max_results,
+      order_by: args.order ? `timestamp ${args.order.toLowerCase()}` : undefined,
+      filter: args.filter,
+      page_token: args.page_token,
+    }),
+});
+
+export const pipelineTools = [pipelinesGet, pipelinesGetEventLog];

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/types.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared tool-definition contract. Each control-plane tool is a self-describing record:
+ * a name, an agent-facing description, a zod input schema (also used to generate the MCP
+ * JSON Schema), the rate-limit family it belongs to, and a handler that takes the REST client
+ * plus validated args and returns plain data.
+ */
+
+import type { z } from "zod";
+import type { DatabricksClient } from "../client.js";
+
+export interface ToolDef<S extends z.ZodTypeAny = z.ZodTypeAny> {
+  name: string;
+  description: string;
+  schema: S;
+  family: string;
+  handler: (client: DatabricksClient, args: z.infer<S>) => Promise<unknown>;
+}
+
+/** Helper that preserves the zod inference while typing the def. */
+export function defineTool<S extends z.ZodTypeAny>(def: ToolDef<S>): ToolDef<S> {
+  return def;
+}

--- a/plugins/mcp/databricks-workspace-mcp/src/tools/unity-catalog.ts
+++ b/plugins/mcp/databricks-workspace-mcp/src/tools/unity-catalog.ts
@@ -1,0 +1,49 @@
+/**
+ * Unity Catalog governance tools (013-AT-ADEC T8 — KEEP). External locations + storage
+ * credentials are the substrate uc-migration-pilot traces for HMS→UC readiness and IAM wiring.
+ * Managed MCP serves `system.information_schema` reads but not the UC governance objects + their
+ * cloud-IAM bindings.
+ */
+
+import { z } from "zod";
+import { defineTool } from "./types.js";
+
+const FAMILY = "unity_catalog";
+
+export const externalLocationsList = defineTool({
+  name: "external_locations_list",
+  description:
+    "List Unity Catalog external locations — each binds a cloud storage URL (s3://, abfss://, gs://) to a storage credential, plus owner, read_only flag, and isolation/binding mode. Use to inventory where UC data physically lives and which credential governs each path during an HMS→UC migration. Read-only. GET /api/2.1/unity-catalog/external-locations.",
+  schema: z
+    .object({
+      max_results: z.number().int().min(1).max(1000).optional().describe("Page size"),
+      page_token: z.string().optional().describe("Opaque token from a prior response"),
+    })
+    .strict(),
+  family: FAMILY,
+  handler: (client, args) =>
+    client.get("/api/2.1/unity-catalog/external-locations", FAMILY, {
+      max_results: args.max_results,
+      page_token: args.page_token,
+    }),
+});
+
+export const storageCredentialsList = defineTool({
+  name: "storage_credentials_list",
+  description:
+    "List Unity Catalog storage credentials — the cloud-IAM principals (AWS IAM role, Azure managed identity / service principal, GCP service account) UC assumes to access storage, with owner, read_only, and used-for-managed-storage flags. Use to trace the IAM wiring behind external locations and audit credential reuse. Read-only. GET /api/2.1/unity-catalog/storage-credentials.",
+  schema: z
+    .object({
+      max_results: z.number().int().min(1).max(1000).optional().describe("Page size"),
+      page_token: z.string().optional().describe("Opaque token from a prior response"),
+    })
+    .strict(),
+  family: FAMILY,
+  handler: (client, args) =>
+    client.get("/api/2.1/unity-catalog/storage-credentials", FAMILY, {
+      max_results: args.max_results,
+      page_token: args.page_token,
+    }),
+});
+
+export const unityCatalogTools = [externalLocationsList, storageCredentialsList];

--- a/plugins/mcp/databricks-workspace-mcp/tests/auth.test.ts
+++ b/plugins/mcp/databricks-workspace-mcp/tests/auth.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { resolveAuth, normalizeHost, detectDeployment } from "../src/auth.js";
+import { DatabricksError } from "../src/errors.js";
+import { jsonResponse, recordingFetch } from "./helpers.js";
+
+const HOST = "https://dbc-test.cloud.databricks.com";
+
+describe("normalizeHost", () => {
+  it("adds https and strips trailing slashes", () => {
+    expect(normalizeHost("dbc-x.cloud.databricks.com/")).toBe("https://dbc-x.cloud.databricks.com");
+    expect(normalizeHost("https://dbc-x.cloud.databricks.com//")).toBe("https://dbc-x.cloud.databricks.com");
+  });
+  it("rejects empty host", () => {
+    expect(() => normalizeHost("   ")).toThrow(DatabricksError);
+  });
+});
+
+describe("detectDeployment", () => {
+  it("defaults to cli", () => {
+    expect(detectDeployment({})).toBe("cli");
+  });
+  it("detects app mode from explicit override or app port", () => {
+    expect(detectDeployment({ DATABRICKS_WORKSPACE_MCP_MODE: "app" })).toBe("app");
+    expect(detectDeployment({ DATABRICKS_APP_PORT: "8000" })).toBe("app");
+  });
+});
+
+describe("resolveAuth — CLI flows", () => {
+  it("PAT", async () => {
+    const a = resolveAuth({ env: { DATABRICKS_HOST: HOST, DATABRICKS_TOKEN: "dapiX" } });
+    expect(a.deployment).toBe("cli");
+    expect(a.provider.mode).toBe("pat");
+    expect(await a.provider.getToken()).toBe("dapiX");
+  });
+
+  it("OAuth U2M (supplied token)", async () => {
+    const a = resolveAuth({ env: { DATABRICKS_HOST: HOST, DATABRICKS_OAUTH_TOKEN: "u2m-abc" } });
+    expect(a.provider.mode).toBe("u2m");
+    expect(await a.provider.getToken()).toBe("u2m-abc");
+  });
+
+  it("PAT wins over M2M when both present (CLI precedence)", () => {
+    const a = resolveAuth({
+      env: { DATABRICKS_HOST: HOST, DATABRICKS_TOKEN: "dapiX", DATABRICKS_CLIENT_ID: "id", DATABRICKS_CLIENT_SECRET: "sec" },
+    });
+    expect(a.provider.mode).toBe("pat");
+  });
+
+  it("throws structured config error when host missing", () => {
+    try {
+      resolveAuth({ env: { DATABRICKS_TOKEN: "dapiX" } });
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(DatabricksError);
+      expect((e as DatabricksError).kind).toBe("config");
+    }
+  });
+
+  it("throws structured auth error when no credentials", () => {
+    try {
+      resolveAuth({ env: { DATABRICKS_HOST: HOST } });
+      expect.unreachable();
+    } catch (e) {
+      expect((e as DatabricksError).kind).toBe("auth");
+    }
+  });
+});
+
+describe("resolveAuth — OAuth M2M (client credentials)", () => {
+  it("exchanges client credentials for a bearer and caches until expiry", async () => {
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ access_token: "m2m-token-1", expires_in: 3600, token_type: "Bearer" }),
+    );
+    let t = 0;
+    const a = resolveAuth({
+      env: { DATABRICKS_HOST: HOST, DATABRICKS_CLIENT_ID: "id", DATABRICKS_CLIENT_SECRET: "sec" },
+      fetchImpl,
+      now: () => t,
+    });
+    expect(a.provider.mode).toBe("m2m");
+    expect(await a.provider.getToken()).toBe("m2m-token-1");
+    // cached — no second token call
+    expect(await a.provider.getToken()).toBe("m2m-token-1");
+    expect(calls.length).toBe(1);
+    expect(calls[0].url).toBe(`${HOST}/oidc/v1/token`);
+    expect(calls[0].headers.authorization).toMatch(/^Basic /);
+    expect(calls[0].body).toContain("grant_type=client_credentials");
+    // advance past expiry -> refetch
+    t = 3_600_000;
+    await a.provider.getToken();
+    expect(calls.length).toBe(2);
+  });
+
+  it("surfaces an auth error when the token endpoint rejects", async () => {
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ error: "invalid_client" }, { status: 401 }));
+    const a = resolveAuth({
+      env: { DATABRICKS_HOST: HOST, DATABRICKS_CLIENT_ID: "id", DATABRICKS_CLIENT_SECRET: "bad" },
+      fetchImpl,
+    });
+    await expect(a.provider.getToken()).rejects.toMatchObject({ kind: "auth", status: 401 });
+  });
+});
+
+describe("resolveAuth — App mode (OAuth M2M only)", () => {
+  it("rejects PAT cleanly in app mode", () => {
+    try {
+      resolveAuth({ deployment: "app", env: { DATABRICKS_HOST: HOST, DATABRICKS_TOKEN: "dapiX" } });
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(DatabricksError);
+      expect((e as DatabricksError).kind).toBe("auth");
+      expect((e as DatabricksError).message).toMatch(/not supported in Databricks App/i);
+    }
+  });
+
+  it("accepts M2M in app mode", () => {
+    const a = resolveAuth({
+      deployment: "app",
+      env: { DATABRICKS_HOST: HOST, DATABRICKS_CLIENT_ID: "id", DATABRICKS_CLIENT_SECRET: "sec" },
+    });
+    expect(a.deployment).toBe("app");
+    expect(a.provider.mode).toBe("m2m");
+  });
+
+  it("requires M2M creds in app mode", () => {
+    expect(() => resolveAuth({ deployment: "app", env: { DATABRICKS_HOST: HOST } })).toThrow(DatabricksError);
+  });
+});

--- a/plugins/mcp/databricks-workspace-mcp/tests/client.test.ts
+++ b/plugins/mcp/databricks-workspace-mcp/tests/client.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { DatabricksError } from "../src/errors.js";
+import { RateLimiter } from "../src/ratelimit.js";
+import { jsonResponse, recordingFetch, testClient } from "./helpers.js";
+
+describe("DatabricksClient — happy path", () => {
+  it("GETs and parses JSON, sending a Bearer token", async () => {
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ ok: true, n: 3 }));
+    const client = testClient(fetchImpl);
+    const res = await client.get<{ ok: boolean; n: number }>("/api/2.0/clusters/list", "clusters");
+    expect(res).toEqual({ ok: true, n: 3 });
+    expect(calls[0].headers.authorization).toBe("Bearer dapiTESTtoken");
+    expect(calls[0].url).toBe("https://dbc-test.cloud.databricks.com/api/2.0/clusters/list");
+  });
+
+  it("serializes query params and POST bodies", async () => {
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({}));
+    const client = testClient(fetchImpl);
+    await client.get("/api/2.0/clusters/get", "clusters", { cluster_id: "abc", limit: 5, skip: undefined });
+    expect(calls[0].url).toContain("cluster_id=abc");
+    expect(calls[0].url).toContain("limit=5");
+    expect(calls[0].url).not.toContain("skip");
+
+    await client.post("/api/2.0/clusters/events", "clusters", { cluster_id: "abc" });
+    expect(calls[1].method).toBe("POST");
+    expect(JSON.parse(calls[1].body!)).toEqual({ cluster_id: "abc" });
+  });
+
+  it("returns {} for an empty 200 body", async () => {
+    const { fetchImpl } = recordingFetch(() => new Response("", { status: 200 }));
+    const client = testClient(fetchImpl);
+    expect(await client.get("/api/2.0/clusters/list", "clusters")).toEqual({});
+  });
+});
+
+describe("DatabricksClient — retry", () => {
+  it("retries on 429 then succeeds, honoring retry-after", async () => {
+    const { fetchImpl, calls } = recordingFetch((_url, _call, i) =>
+      i === 0
+        ? jsonResponse({ message: "rate limited" }, { status: 429, headers: { "retry-after": "0" } })
+        : jsonResponse({ ok: true }),
+    );
+    const client = testClient(fetchImpl);
+    expect(await client.get("/x", "f")).toEqual({ ok: true });
+    expect(calls.length).toBe(2);
+  });
+
+  it("retries on 500 and eventually throws a retriable structured error", async () => {
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ message: "boom" }, { status: 503 }));
+    const client = testClient(fetchImpl, { maxRetries: 2 });
+    try {
+      await client.get("/x", "f");
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(DatabricksError);
+      expect((e as DatabricksError).retriable).toBe(true);
+      expect((e as DatabricksError).status).toBe(503);
+    }
+    expect(calls.length).toBe(3); // 1 + 2 retries
+  });
+
+  it("does NOT retry a 403 and surfaces the Databricks error_code", async () => {
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ error_code: "PERMISSION_DENIED", message: "no access" }, { status: 403 }),
+    );
+    const client = testClient(fetchImpl);
+    try {
+      await client.get("/x", "f");
+      expect.unreachable();
+    } catch (e) {
+      const err = e as DatabricksError;
+      expect(err.kind).toBe("auth");
+      expect(err.errorCode).toBe("PERMISSION_DENIED");
+      expect(err.retriable).toBe(false);
+    }
+    expect(calls.length).toBe(1);
+  });
+
+  it("captures x-request-id on errors", async () => {
+    const { fetchImpl } = recordingFetch(() =>
+      jsonResponse({ error_code: "INVALID_PARAMETER_VALUE", message: "bad" }, { status: 400, headers: { "x-request-id": "req-123" } }),
+    );
+    const client = testClient(fetchImpl);
+    await expect(client.get("/x", "f")).rejects.toMatchObject({ requestId: "req-123" });
+  });
+});
+
+describe("RateLimiter", () => {
+  it("hands out burst tokens then throttles until refill", async () => {
+    let t = 0;
+    const slept: number[] = [];
+    const rl = new RateLimiter({
+      capacity: 2,
+      refillPerSec: 1,
+      now: () => t,
+      sleep: async (ms) => {
+        slept.push(ms);
+        t += ms; // advance virtual clock so refill makes progress
+      },
+    });
+    await rl.acquire(); // token 1 (no wait)
+    await rl.acquire(); // token 2 (no wait)
+    await rl.acquire(); // empty -> must wait ~1000ms for one token
+    expect(slept.length).toBeGreaterThan(0);
+    expect(slept[0]).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/clusters_events.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/clusters_events.json
@@ -1,0 +1,35 @@
+{
+  "events": [
+    {
+      "cluster_id": "0608-120000-leak001",
+      "timestamp": 1717843200000,
+      "type": "CREATING",
+      "details": { "reason": { "code": "USER_REQUEST" } }
+    },
+    {
+      "cluster_id": "0608-120000-leak001",
+      "timestamp": 1717843260000,
+      "type": "STARTING",
+      "details": {}
+    },
+    {
+      "cluster_id": "0608-120000-leak001",
+      "timestamp": 1717843620000,
+      "type": "INIT_SCRIPTS_STARTED",
+      "details": {}
+    },
+    {
+      "cluster_id": "0608-120000-leak001",
+      "timestamp": 1717844040000,
+      "type": "INIT_SCRIPTS_FINISHED",
+      "details": { "init_scripts_execution_duration_seconds": 420 }
+    },
+    {
+      "cluster_id": "0608-120000-leak001",
+      "timestamp": 1717844100000,
+      "type": "RUNNING",
+      "details": { "current_num_workers": 8, "target_num_workers": 8 }
+    }
+  ],
+  "total_count": 5
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/clusters_list.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/clusters_list.json
@@ -1,0 +1,46 @@
+{
+  "clusters": [
+    {
+      "cluster_id": "0608-120000-leak001",
+      "cluster_name": "analytics-adhoc-shared",
+      "state": "RUNNING",
+      "spark_version": "14.3.x-scala2.12",
+      "node_type_id": "i3.2xlarge",
+      "driver_node_type_id": "i3.2xlarge",
+      "num_workers": 8,
+      "autotermination_minutes": 0,
+      "runtime_engine": "STANDARD",
+      "cluster_source": "UI",
+      "data_security_mode": "USER_ISOLATION",
+      "creator_user_name": "analyst@example.com",
+      "start_time": 1717843200000,
+      "custom_tags": { "team": "analytics", "env": "prod" }
+    },
+    {
+      "cluster_id": "0608-120000-job0002",
+      "cluster_name": "nightly-etl",
+      "state": "TERMINATED",
+      "spark_version": "15.4.x-scala2.12",
+      "node_type_id": "m5d.xlarge",
+      "num_workers": 4,
+      "autotermination_minutes": 0,
+      "runtime_engine": "PHOTON",
+      "cluster_source": "UI",
+      "creator_user_name": "data-eng@example.com",
+      "custom_tags": { "team": "data-eng", "env": "prod", "schedule": "nightly" }
+    },
+    {
+      "cluster_id": "0608-120000-auto003",
+      "cluster_name": "ml-training-autoscale",
+      "state": "RUNNING",
+      "spark_version": "15.4.x-scala2.12",
+      "node_type_id": "g5.4xlarge",
+      "autoscale": { "min_workers": 2, "max_workers": 20 },
+      "autotermination_minutes": 30,
+      "runtime_engine": "PHOTON",
+      "cluster_source": "API",
+      "creator_user_name": "ml-platform@example.com",
+      "custom_tags": { "team": "ml", "env": "prod" }
+    }
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/external_locations_list.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/external_locations_list.json
@@ -1,0 +1,22 @@
+{
+  "external_locations": [
+    {
+      "name": "bronze-landing",
+      "url": "s3://acme-lake-bronze/landing/",
+      "credential_name": "lake-ingest-role",
+      "read_only": false,
+      "owner": "data-platform@example.com",
+      "isolation_mode": "ISOLATION_MODE_ISOLATED",
+      "comment": "Raw landing zone"
+    },
+    {
+      "name": "legacy-hms-warehouse",
+      "url": "s3://acme-legacy-hive/warehouse/",
+      "credential_name": "legacy-hive-role",
+      "read_only": true,
+      "owner": "data-platform@example.com",
+      "isolation_mode": "ISOLATION_MODE_OPEN",
+      "comment": "Mounted HMS warehouse pending UC migration"
+    }
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/instance_pools_list.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/instance_pools_list.json
@@ -1,0 +1,32 @@
+{
+  "instance_pools": [
+    {
+      "instance_pool_id": "0608-pool-idle01",
+      "instance_pool_name": "warm-prod-pool",
+      "node_type_id": "i3.2xlarge",
+      "min_idle_instances": 6,
+      "max_capacity": 50,
+      "idle_instance_autotermination_minutes": 0,
+      "stats": {
+        "used_count": 1,
+        "idle_count": 6,
+        "pending_used_count": 0,
+        "pending_idle_count": 0
+      }
+    },
+    {
+      "instance_pool_id": "0608-pool-tight2",
+      "instance_pool_name": "ml-burst-pool",
+      "node_type_id": "g5.4xlarge",
+      "min_idle_instances": 0,
+      "max_capacity": 20,
+      "idle_instance_autotermination_minutes": 15,
+      "stats": {
+        "used_count": 4,
+        "idle_count": 0,
+        "pending_used_count": 1,
+        "pending_idle_count": 0
+      }
+    }
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/pipelines_events.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/pipelines_events.json
@@ -1,0 +1,32 @@
+{
+  "events": [
+    {
+      "id": "evt-7001",
+      "timestamp": "2026-06-08T12:05:00Z",
+      "level": "INFO",
+      "event_type": "flow_progress",
+      "message": "Flow 'bronze' completed.",
+      "details": {
+        "flow_progress": {
+          "status": "COMPLETED",
+          "metrics": { "num_output_rows": 184320, "backlog_bytes": 0 },
+          "data_quality": {
+            "dropped_records": 12,
+            "expectations": [
+              { "name": "valid_id", "dataset": "bronze", "passed_records": 184308, "failed_records": 12 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "evt-7002",
+      "timestamp": "2026-06-08T12:04:30Z",
+      "level": "WARN",
+      "event_type": "flow_progress",
+      "message": "Backpressure detected on flow 'silver'.",
+      "details": { "flow_progress": { "status": "RUNNING", "metrics": { "backlog_bytes": 734003200 } } }
+    }
+  ],
+  "next_page_token": "Cller==token"
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/pipelines_get.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/pipelines_get.json
@@ -1,0 +1,19 @@
+{
+  "pipeline_id": "a1b2c3d4-0000-1111-2222-333344445555",
+  "name": "bronze-ingest-dlt",
+  "state": "RUNNING",
+  "spec": {
+    "id": "a1b2c3d4-0000-1111-2222-333344445555",
+    "name": "bronze-ingest-dlt",
+    "edition": "ADVANCED",
+    "channel": "CURRENT",
+    "photon": true,
+    "serverless": true,
+    "continuous": true,
+    "development": false,
+    "clusters": [{ "label": "default", "autoscale": { "min_workers": 1, "max_workers": 5, "mode": "ENHANCED" } }]
+  },
+  "latest_updates": [
+    { "update_id": "upd-9001", "state": "RUNNING", "creation_time": "2026-06-08T12:00:00Z" }
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/fixtures/storage_credentials_list.json
+++ b/plugins/mcp/databricks-workspace-mcp/tests/fixtures/storage_credentials_list.json
@@ -1,0 +1,20 @@
+{
+  "storage_credentials": [
+    {
+      "name": "lake-ingest-role",
+      "aws_iam_role": { "role_arn": "arn:aws:iam::123456789012:role/databricks-lake-ingest" },
+      "read_only": false,
+      "owner": "data-platform@example.com",
+      "used_for_managed_storage": false,
+      "isolation_mode": "ISOLATION_MODE_ISOLATED"
+    },
+    {
+      "name": "legacy-hive-role",
+      "aws_iam_role": { "role_arn": "arn:aws:iam::123456789012:role/databricks-legacy-hive" },
+      "read_only": true,
+      "owner": "data-platform@example.com",
+      "used_for_managed_storage": false,
+      "isolation_mode": "ISOLATION_MODE_OPEN"
+    }
+  ]
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/helpers.ts
+++ b/plugins/mcp/databricks-workspace-mcp/tests/helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Offline test harness — a fake fetch that serves recorded fixtures, plus client/auth builders
+ * with injected clock, sleep, and rng so every test is deterministic and instant (no network).
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { FetchLike, ResolvedAuth } from "../src/auth.js";
+import { resolveAuth } from "../src/auth.js";
+import { DatabricksClient } from "../src/client.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function loadFixture<T = unknown>(name: string): T {
+  return JSON.parse(readFileSync(join(HERE, "fixtures", `${name}.json`), "utf8")) as T;
+}
+
+export function jsonResponse(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+export interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * A fetch that records every call and dispatches to a handler (url, call) -> Response. The
+ * handler may return a Response or an array of Responses to simulate retry sequences (one per
+ * successive call to the same URL).
+ */
+export function recordingFetch(
+  handler: (url: string, call: RecordedCall, callIndex: number) => Response | Promise<Response>,
+): { fetchImpl: FetchLike; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const fetchImpl: FetchLike = async (input, reqInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const h = reqInit?.headers;
+    if (h && typeof h === "object" && !Array.isArray(h)) {
+      for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+    }
+    const call: RecordedCall = {
+      url,
+      method: (reqInit?.method ?? "GET").toUpperCase(),
+      headers,
+      body: typeof reqInit?.body === "string" ? reqInit.body : undefined,
+    };
+    const idx = calls.length;
+    calls.push(call);
+    return handler(url, call, idx);
+  };
+  return { fetchImpl, calls };
+}
+
+export const TEST_HOST = "https://dbc-test.cloud.databricks.com";
+
+export function patAuth(token = "dapiTESTtoken"): ResolvedAuth {
+  return resolveAuth({ env: { DATABRICKS_HOST: TEST_HOST, DATABRICKS_TOKEN: token } });
+}
+
+/** Build a client wired to the given fetch, with fast deterministic timing. */
+export function testClient(
+  fetchImpl: FetchLike,
+  opts: { auth?: ResolvedAuth; maxRetries?: number } = {},
+): DatabricksClient {
+  return new DatabricksClient({
+    auth: opts.auth ?? patAuth(),
+    fetchImpl,
+    maxRetries: opts.maxRetries ?? 4,
+    backoffBaseMs: 1,
+    backoffMaxMs: 5,
+    sleep: async () => {},
+    now: () => 0,
+    rng: () => 0,
+  });
+}

--- a/plugins/mcp/databricks-workspace-mcp/tests/tools.test.ts
+++ b/plugins/mcp/databricks-workspace-mcp/tests/tools.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { allTools } from "../src/tools/index.js";
+import { callTool } from "../src/server.js";
+import { DatabricksError } from "../src/errors.js";
+import { jsonResponse, loadFixture, recordingFetch, testClient } from "./helpers.js";
+
+/** Route a request to the right fixture by URL. */
+function fixtureFetch() {
+  return recordingFetch((url) => {
+    if (url.includes("/clusters/list")) return jsonResponse(loadFixture("clusters_list"));
+    if (url.includes("/clusters/get")) return jsonResponse(loadFixture("clusters_list"));
+    if (url.includes("/clusters/events")) return jsonResponse(loadFixture("clusters_events"));
+    if (url.includes("/instance-pools/list")) return jsonResponse(loadFixture("instance_pools_list"));
+    if (url.includes("/pipelines/") && url.includes("/events")) return jsonResponse(loadFixture("pipelines_events"));
+    if (url.includes("/pipelines/")) return jsonResponse(loadFixture("pipelines_get"));
+    if (url.includes("/external-locations")) return jsonResponse(loadFixture("external_locations_list"));
+    if (url.includes("/storage-credentials")) return jsonResponse(loadFixture("storage_credentials_list"));
+    return jsonResponse({ error_code: "RESOURCE_DOES_NOT_EXIST", message: url }, { status: 404 });
+  });
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("tool catalog", () => {
+  it("exposes exactly the 8 control-plane tools", () => {
+    expect(allTools.map((t) => t.name).sort()).toEqual(
+      [
+        "clusters_events",
+        "clusters_get",
+        "clusters_list",
+        "external_locations_list",
+        "instance_pools_list",
+        "pipelines_get",
+        "pipelines_get_event_log",
+        "storage_credentials_list",
+      ].sort(),
+    );
+  });
+
+  it("every tool description names a real endpoint and is read-only", () => {
+    for (const t of allTools) {
+      expect(t.description).toMatch(/GET |POST /);
+      expect(t.description.toLowerCase()).toContain("read-only");
+    }
+  });
+});
+
+describe("callTool — happy paths against fixtures", () => {
+  it("clusters_list", async () => {
+    const { fetchImpl, calls } = fixtureFetch();
+    const client = testClient(fetchImpl);
+    const out = parse(await callTool(() => client, "clusters_list", {}));
+    expect(out.clusters).toHaveLength(3);
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].url).toContain("/api/2.0/clusters/list");
+  });
+
+  it("clusters_get requires + forwards cluster_id", async () => {
+    const { fetchImpl, calls } = fixtureFetch();
+    const client = testClient(fetchImpl);
+    await callTool(() => client, "clusters_get", { cluster_id: "0608-120000-leak001" });
+    expect(calls[0].url).toContain("cluster_id=0608-120000-leak001");
+  });
+
+  it("clusters_events is a POST with the cluster_id in the body", async () => {
+    const { fetchImpl, calls } = fixtureFetch();
+    const client = testClient(fetchImpl);
+    const out = parse(await callTool(() => client, "clusters_events", { cluster_id: "0608-120000-leak001", limit: 50 }));
+    expect(out.events).toHaveLength(5);
+    expect(calls[0].method).toBe("POST");
+    expect(JSON.parse(calls[0].body!)).toMatchObject({ cluster_id: "0608-120000-leak001", limit: 50 });
+  });
+
+  it("instance_pools_list", async () => {
+    const { fetchImpl } = fixtureFetch();
+    const out = parse(await callTool(() => testClient(fetchImpl), "instance_pools_list", {}));
+    expect(out.instance_pools[0].min_idle_instances).toBe(6);
+  });
+
+  it("pipelines_get and pipelines_get_event_log hit the right paths", async () => {
+    const { fetchImpl, calls } = fixtureFetch();
+    const client = testClient(fetchImpl);
+    const pid = "a1b2c3d4-0000-1111-2222-333344445555";
+    const got = parse(await callTool(() => client, "pipelines_get", { pipeline_id: pid }));
+    expect(got.spec.edition).toBe("ADVANCED");
+    const log = parse(await callTool(() => client, "pipelines_get_event_log", { pipeline_id: pid, max_results: 25 }));
+    expect(log.events).toHaveLength(2);
+    expect(calls[1].url).toContain(`/pipelines/${pid}/events`);
+  });
+
+  it("external_locations_list and storage_credentials_list", async () => {
+    const { fetchImpl } = fixtureFetch();
+    const client = testClient(fetchImpl);
+    const loc = parse(await callTool(() => client, "external_locations_list", {}));
+    expect(loc.external_locations.map((l: { name: string }) => l.name)).toContain("legacy-hms-warehouse");
+    const cred = parse(await callTool(() => client, "storage_credentials_list", {}));
+    expect(cred.storage_credentials[0].aws_iam_role.role_arn).toMatch(/^arn:aws:iam::/);
+  });
+});
+
+describe("callTool — error handling", () => {
+  it("rejects unknown tools with a structured error", async () => {
+    const { fetchImpl } = fixtureFetch();
+    const r = await callTool(() => testClient(fetchImpl), "nope", {});
+    expect(r.isError).toBe(true);
+    expect(parse(r).error.message).toMatch(/Unknown tool/);
+  });
+
+  it("rejects invalid args before any network call", async () => {
+    const { fetchImpl, calls } = fixtureFetch();
+    const r = await callTool(() => testClient(fetchImpl), "clusters_get", {});
+    expect(r.isError).toBe(true);
+    expect(parse(r).error.message).toMatch(/Invalid arguments/);
+    expect(calls.length).toBe(0);
+  });
+
+  it("rejects unknown extra args (strict schemas)", async () => {
+    const { fetchImpl } = fixtureFetch();
+    const r = await callTool(() => testClient(fetchImpl), "clusters_list", { surprise: 1 });
+    expect(r.isError).toBe(true);
+  });
+
+  it("returns a clean structured auth error when the client provider throws (MCP present, not configured)", async () => {
+    const r = await callTool(
+      () => {
+        throw new DatabricksError({ kind: "auth", message: "No credentials" });
+      },
+      "clusters_list",
+      {},
+    );
+    expect(r.isError).toBe(true);
+    expect(parse(r).error.kind).toBe("auth");
+  });
+
+  it("surfaces an API error from the handler as isError", async () => {
+    const { fetchImpl } = recordingFetch(() =>
+      jsonResponse({ error_code: "PERMISSION_DENIED", message: "nope" }, { status: 403 }),
+    );
+    const r = await callTool(() => testClient(fetchImpl), "clusters_list", {});
+    expect(r.isError).toBe(true);
+    expect(parse(r).error.errorCode).toBe("PERMISSION_DENIED");
+  });
+});

--- a/plugins/mcp/databricks-workspace-mcp/tsconfig.json
+++ b/plugins/mcp/databricks-workspace-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "lib": ["ES2022"],
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/plugins/mcp/databricks-workspace-mcp/vitest.config.ts
+++ b/plugins/mcp/databricks-workspace-mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,28 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  plugins/mcp/databricks-workspace-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.19
+        version: 22.19.19
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
   plugins/mcp/design-to-code:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -330,6 +352,8 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  plugins/mcp/governed-second-brain: {}
 
   plugins/mcp/lumera-agent-memory: {}
 
@@ -7002,7 +7026,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/bun@1.3.11':
     dependencies:
@@ -7015,7 +7039,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/cors@2.8.19':
     dependencies:
@@ -7057,7 +7081,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -7083,7 +7107,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 25.9.1
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -7130,12 +7154,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/unist@3.0.3': {}
 
@@ -7299,6 +7323,14 @@ snapshots:
   '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.7(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -10741,6 +10773,34 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## What

Lands the **databricks-workspace-mcp** plugin and wires it into the marketplace catalog. The TypeScript server + tests already existed on the branch; this PR adds the marketplace-required surface that was missing and registers the plugin.

## Why

Databricks ships five managed MCP servers — all **data plane**. None expose live **control-plane** state (cluster event timelines, instance-pool idle stats, DLT pipeline event logs, Unity Catalog external-location / storage-credential wiring). This server fills that gap. Consuming skills pair it with the managed SQL MCP for `system.*` reads (per `013-AT-ADEC` dual-MCP routing).

## Tool surface (8, all read-only)

`clusters_list` · `clusters_get` · `clusters_events` · `instance_pools_list` · `pipelines_get` · `pipelines_get_event_log` · `external_locations_list` · `storage_credentials_list`

## Added in this PR

- `.claude-plugin/plugin.json` — plugin manifest
- `README.md` — tool table, three auth flows, `.mcp.json` install
- `.env.example` — `DATABRICKS_HOST` + PAT / OAuth U2M / OAuth M2M template
- catalog entry in `marketplace.extended.json` (`category: mcp`, `mcpTools: 8`) → propagated to `marketplace.json` + README TOC via `sync-marketplace`

Auth resolves lazily: `tools/list` works unconfigured; a tool *call* returns a structured auth error until a host + credential are set.

## Verification

- `tsc` build + typecheck clean
- **35/35 vitest tests pass** (fixture-based — no live workspace or credentials needed)
- unicode-hygiene gate clean on new files
- marketplace validator **net-neutral vs baseline** (no new errors introduced)
- no build artifacts staged (`node_modules/`, `dist/` gitignored)

## Not in scope (follow-ups)

- Live-sandbox integration across the three auth modes + `/validate-mcp` against a running server — needs a real Databricks workspace
- Official Databricks-SDK auth and the dual-surface integration helpers (`.mcp.json` template + `/setup-databricks-connector` walkthrough) are tracked in sibling beads
- `[skip auto-bump]` — keep the introductory version at `0.1.0`

Refs jeremylongshore/claude-code-plugins-plus-skills#789

- Jeremy Longshore
intentsolutions.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Databricks Workspace MCP plugin providing 8 control-plane tools for clusters, instance pools, pipelines, and Unity Catalog operations
  * Supports multiple authentication flows: Personal Access Token, OAuth U2M, and OAuth M2M service principals
  * Configurable deployment modes for CLI and HTTP/App-based usage with rate limiting and automatic retry logic

* **Documentation**
  * Updated plugin registry and README to include the new Databricks Workspace MCP plugin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->