### PR TITLE
chore: add Greptile advisory code review config (.greptile/)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,65 @@
+{
+  "strictness": 3,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": true,
+  "fixWithAI": true,
+  "confidenceScoreSection": { "included": true },
+  "sequenceDiagramSection": { "included": true },
+  "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\npnpm-lock.yaml\npackage-lock.json\n*.min.js\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite",
+  "rules": [
+    {
+      "id": "no-gate-weakening",
+      "severity": "high",
+      "rule": "The required CI checks (validate, marketplace-validation, the test matrix, gitleaks/trufflehog, CodeQL, eslint/prettier/ruff/markdownlint/shellcheck, unicode-hygiene) are the deterministic merge gate. NEVER suggest lowering a threshold, skipping/deleting/weakening a test or assertion, disabling a security/policy/typecheck, or reducing a coverage/mutation/audit requirement — unless the same PR explicitly replaces it with a stronger equivalent."
+    },
+    {
+      "id": "marketplace-json-is-generated",
+      "severity": "high",
+      "scope": [".claude-plugin/marketplace.json", "**/package.json", "README.md"],
+      "rule": "`.claude-plugin/marketplace.json` is AUTO-GENERATED from `.claude-plugin/marketplace.extended.json` by `pnpm run sync-marketplace`; the same step regenerates plugin package.json files and the README AUTO-TOC block. Never hand-edit a generated file. A diff that edits marketplace.json directly (without the corresponding marketplace.extended.json change) is a bug — CI's drift gate rejects it."
+    },
+    {
+      "id": "required-fields-authoritative",
+      "severity": "high",
+      "scope": ["scripts/validate-skills-schema.py", "000-docs/SCHEMA_CHANGELOG.md"],
+      "rule": "The IS 8-field ALWAYS_REQUIRED set (name, description, allowed-tools, version, author, license, compatibility, tags) is authoritative; at marketplace tier a missing required field is an ERROR, not a warning. Do not suggest reducing the required set, demoting marketplace errors to warnings, or realigning to Anthropic's permissive floor. Changes to required-fields / tier model / error-vs-warning semantics are approval-gated (see SCHEMA_CHANGELOG NON-NEGOTIABLES)."
+    },
+    {
+      "id": "kernel-pin-frozen-during-soak",
+      "severity": "high",
+      "rule": "The `@intentsolutions/core` kernel pin is frozen at an exact version (no ^/~) during the validator-cutover soak. Do not suggest bumping it, and do not suggest flipping the kernel-shadow or kernel-vendor-hash CI lanes from advisory (continue-on-error) to blocking — that promotion is gated by a separate documented checklist, not a code change."
+    },
+    {
+      "id": "agent-vs-skill-tool-fields",
+      "severity": "medium",
+      "scope": ["plugins/**/agents/*.md", "plugins/**/skills/**/SKILL.md", "agents/*.md"],
+      "rule": "Agents use `tools` (allowlist) + `disallowedTools` (camelCase denylist); skills use `allowed-tools` (kebab allowlist) + optional `disallowed-tools` (kebab denylist). Flag camelCase `disallowedTools` on a skill or kebab `disallowed-tools` on an agent — the validator rejects the mismatch. Authored agents are kernel-strict; banned fields (capabilities, expertise_level, activation_priority, type, category, compatible-with, when_to_use) are errors. An agent body invoking an `mcp__server__tool` not in its `tools` allowlist is an error."
+    },
+    {
+      "id": "no-secrets-no-unicode-trapdoors",
+      "severity": "high",
+      "rule": "No hardcoded secrets, API keys, or tokens in any committed file — including 'for testing' (use tests/fixtures stub servers). No Unicode trapdoors: tag chars (U+E0000-E007F) or bidirectional overrides (CVE-2021-42574 Trojan Source) in SKILL.md / plugin.json / agent / command files are blocked by the unicode-hygiene gate."
+    },
+    {
+      "id": "do-not-rename-canonical-ids",
+      "severity": "high",
+      "rule": "Do not 'normalize' or rename the canonical identifiers: GitHub repo `jeremylongshore/claude-code-plugins-plus-skills`, marketplace catalog id `claude-code-plugins-plus`, or the public install slug `jeremylongshore/claude-code-plugins` (legacy, hardcoded in the CLI, hero snippet, and hundreds of READMEs — renaming is a breaking API change)."
+    },
+    {
+      "id": "marketplace-design-and-build-invariants",
+      "severity": "medium",
+      "scope": ["marketplace/**"],
+      "rule": "Marketplace CSS uses OKLCH colors only — never hex/rgb (marketplace/DESIGN.md). Reject gradients on cards, glassmorphism, drop-shadow stacks, hover:scale on whole cards. `compressHTML` stays disabled in astro.config.mjs (iOS Safari fails on lines > 5000 chars; CI-enforced). Respect the performance budgets (40MB gzipped, 1MB largest file, 2800-4000 routes)."
+    },
+    {
+      "id": "two-package-manager-policy",
+      "severity": "medium",
+      "rule": "pnpm is the package manager EVERYWHERE except marketplace/, which uses npm (CI-enforced). Flag a pnpm command added under marketplace/ or an npm command in a pnpm workspace. Runtime floor is Node >= 20 (Node 18 causes silent workspace-resolution failures)."
+    },
+    {
+      "id": "no-generated-artifacts-committed",
+      "severity": "medium",
+      "rule": "Do not commit generated artifacts: marketplace/public/downloads/ (gitignored, rebuilt in CI from the catalog), marketplace/dist/, or the derived .claude-plugin/marketplace.json. CI rebuilds these from source; committing them leaks local state to prod."
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,32 @@
+{
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "description": "The repo's operating contract: two-catalog system, build pipeline, validator + kernel-SSoT posture, do-not-flip soak discipline, required SKILL.md frontmatter, and the canonical identifiers that must never be renamed."
+    },
+    {
+      "path": "AGENTS.md",
+      "description": "Session protocol — post-compaction recovery, end-of-session push checklist, beads workflow."
+    },
+    {
+      "path": "000-docs/SCHEMA_CHANGELOG.md",
+      "description": "The NON-NEGOTIABLES: the 8-field ALWAYS_REQUIRED set, marketplace-tier error-vs-warning semantics, and which changes are approval-gated."
+    },
+    {
+      "path": "scripts/validate-skills-schema.py",
+      "description": "The authoritative prose-spec validator — the canonical merge gate for frontmatter and markdown body sections, plus the kernel-strict agent gate."
+    },
+    {
+      "path": ".github/workflows/validate-plugins.yml",
+      "description": "The CI gate definitions: plugin structure, catalog invariants, README-TOC sync, and the lint/test matrix."
+    },
+    {
+      "path": "marketplace/DESIGN.md",
+      "description": "The marketplace design constitution — OKLCH-only colors, the Data-Dense Pro family, and explicitly rejected UI patterns."
+    },
+    {
+      "path": "000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md",
+      "description": "The IS enterprise / marketplace skills standard (v3.x) that the validator enforces."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,32 @@
+# claude-code-plugins ("Tons of Skills") — review context for Greptile
+
+This repo is the **Tons of Skills** marketplace for Claude Code plugins and skills (live at https://tonsofskills.com). It is three things at once:
+
+1. A **catalog** of AI-instruction plugins, MCP-server plugins, skills, agents, and SaaS skill-packs under `plugins/` (~450 entries).
+2. A **validator + CI gate system** (`scripts/validate-skills-schema.py` and friends) that grades every authored artifact against the IS marketplace standard.
+3. An **Astro website** (`marketplace/`) that renders the catalog.
+
+## Architecture you must respect
+
+- **Two-catalog system.** `.claude-plugin/marketplace.extended.json` is the **source of truth** (edit this). `.claude-plugin/marketplace.json` is **auto-generated** by `pnpm run sync-marketplace` — never hand-edit it; CI's drift gate rejects divergence. The same step generates plugin `package.json`s and the README AUTO-TOC block.
+- **The prose-spec validator is authoritative.** `scripts/validate-skills-schema.py` is the canonical gate. The `@intentsolutions/core` kernel is the SSoT being migrated to, currently in an **advisory soak** — do not promote the kernel CI lanes from advisory to blocking, and do not bump the frozen kernel pin.
+- **External-sync pipeline.** `sources.yaml` + `scripts/sync-external.mjs` mirror external plugin repos into `plugins/`; synced plugins carry a `.source.json` marker.
+- **Package managers:** pnpm everywhere **except `marketplace/` (npm)**, CI-enforced. Node >= 20 (Node 18 breaks workspace resolution).
+
+## Prioritize (in order)
+
+- **Correctness** — especially in the validator, the sync engine (`scripts/sync-external.mjs`), the marketplace build pipeline, and the CLI (`packages/cli`).
+- **Security** — secrets (gitleaks/trufflehog), Unicode trapdoors (Trojan Source / bidi overrides), supply-chain, and prompt/tool safety in agent & skill definitions.
+- **Gate integrity** — never weaken a CI threshold, test, or assertion (see the `no-gate-weakening` rule).
+- **Catalog & data integrity** — generated-vs-source drift, required-fields / tier semantics, kernel-soak discipline.
+- **Regression risk** across the ~450 catalog entries when a change touches shared scripts or config.
+
+## Deprioritize
+
+- Style-only or subjective-naming comments — eslint, prettier, ruff, markdownlint, and the Python validators already cover these.
+- Churn on generated files: `.claude-plugin/marketplace.json`, generated `package.json`s, the README TOC, `marketplace/dist/`, `marketplace/public/downloads/`.
+- Comments that merely duplicate an existing linter or typechecker.
+
+## Related repos (multi-repo context)
+
+This repo depends on **`@intentsolutions/core`** (the authoring-schema kernel SSoT — a separate package/repo) and deploys to tonsofskills.com via the **intentsolutions-vps-runbook** repo. Greptile's current config schema does not expose a multi-repo `patternRepositories` key, so these are noted here for reviewer context rather than wired into `config.json`.


### PR DESCRIPTION
Adds the current **`.greptile/`** directory config for Greptile AI code review, tailored to this repo.

## What was added

- **`.greptile/config.json`** — `strictness: 3`, `commentTypes: ["logic","syntax"]`, `triggerOnUpdates: true`, `fixWithAI: true`, confidence-score + sequence-diagram sections, an `ignorePatterns` block, and **10 repo-specific structured `rules`**.
- **`.greptile/rules.md`** — reviewer context (what the repo is, the two-catalog architecture, the validator/kernel-soak posture, what to prioritize/deprioritize).
- **`.greptile/files.json`** — 7 design/context files for the reviewer.

## Schema / docs checked

Confirmed against **https://www.greptile.com/docs/code-review/greptile-config**. Notes on key support:

- **Used (docs-confirmed):** `strictness`, `commentTypes`, `triggerOnUpdates`, `rules` (`id`/`rule`/`severity`/`scope`), `ignorePatterns`.
- **Used (in the deployed `claude-code-slack-channel/.greptile/` baseline; docs say config.json "inherits all legacy `greptile.json` fields" but don't enumerate these):** `fixWithAI`, `confidenceScoreSection`, `sequenceDiagramSection`. Flagging the doc gap explicitly.
- **Omitted as unsupported / not a config key:**
  - `statusCheck` — not in the docs. **Greptile is kept advisory by NOT adding its check to branch-protection required checks** (a settings/dashboard action), not via a config key.
  - `patternRepositories` / `context.repos` — not in the docs. Related repos (`@intentsolutions/core` kernel SSoT, `intentsolutions-vps-runbook` deploy) are documented in `rules.md` instead.

## Repo invariants encoded (10 rules)

`no-gate-weakening` (never weaken a CI threshold/test/assertion) · `marketplace-json-is-generated` (never hand-edit the derived catalog) · `required-fields-authoritative` (8-field set, marketplace errors not warnings, approval-gated) · `kernel-pin-frozen-during-soak` · `agent-vs-skill-tool-fields` (camelCase vs kebab; kernel-strict agents) · `no-secrets-no-unicode-trapdoors` · `do-not-rename-canonical-ids` (install slug / repo / catalog id) · `marketplace-design-and-build-invariants` (OKLCH-only, compressHTML off, perf budgets) · `two-package-manager-policy` (pnpm except marketplace/) · `no-generated-artifacts-committed`.

## files.json references

`CLAUDE.md`, `AGENTS.md`, `000-docs/SCHEMA_CHANGELOG.md`, `scripts/validate-skills-schema.py`, `.github/workflows/validate-plugins.yml`, `marketplace/DESIGN.md`, `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md` — all confirmed to exist and be git-tracked.

## Confirmations

- **Greptile is advisory** — no `statusCheck` key; required merge gate stays this repo's CI.
- **No legacy root `greptile.json`** existed, so nothing to migrate or remove.
- **Validation run:** all three files are valid JSON/markdown; prettier-clean; no secrets or local paths; all `files.json` targets exist + tracked.

## Manual dashboard follow-up (cannot be done in-repo)

- Configure org-wide defaults / enforced rules in the Greptile dashboard if desired.
- Verify training / data opt-out in the dashboard if required.
- Confirm the Greptile status check is **not** marked required in branch protection (keeps it advisory).

`[skip auto-bump]`

- Jeremy Longshore
intentsolutions.io