### PR TITLE
fix(prettier-markdown-hook): guard git commit behind ENABLE_AI_COMMITS flag

### DIFF
--- a/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
+++ b/plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh
@@ -302,8 +302,10 @@ Standardized formatting for $changed_files file(s)."
 Automated formatting of $changed_files markdown file(s) by prettier hook."
     fi
 
-    # Step 5: Commit with AI-generated or generic message
-    git commit -m "$commit_message" 2>/dev/null || true
+    # Step 5: Commit only if AI commits explicitly enabled
+    if [[ "$ENABLE_AI_COMMITS" == "true" ]]; then
+        git commit -m "$commit_message" 2>/dev/null || true
+    fi
 
 } > /dev/null 2>&1 &
 


### PR DESCRIPTION
## Summary

**Affects:** `plugins/productivity/prettier-markdown-hook/scripts/format-markdown.sh`

The prettier markdown hook unconditionally runs `git commit` after formatting, regardless of whether the user has opted in to AI-generated commit messages. This causes silent, unexpected commits on every Claude stop event for users who have not set `PRETTIER_ENABLE_AI_COMMITS`.

## Before

```bash
# Step 5: Commit with AI-generated or generic message
git commit -m "$commit_message" 2>/dev/null || true
```

Every run commits, even with a generic fallback message and no opt-in.

## After

```bash
# Step 5: Commit only if AI commits explicitly enabled
if [[ "$ENABLE_AI_COMMITS" == "true" ]]; then
    git commit -m "$commit_message" 2>/dev/null || true
fi
```

The commit step now only runs when `ENABLE_AI_COMMITS` is `true`, which is set exclusively by the `PRETTIER_ENABLE_AI_COMMITS` environment variable — matching the documented opt-in behaviour.

## Impact

Users who have **not** set `PRETTIER_ENABLE_AI_COMMITS` will no longer see unexpected commits created by the hook. Users who have opted in are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)