### PR TITLE
chore(deps): bump @intentsolutions/jrig-cli 0.1.0 → 0.1.1 (criteria_ids scoping fix) [skip auto-bump]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ cd packages/cli && pnpm test -- --grep "pattern"
 # JRig behavioral eval — the published @intentsolutions/jrig-cli (bin `j-rig`),
 # pinned as a root devDep. Invoke via `pnpm exec j-rig` so it resolves the
 # repo's pinned version (node_modules/.bin/j-rig), NOT a global shim.
-pnpm exec j-rig --version         # → 0.1.0 (the real 7-layer CLI)
+pnpm exec j-rig --version         # → 0.1.1 (the real 7-layer CLI)
 pnpm exec j-rig check <skill-dir> # Tier 3A: deterministic (~seconds, free, no API key, no DB)
 
 # Real behavioral eval (opt-in, ~$2-5/skill) — needs a provider API key + the
@@ -176,7 +176,7 @@ The validator itself does a kernel-loaded **shadow read** of `ALWAYS_REQUIRED` (
 
 As of now the soak has **not** met the bar — agreement sits below 99.5%, and the open disagreements are real tool-safety / shell-substitution security cases that the prose-spec validator correctly blocks (so flipping early would weaken a real gate). Until every condition above is satisfied, validator authority stays with `validate-skills-schema.py` and both kernel lanes stay advisory. Promotion to blocking is a separate, later cutover step gated by these conditions — never a side effect of an unrelated PR.
 
-**Alignment note (`@intentsolutions/jrig-cli`).** The `j-rig` behavioral-eval CLI is a root devDep pinned to `@intentsolutions/jrig-cli@0.1.0`, which depends on `@intentsolutions/core@^0.8.0`. The **root** `@intentsolutions/core` pin is now **exactly `0.9.0`** — the same major/minor jrig-cli wants — so the previously-nested duplicate resolves to the shared root-hoisted copy and the kernel-shadow + kernel-vendor lanes read it directly. The pin bump is a coupling update only; the authority flip and the root-pin cutover to `authoring/v2` remain the separate, gated steps above.
+**Alignment note (`@intentsolutions/jrig-cli`).** The `j-rig` behavioral-eval CLI is a root devDep pinned to **exactly `@intentsolutions/jrig-cli@0.1.1`**, which depends on **`@intentsolutions/core@0.9.0` (exact)** — the same version the **root** `@intentsolutions/core` pin carries — so they resolve to one shared root-hoisted copy and the kernel-shadow + kernel-vendor lanes read it directly. (The bump from `0.1.0` → `0.1.1` also picked up the per-test-case `criteria_ids` scoping fix [jrig #162], so `pnpm exec j-rig eval` no longer applies every criterion to every test case — the prior `0.1.0` lacked it. A transitive dep, `@intentsolutions/refiner-core@0.2.0`, still peer-wants `core@^0.8.0`; pnpm surfaces that as a non-fatal warning until refiner-core widens its peer range.) The pin bump is a coupling update only; the authority flip and the root-pin cutover to `authoring/v2` remain the separate, gated steps above.
 
 ### Validator consolidation (already landed)
 

--- a/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
+++ b/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
@@ -140,4 +140,3 @@ So gate the statement. Enumerate the safe verbs, default-deny everything you can
   }
 }
 </script>
-

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@eslint/js": "^9.39.4",
     "@intentsolutions/audit-harness": "^1.1.5",
     "@intentsolutions/core": "0.9.0",
-    "@intentsolutions/jrig-cli": "0.1.0",
+    "@intentsolutions/jrig-cli": "0.1.1",
     "@types/node": "^20.19.41",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@intentsolutions/jrig-cli':
-        specifier: 0.1.0
-        version: 0.1.0(bun-types@1.3.11)
+        specifier: 0.1.1
+        version: 0.1.1(bun-types@1.3.11)
       '@types/node':
         specifier: ^20.19.41
         version: 20.19.41
@@ -256,8 +256,6 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  plugins/mcp/beads-dolt: {}
-
   plugins/mcp/conversational-api-debugger:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -332,6 +330,8 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  plugins/mcp/dolt-mcp-vcs: {}
 
   plugins/mcp/domain-memory-agent:
     dependencies:
@@ -1787,8 +1787,8 @@ packages:
     resolution: {integrity: sha512-XGF3rR/FFgRz1qkiXMEXLijmPX3/9layH9e2wqykMitkl2gX/JREpS6ilRXB1tVnkdcHnDdfAxWstpW/UoGKsA==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
 
-  '@intentsolutions/jrig-cli@0.1.0':
-    resolution: {integrity: sha512-FySjCeY1LBkdN1LFggDYo0kPH9WB++gUMhH78vNQyQikcDc+cFdelEyOBj2K8tOQ2yavuW4OXfvJn9Iug3VzFw==}
+  '@intentsolutions/jrig-cli@0.1.1':
+    resolution: {integrity: sha512-kyI+azhcUtgldGoWVvXkUtRWyPOGqy/HSt3H0ZqB+4VUOInbZ7fuov6pgDO8NWk1pJGCokf5sA35QxDV4dp/TA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -6784,7 +6784,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@intentsolutions/jrig-cli@0.1.0(bun-types@1.3.11)':
+  '@intentsolutions/jrig-cli@0.1.1(bun-types@1.3.11)':
     dependencies:
       '@intentsolutions/core': 0.9.0
       '@intentsolutions/refiner': 0.2.0(@intentsolutions/core@0.9.0)


### PR DESCRIPTION
## Why

The repo pinned `@intentsolutions/jrig-cli@0.1.0`, which **predates jrig #162**. On 0.1.0, `pnpm exec j-rig eval` applies **every criterion to every test case** — so an off-topic `should_not_trigger` control prompt fails unrelated criteria (the *false-blocker bug that inflated NO-SHIP rates*, named in the jrig source comment). 0.1.1 ships the `selectCriteriaForTestCase` scoping fix.

Surfaced dogfooding our own eval on two real external skills (`Xquik-dev/hermes-tweet`, `Xquik-dev/x-twitter-scraper`): with the pinned 0.1.0, control prompts ("capital of France", "Hamlet plot") failed X-safety criteria and drove a spurious `block`. Running 0.1.1 scopes criteria correctly.

## Kernel-coupling safety

0.1.1 depends on `@intentsolutions/core@0.9.0` **(exact)** — the same version the root pins — so it resolves to the shared root-hoisted copy and the **kernel-shadow + kernel-vendor-hash lanes are unaffected** (C = 0.9.0 unchanged; V ≤ C ≤ K holds). This is a coupling/governance update only — **no validator-authority change**, no `authoring/v2` cutover.

## Scope

- `package.json`: `@intentsolutions/jrig-cli` 0.1.0 → 0.1.1
- `pnpm-lock.yaml`: jrig-cli-scoped (7 insertions / 7 deletions)
- `CLAUDE.md`: keep the version-display line + the Alignment note accurate

The pre-existing transitive `@intentsolutions/refiner-core@0.2.0` peer-want of `core@^0.8.0` stays a **non-fatal** pnpm warning (already present on 0.1.0; no `strict-peer-dependencies`).

`[skip auto-bump]` — dependency/governance bump, not a plugin release.

- Jeremy Longshore
intentsolutions.io