### PR TITLE
docs: cross-session coordination pointer in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,16 @@ Tons of Skills — Claude Code plugins marketplace. Live at https://tonsofskills
 
 **Session protocol lives in `AGENTS.md`** — post-compaction recovery, end-of-session push checklist, and beads workflow. Read it before starting work.
 
+## Cross-session coordination — another Claude session may be in this repo
+
+This repo is frequently worked in **parallel** with the `intent-eval-platform` umbrella session (that platform's CCPI validator + jrig-cli + kernel reach into this repo). Sessions are separate processes that share only the filesystem, so stay in sync via the shared surfaces:
+
+- **Read + append the shared journal** on cross-repo work: `~/000-projects/CROSS-SESSION-LOG.md` (append a dated line: what / branch or PR# / status).
+- **Durable cross-cutting tasks:** umbrella beads `~/000-projects/.beads/`, label `cross-session` (`bd list --label cross-session`).
+- **Guard the working tree:** this repo has ONE checkout; a concurrent session can `git checkout`/`reset` it out from under you and **wipe UNCOMMITTED work** (happened 2026-07-01). Commit early, or do multi-step file work in a `git worktree`.
+
+Full protocol (loaded by every session under `/home/jeremy`): `/home/jeremy/CLAUDE.md` § "Cross-session coordination".
+
 ## Essential Commands
 
 ```bash


### PR DESCRIPTION
This repo is frequently worked in **parallel** with the `intent-eval-platform` umbrella session (its CCPI validator + `jrig-cli` + kernel reach in here). On 2026-07-01 a concurrent session's `git checkout`/`reset` wiped an **uncommitted** change here mid-task. This adds a short pointer in `CLAUDE.md` to the house-wide coordination surfaces so a session opened in this repo knows where to look and log:

- **Shared journal** `~/000-projects/CROSS-SESSION-LOG.md` — read + append a dated line on cross-repo work.
- **Umbrella beads** `~/000-projects/.beads/`, label `cross-session`.
- **Working-tree hazard** — commit early / use a `git worktree` for multi-step file work.

The full protocol lives in `/home/jeremy/CLAUDE.md` § "Cross-session coordination" (loaded by every session under `/home/jeremy`, so this repo's sessions already inherit it — this is repo-local reinforcement). Doc-only; no behavior change.

> Authored from an isolated `git worktree` off `origin/main`, precisely to avoid the concurrent-checkout hazard it documents.

- Jeremy Longshore
intentsolutions.io