### PR TITLE
fix(bash): safe empty-array expansion for bash 3.2 (macOS)

### DIFF
--- a/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
+++ b/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
@@ -142,7 +142,9 @@ load_config() {
     fi
 
     # Combine default + custom exclusions (additive pattern)
-    ALL_EXCLUDES=("${DEFAULT_EXCLUDES[@]}" "${EXCLUDE_PATHS[@]}")
+    # Use conditional expansion to avoid unbound variable error on bash 3.2 (macOS default)
+    # when EXCLUDE_PATHS is empty and set -u is active.
+    ALL_EXCLUDES=("${DEFAULT_EXCLUDES[@]}" "${EXCLUDE_PATHS[@]+"${EXCLUDE_PATHS[@]}"}")
 }
 
 # ============================================================================

--- a/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
+++ b/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
@@ -171,7 +171,7 @@ is_excluded_workspace() {
     fi
 
     # Check against configured organization exclusions
-    for org in "${EXCLUDE_ORGS[@]}"; do
+    for org in ${EXCLUDE_ORGS[@]+"${EXCLUDE_ORGS[@]}"}; do
         if [[ "$remote_url" =~ github\.com[:/]$org/ ]]; then
             log_info "Workspace excluded: $org matches $remote_url"
             return 0  # EXCLUDED


### PR DESCRIPTION
## Problem

On macOS, the default shell is **bash 3.2**. When `set -u` is active, expanding an empty array raises an *unbound variable* error:

```bash
# fails on bash 3.2 when EXCLUDE_PATHS is empty
ALL_EXCLUDES=("${DEFAULT_EXCLUDES[@]}" "${EXCLUDE_PATHS[@]}")
# bash: EXCLUDE_PATHS[@]: unbound variable
```

This causes the hook to crash on a stock macOS system whenever no custom `excludePaths` are configured.

## Fix

Use the conditional expansion idiom `${var[@]+"${var[@]}"}`, which expands to nothing when the array is unset or empty and is safe across all bash versions:

```bash
ALL_EXCLUDES=("${DEFAULT_EXCLUDES[@]}" ${EXCLUDE_PATHS[@]+"${EXCLUDE_PATHS[@]}"})
```

No behaviour change when `EXCLUDE_PATHS` has elements.

## Tested on

- macOS bash 3.2.57 (stock macOS shell)
- bash 5.x (Homebrew)

🤖 Generated with [Claude Code](https://claude.com/claude-code)