### PR TITLE
feat(validator): L2 consumer-cutover — drift-gate PLUGIN_JSON_FIELDS against the kernel (schema 3.14.0)

### DIFF
--- a/000-docs/692-AA-AACR-spec-currency-audit-2026-06-28.md
+++ b/000-docs/692-AA-AACR-spec-currency-audit-2026-06-28.md
@@ -1,0 +1,230 @@
+# Spec-Currency Audit — Claude Code authoring artifacts vs IS validators (2026-06-28)
+
+**Code:** 692-AA-AACR · **Author:** Jeremy Longshore · **Date:** 2026-06-28
+**Scope:** Are the Intent Solutions validators (`scripts/validate-skills-schema.py`,
+the `/validate-*` skills, the catalog scripts, the vendored kernel schemas) current
+against the live Anthropic Claude Code authoring specs as of mid-2026?
+**Method:** Six authoring surfaces fetched + cited from `code.claude.com/docs`
+(plugins-reference, skills, sub-agents, hooks, mcp, plugin-marketplaces; docs map
+auto-generated 2026-06-26), then each repo/skill validator cross-checked against the
+verified spec. Four read-only audit passes + the live-doc fetches back every claim.
+
+## 0. Verdict at a glance
+
+| Surface | Enforcer | Spec-currency verdict |
+|---|---|---|
+| **plugin.json manifest** | `validate-skills-schema.py` `PLUGIN_JSON_FIELDS` | **FIXED** — was the one blocking gap (schema 3.12.0 + 3.13.0, merged) |
+| **SKILL.md frontmatter** | `validate-skills-schema.py` `SKILL_FIELDS` | **CURRENT** — all live fields recognized; unknowns warn, not error |
+| **Agent definition** | `validate-skills-schema.py` `AGENT_FIELDS` | **CURRENT** — one intentional IS narrowing (preserved) + one dead constant (fixed) |
+| **hooks** | `/validate-hook` skill (global) | **CURRENT** — one cosmetic table-row omission (fixed in the global skill) |
+| **.mcp.json** | `/validate-mcp` skill (global) + kernel schema | skill: **2 doc gaps (fixed)**; kernel schema: **FLAGGED (architectural)** |
+| **marketplace.json** | catalog scripts + `/validate-marketplace` skill + kernel | **FLAGGED** — blocked behind the kernel `authoring/v1 → v2` cutover (soak-gated) |
+
+**Headline:** the one *blocking* in-repo currency bug was plugin.json (already fixed
+and merged — schema 3.12.0 added 7 GA fields + `experimental`; 3.13.0 flipped
+unrecognized-field handling error → warning + `--strict`). Everything else this repo
+*enforces* is current. The remaining items are (a) intentional IS-overlay choices we
+keep on purpose, (b) cosmetic/doc fixes applied here, or (c) **architectural kernel /
+gated cutover work that must not be changed autonomously** — flagged below for a
+decision.
+
+## 0.5 ROOT CAUSE — why a hand-patch was needed at all (the auto-currency loop is broken in two places)
+
+The point of the spec-drift-watch (`intent-eval-lab/.github/workflows/spec-drift-watch.yml`,
+daily 09:00 UTC, 16 upstream surfaces, FF#2 field-diff → kernel SSoT) is that I should
+**never** have to hand-patch a field set. That it was needed is the real finding. Diagnosis:
+
+1. **The watcher IS alive — but it cannot persist anything it produces.** The latest run
+   logs show it fetching all 16 surfaces, the heartbeat advancing (`last run 24.3h ago`),
+   and `recorded run; all 16 surfaces under the streak threshold` — in the GH Actions
+   **cache**. But **every commit-back push fails**: `main` requires 9 status checks
+   (`enforce_admins:false`), and the `github-actions` bot is not an admin, so a direct push
+   of a fresh (un-checked) commit is rejected. Confirmed in every run log
+   (`archive commit-back push failed (branch protection?) — delta preserved as a workflow
+   artifact`) and in git history (no bot commit-back has **ever** landed on `main`).
+   **Consequence:** the kernel SSoT snapshots, the liveness `.state.json`, the lineage log,
+   and the currency evidence are all frozen at the last **manual** deep-capture PR
+   (#132–#137). The committed `specs/snapshots/.state.json` is `last_run_utc: null` forever
+   → `watcher-liveness.py` prints `"heartbeat bootstrap — no prior run recorded yet (OK)"`
+   → the dead-man heartbeat is inert and the dashboard reads **DEGRADED / no successful live
+   run recorded**. The watcher built to "never fail silent-green" *is* silent-green, because
+   it can't write its own liveness proof back.
+
+2. **Even with a current SSoT, CCP doesn't consume it.** The kernel's vendored
+   plugin-manifest snapshot (`intent-eval-lab/specs/_vendor/upstream/plugin-manifest/`)
+   **already contains** `displayName`, `defaultEnabled`, `channels`, `dependencies`,
+   `userConfig`, `experimental` — captured by a manual run in June. So the drift-watch had
+   the current manifest; CCP's `PLUGIN_JSON_FIELDS` was stale only because it is
+   **hand-maintained and not generated from / validated against the kernel SSoT**. The
+   kernel→CCP consumer-cutover (the SAK Phase-2/Phase-4 work, soak-gated per
+   `project_ccpi_cicd_posture_soak_gate`) is unbuilt, so a current kernel does **not** make
+   CCP current.
+
+**So the cure is not more hand-patches — it is closing two loops:**
+
+- **(L1) Persistence:** make the watcher's commit-back succeed. Options (Jeremy's call —
+  security posture): give the push an **admin/bypass token** (a fine-grained PAT or GitHub
+  App in a bypass allowlist; since `enforce_admins:false`, an admin-authenticated push
+  bypasses the status-check gate), **or** have the watcher open an **auto-mergeable PR** for
+  its captures (keeps `main` gated), **and** set the external dead-man (`SPEC_DRIFT_HEARTBEAT_URL`,
+  currently unset) so absence of the daily ping alerts without any commit. Until L1 lands,
+  the SSoT only advances on manual capture PRs and liveness can't be proven from the repo.
+- **(L2) Consumption:** the gated kernel→CCP consumer-cutover — `PLUGIN_JSON_FIELDS` (and the
+  other hand-maintained validator sets) should be **derived from / drift-gated against** the
+  kernel `authoring/v*` schemas, so a kernel update propagates without a hand-patch.
+
+The individual fixes in §§ 1–8 are correct and worth keeping, but they are **symptom
+treatment**. L1 + L2 are the cure.
+
+## 1. plugin.json — FIXED (reference)
+
+`PLUGIN_JSON_FIELDS` carried only the pre-GA 15 fields and **errored** on every
+unrecognized field. Anthropic had added 7 GA fields + an `experimental` object, and
+its own `claude plugin validate` *warns* (never errors) on unknowns.
+
+- **Schema 3.12.0** — added `displayName`, `defaultEnabled`, `dependencies`,
+  `userConfig`, `channels`, `$schema`, `experimental`; `TYPE_MAP` gained `boolean`.
+- **Schema 3.13.0** — unrecognized plugin.json field → **WARNING** (was ERROR);
+  new `--strict` promotes to error; wrong-type + missing `name` stay errors; difflib
+  "did you mean" hint. NON-NEGOTIABLE #7, approved 2026-06-28.
+
+Source: `code.claude.com/docs/en/plugins-reference` § "Plugin manifest schema" +
+§ "Unrecognized fields". Both fixes merged; `/validate-plugin` reference
+(`plugin-schema.md`) synced to 22 fields.
+
+## 2. SKILL.md frontmatter — CURRENT (no change)
+
+`SKILL_FIELDS` recognizes the full live set, verified against
+`code.claude.com/docs/en/skills` § "Frontmatter reference": `name`, `description`,
+`when_to_use` (underscore — the lone non-kebab key, confirmed against the doc),
+`license`, `compatibility`, `metadata`, `allowed-tools`, `disallowed-tools`,
+`disable-model-invocation`, `user-invocable`, `model`, `effort`, `context`, `agent`,
+`argument-hint`, `arguments`, `hooks`, `paths`, `shell`. Unknown skill fields →
+**warning** ("Will be ignored by the runtime"), matching Anthropic.
+
+> Correction to an earlier in-session claim: a grep-escaping bug (`\|` under
+> `grep -E`) made `agent`/`argument-hint`/`user-invocable`/`when_to_use` look absent.
+> They are all present. There was no SKILL.md gap.
+
+## 3. Agent definition — CURRENT (one fix, one intentional narrowing preserved)
+
+`AGENT_FIELDS` recognizes all 15 optional + 2 required live fields; the
+`permissionMode`, `memory`, and `color` enums match the spec exactly; the
+plugin-restricted set (`hooks`, `mcpServers`, `permissionMode` silently ignored on
+plugin agents) and the banned-field list are correct.
+
+- **FIXED here (dead code):** module-level `VALID_EFFORT_LEVELS` (line 1588) was a
+  stale, unused `["low","medium","high","max"]` — missing `xhigh`. The *live* check
+  uses `AGENT_FIELDS["effort"]` (correct, includes `xhigh`); the dead constant is
+  aligned to avoid a future-use landmine.
+- **PRESERVED (intentional IS narrowing — per the "leave my extras" instruction):**
+  the agent `model` enum (`sonnet|haiku|opus|fable|inherit`) **rejects full
+  `claude-*` model IDs**, which Anthropic permits and which the *skill* path accepts.
+  The code comment states this is a deliberate IS-contract narrowing. Left as-is. If
+  you want the agent path to accept full IDs (matching the skill path + spec), that's
+  a one-line change — say the word.
+
+## 4. hooks — CURRENT (cosmetic fix, global skill)
+
+This repo's `validate-skills-schema.py` does **not** validate hook-event structure
+(it only checks the `hooks` field is a dict / the `hooks.json` parses) — it delegates
+to the `/validate-hook` skill. That skill + its `anthropic-hooks-reference.md` live in
+`~/.claude/skills/` (**not** in this repo's git) and already carry the full current
+event surface (incl. `SessionEnd`, `StopFailure`, `PostToolUseFailure`, `Elicitation`)
+and all 5 handler types with correct required fields.
+
+- **FIXED in the global skill:** the reference's Hook Events *table* omitted a
+  `SessionEnd` row even though the rest of the file uses it — internal inconsistency,
+  now corrected. (Global file; not part of this repo's PR.)
+
+## 5. .mcp.json — skill doc gaps FIXED; kernel schema FLAGGED
+
+Two surfaces, with conflicting transport models:
+
+- **`/validate-mcp` skill (global `~/.claude/skills/`) — FIXED (doc-level):** its
+  transport allowlist was `stdio|http|sse|ws`, missing the **`websocket`** and
+  **`streamable-http`** aliases the spec defines, and it did not mark **`sse`
+  deprecated** (the bundled reference and the kernel `$comment` both do). Aliases
+  added + `sse` deprecation note added.
+- **Kernel schema (`@intentsolutions/core` `authoring/v1/.../mcp-config.v1.json`) —
+  🚩 FLAGGED (architectural, do NOT autonomously change):** the vendored/installed
+  kernel models a non-existent `transport` field (real configs use **`type`**), has
+  **no `url` property**, and makes `command`/`args`/`env` unconditionally required —
+  so it cannot represent any http/sse/ws server and fails even real stdio configs
+  (which carry no `transport` key). This is a kernel SSoT defect, ISEDC-gated, and
+  lives in `@intentsolutions/core`, not here. **Needs a kernel change + ISEDC review.**
+
+## 6. marketplace.json — FLAGGED (blocked on the kernel v1→v2 cutover)
+
+The catalog scripts that are field-agnostic by design (`validate-catalog-invariants.py`,
+`check-catalog-format.py`) are **current**. The gap is that `sync-marketplace.cjs`
+(line ~63) reads the kernel `authoring/**v1**` fold, whose per-entry shape is only
+`name` + `source` (relative-path source). The **current `authoring/v2`** fold (shipped
+in `@intentsolutions/core@0.9.0`) models all the modern per-entry fields
+(`displayName`, `defaultEnabled`, `strict`, `tags`, `category`, …) + all five source
+forms (github / url / git-subdir / npm / relative).
+
+🚩 **FLAGGED (do NOT autonomously change):** pointing the consumer at `authoring/v2` is
+the **kernel-consumer-cutover** that is **soak-gated** per the CCPI CI/CD posture
+(`project_ccpi_cicd_posture_soak_gate`). The modern fields currently survive in the
+CLI catalog only because they pass through the un-stripped path — not because the
+kernel sanctions them. The `/validate-marketplace` skill (global) likewise vendors the
+stale v1 schema and its SKILL.md prose/Step-5 matcher omit the `git-subdir`/`npm`
+object source forms. **All of this should land together with the v2 cutover**, not
+piecemeal (editing prose while the trusted schema stays v1 creates a prose-vs-schema
+mismatch).
+
+- **`relevance` (v2.1.152+):** documented by Anthropic but absent **everywhere**,
+  including kernel `authoring/v2`. This is an **upstream kernel gap** — file against
+  `@intentsolutions/core` to add it to `marketplace-catalog.v2.json` per-entry.
+
+## 7. Kernel version drift — FLAGGED (verify before acting)
+
+`package.json` pins `@intentsolutions/core@0.9.0`, but the audit agents reported the
+installed `node_modules` tree resolving to an older generation (0.4.1 was reported;
+the lockfile shows multiple transitive versions; the package's `exports` block blocks
+a direct version read). Because §5 and §6 both target the kernel, **the authoritative
+mcp-config / marketplace contract is currently ambiguous.** Reconcile first
+(`pnpm install` to relink, confirm `authoring/v2` is present) before any kernel-facing
+change. This is environment/coordination work, not a committed-code fix.
+
+## 8. What was changed by this audit
+
+| Change | Where | Class |
+|---|---|---|
+| Dead `VALID_EFFORT_LEVELS` aligned to include `xhigh` | `scripts/validate-skills-schema.py` (this repo) | hygiene / correctness |
+| `SessionEnd` events-table row added | `~/.claude/skills/.../anthropic-hooks-reference.md` (global) | doc currency |
+| `websocket` + `streamable-http` aliases; `sse` deprecation note | `~/.claude/skills/validate-mcp/SKILL.md` (global) | doc currency |
+| This audit doc | `000-docs/692-AT-AUDT-…` (this repo) | record |
+
+## 9. Open decisions for you (not auto-changed)
+
+**The cure (close the auto-currency loop — see § 0.5):**
+
+0a. **L1 — drift-watch persistence.** Pick the commit-back mechanism so the watcher can
+    write back: admin/bypass push token, or auto-mergeable capture PRs; plus set
+    `SPEC_DRIFT_HEARTBEAT_URL` for durable external liveness. Until this lands, the SSoT
+    only advances on manual capture PRs and liveness can't be proven from the repo.
+
+0b. **L2 — kernel→CCP consumer-cutover.** Derive/drift-gate `PLUGIN_JSON_FIELDS` (and the
+    other hand-maintained validator sets) against the kernel `authoring/v*` schemas, so a
+    kernel update propagates without a hand-patch. Soak-gated (SAK Phase-2/4).
+
+**Smaller items:**
+
+1. **Agent `model` full-IDs** — accept `claude-*` on the agent path (match skill path
+   + spec), or keep the intentional IS narrowing? (Left narrowed for now.)
+2. **Kernel mcp-config schema** (§5) — architectural fix in `@intentsolutions/core`,
+   ISEDC-gated.
+3. **Marketplace `authoring/v1 → v2` cutover** (§6) — soak-gated; lands the modern
+   per-entry fields + source forms in `sync-marketplace.cjs` + the global skill
+   together.
+4. **`relevance`** (§6) — upstream kernel addition.
+5. **Version-drift reconcile** (§7) — `pnpm install` + confirm v2, before 2–4.
+
+## 10. Sources
+
+All verified live 2026-06-28 against `code.claude.com/docs/en/`:
+`plugins-reference`, `skills`, `sub-agents`, `hooks`, `mcp`, `plugin-marketplaces`
+(docs map auto-generated 2026-06-26). Field-level currency for plugin.json is also
+recorded in `SCHEMA_CHANGELOG.md` 3.12.0 + 3.13.0.

--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,32 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.14.0] — 2026-06-28 — L2 consumer-cutover: plugin.json drift-gated against the kernel (additive, advisory)
+
+**Additive MINOR — no change to any required-field set, tier model, or
+error-vs-warning semantics.** Closes the second half of the auto-currency loop
+(692-AA-AACR § 0.5): `PLUGIN_JSON_FIELDS` was hand-maintained with **no** comparison
+to the kernel, so when upstream gained GA fields the validator silently went stale
+and needed a hand-patch (the 3.12.0 event).
+
+- New `load_kernel_plugin_fields()` reads the kernel's **current** plugin-manifest
+  field surface from `@intentsolutions/core` `authoring/**v2**`
+  (`upstream-base ∪ is-overlay`). v2, not v1 — the v1 plugin-manifest fold is an
+  early ~10-field capture; v2 carries the full GA surface. Needs core `>=0.9.0`.
+- `kernel_shadow_report()` gains a `plugin_manifest` block comparing
+  `PLUGIN_JSON_FIELDS` against that surface; `print_kernel_shadow()` warns when CCPI
+  is **stale** (a kernel field we lack). The existing `kernel-shadow-validation.yml`
+  CI lane now surfaces plugin-manifest drift automatically — no more hand-patch.
+- The shadow immediately caught one drift: the kernel sanctions a `metadata`
+  plugin.json field (authoring/v2 is-overlay) that CCPI lacked — **adopted** into
+  `PLUGIN_JSON_FIELDS` (now `fields_match: true`).
+
+**Advisory** (`PLUGIN_JSON_FIELDS` stays authoritative until the DR-049 flip), so no
+NON-NEGOTIABLE is touched — same posture as the existing skill-frontmatter + agent
+kernel shadows.
+
+---
+
 ## [3.13.0] — 2026-06-28 — plugin.json unrecognized-field handling: error → warning, + `--strict` (NON-NEGOTIABLE #7, **approved**)
 
 **Error-vs-warning semantics change — NON-NEGOTIABLE #7. APPROVED by Jeremy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ pnpm test && pnpm typecheck
 pnpm lint
 pnpm run verify                   # Full pipeline — what CI's `verify` job runs
 
-# Validator (schema 3.11.0 — see 000-docs/SCHEMA_CHANGELOG.md)
+# Validator (schema 3.13.0 — see 000-docs/SCHEMA_CHANGELOG.md)
 python3 scripts/validate-skills-schema.py --verbose
 python3 scripts/validate-skills-schema.py --marketplace --verbose
 python3 scripts/validate-skills-schema.py --marketplace --populate-db freshie/inventory.sqlite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Best when you want a one-time submission and don't expect frequent updates.
 7. Run `pnpm run sync-marketplace` to regenerate the CLI-compatible catalog.
 8. Run `./scripts/quick-test.sh` -- this must pass before opening a PR.
 
-Only these fields are allowed in `plugin.json`: `name`, `version`, `description`, `author`, `repository`, `homepage`, `license`, `keywords`. CI rejects anything else.
+`plugin.json` recognizes Anthropic's GA manifest fields — `name` (the only strictly required one), `version`, `description`, `author`, `repository`, `homepage`, `license`, `keywords`, plus newer GA fields like `displayName`, `dependencies`, `userConfig`, `channels`, and `$schema`, and the component-declaration keys (`commands`, `agents`, `skills`, `hooks`, `mcpServers`, …). Unrecognized fields **warn** by default — matching Anthropic's own `claude plugin validate` — and are promoted to errors only under the validator's `--strict` flag; a field with the wrong type, or a missing `name`, always fails. See `000-docs/SCHEMA_CHANGELOG.md` (schema 3.12.0 / 3.13.0).
 
 ### Path B — Auto-sync from your own repo (your repo stays source of truth)
 

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -1585,7 +1585,9 @@ def validate_command(path: Path) -> Dict[str, Any]:
 
 # === AGENT VALIDATION ===
 
-VALID_EFFORT_LEVELS = ["low", "medium", "high", "max"]
+# Mirror of AGENT_FIELDS["effort"]["valid"] (the live check). Kept in sync with the
+# Anthropic effort enum — `xhigh` was added (code.claude.com/docs/en/sub-agents).
+VALID_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"]
 
 
 def find_agent_files(root: Path) -> List[Path]:

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -147,8 +147,21 @@ except ImportError:
 #                       error-vs-warning change — APPROVED by Jeremy Longshore
 #                       2026-06-28 (sign-off recorded in the PR thread). No change
 #                       to any required-fields set or tier semantics.
+# 3.14.0 (2026-06-28) — L2 consumer-cutover (692-AA-AACR § 0.5): PLUGIN_JSON_FIELDS
+#                       is now drift-gated against the kernel's CURRENT (authoring/v2)
+#                       plugin-manifest field surface via load_kernel_plugin_fields()
+#                       + a `plugin_manifest` block in kernel_shadow_report() — so the
+#                       next upstream plugin-manifest field the kernel captures is
+#                       CAUGHT in the kernel-shadow CI lane instead of needing a
+#                       hand-patch (the failure mode that produced 3.12.0). The shadow
+#                       immediately surfaced one drift — the kernel sanctions a
+#                       `metadata` plugin.json field (authoring/v2 is-overlay) CCPI
+#                       lacked — now adopted into PLUGIN_JSON_FIELDS (fields match).
+#                       Advisory (PLUGIN_JSON_FIELDS stays authoritative until the
+#                       DR-049 flip). Reads authoring/V2 (v1 plugin-manifest is stale);
+#                       needs @intentsolutions/core>=0.9.0.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.13.0"
+SCHEMA_VERSION = "3.14.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -522,6 +535,7 @@ PLUGIN_JSON_FIELDS = {
     "license": {"type": "string"},
     "keywords": {"type": "array"},
     "$schema": {"type": "string"},  # GA — JSON Schema URL for editor autocomplete (ignored at load)
+    "metadata": {"type": "object"},  # IS-overlay extension (kernel authoring/v2 plugin-manifest is-overlay) — adopted via the L2 kernel shadow (692-AA-AACR)
     # — Component paths —
     "commands": {"type": "string|array"},
     "agents": {"type": "string|array"},
@@ -656,6 +670,58 @@ def load_kernel_agent_required() -> Optional[set]:
     return required or None
 
 
+# L2 consumer-cutover (692-AA-AACR § 0.5). The plugin-manifest contract is read
+# from authoring/V2, not v1: the v1 fold is an early minimal capture (~10 metadata
+# fields), while v2 is the current deep-capture carrying the full GA surface
+# (displayName/defaultEnabled/dependencies/userConfig/channels/$schema/experimental
+# + all component-path fields). Pinning the plugin shadow to v2 is the
+# "promote authoring/v2 canonical" path; needs @intentsolutions/core>=0.9.0.
+_KERNEL_SCHEMA_DIR_V2 = (
+    Path(__file__).resolve().parents[1]
+    / "node_modules"
+    / "@intentsolutions"
+    / "core"
+    / "schemas"
+    / "authoring"
+    / "v2"
+)
+
+
+def load_kernel_plugin_fields() -> Dict[str, Any]:
+    """Existence-guarded load of the kernel's CURRENT (v2) plugin-manifest field
+    surface — the upstream-base ∪ is-overlay property sets. Returns:
+      {"available": False, "reason": str}                       kernel/v2 absent
+      {"available": True, "properties": set, "required": set, "schema_dir": str}
+    Never raises — a missing/corrupt kernel degrades to available=False.
+    """
+    base = _KERNEL_SCHEMA_DIR_V2 / "upstream-base" / "plugin-manifest.v2.json"
+    overlay = _KERNEL_SCHEMA_DIR_V2 / "is-overlay" / "plugin-manifest.v2.json"
+    if not base.exists():
+        return {
+            "available": False,
+            "reason": (
+                "kernel plugin-manifest v2 schema not found under node_modules/"
+                "@intentsolutions/core/schemas/authoring/v2 — run pnpm install "
+                "(needs @intentsolutions/core>=0.9.0; the v1 plugin-manifest fold is stale)"
+            ),
+        }
+    try:
+        base_doc = json_module.loads(base.read_text(encoding="utf-8"))
+        overlay_doc = (
+            json_module.loads(overlay.read_text(encoding="utf-8")) if overlay.exists() else {}
+        )
+    except (OSError, ValueError) as e:
+        return {"available": False, "reason": f"kernel plugin-manifest schema load failed: {e}"}
+    properties = set(base_doc.get("properties", {}) or {}) | set(overlay_doc.get("properties", {}) or {})
+    required = set(base_doc.get("required", []) or []) | set(overlay_doc.get("required", []) or [])
+    return {
+        "available": True,
+        "properties": properties,
+        "required": required,
+        "schema_dir": "node_modules/@intentsolutions/core/schemas/authoring/v2",
+    }
+
+
 def kernel_shadow_report() -> Dict[str, Any]:
     """Build the kernel-shadow comparison block (machine-readable).
 
@@ -688,6 +754,29 @@ def kernel_shadow_report() -> Dict[str, Any]:
         "in_kernel_properties": "disallowed-tools" in kernel["properties"],
         "match": ("disallowed-tools" in SKILL_FIELDS) == ("disallowed-tools" in kernel["properties"]),
     }
+    # L2 consumer-cutover (692-AA-AACR § 0.5): shadow the hand-maintained
+    # PLUGIN_JSON_FIELDS against the kernel's CURRENT (v2) plugin-manifest field
+    # surface, so the next upstream plugin-manifest field the kernel captures is
+    # CAUGHT here instead of needing a hand-patch (the exact failure mode that
+    # produced schema 3.12.0). Advisory — PLUGIN_JSON_FIELDS stays authoritative
+    # until the DR-049 flip; this only surfaces drift. `stale_missing_from_hand_authored`
+    # is the load-bearing signal: a kernel field we lack means we've gone stale.
+    pj_kernel = load_kernel_plugin_fields()
+    plugin_block: Dict[str, Any] = {
+        "schema": "authoring/v2/plugin-manifest (upstream-base + is-overlay)",
+        "available": pj_kernel["available"],
+    }
+    if pj_kernel["available"]:
+        hand_pj = set(PLUGIN_JSON_FIELDS.keys())
+        kpj = pj_kernel["properties"]
+        plugin_block["hand_authored_fields"] = sorted(hand_pj)
+        plugin_block["kernel_fields"] = sorted(kpj)
+        plugin_block["fields_match"] = hand_pj == kpj
+        plugin_block["stale_missing_from_hand_authored"] = sorted(kpj - hand_pj)
+        plugin_block["only_in_hand_authored"] = sorted(hand_pj - kpj)
+    else:
+        plugin_block["note"] = pj_kernel["reason"]
+    report["plugin_manifest"] = plugin_block
     return report
 
 
@@ -725,6 +814,32 @@ def print_kernel_shadow(report: Dict[str, Any]) -> None:
             f"from the hand-authored registry — add it to SKILL_FIELDS",
             file=sys.stderr,
         )
+    # L2 plugin-manifest shadow (692-AA-AACR § 0.5).
+    pj = report.get("plugin_manifest", {})
+    if not pj.get("available"):
+        print(f"{prefix} NOTE: plugin-manifest shadow skipped — {pj.get('note', 'kernel v2 unavailable')}", file=sys.stderr)
+    elif pj.get("fields_match"):
+        print(
+            f"{prefix} NOTE: PLUGIN_JSON_FIELDS matches the kernel v2 plugin-manifest "
+            f"surface ({len(pj.get('kernel_fields', []))} fields) — plugin.json validator is current",
+            file=sys.stderr,
+        )
+    else:
+        stale = pj.get("stale_missing_from_hand_authored") or []
+        extra = pj.get("only_in_hand_authored") or []
+        if stale:
+            print(
+                f"{prefix} WARNING: PLUGIN_JSON_FIELDS is STALE vs the kernel v2 plugin-manifest "
+                f"surface — missing {stale}. The kernel captured these upstream fields; add them "
+                f"to PLUGIN_JSON_FIELDS (this is the drift that used to require a hand-patch).",
+                file=sys.stderr,
+            )
+        if extra:
+            print(
+                f"{prefix} INFO: PLUGIN_JSON_FIELDS carries fields not in the kernel v2 surface: "
+                f"{extra} (IS extensions or ahead-of-kernel — expected for e.g. 'metadata')",
+                file=sys.stderr,
+            )
 
 
 def detect_component(path: Path) -> tuple:

--- a/tests/test_validate_plugin_json_ga_fields.py
+++ b/tests/test_validate_plugin_json_ga_fields.py
@@ -101,3 +101,37 @@ def test_wrong_type_is_always_an_error_even_without_strict(tmp_path):
     # Anthropic fails wrong-type fields regardless of --strict; so do we.
     result = _validate(tmp_path, {"name": "demo", "keywords": "should-be-an-array"})
     assert any("keywords" in e for e in result["errors"]), result
+
+
+# --- L2 consumer-cutover (schema 3.14.0): kernel plugin-manifest drift gate ---
+
+
+def test_kernel_plugin_shadow_is_in_sync():
+    """PLUGIN_JSON_FIELDS must match the kernel's current (authoring/v2)
+    plugin-manifest field surface. If this fails with `stale=[...]`, the kernel
+    captured an upstream field CCPI hasn't adopted — add it to PLUGIN_JSON_FIELDS.
+    Skips only if the kernel isn't installed (needs @intentsolutions/core>=0.9.0).
+    """
+    pj = validator.kernel_shadow_report().get("plugin_manifest", {})
+    if not pj.get("available"):
+        import pytest
+
+        pytest.skip(f"kernel plugin-manifest v2 unavailable: {pj.get('note')}")
+    assert pj["fields_match"], (
+        f"PLUGIN_JSON_FIELDS drifted from kernel v2 plugin-manifest — "
+        f"stale (missing): {pj['stale_missing_from_hand_authored']}, "
+        f"extra: {pj['only_in_hand_authored']}"
+    )
+
+
+def test_kernel_plugin_surface_carries_the_ga_fields():
+    """Sanity: the kernel surface we gate against is the CURRENT one (v2), i.e.
+    it actually contains the GA fields — guards against silently gating against
+    the stale v1 fold."""
+    pj = validator.load_kernel_plugin_fields()
+    if not pj.get("available"):
+        import pytest
+
+        pytest.skip(f"kernel plugin-manifest v2 unavailable: {pj.get('reason')}")
+    for ga in ("displayName", "defaultEnabled", "userConfig", "channels", "dependencies", "experimental"):
+        assert ga in pj["properties"], f"kernel v2 surface missing GA field {ga!r}"


### PR DESCRIPTION
**Closes the second half of the auto-currency loop** (692-AA-AACR § 0.5). L1 made the kernel SSoT durably current; L2 makes CCPI's plugin validator *consume* it instead of being hand-maintained.

`PLUGIN_JSON_FIELDS` had **no** comparison to the kernel, so an upstream GA-field change silently went stale and required a hand-patch (the 3.12.0 event). Now:

- **`load_kernel_plugin_fields()`** reads the kernel's **current** plugin-manifest surface from `@intentsolutions/core` `authoring/`**`v2`** (`upstream-base ∪ is-overlay`). v2 not v1 — v1 is an early ~10-field capture; v2 carries the full GA surface. Needs core `>=0.9.0` (also reconciled the stale `0.4.1` node_modules install via `pnpm install`).
- **`kernel_shadow_report()`** gains a `plugin_manifest` block; **`print_kernel_shadow()`** WARNs when `PLUGIN_JSON_FIELDS` is stale. The existing **`kernel-shadow-validation.yml`** CI lane now surfaces plugin-manifest drift automatically.
- The shadow **immediately caught a drift**: the kernel sanctions a `metadata` plugin.json field (v2 is-overlay) CCPI lacked → adopted into `PLUGIN_JSON_FIELDS` (now `fields_match: true`, 23 fields).

**Advisory** — `PLUGIN_JSON_FIELDS` stays authoritative until the DR-049 flip; same posture as the skill-frontmatter + agent shadows. No NON-NEGOTIABLE touched. 2 new tests; suite green (11 plugin + 26 frontmatter).

- Jeremy Longshore
intentsolutions.io