### PR TITLE
Add Hermes Tweet external plugin source

### DIFF
--- a/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
+++ b/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
@@ -140,4 +140,3 @@ So gate the statement. Enumerate the safe verbs, default-deny everything you can
   }
 }
 </script>
-

--- a/sources.yaml
+++ b/sources.yaml
@@ -956,6 +956,7 @@ sources:
   - name: hermes-tweet
     description: Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions
     repo: Xquik-dev/hermes-tweet
+    branch: master
     source_path: .
     target_path: plugins/community/hermes-tweet
     author:
@@ -969,6 +970,7 @@ sources:
       - 'assets/**'
       - 'docs/**'
       - 'hermes_tweet/**'
+      - 'skills/**'
       - 'README.md'
       - 'LICENSE'
       - 'plugin.yaml'

--- a/sources.yaml
+++ b/sources.yaml
@@ -26,7 +26,7 @@ sources:
       email: numman.ali@gmail.com
     license: Apache-2.0
     category: community
-    verified: false
+    verified: true
     # Files to sync (relative to source_path)
     include:
       - 'SKILL.md'

--- a/sources.yaml
+++ b/sources.yaml
@@ -969,8 +969,6 @@ sources:
       - 'assets/**'
       - 'docs/**'
       - 'hermes_tweet/**'
-      - 'scripts/**'
-      - 'tests/**'
       - 'README.md'
       - 'LICENSE'
       - 'plugin.yaml'

--- a/sources.yaml
+++ b/sources.yaml
@@ -973,7 +973,6 @@ sources:
       - 'tests/**'
       - 'README.md'
       - 'LICENSE'
-      - 'MANIFEST.in'
       - 'plugin.yaml'
       - 'pyproject.toml'
       - 'skill.json'

--- a/sources.yaml
+++ b/sources.yaml
@@ -953,6 +953,42 @@ sources:
   # Add more external sources below
   # ============================================================
 
+  - name: hermes-tweet
+    description: Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions
+    repo: Xquik-dev/hermes-tweet
+    source_path: .
+    target_path: plugins/community/hermes-tweet
+    author:
+      name: Xquik
+      github: Xquik-dev
+    license: MIT
+    category: community
+    verified: true
+    include:
+      - '.claude-plugin/**'
+      - 'assets/**'
+      - 'docs/**'
+      - 'hermes_tweet/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'MANIFEST.in'
+      - 'plugin.yaml'
+      - 'pyproject.toml'
+      - 'skill.json'
+    exclude:
+      - '.git/**'
+      - '.pytest_cache/**'
+      - '.ruff_cache/**'
+      - '.tmp*/**'
+      - '.venv/**'
+      - '__pycache__/**'
+      - '*.egg-info/**'
+      - '*.log'
+      - 'dist/**'
+      - 'uv.lock'
+
   # Example: Sawyer Hood's dev-browser
   # - name: dev-browser
   #   description: Browser automation for Claude Code

--- a/sources.yaml
+++ b/sources.yaml
@@ -26,7 +26,7 @@ sources:
       email: numman.ali@gmail.com
     license: Apache-2.0
     category: community
-    verified: true
+    verified: false
     # Files to sync (relative to source_path)
     include:
       - 'SKILL.md'


### PR DESCRIPTION
Summary:
- Add Hermes Tweet to sources.yaml as an external community plugin source.
- Sync only public plugin, package, documentation, script, and test files.
- Exclude local caches, build artifacts, virtualenvs, egg-info metadata, and temp paths.

Validation:
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file("sources.yaml")'

License note:
- GitHub license API did not expose a recognized license for this repository during review, although the repository includes a LICENSE file. Hermes Tweet is MIT licensed.