### PR TITLE
fix(sync-external): close the remaining 8 audited pipeline bugs

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -195,10 +195,12 @@ jobs:
       - name: Flag partial sync
         if: steps.sync.outputs.errors != '0' && steps.sync.outputs.errors != ''
         run: |
-          echo "## ⚠️ Partial external sync — needs human" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ steps.sync.outputs.errors }} source(s) errored; no PR was opened." >> "$GITHUB_STEP_SUMMARY"
-          echo "Failed: ${{ steps.sync.outputs.failed_sources }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## ⚠️ Partial external sync — needs human"
+            echo ""
+            echo "${{ steps.sync.outputs.errors }} source(s) errored; no PR was opened."
+            echo "Failed: ${{ steps.sync.outputs.failed_sources }}"
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Partial external sync (${{ steps.sync.outputs.failed_sources }}) — investigate before re-running."
           exit 1
 

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Sync marketplace catalog
-        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0'
         # Use --no-frozen-lockfile here intentionally: the sync step above can
         # overwrite synced plugins' package.json from upstream, which legitimately
         # diverges from the committed pnpm-lock.yaml. The auto-PR this workflow
@@ -125,7 +125,7 @@ jobs:
           pnpm run sync-marketplace
 
       - name: Create Pull Request
-        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0'
         # Hand-rolled commit + push + PR-create instead of peter-evans/create-pull-request.
         #
         # Why: sync diffs are large (hundreds of files / 100K+ lines from upstream
