### PR TITLE
fix(marketplace): enrich-jrig-data warns loudly instead of silently blanking badges

### DIFF
--- a/marketplace/scripts/enrich-jrig-data.mjs
+++ b/marketplace/scripts/enrich-jrig-data.mjs
@@ -42,6 +42,22 @@ const dbPath = path.join(repoRoot, 'freshie', 'inventory.sqlite');
 const outPath = path.join(__dirname, '..', 'src', 'data', 'jrig-data.json');
 
 /**
+ * Emit a loud, CI-visible warning. In GitHub Actions this renders as a
+ * `::warning::` annotation on the run summary (not just buried in the step
+ * log); locally it prints a plain `[enrich-jrig] WARNING:` line. Used instead
+ * of a silent `console.log` in every degradation path: writing `{}` silently
+ * blanks every "JRig-Verified" badge with no signal that the data source is
+ * missing or empty.
+ */
+function warn(message) {
+  const rel = path.relative(repoRoot, outPath);
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    console.log(`::warning file=${rel}::${message}`);
+  }
+  console.warn(`[enrich-jrig] WARNING: ${message}`);
+}
+
+/**
  * Run a SQL query via the `sqlite3` CLI. We avoid the better-sqlite3
  * native module to keep this script dependency-free — the marketplace
  * build already has 6 sequential steps and we'd rather not add a
@@ -84,13 +100,20 @@ function main() {
   const data = {};
 
   if (!fs.existsSync(dbPath)) {
-    console.log(`[enrich-jrig] Freshie DB not found at ${dbPath} — writing empty map`);
+    warn(
+      `Freshie DB not found at ${path.relative(repoRoot, dbPath)} — every ` +
+        `JRig-Verified badge will render "pending". Writing empty map.`,
+    );
     fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');
     return;
   }
 
   if (!tableExists(dbPath, 'forge_proofs')) {
-    console.log('[enrich-jrig] forge_proofs table not yet created — writing empty map');
+    warn(
+      'forge_proofs table not present in the Freshie DB — no JRig behavioral ' +
+        'evals have been persisted. Every JRig-Verified badge will render ' +
+        '"pending". Writing empty map.',
+    );
     fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');
     return;
   }
@@ -116,7 +139,7 @@ function main() {
   );
 
   if (!Array.isArray(rows)) {
-    console.warn('[enrich-jrig] query returned non-array — writing empty map');
+    warn('forge_proofs query returned a non-array result (sqlite3 read failed) — writing empty map.');
     fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');
     return;
   }
@@ -135,6 +158,16 @@ function main() {
   fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');
 
   const verifiedCount = Object.keys(data).length;
+  if (verifiedCount === 0) {
+    warn(
+      'forge_proofs exists but has zero passing tier3-jrig rows — no plugin ' +
+        'has a completed 7-layer behavioral eval yet, so every JRig-Verified ' +
+        'badge renders "pending". Populate a row with: `j-rig eval <plugin> ' +
+        '--models haiku,sonnet,opus --db freshie/inventory.sqlite` (once the ' +
+        'eval→forge_proofs write path lands).',
+    );
+    return;
+  }
   console.log(
     `[enrich-jrig] Wrote ${verifiedCount} JRig-verified plugin entries → ${path.relative(repoRoot, outPath)}`,
   );


### PR DESCRIPTION
## What

`enrich-jrig-data.mjs` previously wrote `{}` via a plain `console.log` (or silently) in **every** degradation path, so a missing/empty `forge_proofs` source blanked every "JRig-Verified" badge to "pending" with **no signal in CI** that anything was wrong. Today the source is empty, so `marketplace/src/data/jrig-data.json` is literally `{}`.

Adds a `warn()` helper that emits a GitHub Actions `::warning::` annotation (surfaced on the run summary, not just buried in the step log) plus a plain line locally, and routes all four degradation paths through it:

- Freshie DB missing
- `forge_proofs` table absent
- `forge_proofs` query returns a non-array (sqlite3 read failed)
- **`forge_proofs` present but ZERO passing `tier3-jrig` rows** (previously invisible — this is the current real state)

The map is still written deterministically (`{}` on any degradation) so the marketplace build stays reproducible; only the silence is removed. Runs from `marketplace/scripts/build.mjs` (`jrig:enrich` step).

## Verified locally

```
$ GITHUB_ACTIONS=true node marketplace/scripts/enrich-jrig-data.mjs
::warning file=marketplace/src/data/jrig-data.json::forge_proofs exists but has zero passing tier3-jrig rows …
[enrich-jrig] WARNING: forge_proofs exists but has zero passing tier3-jrig rows …
```
`jrig-data.json` unchanged (`{}`).

## Why not just populate a real row?

No `INSERT INTO forge_proofs` exists in this repo and j-rig has **zero** `forge_proofs` awareness, so `j-rig eval` does not yet write a `tier3-jrig` row — the eval→`forge_proofs` write path (the "printing press" data-flow, #700/#702) is unbuilt. And `plugins/productivity/plane/.forge/proofs.md` documents Tier 3B (7-layer behavioral eval) as **NOT RUN** (it costs ~\$2–5 + 10–30 min per skill across the model matrix). Lighting a badge without a real cross-model behavioral eval would contradict that documented state — so real-row population is left to the write-path work. This PR makes the current empty state **loud** instead of silent, which is the honest, durable fix.

Part of #927.

**Beads:** `bd_000-projects-gdbue` — under epic `bd_000-projects-4yxwc`.

- Jeremy Longshore
intentsolutions.io