### PR TITLE
fix(sync-external): harden the external-plugin sync pipeline (8 of 16 audited bugs)

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -32,6 +32,15 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize sync runs so a weekly cron + a repository_dispatch (or two
+# dispatches) never execute concurrently. Combined with the unique per-run
+# branch in the Create-PR step, this guarantees no run can clobber another's
+# in-flight work. Do NOT cancel-in-progress: a half-finished sync should
+# complete and open its PR rather than be killed mid-write.
+concurrency:
+  group: sync-external
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -107,7 +116,13 @@ jobs:
         # creates is reviewable, so allowing lockfile updates is safe.
         run: |
           pnpm install --no-frozen-lockfile
-          node scripts/sync-marketplace.cjs
+          # Full derivation, not just the CLI catalog: `pnpm run sync-marketplace`
+          # also runs generate-plugin-package-jsons.mjs (a freshly-synced plugin
+          # needs its package.json for the catalog-invariant gate) and
+          # generate-readme-toc.mjs (the README AUTO-TOC must include the new
+          # entry or the "Verify README TOC" gate fails). Running only
+          # sync-marketplace.cjs skipped both and red-failed every new plugin.
+          pnpm run sync-marketplace
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
@@ -123,14 +138,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BRANCH="sync/external-plugins"
+          # Unique per-run branch. Fixes three bugs at once:
+          #  - no force-push of a SHARED branch, so a concurrent/later sync run
+          #    can't clobber an in-flight PR (the bug that wiped the beads-dolt PR);
+          #  - the `automation/` prefix makes auto-bump-on-pr.yml skip the PR, so
+          #    synced plugin versions no longer drift vs their catalog entry;
+          #  - a unique name can never match an OLD merged PR, so the gh-pr-view
+          #    guard below reliably opens a fresh PR instead of stranding the sync.
+          BRANCH="automation/sync-external-${{ github.run_id }}"
 
           # Configure committer identity for the automated commit
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Branch from current main, force-push (idempotent across re-runs)
-          git checkout -B "$BRANCH"
+          git switch -c "$BRANCH"
 
           # Stage everything the sync wrote, then commit WITHOUT running pre-commit
           # hooks (--no-verify). The auto-PR runs through normal CI on the PR side.
@@ -140,10 +161,11 @@ jobs:
           Automated sync from external plugin sources.
           See sources.yaml for configured sources."
 
-          git push --force-with-lease origin "$BRANCH"
+          git push origin "$BRANCH"
 
-          # Create the PR if one doesn't exist on this branch yet; otherwise the
-          # branch update above is enough — the existing PR shows the new commits.
+          # Open the PR. The per-run branch is unique, so this guard never matches
+          # a prior PR (the old reuse bug matched an already-MERGED PR on the
+          # shared branch and silently skipped creation, stranding the sync).
           if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr create \
               --title "🔄 Sync external plugins" \

--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -148,13 +148,19 @@ function walkFiles(baseDir, relPrefix = '') {
       out.push(...walkFiles(abs, rel));
     } else if (ent.isFile()) {
       let content;
+      let mode;
       try {
-        content = fs.readFileSync(abs, 'utf8');
+        // Read as a Buffer (not utf8) so exact bytes survive the round-trip —
+        // utf8 re-encoding silently corrupts binaries. Capture the upstream
+        // file mode so the executable bit can be restored on write (the
+        // "Check plugin structure" gate requires scripts/*.sh to stay +x).
+        content = fs.readFileSync(abs);
+        mode = fs.statSync(abs).mode;
       } catch {
-        // Binary or unreadable; skip
+        // Unreadable; skip
         continue;
       }
-      out.push({ path: rel, content });
+      out.push({ path: rel, content, mode });
     }
   }
   return out;
