### PR TITLE
fix(blog): collapse trailing blank lines (MD012) — unblock markdownlint gate

### DIFF
--- a/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
+++ b/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
@@ -59,4 +59,3 @@ Also shipped: version-coupling hygiene across `@intentsolutions/core`. Adopted `
 - [The LLM Should Never Do the Math](/posts/llm-never-does-the-math/) — The SQL-first architecture that backs this fix.
 - [CodeQL Caught the Race I Dismissed](/posts/codeql-caught-the-race-i-dismissed/) — Another review tool catching a bug the author had waved off; same shape as Gemini catching the silent lie.
 - [MCP Server Auth: The API Is the Real Boundary](/posts/the-api-is-the-real-boundary/) — The boundary-discipline theme, one layer down the stack.
-


### PR DESCRIPTION
`marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md` had two trailing blank lines at EOF, tripping **MD012/no-multiple-blanks** (line 63).

It is the **only committed markdownlint violation** in the repo (9,912 files linted → 1 error), so it has been failing **both** the `Lint Markdown` gate and the markdownlint step of `Validate Plugins` — on `main` (red since commit `e07e0412`) and therefore on every open PR.

Pure-whitespace fix (collapse trailing blank lines to a single final newline); no content change. Verified `markdownlint-cli2` reports 0 errors on the file.

- Jeremy Longshore
intentsolutions.io