### PR TITLE
feat(validator): drift-gate plugin.json fields against the kernel (3.14.0)

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,32 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.14.0] — 2026-06-28 — L2 consumer-cutover: plugin.json drift-gated against the kernel (additive, advisory)
+
+**Additive MINOR — no change to any required-field set, tier model, or
+error-vs-warning semantics.** Closes the second half of the auto-currency loop
+(692-AA-AACR § 0.5): `PLUGIN_JSON_FIELDS` was hand-maintained with **no** comparison
+to the kernel, so when upstream gained GA fields the validator silently went stale
+and needed a hand-patch (the 3.12.0 event).
+
+- New `load_kernel_plugin_fields()` reads the kernel's **current** plugin-manifest
+  field surface from `@intentsolutions/core` `authoring/**v2**`
+  (`upstream-base ∪ is-overlay`). v2, not v1 — the v1 plugin-manifest fold is an
+  early ~10-field capture; v2 carries the full GA surface. Needs core `>=0.9.0`.
+- `kernel_shadow_report()` gains a `plugin_manifest` block comparing
+  `PLUGIN_JSON_FIELDS` against that surface; `print_kernel_shadow()` warns when CCPI
+  is **stale** (a kernel field we lack). The existing `kernel-shadow-validation.yml`
+  CI lane now surfaces plugin-manifest drift automatically — no more hand-patch.
+- The shadow immediately caught one drift: the kernel sanctions a `metadata`
+  plugin.json field (authoring/v2 is-overlay) that CCPI lacked — **adopted** into
+  `PLUGIN_JSON_FIELDS` (now `fields_match: true`).
+
+**Advisory** (`PLUGIN_JSON_FIELDS` stays authoritative until the DR-049 flip), so no
+NON-NEGOTIABLE is touched — same posture as the existing skill-frontmatter + agent
+kernel shadows.
+
+---
+
 ## [3.13.0] — 2026-06-28 — plugin.json unrecognized-field handling: error → warning, + `--strict` (NON-NEGOTIABLE #7, **approved**)
 
 **Error-vs-warning semantics change — NON-NEGOTIABLE #7. APPROVED by Jeremy

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -147,8 +147,21 @@ except ImportError:
 #                       error-vs-warning change — APPROVED by Jeremy Longshore
 #                       2026-06-28 (sign-off recorded in the PR thread). No change
 #                       to any required-fields set or tier semantics.
+# 3.14.0 (2026-06-28) — L2 consumer-cutover (692-AA-AACR § 0.5): PLUGIN_JSON_FIELDS
+#                       is now drift-gated against the kernel's CURRENT (authoring/v2)
+#                       plugin-manifest field surface via load_kernel_plugin_fields()
+#                       + a `plugin_manifest` block in kernel_shadow_report() — so the
+#                       next upstream plugin-manifest field the kernel captures is
+#                       CAUGHT in the kernel-shadow CI lane instead of needing a
+#                       hand-patch (the failure mode that produced 3.12.0). The shadow
+#                       immediately surfaced one drift — the kernel sanctions a
+#                       `metadata` plugin.json field (authoring/v2 is-overlay) CCPI
+#                       lacked — now adopted into PLUGIN_JSON_FIELDS (fields match).
+#                       Advisory (PLUGIN_JSON_FIELDS stays authoritative until the
+#                       DR-049 flip). Reads authoring/V2 (v1 plugin-manifest is stale);
+#                       needs @intentsolutions/core>=0.9.0.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.13.0"
+SCHEMA_VERSION = "3.14.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -522,6 +535,9 @@ PLUGIN_JSON_FIELDS = {
     "license": {"type": "string"},
     "keywords": {"type": "array"},
     "$schema": {"type": "string"},  # GA — JSON Schema URL for editor autocomplete (ignored at load)