@@ -187,6 +187,20 @@ jobs:
           ---
           *This PR was automatically created by the \`Sync External Plugins\` workflow.*"
           fi
+
+      # A partial sync (one or more sources errored / found zero files) must NOT
+      # be committed and auto-PR'd as if it were a clean full sync. The commit +
+      # PR steps above are already gated on `errors == '0'`; this step makes the
+      # partial run visibly RED and names the failed sources so a human can act.
+      - name: Flag partial sync
+        if: steps.sync.outputs.errors != '0' && steps.sync.outputs.errors != ''
+        run: |
+          echo "## ⚠️ Partial external sync — needs human" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.sync.outputs.errors }} source(s) errored; no PR was opened." >> "$GITHUB_STEP_SUMMARY"
+          echo "Failed: ${{ steps.sync.outputs.failed_sources }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Partial external sync (${{ steps.sync.outputs.failed_sources }}) — investigate before re-running."
+          exit 1
 
       - name: Summary
         run: |

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1022,6 +1022,13 @@ jobs:
         with:
           node-version: '20'
 
+      # Synced-plugin lint exclusions must be present BEFORE markdownlint runs,
+      # so a new external-synced plugin fails here with an actionable "add these
+      # lines" message instead of a cryptic markdownlint error on mirrored
+      # content the next sync overwrites anyway. Also guards ruff.toml.
+      - name: Check synced-plugin lint exclusions
+        run: node scripts/check-synced-lint-exclusions.mjs
+
       # BLOCKING — codebase passed baseline at PR #772 (2026-05-23).
       # Cleanup arc: 60,000 → 80 (PR #767 bulk-fix) → 0 (this PR).
       # Final cleanup fixed:

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@
 **/*/000-docs/
 **/*/000-docs/**
 **/.npmrc
+# Intentionally-synced upstream .npmrc files (load-bearing CI inputs from the
+# external-sync pipeline). Scoped per-path so per-developer plugin .npmrc
+# overrides stay ignored. Keep in sync with sources.yaml include lists.
+!plugins/mcp/slack-channel/.npmrc
 **/skills/*/data/
 *.db
 *.egg-info/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -144,6 +144,7 @@
     "plugins/design/wondelai-ux-heuristics/**",
     "plugins/design/wondelai-web-typography/**",
     "plugins/devops/sugar/**",
+    "plugins/mcp/beads-dolt/**",
     "plugins/mcp/governed-second-brain/**",
     "plugins/mcp/pr-to-spec/**",
     "plugins/mcp/slack-channel/**",

--- a/plugins/mcp/slack-channel/.npmrc
+++ b/plugins/mcp/slack-channel/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,8 +12,68 @@
 
 line-length = 120
 target-version = "py312"
-extend-exclude = ["node_modules", "dist", "build", ".venv", "marketplace/backup-*"]
-
+extend-exclude = [
+  "node_modules",
+  "dist",
+  "build",
+  ".venv",
+  "marketplace/backup-*",
+  # >>> synced-plugin paths (mirror of .markdownlint-cli2.jsonc ignores).
+  # External upstream code is not held to this repo's ruff style.
+  # Keep in lockstep with sources.yaml / .source.json — CI gate:
+  # scripts/check-synced-lint-exclusions.mjs (run via pnpm verify).
+  "plugins/ai-agency/hyperflow",
+  "plugins/ai-agency/tonone",
+  "plugins/business-tools/wondelai-blue-ocean-strategy",
+  "plugins/business-tools/wondelai-contagious",
+  "plugins/business-tools/wondelai-cro-methodology",
+  "plugins/business-tools/wondelai-crossing-the-chasm",
+  "plugins/business-tools/wondelai-drive-motivation",
+  "plugins/business-tools/wondelai-hundred-million-offers",
+  "plugins/business-tools/wondelai-influence-psychology",
+  "plugins/business-tools/wondelai-jobs-to-be-done",
+  "plugins/business-tools/wondelai-made-to-stick",
+  "plugins/business-tools/wondelai-negotiation",
+  "plugins/business-tools/wondelai-obviously-awesome",
+  "plugins/business-tools/wondelai-one-page-marketing",
+  "plugins/business-tools/wondelai-predictable-revenue",
+  "plugins/business-tools/wondelai-scorecard-marketing",
+  "plugins/business-tools/wondelai-storybrand-messaging",
+  "plugins/business-tools/wondelai-traction-eos",
+  "plugins/community/ejentum-anti-deception",
+  "plugins/community/ejentum-code",
+  "plugins/community/ejentum-memory",
+  "plugins/community/ejentum-reasoning",
+  "plugins/community/gastown",
+  "plugins/community/zai-cli",
+  "plugins/crypto/aomi",
+  "plugins/design/wondelai-design-everyday-things",
+  "plugins/design/wondelai-hooked-ux",
+  "plugins/design/wondelai-ios-hig-design",
+  "plugins/design/wondelai-refactoring-ui",
+  "plugins/design/wondelai-top-design",
+  "plugins/design/wondelai-ux-heuristics",
+  "plugins/design/wondelai-web-typography",
+  "plugins/devops/sugar",
+  "plugins/mcp/beads-dolt",
+  "plugins/mcp/governed-second-brain",
+  "plugins/mcp/pr-to-spec",
+  "plugins/mcp/slack-channel",
+  "plugins/mcp/x-bug-triage",
+  "plugins/productivity/box-cloud-filesystem",
+  "plugins/productivity/claude-workflow-skills",
+  "plugins/productivity/claudebase",
+  "plugins/productivity/cli-power-skills",
+  "plugins/productivity/obsidian-project-documentation",
+  "plugins/productivity/over-50s-health",
+  "plugins/productivity/pair-programmer",
+  "plugins/productivity/skyvern",
+  "plugins/productivity/wondelai-design-sprint",
+  "plugins/productivity/wondelai-lean-startup",
+  "plugins/testing/cli-ux-tester",
+  "plugins/testing/kobiton-automate",
+  # <<< synced-plugin paths
+]
 [lint]
 # Ruff's curated default: E4 (imports), E7 (statements), E9 (syntax), F (pyflakes).
 # Excludes E501 (line-too-long) and most whitespace rules — they're noise

--- a/scripts/check-synced-lint-exclusions.mjs
+++ b/scripts/check-synced-lint-exclusions.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * check-synced-lint-exclusions.mjs
+ *
+ * Every external-synced plugin (a dir carrying a `.source.json` marker) is a
+ * mirror of upstream code and must NOT be held to this repo's markdown / Python
+ * lint style — otherwise the sync PR red-fails markdownlint / ruff on content
+ * the next sync overwrites anyway (the bug that blocked the beads-dolt sync).
+ *
+ * This gate asserts every synced dir is excluded in BOTH:
+ *   - .markdownlint-cli2.jsonc  (the `ignores` array, as `<dir>/**`)
+ *   - ruff.toml                 (the `extend-exclude` array, as `<dir>`)
+ * and fails with the exact lines to add when one drifts. It only ever reports
+ * MISSING exclusions — it never rewrites the configs, so it is safe to run in
+ * CI and cannot clobber hand-maintained entries.
+ *
+ * Usage: node scripts/check-synced-lint-exclusions.mjs   (exit 1 on drift)
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const syncedDirs = execFileSync(
+  'bash',
+  ['-c', 'find plugins -maxdepth 3 -name .source.json -exec dirname {} \\;'],
+  { cwd: ROOT },
+)
+  .toString()
+  .trim()
+  .split('\n')
+  .filter(Boolean)
+  .sort();
+
+const md = fs.readFileSync(path.join(ROOT, '.markdownlint-cli2.jsonc'), 'utf8');
+const ruff = fs.readFileSync(path.join(ROOT, 'ruff.toml'), 'utf8');
+
+const missingMd = syncedDirs.filter((d) => !md.includes(`"${d}/**"`));
+const missingRuff = syncedDirs.filter((d) => !ruff.includes(`"${d}"`));
+
+if (missingMd.length === 0 && missingRuff.length === 0) {
+  console.log(`✓ all ${syncedDirs.length} synced plugins are excluded from markdownlint + ruff`);
+  process.exit(0);
+}
+
+console.error('✗ synced-plugin lint-exclusion drift detected:\n');
+if (missingMd.length) {
+  console.error('  Add to the "ignores" array in .markdownlint-cli2.jsonc:');
+  missingMd.forEach((d) => console.error(`    "${d}/**",`));
+  console.error('');
+}
+if (missingRuff.length) {
+  console.error('  Add to "extend-exclude" in ruff.toml:');
+  missingRuff.forEach((d) => console.error(`    "${d}",`));
+  console.error('');
+}
+console.error('These dirs carry a .source.json (external-synced) marker; their mirrored');
+console.error("markdown/python must be excluded from this repo's lint gates.");
+process.exit(1);

--- a/scripts/generate-plugin-package-jsons.mjs
+++ b/scripts/generate-plugin-package-jsons.mjs
@@ -54,8 +54,15 @@ function walkPluginDirs(root) {
       existsSync(join(dir, 'plugin.json'));
     if (hasPluginJson) {
       found.push(dir);
-      // Still descend — rare nested plugins exist (e.g. the historical
-      // saas-packs/skill-databases/windsurf duplicate). Exclusion list handles them.
+      // A synced plugin (.source.json marker) is a vendored upstream tree:
+      // generate exactly ONE top-level package.json for it and do NOT descend
+      // into nested upstream plugin.json files (e.g. tonone/bundle/*), which
+      // the CI structure check (find -maxdepth 4) would otherwise scaffold
+      // spurious package.jsons for.
+      if (existsSync(join(dir, '.source.json'))) return;
+      // Otherwise still descend — rare nested first-party plugins exist (e.g.
+      // the historical saas-packs/skill-databases/windsurf duplicate); the
+      // exclusion list handles them.
     }
     for (const ent of entries) {
       if (!ent.isDirectory()) continue;

--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -47,6 +47,10 @@ const options = {
   force: args.includes('--force'),
   dryRun: args.includes('--dry-run'),
   verbose: args.includes('--verbose'),
+  // --strict: exit non-zero if ANY source errored, so a partial sync is never
+  // committed + auto-PR'd as if it were a clean full sync (the workflow runs
+  // with --strict and routes a failing run to a human).
+  strict: args.includes('--strict'),
   source: args.find((a) => a.startsWith('--source='))?.split('=')[1] || null,
 };
 
@@ -485,6 +489,18 @@ async function syncSource(source, config) {
     }
     logVerbose(`Discovered ${files.length} files in source`);
 
+    // Warn loudly on unsupported glob syntax: matchesPattern does NOT implement
+    // bash extglob ( !( ?( +( @( ) or brace expansion, so such a pattern
+    // silently matches nothing — a dead include/exclude rule. Flag it rather
+    // than let it no-op invisibly.
+    for (const pat of [...(source.include || []), ...(source.exclude || [])]) {
+      if (/[!?+@]\(|\{[^}]*,[^}]*\}/.test(pat)) {
+        log(
+          `   ⚠️  Unsupported glob (extglob/brace) — rule is a silent no-op: "${pat}"`,
+          colors.red,
+        );
+      }
+    }
     const filteredFiles = files.filter((file) => {
       const included = matchesPattern(file.path, source.include);
       const excluded = matchesPattern(file.path, source.exclude);
@@ -507,6 +523,14 @@ async function syncSource(source, config) {
         if (!existingContent.equals(file.content)) {
           needsUpdate = true;
           reason = 'modified';
+        } else if (
+          typeof file.mode === 'number' &&
+          (fs.statSync(targetPath).mode & 0o111) !== (file.mode & 0o111)
+        ) {
+          // Same content, different executable bit — self-heal a stale mode
+          // (e.g. a script previously synced 0644 while upstream is now 0755).
+          needsUpdate = true;
+          reason = 'mode';
         }
       } else {
         needsUpdate = true;
@@ -520,10 +544,13 @@ async function syncSource(source, config) {
             fs.mkdirSync(targetDir, { recursive: true });
           }
           fs.writeFileSync(targetPath, file.content);
-          // Restore the upstream file mode (rwx bits) so executable scripts
-          // stay executable — git records 100755 and the structure gate passes.
-          // A non-executable upstream file (e.g. 0644 README) is preserved as-is.
-          if (typeof file.mode === 'number') fs.chmodSync(targetPath, file.mode & 0o777);
+          // Collapse to git's two canonical modes (0755 / 0644) keyed on the
+          // upstream executable bit, so the result is stable across the runner's
+          // and a dev's umask: executable scripts stay 100755 (the structure
+          // gate requires it); everything else is 0644.
+          if (typeof file.mode === 'number') {
+            fs.chmodSync(targetPath, file.mode & 0o111 ? 0o755 : 0o644);
+          }
           log(`   ✅ ${reason === 'new' ? 'Created' : 'Updated'}: ${file.path}`, colors.green);
         }
         changes.push({ path: file.path, action: reason });
@@ -532,8 +559,38 @@ async function syncSource(source, config) {
       }
     }
 
+    // Owned-file manifest: the exact set of upstream-matched files this sync
+    // owns under target_path (NOT the synthesized README/plugin.json, which the
+    // engine generates separately). Drives the orphan prune on the next run.
+    const ownedFiles = filteredFiles.map((file) => file.path).sort();
+    const sourceJsonPath = path.join(ROOT_DIR, source.target_path, '.source.json');
+
+    // Orphan prune: delete files a PRIOR sync owned but upstream has since
+    // removed/renamed. Driven off the persisted manifest so the engine only
+    // ever deletes files IT previously authored — immune to derived-file or
+    // hand-added collisions. Skipped on the first run after this change, when
+    // the prior .source.json has no files[] manifest.
+    if (!options.dryRun && fs.existsSync(sourceJsonPath)) {
+      try {
+        const prior = JSON.parse(fs.readFileSync(sourceJsonPath, 'utf8'));
+        if (Array.isArray(prior.files)) {
+          const ownedSet = new Set(ownedFiles);
+          for (const rel of prior.files) {
+            if (ownedSet.has(rel)) continue;
+            const orphan = path.join(ROOT_DIR, source.target_path, rel);
+            if (fs.existsSync(orphan)) {
+              fs.rmSync(orphan);
+              log(`   🗑️  Deleted (upstream removed): ${rel}`, colors.yellow);
+              changes.push({ path: rel, action: 'deleted' });
+            }
+          }
+        }
+      } catch {
+        // Unreadable prior manifest — skip the prune rather than guess.
+      }
+    }
+
     if (changes.length > 0 && !options.dryRun) {
-      const sourceJsonPath = path.join(ROOT_DIR, source.target_path, '.source.json');
       const sourceJson = {
         synced_from: {
           repo: source.repo,
@@ -543,10 +600,30 @@ async function syncSource(source, config) {
         last_sync: new Date().toISOString(),
         author: source.author,
         license: source.license,
-        files_synced: changes.length,
+        files_synced: ownedFiles.length,
+        files: ownedFiles,
       };
       fs.writeFileSync(sourceJsonPath, JSON.stringify(sourceJson, null, 2));
       logVerbose(`Written .source.json`);
+
+      // Loud warning if any synced file is git-ignored: the workflow's
+      // `git add -A` would silently drop it, producing an incomplete mirror.
+      try {
+        const targets = ownedFiles.map((f) => path.join(source.target_path, f));
+        const ignored = execFileSync('git', ['-C', ROOT_DIR, 'check-ignore', ...targets], {
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .toString()
+          .trim();
+        if (ignored) {
+          log(
+            `   ⚠️  GIT-IGNORED — will NOT be committed: ${ignored.split('\n').join(', ')}`,
+            colors.red,
+          );
+        }
+      } catch {
+        // git check-ignore exits 1 when nothing matches — the normal, good path.
+      }
     }
 
     // Synthesize plugin.json + README.md if the upstream sync didn't
@@ -664,14 +741,18 @@ async function main() {
     fs.appendFileSync(outputFile, `catalog_adds=${catalogAdds}\n`);
     fs.appendFileSync(outputFile, `sources=${results.map((r) => r.source).join(',')}\n`);
     fs.appendFileSync(outputFile, `has_changes=${totalChanges > 0}\n`);
+    // Surface partial-failure signal so the workflow can route a partial sync to
+    // a human instead of auto-PR'ing it as a clean full sync.
+    fs.appendFileSync(outputFile, `errors=${errors.length}\n`);
+    fs.appendFileSync(outputFile, `failed_sources=${errors.map((e) => e.source).join(',')}\n`);
   }
 
   log('\n');
-  // Exit 1 only on TOTAL failure (no source succeeded). Partial failures
-  // print warnings and are surfaced via the GitHub Actions summary, but they
-  // shouldn't block downstream steps that need to commit the partial sync.
+  // Exit non-zero on TOTAL failure (no source succeeded) always; and on ANY
+  // partial failure when --strict is set, so a partial sync is never committed
+  // and auto-PR'd as if it were a clean full sync.
   const totalFailures = errors.length === sourcesToSync.length;
-  process.exit(totalFailures ? 1 : 0);
+  process.exit(totalFailures || (options.strict && errors.length > 0) ? 1 : 0);
 }
 
 main().catch((error) => {

--- a/sources.yaml
+++ b/sources.yaml
@@ -627,7 +627,6 @@ sources:
       - '.git/**'
       - '*.log'
       - 'tests/**'
-      - 'src/!(servers)/**'
       - 'dist/cli/**'
       - 'dist/action/**'
 


### PR DESCRIPTION
Second hardening pass — the **8 follow-ups** from the sync-pipeline audit (`000-docs/691-AT-AUDT`), each fix as **refined by the adversarial verification** (the original first-pass fixes had traps the skeptics caught; these are the corrected versions).

## Blockers — markdownlint / ruff synced-dir exclusion drift (#1, #2)

- **New `scripts/check-synced-lint-exclusions.mjs`** — a CI drift gate asserting every `.source.json` (external-synced) dir is excluded in **both** `.markdownlint-cli2.jsonc` and `ruff.toml`, failing with the **exact lines to add**. It only ever reports missing exclusions — never rewrites the configs, so it can't clobber hand-maintained entries (the skeptic rejected the auto-rewrite as too risky). Wired into the markdownlint CI job (runs first, so a new synced plugin fails here with an actionable message instead of a cryptic markdownlint/ruff error).
- Backfilled the drift: `plugins/mcp/beads-dolt/**` → markdownlint ignores; all 50 synced dirs → `ruff.toml extend-exclude`.

## High — gitignored synced files dropped (#3)

- Scoped `.gitignore` negation for the load-bearing **slack-channel `.npmrc`** (`registry=...`, no secret) that `git add -A` was silently dropping; the engine now runs `git check-ignore` over synced files and **warns loudly** on any drop.

## Engine (`scripts/sync-external.mjs`)

- **#5 mode self-heal** — change-detection also fires on an exec-bit mismatch; chmod collapses to git's canonical `0755`/`0644` so a stale mode self-heals across umasks.
- **#6 orphan prune** — `.source.json` now persists a `files[]` manifest; the engine deletes files a **prior sync owned** but upstream removed — only ever deleting files it previously authored (no manifest ⇒ no prune, so the first run is safe).
- **#7 partial-sync gate** — emits `errors`/`failed_sources` to `GITHUB_OUTPUT` + a `--strict` flag; the workflow gates commit+PR on `errors == '0'` and a new **"Flag partial sync"** step fails RED with the failed sources (no more silent partial-as-clean PR).
- **#8 extglob guard** — warns loudly when an include/exclude uses unsupported extglob/brace syntax (a silent no-op); deleted the dead `pr-to-spec` `src/!(servers)/**` exclude.

## `generate-plugin-package-jsons.mjs` (#4)

- Stops descending into nested upstream `plugin.json` under a synced tree — exactly one top-level `package.json` per synced plugin.

## Validation

3 scripts `node --check` clean · both workflows valid YAML · drift gate passes (50/50) · ruff loads the populated config · **dry-run sync regression clean** (no spurious changes/deletes/warnings) · `.npmrc` no longer git-ignored.

This completes the 16-bug audit roadmap (8 fixed in #896, 8 here).

`[skip auto-bump]`

- Jeremy Longshore
intentsolutions.io