### PR TITLE
ci: report-only deadline gates on frontmatter --strict + npm-audit (honest counts, no silent rot)

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -279,9 +279,24 @@ jobs:
               dir=$(dirname "$package")
               cd "$dir"
 
-              # Check for npm audit
+              # npm-audit policy — REPORT-ONLY (loud, not blocking) until the
+              # date below. Decision: a hard block on high/critical would
+              # red-wall every PR whenever an unrelated upstream advisory drops
+              # (this repo vendors ~450 plugins, each with its own deps) — i.e.
+              # fail on state the PR never touched. The prior `npm audit
+              # --production || true` was the opposite failure: silent, so a
+              # real high/critical advisory produced no signal at all. This is
+              # the honest middle — audit at --audit-level=high and SURFACE
+              # findings as a CI ::warning:: annotation, without failing.
+              #
+              # REPORT-ONLY-UNTIL: 2026-09-30 (npm-audit policy revisit; #927)
+              # When this lapses, check-ci-deadlines.py fails the build — revisit
+              # whether to flip to blocking (e.g. scoped to the changed plugin's
+              # deps only) or extend with a documented reason.
               if command -v npm &> /dev/null; then
-                npm audit --production || true
+                if ! npm audit --production --audit-level=high; then
+                  echo "::warning file=$dir/package.json::npm audit found high/critical advisories in $dir — report-only until 2026-09-30 (npm-audit policy, #927)"
+                fi
               fi
 
               cd -
@@ -555,14 +570,23 @@ jobs:
           echo "✅ Single-skill validation passed"
 
           # 4. ccpi validate backward compat
-          # TEMPORARY: non-blocking until the 182 pre-existing frontmatter
-          # errors are cleared. See issue #604 for full scope + reversal plan.
-          # REVERT `|| true` → `|| exit 1` in the same PR that clears the
-          # last frontmatter error. Do NOT leave this non-blocking any longer
-          # than required to work through the cleanup campaign.
-          echo "Running ccpi validate (reporting mode until frontmatter cleanup — see #604)..."
+          # TEMPORARY: non-blocking until the frontmatter cleanup campaign
+          # clears. Live count as of 2026-07-01: 317 errors of 672 frontmatter
+          # items (reproduce: `node packages/cli/dist/index.js validate --strict`,
+          # read the "Frontmatter Summary" line). Issue #604 (the original
+          # tracker) was CLOSED while 182 errors remained and the count has
+          # since GROWN to 317 — the campaign did NOT finish and this gate was
+          # never flipped. Re-tracked under #927.
+          #
+          # REPORT-ONLY-UNTIL: 2026-09-30 (frontmatter --strict campaign; #927)
+          # The check-ci-deadlines job (above) FAILS the build once this date
+          # passes, so this mitigation cannot rot silently into a permanent
+          # bypass. Before the date: clear the errors and flip `|| true` →
+          # `|| exit 1` in one PR (the real fix), or extend the date with a
+          # documented reason. Flipping now would red-wall every PR (317 errors).
+          echo "Running ccpi validate (reporting mode until frontmatter cleanup — see #927; 317 errors as of 2026-07-01)..."
           node packages/cli/dist/index.js validate --strict || true
-          echo "✅ ccpi validate complete (non-blocking)"
+          echo "✅ ccpi validate complete (non-blocking; report-only until 2026-09-30 — see check-ci-deadlines)"
 
           echo "✅ All validation tests passed"
 


### PR DESCRIPTION
Two long-lived `|| true` relaxations in `validate-plugins.yml` had **no forcing function**, so they could rot into permanent silent bypasses. Both now carry a `# REPORT-ONLY-UNTIL: 2026-09-30` marker — the `check-ci-deadlines` job already runs in this workflow and **fails the build once a marker lapses**.

### B1 — frontmatter `validate --strict` (line ~564)

- **Corrected the stale count.** The comment said "182 pre-existing errors" and pointed at #604 as the active tracker. **#604 is CLOSED**, and the live count has **grown to 317 of 672** frontmatter items (verified via the CLI's own `Frontmatter Summary` line). The campaign never finished and the gate was never flipped. Re-tracked under #927.
- Added the deadline marker. **NOT** flipping `|| true` → `|| exit 1` this pass — 317 live errors would red-wall every PR. The flip is the follow-on once the campaign clears; the marker guarantees it can't be silently forgotten.

### B3 — npm-audit policy (line ~284)

- **Decision: report-only-with-deadline, not hard-block.** A hard block on high/critical would red-wall every PR whenever an unrelated upstream advisory drops (this repo vendors ~450 plugins with their own deps) — failing on state the PR never touched. The prior `npm audit --production || true` was the opposite failure: fully silent.
- New behavior: audit at `--audit-level=high` and **surface findings as a CI `::warning::` annotation** (loud), without failing. The deadline forces a revisit (e.g. flip to blocking scoped to the changed plugin's deps).

### Verified

- `check-ci-deadlines.py` detects both markers as future (92 days out); build passes.
- YAML lints clean.

No rule was loosened — two silent/untracked relaxations became **loud + time-bound**. Part of #927.

**Beads:** `bd_000-projects-xxc6e` (B1), `bd_000-projects-ep5mx` (B3) — under epic `bd_000-projects-4yxwc`.

- Jeremy Longshore
intentsolutions.io