### PR TITLE
chore: revert AI PR review to Gemini (Greptile paused — quota)

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,19 +1,17 @@
 # Gemini Code Assist GitHub App configuration.
 # https://developers.google.com/gemini-code-assist/docs/customize-review-github
 #
-# Why this exists: every PR was getting an auto-review from gemini-code-assist[bot]
-# that duplicated coverage we already have via our own pr-prescreen workflow
-# (.github/workflows/pr-prescreen.yml) plus the required validate + marketplace-validation
-# checks. The noise overwhelmed real human-authored feedback on contributor PRs.
-#
-# This disables the auto-review and pull-request-opened summaries from the
-# Gemini Code Assist GitHub App. To re-enable, set both flags to false (default).
+# 2026-06-25: re-enabled. Greptile (the 2026-06-23 replacement) is paused after
+# exhausting its 50-review/month quota, so Gemini Code Assist is the active AI
+# reviewer again. `comment_severity_threshold: HIGH` is kept to hold down the
+# review noise that originally motivated disabling it — only HIGH-severity
+# findings are posted; the deterministic CI checks remain the merge gate.
 #
 # This is NOT the same as the run-gemini-cli action (which used to live in
 # .github/workflows/gemini-code-review.yml and was deleted in PR #721).
 
 have_fun: false
 code_review:
-  disable: true
+  disable: false
   comment_severity_threshold: HIGH
-  pull_opened_summary: false
+  pull_opened_summary: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Run `./scripts/quick-test.sh` locally to catch most issues before pushing.
 ### What happens when you open the PR
 
 1. GitHub runs all 15+ validators (`validate-plugins.yml`). **These required checks are the gate** — your PR is mergeable once they're green.
-2. An AI reviewer (**Greptile**) posts inline comments when it's active on the PR. Treat its findings like any review: address them, or reply if you think it got something wrong and a human will weigh in.
+2. An AI reviewer posts inline comments when it's active on the PR. Treat its findings like any review: address them, or reply if you think it got something wrong and a human will weigh in.
 3. A maintainer gets a Slack ping and follows up.
 4. Push fixes; the required checks re-run on each push.
 5. Once the required checks pass and any review threads are resolved, a maintainer reviews and merges.


### PR DESCRIPTION
Greptile (the 2026-06-23 AI-reviewer adoption) is **paused** — the account hit its **50-review/month** quota. This re-enables **Gemini Code Assist** as the active AI reviewer.

## Changes
- **`.gemini/config.yaml`** — `code_review.disable: false`, `pull_opened_summary: true`; kept `comment_severity_threshold: HIGH` to limit the noise that originally motivated disabling it. (The Gemini App is confirmed still installed.)
- **`CONTRIBUTING.md`** — reviewer wording made tool-agnostic ("an AI reviewer"), accurate regardless of which AI is active.

## Kept, not removed
- The **`.greptile/`** config (#897) stays in the repo — dormant while quota is out, reactivates when it resets next month. Nothing to undo there.

## Invariant preserved
Both reviewers are **advisory**; the deterministic merge gate is always the required CI checks — so a paused/quota'd reviewer never blocks a merge.

`[skip auto-bump]`

- Jeremy Longshore
intentsolutions.io