### PR TITLE
fix: close two supersession carve-outs — sentry Overview gates + hubspot v2.0.0 catalog sync

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -8857,8 +8857,8 @@
     {
       "name": "hubspot-pack",
       "source": "./plugins/saas-packs/hubspot-pack",
-      "description": "Claude Code skill pack for HubSpot (30 skills)",
-      "version": "1.0.0",
+      "description": "Claude Code skill pack for HubSpot (10 production-engineer skills)",
+      "version": "2.0.0",
       "category": "saas-packs",
       "keywords": ["hubspot", "saas", "sdk", "integration"],
       "author": {
@@ -8867,13 +8867,7 @@
         "url": "https://github.com/jeremylongshore"
       },
       "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-21T00:00:00.000Z"
+        "skills": 10
       }
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7457,8 +7457,8 @@
     {
       "name": "hubspot-pack",
       "source": "./plugins/saas-packs/hubspot-pack",
-      "description": "Claude Code skill pack for HubSpot (30 skills)",
-      "version": "1.0.0",
+      "description": "Claude Code skill pack for HubSpot (10 production-engineer skills)",
+      "version": "2.0.0",
       "category": "saas-packs",
       "keywords": [
         "hubspot",

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `guidewire-pack`    | Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform…        |
 | `hex-pack`          | Claude Code skill pack for Hex (18 skills)                                                                                                  |
 | `hootsuite-pack`    | Claude Code skill pack for Hootsuite (18 skills)                                                                                            |
-| `hubspot-pack`      | Claude Code skill pack for HubSpot (30 skills)                                                                                              |
+| `hubspot-pack`      | Claude Code skill pack for HubSpot (10 production-engineer skills)                                                                          |
 | `ideogram-pack`     | Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows.…       |
 | `instantly-pack`    | Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier…      |
 | `intercom-pack`     | Claude Code skill pack for Intercom (24 skills)                                                                                             |

--- a/plugins/saas-packs/TRACKER.csv
+++ b/plugins/saas-packs/TRACKER.csv
@@ -69,7 +69,7 @@ grammarly,Grammarly,flagship,24,@intentsolutionsio/grammarly-skill-md-pack,reser
 shopify,Shopify,flagship+,30,@intentsolutionsio/shopify-skill-md-pack,reserved,ccpi-shopify,30,0,not_started,not_added,Extended #68
 canva,Canva,flagship+,30,@intentsolutionsio/canva-skill-md-pack,reserved,ccpi-canva,30,0,not_started,not_added,Extended #69
 clickup,ClickUp,flagship,24,@intentsolutionsio/clickup-skill-md-pack,reserved,ccpi-clickup,24,0,not_started,not_added,Extended #70
-hubspot,HubSpot,flagship+,30,@intentsolutionsio/hubspot-skill-md-pack,reserved,ccpi-hubspot,30,0,not_started,not_added,Extended #71
+hubspot,HubSpot,flagship+,10,@intentsolutionsio/hubspot-skill-md-pack,reserved,ccpi-hubspot,10,0,not_started,added,v2.0.0 rebuild: 10 production-engineer skills (a04d1a23e); catalog synced 2026-07-02
 salesforce,Salesforce,flagship+,30,@intentsolutionsio/salesforce-skill-md-pack,reserved,ccpi-salesforce,30,0,not_started,not_added,Extended #72
 adobe,Adobe,flagship+,30,@intentsolutionsio/adobe-skill-md-pack,reserved,ccpi-adobe,30,0,not_started,not_added,Extended #73
 palantir,Palantir,flagship,24,@intentsolutionsio/palantir-skill-md-pack,reserved,ccpi-palantir,24,0,not_started,not_added,Extended #74

--- a/plugins/saas-packs/hubspot-pack/README.md
+++ b/plugins/saas-packs/hubspot-pack/README.md
@@ -1,6 +1,6 @@
 # HubSpot Skill Pack
 
-> Claude Code skill pack for HubSpot CRM integration -- 30 skills covering the CRM v3 API, marketing automation, sales pipelines, and production operations.
+> Claude Code skill pack for HubSpot CRM integration -- 10 production-engineer skills built from a real-world pain catalog, covering auth, webhooks, dedup, migrations, pipeline automation, and rate-limit survival on the CRM v3 API.
 
 ## What is HubSpot?
 
@@ -8,7 +8,7 @@ HubSpot is a CRM platform for marketing, sales, and customer service. The HubSpo
 
 ## Pack Overview
 
-This pack provides 30 auto-activating skills covering the full lifecycle of a HubSpot integration: from first install to production-grade architecture. All skills use real HubSpot API endpoints (`/crm/v3/objects/*`), the actual `@hubspot/api-client` SDK, and documented error responses.
+Version 2.0.0 is a deliberate rebuild: the original 30 template skills were replaced by 10 deeper, pain-catalog-grounded skills written for production engineers. Each skill targets the failure modes that actually burn HubSpot integrations — wrong-winner merges, webhook replay storms, portal quota exhaustion, cross-portal contamination — using real HubSpot API endpoints (`/crm/v3/objects/*`), the actual `@hubspot/api-client` SDK, and documented error responses.
 
 ## Installation
 
@@ -55,55 +55,18 @@ const batch = await client.crm.contacts.batchApi.read({
 
 ## Skills Included
 
-### Standard Skills (S01-S12)
-
-| Skill | Description |
-|-------|-------------|
-| `hubspot-install-auth` | Install `@hubspot/api-client`, configure private app tokens and OAuth 2.0 |
-| `hubspot-hello-world` | CRUD operations on contacts, companies, and deals with real endpoints |
-| `hubspot-local-dev-loop` | Dev workflow with Vitest mocks, test accounts, and hot reload |
-| `hubspot-sdk-patterns` | Typed client wrappers, batch operations, pagination, error classification |
-| `hubspot-core-workflow-a` | Contact-to-deal sales pipeline: upsert, associate, advance stages, log notes |
-| `hubspot-core-workflow-b` | Marketing automation: lists, forms, tickets, tasks, cross-object search |
-| `hubspot-common-errors` | Real HubSpot error responses (401, 403, 409, 429) with fixes |
-| `hubspot-debug-bundle` | Collect correlation IDs, rate limit state, and SDK diagnostics |
-| `hubspot-rate-limits` | Backoff with Retry-After, request queues, batch call reduction |
-| `hubspot-security-basics` | Token rotation, webhook v3 signature verification, scope management |
-| `hubspot-prod-checklist` | Health checks, monitoring alerts, deploy verification scripts |
-| `hubspot-upgrade-migration` | SDK version upgrades: API key to token, associations v3 to v4 |
-
-### Pro Skills (P13-P18)
-
-| Skill | Description |
-|-------|-------------|
-| `hubspot-ci-integration` | GitHub Actions CI with test account, integration tests, secret scanning |
-| `hubspot-deploy-integration` | Deploy to Vercel, Fly.io, Cloud Run with secret management |
-| `hubspot-webhooks-events` | CRM webhook subscriptions, v3 signature verification, idempotent handlers |
-| `hubspot-performance-tuning` | Batch APIs (100x reduction), caching, search optimization, streaming pagination |
-| `hubspot-cost-tuning` | API call monitoring, polling-to-webhook migration, batch vs individual analysis |
-| `hubspot-reference-architecture` | Layered architecture: infrastructure, service, API layers with association constants |
-
-### Flagship Skills (F19-F24)
-
-| Skill | Description |
-|-------|-------------|
-| `hubspot-multi-env-setup` | Dev/staging/prod with separate portals, secret managers, environment guards |
-| `hubspot-observability` | Prometheus metrics, OpenTelemetry tracing, Pino logging, AlertManager rules |
-| `hubspot-incident-runbook` | Triage scripts, decision trees, 401/429/5xx response playbooks, postmortem template |
-| `hubspot-data-handling` | GDPR delete API, data export, PII redaction, consent tracking |
-| `hubspot-enterprise-rbac` | Multi-token role-based access, OAuth multi-portal, audit trails |
-| `hubspot-migration-deep-dive` | Batch import with field mapping, upsert, deal associations, validation |
-
-### Flagship+ Skills (X25-X30)
-
-| Skill | Description |
-|-------|-------------|
-| `hubspot-advanced-troubleshooting` | Layer-by-layer diagnostics, correlation ID tracking, timing analysis |
-| `hubspot-load-scale` | k6 load tests, capacity planning calculator, batch aggregation patterns |
-| `hubspot-reliability-patterns` | Circuit breakers, graceful degradation, dead letter queues, health checks |
-| `hubspot-policy-guardrails` | ESLint rules, CI token scanning, runtime self-rate-limiting, pre-commit hooks |
-| `hubspot-architecture-variants` | Embedded vs service layer vs gateway patterns with decision matrix |
-| `hubspot-known-pitfalls` | 10 real anti-patterns: deprecated auth, search limits, wrong association IDs |
+| Skill | What it covers |
+|-------|----------------|
+| `hubspot-auth` | Authenticate production integrations (private app tokens vs OAuth), scope design, and auth-side failure modes |
+| `hubspot-webhook-handlers` | v3 webhook handlers that survive production: HMAC-SHA256 signature verification, Redis SET NX deduplication, async batch processing |
+| `hubspot-rate-limit-survival` | The daily 500K portal quota, per-10s burst limits, batch API efficiency (100x), token bucket pattern, queue-based smoothing |
+| `hubspot-contact-dedup` | Deduplication at production scale: import storms, wrong-winner merges, fuzzy-match blind spots, association orphans |
+| `hubspot-bulk-migration` | Bulk migration in or out of HubSpot (Salesforce, Pipedrive, Copper) with field mapping, ID continuity, association re-linking |
+| `hubspot-deal-pipeline-automation` | Stage automation loops, stale-deal safe-close logic, and pipeline auditing without destroying real pipeline |
+| `hubspot-lifecycle-and-lists` | Lifecycle stage progression guards and list segmentation without silently destroying CRM trust |
+| `hubspot-product-event-sync` | Idempotent batched sync of backend product events into contact/company custom properties (the Segment pattern without Segment) |
+| `hubspot-warehouse-sync` | CRM-to-warehouse sync (BigQuery, Snowflake, Postgres): initial backfill of millions of records under quota, then incremental |
+| `hubspot-agency-multi-portal` | Managing 10-100 client portals with credential isolation, per-portal audit trails, and GDPR/CCPA separation |
 
 ## Key HubSpot API Concepts
 
@@ -118,10 +81,10 @@ const batch = await client.crm.contacts.batchApi.read({
 
 Skills trigger automatically when you discuss HubSpot topics:
 
-- "Help me set up HubSpot" triggers `hubspot-install-auth`
-- "Create a contact in HubSpot" triggers `hubspot-hello-world`
-- "I'm getting a 429 error from HubSpot" triggers `hubspot-rate-limits`
-- "Deploy my HubSpot integration" triggers `hubspot-deploy-integration`
+- "Set up HubSpot auth for production" triggers `hubspot-auth`
+- "Our webhook handler is double-processing events" triggers `hubspot-webhook-handlers`
+- "I'm getting 429s from HubSpot" triggers `hubspot-rate-limit-survival`
+- "We have thousands of duplicate contacts" triggers `hubspot-contact-dedup`
 
 ## License
 

--- a/plugins/saas-packs/hubspot-pack/package.json
+++ b/plugins/saas-packs/hubspot-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/hubspot-pack",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Claude Code skill pack for HubSpot - 10 production-engineer skills covering auth, dedup, lifecycle, deal pipeline, warehouse sync, product events, webhooks, bulk migration, rate limits, and multi-portal agency ops",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/hubspot-pack/package.json
+++ b/plugins/saas-packs/hubspot-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/hubspot-pack",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Claude Code skill pack for HubSpot - 10 production-engineer skills covering auth, dedup, lifecycle, deal pipeline, warehouse sync, product events, webhooks, bulk migration, rate limits, and multi-portal agency ops",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/sentry-pack/package.json
+++ b/plugins/saas-packs/sentry-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/sentry-pack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Claude Code skill pack for Sentry - 30 skills covering error tracking, performance monitoring, release management, and production operations",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/sentry-pack/package.json
+++ b/plugins/saas-packs/sentry-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/sentry-pack",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Claude Code skill pack for Sentry - 30 skills covering error tracking, performance monitoring, release management, and production operations",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/sentry-pack/skills/sentry-cost-tuning/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-cost-tuning/SKILL.md
@@ -26,6 +26,8 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Cost Tuning
 
+## Overview
+
 Reduce Sentry spend by 60-95% through SDK-level sampling, server-side inbound filters, `beforeSend` event dropping, and quota management — without losing visibility into production errors that matter.
 
 ## Prerequisites

--- a/plugins/saas-packs/sentry-pack/skills/sentry-load-scale/SKILL.md
+++ b/plugins/saas-packs/sentry-pack/skills/sentry-load-scale/SKILL.md
@@ -28,6 +28,8 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Sentry Load & Scale
 
+## Overview
+
 Configure Sentry for applications processing 1M+ requests/day without sacrificing error visibility, burning through quota, or adding measurable SDK overhead. Covers adaptive sampling, connection pooling, multi-region tagging, quota management, SDK benchmarking, batch submission, load testing, and self-hosted deployment considerations.
 
 ## Prerequisites


### PR DESCRIPTION
Backlog Zero Wave 1 execution on the supersession epic (cluster issue #938; campaign umbrella intent-solutions-io/intent-os#21). One commit per bead:

1. **sentry-pack**: add the missing `## Overview` sections to `sentry-cost-tuning` and `sentry-load-scale` — the pack's only two marketplace-tier gate failures. Validator re-run confirms both files clean (warnings only, matching passing siblings); the pack's 90.6/100 average now stands without errors.
2. **hubspot-pack**: sync both catalogs, the pack README, and TRACKER.csv to the shipped 10-skill v2.0.0 reality (was advertising the retired 30-skill v1.0.0 pack, with a stale verification block scoring the old pack). Extended catalog edited surgically; `marketplace.json` + README TOC regenerated via `sync-marketplace`.

Bead closes follow after merge, with this PR as evidence.

Refs jeremylongshore/claude-code-plugins-plus-skills#938

- Jeremy Longshore
intentsolutions.io

[skip auto-bump] — bot bumps already landed (two package.json patch bumps); skipping further auto-bumps so human pushes can retrigger gated checks.
