### PR TITLE
chore(deps): bump @intentsolutions/jrig-cli 0.1.1 → 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@eslint/js": "^9.39.4",
     "@intentsolutions/audit-harness": "^1.1.5",
     "@intentsolutions/core": "0.9.0",
-    "@intentsolutions/jrig-cli": "0.1.1",
+    "@intentsolutions/jrig-cli": "0.1.2",
     "@types/node": "^20.19.41",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@intentsolutions/jrig-cli':
-        specifier: 0.1.1
-        version: 0.1.1(bun-types@1.3.11)
+        specifier: 0.1.2
+        version: 0.1.2(bun-types@1.3.11)
       '@types/node':
         specifier: ^20.19.41
         version: 20.19.41
@@ -1787,8 +1787,8 @@ packages:
     resolution: {integrity: sha512-XGF3rR/FFgRz1qkiXMEXLijmPX3/9layH9e2wqykMitkl2gX/JREpS6ilRXB1tVnkdcHnDdfAxWstpW/UoGKsA==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
 
-  '@intentsolutions/jrig-cli@0.1.1':
-    resolution: {integrity: sha512-kyI+azhcUtgldGoWVvXkUtRWyPOGqy/HSt3H0ZqB+4VUOInbZ7fuov6pgDO8NWk1pJGCokf5sA35QxDV4dp/TA==}
+  '@intentsolutions/jrig-cli@0.1.2':
+    resolution: {integrity: sha512-UkrdEerwf/58Je5OOLLA9n6NmnnCtyp+ySnGPACANAuZSWpC+x4WdwgPyMz4YSZS++aJuHpyUerOUQa2RHMkJw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -6784,7 +6784,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@intentsolutions/jrig-cli@0.1.1(bun-types@1.3.11)':
+  '@intentsolutions/jrig-cli@0.1.2(bun-types@1.3.11)':
     dependencies:
       '@intentsolutions/core': 0.9.0
       '@intentsolutions/refiner': 0.2.0(@intentsolutions/core@0.9.0)


### PR DESCRIPTION
## What

Bumps the exact pin `@intentsolutions/jrig-cli` `0.1.1 → 0.1.2` and refreshes the lockfile.

## Why

The pin was **exact** at `0.1.1`, which predates four fixes merged to j-rig `main` on 2026-06-30 and now published as `@intentsolutions/jrig-cli@0.1.2` (sigstore provenance):

| PR | Change |
|---|---|
| #173 | `fix(providers)`: raise functional-exec `max_tokens` + surface length-truncation |
| #175 | `fix(providers)`: recover judge verdict from truncated/fenced JSON (`{verdict: yes\|no}` no longer mis-bucketed as `unsure`) |
| #172 | `feat(eval)`: `--emit-bundle` `gate-result/v1` Evidence Bundle |
| #174 | `feat(cli)`: `scaffold-spec` |

Stranded at `0.1.1`, this repo's skill evals still hit the #173 + #175 truncation bugs that inflate **false NO-SHIP** — the exact failure the Xquik dogfood surfaced (`693-AA-AACR`). j-rig runs here as a **build-time enrichment step** (not a PR merge gate), so blast radius is verification badges + manual evals, not the merge gate.

## Scope

- `package.json` pin + `pnpm-lock.yaml` (change scoped to the jrig-cli entry).
- The pre-existing `@intentsolutions/refiner-core@0.2.0` peer-range warning (wants `core ^0.8.0`, repo has `0.9.0`) is unrelated to this bump — it's a refiner-core packaging range, surfaced by any install.

Part of #927 (pin-bump + CI-hardening cluster).

**Beads:** `bd_000-projects-ediiy` — under epic `bd_000-projects-4yxwc`.

- Jeremy Longshore
intentsolutions.io