### PR TITLE
chore(sync): materialize beads-dolt into the catalog

### DIFF
--- a/plugins/mcp/slack-channel/.source.json
+++ b/plugins/mcp/slack-channel/.source.json
@@ -4,7 +4,7 @@
     "path": ".",
     "branch": "main"
   },
-  "last_sync": "2026-06-17T16:28:15.531Z",
+  "last_sync": "2026-06-25T00:36:05.199Z",
   "author": {
     "name": "Jeremy Longshore",
     "github": "jeremylongshore",

--- a/plugins/mcp/slack-channel/ACCESS.md
+++ b/plugins/mcp/slack-channel/ACCESS.md
@@ -66,10 +66,26 @@ Array of Slack user IDs (e.g., `U12345678`) allowed to send DMs. Managed via `/s
 ### `channels`
 Map of channel IDs to policies. Only channels listed here are monitored.
 
-- `requireMention`: If true, only messages that @mention the bot are delivered
+- `requireMention`: If true (**the default for newly opted-in channels** — "mention-to-engage"), only messages that @mention the bot are delivered. Once a human has mentioned the bot in a thread, their later messages in that same thread are delivered **without re-mentioning** (thread-stickiness, `ccsc-apj.1`); peer agents are never sticky and must @mention every message. If false ("ambient"), every message in the channel is delivered.
 - `allowFrom`: If non-empty, only these user IDs are delivered from this channel
 - `allowBotIds`: Opt-in list of bot user IDs allowed to deliver messages in this channel. Absent or empty (default) = all bot messages dropped. See "Multi-agent coordination" below.
 - `audit`: Audit-log projection mode for this channel. See "Audit projection (`audit`)" below. Absent or `'off'` (default) = no projection. Values: `'off'` | `'compact'` | `'full'`.
+- `perUserSessions`: If true, each distinct sender gets their **own** session within a shared thread — separate state file, supervisor handle, and `ownerId` — so two humans talking in one thread don't share bridge-session state (`ccsc-kl410`). Absent or false (default) = one shared session per (channel, thread). Isolates the bridge's per-thread book-keeping, not Claude's own conversation memory.
+- `channelCircuitBreaker`: Channel-wide peer-bot circuit breaker (`ccsc-0k7x2`) — trips when total bot velocity across **all** allowlisted bots is runaway-high, catching A→B→C→A rings the per-bot limit misses. Absent = default (40 msgs / 60s). `{ "count": 0, "windowMs": 0 }` disables.
+
+### Interaction modes
+
+A channel runs in one of three operator-chosen modes. This is CCSC's edge over a single-mode `@`-bot: you decide whether humans can talk past Claude, and whether Claude must be addressed explicitly.
+
+| Mode | `access.json` | When to use |
+|---|---|---|
+| **Mention-to-engage** (default) | `"requireMention": true` | Shared human channels. People converse freely; Claude only hears messages that `@`-mention it. After one mention, the thread stays engaged so the human can keep talking without re-mentioning (thread-stickiness). |
+| **Ambient** | `"requireMention": false` | A dedicated bot channel where every message is meant for Claude. |
+| **Per-user allowlist** | `"allowFrom": ["U…"]` | Restrict *which humans* Claude even hears; composes with either mode above. |
+
+**Default:** newly opted-in channels default to **mention-to-engage** (`/slack-channel:access channel <id>`); pass `--ambient` to opt into ambient instead. This keeps Claude quiet by default in shared channels — humans can talk to each other without any agent receiving the message until someone `@`-mentions it.
+
+**Thread-stickiness is human-only (`ccsc-apj.1`).** Once a human engages a thread by mentioning the bot, their subsequent messages *in that thread* are delivered without a fresh mention ("mention once, then converse"). **Peer agents (`allowBotIds`) are never sticky** — a peer bot must `@`-mention the bot on every message. Making agents sticky would re-open the bot-loop/noise problem the peer-bot rate limiter guards, so agent engagement stays per-message-explicit.
 
 ### Multi-agent coordination (`allowBotIds`)
 

--- a/plugins/mcp/slack-channel/README.md
+++ b/plugins/mcp/slack-channel/README.md
@@ -181,10 +181,12 @@ See [ACCESS.md](ACCESS.md) for the full schema.
 /slack-channel:access policy allowlist       # Only pre-approved users
 /slack-channel:access add U12345678          # Add a user
 /slack-channel:access remove U12345678       # Remove a user
-/slack-channel:access channel C12345678      # Opt in a channel
-/slack-channel:access channel C12345678 --mention  # Require @mention
+/slack-channel:access channel C12345678      # Opt in a channel (default: mention-to-engage)
+/slack-channel:access channel C12345678 --ambient  # Ambient: Claude hears every message
 /slack-channel:access status                 # Show current config
 ```
+
+**Interaction modes.** A newly opted-in channel defaults to **mention-to-engage** (`requireMention: true`): people converse freely and Claude only sees messages that `@`-mention it — and once a human mentions the bot in a thread, they can keep talking in that thread without re-mentioning (peer agents must `@`-mention every time). Pass `--ambient` for a dedicated bot channel where Claude hears everything, or `--allow <ids>` to restrict which humans are heard. See [ACCESS.md](ACCESS.md#interaction-modes).
 
 ### Multi-agent coordination
 

--- a/plugins/mcp/slack-channel/admin.ts
+++ b/plugins/mcp/slack-channel/admin.ts
@@ -39,6 +39,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { JournalWriter } from './journal.ts'
 import { DEFAULT_MUTE_TTL_MS, type MuteStore, parseSlackMention } from './mute-store.ts'
+import type { RateLimitConfig } from './peer-bot-rate-limit.ts'
 import type { NonceStore } from './nonce-hitl.ts'
 import { verifyNonce } from './nonce-hitl.ts'
 
@@ -99,11 +100,35 @@ export interface AdminUnmuteCommand extends AdminCommandBase {
   targetBotId: string
 }
 
+/** !mute-status — READ-ONLY (ccsc-yl6k9): list the channel's active peer-bot
+ *  mutes + remaining TTL. No arg, no state change. */
+export interface AdminMuteStatusCommand extends AdminCommandBase {
+  kind: 'mute-status'
+}
+
+/** !rate-limit — READ-ONLY (ccsc-yl6k9): show the channel's effective peer-bot
+ *  rate limit + circuit-breaker thresholds. No arg, no state change. Tuning the
+ *  numbers stays terminal-only (access.json) by design — a Slack message must
+ *  never loosen a security limit. */
+export interface AdminRateLimitCommand extends AdminCommandBase {
+  kind: 'rate-limit'
+}
+
+/** !agents — READ-ONLY (ccsc-4e9bf): list the peer bots seen active in this
+ *  channel recently. A lightweight "who's online" view; no arg, no state
+ *  change. */
+export interface AdminAgentsCommand extends AdminCommandBase {
+  kind: 'agents'
+}
+
 export type AdminCommand =
   | AdminClearCommand
   | AdminRestartCommand
   | AdminMuteCommand
   | AdminUnmuteCommand
+  | AdminMuteStatusCommand
+  | AdminRateLimitCommand
+  | AdminAgentsCommand
 
 // ---------------------------------------------------------------------------
 // Parser — text → AdminCommand
@@ -129,7 +154,10 @@ export type AdminCommand =
  *  downstream `parseSlackMention` accepts spaces inside the
  *  display-name capture (`[^>]*`).
  */
-const ADMIN_COMMAND_RE = /^!(clear|restart|mute|unmute)(?:\s+(.+))?$/
+// `mute-status` / `rate-limit` precede `mute` so the longer verb wins the
+// alternation; both take no argument (ccsc-yl6k9).
+const ADMIN_COMMAND_RE =
+  /^!(clear|restart|mute-status|rate-limit|agents|mute|unmute)(?:\s+(.+))?$/
 
 /** Parse a normalized text body into an `AdminCommand`, or `null` if
  *  the text doesn't match an admin verb. Pure function — no side
@@ -153,7 +181,14 @@ export function parseAdminCommand(
 ): AdminCommand | null {
   const match = ADMIN_COMMAND_RE.exec(text.trim())
   if (match === null) return null
-  const verb = match[1] as 'clear' | 'restart' | 'mute' | 'unmute'
+  const verb = match[1] as
+    | 'clear'
+    | 'restart'
+    | 'mute'
+    | 'unmute'
+    | 'mute-status'
+    | 'rate-limit'
+    | 'agents'
   const arg = match[2]
 
   if (verb === 'clear') {
@@ -163,6 +198,14 @@ export function parseAdminCommand(
     // refuse it for other reasons). This is the conservative choice.
     if (arg !== undefined) return null
     return { kind: 'clear', ...envelope }
+  }
+
+  // !mute-status / !rate-limit / !agents — read-only, no argument (ccsc-yl6k9,
+  // ccsc-4e9bf). Same conservative rule as !clear: a stray arg falls through to
+  // normal chat.
+  if (verb === 'mute-status' || verb === 'rate-limit' || verb === 'agents') {
+    if (arg !== undefined) return null
+    return { kind: verb, ...envelope }
   }
 
   if (verb === 'restart') {
@@ -191,6 +234,9 @@ export type DispatchOutcome =
   | { kind: 'executed'; verb: 'clear' | 'restart' | 'mute' | 'unmute' }
   | { kind: 'challenge_issued'; nonce: string; expiresAt: number }
   | { kind: 'denied'; reason: string }
+  /** Read-only verb result (ccsc-yl6k9). The dispatcher built a status
+   *  message; the caller posts it to the channel. No state changed. */
+  | { kind: 'status'; verb: 'mute-status' | 'rate-limit' | 'agents'; message: string }
 
 /** Dependencies the dispatcher needs. Injected so tests can swap
  *  mocks for the side-effectful pieces (tmux, journal, Slack, nonce
@@ -236,6 +282,20 @@ export interface DispatchDeps {
   /** Clock for mute TTL math. Defaults to `Date.now`. Tests inject
    *  for deterministic expiry assertions. */
   now?: () => number
+  /** Resolve the channel's EFFECTIVE peer-bot rate-limit + circuit-breaker
+   *  config (policy override or the built-in default) for the read-only
+   *  `!rate-limit` verb (ccsc-yl6k9). The server computes this from
+   *  access.json + the DEFAULT_* constants. Absent → `!rate-limit` reports
+   *  that the limits view is unavailable. */
+  getChannelRateLimits?: (channelId: string) => {
+    peerBot: RateLimitConfig
+    channel: RateLimitConfig
+  }
+  /** List peer-bot user IDs seen active in the channel recently, for the
+   *  read-only `!agents` verb (ccsc-4e9bf). The server derives this from the
+   *  peer-bot rate-limit store's per-channel activity. Absent → `!agents`
+   *  reports the view is unavailable. */
+  getActiveAgents?: (channelId: string, now: number) => string[]
 }
 
 /** Dispatch an admin command through the full pipeline:
@@ -268,6 +328,29 @@ export async function dispatchAdminCommand(
   cmd: AdminCommand,
   deps: DispatchDeps,
 ): Promise<DispatchOutcome> {
+  // Read-only verbs (ccsc-yl6k9): allowlist-gated like every admin verb, but
+  // NOT journaled — they change no state, and the journal records decisions,
+  // not queries. Handled before the generic gate below so they never reach
+  // journalAttempt, whose kindMap only covers state-changing verbs.
+  if (cmd.kind === 'mute-status' || cmd.kind === 'rate-limit' || cmd.kind === 'agents') {
+    if (!deps.isAllowed(cmd.channelId, cmd.requestedBy)) {
+      return {
+        kind: 'denied',
+        reason: 'requester not authorized for admin commands in this channel',
+      }
+    }
+    const now = deps.now !== undefined ? deps.now() : Date.now()
+    let message: string
+    if (cmd.kind === 'mute-status') {
+      message = formatMuteStatus(deps.muteStore, cmd.channelId, now)
+    } else if (cmd.kind === 'rate-limit') {
+      message = formatRateLimit(deps.getChannelRateLimits, cmd.channelId)
+    } else {
+      message = formatAgents(deps.getActiveAgents, cmd.channelId, now)
+    }
+    return { kind: 'status', verb: cmd.kind, message }
+  }
+
   // Allowlist gate — same shape regardless of verb.
   if (!deps.isAllowed(cmd.channelId, cmd.requestedBy)) {
     await journalAttempt(deps, cmd, 'denied', 'requester not on adminCommands.allowFrom')
@@ -353,12 +436,78 @@ export async function dispatchAdminCommand(
   return { kind: 'executed', verb: 'restart' }
 }
 
+// ---------------------------------------------------------------------------
+// Read-only verb formatters (ccsc-yl6k9) — pure, no side effects
+// ---------------------------------------------------------------------------
+
+/** "4m 12s" / "45s" from a millisecond duration (floored at 0). */
+function formatRemaining(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000))
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return m > 0 ? `${m}m ${s}s` : `${s}s`
+}
+
+/** "10 msgs / 60s" or "disabled" for a rate-limit config. Defensive against a
+ *  missing/malformed cfg from a hand-edited access.json (Gemini, PR #249). */
+function describeLimit(cfg: RateLimitConfig | undefined | null): string {
+  if (!cfg || cfg.count <= 0 || cfg.windowMs <= 0) return 'disabled'
+  return `${cfg.count} msgs / ${Math.round(cfg.windowMs / 1000)}s`
+}
+
+/** Build the `!mute-status` message — the channel's active peer-bot mutes with
+ *  remaining TTL. Read-only; never mutates the store. */
+function formatMuteStatus(store: MuteStore | undefined, channelId: string, now: number): string {
+  if (store === undefined) return ':mute: Mute status is unavailable (no mute store configured).'
+  const mutes = store.list(channelId, now)
+  if (mutes.length === 0) return ':mute: No active peer-bot mutes in this channel.'
+  const lines = mutes.map(
+    (m) => `• <@${m.botId}> — ${formatRemaining(m.expiresAt - now)} left (muted by <@${m.mutedBy}>)`,
+  )
+  return `:mute: *Active peer-bot mutes:*\n${lines.join('\n')}`
+}
+
+/** Build the `!agents` message — peer bots seen active in the channel recently
+ *  (ccsc-4e9bf). Read-only "who's online" view. */
+function formatAgents(
+  resolve: DispatchDeps['getActiveAgents'],
+  channelId: string,
+  now: number,
+): string {
+  if (resolve === undefined) return ':satellite_antenna: Agent activity view is unavailable.'
+  const bots = resolve(channelId, now)
+  if (bots.length === 0) return ':satellite_antenna: No peer agents active in this channel recently.'
+  const lines = bots.map((b) => `• <@${b}>`)
+  return `:satellite_antenna: *Peer agents active recently:*\n${lines.join('\n')}`
+}
+
+/** Build the `!rate-limit` message — the channel's effective per-bot limit and
+ *  channel-wide circuit breaker. Read-only; tuning stays terminal-only. */
+function formatRateLimit(
+  resolve: DispatchDeps['getChannelRateLimits'],
+  channelId: string,
+): string {
+  if (resolve === undefined) return ':bar_chart: Rate-limit view is unavailable.'
+  const limits = resolve(channelId)
+  if (limits === undefined || limits === null) {
+    return ':bar_chart: Rate-limit view is unavailable.'
+  }
+  const { peerBot, channel } = limits
+  return [
+    ':bar_chart: *Effective peer-bot limits for this channel:*',
+    `• Per-bot: ${describeLimit(peerBot)}`,
+    `• Channel breaker: ${describeLimit(channel)}`,
+    '_Tuning is terminal-only — edit the channel policy via `/slack-channel:access`._',
+  ].join('\n')
+}
+
 /** Common journal-write path for admin events. Records verb +
  *  outcome + requester + channel. Defensive on throw — admin
- *  decision is authoritative even on a broken journal. */
+ *  decision is authoritative even on a broken journal. Status verbs
+ *  (mute-status / rate-limit) are read-only and never reach here. */
 async function journalAttempt(
   deps: DispatchDeps,
-  cmd: AdminCommand,
+  cmd: Exclude<AdminCommand, AdminMuteStatusCommand | AdminRateLimitCommand | AdminAgentsCommand>,
   outcome: 'allow' | 'denied',
   reason?: string,
 ): Promise<void> {

--- a/plugins/mcp/slack-channel/journal.ts
+++ b/plugins/mcp/slack-channel/journal.ts
@@ -13,7 +13,7 @@
  *     v:        1,                          // schema version; chain refuses mixed versions
  *     ts:       '2026-04-19T12:34:56.789Z', // ISO-8601 UTC with ms precision
  *     seq:      42,                         // monotonic per chain
- *     kind:     'gate.inbound.drop',        // discriminated union of 36 event kinds
+ *     kind:     'gate.inbound.drop',        // discriminated union of 37 event kinds
  *     toolName?: 'reply',
  *     input?:   { chat_id: 'C01', text: '...' },     // post-redaction
  *     outcome?: 'allow' | 'deny' | 'require' | 'drop' | 'n/a',
@@ -81,6 +81,9 @@ export const EventKind = z.enum([
   'session.quiesce',
   'session.deactivate',
   'session.quarantine',
+  // Global backpressure: a NEW activation refused because the supervisor is at
+  // its maxConcurrentSessions cap (ccsc-4e9bf). Records the load-shed decision.
+  'session.activate_rejected',
   // Boot-time crash recovery (ccsc-o7x.1.2). `recoverOnStartup()` emits one
   // event per session with a persisted in-flight-turn marker: `.requeued` when
   // the marker's heartbeat has lapsed (owner provably dead → the marker is
@@ -143,7 +146,7 @@ export const EventKind = z.enum([
   'manifest.publish',
 ])
 
-/** TypeScript string union of the 36 event kinds. */
+/** TypeScript string union of the 37 event kinds. */
 export type EventKind = z.infer<typeof EventKind>
 
 // ---------------------------------------------------------------------------

--- a/plugins/mcp/slack-channel/lib.ts
+++ b/plugins/mcp/slack-channel/lib.ts
@@ -13,7 +13,10 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSyn
 import { chmod, readFile, rename, unlink, writeFile } from 'node:fs/promises'
 import { basename, join, resolve, sep } from 'node:path'
 import { z } from 'zod'
-import { DEFAULT_PEER_BOT_RATE_LIMIT } from './peer-bot-rate-limit.ts'
+import {
+  DEFAULT_CHANNEL_CIRCUIT_BREAKER,
+  DEFAULT_PEER_BOT_RATE_LIMIT,
+} from './peer-bot-rate-limit.ts'
 
 // ---------------------------------------------------------------------------
 // Constants (re-exported so server.ts and tests share the same values)
@@ -77,6 +80,20 @@ export interface ChannelPolicy {
    *  applies (10 msgs in 60s). Set `{ count: 0, windowMs: 0 }` only
    *  to explicitly DISABLE the limit; default-on is intentional. */
   peerBotRateLimit?: { count: number; windowMs: number }
+  /** Channel-wide circuit breaker for N-cycle (A→B→C→A) peer-bot loops
+   *  (ccsc-0k7x2). The per-(channel, bot) `peerBotRateLimit` only breaks
+   *  PAIRWISE loops; a 3+-bot ring keeps each sender under its own cap, so
+   *  this aggregate counter trips the whole channel's bot traffic when total
+   *  peer-bot velocity is runaway-high. Absent →
+   *  DEFAULT_CHANNEL_CIRCUIT_BREAKER (40 msgs in 60s). Set
+   *  `{ count: 0, windowMs: 0 }` to DISABLE; default-on is intentional. */
+  channelCircuitBreaker?: { count: number; windowMs: number }
+  /** Per-user session isolation (ccsc-kl410). When true, each distinct sender
+   *  in this channel gets their own session within a shared thread — separate
+   *  state file + supervisor handle + ownerId — so two humans in one thread do
+   *  not share context/ownership. Absent or false → one shared session per
+   *  (channel, thread) (the default; behavior unchanged). */
+  perUserSessions?: boolean
 }
 
 export interface PendingEntry {
@@ -109,14 +126,29 @@ export interface Access {
 
 export type GateAction = 'deliver' | 'drop' | 'pair'
 
-/** Structured reason for a drop. Optional — only set by drop paths
- *  that benefit from operator-visible distinguishing. Self-echo and
- *  generic policy-miss drops omit it; rate-limit drops (ccsc-gyt)
- *  surface as `'rate.cross_bot_loop'` so an operator can grep the
- *  journal for runaway-loop incidents. */
+/** Structured reason for a drop. As of ccsc-apj.2 EVERY inbound gate
+ *  drop carries one, so an operator reading the journal can always tell
+ *  *why* Claude stayed silent (gate.inbound.drop records it — server.ts).
+ *  Grouped by the stage that produced the drop. */
 export type GateDropReason =
-  | 'rate.cross_bot_loop' // ccsc-gyt — peer-bot exceeded per-(channel, bot_id) sliding window
-  | 'admin.muted' // ccsc-gjm (future) — operator muted this peer bot in this channel
+  // -- bot-event stage (handleBotEvent) --
+  | 'self.echo' // dropped our own message (bot_id / app_id / botUserId match)
+  | 'bot.not_allowlisted' // peer bot not in the channel's allowBotIds
+  | 'admin.muted' // ccsc-gjm — operator muted this peer bot in this channel
+  | 'rate.cross_bot_loop' // ccsc-gyt — peer bot exceeded per-(channel, bot_id) sliding window
+  | 'rate.channel_cycle' // ccsc-0k7x2 — channel-wide peer-bot velocity tripped the circuit breaker (N-cycle ring)
+  | 'bot.permission_relay' // peer-bot message looked like a permission-approval relay
+  // -- top-level stage (gate) --
+  | 'subtype.filtered' // non-message subtype (message_changed, message_deleted, …) — see ccsc-apj.3
+  | 'event.no_user' // event carried no user id
+  // -- DM stage (handleDmEvent) --
+  | 'dm.policy_closed' // dmPolicy is 'allowlist'/'disabled' and sender not allowlisted
+  | 'dm.pairing_cap' // sender hit MAX_PAIRING_REPLIES for their pending code
+  | 'dm.pending_full' // MAX_PENDING pairing codes outstanding
+  // -- channel stage (handleChannelEvent) --
+  | 'channel.not_opted' // channel not opted in (no ChannelPolicy)
+  | 'channel.allowfrom_miss' // sender not in the channel's allowFrom
+  | 'channel.require_mention' // requireMention channel, no mention, thread not engaged (ccsc-apj.1)
 
 export interface GateResult {
   action: GateAction
@@ -145,6 +177,13 @@ export interface SessionKey {
   /** Slack thread_ts, e.g. `1711000000.000100`. For top-level messages the
    *  supervisor uses the message `ts` as the thread value. */
   thread: string
+  /** Optional Slack user_id for per-user session isolation (ccsc-kl410). When a
+   *  channel sets `perUserSessions`, each distinct sender gets their own
+   *  session WITHIN a shared thread — a distinct supervisor `keyId` and a
+   *  distinct on-disk file (`sessions/<channel>/<userId>/<thread>.json`) — so
+   *  two humans talking in one thread don't share session state / ownerId.
+   *  Absent → the legacy shared per-(channel, thread) session. */
+  userId?: string
 }
 
 /** Schema version for a persisted Session file. Bumped on incompatible
@@ -518,30 +557,39 @@ export function sessionPath(root: string, key: SessionKey): string {
   if (!isValidSessionComponent(key.thread)) {
     throw new Error(`sessionPath: invalid thread component: ${JSON.stringify(key.thread)}`)
   }
+  // ccsc-kl410 — per-user isolation adds a `userId` directory level. Validate
+  // it with the SAME component rule (no `.`/`..`, restricted charset) so it
+  // can never inject path traversal — the on-disk leaf becomes
+  // `sessions/<channel>/<userId>/<thread>.json`.
+  if (key.userId !== undefined && (key.userId === '' || !isValidSessionComponent(key.userId))) {
+    throw new Error(`sessionPath: invalid userId component: ${JSON.stringify(key.userId)}`)
+  }
 
   // Canonicalize the state root. Throws ENOENT if the caller did not
   // pre-create it — matches server.ts bootstrap which mkdirs STATE_DIR
   // before any session activity.
   const resolvedRoot = realpathSync.native(resolve(root))
 
-  // Rule 3: create sessions/<channel>/ at 0o700. mkdirSync(recursive)
-  // is idempotent; the mode applies only to newly created dirs, which
-  // is the doc's "on first use" semantic.
+  // Rule 3: create the session leaf dir at 0o700 — `sessions/<channel>/`
+  // (shared) or `sessions/<channel>/<userId>/` (per-user). mkdirSync(recursive)
+  // is idempotent; the mode applies only to newly created dirs, which is the
+  // doc's "on first use" semantic.
   const channelDir = join(resolvedRoot, 'sessions', key.channel)
-  mkdirSync(channelDir, { recursive: true, mode: 0o700 })
+  const leafDir = key.userId !== undefined ? join(channelDir, key.userId) : channelDir
+  mkdirSync(leafDir, { recursive: true, mode: 0o700 })
 
-  // Rule 2: realpath the (now-extant) per-channel dir and assert the
-  // state root is still a prefix. Catches symlink-based escape.
-  const resolvedChannelDir = realpathSync.native(channelDir)
-  if (!isUnderRoot(resolvedChannelDir, resolvedRoot)) {
+  // Rule 2: realpath the (now-extant) leaf dir and assert the state root is
+  // still a prefix. Catches symlink-based escape via channel OR userId.
+  const resolvedLeafDir = realpathSync.native(leafDir)
+  if (!isUnderRoot(resolvedLeafDir, resolvedRoot)) {
     throw new Error(
-      `sessionPath: resolved channel dir escapes state root (channel=${JSON.stringify(
+      `sessionPath: resolved session dir escapes state root (channel=${JSON.stringify(
         key.channel,
-      )})`,
+      )}, userId=${JSON.stringify(key.userId)})`,
     )
   }
 
-  return join(resolvedChannelDir, `${key.thread}.json`)
+  return join(resolvedLeafDir, `${key.thread}.json`)
 }
 
 /** Atomic writer for session files.
@@ -1635,6 +1683,21 @@ export interface GateOptions {
    *  tests can use a deterministic Date.now(). Defaults to wall
    *  clock. */
   now?: () => number
+  /** Session-thread keys — `deliveredThreadKey(channel, thread_ts ?? ts)` —
+   *  for threads that have already delivered an inbound message this
+   *  process, i.e. threads a HUMAN has "engaged" by mentioning the bot at
+   *  least once (ccsc-apj.1). On a `requireMention` channel, a human
+   *  message in an already-engaged thread is delivered WITHOUT a fresh
+   *  mention ("mention once, then converse"). Keyed by the SESSION thread
+   *  (`thread_ts ?? ts`), NOT the raw `thread_ts`, so a top-level mention
+   *  and its in-thread follow-ups resolve to the same slot — this is why it
+   *  is a distinct set from the outbound `deliveredThreads` (which is keyed
+   *  by raw `thread_ts` for the cross-thread leak guard). Peer bots
+   *  (`ev.bot_id`) are NEVER sticky — they must mention every message,
+   *  which keeps the loop/noise risk bounded (the peer-bot rate limiter is
+   *  the backstop). Absent (tests / no wiring) → no thread is engaged, so
+   *  `requireMention` behaves exactly as before. */
+  engagedThreads?: ReadonlySet<string>
 }
 
 /**
@@ -1654,7 +1717,7 @@ function handleBotEvent(ev: Record<string, unknown>, opts: GateOptions): GateRes
     (opts.selfBotId && ev.bot_id === opts.selfBotId) ||
     (opts.selfAppId && botProfile.app_id === opts.selfAppId) ||
     (ev.user && ev.user === opts.botUserId)
-  if (isSelfEcho) return { action: 'drop' }
+  if (isSelfEcho) return { action: 'drop', dropReason: 'self.echo' }
 
   // Per-channel opt-in: only deliver if the channel explicitly lists this
   // bot's user ID in allowBotIds. No allowBotIds = all bots dropped.
@@ -1662,7 +1725,7 @@ function handleBotEvent(ev: Record<string, unknown>, opts: GateOptions): GateRes
   const policy = opts.access.channels[channel]
   const botUser = ev.user as string | undefined
   if (!policy?.allowBotIds?.length || !botUser || !policy.allowBotIds.includes(botUser)) {
-    return { action: 'drop' }
+    return { action: 'drop', dropReason: 'bot.not_allowlisted' }
   }
 
   // ccsc-gjm — operator-initiated mute. Check the mute store BEFORE
@@ -1700,12 +1763,28 @@ function handleBotEvent(ev: Record<string, unknown>, opts: GateOptions): GateRes
     }
   }
 
+  // ccsc-0k7x2 — channel-wide circuit breaker for N-cycle (A→B→C→A) rings.
+  // The per-(channel, bot) check above only breaks PAIRWISE loops; a 3+-bot
+  // ring keeps each sender under its own cap, so it slips through. This
+  // aggregate counter trips the whole channel's peer-bot traffic when total
+  // velocity is runaway-high. Default-on at DEFAULT_CHANNEL_CIRCUIT_BREAKER
+  // (40 msgs in 60s); { count: 0, windowMs: 0 } disables.
+  if (opts.peerBotRateLimitStore !== undefined) {
+    const breaker = policy.channelCircuitBreaker ?? DEFAULT_CHANNEL_CIRCUIT_BREAKER
+    if (breaker.count > 0 && breaker.windowMs > 0) {
+      const now = opts.now !== undefined ? opts.now() : Date.now()
+      if (!opts.peerBotRateLimitStore.checkChannel(channel, now, breaker)) {
+        return { action: 'drop', dropReason: 'rate.channel_cycle' }
+      }
+    }
+  }
+
   // Belt-and-suspenders: drop peer-bot messages that look like permission
   // relay replies. The global allowFrom check at server.ts already blocks
   // peer bots from approving tool calls, but this gate-level check prevents
   // regression if that guard is ever loosened.
   const text = ((ev.text as string) || '').trim()
-  if (PERMISSION_REPLY_RE.test(text)) return { action: 'drop' }
+  if (PERMISSION_REPLY_RE.test(text)) return { action: 'drop', dropReason: 'bot.permission_relay' }
 
   // Fall through to normal access-control checks (subtype, allowFrom,
   // requireMention). The channel policy's allowFrom and requireMention
@@ -1725,7 +1804,7 @@ async function handleDmEvent(ev: Record<string, unknown>, opts: GateOptions): Pr
     return { action: 'deliver', access }
   }
   if (access.dmPolicy === 'allowlist' || access.dmPolicy === 'disabled') {
-    return { action: 'drop' }
+    return { action: 'drop', dropReason: 'dm.policy_closed' }
   }
 
   // Pairing mode — check if there's already a pending code for this user
@@ -1736,13 +1815,13 @@ async function handleDmEvent(ev: Record<string, unknown>, opts: GateOptions): Pr
         if (!staticMode) saveAccess(access)
         return { action: 'pair', code, isResend: true }
       }
-      return { action: 'drop' } // Hit reply cap
+      return { action: 'drop', dropReason: 'dm.pairing_cap' } // Hit reply cap
     }
   }
 
   // Cap total pending
   if (Object.keys(access.pending).length >= MAX_PENDING) {
-    return { action: 'drop' }
+    return { action: 'drop', dropReason: 'dm.pending_full' }
   }
 
   // Generate new pairing code
@@ -1766,14 +1845,29 @@ function handleChannelEvent(ev: Record<string, unknown>, opts: GateOptions): Gat
   const { access, botUserId } = opts
   const channel = ev.channel as string
   const policy = access.channels[channel]
-  if (!policy) return { action: 'drop' }
+  if (!policy) return { action: 'drop', dropReason: 'channel.not_opted' }
 
   if (policy.allowFrom.length > 0 && !policy.allowFrom.includes(ev.user as string)) {
-    return { action: 'drop' }
+    return { action: 'drop', dropReason: 'channel.allowfrom_miss' }
   }
 
   if (policy.requireMention && !isMentioned(ev, botUserId)) {
-    return { action: 'drop' }
+    // ccsc-apj.1 — thread-sticky engagement. Once a HUMAN has engaged a
+    // thread by mentioning the bot, subsequent human messages in that same
+    // thread are delivered without a fresh mention ("mention once, then
+    // converse"). The engaged set is keyed by the SESSION thread
+    // (thread_ts ?? ts) so a top-level mention (ts=T1) and its in-thread
+    // follow-ups (thread_ts=T1) resolve to the same slot. Peer bots
+    // (ev.bot_id) are NEVER sticky — they must mention every message, so
+    // the loop/noise risk stays bounded (the peer-bot rate limiter is the
+    // backstop). A mention is still required to OPEN a thread.
+    if (!ev.bot_id && opts.engagedThreads !== undefined) {
+      const threadTs = (ev.thread_ts as string | undefined) ?? (ev.ts as string | undefined)
+      if (opts.engagedThreads.has(deliveredThreadKey(channel, threadTs))) {
+        return { action: 'deliver', access }
+      }
+    }
+    return { action: 'drop', dropReason: 'channel.require_mention' }
   }
 
   return { action: 'deliver', access }
@@ -1789,10 +1883,12 @@ export async function gate(event: unknown, opts: GateOptions): Promise<GateResul
   }
 
   // 2. Drop non-message subtypes (message_changed, message_deleted, etc.)
-  if (ev.subtype && ev.subtype !== 'file_share') return { action: 'drop' }
+  if (ev.subtype && ev.subtype !== 'file_share') {
+    return { action: 'drop', dropReason: 'subtype.filtered' }
+  }
 
   // 3. No user ID = drop
-  if (!ev.user) return { action: 'drop' }
+  if (!ev.user) return { action: 'drop', dropReason: 'event.no_user' }
 
   // 4. DM handling
   if (ev.channel_type === 'im') return handleDmEvent(ev, opts)
@@ -1801,8 +1897,53 @@ export async function gate(event: unknown, opts: GateOptions): Promise<GateResul
   return handleChannelEvent(ev, opts)
 }
 
+/** True when `botUserId` is mentioned in a way that should ENGAGE the bot
+ *  (ccsc-apj.4). Prefers Slack's structured `blocks`: a real mention is a
+ *  `user` element whose `user_id` is the bot, sitting in a normal
+ *  rich-text section/list — NOT inside a code block
+ *  (`rich_text_preformatted`) or a blockquote (`rich_text_quote`), where a
+ *  `<@bot>` is being quoted/displayed, not addressed. When `blocks` are
+ *  present they are authoritative (no substring fallback) so a mention
+ *  buried in a code block cannot falsely engage on a requireMention
+ *  channel. When `blocks` are absent (minimal events), fall back to the
+ *  legacy raw-text substring check. */
+function richTextMentionsBot(blocks: unknown, botUserId: string): boolean {
+  // Recursive walk over the rich-text tree. A `user` node addressing the bot
+  // counts UNLESS it sits inside a code block (`rich_text_preformatted`) or a
+  // blockquote (`rich_text_quote`) — those subtrees are pruned so a quoted
+  // `<@bot>` cannot engage. Handles arbitrary nesting (sections, lists).
+  const walk = (node: unknown): boolean => {
+    if (Array.isArray(node)) {
+      for (const n of node) if (walk(n)) return true
+      return false
+    }
+    if (!node || typeof node !== 'object') return false
+    const o = node as Record<string, unknown>
+    if (o.type === 'user' && o.user_id === botUserId) return true
+    if (o.type === 'rich_text_preformatted' || o.type === 'rich_text_quote') return false
+    return walk(o.elements)
+  }
+  return walk(blocks)
+}
+
 function isMentioned(event: Record<string, unknown>, botUserId: string): boolean {
   if (!botUserId) return false
+  // The structured path is authoritative ONLY when the message actually carries
+  // a `rich_text` block — that is where Slack encodes code/quote containers, so
+  // we can distinguish an addressed mention from a quoted one and must NOT fall
+  // back to substring (which would re-match a `<@bot>` inside a code block).
+  // Messages with only LAYOUT blocks (Block Kit `section`/`context`, common for
+  // bots/integrations posting via the API) carry no rich_text, so they fall
+  // through to the substring check — otherwise a real peer-bot mention would be
+  // missed and multi-agent coordination (`allowBotIds`) would break.
+  const blocks = event.blocks
+  if (
+    Array.isArray(blocks) &&
+    blocks.some((b) => (b as Record<string, unknown> | null)?.type === 'rich_text')
+  ) {
+    return richTextMentionsBot(blocks, botUserId)
+  }
+  // Fallback: no blocks, or layout-only blocks → legacy raw-text substring check.
   const text = (event.text as string | undefined) || ''
   return text.includes(`<@${botUserId}>`)
 }

--- a/plugins/mcp/slack-channel/mute-store.ts
+++ b/plugins/mcp/slack-channel/mute-store.ts
@@ -61,9 +61,11 @@ export interface MuteStore {
   /** Diagnostic — list live mutes for a channel. Used by audit
    *  projection and operator-facing status commands. */
   list(channelId: string, now: number): readonly MuteEntry[]
-  /** Sweep all expired entries across all channels. Returns the
-   *  count removed. Called periodically by the reaper. */
-  prune(now: number): number
+  /** Sweep all expired entries across all channels. Returns the removed
+   *  entries (ccsc-yl6k9) so the reaper can post a "mute expired" notice for
+   *  each — operators aren't surprised when a bot silently un-mutes. Called
+   *  periodically by the reaper. */
+  prune(now: number): readonly MuteEntry[]
   /** Diagnostic — total live entries across all channels. */
   size(): number
 }
@@ -117,14 +119,14 @@ export function createMuteStore(): MuteStore {
       return result
     },
     prune(now) {
-      let removed = 0
+      const expired: MuteEntry[] = []
       for (const [key, entry] of entries) {
         if (entry.expiresAt <= now) {
           entries.delete(key)
-          removed += 1
+          expired.push(entry)
         }
       }
-      return removed
+      return expired
     },
     size() {
       return entries.size

--- a/plugins/mcp/slack-channel/package.json
+++ b/plugins/mcp/slack-channel/package.json
@@ -20,7 +20,10 @@
   },
   "overrides": {
     "axios": "^1.16.1",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "form-data": "^4.0.6",
+    "ws": "^8.21.0",
+    "hono": "^4.12.25"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/plugins/mcp/slack-channel/peer-bot-rate-limit.ts
+++ b/plugins/mcp/slack-channel/peer-bot-rate-limit.ts
@@ -57,6 +57,21 @@ export const DEFAULT_PEER_BOT_RATE_LIMIT: RateLimitConfig = {
   windowMs: 60_000,
 }
 
+/** Channel-wide circuit-breaker default: 40 peer-bot messages in 60s summed
+ *  across ALL bots in a channel (ccsc-0k7x2). The per-(channel, bot) limit
+ *  above only breaks PAIRWISE loops — an A→B→C→A ring keeps every sender under
+ *  its own cap, so the ring never trips it. This aggregate counter sits on top
+ *  and trips the whole channel's bot traffic when total peer-bot velocity is
+ *  runaway-high. Set to ~4× the per-bot default so a legitimate 2–3 bot
+ *  exchange interleaved with human work never trips it, but a runaway ring
+ *  (which fires as fast as the pipeline allows) does within seconds. Operators
+ *  tune via `ChannelPolicy.channelCircuitBreaker`; `{ count: 0, windowMs: 0 }`
+ *  disables it. */
+export const DEFAULT_CHANNEL_CIRCUIT_BREAKER: RateLimitConfig = {
+  count: 40,
+  windowMs: 60_000,
+}
+
 /** Persistent state for the rate limiter. Carries per-(channel, botId)
  *  timestamp arrays under the longest configured window. Tests can
  *  inject this directly; production wires a single module-level store
@@ -80,6 +95,16 @@ export interface PeerBotRateLimitStore {
    *  Old timestamps (outside the window) are pruned on every call.
    *  This keeps memory bounded without a separate sweep task. */
   check(channelId: string, botId: string, now: number, config: RateLimitConfig): boolean
+  /** Record a peer-bot message toward the CHANNEL-WIDE aggregate and return
+   *  whether the channel is still under its circuit-breaker threshold
+   *  (ccsc-0k7x2). Same sliding-window semantics as `check()` but keyed by
+   *  channel alone, so it counts every allowlisted bot's traffic together —
+   *  catching N-cycle (A→B→C→A) rings that stay under the per-bot cap. */
+  checkChannel(channelId: string, now: number, config: RateLimitConfig): boolean
+  /** List the bot IDs that posted in `channelId` within `windowMs` of `now`
+   *  (ccsc-4e9bf) — a lightweight "agents online" view derived from the
+   *  per-(channel, bot) activity already tracked. Read-only, no mutation. */
+  activeBots(channelId: string, now: number, windowMs: number): string[]
   /** Sweep entries with all-expired timestamps. Called periodically
    *  by the reaper (similar to nonce-store pruneExpired). */
   prune(now: number, maxWindowMs: number): number
@@ -91,70 +116,99 @@ export interface PeerBotRateLimitStore {
 // In-memory store
 // ---------------------------------------------------------------------------
 
+/** Shared sliding-window decision used by both the per-(channel, bot) limit and
+ *  the per-channel aggregate breaker. Prunes stale timestamps for `key`, then
+ *  ALLOWS (append + true) when under `config.count`, or DROPS (no append +
+ *  false) at/over it. `{ count: 0 }` / `{ windowMs: 0 }` disables → always
+ *  allow (and never records). Not appending on a drop keeps the array from
+ *  growing during the drop window. */
+function slidingWindowAllow(
+  buckets: Map<string, number[]>,
+  key: string,
+  now: number,
+  config: RateLimitConfig,
+): boolean {
+  // Operator opt-out: { count: 0, windowMs: 0 } disables the limit for this
+  // call — always allow, record nothing. `<= 0` (not `=== 0`) so a negative
+  // misconfiguration also disables rather than producing surprising behavior.
+  // Single coherent semantic across the store + gate (per Gemini reviews on
+  // PRs #182 and #246).
+  if (config.count <= 0 || config.windowMs <= 0) return true
+
+  const arr = buckets.get(key) ?? []
+  // Drop stale timestamps before evaluating. In-place filter, memory bounded.
+  const cutoff = now - config.windowMs
+  let writeIdx = 0
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i]! > cutoff) {
+      arr[writeIdx++] = arr[i]!
+    }
+  }
+  arr.length = writeIdx
+
+  if (arr.length >= config.count) {
+    // Over threshold — DO NOT append. The next call after enough old entries
+    // age out will succeed naturally. `arr` is necessarily non-empty here
+    // (config.count >= 1 after the guard above, and arr.length >= config.count).
+    buckets.set(key, arr)
+    return false
+  }
+
+  arr.push(now)
+  buckets.set(key, arr)
+  return true
+}
+
+/** Sweep a bucket map of entries whose timestamps are all older than the
+ *  window; returns the number of (key) entries removed. */
+function pruneBuckets(buckets: Map<string, number[]>, now: number, maxWindowMs: number): number {
+  let removed = 0
+  const cutoff = now - maxWindowMs
+  for (const [key, arr] of buckets) {
+    let writeIdx = 0
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i]! > cutoff) {
+        arr[writeIdx++] = arr[i]!
+      }
+    }
+    if (writeIdx === 0) {
+      buckets.delete(key)
+      removed += 1
+    } else {
+      arr.length = writeIdx
+    }
+  }
+  return removed
+}
+
 /** Build a fresh in-memory rate-limit store. */
 export function createPeerBotRateLimitStore(): PeerBotRateLimitStore {
-  // Map<`${channelId}\0${botId}`, number[]>. NUL separator is safe
-  // because Slack IDs are alphanumeric (no embedded NULs).
+  // Per-(channel, bot) buckets, keyed `${channelId}\0${botId}`. NUL separator
+  // is safe because Slack IDs are alphanumeric (no embedded NULs).
   const buckets = new Map<string, number[]>()
-
-  function keyOf(channelId: string, botId: string): string {
-    return `${channelId}\0${botId}`
-  }
+  // Per-channel aggregate buckets for the circuit breaker (ccsc-0k7x2), keyed
+  // by channelId alone — a separate map so the two windows never collide.
+  const channelBuckets = new Map<string, number[]>()
 
   return {
     check(channelId, botId, now, config) {
-      // Operator opt-out: { count: 0, windowMs: 0 } (or either zero)
-      // means "disable the rate limit for this call". Always allow,
-      // do NOT record a timestamp. This matches the ChannelPolicy
-      // contract documented in lib.ts and the gate-integration
-      // short-circuit. Per Gemini review on PR #182 — single
-      // coherent semantic across the store + gate.
-      if (config.count === 0 || config.windowMs === 0) return true
-
-      const key = keyOf(channelId, botId)
-      const arr = buckets.get(key) ?? []
-      // Drop stale timestamps before evaluating. In-place filter to
-      // keep memory bounded.
-      const cutoff = now - config.windowMs
-      let writeIdx = 0
-      for (let i = 0; i < arr.length; i++) {
-        if (arr[i]! > cutoff) {
-          arr[writeIdx++] = arr[i]!
-        }
+      return slidingWindowAllow(buckets, `${channelId}\0${botId}`, now, config)
+    },
+    checkChannel(channelId, now, config) {
+      return slidingWindowAllow(channelBuckets, channelId, now, config)
+    },
+    activeBots(channelId, now, windowMs) {
+      const prefix = `${channelId}\0`
+      const cutoff = now - windowMs
+      const result: string[] = []
+      for (const [key, arr] of buckets) {
+        if (!key.startsWith(prefix)) continue
+        if (arr.some((ts) => ts > cutoff)) result.push(key.slice(prefix.length))
       }
-      arr.length = writeIdx
-
-      if (arr.length >= config.count) {
-        // Over threshold — DO NOT append. The next call after enough
-        // old entries age out will succeed naturally.
-        if (arr.length === 0) buckets.delete(key)
-        else buckets.set(key, arr)
-        return false
-      }
-
-      arr.push(now)
-      buckets.set(key, arr)
-      return true
+      return result
     },
     prune(now, maxWindowMs) {
-      let removed = 0
-      const cutoff = now - maxWindowMs
-      for (const [key, arr] of buckets) {
-        // Filter in-place; drop the whole entry if no live timestamps.
-        let writeIdx = 0
-        for (let i = 0; i < arr.length; i++) {
-          if (arr[i]! > cutoff) {
-            arr[writeIdx++] = arr[i]!
-          }
-        }
-        if (writeIdx === 0) {
-          buckets.delete(key)
-          removed += 1
-        } else {
-          arr.length = writeIdx
-        }
-      }
-      return removed
+      return pruneBuckets(buckets, now, maxWindowMs) + pruneBuckets(channelBuckets, now, maxWindowMs)
     },
     size() {
       return buckets.size

--- a/plugins/mcp/slack-channel/server.test.ts
+++ b/plugins/mcp/slack-channel/server.test.ts
@@ -80,6 +80,7 @@ import {
   validateSendableRoots,
 } from './lib.ts'
 import {
+  beginDurableStream,
   createDeliverySendDeps,
   createReplyPoster,
   DurableUnavailableError,
@@ -363,6 +364,92 @@ describe('gate', () => {
     expect(result.action).toBe('deliver')
   })
 
+  // -- requireMention thread-stickiness (ccsc-apj.1) --
+  // "Mention once, then converse": a human who has engaged a thread by
+  // mentioning the bot can keep talking in that thread without re-mentioning.
+  // The engaged set is keyed by the SESSION thread (thread_ts ?? ts).
+
+  test('delivers un-mentioned human reply when the thread is already engaged (ccsc-apj.1)', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess({
+      channels: { C_MENTION: { requireMention: true, allowFrom: [] } },
+    })
+    const engagedThreads = new Set([deliveredThreadKey('C_MENTION', '1711.0001')])
+    const result = await gate(
+      {
+        user: 'U123',
+        channel: 'C_MENTION',
+        channel_type: 'channel',
+        text: 'and also do Y',
+        thread_ts: '1711.0001',
+        ts: '1711.0002',
+      },
+      makeOpts({ access, botUserId: 'U_BOT', engagedThreads }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  test('delivers un-mentioned human top-level follow-up keyed by session thread (ccsc-apj.1)', async () => {
+    // Opener was a top-level mention ts=T1 → engaged key uses thread_ts ?? ts = T1.
+    // The bot replied in thread T1; the human's follow-up arrives with thread_ts=T1.
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess({
+      channels: { C_MENTION: { requireMention: true, allowFrom: [] } },
+    })
+    const engagedThreads = new Set([deliveredThreadKey('C_MENTION', 'T1')])
+    const result = await gate(
+      {
+        user: 'U123',
+        channel: 'C_MENTION',
+        channel_type: 'channel',
+        text: 'thanks',
+        thread_ts: 'T1',
+        ts: 'T2',
+      },
+      makeOpts({ access, botUserId: 'U_BOT', engagedThreads }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  test('still drops un-mentioned human message when the thread is NOT yet engaged (ccsc-apj.1)', async () => {
+    const access = makeAccess({
+      channels: { C_MENTION: { requireMention: true, allowFrom: [] } },
+    })
+    const result = await gate(
+      {
+        user: 'U123',
+        channel: 'C_MENTION',
+        channel_type: 'channel',
+        text: 'hi',
+        thread_ts: 'T9',
+        ts: 'T9',
+      },
+      makeOpts({ access, botUserId: 'U_BOT', engagedThreads: new Set() }),
+    )
+    expect(result.action).toBe('drop')
+  })
+
+  test('does NOT make peer bots sticky — un-mentioned peer bot in an engaged thread is dropped (ccsc-apj.1)', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess({
+      channels: { C_MENTION: { requireMention: true, allowFrom: [], allowBotIds: ['U_PEER'] } },
+    })
+    const engagedThreads = new Set([deliveredThreadKey('C_MENTION', 'T1')])
+    const result = await gate(
+      {
+        bot_id: 'B_PEER',
+        user: 'U_PEER',
+        channel: 'C_MENTION',
+        channel_type: 'channel',
+        text: 'still looping',
+        thread_ts: 'T1',
+        ts: 'T2',
+      },
+      makeOpts({ access, botUserId: 'U_BOT', engagedThreads }),
+    )
+    expect(result.action).toBe('drop')
+  })
+
   test('drops channel messages when user not in channel allowFrom', async () => {
     const access = makeAccess({
       channels: { C_RESTRICTED: { requireMention: false, allowFrom: ['U_VIP'] } },
@@ -383,6 +470,265 @@ describe('gate', () => {
       makeOpts({ access }),
     )
     expect(result.action).toBe('deliver')
+  })
+
+  // -- isMentioned via Slack blocks (ccsc-apj.4) --
+  // A <@bot> quoted inside a code block or blockquote must NOT engage a
+  // requireMention channel; a real mention in a normal section/list must.
+
+  test('engages on a real mention in a rich_text section via blocks (ccsc-apj.4)', async () => {
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      {
+        user: 'U1',
+        channel: 'C_M',
+        channel_type: 'channel',
+        text: 'hey <@U_BOT> help',
+        blocks: [
+          {
+            type: 'rich_text',
+            elements: [
+              {
+                type: 'rich_text_section',
+                elements: [
+                  { type: 'text', text: 'hey ' },
+                  { type: 'user', user_id: 'U_BOT' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  test('does NOT engage on a <@bot> inside a code block (ccsc-apj.4)', async () => {
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      {
+        user: 'U1',
+        channel: 'C_M',
+        channel_type: 'channel',
+        // raw text still contains <@U_BOT> — proving the substring check would have falsely matched
+        text: 'see `<@U_BOT>`',
+        blocks: [
+          {
+            type: 'rich_text',
+            elements: [
+              { type: 'rich_text_preformatted', elements: [{ type: 'user', user_id: 'U_BOT' }] },
+            ],
+          },
+        ],
+      },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('drop')
+    expect(result.dropReason).toBe('channel.require_mention')
+  })
+
+  test('does NOT engage on a <@bot> inside a blockquote (ccsc-apj.4)', async () => {
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      {
+        user: 'U1',
+        channel: 'C_M',
+        channel_type: 'channel',
+        text: '> <@U_BOT> said hi',
+        blocks: [
+          {
+            type: 'rich_text',
+            elements: [{ type: 'rich_text_quote', elements: [{ type: 'user', user_id: 'U_BOT' }] }],
+          },
+        ],
+      },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('drop')
+  })
+
+  test('engages on a mention nested inside a rich_text_list (ccsc-apj.4)', async () => {
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      {
+        user: 'U1',
+        channel: 'C_M',
+        channel_type: 'channel',
+        text: '- <@U_BOT>',
+        blocks: [
+          {
+            type: 'rich_text',
+            elements: [
+              {
+                type: 'rich_text_list',
+                elements: [
+                  { type: 'rich_text_section', elements: [{ type: 'user', user_id: 'U_BOT' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  test('falls back to substring mention when no blocks are present (ccsc-apj.4)', async () => {
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      { user: 'U1', channel: 'C_M', channel_type: 'channel', text: 'hey <@U_BOT>' },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  test('falls back to substring when blocks are layout-only with no rich_text (ccsc-apj.4)', async () => {
+    // Block Kit section/context blocks (typical of bots/integrations) carry no
+    // rich_text, so the structured path must not swallow a real mention.
+    const access = makeAccess({ channels: { C_M: { requireMention: true, allowFrom: [] } } })
+    const result = await gate(
+      {
+        user: 'U1',
+        channel: 'C_M',
+        channel_type: 'channel',
+        text: 'hey <@U_BOT>',
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'hey <@U_BOT>' } }],
+      },
+      makeOpts({ access, botUserId: 'U_BOT' }),
+    )
+    expect(result.action).toBe('deliver')
+  })
+
+  // -- dropReason on every drop branch (ccsc-apj.2) --
+  // Each inbound drop now carries a structured reason so the journal
+  // (gate.inbound.drop, server.ts) explains why Claude stayed silent.
+
+  test('self-echo drop carries dropReason self.echo (ccsc-apj.2)', async () => {
+    const result = await gate(
+      { bot_id: 'B_BOT', user: 'U_BOT', channel: 'C1', channel_type: 'channel' },
+      makeOpts(),
+    )
+    expect(result.action).toBe('drop')
+    expect(result.dropReason).toBe('self.echo')
+  })
+
+  test('non-allowlisted bot drop carries dropReason bot.not_allowlisted (ccsc-apj.2)', async () => {
+    const access = makeAccess({ channels: { C1: { requireMention: false, allowFrom: [] } } })
+    const result = await gate(
+      { bot_id: 'B_PEER', user: 'U_PEER', channel: 'C1', channel_type: 'channel', text: 'hi' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('bot.not_allowlisted')
+  })
+
+  test('permission-relay bot drop carries dropReason bot.permission_relay (ccsc-apj.2)', async () => {
+    const access = makeAccess({
+      channels: { C1: { requireMention: false, allowFrom: [], allowBotIds: ['U_PEER'] } },
+    })
+    const result = await gate(
+      {
+        bot_id: 'B_PEER',
+        user: 'U_PEER',
+        channel: 'C1',
+        channel_type: 'channel',
+        text: 'yes abcde',
+      },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('bot.permission_relay')
+  })
+
+  test('filtered subtype drop carries dropReason subtype.filtered (ccsc-apj.2)', async () => {
+    const result = await gate(
+      { subtype: 'message_changed', user: 'U1', channel_type: 'channel', channel: 'C1' },
+      makeOpts(),
+    )
+    expect(result.dropReason).toBe('subtype.filtered')
+  })
+
+  test('no-user drop carries dropReason event.no_user (ccsc-apj.2)', async () => {
+    const result = await gate({ channel_type: 'channel', channel: 'C1' }, makeOpts())
+    expect(result.dropReason).toBe('event.no_user')
+  })
+
+  test('closed-DM drop carries dropReason dm.policy_closed (ccsc-apj.2)', async () => {
+    const access = makeAccess({ dmPolicy: 'disabled' })
+    const result = await gate(
+      { user: 'U_X', channel_type: 'im', channel: 'D1' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('dm.policy_closed')
+  })
+
+  test('pairing-cap drop carries dropReason dm.pairing_cap (ccsc-apj.2)', async () => {
+    const access = makeAccess({
+      dmPolicy: 'pairing',
+      pending: {
+        ABC123: {
+          senderId: 'U_M',
+          chatId: 'D1',
+          createdAt: Date.now(),
+          expiresAt: Date.now() + PAIRING_EXPIRY_MS,
+          replies: MAX_PAIRING_REPLIES,
+        },
+      },
+    })
+    const result = await gate(
+      { user: 'U_M', channel_type: 'im', channel: 'D1' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('dm.pairing_cap')
+  })
+
+  test('pending-full drop carries dropReason dm.pending_full (ccsc-apj.2)', async () => {
+    const pending: Access['pending'] = {}
+    for (let i = 0; i < MAX_PENDING; i++) {
+      pending[`CODE${i}`] = {
+        senderId: `U_P${i}`,
+        chatId: 'D1',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + PAIRING_EXPIRY_MS,
+        replies: 1,
+      }
+    }
+    const access = makeAccess({ dmPolicy: 'pairing', pending })
+    const result = await gate(
+      { user: 'U_OVF', channel_type: 'im', channel: 'D1' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('dm.pending_full')
+  })
+
+  test('non-opted channel drop carries dropReason channel.not_opted (ccsc-apj.2)', async () => {
+    const result = await gate(
+      { user: 'U1', channel: 'C_UNKNOWN', channel_type: 'channel' },
+      makeOpts(),
+    )
+    expect(result.dropReason).toBe('channel.not_opted')
+  })
+
+  test('channel allowFrom miss drop carries dropReason channel.allowfrom_miss (ccsc-apj.2)', async () => {
+    const access = makeAccess({
+      channels: { C_R: { requireMention: false, allowFrom: ['U_VIP'] } },
+    })
+    const result = await gate(
+      { user: 'U_NO', channel: 'C_R', channel_type: 'channel' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('channel.allowfrom_miss')
+  })
+
+  test('requireMention no-mention drop carries dropReason channel.require_mention (ccsc-apj.2)', async () => {
+    const access = makeAccess({
+      channels: { C_M: { requireMention: true, allowFrom: [] } },
+    })
+    const result = await gate(
+      { user: 'U1', channel: 'C_M', channel_type: 'channel', text: 'hi' },
+      makeOpts({ access }),
+    )
+    expect(result.dropReason).toBe('channel.require_mention')
   })
 
   // -- allowBotIds (cross-bot coordination) --
@@ -2071,6 +2417,45 @@ describe('sessionPath', () => {
 
   test('rejects empty channel component', () => {
     expect(() => sessionPath(tmpRoot, key('', 'T1.0'))).toThrow(/invalid channel component/)
+  })
+
+  // ── ccsc-kl410: per-user session isolation ─────────────────────────────
+
+  test('per-user key nests the file under a userId dir within the channel', () => {
+    const p = sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: 'U_ALICE' })
+    expect(p).toBe(join(tmpRoot, 'sessions', 'C_CHAN', 'U_ALICE', 'T1.0.json'))
+  })
+
+  test('two users in the same thread get distinct session files', () => {
+    const pA = sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: 'U_ALICE' })
+    const pB = sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: 'U_BOB' })
+    const shared = sessionPath(tmpRoot, key('C_CHAN', 'T1.0'))
+    expect(pA).not.toBe(pB)
+    expect(pA).not.toBe(shared)
+    expect(pB).not.toBe(shared)
+  })
+
+  test('undefined userId is the legacy shared path (unchanged)', () => {
+    const p = sessionPath(tmpRoot, key('C_CHAN', 'T1.0'))
+    expect(p).toBe(join(tmpRoot, 'sessions', 'C_CHAN', 'T1.0.json'))
+  })
+
+  test('rejects userId component that is exactly .. (path-injection guard)', () => {
+    expect(() => sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: '..' })).toThrow(
+      /invalid userId component/,
+    )
+  })
+
+  test('rejects userId component with /', () => {
+    expect(() =>
+      sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: 'U/X' }),
+    ).toThrow(/invalid userId component/)
+  })
+
+  test('rejects empty userId component (no collision with the shared session)', () => {
+    expect(() => sessionPath(tmpRoot, { channel: 'C_CHAN', thread: 'T1.0', userId: '' })).toThrow(
+      /invalid userId component/,
+    )
   })
 
   test('rejects thread component that is exactly ..', () => {
@@ -5371,6 +5756,55 @@ describe('cross-(channel,thread) session isolation (ccsc-1iw.1)', () => {
     expect(b.session.data.mark).toBeUndefined()
   })
 
+  test('per-user keys isolate two users in the same channel+thread (ccsc-kl410)', async () => {
+    // With perUserSessions, Alice and Bob share a Slack thread but get separate
+    // sessions — distinct keyId, distinct on-disk file, own ownerId.
+    const sup = makeSupervisor()
+    const alice = await sup.activate(
+      { channel: 'C_OPS', thread: 'T1', userId: 'U_ALICE' },
+      'U_ALICE',
+    )
+    const bob = await sup.activate({ channel: 'C_OPS', thread: 'T1', userId: 'U_BOB' }, 'U_BOB')
+
+    expect(alice).not.toBe(bob)
+    await alice.update((s) => ({ ...s, data: { ...s.data, secret: 'alice-only' } }))
+    await bob.update((s) => ({ ...s, data: { ...s.data, secret: 'bob-only' } }))
+
+    // No bleed in the live handles…
+    expect(alice.session.data.secret).toBe('alice-only')
+    expect(bob.session.data.secret).toBe('bob-only')
+    expect(alice.session.ownerId).toBe('U_ALICE')
+    expect(bob.session.ownerId).toBe('U_BOB')
+
+    // …nor on disk: each per-user file holds only its own secret.
+    const onDiskAlice = JSON.parse(
+      readFileSync(
+        sessionPath(tmpRoot, { channel: 'C_OPS', thread: 'T1', userId: 'U_ALICE' }),
+        'utf8',
+      ),
+    ) as Session
+    const onDiskBob = JSON.parse(
+      readFileSync(
+        sessionPath(tmpRoot, { channel: 'C_OPS', thread: 'T1', userId: 'U_BOB' }),
+        'utf8',
+      ),
+    ) as Session
+    expect(onDiskAlice.data.secret).toBe('alice-only')
+    expect(onDiskBob.data.secret).toBe('bob-only')
+  })
+
+  test('a per-user session does not collide with the shared (no-userId) session in one thread (ccsc-kl410)', async () => {
+    const sup = makeSupervisor()
+    const shared = await sup.activate({ channel: 'C_OPS', thread: 'T1' }, 'U_SHARED')
+    const peruser = await sup.activate(
+      { channel: 'C_OPS', thread: 'T1', userId: 'U_ALICE' },
+      'U_ALICE',
+    )
+    expect(shared).not.toBe(peruser)
+    await shared.update((s) => ({ ...s, data: { ...s.data, mark: 'shared' } }))
+    expect(peruser.session.data.mark).toBeUndefined()
+  })
+
   test('an inbound thread value that embeds traversal toward another session is rejected before any read', async () => {
     const sup = makeSupervisor()
     // Seed a victim session the attacker would like to read.
@@ -7159,6 +7593,120 @@ describe('deliverChunkedReplyDurably (ccsc-o7x.4)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Durable streaming reply finalize — beginDurableStream (ccsc-o7x.6). A stream
+// records ONE full-text obligation up front; completing marks it delivered, an
+// in-process failure marks it dead, and a process crash (neither mark called)
+// leaves it pending so the poller redelivers the final message. (ADR-002
+// addendum.)
+// ---------------------------------------------------------------------------
+
+describe('beginDurableStream (ccsc-o7x.6)', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let nowValue: number
+  const key = { channel: 'C_STREAM', thread: 'T1' }
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'supervisor-stream-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    nowValue = 1_700_000_000_000
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor() {
+    return createSessionSupervisor({
+      stateRoot: tmpRoot,
+      log: () => {},
+      clock: () => nowValue,
+      leaseTtlMs: 1000,
+      ownerId: 'OWNER-1',
+    })
+  }
+
+  /** Pre-create the session file so the owner-less activate resolves it from
+   *  disk (mirrors a session the inbound message created). */
+  async function seedSession() {
+    const seed = makeSupervisor()
+    await seed.activate(key, 'U')
+  }
+
+  const reply = { id: 's-1', channel: 'C_STREAM', thread: 'T1', text: 'the full streamed reply' }
+
+  test('records ONE pending obligation carrying the FULL text before returning', async () => {
+    await seedSession()
+    const sup = makeSupervisor()
+
+    await beginDurableStream({ supervisor: sup }, reply)
+
+    const reloaded = await loadSession(tmpRoot, sessionPath(tmpRoot, key))
+    expect(reloaded.outbox).toHaveLength(1)
+    // Full text as the payload — a stream-finalize obligation, NOT a chunk.
+    expect(reloaded.outbox?.[0]).toMatchObject({
+      id: 's-1',
+      state: 'pending',
+      payload: 'the full streamed reply',
+    })
+    // Pending → a crash here means the poller redelivers the final message.
+    expect((await sup.pendingDeliveries()).map((o) => o.id)).toEqual(['s-1'])
+  })
+
+  test('markDelivered: stream completed → obligation delivered, nothing pending', async () => {
+    await seedSession()
+    const sup = makeSupervisor()
+    const handle = await beginDurableStream({ supervisor: sup }, reply)
+
+    await handle.markDelivered()
+
+    const reloaded = await loadSession(tmpRoot, sessionPath(tmpRoot, key))
+    expect(reloaded.outbox?.[0]).toMatchObject({ id: 's-1', state: 'delivered', attempts: 1 })
+    expect(await sup.pendingDeliveries()).toHaveLength(0)
+  })
+
+  test('markDead: in-process stream failure → obligation dead with the reason, nothing pending', async () => {
+    await seedSession()
+    const sup = makeSupervisor()
+    const handle = await beginDurableStream({ supervisor: sup }, reply)
+
+    await handle.markDead('failed mid-stream: channel removed')
+
+    const reloaded = await loadSession(tmpRoot, sessionPath(tmpRoot, key))
+    expect(reloaded.outbox?.[0]).toMatchObject({
+      id: 's-1',
+      state: 'dead',
+      attempts: 1,
+      lastError: 'failed mid-stream: channel removed',
+    })
+    // Dead, not pending → the poller never auto-redelivers a gate-rejected stream.
+    expect(await sup.pendingDeliveries()).toHaveLength(0)
+  })
+
+  test('crash mid-stream (neither mark called) leaves the obligation pending across a restart', async () => {
+    await seedSession()
+    const sup = makeSupervisor()
+    // Begin, then "crash": never call markDelivered/markDead.
+    await beginDurableStream({ supervisor: sup }, reply)
+
+    // A fresh supervisor (simulating a restart) still sees the pending obligation
+    // — the boot-drain / poller redelivers the full text.
+    const afterRestart = makeSupervisor()
+    expect((await afterRestart.pendingDeliveries()).map((o) => o.id)).toEqual(['s-1'])
+  })
+
+  test('throws DurableUnavailableError (records nothing) when the session cannot be activated', async () => {
+    // No seedSession() — the session file does not exist and the owner-less
+    // activate rejects, so nothing is recorded.
+    const sup = makeSupervisor()
+
+    await expect(beginDurableStream({ supervisor: sup }, reply)).rejects.toBeInstanceOf(
+      DurableUnavailableError,
+    )
+    expect(await sup.pendingDeliveries()).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // SessionSupervisor.quiesce — 000-docs/session-state-machine.md §119-124, §266
 // ---------------------------------------------------------------------------
 
@@ -7798,10 +8346,12 @@ describe('JournalEvent', () => {
     // (ccsc-22l) + policy.deny.context_stripped (ccsc-06s) +
     // 5 admin.* kinds (ccsc-3w0) + system.stream_finalize (ccsc-ele) +
     // 4 admin.mute/unmute kinds (ccsc-gjm) + 2 session.recovery.* kinds
-    // (ccsc-o7x.1.2: session.recovery.requeued, session.recovery.orphaned).
+    // (ccsc-o7x.1.2: session.recovery.requeued, session.recovery.orphaned) +
+    // session.activate_rejected (ccsc-4e9bf backpressure).
     // If this number drifts, update the doc count in journal.ts's header
     // comment too.
-    expect(kinds).toHaveLength(36)
+    expect(kinds).toHaveLength(37)
+    expect(kinds).toContain('session.activate_rejected')
     expect(kinds).toContain('manifest.read')
     expect(kinds).toContain('manifest.read.cached')
     expect(kinds).toContain('manifest.publish')
@@ -14472,6 +15022,139 @@ describe('ccsc-3w0 — parseAdminCommand', () => {
     const { parseAdminCommand } = await import('./admin.ts')
     expect(parseAdminCommand('<@U_BOT> !clear', envelope)).toBeNull()
   })
+
+  test('parses !mute-status into AdminMuteStatusCommand (ccsc-yl6k9)', async () => {
+    const { parseAdminCommand } = await import('./admin.ts')
+    expect(parseAdminCommand('!mute-status', envelope)).toEqual({
+      kind: 'mute-status',
+      ...envelope,
+    })
+  })
+
+  test('parses !rate-limit into AdminRateLimitCommand (ccsc-yl6k9)', async () => {
+    const { parseAdminCommand } = await import('./admin.ts')
+    expect(parseAdminCommand('!rate-limit', envelope)).toEqual({ kind: 'rate-limit', ...envelope })
+  })
+
+  test('rejects !mute-status / !rate-limit with an argument (ccsc-yl6k9)', async () => {
+    const { parseAdminCommand } = await import('./admin.ts')
+    expect(parseAdminCommand('!mute-status foo', envelope)).toBeNull()
+    expect(parseAdminCommand('!rate-limit 5', envelope)).toBeNull()
+  })
+})
+
+describe('ccsc-yl6k9 — read-only admin verbs (mute-status / rate-limit)', () => {
+  const envelope = {
+    channelId: 'C_OPS',
+    requestedBy: 'U_ALICE',
+    threadTs: '1700000000.000100',
+    messageTs: '1700000000.000100',
+  }
+
+  function baseDeps(
+    overrides: Partial<import('./admin.ts').DispatchDeps> = {},
+  ): import('./admin.ts').DispatchDeps {
+    return {
+      isAllowed: () => true,
+      journalWrite: async () => undefined,
+      quiesceAndDeactivate: async () => {},
+      sendTmuxKeys: async () => {},
+      issueChallenge: async () => ({ nonce: 'x', expiresAt: 0 }),
+      verifyChallenge: () => ({ ok: false, reason: 'unknown' }),
+      postReaction: async () => {},
+      ...overrides,
+    }
+  }
+
+  test('!mute-status returns a status outcome listing active mutes', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const { createMuteStore } = await import('./mute-store.ts')
+    const store = createMuteStore()
+    store.mute('C_OPS', 'B_NOISY', 1_000_000 + 60_000, 'U_ALICE', 1_000_000)
+    const result = await dispatchAdminCommand(
+      { kind: 'mute-status', ...envelope },
+      baseDeps({ muteStore: store, now: () => 1_000_000 }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') {
+      expect(result.verb).toBe('mute-status')
+      expect(result.message).toContain('B_NOISY')
+    }
+  })
+
+  test('!mute-status reports no active mutes when the store is empty', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const { createMuteStore } = await import('./mute-store.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'mute-status', ...envelope },
+      baseDeps({ muteStore: createMuteStore(), now: () => 1_000_000 }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') expect(result.message).toMatch(/No active/i)
+  })
+
+  test('!rate-limit reports the effective per-bot + channel-breaker thresholds', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'rate-limit', ...envelope },
+      baseDeps({
+        getChannelRateLimits: () => ({
+          peerBot: { count: 10, windowMs: 60_000 },
+          channel: { count: 40, windowMs: 60_000 },
+        }),
+      }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') {
+      expect(result.message).toContain('10 msgs / 60s')
+      expect(result.message).toContain('40 msgs / 60s')
+    }
+  })
+
+  test('!rate-limit shows "disabled" when a limit is { count: 0 }', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'rate-limit', ...envelope },
+      baseDeps({
+        getChannelRateLimits: () => ({
+          peerBot: { count: 0, windowMs: 0 },
+          channel: { count: 40, windowMs: 60_000 },
+        }),
+      }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') expect(result.message).toContain('disabled')
+  })
+
+  test('!rate-limit degrades gracefully when the resolver returns undefined (ccsc-yl6k9)', async () => {
+    // Defensive against a malformed/missing config (Gemini, PR #249).
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'rate-limit', ...envelope },
+      baseDeps({ getChannelRateLimits: () => undefined as unknown as never }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') expect(result.message).toMatch(/unavailable/i)
+  })
+
+  test('read-only verbs are allowlist-gated — non-allowlisted user denied, not journaled', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const { createMuteStore } = await import('./mute-store.ts')
+    const journal: unknown[] = []
+    const result = await dispatchAdminCommand(
+      { kind: 'mute-status', ...envelope },
+      baseDeps({
+        isAllowed: () => false,
+        journalWrite: async (i) => {
+          journal.push(i)
+          return undefined
+        },
+        muteStore: createMuteStore(),
+      }),
+    )
+    expect(result.kind).toBe('denied')
+    expect(journal.length).toBe(0) // reads are not journaled
+  })
 })
 
 describe('ccsc-3w0 — stripBotMention (Gemini #1 from original PR #157)', () => {
@@ -15358,6 +16041,319 @@ describe('ccsc-ele — Gemini #181 review fixes', () => {
 // A→B→A runaway loops when multiple peer bots are opted into one
 // channel via allowBotIds.
 
+describe('ccsc-0k7x2 — channel-wide circuit breaker', () => {
+  test('checkChannel counts ALL bots together and trips at the threshold', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 3, windowMs: 60_000 }
+    // Three different senders, each well under any per-bot cap, together exhaust
+    // the channel aggregate: 3 allowed, the 4th (from any bot) trips the ring.
+    expect(store.checkChannel('C_OPS', 1_000_000, cfg)).toBe(true)
+    expect(store.checkChannel('C_OPS', 1_000_100, cfg)).toBe(true)
+    expect(store.checkChannel('C_OPS', 1_000_200, cfg)).toBe(true)
+    expect(store.checkChannel('C_OPS', 1_000_300, cfg)).toBe(false)
+  })
+
+  test('checkChannel is independent per channel', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 1, windowMs: 60_000 }
+    expect(store.checkChannel('C_A', 1_000_000, cfg)).toBe(true)
+    expect(store.checkChannel('C_A', 1_000_100, cfg)).toBe(false)
+    expect(store.checkChannel('C_B', 1_000_200, cfg)).toBe(true)
+  })
+
+  test('checkChannel resets after the window slides', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 1, windowMs: 60_000 }
+    expect(store.checkChannel('C_OPS', 1_000_000, cfg)).toBe(true)
+    expect(store.checkChannel('C_OPS', 1_000_100, cfg)).toBe(false)
+    // Past the window → old entry pruned, allowed again
+    expect(store.checkChannel('C_OPS', 1_000_000 + 60_001, cfg)).toBe(true)
+  })
+
+  test('checkChannel { count: 0 } disables (always allows)', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 0, windowMs: 0 }
+    for (let i = 0; i < 100; i++) {
+      expect(store.checkChannel('C_OPS', 1_000_000 + i, cfg)).toBe(true)
+    }
+  })
+
+  test('prune sweeps channel-aggregate buckets too', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 5, windowMs: 60_000 }
+    store.checkChannel('C_OPS', 1_000_000, cfg)
+    // Long after the window, prune removes the stale channel bucket.
+    expect(store.prune(1_000_000 + 120_000, 60_000)).toBeGreaterThanOrEqual(1)
+  })
+
+  test('gate trips an A→B→C→A ring with rate.channel_cycle though each bot is under its per-bot cap', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const { gate } = await import('./lib.ts')
+    const store = createPeerBotRateLimitStore()
+    const access: Access = {
+      dmPolicy: 'allowlist',
+      allowFrom: [],
+      channels: {
+        C_RING: {
+          requireMention: false,
+          allowFrom: [],
+          allowBotIds: ['U_A', 'U_B', 'U_C'],
+          peerBotRateLimit: { count: 100, windowMs: 60_000 }, // generous → per-bot never trips first
+          channelCircuitBreaker: { count: 5, windowMs: 60_000 },
+        },
+      },
+      pending: {},
+    }
+    let now = 1_000_000
+    const opts = {
+      access,
+      staticMode: true,
+      saveAccess: () => {},
+      botUserId: 'U_BRIDGE_BOT',
+      selfBotId: 'B_BRIDGE',
+      selfAppId: 'A_BRIDGE',
+      peerBotRateLimitStore: store,
+      now: () => now,
+    }
+    const ring = ['U_A', 'U_B', 'U_C', 'U_A', 'U_B'] // 5 messages, each sender ≤ 2
+    for (const user of ring) {
+      const r = await gate(
+        {
+          type: 'message',
+          channel: 'C_RING',
+          user,
+          bot_id: `B_${user}`,
+          text: 'looping',
+          ts: '1700000000.000100',
+        },
+        opts,
+      )
+      expect(r.action).not.toBe('drop')
+      now += 100
+    }
+    // 6th message: channel aggregate (5) is at threshold → breaker trips.
+    const tripped = await gate(
+      {
+        type: 'message',
+        channel: 'C_RING',
+        user: 'U_C',
+        bot_id: 'B_U_C',
+        text: 'looping',
+        ts: '1700000000.000100',
+      },
+      opts,
+    )
+    expect(tripped.action).toBe('drop')
+    expect(tripped.dropReason).toBe('rate.channel_cycle')
+  })
+
+  test('gate channelCircuitBreaker { count: 0 } disables the breaker', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const { gate } = await import('./lib.ts')
+    const store = createPeerBotRateLimitStore()
+    const access: Access = {
+      dmPolicy: 'allowlist',
+      allowFrom: [],
+      channels: {
+        C_RING: {
+          requireMention: false,
+          allowFrom: [],
+          allowBotIds: ['U_A'],
+          peerBotRateLimit: { count: 0, windowMs: 0 },
+          channelCircuitBreaker: { count: 0, windowMs: 0 },
+        },
+      },
+      pending: {},
+    }
+    const opts = {
+      access,
+      staticMode: true,
+      saveAccess: () => {},
+      botUserId: 'U_BRIDGE_BOT',
+      selfBotId: 'B_BRIDGE',
+      selfAppId: 'A_BRIDGE',
+      peerBotRateLimitStore: store,
+      now: () => 1_000_000,
+    }
+    for (let i = 0; i < 50; i++) {
+      const r = await gate(
+        {
+          type: 'message',
+          channel: 'C_RING',
+          user: 'U_A',
+          bot_id: 'B_A',
+          text: 'x',
+          ts: '1700000000.000100',
+        },
+        opts,
+      )
+      expect(r.dropReason).not.toBe('rate.channel_cycle')
+    }
+  })
+})
+
+describe('ccsc-4e9bf — backpressure + agents-online', () => {
+  test('resolveMaxConcurrentSessions parses a positive integer', async () => {
+    const { resolveMaxConcurrentSessions } = await import('./supervisor.ts')
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: '50' })).toBe(50)
+  })
+
+  test('resolveMaxConcurrentSessions → undefined for unset/empty/non-numeric/non-positive', async () => {
+    const { resolveMaxConcurrentSessions } = await import('./supervisor.ts')
+    expect(resolveMaxConcurrentSessions({})).toBeUndefined()
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: '' })).toBeUndefined()
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: 'abc' })).toBeUndefined()
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: '0' })).toBeUndefined()
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: '-5' })).toBeUndefined()
+  })
+
+  test('resolveMaxConcurrentSessions floors a float', async () => {
+    const { resolveMaxConcurrentSessions } = await import('./supervisor.ts')
+    expect(resolveMaxConcurrentSessions({ SLACK_MAX_CONCURRENT_SESSIONS: '3.9' })).toBe(3)
+  })
+
+  describe('supervisor cap', () => {
+    let rawRoot: string
+    let tmpRoot: string
+    const journalEvents: Array<{ kind: string; reason?: string }> = []
+    beforeEach(() => {
+      rawRoot = mkdtempSync(join(tmpdir(), 'bp-'))
+      tmpRoot = realpathSync.native(rawRoot)
+      journalEvents.length = 0
+    })
+    afterEach(() => rmSync(rawRoot, { recursive: true, force: true }))
+    function makeSup(maxConcurrentSessions?: number) {
+      return createSessionSupervisor({
+        stateRoot: tmpRoot,
+        log: () => {},
+        clock: () => 1_700_000_000_000,
+        maxConcurrentSessions,
+        journal: {
+          writeEvent: async (e: { kind: string; reason?: string }) => {
+            journalEvents.push(e)
+            return {}
+          },
+        } as unknown as import('./journal.ts').JournalWriter,
+      })
+    }
+
+    test('allows new sessions up to the cap, rejects the next new one', async () => {
+      const sup = makeSup(2)
+      await sup.activate({ channel: 'C1', thread: 'T1' }, 'U1')
+      await sup.activate({ channel: 'C2', thread: 'T2' }, 'U2')
+      await expect(sup.activate({ channel: 'C3', thread: 'T3' }, 'U3')).rejects.toThrow(
+        /maxConcurrentSessions/,
+      )
+    })
+
+    test('reactivating an already-live session is never capped', async () => {
+      const sup = makeSup(1)
+      const a = await sup.activate({ channel: 'C1', thread: 'T1' }, 'U1')
+      const again = await sup.activate({ channel: 'C1', thread: 'T1' }, 'U1')
+      expect(again).toBe(a)
+    })
+
+    test('the over-cap rejection is journaled as session.activate_rejected', async () => {
+      const sup = makeSup(1)
+      await sup.activate({ channel: 'C1', thread: 'T1' }, 'U1')
+      await expect(sup.activate({ channel: 'C2', thread: 'T2' }, 'U2')).rejects.toThrow()
+      await new Promise((r) => setTimeout(r, 0)) // flush the fire-and-forget journal write
+      const rej = journalEvents.find((e) => e.kind === 'session.activate_rejected')
+      expect(rej).toBeDefined()
+      expect(rej?.reason).toContain('maxConcurrentSessions')
+    })
+
+    test('undefined cap = unlimited (no rejection across many activations)', async () => {
+      const sup = makeSup(undefined)
+      for (let i = 0; i < 12; i++) {
+        await sup.activate({ channel: `C${i}`, thread: 'T' }, 'U')
+      }
+      expect(journalEvents.find((e) => e.kind === 'session.activate_rejected')).toBeUndefined()
+    })
+
+    test('cap counts DISTINCT sessions under concurrency — cap=2, 3 fired at once → 2 ok, 1 rejected', async () => {
+      // Guards the live∪activating double-count fix (Gemini, PR #250): a key
+      // briefly in both maps must not inflate the count.
+      const sup = makeSup(2)
+      const results = await Promise.allSettled([
+        sup.activate({ channel: 'C1', thread: 'T' }, 'U'),
+        sup.activate({ channel: 'C2', thread: 'T' }, 'U'),
+        sup.activate({ channel: 'C3', thread: 'T' }, 'U'),
+      ])
+      expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(2)
+      expect(results.filter((r) => r.status === 'rejected')).toHaveLength(1)
+    })
+  })
+
+  test('activeBots lists bots active within the window, excluding stale + other channels', async () => {
+    const { createPeerBotRateLimitStore } = await import('./peer-bot-rate-limit.ts')
+    const store = createPeerBotRateLimitStore()
+    const cfg = { count: 100, windowMs: 60_000 }
+    store.check('C_OPS', 'B_alice', 1_000_000, cfg)
+    store.check('C_OPS', 'B_bob', 1_000_000, cfg)
+    store.check('C_OTHER', 'B_carol', 1_000_000, cfg)
+    expect(store.activeBots('C_OPS', 1_002_000, 5_000).sort()).toEqual(['B_alice', 'B_bob'])
+    // After the window, none are active.
+    expect(store.activeBots('C_OPS', 1_000_000 + 10_000, 5_000)).toEqual([])
+  })
+
+  const envelope = {
+    channelId: 'C_OPS',
+    requestedBy: 'U_ALICE',
+    threadTs: '1700000000.000100',
+    messageTs: '1700000000.000100',
+  }
+  function adminDeps(
+    overrides: Partial<import('./admin.ts').DispatchDeps> = {},
+  ): import('./admin.ts').DispatchDeps {
+    return {
+      isAllowed: () => true,
+      journalWrite: async () => undefined,
+      quiesceAndDeactivate: async () => {},
+      sendTmuxKeys: async () => {},
+      issueChallenge: async () => ({ nonce: 'x', expiresAt: 0 }),
+      verifyChallenge: () => ({ ok: false, reason: 'unknown' }),
+      postReaction: async () => {},
+      ...overrides,
+    }
+  }
+
+  test('parses !agents; rejects !agents with an argument', async () => {
+    const { parseAdminCommand } = await import('./admin.ts')
+    expect(parseAdminCommand('!agents', envelope)).toEqual({ kind: 'agents', ...envelope })
+    expect(parseAdminCommand('!agents foo', envelope)).toBeNull()
+  })
+
+  test('!agents lists active peer agents', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'agents', ...envelope },
+      adminDeps({ getActiveAgents: () => ['B_alice', 'B_bob'] }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') {
+      expect(result.verb).toBe('agents')
+      expect(result.message).toContain('B_alice')
+      expect(result.message).toContain('B_bob')
+    }
+  })
+
+  test('!agents reports none when no agents active', async () => {
+    const { dispatchAdminCommand } = await import('./admin.ts')
+    const result = await dispatchAdminCommand(
+      { kind: 'agents', ...envelope },
+      adminDeps({ getActiveAgents: () => [] }),
+    )
+    expect(result.kind).toBe('status')
+    if (result.kind === 'status') expect(result.message).toMatch(/No peer agents/i)
+  })
+})
+
 describe('ccsc-gyt — createPeerBotRateLimitStore', () => {
   test('first message from a (channel, bot) pair is allowed', async () => {
     const { createPeerBotRateLimitStore, DEFAULT_PEER_BOT_RATE_LIMIT } = await import(
@@ -15745,7 +16741,9 @@ describe('ccsc-gjm — MuteStore', () => {
     store.mute('C1', 'B1', 1_000_100, 'U', 1_000_000)
     store.mute('C2', 'B2', 1_000_200, 'U', 1_000_000)
     store.mute('C3', 'B3', 9_999_999_999, 'U', 1_000_000)
-    expect(store.prune(1_500_000)).toBe(2)
+    // prune now returns the removed entries (ccsc-yl6k9) so the reaper can
+    // notify on auto-expiry; two of the three are past their TTL.
+    expect(store.prune(1_500_000).length).toBe(2)
     expect(store.size()).toBe(1)
   })
 

--- a/plugins/mcp/slack-channel/server.ts
+++ b/plugins/mcp/slack-channel/server.ts
@@ -79,7 +79,11 @@ import {
 } from './manifest.ts'
 import { createMuteStore } from './mute-store.ts'
 import { createMemoryNonceStore, mintNonce, verifyNonce } from './nonce-hitl.ts'
-import { createPeerBotRateLimitStore } from './peer-bot-rate-limit.ts'
+import {
+  createPeerBotRateLimitStore,
+  DEFAULT_CHANNEL_CIRCUIT_BREAKER,
+  DEFAULT_PEER_BOT_RATE_LIMIT,
+} from './peer-bot-rate-limit.ts'
 import {
   type ApprovalKey,
   approvalKey,
@@ -93,13 +97,15 @@ import {
   evaluate as policyEvaluate,
 } from './policy.ts'
 import {
+  beginDurableStream,
   createDeliverySendDeps,
   createReplyPoster,
+  type DurableStreamHandle,
   DurableUnavailableError,
   deliverChunkedReplyDurably,
   deliverReplyDurably,
 } from './slack-delivery.ts'
-import { streamReply } from './stream-reply.ts'
+import { type StreamReplyResult, streamReply } from './stream-reply.ts'
 
 // ---------------------------------------------------------------------------
 // --verify-audit-log subcommand (ccsc-t7j, Epic 30-A.15)
@@ -138,7 +144,12 @@ if (_verifyPath !== null) {
   }
 }
 
-import { createSessionSupervisor, resolveIdleMs, type SessionSupervisor } from './supervisor.ts'
+import {
+  createSessionSupervisor,
+  resolveIdleMs,
+  resolveMaxConcurrentSessions,
+  type SessionSupervisor,
+} from './supervisor.ts'
 
 // Re-export constants so they stay in one place (lib.ts)
 export { MAX_PAIRING_REPLIES, MAX_PENDING, PAIRING_EXPIRY_MS } from './lib.ts'
@@ -556,6 +567,56 @@ function assertNoSecretValues(payload: string): void {
 // enforce thread-level isolation per session-state-machine.md §207.
 const deliveredThreads = new Set<string>()
 
+// ccsc-apj.1 — threads a HUMAN has "engaged" by mentioning the bot at
+// least once. Keyed by the SESSION thread `deliveredThreadKey(channel,
+// thread_ts ?? ts)` (NOT raw thread_ts like deliveredThreads above), so a
+// top-level mention (ts=T1) and its in-thread follow-ups (thread_ts=T1)
+// share one slot. gate() consults this to let a human keep talking in an
+// engaged thread without re-mentioning on a requireMention channel. Peer
+// bots are never added here as sticky — the inbound gate refuses to make
+// ev.bot_id messages sticky regardless. Session-lifetime cache.
+const engagedThreads = new Set<string>()
+// Bound the engaged-thread cache so it can't grow without limit over a long
+// process lifetime (CodeRabbit, PR #244). At capacity the oldest entry is
+// evicted; a human in an evicted thread simply re-mentions to re-engage.
+const MAX_ENGAGED_THREADS = 10_000
+
+/** Record a thread as engaged for mention-stickiness, bounding the cache.
+ *  Sets iterate in insertion order, so the first key is the oldest; evict it
+ *  when at capacity (only when adding a genuinely new key). */
+function recordEngagedThread(key: string): void {
+  if (engagedThreads.size >= MAX_ENGAGED_THREADS && !engagedThreads.has(key)) {
+    const oldest = engagedThreads.values().next().value
+    if (oldest !== undefined) engagedThreads.delete(oldest)
+  }
+  engagedThreads.add(key)
+}
+
+/** Build the SessionKey for an inbound event. When the channel opts into
+ *  per-user session isolation (ccsc-kl410), the sender's userId is added so two
+ *  humans in one thread get separate sessions; otherwise the legacy shared
+ *  (channel, thread) key. Default-safe: no flag → shared, behavior unchanged. */
+function inboundSessionKey(
+  channelId: string,
+  threadKey: string,
+  access: Access,
+  ev: Record<string, unknown>,
+): import('./lib.ts').SessionKey {
+  // Sender identity: the human user_id, or the bot's id for a peer bot. Validate
+  // it is a NON-EMPTY string before keying (ev fields are `unknown`); an
+  // empty/absent sender falls back to the shared session rather than building an
+  // invalid empty-userId key (Gemini, PR #248).
+  const senderId = (ev.user ?? ev.bot_id) as unknown
+  if (
+    access.channels[channelId]?.perUserSessions === true &&
+    typeof senderId === 'string' &&
+    senderId !== ''
+  ) {
+    return { channel: channelId, thread: threadKey, userId: senderId }
+  }
+  return { channel: channelId, thread: threadKey }
+}
+
 // Dedupe events across `message` and `app_mention` subscriptions. Keyed on
 // (channel, ts). See isDuplicateEvent in lib.ts for rationale.
 const seenEvents = new Map<string, number>()
@@ -673,6 +734,9 @@ async function gate(event: unknown): Promise<GateResult> {
     // bounded under sustained load.
     muteStore: adminMuteStore,
     peerBotRateLimitStore: peerBotRateLimitStore,
+    // ccsc-apj.1 — engaged-thread set so a human can keep talking in a
+    // thread they already mentioned the bot in, without re-mentioning.
+    engagedThreads,
   })
 }
 
@@ -1086,13 +1150,85 @@ async function executeReplyFileUploads(
   }
 }
 
+/** ccsc-o7x.6 — record a stream-finalize obligation (full text) if the session
+ *  can go durable, else `null` (best-effort — stream without a net, the prior
+ *  behavior). Module-level so `executeReplyStreamingPath` stays under CRAP-30.
+ *
+ *  The obligation here is a crash safety-net that is SEPARATE from the send (the
+ *  send is the stream itself), unlike the text/chunked durable paths where the
+ *  obligation IS the send. So ANY failure to set it up — `DurableUnavailableError`
+ *  (no session/lease) OR a `recordTerminalDelivery` write failure (disk, fence) —
+ *  degrades to best-effort streaming rather than failing the reply. This keeps
+ *  o7x.6 durability strictly additive: it can never make streaming worse than the
+ *  pre-o7x.6 behavior. A non-`DurableUnavailableError` failure is logged to
+ *  stderr (it signals a real storage problem) but never propagated. */
+async function maybeBeginDurableStream(
+  chatId: string,
+  threadTs: string | undefined,
+  text: string,
+): Promise<DurableStreamHandle | null> {
+  if (supervisor === null || threadTs === undefined) return null
+  try {
+    return await beginDurableStream(
+      { supervisor },
+      { id: randomUUID(), channel: chatId, thread: threadTs, text },
+    )
+  } catch (err) {
+    if (!(err instanceof DurableUnavailableError)) {
+      console.error('[slack] beginDurableStream failed; streaming best-effort', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return null
+  }
+}
+
+/** ccsc-o7x.6 — resolve the stream-finalize obligation from the `streamReply`
+ *  outcome: `completed` → `delivered`; any clean in-process failure
+ *  (`failed_mid_stream` or `gate_rejected_at_start`) → `dead` (the partial
+ *  message that landed is the same best-effort outcome as before; the poller does
+ *  NOT re-run the outbound gate, so a gate-rejected stream must never be
+ *  auto-redelivered). A process crash never reaches here, leaving the obligation
+ *  `pending` for the poller to redeliver. No-op when there is no durable handle. */
+async function resolveStreamObligation(
+  durable: DurableStreamHandle | null,
+  result: StreamReplyResult,
+): Promise<void> {
+  if (durable === null) return
+  switch (result.kind) {
+    case 'completed':
+      await durable.markDelivered()
+      return
+    case 'failed_mid_stream':
+      await durable.markDead(`failed mid-stream: ${result.reason}`)
+      return
+    case 'gate_rejected_at_start':
+      await durable.markDead(`stream rejected at start: ${result.reason}`)
+      return
+    default: {
+      // Exhaustiveness guard: a new StreamReplyResult variant must declare its
+      // obligation resolution here, failing to compile rather than silently
+      // dead-lettering with a misleading reason (matches the
+      // permissionRouteJournalEvents never-guard, ccsc-175).
+      const _exhaustive: never = result
+      return _exhaustive
+    }
+  }
+}
+
 /** ccsc-h1h — extracted streaming path for executeReply. Posts the
  *  reply via streamReply (single message that grows via chat.update)
  *  + handles the file-upload tail + builds the result. streamReply
  *  emits its own gate.outbound.allow + system.stream_finalize events
  *  so this path does NOT write a separate allow event. Kept as a
  *  module-level function so executeReply itself stays under the
- *  CRAP-30 threshold. */
+ *  CRAP-30 threshold.
+ *
+ *  ccsc-o7x.6 — wraps the stream in a stream-finalize obligation so a process
+ *  crash mid-stream redelivers the full text as a fresh message (ADR-002
+ *  addendum). The obligation is recorded BEFORE streaming and resolved after:
+ *  delivered on completion, dead on any in-process failure, left pending only by
+ *  an actual crash. */
 async function executeReplyStreamingPath(opts: {
   chatId: string
   threadTs: string | undefined
@@ -1102,40 +1238,60 @@ async function executeReplyStreamingPath(opts: {
   ctx: ToolContext
 }): Promise<ToolResult> {
   const { chatId, threadTs, text, files, limit, ctx } = opts
-  const result = await streamReply(
-    { channel: chatId, threadTs, text, chunkSize: limit },
-    {
-      assertOutboundAllowed: (c, t) => ctx.assertOutboundAllowed(c, t),
-      postMessage: async (a) => {
-        const res = await ctx.web.chat.postMessage({
-          channel: a.channel,
-          text: a.text,
-          thread_ts: a.thread_ts,
-          unfurl_links: false,
-          unfurl_media: false,
-        })
-        const ts = res.ts as string | undefined
-        // Per Gemini review on PR #188: validate ts BEFORE returning
-        // an empty string downstream. streamReply's invariant is that
-        // subsequent chat.update calls target a real ts; an empty
-        // string would cause each update to fail with a confusing
-        // "channel_not_found"-style Slack error. Throw here so
-        // streamReply's init-failure path runs cleanly + the
-        // system.stream_finalize event records the failure reason.
-        if (!ts) throw new Error('chat.postMessage returned no ts')
-        return { ts }
+
+  const durable = await maybeBeginDurableStream(chatId, threadTs, text)
+
+  let result: StreamReplyResult
+  try {
+    result = await streamReply(
+      { channel: chatId, threadTs, text, chunkSize: limit },
+      {
+        assertOutboundAllowed: (c, t) => ctx.assertOutboundAllowed(c, t),
+        postMessage: async (a) => {
+          const res = await ctx.web.chat.postMessage({
+            channel: a.channel,
+            text: a.text,
+            thread_ts: a.thread_ts,
+            unfurl_links: false,
+            unfurl_media: false,
+          })
+          const ts = res.ts as string | undefined
+          // Per Gemini review on PR #188: validate ts BEFORE returning
+          // an empty string downstream. streamReply's invariant is that
+          // subsequent chat.update calls target a real ts; an empty
+          // string would cause each update to fail with a confusing
+          // "channel_not_found"-style Slack error. Throw here so
+          // streamReply's init-failure path runs cleanly + the
+          // system.stream_finalize event records the failure reason.
+          if (!ts) throw new Error('chat.postMessage returned no ts')
+          return { ts }
+        },
+        updateMessage: async (a) => {
+          await ctx.web.chat.update({ channel: a.channel, ts: a.ts, text: a.text })
+        },
+        // Per Gemini review on PR #188: inject toolName so streamReply's
+        // gate.outbound.allow + system.stream_finalize events attribute
+        // to 'reply' in the audit log (streamReply is a generic
+        // primitive; it doesn't know the calling tool's name).
+        journalWrite: async (input) => ctx.journalWrite({ ...input, toolName: 'reply' }),
+        sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
       },
-      updateMessage: async (a) => {
-        await ctx.web.chat.update({ channel: a.channel, ts: a.ts, text: a.text })
-      },
-      // Per Gemini review on PR #188: inject toolName so streamReply's
-      // gate.outbound.allow + system.stream_finalize events attribute
-      // to 'reply' in the audit log (streamReply is a generic
-      // primitive; it doesn't know the calling tool's name).
-      journalWrite: async (input) => ctx.journalWrite({ ...input, toolName: 'reply' }),
-      sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
-    },
-  )
+    )
+  } catch (streamErr) {
+    // streamReply re-throws on init failure (the journal-allow write or the
+    // initial postMessage threw before any chunk landed). Resolve the obligation
+    // terminal — best-effort, NOT auto-redelivered — then re-throw so the agent
+    // sees the real failure, exactly as before. Leaving it pending would risk a
+    // double-send (the agent may retry AND the poller would redeliver).
+    await durable?.markDead(streamErr instanceof Error ? streamErr.message : String(streamErr))
+    throw streamErr
+  }
+
+  // Resolve the stream-finalize obligation before any throw, so a
+  // gate_rejected_at_start marks dead (never auto-redelivered) rather than
+  // staying pending.
+  await resolveStreamObligation(durable, result)
+
   if (result.kind === 'gate_rejected_at_start') {
     // Unreachable in practice — assertOutboundAllowed already passed
     // in executeReply — but documented as the structured outcome.
@@ -2747,11 +2903,26 @@ async function deliverEvent(ev: Record<string, unknown>, access: Access): Promis
   const incomingThreadTs = ev.thread_ts as string | undefined
   deliveredThreads.add(libDeliveredThreadKey(channelId, incomingThreadTs))
 
+  // ccsc-apj.1 — mark this thread engaged for mention-stickiness, but ONLY
+  // for human deliveries. A human mentioning the bot opens the thread for
+  // mention-free human follow-ups; a peer bot must keep mentioning, so a
+  // bot-only thread never becomes sticky. Keyed by the session thread
+  // (thread_ts ?? ts) so a top-level mention and its in-thread replies match.
+  if (!ev.bot_id) {
+    recordEngagedThread(libDeliveredThreadKey(channelId, incomingThreadTs ?? (ev.ts as string)))
+  }
+
+  // ccsc-kl410 — per-user session isolation (helper keeps deliverEvent under the
+  // CRAP gate). Built once and used for both the journal record (so the chosen
+  // key shape is auditable) and the supervisor activation below.
+  const threadKey = incomingThreadTs ?? (ev.ts as string)
+  const sessionKey = inboundSessionKey(channelId, threadKey, access, ev)
+
   journalWrite({
     kind: 'gate.inbound.deliver',
     outcome: 'allow',
     actor: ev.bot_id ? 'peer_agent' : 'session_owner',
-    sessionKey: { channel: channelId, thread: incomingThreadTs ?? (ev.ts as string) },
+    sessionKey,
     input: {
       channel: channelId,
       user: ev.bot_id ? (ev.bot_id as string) : (ev.user as string | undefined),
@@ -2769,11 +2940,7 @@ async function deliverEvent(ev: Record<string, unknown>, access: Access): Promis
   // and DROP — do not propagate so the event loop stays alive for
   // other sessions. Same policy for handle.update() failures.
   if (supervisor !== null) {
-    await activateAndTouch(
-      supervisor,
-      { channel: channelId, thread: incomingThreadTs ?? (ev.ts as string) },
-      ev.user as string | undefined,
-    )
+    await activateAndTouch(supervisor, sessionKey, ev.user as string | undefined)
   }
 
   // Track last active channel for permission relay
@@ -3137,6 +3304,18 @@ async function tryDispatchAdminVerb(ev: Record<string, unknown>, access: Access)
       }
     },
     muteStore: adminMuteStore,
+    // ccsc-yl6k9 — effective rate-limit view for the read-only !rate-limit verb.
+    getChannelRateLimits: (chId: string) => {
+      const chPolicy = getAccess().channels?.[chId]
+      return {
+        peerBot: chPolicy?.peerBotRateLimit ?? DEFAULT_PEER_BOT_RATE_LIMIT,
+        channel: chPolicy?.channelCircuitBreaker ?? DEFAULT_CHANNEL_CIRCUIT_BREAKER,
+      }
+    },
+    // ccsc-4e9bf — "agents online": peer bots active in the last 5 min, derived
+    // from the rate-limit store's per-channel activity.
+    getActiveAgents: (chId: string, now: number) =>
+      peerBotRateLimitStore.activeBots(chId, now, 5 * 60_000),
   }
 
   try {
@@ -3145,6 +3324,19 @@ async function tryDispatchAdminVerb(ev: Record<string, unknown>, access: Access)
       // No emoji reaction at challenge phase — the DM IS the visible
       // feedback that something happened. Reaction lands when the
       // operator redeems.
+    } else if (outcome.kind === 'status') {
+      // ccsc-yl6k9 — post the read-only status message back into the thread.
+      try {
+        await web.chat.postMessage({
+          channel: channelId,
+          thread_ts: threadTs,
+          text: outcome.message,
+          unfurl_links: false,
+          unfurl_media: false,
+        })
+      } catch (err) {
+        console.error('[slack] admin status post failed:', err)
+      }
     }
     return true
   } catch (err) {
@@ -3418,6 +3610,9 @@ async function main(): Promise<void> {
     stateRoot: STATE_DIR,
     idleMs: resolveIdleMs(process.env),
     journal: journal ?? undefined,
+    // ccsc-4e9bf — optional global backpressure cap (SLACK_MAX_CONCURRENT_SESSIONS).
+    // Unset → unlimited (default).
+    maxConcurrentSessions: resolveMaxConcurrentSessions(process.env),
   })
 
   // Idle reaper: one pass every 60 s, finds sessions whose lastActiveAt is
@@ -3430,7 +3625,18 @@ async function main(): Promise<void> {
   reaperTimer = setInterval(() => {
     void supervisor!.reapIdle()
     const now = Date.now()
-    adminMuteStore.prune(now)
+    for (const expired of adminMuteStore.prune(now)) {
+      // ccsc-yl6k9 — notify the channel when a mute auto-expires so a bot
+      // un-muting is never a silent surprise. Best-effort; never blocks the reaper.
+      void web.chat
+        .postMessage({
+          channel: expired.channelId,
+          text: `:loud_sound: <@${expired.botId}> un-muted (mute expired).`,
+          unfurl_links: false,
+          unfurl_media: false,
+        })
+        .catch((err) => console.error('[slack] mute-expiry notice failed:', err))
+    }
     // The reaper's job is "drop entries that NO conceivable window
     // would still consider live" — NOT to match the default window.
     // Per Gemini high-priority fix on PR #187: a hardcoded 60s

--- a/plugins/mcp/slack-channel/skills/access/SKILL.md
+++ b/plugins/mcp/slack-channel/skills/access/SKILL.md
@@ -20,7 +20,7 @@ Manage who can reach your Claude Code session through Slack.
 /slack-channel:access policy <pairing|allowlist|disabled>   # Set DM policy
 /slack-channel:access add <slack_user_id>                   # Add user to allowlist
 /slack-channel:access remove <slack_user_id>                # Remove from allowlist
-/slack-channel:access channel <channel_id> [--mention] [--allow <user_id,...>]  # Opt in a channel
+/slack-channel:access channel <channel_id> [--ambient] [--allow <user_id,...>]  # Opt in a channel (default: mention-to-engage)
 /slack-channel:access channel remove <channel_id>           # Remove channel opt-in
 /slack-channel:access status                                # Show current config
 ```
@@ -64,13 +64,23 @@ Parse `$ARGUMENTS` and execute the matching subcommand:
 3. Save with 0o600
 4. Show confirmation
 
-### `channel <channel_id> [--mention] [--allow <ids>]`
+### `channel <channel_id> [--ambient] [--allow <ids>]`
+
+Opting a channel in chooses an **interaction mode**. There are three; pick one:
+
+| Mode | `access.json` | Behavior |
+|---|---|---|
+| **Mention-to-engage** (default) | `requireMention: true` | Humans converse freely; Claude only sees messages that `@`-mention it. Once a human mentions the bot in a thread, they keep talking in that thread without re-mentioning (thread-stickiness, `ccsc-apj.1`). **Peer agents are never sticky — they must `@`-mention every message.** |
+| **Ambient** (`--ambient`) | `requireMention: false` | Claude sees every message in the channel. Use for a dedicated bot channel where every message is for Claude. |
+| **Per-user allowlist** (`--allow`) | `allowFrom: [ids]` | Only the listed users are heard. Composes with either mode above. |
+
 1. Parse options:
-   - `--mention`: require @mention to trigger (default: false)
-   - `--allow <id1,id2>`: restrict to specific users in that channel
-2. Add/update `channels[channel_id]` in `access.json`
+   - (no flag) → **mention-to-engage**: write `requireMention: true` (the safe default — humans can chat without Claude listening to everything).
+   - `--ambient` → **ambient**: write `requireMention: false`.
+   - `--allow <id1,id2>` → also set the channel's `allowFrom` to those users (works with either mode).
+2. Add/update `channels[channel_id]` in `access.json`. **Default `requireMention: true`** unless `--ambient` is given.
 3. Save with 0o600
-4. Show the channel policy
+4. Show the channel policy and state which interaction mode is now active.
 
 ### `channel remove <channel_id>`
 1. Delete `channels[channel_id]`

--- a/plugins/mcp/slack-channel/skills/configure/SKILL.md
+++ b/plugins/mcp/slack-channel/skills/configure/SKILL.md
@@ -59,6 +59,10 @@ Configure the Slack channel with your bot token and app-level token.
 
    Or for development:
      claude --dangerously-load-development-channels server:slack
+
+   Next: opt in a channel and pick its interaction mode with
+   /slack-channel:access channel <id>  (defaults to mention-to-engage;
+   pass --ambient for a dedicated bot channel). See ACCESS.md "Interaction modes".
    ```
 
 ## Security

--- a/plugins/mcp/slack-channel/slack-delivery.ts
+++ b/plugins/mcp/slack-channel/slack-delivery.ts
@@ -328,6 +328,88 @@ export async function deliverChunkedReplyDurably(
   return { status: 'delivered', ts: firstTs, sent: delivered }
 }
 
+// ---------------------------------------------------------------------------
+// Durable streaming reply finalize (ccsc-o7x.6 — ADR-002 addendum)
+// ---------------------------------------------------------------------------
+
+/** A streaming reply to make crash-durable. `id` is a fresh per-reply UUID (the
+ *  obligation id and thus idempotency key); `text` is the COMPLETE reply text —
+ *  the stream-finalize payload the poller redelivers on a crash, NOT a chunk. */
+export interface DurableStream {
+  id: string
+  channel: string
+  thread: string
+  text: string
+}
+
+/** Handle returned by `beginDurableStream` so the caller can resolve the
+ *  stream-finalize obligation once `streamReply` returns. Call EXACTLY ONE of
+ *  `markDelivered` (stream completed) / `markDead` (stream failed in-process).
+ *  Calling neither — the process crashed mid-stream — is the whole point: the
+ *  obligation stays `pending` and the poller redelivers. Both marks are
+ *  best-effort (a fenced mark failure leaves the poller to reconcile from disk)
+ *  and never throw. */
+export interface DurableStreamHandle {
+  markDelivered(): Promise<void>
+  markDead(reason: string): Promise<void>
+}
+
+/** Record a stream-finalize obligation BEFORE a streaming reply begins
+ *  (ccsc-o7x.6, ADR-002 addendum). Activates the `(channel, thread)` session and
+ *  appends ONE `pending` `DeliveryObligation` carrying the FULL reply text, then
+ *  returns a handle to resolve it once the stream ends:
+ *
+ *    - stream COMPLETES        → `markDelivered()` — the streamed message holds
+ *      the full content; nothing is owed;
+ *    - stream FAILS in-process → `markDead(reason)` — NOT left pending: the
+ *      poller's send does not re-run the outbound gate, and `streamReply` cannot
+ *      distinguish a gate rejection from a transient Slack error, so a
+ *      gate-rejected stream must never be auto-redelivered. The partial message
+ *      that landed is the same best-effort outcome as before;
+ *    - process CRASHES mid-stream → neither mark runs, the obligation stays
+ *      `pending`, and the boot-drain / poller redelivers the full text as a fresh
+ *      `chat.postMessage` (the partial streamed message is orphaned).
+ *
+ *  Throws `DurableUnavailableError` BEFORE recording if the session can't be
+ *  activated or holds no lease — the caller then streams best-effort, no net
+ *  (prior behavior). Mirrors `deliverReplyDurably`'s activate→lease→record
+ *  prologue; the difference is the send is the caller's progressive stream, not
+ *  an inline post, so this only records + hands back the resolve hooks. */
+export async function beginDurableStream(
+  deps: { supervisor: SessionSupervisor },
+  reply: DurableStream,
+): Promise<DurableStreamHandle> {
+  let handle: SessionHandle
+  try {
+    handle = await deps.supervisor.activate({ channel: reply.channel, thread: reply.thread })
+  } catch (err) {
+    throw new DurableUnavailableError(
+      `cannot activate session: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  const lease = handle.lease
+  if (lease === null) throw new DurableUnavailableError('session holds no lease')
+  const token = lease.token
+
+  // Record the full-text obligation BEFORE the stream starts (crash-before /
+  // crash-during-stream safe).
+  await handle.recordTerminalDelivery(token, {
+    id: reply.id,
+    channel: reply.channel,
+    thread: reply.thread,
+    payload: reply.text,
+  })
+
+  return {
+    markDelivered(): Promise<void> {
+      return markObligation(handle, token, reply.id, { state: 'delivered', attempts: 1 })
+    },
+    markDead(reason: string): Promise<void> {
+      return markObligation(handle, token, reply.id, { state: 'dead', attempts: 1, lastError: reason })
+    },
+  }
+}
+
 /** Best-effort fenced patch of one obligation's state. Never throws: a fenced /
  *  save failure leaves the obligation as-is for the poller to reconcile (see
  *  `deliverReplyDurably`). */

--- a/plugins/mcp/slack-channel/supervisor.ts
+++ b/plugins/mcp/slack-channel/supervisor.ts
@@ -547,6 +547,12 @@ export interface SupervisorOptions {
    *  session lifecycle (audit-journal-architecture.md invariant: broken
    *  journal MUST NOT take down the hot path). */
   journal?: JournalWriter
+  /** Global backpressure cap on concurrently-live sessions (ccsc-4e9bf). When
+   *  set, `activate()` REJECTS a NEW session once `live + in-flight` is at the
+   *  cap, so a burst (e.g. a runaway multi-agent channel) can't exhaust file
+   *  handles / memory. Reactivating an already-live session is never capped.
+   *  Absent → unlimited (default; behavior unchanged). */
+  maxConcurrentSessions?: number
 }
 
 /** Default idle threshold: 4 hours in ms. Documented in
@@ -568,6 +574,19 @@ export function resolveIdleMs(env: Record<string, string | undefined> = process.
   if (raw === undefined || raw === '') return DEFAULT_IDLE_MS
   const parsed = Number(raw)
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_IDLE_MS
+  return Math.floor(parsed)
+}
+
+/** Parse `SLACK_MAX_CONCURRENT_SESSIONS` (ccsc-4e9bf) → a positive integer cap,
+ *  or `undefined` (= unlimited) when unset/empty/non-numeric/non-positive. Same
+ *  pure-relative-to-`env` contract as `resolveIdleMs`. */
+export function resolveMaxConcurrentSessions(
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  const raw = env.SLACK_MAX_CONCURRENT_SESSIONS
+  if (raw === undefined || raw === '') return undefined
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined
   return Math.floor(parsed)
 }
 
@@ -603,7 +622,7 @@ export function createSessionSupervisor(opts: SupervisorOptions): SessionSupervi
   const leaseTtlMs = opts.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS
   const ownerId =
     opts.ownerId ?? `slack-supervisor-${typeof process !== 'undefined' ? process.pid : 0}`
-  const { stateRoot, journal } = opts
+  const { stateRoot, journal, maxConcurrentSessions } = opts
 
   // Process-monotonic lease token source (ccsc-o7x.1.1). Every acquisition gets
   // a strictly higher token than any prior one across all keys, so a superseded
@@ -654,10 +673,12 @@ export function createSessionSupervisor(opts: SupervisorOptions): SessionSupervi
   const activating = new Map<string, Promise<SessionHandle>>()
 
   function keyId(k: SessionKey): string {
-    // `\0` is not a legal character in a Slack channel/ts string, so it
-    // is safe as a separator. Avoids the `"C1:T1" vs "C:1T1"` collision
-    // you would get with a single-colon join.
-    return `${k.channel}\0${k.thread}`
+    // `\0` is not a legal character in a Slack channel/ts/user string, so it
+    // is safe as a separator. Avoids the `"C1:T1" vs "C:1T1"` collision you
+    // would get with a single-colon join. The trailing userId segment (empty
+    // when absent) keeps a per-user key (ccsc-kl410) from ever colliding with
+    // the shared (channel, thread) key.
+    return `${k.channel}\0${k.thread}\0${k.userId ?? ''}`
   }
 
   async function doActivate(
@@ -781,6 +802,47 @@ export function createSessionSupervisor(opts: SupervisorOptions): SessionSupervi
       const inflight = activating.get(id)
       if (inflight !== undefined) {
         return inflight
+      }
+
+      // ccsc-4e9bf — global backpressure. A genuinely NEW session is refused
+      // once live + in-flight activations are at the cap, so a runaway burst
+      // can't exhaust resources. The load-shed decision is BOTH logged (operator
+      // stderr) and journaled (audit record of the refusal, per the ccsc-4e9bf
+      // acceptance criteria). The caller (deliverEvent) logs + drops the message.
+      if (maxConcurrentSessions !== undefined) {
+        // Count DISTINCT in-progress sessions. A key whose doActivate has
+        // already resolved is briefly in BOTH `live` and `activating` (the
+        // .finally cleanup runs a microtask later), so `live.size +
+        // activating.size` would double-count it and could reject spuriously
+        // near the cap (Gemini, PR #250). Count in-flight keys not yet in
+        // `live`, plus live. `activating` is small (concurrent activations).
+        let inFlightNew = 0
+        for (const k of activating.keys()) if (!live.has(k)) inFlightNew++
+        const active = live.size + inFlightNew
+        if (active >= maxConcurrentSessions) {
+          log('session.activate_rejected', {
+            channel: key.channel,
+            thread: key.thread,
+            reason: 'max_concurrent_sessions',
+            active,
+            cap: maxConcurrentSessions,
+          })
+          // Fire-and-forget: the journal must never block the hot path (audit-
+          // journal-architecture.md invariant); journalWrite is internally
+          // resilient and swallows its own failures.
+          void journalWrite({
+            kind: 'session.activate_rejected',
+            outcome: 'deny',
+            actor: 'system',
+            sessionKey: key,
+            reason: `maxConcurrentSessions cap (${maxConcurrentSessions}) reached; active=${active}`,
+          })
+          return Promise.reject(
+            new Error(
+              `SessionSupervisor.activate: at maxConcurrentSessions cap (${maxConcurrentSessions})`,
+            ),
+          )
+        }
       }
 
       const promise = doActivate(key, initialOwnerId).finally(() => {


### PR DESCRIPTION
Automated external-plugin sync output for **beads-dolt** (`jeremylongshore/beads-dolt`), triggered after #892 registered it in `sources.yaml`.

Mirrors 19 files into `plugins/mcp/beads-dolt/` (skill + 5 agents + 6 scripts + `.mcp.json` + manifests + references), writes `.source.json`, and auto-adds the catalog entry to `marketplace.extended.json` (propagated to `marketplace.json`).

Created manually because the `sync-external.yml` PR-create step's idempotency check (`gh pr view sync/external-plugins`) matched a prior **merged** PR (#875) on the reused branch and skipped opening a new one — a recurring workflow bug worth a follow-up fix.

- Jeremy Longshore
intentsolutions.io

[skip auto-bump]