### PR TITLE
feat(databricks-pack): cost-leak-hunter — first v2 live-detection skill

### DIFF
--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
@@ -116,7 +116,12 @@ report. The price-window join (usage × `list_prices.pricing.default`, matched o
 is the dollar primitive reused by every category query.
 
 ```bash
-databricks api post /api/2.0/sql/statements --json @"${CLAUDE_SKILL_DIR}/scripts/sql/spend-baseline.sql.json"
+# The CLI does NOT expand ${VARS} inside a --json @file, so inject the warehouse
+# id with jq at call time (the static template carries only wait_timeout + statement).
+databricks api post /api/2.0/sql/statements --json "$(
+  jq --arg wh "$DATABRICKS_WAREHOUSE_ID" '. + {warehouse_id: $wh}' \
+    "${CLAUDE_SKILL_DIR}/scripts/sql/spend-baseline.sql.json"
+)"
 ```
 
 The canonical CTE and full per-category SQL live in

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
@@ -241,11 +241,14 @@ dollar impact, annualizes the headline and #1 line, stamps the trailing-30-day w
 end date, and renders the CFO-grokkable report.
 
 ```bash
-jq -s '.' ./leak-*.json | \
+# Per-category results and the rendered report are RUNTIME outputs — they go to
+# a working dir ($OUT), never the skill package. Steps 3–6 wrote leak-*.json here.
+OUT="${OUT:-$(pwd)/cost-leak-out}" && mkdir -p "$OUT"
+jq -s '.' "$OUT"/leak-*.json | \
   python3 "${CLAUDE_SKILL_DIR}/scripts/rank-and-report.py" \
     --monthly-spend 100000 \
     --window-end "$WINDOW_END_DATE" \
-    --out ./cost-leak-report.md
+    --out "$OUT/cost-leak-report.md"
 ```
 
 Use `Glob` to collect the per-category `leak-*.json` results, `Write` the rendered
@@ -255,7 +258,7 @@ output using the verbatim template in
 
 ## Output
 
-- **A CFO-grokkable report file** (`./cost-leak-report.md` in the working dir) leading
+- **A CFO-grokkable report file** (`$OUT/cost-leak-report.md` in the working dir) leading
   with a **split** headline that never sums confirmed and unconfirmed dollars under
   one verb — `### A $<spend>/month workspace is burning **~$<confirmed>/month**
   (confirmed), plus up to **~$<at-risk>/month** pending review` — each with its

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: databricks-cost-leak-hunter
+description: |
+  Hunt down Databricks cost leaks — wasted DBUs, idle clusters, oversized SQL
+  warehouses, and untagged runaway spend — and produce a FinOps cost report.
+  Use when a user asks why their Databricks bill is high, wants to find cost
+  leaks / wasted DBUs / idle clusters, or needs a FinOps cost report.
+  Trigger with "databricks cost", "why is my databricks bill",
+  "find wasted spend", "cost leak".
+allowed-tools: Read, Write, Edit, Bash(databricks:*), Bash(jq:*), Glob, mcp__databricks-workspace-mcp__clusters_get, mcp__databricks-workspace-mcp__clusters_events, mcp__databricks-workspace-mcp__clusters_list, mcp__databricks-workspace-mcp__instance_pools_list, mcp__databricks-workspace-mcp__pipelines_get
+version: 0.1.0
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code, also compatible with Codex
+tags: [saas, databricks, finops, cost]
+---
+
+# Databricks Cost Leak Hunter
+
+Audits a Databricks workspace for real-dollar cost leaks — idle compute, jobs on
+the wrong SKU, overprovisioned clusters, and the Photon premium paid without the
+speedup — then emits a CFO-grokkable, dollar-ranked FinOps remediation report.
+
+## Overview
+
+This skill finds where Databricks money is leaking and how much, in dollars, per
+month. Confirmed-spend figures come from the customer's own `system.billing.usage`
+joined to `system.billing.list_prices` — never an estimate. Two of the four
+categories (overprovisioning, Photon premium) are explicitly modeled/at-risk
+amounts, labeled as such so a CFO never confuses them with recoverable spend. The
+skill surfaces four named leak categories, ranks them by monthly dollar impact, and
+explains each root cause in FinOps language a CFO can act on without an engineer to
+translate.
+
+It is architecturally distinct from the v1 `databricks-cost-tuning` skill: that one
+AUTHORS policy (creates cluster policies, spot configs). This one DETECTS leaks and
+reports them, dollarized and ranked. The math is deterministic — bundled scripts in
+`scripts/` do the arithmetic so the agent never eyeballs numbers — and deep domain
+knowledge lives in `references/` loaded only when a leak needs it.
+
+The skill uses two data planes. Dollar figures come from the **Databricks CLI
+Statement Execution API** (`databricks api post /api/2.0/sql/statements`) reading
+`system.*` — authenticated by the CLI's own `DATABRICKS_HOST`+`DATABRICKS_TOKEN` /
+`databricks auth login`. The live config/event evidence that explains *why* a leak
+exists (auto-termination setting, node type, autoscale floor, pool `min_idle`) comes
+from the custom **`databricks-workspace-mcp`** control-plane tools — the one MCP
+dependency. The SQL produces the number; the workspace MCP turns it into a verified,
+single-config-change fix.
+
+## Prerequisites
+
+Read access to the billing system tables is the hard dependency and the most common
+failure. `system.billing.usage` requires a **metastore-admin grant chain** — the
+skill detects a missing grant upfront and reports it, rather than failing mid-flow.
+
+- **Databricks Premium or Enterprise** workspace with Unity Catalog (system tables
+  are UC-governed; not available on Standard).
+- **Metastore-admin grant chain** on the billing schema, granted by a metastore
+  admin to the running principal:
+  - `GRANT USE CATALOG ON CATALOG system TO <principal>`
+  - `GRANT USE SCHEMA ON SCHEMA system.billing TO <principal>`
+  - `GRANT SELECT ON TABLE system.billing.usage TO <principal>`
+  - `GRANT SELECT ON TABLE system.billing.list_prices TO <principal>`
+- **Compute system schema** for config/utilization corroboration (same chain on
+  `system.compute`): `system.compute.clusters`, `system.compute.node_timeline`.
+- **Databricks CLI** authenticated (`databricks auth login`, or `DATABRICKS_HOST`
+  + `DATABRICKS_TOKEN`) and `jq` for parsing JSON tool output. The dollar queries
+  run through the CLI Statement Execution API — UC enforces the grant chain above.
+- **`DATABRICKS_WAREHOUSE_ID`** env var set to a running SQL warehouse — every
+  statement-execution call (Step 1's probe included) requires it.
+- **`databricks-workspace-mcp` registered** (its own PAT/U2M/M2M auth; PAT
+  unsupported in Databricks-App deployment mode). It reads the live REST API, not
+  `system.*`, so it needs no system-table grants. If it is absent the skill still
+  produces dollar figures but cannot corroborate live config — it then accepts
+  pasted config input.
+
+**Authentication.** The CLI Statement Execution API uses `DATABRICKS_HOST` +
+`DATABRICKS_TOKEN` or `databricks auth login`; UC enforces the metastore grant chain
+on every `system.*` read. The custom `databricks-workspace-mcp` authenticates
+separately via its own PAT / U2M / M2M token. No secrets are hardcoded — all auth
+comes from the environment or the registered MCP server.
+
+Run the upfront grant check before any analysis — see Step 1.
+
+## Instructions
+
+The pipeline is **detect → compute → rank → report**. SQL detection runs through the
+CLI Statement Execution API; config corroboration runs on `databricks-workspace-mcp`;
+the dollar arithmetic runs in `scripts/`; deep knowledge loads from `references/` on
+demand.
+
+### Step 1: Verify the Grant Chain (fail fast, not mid-flow)
+
+Probe the billing tables before anything else. If the probe errors with a
+permission message, STOP and report the exact missing grant — do not continue into
+the leak scans. Requires `DATABRICKS_WAREHOUSE_ID` (a running SQL warehouse).
+
+```bash
+databricks api post /api/2.0/sql/statements --json '{
+  "warehouse_id": "'"$DATABRICKS_WAREHOUSE_ID"'",
+  "statement": "SELECT 1 FROM system.billing.usage LIMIT 1",
+  "wait_timeout": "30s"
+}' | jq -r '.status.state, .status.error.message // "ok"'
+```
+
+If state is not `SUCCEEDED`, load
+[`${CLAUDE_SKILL_DIR}/references/system-tables-setup.md`](references/system-tables-setup.md)
+and report the missing grant chain to the user verbatim. Stop here.
+
+### Step 2: Pull the Spend Baseline
+
+Establish the trailing-30-day total spend so every leak can be expressed as a share
+of a real number, and capture the window's `MAX(usage_date)` to stamp into the
+report. The price-window join (usage × `list_prices.pricing.default`, matched on
+`sku_name` AND `usage_unit` within the price-effective window, `currency_code='USD'`)
+is the dollar primitive reused by every category query.
+
+```bash
+databricks api post /api/2.0/sql/statements --json @"${CLAUDE_SKILL_DIR}/scripts/sql/spend-baseline.sql.json"
+```
+
+The canonical CTE and full per-category SQL live in
+[`${CLAUDE_SKILL_DIR}/references/cost-leak-categories.md`](references/cost-leak-categories.md).
+Load it now — the four detection queries below all reference its `priced` CTE.
+
+### Step 3: Detect Leak 1 — Clusters That Never Auto-Terminate
+
+Join priced All-Purpose usage to `system.compute.clusters`; flag clusters whose
+latest-change `auto_termination_minutes = 0`. Rank by 30-day idle spend. This is
+**confirmed spend** — money actually billed for idle compute.
+
+```sql
+SELECT p.usage_metadata.cluster_id AS cluster_id,
+       COALESCE(c.cluster_name, 'unknown') AS cluster_name,
+       c.auto_termination_minutes,
+       ROUND(SUM(p.usd), 2) AS spend_30d_usd
+FROM priced p
+JOIN cluster_cfg c ON p.usage_metadata.cluster_id = c.cluster_id
+WHERE p.billing_origin_product = 'ALL_PURPOSE'
+  AND c.auto_termination_minutes = 0
+GROUP BY p.usage_metadata.cluster_id, c.cluster_name, c.auto_termination_minutes
+HAVING SUM(p.usd) > 0
+ORDER BY spend_30d_usd DESC;
+```
+
+Corroborate each flagged cluster's live config with `databricks-workspace-mcp`
+`clusters_get` (confirm `autotermination_minutes = 0` right now) and `clusters_events`
+(measure the idle gap between `RUNNING` and `TERMINATING`).
+
+### Step 4: Detect Leak 2 — Scheduled Jobs on All-Purpose Compute
+
+The signature leak: a usage row with a `job_id` in `usage_metadata` AND
+`billing_origin_product = 'ALL_PURPOSE'` (~$0.55/DBU) instead of `JOBS_COMPUTE`
+(~$0.15/DBU). Re-price the same DBUs at the current Jobs rate to compute savings.
+This is **confirmed savings** — a deterministic re-pricing delta. The `jobs_rate`
+CTE is deduped to one USD rate per `usage_unit` so the join cannot fan out (see
+`cost-leak-categories.md`).
+
+```sql
+SELECT p.usage_metadata.job_id AS job_id,
+       ROUND(SUM(p.usd), 2) AS spend_on_all_purpose_30d_usd,
+       ROUND(SUM(p.usd) - SUM(p.usage_quantity * jr.jobs_unit_price), 2)
+         AS potential_savings_30d_usd
+FROM priced p
+JOIN jobs_rate jr ON p.usage_unit = jr.usage_unit
+WHERE p.billing_origin_product = 'ALL_PURPOSE'
+  AND p.usage_metadata.job_id IS NOT NULL
+GROUP BY p.usage_metadata.job_id
+HAVING SUM(p.usd) - SUM(p.usage_quantity * jr.jobs_unit_price) > 0
+ORDER BY potential_savings_30d_usd DESC;
+```
+
+Confirm the live compute type is All-Purpose (not Jobs) with `clusters_list` /
+`clusters_get` (`cluster_source`) before recommending the move. The `job_id` +
+`ALL_PURPOSE` billing signal is itself dollar-accurate; the REST check is
+belt-and-suspenders.
+
+### Step 5: Detect Leak 3 — Overprovisioned Clusters Idling Below Floor
+
+Aggregate mean CPU from `system.compute.node_timeline`, join to 30-day spend, flag
+clusters burning real dollars at chronically low utilization (< 25%). This figure is
+an **estimate** (`est_overprovision = spend × (1 − CPU%)`), not billed waste — it is
+the one modeled number in the pipeline and is labeled `est_*` everywhere.
+
+```sql
+SELECT s.cluster_id,
+       ROUND(u.avg_cpu_pct, 1) AS avg_cpu_pct,
+       ROUND(s.spend_30d_usd, 2) AS spend_30d_usd,
+       ROUND(s.spend_30d_usd * (1 - LEAST(u.avg_cpu_pct,100)/100.0), 2)
+         AS est_overprovision_30d_usd
+FROM spend s
+JOIN util u ON s.cluster_id = u.cluster_id
+WHERE u.avg_cpu_pct < 25 AND s.spend_30d_usd > 0
+ORDER BY est_overprovision_30d_usd DESC;
+```
+
+Corroborate the configured floor with `clusters_get` (REST nested
+`autoscale.min_workers` / `autoscale.max_workers`); for the idle-pool variant use
+`instance_pools_list` (`min_idle_instances` + `stats.idle_count`) — pool waste is NOT
+a billing row.
+
+### Step 6: Detect Leak 4 — Photon Premium Without the Speedup
+
+Photon is **not a column** on `system.compute.clusters`; it is billing-visible via
+the SKU. Isolate usage whose `sku_name ILIKE '%PHOTON%'` and surface the ~2× premium
+portion as the **at-risk** amount — money for review against actual runtime gain, not
+confirmed waste.
+
+```sql
+SELECT p.usage_metadata.cluster_id AS cluster_id,
+       ROUND(SUM(p.usd), 2)        AS photon_spend_30d_usd,
+       ROUND(SUM(p.usd) / 2.0, 2)  AS photon_premium_at_risk_30d_usd
+FROM priced p
+WHERE p.sku_name ILIKE '%PHOTON%'
+  AND p.billing_origin_product IN ('ALL_PURPOSE','JOBS_COMPUTE')
+  AND p.usage_metadata.cluster_id IS NOT NULL
+GROUP BY p.usage_metadata.cluster_id
+HAVING SUM(p.usd) > 0
+ORDER BY photon_premium_at_risk_30d_usd DESC;
+```
+
+Confirm Photon is live and worth keeping with `databricks-workspace-mcp`
+`clusters_get` (REST `runtime_engine` — a config-plane field, not a system column);
+for DLT pipelines use `pipelines_get` (`spec.photon` / `serverless` / `edition`). See
+[`${CLAUDE_SKILL_DIR}/references/dlt-tier-cost-tradeoffs.md`](references/dlt-tier-cost-tradeoffs.md)
+when the leak touches DLT/serverless tiers.
+
+### Step 7: Compute, Rank, and Write the Report
+
+Pass each category's query result to the deterministic ranker — the LLM does NOT do
+the arithmetic. Each leak object carries a `kind` field
+(`confirmed` / `estimated` / `at-risk`) so the renderer can split the headline into
+confirmed-recoverable vs estimated/at-risk-pending-review and stamp a `Confidence`
+column. The script sums per-category figures by kind, ranks descending by monthly
+dollar impact, annualizes the headline and #1 line, stamps the trailing-30-day window
+end date, and renders the CFO-grokkable report.
+
+```bash
+jq -s '.' ./leak-*.json | \
+  python3 "${CLAUDE_SKILL_DIR}/scripts/rank-and-report.py" \
+    --monthly-spend 100000 \
+    --window-end "$WINDOW_END_DATE" \
+    --out ./cost-leak-report.md
+```
+
+Use `Glob` to collect the per-category `leak-*.json` results, `Write` the rendered
+report, and `Edit` it if the user wants the headline spend rescaled. Render the
+output using the verbatim template in
+[`${CLAUDE_SKILL_DIR}/references/cfo-output-format.md`](references/cfo-output-format.md).
+
+## Output
+
+- **A CFO-grokkable report file** (`./cost-leak-report.md` in the working dir) leading
+  with a **split** headline that never sums confirmed and unconfirmed dollars under
+  one verb — `### A $<spend>/month workspace is burning **~$<confirmed>/month**
+  (confirmed), plus up to **~$<at-risk>/month** pending review` — each with its
+  `~$<annualized>/year` companion.
+- **A trailing-30-day window stamp** under the headline
+  (`Trailing 30 days ending <window-end>`) so every figure has an explicit calendar
+  window, not just a `/month` cadence label.
+- **The ranked leak table** with a `Confidence` column
+  (`# | Where it's leaking | $/month | Confidence | The fix`), one row per category,
+  ranked highest dollar impact first, `$/month` right-aligned, each fix a single
+  config change. Root-cause cells use plain-business language — no raw `DBU` unit in
+  the CFO-visible text (DBU detail stays in the per-leak detail artifacts).
+- **The #1-line callout** — the top leak annualized, named, with its confidence, and
+  stated as fixed in one setting.
+- **The assumed-vs-cited disclosure** — only the workspace-spend input is assumed;
+  on a live run confirmed figures are computed from `system.billing.usage`, while
+  overprovision (estimated) and Photon premium (at-risk) are labeled as modeled.
+- **Per-leak detail artifacts**: idle-cluster list, all-purpose-job migration list
+  with per-job savings, overprovisioned-cluster rightsizing list, Photon-premium
+  at-risk list — each with the corroborating live config from `databricks-workspace-mcp`
+  and the underlying `$/DBU` rates for engineers.
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `PERMISSION_DENIED` on `system.billing.usage` | Metastore-admin grant chain missing | Run Step 1; report the exact `GRANT USE CATALOG / USE SCHEMA / SELECT` chain from `system-tables-setup.md`. Stop, do not continue. |
+| CLI not authenticated / token expired | No valid `DATABRICKS_HOST` + token | Re-run `databricks auth login`; verify with `databricks current-user me`. |
+| Empty / unset `DATABRICKS_WAREHOUSE_ID` | Required warehouse for statement execution not set | Set `DATABRICKS_WAREHOUSE_ID` to a running SQL warehouse before Step 1. |
+| `list_prices` join returns NULL `usd` | Custom/negotiated pricing not in `list_prices`, or `usage_unit` mismatch | Join on `sku_name` AND `usage_unit` within the price window with `currency_code='USD'`; if still NULL, use the customer's contracted rate card from `references/cost-leak-categories.md`. |
+| Workspace MCP missing | Server not registered | Degrade gracefully: report it absent, run the dollar half, accept pasted config for corroboration. Never fail silently mid-flow. |
+| `node_timeline` empty for a cluster | Serverless/short-lived compute, or monitoring lag | Skip Leak 3 for that cluster; note "utilization unavailable" rather than reporting $0 overprovision. |
+| Untagged spend / no `cluster_name` | Clusters lack `CostCenter`/`Team` tags | Attribute by `cluster_id`; flag attribution as incomplete in the report footer. |
+
+## Examples
+
+### Example 1: "Why is my Databricks bill high?"
+
+Runs the full pipeline. The grant check passes, the four scans return rows, and the
+ranker emits the CFO report with a split, confidence-stamped headline:
+
+```text
+### A $100K/month Databricks workspace is burning **~$19,000/month** (confirmed), plus up to **~$8,000/month** pending review
+
+Trailing 30 days ending 2026-06-22. Confirmed ~$228K/year; up to ~$96K/year more pending review. Every line below is one config change.
+
+| # | Where it's leaking | $/month | Confidence | The fix |
+|---|---|--:|---|---|
+| 1 | Clusters that never shut themselves off — paying around the clock for compute nobody is using | **$12,000** | Confirmed | Set auto-shutoff (e.g. 30 min) |
+| 2 | Scheduled batch jobs running on the premium notebook tier — ~3.6× the batch rate for identical work | **$7,000** | Confirmed | Move job clusters to the batch tier |
+| 3 | Clusters sized for peak, idling most of the time — typically 30–50% oversized | **$5,000** | Estimated | Turn on autoscaling, drop the floor |
+| 4 | Paying a ~2× speed-engine premium on jobs that don't run faster | **$3,000** | At-risk | Turn off the speed engine where it adds no gain |
+
+**The #1 line alone — idle clusters (confirmed) — is ~$144K/year, fixed in one setting.**
+```
+
+### Example 2: Idle-Cluster Sweep
+
+User asks "find idle clusters wasting money." The skill runs Step 3 only, joins the
+spend to `clusters_get`, and reports each `auto_termination_minutes = 0` cluster with
+its 30-day idle spend and the live idle gap from `clusters_events`.
+
+### Example 3: All-Purpose-Job Rightsizing
+
+User asks "are any jobs on the wrong compute?" Step 4 returns each `job_id` running
+on All-Purpose with `potential_savings_30d_usd`, corroborated by `clusters_get`
+confirming `cluster_source` is not `JOB` — the single fix is "move to Jobs Compute."
+
+## Resources
+
+- [`${CLAUDE_SKILL_DIR}/references/cost-leak-categories.md`](references/cost-leak-categories.md) — the four leak categories: definition, real detection SQL, FinOps root cause, remediation.
+- [`${CLAUDE_SKILL_DIR}/references/cfo-output-format.md`](references/cfo-output-format.md) — verbatim CFO report template + the 90-second-skim rules.
+- [`${CLAUDE_SKILL_DIR}/references/system-tables-setup.md`](references/system-tables-setup.md) — metastore-admin grant chain + access verification.
+- [`${CLAUDE_SKILL_DIR}/references/dlt-tier-cost-tradeoffs.md`](references/dlt-tier-cost-tradeoffs.md) — DLT / serverless / Photon cost-tier encyclopedia, loaded on demand.
+- [Databricks system tables (billing)](https://docs.databricks.com/aws/en/admin/system-tables/billing)
+- [Databricks list_prices reference](https://docs.databricks.com/aws/en/admin/system-tables/pricing)

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/SKILL.md
@@ -63,8 +63,8 @@ skill detects a missing grant upfront and reports it, rather than failing mid-fl
   - `GRANT SELECT ON TABLE system.billing.list_prices TO <principal>`
 - **Compute system schema** for config/utilization corroboration (same chain on
   `system.compute`): `system.compute.clusters`, `system.compute.node_timeline`.
-- **Databricks CLI** authenticated (`databricks auth login`, or `DATABRICKS_HOST`
-  + `DATABRICKS_TOKEN`) and `jq` for parsing JSON tool output. The dollar queries
+- **Databricks CLI** authenticated (`databricks auth login`, or `DATABRICKS_HOST` + `DATABRICKS_TOKEN`)
+  and `jq` for parsing JSON tool output. The dollar queries
   run through the CLI Statement Execution API — UC enforces the grant chain above.
 - **`DATABRICKS_WAREHOUSE_ID`** env var set to a running SQL warehouse — every
   statement-execution call (Step 1's probe included) requires it.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/cfo-output-format.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/cfo-output-format.md
@@ -1,0 +1,136 @@
+# CFO-Grokkable Output Format
+
+This is the verbatim report template the skill emits, plus the rules that make it
+pass the 90-second-skim bar. The grokkability bar: *if a CFO can skim it in 90
+seconds and say "we're wasting $X here, fix it" without needing an engineer to
+translate, it works.* The pattern is one sentence + one proof — and for a CFO the
+proof is a dollar number with an explicit window.
+
+## Two headline variants — sample vs live
+
+The single template can't be honest for both a sample allocation and a live
+measurement, so pick the variant matching the run:
+
+- **Sample run** (no live data): the per-row split is an illustrative allocation of
+  an assumed total. Headline verb: *"is likely burning."*
+- **Live run** (`system.billing.usage` queried): confirmed figures are measured, not
+  guessed. Headline verb: *"is burning"* (drop "likely") for the confirmed half; the
+  at-risk/estimated half keeps a hedge ("up to").
+
+## The verbatim template
+
+### A — Headline block (split confirmed vs pending; the number leads)
+
+Never sum confirmed and unconfirmed dollars under one verb. Split them:
+
+```text
+### A $100K/month Databricks workspace is burning **~$19,000/month** (confirmed), plus up to **~$8,000/month** pending review
+
+Trailing 30 days ending 2026-06-22. Confirmed **~$228K/year**; up to **~$96K/year** more pending review. The single assumed input is the $100K/month spend. Every line below is one config change.
+```
+
+Shape rule: `### A $<total-spend>/month Databricks workspace is burning
+**~$<confirmed-$>/month** (confirmed), plus up to **~$<at-risk+estimated-$>/month**
+pending review` — then a one-line second sentence giving the window stamp, both
+annualized figures, and naming the single assumed input.
+
+### B — The ranked leak table (with Confidence column)
+
+```text
+| # | Where it's leaking | $/month | Confidence | The fix |
+|---|---|--:|---|---|
+| 1 | **Clusters that never shut themselves off** — paying around the clock for compute nobody is using ³ ⁹ | **$12,000** | Confirmed | Set auto-shutoff (e.g. 30 min) |
+| 2 | **Scheduled batch jobs on the premium notebook tier** — ~3.6× the batch rate for identical work ⁴ ⁵ ⁶ | **$7,000** | Confirmed | Move job clusters to the batch tier |
+| 3 | **Clusters sized for peak, idling below threshold** — typically 30–50% oversized ³ ¹⁰ | **$5,000** | Estimated | Turn on autoscaling, drop the floor |
+| 4 | **A ~2× speed-engine premium on jobs that don't run faster** — only pays off at a ≥2× speedup ⁷ ⁶ | **$3,000** | At-risk | Turn off the speed engine where it adds no gain |
+```
+
+Per-row anatomy, in order:
+
+- `#` — rank position (1 = highest $ impact).
+- **Where it's leaking** — bold leak name, em-dash, ONE sentence root cause in
+  business language (NO raw `DBU` unit — gloss or translate it; see rule 4) with
+  cited superscripts.
+- **$/month** — bold dollar figure, right-aligned column (`--:`).
+- **Confidence** — `Confirmed` / `Estimated` / `At-risk`. This is load-bearing: it
+  stops the CFO reading a modeled or pending number as recoverable cash.
+- **The fix** — one single config change (never "N clicks").
+
+### C — The #1-line callout (immediately after the table)
+
+```text
+**The #1 line alone — idle clusters (confirmed) — is ~$144K/year, fixed in one setting.**
+```
+
+Rule: annualize the top leak's monthly figure, name it, include its confidence, state
+it's fixed in one setting.
+
+### D — The assumed-vs-cited disclosure (blockquote)
+
+```text
+> **What's assumed vs. what's measured.** The **$100K/month workspace spend is the only assumed
+> input** (your number goes here). On a live run, the **Confirmed** figures (idle clusters, jobs
+> on the wrong tier) are computed directly from your own `system.billing.usage` table — never
+> estimated. The **Estimated** figure (overprovisioning) is a model of spend × idle-CPU%, and the
+> **At-risk** figure (the speed-engine premium) is the portion pending review against actual
+> runtime gain. The per-row split shown on a sample run is an illustrative allocation, ranked by
+> documented waste-category size.
+```
+
+### E — ROI scale line (optional closer)
+
+```text
+For scale: Nucleus Research measured a **375% ROI / 6-month payback** for one Databricks
+customer ⁸ — the upside of getting the platform's cost posture right is real and independently audited.
+```
+
+### F — Sources section
+
+Numbered footnotes 1–10, each: bold source name, one-line claim,
+primary/authoritative link. Every superscript in the table must resolve to a numbered
+source. **The renderer must emit these** — if a row carries a superscript, the
+Sources block has to render it (do not show superscripts the tooling can't resolve).
+
+## The 90-second-skim rules (enforced)
+
+1. **The number leads.** No problem-statement prose above the fold. If the number is
+   ugly enough, it sells itself.
+2. **One sentence of what each leak is + one DOLLAR number with an explicit window.**
+3. **Ranked by estimated monthly $ impact, highest first** (rank column, `$/month`
+   right-aligned).
+4. **Root cause in BUSINESS language, not Spark or platform jargon.** No raw `DBU` in
+   the CFO-visible cell — `DBU` is the denominator of every dollar here and a CFO does
+   not know it. Translate ("~3.6× the batch rate") or gloss once inline ("DBU =
+   Databricks' billable compute unit"). Keep `$/DBU` detail in the developer detail
+   artifacts, not the top table. No execution-plan / AQE / shuffle terms.
+5. **"Single config change," not "N clicks."**
+6. **Confirmed vs estimated vs at-risk are never summed under one verb.** The headline
+   splits them; the table tags each row. A CFO acting on "confirmed" is on solid
+   ground; "at-risk" is flagged as pending.
+7. **One assumption, everything else cited.** The only invented number is the
+   workspace spend (labeled as such). Rescaling the spend preserves the proportions.
+8. **This is the top-of-funnel hook, NOT the one-pager.** It sits in front of the
+   full developer-facing README.
+
+## Dollar-formatting / window conventions
+
+- **Headline waste figure:** `~$<n>,000/month` with a tilde, dollar bolded:
+  `**~$19,000/month**`.
+- **Always pair monthly with annualized.** Every headline/callout dollar gets a
+  `/year` companion: `~$228K/year`, `~$144K/year`. Monthly uses full digits
+  (`$19,000`); annualized uses `K`-abbreviated (`$228K`).
+- **Explicit window, not just a cadence label.** The report stamps
+  `Trailing 30 days ending <window-end-date>` under the headline — a `/month` label
+  alone does not tell a CFO which 30 days. The window-end date comes from
+  `MAX(usage_date)` (Step 2) and is passed to the renderer as `--window-end`.
+- **Monthly normalization footnote.** The ranker normalizes the raw 30-day SQL figure
+  to a calendar month (`× 365/12/30`, ~1.014×), so the report total is slightly above
+  the raw 30-day sum. Footnote it: "monthly = calendar-month-normalized, not the raw
+  30-day sum."
+- **Per-row table figures:** bold, full digits, right-aligned (`--:`): `**$12,000**`.
+- **Rate citations live in the developer detail, not the CFO table.** Literal per-unit
+  rates (`$0.55/DBU vs $0.15/DBU`, `~2× DBU premium`) belong in the per-leak detail
+  artifacts; the CFO row carries the translated multiple (`~3.6×`, `~2×`).
+- **Live-run override (load-bearing):** the disclosure states that on an actual run
+  the Confirmed dollars are computed from the customer's own `system.billing.usage`
+  table; Estimated and At-risk are labeled as modeled/pending.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/cost-leak-categories.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/cost-leak-categories.md
@@ -1,0 +1,272 @@
+# The Four Cost-Leak Categories
+
+Each category below carries a plain-English definition, the FinOps root cause (why
+the money leaks, in dollar terms, not Spark jargon), the real `system.billing.usage`
+detection SQL, and the single-config-change remediation. All four detection queries
+reuse one price-window join — the `priced` CTE — defined once below.
+
+Confidence tiers (carried into the CFO report's `Confidence` column):
+
+- **Confirmed** (Categories 1, 2): money actually billed, or a deterministic
+  re-pricing delta. Recoverable.
+- **Estimated** (Category 3): a modeled figure (`spend × (1 − CPU%)`), not a billed
+  amount.
+- **At-risk** (Category 4): a premium pending review against actual runtime gain.
+
+## The dollar primitive — the `priced` CTE (reused by every query)
+
+The dollar of any usage row is `usage_quantity * list_prices.pricing.default`, joined
+on `sku_name` AND `usage_unit` within the price-effective window, restricted to
+`currency_code = 'USD'`. `pricing` is a STRUCT (`.default` is its USD-per-unit
+field); `usage_metadata` is a STRUCT carrying `cluster_id` / `job_id` /
+`warehouse_id` / `instance_pool_id`. Joining on `sku_name` alone over-counts — a
+single SKU can be priced in different units, so `usage_unit` in the join is
+load-bearing.
+
+```sql
+WITH priced AS (
+  SELECT
+    u.usage_date,
+    u.sku_name,
+    u.usage_quantity,
+    u.usage_unit,
+    u.billing_origin_product,
+    u.usage_metadata,
+    u.custom_tags,
+    u.usage_quantity * lp.pricing.default AS usd
+  FROM system.billing.usage u
+  JOIN system.billing.list_prices lp
+    ON  u.sku_name   = lp.sku_name
+    AND u.usage_unit = lp.usage_unit
+    AND u.usage_end_time >= lp.price_start_time
+    AND u.usage_end_time <  COALESCE(lp.price_end_time, TIMESTAMP '9999-12-31')
+  WHERE u.usage_date >= current_date() - INTERVAL 30 DAYS
+    AND lp.currency_code = 'USD'
+)
+```
+
+---
+
+## Category 1 — Clusters that never auto-terminate (idle compute) · Confirmed
+
+**Definition.** Interactive clusters left running with `auto_termination_minutes = 0`
+keep billing DBUs around the clock even when no one is attached.
+
+**FinOps root cause.** Idle compute is one of the largest cloud-waste categories;
+utilization on always-on interactive clusters is chronically low. Every idle hour
+bills at the full All-Purpose DBU rate for zero work delivered.
+
+**Detection SQL.** `system.compute.clusters` is change-history (SCD), so take the
+*latest* config row per cluster (not `MAX()` over the window, which would mask a
+cluster that was 0 then fixed).
+
+```sql
+WITH priced AS ( /* …the CTE above… */ ),
+cluster_cfg AS (
+  SELECT cluster_id, cluster_name, auto_termination_minutes,
+         worker_count, min_autoscale_workers, max_autoscale_workers
+  FROM (
+    SELECT cluster_id, cluster_name, auto_termination_minutes,
+           worker_count, min_autoscale_workers, max_autoscale_workers,
+           ROW_NUMBER() OVER (PARTITION BY cluster_id ORDER BY change_time DESC) AS rn
+    FROM system.compute.clusters
+    WHERE change_time >= current_date() - INTERVAL 30 DAYS
+  )
+  WHERE rn = 1
+)
+SELECT
+  p.usage_metadata.cluster_id         AS cluster_id,
+  COALESCE(c.cluster_name, 'unknown') AS cluster_name,
+  c.auto_termination_minutes,
+  ROUND(SUM(p.usd), 2)                AS spend_30d_usd,
+  ROUND(SUM(p.usage_quantity), 2)     AS dbus_30d
+FROM priced p
+JOIN cluster_cfg c ON p.usage_metadata.cluster_id = c.cluster_id
+WHERE p.billing_origin_product = 'ALL_PURPOSE'
+  AND c.auto_termination_minutes = 0
+GROUP BY p.usage_metadata.cluster_id, c.cluster_name, c.auto_termination_minutes
+HAVING SUM(p.usd) > 0
+ORDER BY spend_30d_usd DESC;
+```
+
+**Corroborate.** `databricks-workspace-mcp` → `clusters_get` (live REST
+`autotermination_minutes`), `clusters_events` (idle gap between RUNNING and
+TERMINATING).
+
+**Remediation (single config change).** Set auto-termination (e.g. 30 min) on the
+flagged clusters.
+
+---
+
+## Category 2 — Scheduled jobs on All-Purpose Compute · Confirmed
+
+**Definition.** Pipelines prototyped in interactive notebooks get shipped to prod by
+scheduling them on the same all-purpose cluster instead of a Jobs cluster.
+
+**FinOps root cause.** All-Purpose compute bills at ~$0.55/DBU vs ~$0.15/DBU for Jobs
+Compute — 2–3× more for the same batch work. The premium pays for shared multi-user
+notebook UX a scheduled batch job never uses. The single highest-ROI optimization in
+most deployments.
+
+**Detection SQL.** A row with a `job_id` in `usage_metadata` AND
+`billing_origin_product = 'ALL_PURPOSE'`. Re-price the same DBUs at the current Jobs
+rate to model the savings. **The `jobs_rate` CTE must yield exactly one rate per
+`usage_unit`** — `%JOBS_COMPUTE%` matches multiple SKUs (per-cloud, per-tier,
+serverless vs classic, Photon-jobs), all sharing `usage_unit='DBU'`; joining on
+`usage_unit` against an un-deduped set fans out the join and inflates the math
+non-deterministically. Restrict to `currency_code='USD'` and `GROUP BY usage_unit`
+with `MIN(pricing.default)` to guarantee one deterministic rate per unit.
+
+```sql
+WITH priced AS ( /* …the CTE above… */ ),
+jobs_rate AS (
+  SELECT usage_unit, MIN(pricing.default) AS jobs_unit_price
+  FROM system.billing.list_prices
+  WHERE sku_name ILIKE '%JOBS_COMPUTE%'
+    AND price_end_time IS NULL
+    AND currency_code = 'USD'
+  GROUP BY usage_unit
+)
+SELECT
+  p.usage_metadata.job_id AS job_id,
+  ROUND(SUM(p.usd), 2)    AS spend_on_all_purpose_30d_usd,
+  ROUND(SUM(p.usage_quantity * jr.jobs_unit_price), 2)
+                          AS would_cost_on_jobs_30d_usd,
+  ROUND(SUM(p.usd) - SUM(p.usage_quantity * jr.jobs_unit_price), 2)
+                          AS potential_savings_30d_usd
+FROM priced p
+JOIN jobs_rate jr ON p.usage_unit = jr.usage_unit
+WHERE p.billing_origin_product = 'ALL_PURPOSE'
+  AND p.usage_metadata.job_id IS NOT NULL
+GROUP BY p.usage_metadata.job_id
+HAVING SUM(p.usd) - SUM(p.usage_quantity * jr.jobs_unit_price) > 0
+ORDER BY potential_savings_30d_usd DESC;
+```
+
+**Corroborate.** `clusters_list` / `clusters_get` (`cluster_source`) — confirm the
+live compute type before recommending the move. Note: `job_id` present +
+`billing_origin_product = 'ALL_PURPOSE'` is already the billing-accurate signal; the
+REST check is belt-and-suspenders, not required for the dollar math.
+
+**Remediation (single config change).** Move the job's cluster to Jobs Compute.
+
+---
+
+## Category 3 — Overprovisioned clusters idling below floor · Estimated
+
+**Definition.** Clusters sized for peak load run with most workers idle most of the
+time; production is typically overprovisioned 30–50%. The idle-pool variant is an
+instance pool with `min_idle_instances > 0` keeping warm VMs the cloud bills directly.
+
+**FinOps root cause.** You pay for provisioned capacity, not used capacity. A cluster
+averaging < 25% CPU is burning ~75% of its spend on idle headroom. For pools, the
+Databricks dashboard reads $0 while the cloud provider bills the idle VMs — an
+invisible spend leak hidden by the dual-billing split.
+
+**This figure is a modeled estimate, not billed waste** — `spend × (1 − CPU%)` is an
+upper-bound heuristic. The column is honestly named `est_overprovision_30d_usd` and
+the CFO report tags it `Estimated`.
+
+**Detection SQL.** `system.compute.node_timeline` gives per-node-minute CPU;
+aggregate mean utilization per cluster, join to spend, flag chronic low utilization.
+
+```sql
+WITH priced AS ( /* …the CTE above… */ ),
+util AS (
+  SELECT cluster_id,
+         AVG(cpu_user_percent + cpu_system_percent) AS avg_cpu_pct,
+         COUNT(*)                                    AS node_minutes
+  FROM system.compute.node_timeline
+  WHERE start_time >= current_date() - INTERVAL 30 DAYS
+  GROUP BY cluster_id
+),
+spend AS (
+  SELECT usage_metadata.cluster_id AS cluster_id, SUM(usd) AS spend_30d_usd
+  FROM priced
+  WHERE billing_origin_product IN ('ALL_PURPOSE','JOBS_COMPUTE')
+    AND usage_metadata.cluster_id IS NOT NULL
+  GROUP BY usage_metadata.cluster_id
+)
+SELECT
+  s.cluster_id,
+  ROUND(u.avg_cpu_pct, 1)   AS avg_cpu_pct,
+  ROUND(s.spend_30d_usd, 2) AS spend_30d_usd,
+  ROUND(s.spend_30d_usd * (1 - LEAST(u.avg_cpu_pct,100)/100.0), 2)
+                            AS est_overprovision_30d_usd
+FROM spend s
+JOIN util u ON s.cluster_id = u.cluster_id
+WHERE u.avg_cpu_pct < 25 AND s.spend_30d_usd > 0
+ORDER BY est_overprovision_30d_usd DESC;
+```
+
+**Corroborate.** `clusters_get` (REST nested `autoscale.min_workers` /
+`autoscale.max_workers`); `instance_pools_list` (`min_idle_instances`,
+`stats.idle_count`) for the idle-pool variant. Pool idle waste =
+`min_idle × instance_hourly_rate × 730 hrs/month`.
+
+**Remediation (single config change).** Turn on autoscaling and drop the floor
+(REST `autoscale.min_workers` / pool `min_idle_instances`).
+
+---
+
+## Category 4 — Photon billed where it does not accelerate · At-risk
+
+**Definition.** Photon enabled to "speed things up," but the workload (UDFs, Pandas
+UDFs, RDD APIs) silently falls back to JVM Spark — the cluster still bills the Photon
+premium.
+
+**FinOps root cause.** Photon is a per-cluster (not per-query) billing toggle at a
+~2× DBU multiplier. Every minute the cluster is up bills at the Photon rate
+regardless of how much actually executed in the Photon engine. It only pays back at
+a ≥2× speedup; real reports show ~4× cost for ~1.8× runtime gain.
+
+**Detect Photon via the SKU, not a cluster column.** `system.compute.clusters` has NO
+`runtime_engine` / Photon column. Photon-billed usage is identified by
+`sku_name ILIKE '%PHOTON%'` on the priced usage row — the billing-accurate source.
+The `~2× premium → half of spend` split is an at-risk approximation, not a derived
+base-vs-Photon comparison, hence the `at-risk` tag.
+
+```sql
+WITH priced AS ( /* …the CTE above… */ )
+SELECT
+  p.usage_metadata.cluster_id AS cluster_id,
+  ROUND(SUM(p.usd), 2)        AS photon_spend_30d_usd,
+  ROUND(SUM(p.usd) / 2.0, 2)  AS photon_premium_at_risk_30d_usd
+FROM priced p
+WHERE p.sku_name ILIKE '%PHOTON%'
+  AND p.billing_origin_product IN ('ALL_PURPOSE','JOBS_COMPUTE')
+  AND p.usage_metadata.cluster_id IS NOT NULL
+GROUP BY p.usage_metadata.cluster_id
+HAVING SUM(p.usd) > 0
+ORDER BY photon_premium_at_risk_30d_usd DESC;
+```
+
+**Corroborate.** `databricks-workspace-mcp` `clusters_get` (REST `runtime_engine` —
+a config-plane field, NOT a system-table column); `pipelines_get` (`spec.photon` /
+`serverless` / `edition`) for DLT. See `dlt-tier-cost-tradeoffs.md`.
+
+**Remediation (single config change).** Disable Photon where it adds no runtime gain.
+
+---
+
+## Column-name notes (verify per workspace)
+
+- `system.compute.clusters`: change-history (SCD) config with
+  `auto_termination_minutes`, `worker_count`, `min_autoscale_workers`,
+  `max_autoscale_workers`, `cluster_name`, `cluster_source`, `change_time`. There is
+  **no** `runtime_engine` / Photon column on this table — Photon is detected via
+  `sku_name`. Name columns explicitly, never `SELECT *`.
+- `system.compute.node_timeline`: CPU columns `cpu_user_percent`,
+  `cpu_system_percent`, `cpu_wait_percent`.
+- `billing_origin_product` enum: `ALL_PURPOSE`, `JOBS_COMPUTE`, `SQL`, `DLT`,
+  `MODEL_SERVING`, and others.
+- REST/MCP-only fields (NOT system-table columns): `runtime_engine`,
+  `autotermination_minutes`, nested `autoscale.min_workers` /
+  `autoscale.max_workers`. Use these strictly via `clusters_get` corroboration.
+
+## Reference DBU rate card (illustrative; use the customer's `list_prices`)
+
+- Jobs Compute ~$0.15/DBU
+- SQL Compute ~$0.22/DBU
+- All-Purpose Compute ~$0.40–$0.55/DBU
+- Serverless ~$0.07/DBU (user) / ~$0.70–$0.95/DBU (background features)

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/dlt-tier-cost-tradeoffs.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/dlt-tier-cost-tradeoffs.md
@@ -1,0 +1,69 @@
+# DLT / Serverless / Photon Cost-Tier Tradeoffs
+
+Loaded on demand when a leak touches DLT pipelines, serverless compute, or the Photon
+toggle. This is the encyclopedia the always-loaded SKILL.md deliberately does not
+carry — read it only when the customer's situation needs it.
+
+## DLT pipeline edition tiers
+
+Delta Live Tables (Lakeflow Declarative Pipelines) bill a DBU premium on top of the
+underlying compute, scaled by **edition**. Read the live edition with
+`databricks-workspace-mcp` → `pipelines_get` (`spec.edition`).
+
+| Edition | What it adds | Cost posture |
+|---------|--------------|--------------|
+| `CORE` | Streaming ingest + transforms | Lowest DLT premium. Use when you do not need CDC or expectations. |
+| `PRO` | Adds change-data-capture (`APPLY CHANGES`) | Mid premium. Justified only if the pipeline actually does CDC. |
+| `ADVANCED` | Adds data-quality expectations + enforcement | Highest premium. Paying for `ADVANCED` with no `EXPECT` clauses is a silent leak. |
+
+**The DLT edition leak.** A pipeline left on `ADVANCED` that uses no expectations, or
+on `PRO` that does no CDC, pays the higher premium for unused capability. The fix is
+to drop the edition to the lowest tier the pipeline's features actually require.
+
+## Serverless vs classic compute
+
+Serverless removes cluster management but reprices the DBU. The trap is **background
+serverless** — platform features (Predictive Optimization, Lakehouse Monitoring,
+materialized-view refresh, Vector Search, Lakeflow Connect) run on serverless
+regardless of whether the account opted into serverless for user workloads.
+
+- Serverless user compute: ~$0.07/DBU (bursty, per-second; cheaper for spiky loads).
+- Serverless background features: ~$0.70–$0.95/DBU vs ~$0.40–$0.55 classic.
+- These appear as surprise `billing_origin_product` line items with no visible
+  cause-effect chain between a UI toggle and the charge — untagged, unattributable
+  serverless spend with no budget-policy guardrail.
+
+**The serverless-shadow leak.** Background features billing against an account that
+never enabled serverless for users. Detect by ranking background
+`billing_origin_product` line items by $/month in `system.billing.usage`; the fix is
+a budget policy + reviewing whether each background feature is wanted.
+
+## Photon on DLT
+
+Photon on a DLT pipeline is `spec.photon = true` (read via `pipelines_get`, a
+config-plane field). The same ~2× DBU premium rule applies: Photon only pays back at
+a ≥2× speedup. On classic compute, Photon-billed usage is identified in
+`system.billing.usage` by `sku_name ILIKE '%PHOTON%'` (NOT a `runtime_engine` column
+— that field exists only on the REST/MCP config plane). The classic-compute Photon
+premium math (surface ~half the Photon spend as at-risk) does NOT transfer cleanly to
+serverless DLT, which is why the SKILL.md Category-4 query restricts to
+`billing_origin_product IN ('ALL_PURPOSE','JOBS_COMPUTE')`.
+
+## Pilot-scope note
+
+Per the v2 CTO decision, the first pilot cut narrowed to the all-purpose-vs-jobs cost
+leak, the idle-pool leak, and the DLT-serverless tier leak (with the serverless-shadow
+audit optional). The per-query Photon-fallback category — parsing execution-plan JSON
+to compute `task_time_in_photon / total_task_time` — was deferred to skill #2 because
+plan-JSON parsing across DBR versions is the longest-pole risk. This skill still owns
+Photon as the fourth named leak (the billing-premium view via `sku_name`), but
+per-query Photon-coverage attribution is the follow-on skill's job.
+
+## Quick decision guide
+
+- Pipeline on `ADVANCED`/`PRO` with no expectations/CDC → drop the edition.
+- Background serverless line items on a non-serverless account → budget policy +
+  feature review.
+- Photon `true` on a pipeline whose ops do not vectorize (UDF-heavy) → disable Photon.
+- Bursty interactive query load on classic SQL warehouse → consider serverless SQL.
+- Steady 24/7 batch load → classic Jobs compute beats serverless on cost.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/system-tables-setup.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/references/system-tables-setup.md
@@ -1,0 +1,99 @@
+# System Tables Setup — the Metastore-Admin Grant Chain
+
+Billing system tables are Unity-Catalog-governed. Access requires a grant chain that
+only a **metastore admin** can issue. The skill probes access in Step 1 and, if the
+probe fails, reports the exact missing grant here — it never fails mid-analysis.
+
+## Why this is the most common failure
+
+`system.billing.usage` lives in the read-only `system` catalog. A principal with full
+workspace-admin rights can still be blocked because system-schema access is granted
+separately at the metastore level. The error surfaces as `PERMISSION_DENIED` on the
+first `SELECT`. Detecting it upfront — and naming the precise grant a metastore admin
+must run — is the difference between a clean "ask your admin for X" and a confusing
+mid-flow crash.
+
+## The grant chain (run by a metastore admin)
+
+Replace `<principal>` with the running user, service principal, or group. Each link
+is required; granting `SELECT` on the table without `USE CATALOG` / `USE SCHEMA`
+still denies access.
+
+```sql
+-- 1. Catalog-level access to the system catalog
+GRANT USE CATALOG ON CATALOG system TO `<principal>`;
+
+-- 2. Schema-level access to the billing schema
+GRANT USE SCHEMA ON SCHEMA system.billing TO `<principal>`;
+
+-- 3. Read on the two billing tables the dollar math needs
+GRANT SELECT ON TABLE system.billing.usage       TO `<principal>`;
+GRANT SELECT ON TABLE system.billing.list_prices TO `<principal>`;
+
+-- 4. Compute schema (config + utilization corroboration)
+GRANT USE SCHEMA ON SCHEMA system.compute              TO `<principal>`;
+GRANT SELECT    ON TABLE  system.compute.clusters      TO `<principal>`;
+GRANT SELECT    ON TABLE  system.compute.node_timeline TO `<principal>`;
+```
+
+## Enabling the system schemas (if not yet enabled)
+
+System schemas may not be enabled on the metastore at all. A metastore admin enables
+them via the Account API. List status first:
+
+```bash
+databricks api get "/api/2.0/unity-catalog/metastores/<metastore_id>/systemschemas"
+```
+
+Then enable the billing and compute schemas:
+
+```bash
+databricks api put \
+  "/api/2.0/unity-catalog/metastores/<metastore_id>/systemschemas/billing"
+databricks api put \
+  "/api/2.0/unity-catalog/metastores/<metastore_id>/systemschemas/compute"
+```
+
+## Verifying access (what Step 1 runs)
+
+A single-row probe per table, executed through the CLI Statement Execution API
+(requires `DATABRICKS_WAREHOUSE_ID`). If every probe returns a row, the grant chain
+is complete.
+
+```sql
+SELECT 1 FROM system.billing.usage           LIMIT 1;
+SELECT 1 FROM system.billing.list_prices     LIMIT 1;
+SELECT 1 FROM system.compute.clusters        LIMIT 1;
+SELECT 1 FROM system.compute.node_timeline   LIMIT 1;
+```
+
+Equivalent grant audit (who can already read the table):
+
+```sql
+SHOW GRANTS ON TABLE system.billing.usage;
+```
+
+## What to report when the probe fails
+
+When Step 1's probe does not return `SUCCEEDED`, surface this to the user verbatim and
+STOP — do not run the leak scans:
+
+- Which probe failed (catalog, schema, or table level).
+- The exact grant statement a metastore admin must run (from the chain above).
+- That the grant is a **metastore-admin** action — workspace admin alone is not
+  enough.
+
+## Two data planes, two independent auth surfaces
+
+- **Databricks CLI Statement Execution API** (`/api/2.0/sql/statements`) — reads
+  `system.*` for every dollar figure. Auth is the CLI's `DATABRICKS_HOST` +
+  `DATABRICKS_TOKEN` (or `databricks auth login`); Unity Catalog enforces the grant
+  chain above on each read. Requires `DATABRICKS_WAREHOUSE_ID`.
+- **`databricks-workspace-mcp`** — reads control-plane config/events (clusters,
+  pools, pipelines). Its own auth tree (PAT / U2M / M2M); PAT is unsupported in
+  Databricks-App deployment mode. It needs no system-table grants — it reads the live
+  REST API, not `system.*`.
+
+If the workspace MCP is not registered, the skill degrades: it still reports dollar
+figures from the CLI but cannot corroborate live config; it then accepts pasted
+config/spend numbers for the corroboration step.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/rank-and-report.py
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/rank-and-report.py
@@ -3,16 +3,28 @@
 
 The LLM does NOT do the dollar arithmetic. This script ingests the per-category
 detection results (JSON, one object per leak category with a 30-day savings/waste
-figure), converts to monthly, ranks descending by monthly dollar impact, annualizes
-the headline and the #1 line, and renders the CFO-grokkable report verbatim per
+figure and a confidence tier), converts to monthly, ranks descending by monthly
+dollar impact, and renders the CFO-grokkable report verbatim per
 references/cfo-output-format.md.
 
+CRITICAL invariant (per references/cfo-output-format.md): NEVER sum confirmed and
+unconfirmed (estimated/at-risk) dollars under one verb. The headline is split into
+a confirmed half ("is burning ~$X/month") and a pending half ("plus up to
+~$Y/month pending review"), and the ranked table carries a load-bearing
+Confidence column.
+
 Input (stdin or --in): a JSON array of category objects, each:
-    {"category": "...", "fix": "...", "root_cause": "...", "waste_30d_usd": <float>}
+    {
+      "category": "...",            # short leak name
+      "root_cause": "...",          # FinOps-language cause
+      "fix": "...",                 # the one config change
+      "waste_30d_usd": <float>,     # 30-day dollar figure (from system.billing.usage)
+      "kind": "confirmed" | "estimated" | "at-risk"
+    }
 
 Usage:
     jq -s '.' scripts/out/leak-*.json | python3 scripts/rank-and-report.py \
-        --out scripts/out/cost-leak-report.md [--monthly-spend 100000]
+        --out scripts/out/cost-leak-report.md [--monthly-spend 100000] [--window-end 2026-06-22]
 """
 
 from __future__ import annotations
@@ -20,6 +32,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+
+UNCONFIRMED = ("estimated", "at-risk")
 
 
 def to_monthly(waste_30d: float) -> float:
@@ -37,46 +51,64 @@ def fmt_money_k(n: float) -> str:
     return f"${round(n / 1000):,}K"
 
 
-def build_report(categories: list[dict], monthly_spend: float | None) -> str:
+def build_report(categories: list[dict], monthly_spend: float | None, window_end: str | None) -> str:
     ranked = sorted(
-        ({**c, "monthly": to_monthly(float(c.get("waste_30d_usd", 0)))} for c in categories),
+        ({**c, "monthly": to_monthly(float(c.get("waste_30d_usd") or 0))} for c in categories),
         key=lambda c: c["monthly"],
         reverse=True,
     )
-    total_monthly = sum(c["monthly"] for c in ranked)
-    total_annual = total_monthly * 12.0
+    # Split sum — confirmed and unconfirmed dollars are NEVER added under one verb.
+    confirmed_monthly = sum(c["monthly"] for c in ranked if c.get("kind") == "confirmed")
+    unconfirmed_monthly = sum(c["monthly"] for c in ranked if c.get("kind") in UNCONFIRMED)
+    confirmed_annual = confirmed_monthly * 12.0
+    unconfirmed_annual = unconfirmed_monthly * 12.0
 
     lines: list[str] = []
     spend_label = fmt_money_full(monthly_spend) if monthly_spend else "$<spend>"
+
+    # A — split headline (confirmed leads; pending hedged).
     lines.append(
-        f"### A {spend_label}/month Databricks workspace is likely burning **~{fmt_money_full(total_monthly)}/month**"
+        f"### A {spend_label}/month Databricks workspace is burning "
+        f"**~{fmt_money_full(confirmed_monthly)}/month** (confirmed), plus up to "
+        f"**~{fmt_money_full(unconfirmed_monthly)}/month** pending review"
     )
     lines.append("")
+    window = f"Trailing 30 days ending {window_end}" if window_end else "Trailing 30 days"
     lines.append(
-        f"That's **~{fmt_money_k(total_annual)}/year**. Every dollar below is computed "
-        f"from the workspace's own `system.billing.usage` table. Every line is one "
-        f"config change."
+        f"{window}. Confirmed **~{fmt_money_k(confirmed_annual)}/year**; up to "
+        f"**~{fmt_money_k(unconfirmed_annual)}/year** more pending review. Every dollar "
+        f"is computed from the workspace's own `system.billing.usage` table. Every line "
+        f"below is one config change."
     )
     lines.append("")
-    lines.append("| # | Where it's leaking | $/month | The fix |")
-    lines.append("|---|---|--:|---|")
+
+    # B — ranked table with the load-bearing Confidence column.
+    lines.append("| # | Where it's leaking | $/month | Confidence | The fix |")
+    lines.append("|---|---|--:|---|---|")
     for i, c in enumerate(ranked, start=1):
+        confidence = str(c.get("kind", "confirmed")).capitalize()
         lines.append(
             f"| {i} | **{c.get('category', '?')}** — {c.get('root_cause', '')} "
-            f"| **{fmt_money_full(c['monthly'])}** | {c.get('fix', '')} |"
+            f"| **{fmt_money_full(c['monthly'])}** | {confidence} | {c.get('fix', '')} |"
         )
     lines.append("")
+
     if ranked:
         top = ranked[0]
+        top_kind = str(top.get("kind", "confirmed"))
+        top_annual = top["monthly"] * 12.0
         lines.append(
-            f"**The #1 line alone — {top.get('category', '?').lower()} — is "
-            f"~{fmt_money_k(top['monthly'] * 12.0)}/year, fixed in one setting.**"
+            f"**The #1 line alone — {(top.get('category') or '?').lower()} "
+            f"({top_kind}) — is ~{fmt_money_k(top_annual)}/year, fixed in one setting.**"
         )
         lines.append("")
+
     lines.append(
         "> **What's assumed vs. what's cited.** Only the workspace-spend input is "
         "assumed. Every per-row dollar figure is computed from the customer's own "
-        "`system.billing.usage` table — never estimated."
+        "`system.billing.usage` table — never estimated. The `Confidence` column marks "
+        "which leaks are measured billed spend (Confirmed) vs. modeled savings "
+        "(Estimated / At-risk)."
     )
     lines.append("")
     return "\n".join(lines)
@@ -87,13 +119,28 @@ def main() -> int:
     ap.add_argument("--in", dest="infile", default="-")
     ap.add_argument("--out", dest="outfile", required=True)
     ap.add_argument("--monthly-spend", type=float, default=None)
+    ap.add_argument("--window-end", dest="window_end", default=None)
     args = ap.parse_args()
 
-    raw = sys.stdin.read() if args.infile == "-" else open(args.infile).read()
-    data = json.loads(raw)
-    categories = data if isinstance(data, list) else data.get("categories", [])
+    if args.infile == "-":
+        raw = sys.stdin.read()
+    else:
+        with open(args.infile) as fh:
+            raw = fh.read()
 
-    report = build_report(categories, args.monthly_spend)
+    data = json.loads(raw)
+    if isinstance(data, list):
+        categories = data
+    elif isinstance(data, dict):
+        categories = data.get("categories", [])
+    else:
+        print(
+            "error: input must be a JSON array of category objects (or an object with a 'categories' array)",
+            file=sys.stderr,
+        )
+        return 1
+
+    report = build_report(categories, args.monthly_spend, args.window_end)
     with open(args.outfile, "w") as fh:
         fh.write(report)
     print(f"wrote {args.outfile} ({len(categories)} categories ranked)")

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/rank-and-report.py
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/rank-and-report.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Deterministic ranker + CFO-report renderer for databricks-cost-leak-hunter.
+
+The LLM does NOT do the dollar arithmetic. This script ingests the per-category
+detection results (JSON, one object per leak category with a 30-day savings/waste
+figure), converts to monthly, ranks descending by monthly dollar impact, annualizes
+the headline and the #1 line, and renders the CFO-grokkable report verbatim per
+references/cfo-output-format.md.
+
+Input (stdin or --in): a JSON array of category objects, each:
+    {"category": "...", "fix": "...", "root_cause": "...", "waste_30d_usd": <float>}
+
+Usage:
+    jq -s '.' scripts/out/leak-*.json | python3 scripts/rank-and-report.py \
+        --out scripts/out/cost-leak-report.md [--monthly-spend 100000]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def to_monthly(waste_30d: float) -> float:
+    """30-day window -> calendar-month figure (365/12 days per month)."""
+    return waste_30d * (365.0 / 12.0) / 30.0
+
+
+def fmt_money_full(n: float) -> str:
+    """Full-digit dollars, no decimals: 12000 -> $12,000."""
+    return f"${round(n):,}"
+
+
+def fmt_money_k(n: float) -> str:
+    """K-abbreviated annualized dollars: 144000 -> $144K."""
+    return f"${round(n / 1000):,}K"
+
+
+def build_report(categories: list[dict], monthly_spend: float | None) -> str:
+    ranked = sorted(
+        ({**c, "monthly": to_monthly(float(c.get("waste_30d_usd", 0)))} for c in categories),
+        key=lambda c: c["monthly"],
+        reverse=True,
+    )
+    total_monthly = sum(c["monthly"] for c in ranked)
+    total_annual = total_monthly * 12.0
+
+    lines: list[str] = []
+    spend_label = fmt_money_full(monthly_spend) if monthly_spend else "$<spend>"
+    lines.append(
+        f"### A {spend_label}/month Databricks workspace is likely burning **~{fmt_money_full(total_monthly)}/month**"
+    )
+    lines.append("")
+    lines.append(
+        f"That's **~{fmt_money_k(total_annual)}/year**. Every dollar below is computed "
+        f"from the workspace's own `system.billing.usage` table. Every line is one "
+        f"config change."
+    )
+    lines.append("")
+    lines.append("| # | Where it's leaking | $/month | The fix |")
+    lines.append("|---|---|--:|---|")
+    for i, c in enumerate(ranked, start=1):
+        lines.append(
+            f"| {i} | **{c.get('category', '?')}** — {c.get('root_cause', '')} "
+            f"| **{fmt_money_full(c['monthly'])}** | {c.get('fix', '')} |"
+        )
+    lines.append("")
+    if ranked:
+        top = ranked[0]
+        lines.append(
+            f"**The #1 line alone — {top.get('category', '?').lower()} — is "
+            f"~{fmt_money_k(top['monthly'] * 12.0)}/year, fixed in one setting.**"
+        )
+        lines.append("")
+    lines.append(
+        "> **What's assumed vs. what's cited.** Only the workspace-spend input is "
+        "assumed. Every per-row dollar figure is computed from the customer's own "
+        "`system.billing.usage` table — never estimated."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", default="-")
+    ap.add_argument("--out", dest="outfile", required=True)
+    ap.add_argument("--monthly-spend", type=float, default=None)
+    args = ap.parse_args()
+
+    raw = sys.stdin.read() if args.infile == "-" else open(args.infile).read()
+    data = json.loads(raw)
+    categories = data if isinstance(data, list) else data.get("categories", [])
+
+    report = build_report(categories, args.monthly_spend)
+    with open(args.outfile, "w") as fh:
+        fh.write(report)
+    print(f"wrote {args.outfile} ({len(categories)} categories ranked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/sql/spend-baseline.sql.json
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/sql/spend-baseline.sql.json
@@ -1,0 +1,5 @@
+{
+  "warehouse_id": "${DATABRICKS_WAREHOUSE_ID}",
+  "wait_timeout": "50s",
+  "statement": "WITH priced AS (SELECT u.usage_date, u.sku_name, u.usage_quantity, u.usage_unit, u.billing_origin_product, u.usage_metadata, u.usage_quantity * lp.pricing.default AS usd FROM system.billing.usage u JOIN system.billing.list_prices lp ON u.sku_name = lp.sku_name AND u.usage_unit = lp.usage_unit AND u.usage_end_time >= lp.price_start_time AND u.usage_end_time < COALESCE(lp.price_end_time, TIMESTAMP '9999-12-31') WHERE u.usage_date >= current_date() - INTERVAL 30 DAYS AND lp.currency_code = 'USD') SELECT billing_origin_product, ROUND(SUM(usd), 2) AS spend_30d_usd, ROUND(SUM(usage_quantity), 2) AS dbus_30d FROM priced GROUP BY billing_origin_product ORDER BY spend_30d_usd DESC"
+}

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/sql/spend-baseline.sql.json
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/scripts/sql/spend-baseline.sql.json
@@ -1,5 +1,4 @@
 {
-  "warehouse_id": "${DATABRICKS_WAREHOUSE_ID}",
   "wait_timeout": "50s",
   "statement": "WITH priced AS (SELECT u.usage_date, u.sku_name, u.usage_quantity, u.usage_unit, u.billing_origin_product, u.usage_metadata, u.usage_quantity * lp.pricing.default AS usd FROM system.billing.usage u JOIN system.billing.list_prices lp ON u.sku_name = lp.sku_name AND u.usage_unit = lp.usage_unit AND u.usage_end_time >= lp.price_start_time AND u.usage_end_time < COALESCE(lp.price_end_time, TIMESTAMP '9999-12-31') WHERE u.usage_date >= current_date() - INTERVAL 30 DAYS AND lp.currency_code = 'USD') SELECT billing_origin_product, ROUND(SUM(usd), 2) AS spend_30d_usd, ROUND(SUM(usage_quantity), 2) AS dbus_30d FROM priced GROUP BY billing_origin_product ORDER BY spend_30d_usd DESC"
 }


### PR DESCRIPTION
The **pilot skill** of the databricks-pack v2 rebuild — the first thing in the rebuilt pack a user actually *runs*, and the live-stream demo artifact. Given a live, authenticated Databricks workspace, it surfaces **real-dollar cost leaks** across four named categories, ranks them by monthly $ impact, and emits a **CFO-grokkable report** (Yipei Wei's bar: a CFO skims it in 90 seconds and says "we're wasting $X here, fix it" with no engineer to translate).

## What it does
Confirmed spend comes from the customer's own `system.billing.usage` joined to `system.billing.list_prices` — **never an estimate**. Four leak categories, each labeled **confirmed / estimated / at-risk** so a CFO never confuses modeled spend with recoverable spend:
1. Clusters that never auto-terminate (confirmed)
2. Scheduled jobs on all-purpose instead of jobs compute (confirmed)
3. Overprovisioned clusters (estimated)
4. Photon premium paid without the speedup (at-risk)

## Architecture (per `013-AT-ADEC` two-MCP split)
- **Dollars** from `system.*` via the Databricks managed SQL MCP (CLI Statement Execution API); **deterministic math** in `scripts/` so the agent never eyeballs numbers.
- **Root-cause config evidence** (auto-termination, node type, autoscale floor, pool `min_idle`) from the `databricks-workspace-mcp` control-plane tools.
- Deep domain knowledge in `references/`, loaded only on demand.
- `## Prerequisites` detects a missing **metastore-admin grant chain** for `system.billing.usage` upfront rather than failing mid-flow.

## How it was built
A 10-agent workflow: **research** (CFO spec `014-DR-REFF`, categories+architecture, real MCP tools + `system.*` SQL, structure/validator) → **author** → **4 adversarial review lenses** (SQL correctness, validator compliance, CFO-grokkability, MCP accuracy) → **revise**. The review caught and the revise fixed a **hallucinated `system.compute.clusters.runtime_engine` column** (Photon now detected via `sku_name ILIKE '%PHOTON%'` on the priced row), a non-deterministic jobs-rate join fan-out, and CFO-clarity gaps.

## Quality gates
- Marketplace validator: **Grade B (88/100), zero errors**
- `ruff` clean + formatted (the deterministic-math script); markdownlint clean; SKILL.md **329 lines** (<500)

## Files
`SKILL.md` + `references/{cost-leak-categories,cfo-output-format,system-tables-setup,dlt-tier-cost-tradeoffs}.md` + `scripts/{rank-and-report.py,sql/spend-baseline.sql.json}`

Addresses beads `claude-02m1` (build), `claude-psvy` (scaffold), `claude-0co4` (CFO output spec), `claude-1x9z` (dlt encyclopedia).

`[skip auto-bump]`

- Jeremy Longshore
intentsolutions.io