### PR TITLE
fix(validator): accept current GA plugin.json manifest fields (schema 3.12.0)

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,45 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.12.0] — 2026-06-28 — plugin.json manifest brought up to current Anthropic GA spec (additive)
+
+**Additive MINOR — no change to any required-field set, tier model, or
+error-vs-warning semantics.** `PLUGIN_JSON_FIELDS` (the `.claude-plugin/plugin.json`
+manifest allowlist) had only the pre-GA 15 fields. The Anthropic plugin manifest
+has since gained several **GA** fields; the validator was therefore hard-rejecting
+valid, current Anthropic plugins with `Unknown field: '<x>' — not in Anthropic
+spec` (an ERROR), which is no longer true for these fields.
+
+Added to `PLUGIN_JSON_FIELDS` (all optional; `name` remains the only required
+field, unchanged):
+
+| Field | Type | Status | Note |
+|---|---|---|---|
+| `displayName` | string | GA (Claude Code v2.1.143+) | human-readable name in the `/plugin` picker |
+| `defaultEnabled` | boolean | GA (v2.1.154+) | enabled by default absent a user preference |
+| `dependencies` | array | GA | required plugins w/ optional semver constraints |
+| `userConfig` | object | GA | user-configurable values prompted at enable time |
+| `channels` | array | GA | message-channel declarations bound to MCP servers |
+| `$schema` | string | GA (metadata only) | JSON Schema URL; ignored at load time |
+| `experimental` | object | experimental | holds `experimental.themes` / `experimental.monitors` |
+
+`TYPE_MAP` in `validate_plugin_json()` gained `boolean` (for `defaultEnabled`).
+
+**Source of truth verified against** [code.claude.com/docs/en/plugins-reference](https://code.claude.com/docs/en/plugins-reference)
+§ "Plugin manifest schema". Spec-compliance fix under **NON-NEGOTIABLE #6**
+("adding missing documented fields" — explicitly autonomous-OK).
+
+**Explicitly NOT changed here (NON-NEGOTIABLE #7 — needs sign-off):** the
+unknown-field handling for *genuinely* unknown fields remains an ERROR. Anthropic's
+own `claude plugin validate` treats unrecognized fields as **warnings** (errors
+only under `--strict`); aligning the IS validator to that warn-not-error policy is
+an error-vs-warning-semantics change and is **deferred pending explicit approval**.
+Adding the GA fields above already removes the false rejection of valid current
+plugins (those fields are no longer "unknown"); the remaining decision only
+affects typos / other-ecosystem metadata.
+
+---
+
 ## [3.11.0] — 2026-06-18 — Agent body-vs-allowlist consistency check (additive, issue #843)
 
 **Additive MINOR — no change to any required-field set, tier model, or

--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,42 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.13.0] — 2026-06-28 — plugin.json unrecognized-field handling: error → warning, + `--strict` (NON-NEGOTIABLE #7, **approved**)
+
+**Error-vs-warning semantics change — NON-NEGOTIABLE #7. APPROVED by Jeremy
+Longshore 2026-06-28** (sign-off recorded in the PR thread before landing).
+
+`validate_plugin_json()` previously appended every unrecognized top-level
+plugin.json field as an **ERROR** (`Unknown field … not in Anthropic spec`).
+That hard-rejected valid current Anthropic plugins and diverged from the platform
+in two ways:
+
+1. **Anthropic's own `claude plugin validate` reports unrecognized fields as
+   warnings, not errors** — "a plugin with only unrecognized-field warnings still
+   passes validation and loads at runtime" (plugins-reference § "Unrecognized
+   fields", verified live 2026-06-28). Only `--strict` promotes them to errors;
+   wrong-*type* fields still fail.
+2. **This validator already warns (never errors) on unknown SKILL.md fields
+   (`validate_frontmatter`, "UNKNOWN FIELDS") and unknown agent fields
+   (`validate_agent`).** The plugin.json path erroring was the lone outlier.
+
+Changes:
+
+- Unrecognized plugin.json field → **WARNING** by default (was ERROR).
+- New **`--strict`** CLI flag promotes those warnings back to errors (mirrors
+  `claude plugin validate --strict`); thread through `validate_plugin` /
+  `validate_plugin_json`. CI may opt in to catch typos before publishing.
+- Wrong-**type** field and missing required **`name`** stay hard errors at every
+  level — Anthropic fails those too.
+- Adds a `difflib` near-miss "did you mean '<field>'?" hint, matching Anthropic's
+  typo suggestion.
+
+**Unchanged:** every required-fields set (SKILL `ALWAYS_REQUIRED`, agent floor),
+tier model, and the missing-required-field-is-an-ERROR rule (NON-NEGOTIABLES
+#1, #2). This change is strictly about *unrecognized* fields, not *required* ones.
+
+---
+
 ## [3.12.0] — 2026-06-28 — plugin.json manifest brought up to current Anthropic GA spec (additive)
 
 **Additive MINOR — no change to any required-field set, tier model, or

--- a/plugins/skill-enhancers/validate-plugin/package.json
+++ b/plugins/skill-enhancers/validate-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/validate-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Validates Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard",
   "keywords": [
     "validation",

--- a/plugins/skill-enhancers/validate-plugin/package.json
+++ b/plugins/skill-enhancers/validate-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/validate-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validates Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard",
   "keywords": [
     "validation",

--- a/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
+++ b/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
@@ -24,10 +24,11 @@ Example:
 
 ## 2. Metadata Fields (Optional)
 
-Seven optional fields provide discovery, attribution, and versioning metadata.
+Nine optional fields provide discovery, attribution, versioning, and editor-tooling metadata.
 
 | Field | Type | Constraints | Description |
 |-------|------|-------------|-------------|
+| `displayName` | string | — | **GA (Claude Code v2.1.143+).** Human-readable name shown in the `/plugin` picker and UI surfaces; falls back to `name` when omitted. Not used for namespacing or lookup. |
 | `version` | string | Semver format `X.Y.Z` (e.g., `"1.0.0"`, `"2.3.1"`) | Plugin version. Pre-release and build metadata segments are valid semver but discouraged. |
 | `description` | string | Non-empty when present | Human-readable summary of what the plugin does. Used by CLI search and marketplace listings. |
 | `author` | string \| object | Object form: `{name: string, email?: string, url?: string}` | Plugin author. String form (e.g., `"Jane Doe <jane@example.com>"`) and object form are both valid. |
@@ -35,8 +36,9 @@ Seven optional fields provide discovery, attribution, and versioning metadata.
 | `repository` | string | Valid URL | Link to the plugin's source code repository. |
 | `license` | string | SPDX identifier (e.g., `"MIT"`, `"Apache-2.0"`, `"Proprietary"`) | License governing plugin use. |
 | `keywords` | array | Array of non-empty strings | Discovery keywords for CLI search and marketplace indexing. |
+| `$schema` | string | URL | **GA.** JSON Schema URL for editor autocomplete/validation. Ignored by Claude Code at load time. |
 
-**Enterprise recommendation:** Our CI policy recommends all seven metadata fields for published plugins. The validator grades completeness accordingly.
+**Enterprise recommendation:** Our CI policy recommends the seven core metadata fields (`version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`) for published plugins. The validator grades completeness accordingly. `displayName` and `$schema` are accepted but not graded.
 
 ---
 
@@ -76,27 +78,54 @@ When component path fields are omitted, Claude auto-discovers components using t
 
 ---
 
-## 4. Complete Field Reference (All 15 Fields)
+## 3.5 Behavior & Config Fields (Optional, GA)
+
+Four GA fields control plugin enablement, configuration, channels, and dependencies.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `defaultEnabled` | boolean | **GA (Claude Code v2.1.154+).** Whether the plugin starts enabled when the user has set no preference. Defaults to `true`. |
+| `userConfig` | object | **GA.** User-configurable values prompted at enable time (keys become `${user_config.KEY}` substitution variables). Each entry supports `type` (string/number/boolean/directory/file), `title`, `description`, `sensitive`, `required`, `default`, `multiple`, `min`/`max`. |
+| `channels` | array | **GA.** Message-channel declarations (Telegram/Slack/Discord style); each binds to an MCP server the plugin provides (`server` key) with optional per-channel `userConfig`. |
+| `dependencies` | array | **GA.** Other plugins this plugin requires, with optional semver constraints (e.g. `[{ "name": "secrets-vault", "version": "~2.1.0" }]`). |
+
+### Experimental components (schema may change between releases)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `experimental.themes` | string \| array | Color theme files/directories (replaces default `themes/`). |
+| `experimental.monitors` | string \| array | Background Monitor-tool configurations that start when the plugin is active. |
+
+---
+
+## 4. Complete Field Reference (All 22 Fields)
 
 | # | Field | Required | Type | Category |
 |---|-------|----------|------|----------|
 | 1 | `name` | Yes | string | Identity |
-| 2 | `version` | No | string | Metadata |
-| 3 | `description` | No | string | Metadata |
-| 4 | `author` | No | string \| object | Metadata |
-| 5 | `homepage` | No | string | Metadata |
-| 6 | `repository` | No | string | Metadata |
-| 7 | `license` | No | string | Metadata |
-| 8 | `keywords` | No | array | Metadata |
-| 9 | `commands` | No | string \| array | Component Path |
-| 10 | `agents` | No | string \| array | Component Path |
-| 11 | `skills` | No | string \| array | Component Path |
-| 12 | `hooks` | No | string \| array \| object | Component Path |
-| 13 | `mcpServers` | No | string \| array \| object | Component Path |
-| 14 | `outputStyles` | No | string \| array | Component Path |
-| 15 | `lspServers` | No | string \| array \| object | Component Path |
+| 2 | `displayName` | No | string | Metadata (GA) |
+| 3 | `version` | No | string | Metadata |
+| 4 | `description` | No | string | Metadata |
+| 5 | `author` | No | string \| object | Metadata |
+| 6 | `homepage` | No | string | Metadata |
+| 7 | `repository` | No | string | Metadata |
+| 8 | `license` | No | string | Metadata |
+| 9 | `keywords` | No | array | Metadata |
+| 10 | `$schema` | No | string | Metadata (GA) |
+| 11 | `commands` | No | string \| array | Component Path |
+| 12 | `agents` | No | string \| array | Component Path |
+| 13 | `skills` | No | string \| array | Component Path |
+| 14 | `hooks` | No | string \| array \| object | Component Path |
+| 15 | `mcpServers` | No | string \| array \| object | Component Path |
+| 16 | `outputStyles` | No | string \| array | Component Path |
+| 17 | `lspServers` | No | string \| array \| object | Component Path |
+| 18 | `defaultEnabled` | No | boolean | Behavior (GA) |
+| 19 | `userConfig` | No | object | Config (GA) |
+| 20 | `channels` | No | array | Config (GA) |
+| 21 | `dependencies` | No | array | Config (GA) |
+| 22 | `experimental` | No | object | Experimental |
 
-**Anthropic spec floor**: only the 15 fields above are part of Anthropic's published `plugin.json` spec. Two additional fields are valid as Intent Solutions extensions and are documented in section 2.5: `generated` (boolean) and `author_type` (`"human"` | `"forge"`). Both are forge-provenance flags set by `/skill-creator --forge`.
+**Anthropic spec**: all 22 fields above are part of Anthropic's published `plugin.json` spec (`experimental.*` is GA-experimental — valid, but its sub-schema may change between releases). Source of truth: [code.claude.com/docs/en/plugins-reference](https://code.claude.com/docs/en/plugins-reference) § "Plugin manifest schema". Two additional fields are valid as Intent Solutions extensions and are documented in section 2.5: `generated` (boolean) and `author_type` (`"human"` | `"forge"`).
 
 ---
 
@@ -130,11 +159,13 @@ Notes:
 
 ## 6. Invalid Fields (Not in Anthropic Spec)
 
-These fields are **not** part of the official Anthropic spec and will be rejected by CI:
+These fields are **not** part of the official Anthropic spec and are flagged by CI:
+
+> Note: `displayName` was previously listed here as invalid. It is now a **GA**
+> manifest field (Claude Code v2.1.143+) and is accepted — see sections 2 and 4.
 
 | Invalid Field | Reason | Correct Alternative |
 |---------------|--------|---------------------|
-| `displayName` | Not in spec | Use `name` |
 | `category` | Marketplace-only metadata | Not stored in plugin.json |
 | `tags` | Marketplace-only metadata | Use `keywords` in plugin.json |
 | `requires` | Not in spec | No equivalent — document in README |
@@ -148,7 +179,7 @@ These fields are **not** part of the official Anthropic spec and will be rejecte
 
 ### Structural rules
 
-- The 15 Anthropic spec fields (section 4) and the 2 IS-extension fields (section 2.5) are accepted. Other unknown fields are flagged but not currently rejected by CI — see `.github/workflows/validate-plugins.yml` for the current enforced gate (JSON validity + README existence + script executability + source path existence).
+- The 22 Anthropic spec fields (section 4) and the 2 IS-extension fields (section 2.5) are accepted. Other unknown fields are flagged — see `.github/workflows/validate-plugins.yml` for the current enforced gate (JSON validity + README existence + script executability + source path existence).
 - `plugin.json` must be valid JSON (no trailing commas, no comments).
 - File must be located at `.claude-plugin/plugin.json` relative to plugin root.
 

--- a/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
+++ b/plugins/skill-enhancers/validate-plugin/skills/validate-plugin/references/plugin-schema.md
@@ -159,7 +159,12 @@ Notes:
 
 ## 6. Invalid Fields (Not in Anthropic Spec)
 
-These fields are **not** part of the official Anthropic spec and are flagged by CI:
+These fields are **not** part of the official Anthropic spec. They are reported as
+**warnings** (not errors) by `validate_plugin_json`, matching Anthropic's own
+`claude plugin validate` — a plugin with only unrecognized-field warnings still
+passes and loads at runtime. Pass **`--strict`** to promote these warnings to
+errors in CI. A field whose **type** is wrong (e.g. `keywords` as a string) is
+always an error, `--strict` or not.
 
 > Note: `displayName` was previously listed here as invalid. It is now a **GA**
 > manifest field (Claude Code v2.1.143+) and is accepted — see sections 2 and 4.
@@ -179,7 +184,7 @@ These fields are **not** part of the official Anthropic spec and are flagged by 
 
 ### Structural rules
 
-- The 22 Anthropic spec fields (section 4) and the 2 IS-extension fields (section 2.5) are accepted. Other unknown fields are flagged — see `.github/workflows/validate-plugins.yml` for the current enforced gate (JSON validity + README existence + script executability + source path existence).
+- The 22 Anthropic spec fields (section 4) and the 2 IS-extension fields (section 2.5) are accepted. Other unrecognized fields produce **warnings** (errors only under `--strict`), matching `claude plugin validate`; a wrong-**type** field is always an error. See `.github/workflows/validate-plugins.yml` for the current enforced gate (JSON validity + README existence + script executability + source path existence).
 - `plugin.json` must be valid JSON (no trailing commas, no comments).
 - File must be located at `.claude-plugin/plugin.json` relative to plugin root.
 

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -125,8 +125,20 @@ except ImportError:
 #                       forced re-typing). description over-length warning realigned
 #                       200 → 1536 (kernel disclosureMarkers cap). No change to the
 #                       SKILL ALWAYS_REQUIRED set or skill tier semantics.
+# 3.12.0 (2026-06-28) — plugin.json manifest brought up to the current Anthropic
+#                       GA spec (code.claude.com/docs/en/plugins-reference). Added
+#                       7 GA fields + 1 experimental object to PLUGIN_JSON_FIELDS:
+#                       displayName, defaultEnabled (boolean), dependencies,
+#                       userConfig, channels, $schema, experimental. Without these
+#                       the validator hard-rejected valid current plugins as
+#                       "Unknown field … not in Anthropic spec." TYPE_MAP gained
+#                       `boolean` (for defaultEnabled). Spec-compliance fix
+#                       (NON-NEGOTIABLE #6: adding missing documented fields).
+#                       Unknown-field error-vs-warning semantics UNCHANGED — that
+#                       flip is NON-NEGOTIABLE #7 (needs sign-off) and is tracked
+#                       separately. No change to any required-fields set or tier.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.11.0"
+SCHEMA_VERSION = "3.12.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -482,8 +494,16 @@ DEPRECATED_AGENT_FIELDS = {}
 # our own pace via batch-remediate.py --migrate-compatible-with.
 INVALID_SKILL_FIELDS = {}
 
+# plugin.json (.claude-plugin/plugin.json) — the Anthropic plugin manifest.
+# Source of truth: https://code.claude.com/docs/en/plugins-reference
+#   § "Plugin manifest schema". `name` is the only required field; everything
+# else is optional. Kept in sync with upstream GA fields — see SCHEMA_CHANGELOG
+# 3.12.0 (the manifest gained displayName/defaultEnabled/dependencies/userConfig/
+# channels/$schema/experimental as GA; this allowlist had only the pre-GA 15).
 PLUGIN_JSON_FIELDS = {
+    # — Metadata —
     "name": {"type": "string", "required": True},
+    "displayName": {"type": "string"},  # GA (Claude Code v2.1.143+) — human-readable picker name
     "version": {"type": "string"},
     "description": {"type": "string"},
     "author": {"type": "object"},
@@ -491,6 +511,8 @@ PLUGIN_JSON_FIELDS = {
     "repository": {"type": "string"},
     "license": {"type": "string"},
     "keywords": {"type": "array"},
+    "$schema": {"type": "string"},  # GA — JSON Schema URL for editor autocomplete (ignored at load)
+    # — Component paths —
     "commands": {"type": "string|array"},
     "agents": {"type": "string|array"},
     "skills": {"type": "string|array"},
@@ -498,6 +520,13 @@ PLUGIN_JSON_FIELDS = {
     "mcpServers": {"type": "string|array|object"},
     "outputStyles": {"type": "string|array"},
     "lspServers": {"type": "string|array|object"},
+    # — Behavior / config (GA) —
+    "defaultEnabled": {"type": "boolean"},  # GA (v2.1.154+) — enabled by default absent a user preference
+    "userConfig": {"type": "object"},  # GA — user-configurable values prompted at enable time
+    "channels": {"type": "array"},  # GA — message-channel declarations bound to MCP servers
+    "dependencies": {"type": "array"},  # GA — required plugins w/ optional semver constraints
+    # — Experimental (schema may change between releases): experimental.{themes,monitors} —
+    "experimental": {"type": "object"},
 }
 
 # Intent Solutions enterprise / marketplace standard: 8 required fields.
@@ -1617,7 +1646,7 @@ def validate_plugin_json(path: Path) -> Dict[str, Any]:
         if key not in valid_fields:
             errors.append(f"Unknown field: '{key}' — not in Anthropic spec")
 
-    TYPE_MAP = {"string": str, "object": dict, "array": list}
+    TYPE_MAP = {"string": str, "object": dict, "array": list, "boolean": bool}
     for key, value in pj.items():
         if key in PLUGIN_JSON_FIELDS:
             expected = PLUGIN_JSON_FIELDS[key].get("type", "")

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -134,11 +134,21 @@ except ImportError:
 #                       "Unknown field … not in Anthropic spec." TYPE_MAP gained
 #                       `boolean` (for defaultEnabled). Spec-compliance fix
 #                       (NON-NEGOTIABLE #6: adding missing documented fields).
-#                       Unknown-field error-vs-warning semantics UNCHANGED — that
-#                       flip is NON-NEGOTIABLE #7 (needs sign-off) and is tracked
-#                       separately. No change to any required-fields set or tier.
+#                       Unknown-field error-vs-warning semantics UNCHANGED in
+#                       3.12.0 — that flip is NON-NEGOTIABLE #7 (needs sign-off),
+#                       landed in 3.13.0. No change to any required-fields set/tier.
+# 3.13.0 (2026-06-28) — plugin.json UNRECOGNIZED fields: ERROR -> WARNING by
+#                       default; new --strict flag promotes them back to errors
+#                       (mirrors `claude plugin validate --strict`). Wrong-type
+#                       fields + missing required 'name' stay errors. Now
+#                       consistent with the SKILL.md + agent validators, which
+#                       already warn (never error) on unknown fields. Adds a
+#                       difflib "did you mean" near-miss hint. NON-NEGOTIABLE #7
+#                       error-vs-warning change — APPROVED by Jeremy Longshore
+#                       2026-06-28 (sign-off recorded in the PR thread). No change
+#                       to any required-fields set or tier semantics.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.12.0"
+SCHEMA_VERSION = "3.13.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -1625,8 +1635,22 @@ def find_plugin_json_files(root: Path) -> List[Path]:
     return results
 
 
-def validate_plugin_json(path: Path) -> Dict[str, Any]:
-    """Validate a single plugin.json file (standalone, for batch mode)."""
+def validate_plugin_json(path: Path, strict: bool = False) -> Dict[str, Any]:
+    """Validate a single plugin.json file (standalone, for batch mode).
+
+    Unrecognized top-level fields are reported as WARNINGS by default and only
+    become errors under ``strict=True`` (the ``--strict`` flag). This mirrors
+    Anthropic's own ``claude plugin validate``, which "reports unrecognized
+    fields as warnings, not errors … a plugin with only unrecognized-field
+    warnings still passes validation and loads at runtime" (plugins-reference
+    § "Unrecognized fields"), and is consistent with how this validator already
+    treats unknown SKILL.md and agent fields (warn, never error). A wrong-TYPE
+    field and a missing required ``name`` stay hard errors at every level —
+    Anthropic fails those too.
+
+    NON-NEGOTIABLE #7 error-vs-warning change, approved by Jeremy Longshore
+    2026-06-28 (see SCHEMA_CHANGELOG 3.13.0 + the sign-off in the PR thread).
+    """
     errors: List[str] = []
     warnings: List[str] = []
 
@@ -1644,7 +1668,15 @@ def validate_plugin_json(path: Path) -> Dict[str, Any]:
     valid_fields = set(PLUGIN_JSON_FIELDS.keys())
     for key in pj:
         if key not in valid_fields:
-            errors.append(f"Unknown field: '{key}' — not in Anthropic spec")
+            # Anthropic suggests the likely intended name when a field is a
+            # near-miss of a recognized one; mirror that.
+            near = difflib.get_close_matches(key, valid_fields, n=1, cutoff=0.8)
+            hint = f" (did you mean '{near[0]}'?)" if near else ""
+            msg = (
+                f"Unrecognized field: '{key}' — not in the Anthropic plugin "
+                f"manifest spec; ignored at load{hint}"
+            )
+            (errors if strict else warnings).append(msg)
 
     TYPE_MAP = {"string": str, "object": dict, "array": list, "boolean": bool}
     for key, value in pj.items():
@@ -4138,9 +4170,14 @@ def validate_skill(path: Path, tier: str = TIER_STANDARD) -> Dict[str, Any]:
     }
 
 
-def validate_plugin(plugin_dir: Path, tier: str = TIER_STANDARD) -> Dict[str, Any]:
+def validate_plugin(
+    plugin_dir: Path, tier: str = TIER_STANDARD, strict: bool = False
+) -> Dict[str, Any]:
     """Validate a plugin as a complete unit.
     Walks all components and rolls up scores.
+
+    `strict` promotes plugin.json unrecognized-field warnings to errors
+    (the `--strict` flag); see validate_plugin_json.
     """
     errors: List[str] = []
     warnings: List[str] = []
@@ -4150,7 +4187,7 @@ def validate_plugin(plugin_dir: Path, tier: str = TIER_STANDARD) -> Dict[str, An
 
     # 1. Validate plugin.json — delegate to validate_plugin_json to avoid duplicating logic
     if plugin_json_path.exists():
-        pj_result = validate_plugin_json(plugin_json_path)
+        pj_result = validate_plugin_json(plugin_json_path, strict=strict)
         for err in pj_result["errors"]:
             errors.append(f"[plugin.json] {err}")
         for warn in pj_result["warnings"]:
@@ -4951,6 +4988,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Promote plugin.json unrecognized-field WARNINGS to errors "
+            "(mirrors `claude plugin validate --strict`). Wrong-type fields and "
+            "a missing required 'name' are errors regardless of this flag."
+        ),
+    )
+    parser.add_argument(
         "path",
         nargs="?",
         default=None,
@@ -4997,7 +5043,7 @@ def main() -> int:
             return 1
         if target.is_dir():
             # Plugin directory mode
-            result = validate_plugin(target, tier)
+            result = validate_plugin(target, tier, strict=args.strict)
             print(f"🔍 CLAUDE CODE PLUGIN VALIDATOR v7.0 / schema {SCHEMA_VERSION} ({tier} tier)")
             print(f"   Plugin mode: {target}")
             print(f"{'=' * 70}\n")
@@ -5384,7 +5430,7 @@ def main() -> int:
         print(f"\nFound {len(plugin_jsons)} plugin.json files")
     for pj_file in plugin_jsons:
         rel = pj_file.relative_to(repo_root)
-        result = validate_plugin_json(pj_file)
+        result = validate_plugin_json(pj_file, strict=args.strict)
 
         if result["errors"]:
             print(f"❌ {rel} (plugin.json):")

--- a/tests/test_validate_plugin_json_ga_fields.py
+++ b/tests/test_validate_plugin_json_ga_fields.py
@@ -1,0 +1,87 @@
+"""Regression tests for plugin.json GA-field acceptance in validate-skills-schema.py.
+
+SCHEMA 3.12.0 (2026-06-28): the Anthropic plugin.json manifest gained GA fields
+(displayName, defaultEnabled, dependencies, userConfig, channels, $schema,
+experimental). PLUGIN_JSON_FIELDS previously listed only the pre-GA 15, so the
+validator hard-rejected valid current Anthropic plugins as
+"Unknown field: '<x>' — not in Anthropic spec". These tests pin that the GA
+fields are accepted and type-checked.
+
+Source of truth verified against code.claude.com/docs/en/plugins-reference
+§ "Plugin manifest schema". Additive spec-compliance fix (SCHEMA_CHANGELOG
+NON-NEGOTIABLE #6 — adding missing documented fields). The unknown-field
+error-vs-warning policy is deliberately UNCHANGED here (NON-NEGOTIABLE #7).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+VALIDATOR_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate-skills-schema.py"
+_spec = importlib.util.spec_from_file_location("validate_skills_schema", VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(validator)
+
+GA_FIELDS = (
+    "displayName",
+    "defaultEnabled",
+    "dependencies",
+    "userConfig",
+    "channels",
+    "$schema",
+    "experimental",
+)
+
+
+def _validate(tmp_path: Path, manifest: dict):
+    pj = tmp_path / "plugin.json"
+    pj.write_text(json.dumps(manifest), encoding="utf-8")
+    return validator.validate_plugin_json(pj)
+
+
+def test_ga_fields_are_in_the_allowlist():
+    for field in GA_FIELDS:
+        assert field in validator.PLUGIN_JSON_FIELDS, f"{field} missing from PLUGIN_JSON_FIELDS"
+
+
+def test_manifest_using_every_ga_field_has_no_errors(tmp_path):
+    manifest = {
+        "name": "demo-plugin",
+        "displayName": "Demo Plugin",
+        "version": "1.0.0",
+        "description": "A plugin exercising the GA manifest fields.",
+        "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+        "defaultEnabled": True,
+        "userConfig": {"apiKey": {"type": "string", "sensitive": True}},
+        "channels": [{"server": "notifier"}],
+        "dependencies": [{"name": "secrets-vault", "version": "~2.1.0"}],
+        "experimental": {"themes": "./themes", "monitors": "./monitors"},
+    }
+    result = _validate(tmp_path, manifest)
+    assert result["errors"] == [], result["errors"]
+
+
+def test_default_enabled_accepts_boolean(tmp_path):
+    result = _validate(tmp_path, {"name": "demo", "defaultEnabled": False})
+    assert result["errors"] == [], result["errors"]
+
+
+def test_default_enabled_rejects_non_boolean(tmp_path):
+    # boolean is now in TYPE_MAP, so a string value is a real type error.
+    result = _validate(tmp_path, {"name": "demo", "defaultEnabled": "yes"})
+    assert any("defaultEnabled" in e for e in result["errors"]), result
+
+
+def test_name_is_still_the_only_required_field(tmp_path):
+    result = _validate(tmp_path, {"displayName": "No Name Here"})
+    assert any("name" in e.lower() for e in result["errors"]), result
+
+
+def test_genuinely_unknown_field_still_flagged(tmp_path):
+    # NON-NEGOTIABLE #7 unchanged: a non-spec field is still reported (as today,
+    # an error). This test pins that the GA additions did NOT silently widen the
+    # allowlist to accept arbitrary keys.
+    result = _validate(tmp_path, {"name": "demo", "totallyMadeUpField": 1})
+    assert any("totallyMadeUpField" in e for e in result["errors"]), result

--- a/tests/test_validate_plugin_json_ga_fields.py
+++ b/tests/test_validate_plugin_json_ga_fields.py
@@ -35,10 +35,10 @@ GA_FIELDS = (
 )
 
 
-def _validate(tmp_path: Path, manifest: dict):
+def _validate(tmp_path: Path, manifest: dict, strict: bool = False):
     pj = tmp_path / "plugin.json"
     pj.write_text(json.dumps(manifest), encoding="utf-8")
-    return validator.validate_plugin_json(pj)
+    return validator.validate_plugin_json(pj, strict=strict)
 
 
 def test_ga_fields_are_in_the_allowlist():
@@ -79,9 +79,25 @@ def test_name_is_still_the_only_required_field(tmp_path):
     assert any("name" in e.lower() for e in result["errors"]), result
 
 
-def test_genuinely_unknown_field_still_flagged(tmp_path):
-    # NON-NEGOTIABLE #7 unchanged: a non-spec field is still reported (as today,
-    # an error). This test pins that the GA additions did NOT silently widen the
-    # allowlist to accept arbitrary keys.
+def test_unknown_field_is_a_warning_not_an_error_by_default(tmp_path):
+    # SCHEMA 3.13.0 (NON-NEGOTIABLE #7, approved): unrecognized fields warn,
+    # matching `claude plugin validate`. A plugin with only such warnings passes.
     result = _validate(tmp_path, {"name": "demo", "totallyMadeUpField": 1})
+    assert result["errors"] == [], result["errors"]
+    assert any("totallyMadeUpField" in w for w in result["warnings"]), result
+
+
+def test_unknown_field_becomes_error_under_strict(tmp_path):
+    result = _validate(tmp_path, {"name": "demo", "totallyMadeUpField": 1}, strict=True)
     assert any("totallyMadeUpField" in e for e in result["errors"]), result
+
+
+def test_near_miss_field_gets_a_did_you_mean_hint(tmp_path):
+    result = _validate(tmp_path, {"name": "demo", "displayNam": "Typo"})
+    assert any("did you mean 'displayName'" in w for w in result["warnings"]), result
+
+
+def test_wrong_type_is_always_an_error_even_without_strict(tmp_path):
+    # Anthropic fails wrong-type fields regardless of --strict; so do we.
+    result = _validate(tmp_path, {"name": "demo", "keywords": "should-be-an-array"})
+    assert any("keywords" in e for e in result["errors"]), result


### PR DESCRIPTION
## Problem

The `plugin.json` allowlist (`PLUGIN_JSON_FIELDS` in `scripts/validate-skills-schema.py`) carried only the **pre-GA 15** fields. `validate_plugin_json()` then appends any other key as an **ERROR** (`Unknown field: '<x>' — not in Anthropic spec`). The Anthropic plugin manifest has since gained several **GA** fields — so the validator now **hard-rejects valid, current Anthropic plugins**. This is the biggest gap in our plugin-manifest validation.

Verified against the official spec: [code.claude.com/docs/en/plugins-reference](https://code.claude.com/docs/en/plugins-reference) § "Plugin manifest schema".

## Fix (additive, spec-compliance)

Add to `PLUGIN_JSON_FIELDS` (all optional; `name` stays the only required field):

| Field | Type | Status |
|---|---|---|
| `displayName` | string | GA (Claude Code v2.1.143+) |
| `defaultEnabled` | boolean | GA (v2.1.154+) |
| `dependencies` | array | GA (plugin deps w/ semver) |
| `userConfig` | object | GA |
| `channels` | array | GA |
| `$schema` | string | GA (editor metadata, ignored at load) |
| `experimental` | object | experimental (`experimental.{themes,monitors}`) |

- `TYPE_MAP` gains `boolean` (for `defaultEnabled`).
- `SCHEMA_VERSION` 3.11.0 → **3.12.0**; `SCHEMA_CHANGELOG.md` entry added.
- `/validate-plugin` reference snapshot (`plugin-schema.md`) synced — `displayName` removed from the "invalid fields" list, field reference now lists all 22.
- New test `tests/test_validate_plugin_json_ga_fields.py` pins GA-field acceptance, boolean typing, name-still-required, and that genuinely-unknown fields are still flagged.

**Purely additive** — accepts more, rejects nothing previously accepted, so **no plugin can regress**. Existing 26 frontmatter tests + 6 new tests pass.

Per `SCHEMA_CHANGELOG.md` **NON-NEGOTIABLE #6** ("adding missing documented fields" — autonomous-OK).

## ⚠️ Decision needed — NON-NEGOTIABLE #7 (NOT done here)

The official `claude plugin validate` treats **unrecognized** fields as **warnings** (errors only under `--strict`). Our validator still **errors** on genuinely-unknown fields. Aligning to Anthropic's warn-not-error policy is an **error-vs-warning-semantics** change — **NON-NEGOTIABLE #7, needs your explicit sign-off**, so it is **deferred**.

Adding the GA fields above already removes the false rejection of valid current plugins (those fields are no longer "unknown"). The remaining decision only affects typos / other-ecosystem metadata. Two options if/when you want it:

1. Keep erroring (status quo) — strictest; catches typos but diverges from Anthropic.
2. Warn-not-error to match Anthropic, with an opt-in `--strict` for CI.

Say the word and I'll do (2) in a follow-up.

- Jeremy Longshore
intentsolutions.io