### PR TITLE
feat(spotlight): databricks-pack — Killer Skill of the Week + Jeremy's Stash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Or use Claude's built-in command:
 
 <!-- KILLER-SKILL:START — do not edit; run `node scripts/render-spotlight.mjs` -->
 
-> **Killer Skill of the Week** — [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate) by [Kobiton Inc.](https://github.com/kobiton)
+> **Killer Skill of the Week** — [databricks-pack](https://tonsofskills.com/plugins/databricks-pack) by [Jeremy Longshore](https://github.com/jeremylongshore)
 >
-> **Real mobile devices on demand — no emulators, no flaky CI**
+> **Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess**
 >
-> Kobiton's automate plugin gives Claude Code, Cursor, Codex, and Gemini CLI direct access to the Kobiton real-device cloud via remote MCP. 12 tools across three surfaces — Devices (list / reserve / status / terminate), Sessions (list / get / artifacts / terminate), and Apps (upload / confirm / list / get) — plus 3 specialist agents for device picking, Appium capability reconciliation, and session triage. One install, real iOS + Android hardware, no emulator drift.
+> The databricks-cost-leak-hunter skill audits a workspace for real-dollar cost leaks and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure is computed from the customer's own system.billing.usage joined to list_prices — never an estimate. Four named leaks — idle clusters that never auto-terminate, scheduled jobs on All-Purpose compute (2–3× overpay), overprovisioned clusters, and the Photon premium paid without the speedup — each tagged confirmed / estimated / at-risk so a CFO never confuses billed waste with modeled savings. A deterministic Python ranker does the arithmetic (the LLM never eyeballs a number), and the databricks-workspace-mcp control plane turns each leak into a single-config-change fix. One of 24 skills in the Databricks pack.
 >
-> _"Mobile testing that runs where the bugs actually live — on the device, not the simulator."_ — Kobiton Inc.
+> _"A $100K/month Databricks workspace is likely burning ~$27,000/month — and every line is one config change."_ — Jeremy Longshore
 >
-> Grade: A | Week of May 20, 2026 (W21) | [Browse on Marketplace](https://tonsofskills.com/plugins/kobiton-automate)
+> Grade: A | Week of June 30, 2026 (W27) | [Browse on Marketplace](https://tonsofskills.com/plugins/databricks-pack)
 >
-> Previous picks: [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
+> Previous picks: [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate), [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
 
 <!-- KILLER-SKILL:END -->
 

--- a/marketplace/src/data/jeremys-stash.json
+++ b/marketplace/src/data/jeremys-stash.json
@@ -1,7 +1,17 @@
 {
   "title": "Jeremy's Stash",
-  "subtitle": "Standalone plugins I built and maintain. Each has its own repo you can clone directly.",
+  "subtitle": "Plugins and packs I built and maintain — my own picks. Most ship as a standalone repo you can clone directly.",
   "items": [
+    {
+      "name": "Databricks Cost Leak Hunter",
+      "slug": "databricks-pack",
+      "description": "Audits a Databricks workspace for real-dollar cost leaks — idle clusters, jobs on the wrong compute, overprovisioning, the Photon premium — and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure comes from the customer's own system.billing.usage, never an estimate. The headline skill of the 24-skill Databricks pack.",
+      "repoUrl": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/tree/main/plugins/saas-packs/databricks-pack",
+      "pluginLink": "/plugins/databricks-pack",
+      "tags": ["databricks", "finops", "cost", "saas"],
+      "grade": "A",
+      "new": true
+    },
     {
       "name": "Box Cloud Filesystem",
       "slug": "box-cloud-filesystem",
@@ -10,11 +20,11 @@
       "pluginLink": "/plugins/box-cloud-filesystem",
       "tags": ["cloud-storage", "hooks", "sync"],
       "grade": "A",
-      "new": true
+      "new": false
     }
   ],
   "meta": {
-    "lastUpdated": "2026-03-17",
+    "lastUpdated": "2026-06-30",
     "curatedBy": "Jeremy Longshore"
   }
 }

--- a/marketplace/src/data/spotlights.json
+++ b/marketplace/src/data/spotlights.json
@@ -1,19 +1,32 @@
 {
-  "week": "2026-W21",
+  "week": "2026-W27",
   "title": "Killer Skill of the Week",
   "spotlight": {
-    "pluginSlug": "kobiton-automate",
-    "headline": "Real mobile devices on demand — no emulators, no flaky CI",
-    "whyKiller": "Kobiton's automate plugin gives Claude Code, Cursor, Codex, and Gemini CLI direct access to the Kobiton real-device cloud via remote MCP. 12 tools across three surfaces — Devices (list / reserve / status / terminate), Sessions (list / get / artifacts / terminate), and Apps (upload / confirm / list / get) — plus 3 specialist agents for device picking, Appium capability reconciliation, and session triage. One install, real iOS + Android hardware, no emulator drift.",
-    "author": "Kobiton Inc.",
-    "authorGithub": "kobiton",
+    "pluginSlug": "databricks-pack",
+    "headline": "Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess",
+    "whyKiller": "The databricks-cost-leak-hunter skill audits a workspace for real-dollar cost leaks and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure is computed from the customer's own system.billing.usage joined to list_prices — never an estimate. Four named leaks — idle clusters that never auto-terminate, scheduled jobs on All-Purpose compute (2–3× overpay), overprovisioned clusters, and the Photon premium paid without the speedup — each tagged confirmed / estimated / at-risk so a CFO never confuses billed waste with modeled savings. A deterministic Python ranker does the arithmetic (the LLM never eyeballs a number), and the databricks-workspace-mcp control plane turns each leak into a single-config-change fix. One of 24 skills in the Databricks pack.",
+    "author": "Jeremy Longshore",
+    "authorGithub": "jeremylongshore",
     "grade": "A",
-    "skillCount": 1,
-    "category": "testing",
-    "link": "/plugins/kobiton-automate",
-    "quote": "Mobile testing that runs where the bugs actually live — on the device, not the simulator."
+    "skillCount": 24,
+    "category": "saas-packs",
+    "link": "/plugins/databricks-pack",
+    "quote": "A $100K/month Databricks workspace is likely burning ~$27,000/month — and every line is one config change."
   },
   "hallOfFame": [
+    {
+      "week": "2026-W21",
+      "pluginSlug": "kobiton-automate",
+      "headline": "Real mobile devices on demand — no emulators, no flaky CI",
+      "whyKiller": "Kobiton's automate plugin gives Claude Code, Cursor, Codex, and Gemini CLI direct access to the Kobiton real-device cloud via remote MCP. 12 tools across three surfaces — Devices (list / reserve / status / terminate), Sessions (list / get / artifacts / terminate), and Apps (upload / confirm / list / get) — plus 3 specialist agents for device picking, Appium capability reconciliation, and session triage. One install, real iOS + Android hardware, no emulator drift.",
+      "author": "Kobiton Inc.",
+      "authorGithub": "kobiton",
+      "grade": "A",
+      "skillCount": 1,
+      "category": "testing",
+      "link": "/plugins/kobiton-automate",
+      "quote": "Mobile testing that runs where the bugs actually live — on the device, not the simulator."
+    },
     {
       "week": "2026-W18",
       "pluginSlug": "skyvern",
@@ -113,8 +126,8 @@
     }
   ],
   "meta": {
-    "version": "2.4.0",
-    "lastUpdated": "2026-05-20",
+    "version": "2.5.0",
+    "lastUpdated": "2026-06-30",
     "curatedBy": "Jeremy Longshore"
   }
 }


### PR DESCRIPTION
## Killer Skill of the Week → `databricks-pack` (cost-leak-hunter)

Editorial pick (Jeremy). Rotates the spotlight to the **databricks-cost-leak-hunter** skill and adds it to Jeremy's Stash.

**Spotlight** (`marketplace/src/data/spotlights.json` + README block, via `promote-spotlight.mjs`):
- `kobiton-automate` (W21) → hallOfFame
- `databricks-pack` → spotlight (W27): *"Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess."*
- README `KILLER-SKILL` block regenerated by `render-spotlight.mjs`.

**Jeremy's Stash** (`marketplace/src/data/jeremys-stash.json`):
- adds **Databricks Cost Leak Hunter** (links `/plugins/databricks-pack`).
- subtitle broadened ("plugins and packs… most ship as a standalone repo") since `databricks-pack` lives in the monorepo, not a standalone clone — keeping the section's claim accurate.

## Verified alongside this

- **Marketplace:** `databricks-pack` is a live catalog entry (saas-packs).
- **Cowork download:** built zip, ~203 KB, 24 skills.
- Companion artifacts (not in this PR): [CFO sample-output gist](https://gist.github.com/jeremylongshore/c85139d2808877c9c40fe8099f5800d9) · [technical breakdown gist](https://gist.github.com/jeremylongshore/397500229c5f8e0b33173e460a1d1c9f) · architecture diagram live at `demos.intentsolutions.io/databricks-cost-leak-hunter/architecture.html`.

Data/content change only (no `plugins/**`). `[skip auto-bump]`.

- Jeremy Longshore
intentsolutions.io