+    "metadata": {
+        "type": "object"
+    },  # IS-overlay extension (kernel authoring/v2 plugin-manifest is-overlay) — adopted via the L2 kernel shadow (692-AA-AACR)
     # — Component paths —
     "commands": {"type": "string|array"},
     "agents": {"type": "string|array"},
@@ -656,6 +672,50 @@ def load_kernel_agent_required() -> Optional[set]:
     return required or None
 
 
+# L2 consumer-cutover (692-AA-AACR § 0.5). The plugin-manifest contract is read
+# from authoring/V2, not v1: the v1 fold is an early minimal capture (~10 metadata
+# fields), while v2 is the current deep-capture carrying the full GA surface
+# (displayName/defaultEnabled/dependencies/userConfig/channels/$schema/experimental
+# + all component-path fields). Pinning the plugin shadow to v2 is the
+# "promote authoring/v2 canonical" path; needs @intentsolutions/core>=0.9.0.
+_KERNEL_SCHEMA_DIR_V2 = (
+    Path(__file__).resolve().parents[1] / "node_modules" / "@intentsolutions" / "core" / "schemas" / "authoring" / "v2"
+)
+
+
+def load_kernel_plugin_fields() -> Dict[str, Any]:
+    """Existence-guarded load of the kernel's CURRENT (v2) plugin-manifest field
+    surface — the upstream-base ∪ is-overlay property sets. Returns:
+      {"available": False, "reason": str}                       kernel/v2 absent
+      {"available": True, "properties": set, "required": set, "schema_dir": str}
+    Never raises — a missing/corrupt kernel degrades to available=False.
+    """
+    base = _KERNEL_SCHEMA_DIR_V2 / "upstream-base" / "plugin-manifest.v2.json"
+    overlay = _KERNEL_SCHEMA_DIR_V2 / "is-overlay" / "plugin-manifest.v2.json"
+    if not base.exists():
+        return {
+            "available": False,
+            "reason": (
+                "kernel plugin-manifest v2 schema not found under node_modules/"
+                "@intentsolutions/core/schemas/authoring/v2 — run pnpm install "
+                "(needs @intentsolutions/core>=0.9.0; the v1 plugin-manifest fold is stale)"
+            ),
+        }
+    try:
+        base_doc = json_module.loads(base.read_text(encoding="utf-8"))
+        overlay_doc = json_module.loads(overlay.read_text(encoding="utf-8")) if overlay.exists() else {}
+    except (OSError, ValueError) as e:
+        return {"available": False, "reason": f"kernel plugin-manifest schema load failed: {e}"}
+    properties = set(base_doc.get("properties", {}) or {}) | set(overlay_doc.get("properties", {}) or {})
+    required = set(base_doc.get("required", []) or []) | set(overlay_doc.get("required", []) or [])
+    return {
+        "available": True,
+        "properties": properties,
+        "required": required,
+        "schema_dir": "node_modules/@intentsolutions/core/schemas/authoring/v2",
+    }
+
+
 def kernel_shadow_report() -> Dict[str, Any]:
     """Build the kernel-shadow comparison block (machine-readable).
 
@@ -688,6 +748,29 @@ def kernel_shadow_report() -> Dict[str, Any]:
         "in_kernel_properties": "disallowed-tools" in kernel["properties"],
         "match": ("disallowed-tools" in SKILL_FIELDS) == ("disallowed-tools" in kernel["properties"]),
     }
+    # L2 consumer-cutover (692-AA-AACR § 0.5): shadow the hand-maintained
+    # PLUGIN_JSON_FIELDS against the kernel's CURRENT (v2) plugin-manifest field
+    # surface, so the next upstream plugin-manifest field the kernel captures is
+    # CAUGHT here instead of needing a hand-patch (the exact failure mode that
+    # produced schema 3.12.0). Advisory — PLUGIN_JSON_FIELDS stays authoritative
+    # until the DR-049 flip; this only surfaces drift. `stale_missing_from_hand_authored`
+    # is the load-bearing signal: a kernel field we lack means we've gone stale.
+    pj_kernel = load_kernel_plugin_fields()
+    plugin_block: Dict[str, Any] = {
+        "schema": "authoring/v2/plugin-manifest (upstream-base + is-overlay)",
+        "available": pj_kernel["available"],
+    }
+    if pj_kernel["available"]:
+        hand_pj = set(PLUGIN_JSON_FIELDS.keys())
+        kpj = pj_kernel["properties"]
+        plugin_block["hand_authored_fields"] = sorted(hand_pj)
+        plugin_block["kernel_fields"] = sorted(kpj)
+        plugin_block["fields_match"] = hand_pj == kpj
+        plugin_block["stale_missing_from_hand_authored"] = sorted(kpj - hand_pj)
+        plugin_block["only_in_hand_authored"] = sorted(hand_pj - kpj)
+    else:
+        plugin_block["note"] = pj_kernel["reason"]
+    report["plugin_manifest"] = plugin_block
     return report
 
 
@@ -725,6 +808,35 @@ def print_kernel_shadow(report: Dict[str, Any]) -> None:
             f"from the hand-authored registry — add it to SKILL_FIELDS",
             file=sys.stderr,
         )
+    # L2 plugin-manifest shadow (692-AA-AACR § 0.5).
+    pj = report.get("plugin_manifest", {})
+    if not pj.get("available"):
+        print(
+            f"{prefix} NOTE: plugin-manifest shadow skipped — {pj.get('note', 'kernel v2 unavailable')}",
+            file=sys.stderr,
+        )
+    elif pj.get("fields_match"):
+        print(
+            f"{prefix} NOTE: PLUGIN_JSON_FIELDS matches the kernel v2 plugin-manifest "
+            f"surface ({len(pj.get('kernel_fields', []))} fields) — plugin.json validator is current",
+            file=sys.stderr,
+        )
+    else:
+        stale = pj.get("stale_missing_from_hand_authored") or []
+        extra = pj.get("only_in_hand_authored") or []
+        if stale:
+            print(
+                f"{prefix} WARNING: PLUGIN_JSON_FIELDS is STALE vs the kernel v2 plugin-manifest "
+                f"surface — missing {stale}. The kernel captured these upstream fields; add them "
+                f"to PLUGIN_JSON_FIELDS (this is the drift that used to require a hand-patch).",
+                file=sys.stderr,
+            )
+        if extra:
+            print(
+                f"{prefix} INFO: PLUGIN_JSON_FIELDS carries fields not in the kernel v2 surface: "
+                f"{extra} (IS extensions or ahead-of-kernel — expected for e.g. 'metadata')",
+                file=sys.stderr,
+            )
 
 
 def detect_component(path: Path) -> tuple:
@@ -1674,10 +1786,7 @@ def validate_plugin_json(path: Path, strict: bool = False) -> Dict[str, Any]:
             # near-miss of a recognized one; mirror that.
             near = difflib.get_close_matches(key, valid_fields, n=1, cutoff=0.8)
             hint = f" (did you mean '{near[0]}'?)" if near else ""
-            msg = (
-                f"Unrecognized field: '{key}' — not in the Anthropic plugin "
-                f"manifest spec; ignored at load{hint}"
-            )
+            msg = f"Unrecognized field: '{key}' — not in the Anthropic plugin manifest spec; ignored at load{hint}"
             (errors if strict else warnings).append(msg)
 
     TYPE_MAP = {"string": str, "object": dict, "array": list, "boolean": bool}
@@ -4172,9 +4281,7 @@ def validate_skill(path: Path, tier: str = TIER_STANDARD) -> Dict[str, Any]:
     }
 
 
-def validate_plugin(
-    plugin_dir: Path, tier: str = TIER_STANDARD, strict: bool = False
-) -> Dict[str, Any]:
+def validate_plugin(plugin_dir: Path, tier: str = TIER_STANDARD, strict: bool = False) -> Dict[str, Any]:
     """Validate a plugin as a complete unit.
     Walks all components and rolls up scores.
 

