### PR TITLE
fix(ci): auto-bump skips fork PRs (they can't be bumped)

### DIFF
--- a/.github/workflows/auto-bump-on-pr.yml
+++ b/.github/workflows/auto-bump-on-pr.yml
@@ -21,6 +21,10 @@ name: Auto-bump changed plugin patch versions
 # discipline across 400+ plugins while keeping per-PR patch traceability.
 #
 # Skip conditions:
+#   - PR head is a FORK (`head.repo.full_name != github.repository`). Fork PRs
+#     run with a read-only token and their branch lives in the fork, so the
+#     bump's checkout+push-back cannot work — it would only red-fail an otherwise
+#     good external contribution. Skip cleanly instead (maintainer bumps at merge).
 #   - PR head branch starts with `automation/` (avoids self-bumping the
 #     automation/npm-stats and similar generated PRs).
 #   - PR title or body contains `[skip auto-bump]`.
@@ -33,7 +37,7 @@ on:
       - 'packages/**'
 
 permissions:
-  contents: write       # commit bump back to PR branch
+  contents: write # commit bump back to PR branch
   pull-requests: read
 
 concurrency:
@@ -45,6 +49,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.head_ref, 'automation/') &&
       !contains(github.event.pull_request.title, '[skip auto-bump]') &&
       !contains(github.event.pull_request.body, '[skip auto-bump]')


### PR DESCRIPTION
The `bump` (auto-bump-on-pr) job red-fails on **every external contributor's fork PR** that touches `plugins/**` — it checks out `github.head_ref` and pushes a version bump back, but a fork's branch isn't in this repo and the token is read-only, so checkout dies with *"A branch or tag with the name '…' could not be found."* (seen on #842, a fully-validated submission).

Gate the job on `head.repo.full_name == github.repository` so fork PRs **skip cleanly** instead of red-failing. Same-repo PRs are unaffected. Maintainer bumps the version at merge.

`[skip auto-bump]`

- Jeremy Longshore
intentsolutions.io