### PR TITLE
chore(sources): register beads-dolt for external-repo marketplace sync

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -4,7 +4,8 @@
 # This allows plugin authors to maintain their plugins in their own repos
 # while we automatically mirror updates to our marketplace.
 #
-# Sync runs: Daily at midnight UTC via GitHub Actions
+# Sync runs: Weekly, Mondays 06:00 UTC via GitHub Actions (plus on-demand
+#            workflow_dispatch and repository_dispatch: external-plugin-sync)
 # Workflow: .github/workflows/sync-external.yml
 # Script: scripts/sync-external.mjs
 
@@ -731,6 +732,36 @@ sources:
       - '.mcp.json'
       - 'skills/**'
       - 'plugin-runtime/**'
+      - 'README.md'
+      - 'LICENSE'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
+  # ============================================================
+  # beads-dolt (Jeremy Longshore / Intent Solutions)
+  # https://github.com/jeremylongshore/beads-dolt
+  # ============================================================
+
+  - name: beads-dolt
+    description: Dolt/DoltHub-aware upgrade to the beads (bd) task tracker — a skill that surfaces visibility/no-remote root causes and the remote-add + push fix, five expert agents grounded in bd+Dolt internals, and a wired dolt-mcp server for SQL access to the bead graph.
+    repo: jeremylongshore/beads-dolt
+    source_path: .
+    target_path: plugins/mcp/beads-dolt
+    author:
+      name: Jeremy Longshore
+      github: jeremylongshore
+      email: jeremy@intentsolutions.io
+    license: Apache-2.0
+    category: mcp
+    verified: true
+    include:
+      - '.claude-plugin/**'
+      - '.mcp.json'
+      - 'skills/**'
+      - 'agents/**'
+      - 'scripts/**'
       - 'README.md'
       - 'LICENSE'
     exclude:


### PR DESCRIPTION
## What

Registers **beads-dolt** (`jeremylongshore/beads-dolt`) in `sources.yaml` so the marketplace mirrors it automatically — the **external-sync path** (Path B), identical to how `governed-second-brain` is handled.

## Why this is the right mechanism

beads-dolt is maintained in its own repo. The two ways into the marketplace are:

- **Path A (in-repo / vendored):** source lives in `plugins/**` here, hand-cataloged. Right for plugins developed *in* this repo (e.g. databricks-workspace-mcp).
- **Path B (external sync):** source lives in its own repo, registered in `sources.yaml`; the weekly workflow mirrors it in + auto-generates the catalog entry + drops a `.source.json`. Right for separately-maintained repos.

Being a Jeremy-owned repo doesn't make it in-repo — `governed-second-brain` (also self-owned) uses Path B. This entry follows that precedent exactly, so beads-dolt **stays up to date with its upstream with zero further action**: register once, the weekly sync (Mondays 06:00 UTC) pulls changes into a reviewable auto-PR forever. No hand-vendoring, no stale frozen copy.

## The entry

- `repo: jeremylongshore/beads-dolt`, `source_path: .`, `target_path: plugins/mcp/beads-dolt`
- `category: mcp` (path-derived per `validate-catalog-invariants.py`; matches the governed-second-brain precedent)
- `include`: `.claude-plugin/**`, `.mcp.json`, `skills/**`, `agents/**`, `scripts/**`, `README.md`, `LICENSE`

## Verification

`node scripts/sync-external.mjs --source=beads-dolt --dry-run` clones `main`, filters to **19 files** (skill + 5 agents + 6 scripts + `.mcp.json` + both manifests + references), and reports **"Would add catalog entry: beads-dolt."** No files written by the dry-run.

## After merge

The weekly cron mirrors it automatically. To land it immediately instead of waiting for Monday: `gh workflow run sync-external.yml -f source=beads-dolt` — which opens a second reviewable `sync/external-plugins` PR with the mirrored files + catalog entry.

## Doc-drift fix

`sources.yaml` header said *"Daily at midnight UTC"*; the workflow is actually *weekly, Mondays 06:00 UTC* (changed 2026-05-31). Corrected.

## Not included (optional follow-up)

Instant push-to-sync propagation via `repository_dispatch: external-plugin-sync` — the workflow already accepts it, but no upstream repo fires it yet (not even governed-second-brain). Wiring it for beads-dolt is a separate ~15-line workflow + a cross-repo dispatch PAT.

- Jeremy Longshore
intentsolutions.io