@@ -441,7 +447,10 @@ function ensureCatalogEntry(source) {
   const before = text.slice(0, closeMatch.index);
   const lastEntryClose = closeMatch[1];
   const arrayClose = closeMatch[2];
-  const updated = `${before}${lastEntryClose.replace(/}(\s*)$/, '},$1')}${entryJson}${arrayClose}`;
+  // Insert a newline between the prior entry's `},` and the new entry so the
+  // seam is `},\n    {` (matching the file's canonical formatting) instead of
+  // jamming them onto one line as `},    {`, which the catalog-format gate flags.
+  const updated = `${before}${lastEntryClose.replace(/}(\s*)$/, '},')}\n${entryJson}${arrayClose}`;
 
   fs.writeFileSync(CATALOG_FILE, updated);
   log(`   📋 Added catalog entry: ${source.name}`, colors.green);
@@ -491,8 +500,11 @@ async function syncSource(source, config) {
       let reason = 'new';
 
       if (fs.existsSync(targetPath)) {
-        const existingContent = fs.readFileSync(targetPath, 'utf8');
-        if (existingContent !== file.content) {
+        // Buffer-to-Buffer compare. file.content is now a Buffer; comparing it
+        // against a utf8 string would ALWAYS be unequal, marking every synced
+        // file "modified" on every run (churning all sources + bloating diffs).
+        const existingContent = fs.readFileSync(targetPath);
+        if (!existingContent.equals(file.content)) {
           needsUpdate = true;
           reason = 'modified';
         }
@@ -508,6 +520,10 @@ async function syncSource(source, config) {
             fs.mkdirSync(targetDir, { recursive: true });
           }
           fs.writeFileSync(targetPath, file.content);
+          // Restore the upstream file mode (rwx bits) so executable scripts
+          // stay executable — git records 100755 and the structure gate passes.
+          // A non-executable upstream file (e.g. 0644 README) is preserved as-is.
+          if (typeof file.mode === 'number') fs.chmodSync(targetPath, file.mode & 0o777);
           log(`   ✅ ${reason === 'new' ? 'Created' : 'Updated'}: ${file.path}`, colors.green);
         }
         changes.push({ path: file.path, action: reason });


### PR DESCRIPTION
Hardens the external-plugin sync pipeline after a multi-agent audit (55 agents; every fix adversarially verified by 3 skeptics each). These are the failures that made the **beads-dolt** sync unlandable (it was ultimately vendored — #895).

## Why the triple-check mattered — traps caught before they shipped

- The `+x` fix coupled a Buffer read that left change-detection comparing Buffer-vs-string → would have marked **all ~60 plugins "modified" every run**. → revised to Buffer `.equals()` (regression-tested).
- The markdownlint "durable fix" used a **non-existent `--ignore` flag**. → rejected.
- A proposed `catalog == package.json` version invariant would have **hard-failed 433/452 plugins**. → rejected.
- The catalog-seam "robust rewrite" would have blown the **+400-line catalog-format CI budget**. → revised to a 1-char newline insert.

## Fixed here (8 of 16)

**`scripts/sync-external.mjs`**
- `walkFiles` reads content as a **Buffer** (not utf8) + captures upstream `mode` → fixes silent **binary corruption** + enables `+x` restore.
- change-detection compares **`Buffer.equals()`** → unchanged files aren't re-written every run. *Dry-run regression-tested: an already-synced source reports "No changes detected."*
- `fs.chmodSync(target, mode & 0o777)` after write → `scripts/*.sh` stay `100755` ("Check plugin structure" gate); `0644` files unchanged.
- `ensureCatalogEntry` seam is now `},\n    {` not `},    {`.

**`.github/workflows/sync-external.yml`**
- post-sync runs the **full `pnpm run sync-marketplace`** (catalog + `generate-plugin-package-jsons.mjs` + `generate-readme-toc.mjs`) → fixes missing-`package.json` (catalog-invariant) + stale-TOC gates.
- PR branch → **unique per-run `automation/sync-external-<run_id>`**: no force-push of a shared branch (no clobber), `automation/` prefix makes auto-bump skip it (no version drift), unique name can't match an old merged PR (the `gh pr view` guard reliably opens a fresh PR).
- `concurrency: { group: sync-external, cancel-in-progress: false }` serializes runs.

## The 16 bugs

| Sev | Bug | Status |
|---|---|---|
| blocker | synced `.sh` lose `+x` | ✅ |
| blocker | binary files corrupted (utf8 round-trip) | ✅ |
| blocker | workflow runs only `.cjs` → no `package.json` | ✅ |
| blocker | workflow → stale README TOC | ✅ |
| blocker | markdownlint `ignores` drift | 📋 |
| blocker | ruff no synced-dir exclusion | 📋 |
| blocker | shared-branch force-push clobbers prior sync | ✅ |
| blocker | PR-create guard matches old merged PR | ✅ |
| high | auto-bump version drift on sync PR | ✅ |
| high | malformed catalog `},    {` seam | ✅ |
| high | gitignored synced files dropped | 📋 |
| medium | package.json generator pollutes nested | 📋 |
| medium | mode-only change never corrected | 📋 |
| medium | no orphan prune on upstream removal | 📋 |
| medium | partial sync shipped as clean | 📋 |
| low | matchesPattern extglob silent no-op | 📋 |

## Tracked follow-ups (8)

The remaining 8 (incl. the markdownlint/ruff exclusion-drift blockers — a `sync-lint-ignores.mjs` codegen + drift gate) have verified fixes recorded in the local audit doc `000-docs/691-AT-AUDT-…` (000-docs is gitignored). Happy to do them as a follow-up PR.

`[skip auto-bump]` — no `plugins/**` changes.

- Jeremy Longshore
intentsolutions.io