--- a/tests/test_validate_plugin_json_ga_fields.py
+++ b/tests/test_validate_plugin_json_ga_fields.py
@@ -101,3 +101,37 @@ def test_wrong_type_is_always_an_error_even_without_strict(tmp_path):
     # Anthropic fails wrong-type fields regardless of --strict; so do we.
     result = _validate(tmp_path, {"name": "demo", "keywords": "should-be-an-array"})
     assert any("keywords" in e for e in result["errors"]), result
+
+
+# --- L2 consumer-cutover (schema 3.14.0): kernel plugin-manifest drift gate ---
+
+
+def test_kernel_plugin_shadow_is_in_sync():
+    """PLUGIN_JSON_FIELDS must match the kernel's current (authoring/v2)
+    plugin-manifest field surface. If this fails with `stale=[...]`, the kernel
+    captured an upstream field CCPI hasn't adopted — add it to PLUGIN_JSON_FIELDS.
+    Skips only if the kernel isn't installed (needs @intentsolutions/core>=0.9.0).
+    """
+    pj = validator.kernel_shadow_report().get("plugin_manifest", {})
+    if not pj.get("available"):
+        import pytest
+
+        pytest.skip(f"kernel plugin-manifest v2 unavailable: {pj.get('note')}")
+    assert pj["fields_match"], (
+        f"PLUGIN_JSON_FIELDS drifted from kernel v2 plugin-manifest — "
+        f"stale (missing): {pj['stale_missing_from_hand_authored']}, "
+        f"extra: {pj['only_in_hand_authored']}"
+    )
+
+
+def test_kernel_plugin_surface_carries_the_ga_fields():
+    """Sanity: the kernel surface we gate against is the CURRENT one (v2), i.e.
+    it actually contains the GA fields — guards against silently gating against
+    the stale v1 fold."""
+    pj = validator.load_kernel_plugin_fields()
+    if not pj.get("available"):
+        import pytest
+
+        pytest.skip(f"kernel plugin-manifest v2 unavailable: {pj.get('reason')}")
+    for ga in ("displayName", "defaultEnabled", "userConfig", "channels", "dependencies", "experimental"):
+        assert ga in pj["properties"], f"kernel v2 surface missing GA field {ga!r}"


### PR DESCRIPTION
**Closes L2 — the second half of the auto-currency loop** (`692-AA-AACR § 0.5`). L1 made the kernel SSoT durably current; L2 makes CCPI's plugin validator *consume* it instead of being hand-maintained.

`PLUGIN_JSON_FIELDS` had **no** comparison to the kernel, so an upstream GA-field change silently went stale and required a hand-patch (the 3.12.0 event). Now:

- **`load_kernel_plugin_fields()`** reads the kernel's **current** plugin-manifest surface from `@intentsolutions/core` `authoring/`**`v2`** (`upstream-base ∪ is-overlay`). v2 not v1 — v1 is an early ~10-field capture; v2 has the full GA surface. Needs core `>=0.9.0` (also reconciled a stale `0.4.1` node_modules install).
- **`kernel_shadow_report()`** gains a `plugin_manifest` block; **`print_kernel_shadow()`** warns when `PLUGIN_JSON_FIELDS` is stale. The existing **`kernel-shadow-validation`** CI lane now surfaces plugin-manifest drift automatically.
- The shadow **caught a drift on first run**: the kernel sanctions a `metadata` plugin.json field (v2 is-overlay) CCPI lacked → adopted (now `fields_match: true`).

**Advisory** — `PLUGIN_JSON_FIELDS` stays authoritative until the DR-049 flip; same posture as the skill + agent shadows. No NON-NEGOTIABLE touched. 2 new tests; suite green (11 plugin + 26 frontmatter).

- Jeremy Longshore
intentsolutions.io