### PR TITLE
fix: Wave 1 chores — Blocknative migration + freshie inventory repopulate

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -2606,7 +2606,7 @@
       "name": "gas-fee-optimizer",
       "source": "./plugins/crypto/gas-fee-optimizer",
       "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "crypto",
       "keywords": ["gas", "fees", "ethereum", "optimization", "transaction", "l2"],
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2397,7 +2397,7 @@
       "name": "gas-fee-optimizer",
       "source": "./plugins/crypto/gas-fee-optimizer",
       "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "crypto",
       "keywords": [
         "gas",

--- a/plugins/crypto/gas-fee-optimizer/.claude-plugin/plugin.json
+++ b/plugins/crypto/gas-fee-optimizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-fee-optimizer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Optimize transaction gas fees with timing and routing recommendations",
   "author": {
     "name": "Claude Code Plugins",

--- a/plugins/crypto/gas-fee-optimizer/README.md
+++ b/plugins/crypto/gas-fee-optimizer/README.md
@@ -111,9 +111,9 @@ Or use the shortcut:
 
 Analysis references:
 
-- Etherscan Gas Tracker
+- Etherscan Gas Oracle (primary — free API key)
 - ETH Gas Station
-- Blocknative (mempool data)
+- Alchemy/Infura `eth_feeHistory` (no-key RPC fallback)
 - L2Fees.info
 - Gas Now
 

--- a/plugins/crypto/gas-fee-optimizer/commands/optimize-gas.md
+++ b/plugins/crypto/gas-fee-optimizer/commands/optimize-gas.md
@@ -137,9 +137,9 @@ Total Cost = (Base Fee + Priority Fee) × Gas Units
 
 When providing recommendations, check:
 
-- **Etherscan Gas Tracker**: Current gas prices
+- **Etherscan Gas Oracle**: Current gas prices (SafeGasPrice/ProposeGasPrice/FastGasPrice; free API key, 5 calls/sec)
 - **ETH Gas Station**: Historical patterns
-- **Blocknative**: Real-time mempool
+- **Alchemy/Infura `eth_feeHistory`**: Base-fee history and priority-fee percentiles (no API key required)
 - **L2Fees.info**: Layer 2 comparison
 - **Gas Now**: Timing predictions
 

--- a/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/ARD.md
+++ b/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/ARD.md
@@ -19,7 +19,7 @@ Data Collection → Analysis → Recommendation → Display
 ```
 Input: User request (current gas, optimal time, estimate for operation)
           ↓
-Fetch: Multiple gas oracles (RPC, Etherscan, Blocknative)
+Fetch: Multiple gas oracles (Etherscan Gas Oracle, RPC eth_feeHistory)
           ↓
 Aggregate: Combine sources, calculate percentiles
           ↓
@@ -57,15 +57,39 @@ skills/optimizing-gas-fees/
 - **Method**: `eth_gasPrice`, `eth_feeHistory`
 - **Data**: Current gas price, base fee history
 
-### Etherscan Gas Tracker
+### Etherscan Gas Oracle (Primary)
 
-- **Endpoint**: `https://api.etherscan.io/api?module=gastracker`
-- **Data**: Safe/Proposed/Fast gas prices
+- **Endpoint**: `https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=<ETHERSCAN_API_KEY>`
+- **Auth**: free API key via the `ETHERSCAN_API_KEY` environment variable
+- **Rate limit**: 5 calls/sec on the free tier — cache responses (see Performance Considerations)
+- **Data**: `SafeGasPrice` / `ProposeGasPrice` / `FastGasPrice` (gwei, returned as strings in `result`), plus `suggestBaseFee`
 
-### Blocknative (Optional)
+Example `result` payload:
 
-- **Endpoint**: `https://api.blocknative.com/gasprices/blockprices`
-- **Data**: Confidence-based predictions
+```json
+{
+  "LastBlock": "19640000",
+  "SafeGasPrice": "12",
+  "ProposeGasPrice": "13",
+  "FastGasPrice": "15",
+  "suggestBaseFee": "11.85"
+}
+```
+
+Map the three price points to tiers: Safe → slow, Propose → standard, Fast → fast; derive
+the instant tier locally from fee-history percentiles.
+
+### RPC `eth_feeHistory` (No-Key Fallback)
+
+- **Endpoint**: any Ethereum JSON-RPC provider (Alchemy, Infura, or a public RPC URL)
+- **Auth**: none beyond the RPC URL itself
+- **Data**: recent base fees + priority-fee reward percentiles; compute slow/standard/fast/instant tiers locally from the percentile spread
+
+> **Migration note (2026-06-19)**: the third-party mempool gas-prediction API this
+> plugin previously documented shut down on 2026-06-19 and was removed as a data
+> source. Its confidence-based next-block predictions have no direct equivalent above —
+> tiers are approximated from Etherscan's three price points and `eth_feeHistory`
+> reward percentiles instead.
 
 ## Component Design
 

--- a/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/PRD.md
+++ b/plugins/crypto/gas-fee-optimizer/skills/optimizing-gas-fees/PRD.md
@@ -50,9 +50,8 @@ Users often overpay for gas or have transactions stuck due to poor fee estimatio
 
 | API | Purpose | Auth |
 |-----|---------|------|
-| Ethereum RPC | Real-time gas prices | RPC URL |
-| Etherscan Gas Tracker | Gas oracle | API key (free) |
-| Blocknative | Gas predictions | API key (free tier) |
+| Ethereum RPC (`eth_feeHistory`) | Real-time gas prices, base-fee history fallback | RPC URL (Alchemy/Infura or public endpoint, no key required) |
+| Etherscan Gas Oracle | Gas oracle (primary) | `ETHERSCAN_API_KEY` (free key, 5 calls/sec) |
 | CoinGecko | ETH/MATIC price for USD conversion | No auth |
 
 ## Success Metrics


### PR DESCRIPTION
## What / why

### Commit 1 — `fix(gas-fee-optimizer): migrate off the shut-down Blocknative gas API`

**Urgent:** the Blocknative gas API (`api.blocknative.com/gasprices/blockprices`) shut down on **2026-06-19**; the shipped plugin docs still cited it as a data source. This migrates the documented gas-price sources to alternatives that exist today:

- **Primary:** Etherscan Gas Oracle (`module=gastracker&action=gasoracle`) — free `ETHERSCAN_API_KEY`, 5 calls/sec free tier, returns `SafeGasPrice`/`ProposeGasPrice`/`FastGasPrice` as strings in `result` (example payload added to the ARD).
- **No-key fallback:** RPC `eth_feeHistory` via Alchemy/Infura or any public endpoint.
- Blocknative's confidence-level predictions have no direct equivalent — the ARD now honestly notes tiers are approximated from the oracle's three price points + fee-history reward percentiles, which is exactly what the skill's `gas_fetcher.py` already implements (the code never called Blocknative; the drift was doc-only).
- Files: plugin README, `commands/optimize-gas.md`, skill `PRD.md` + `ARD.md`; plugin.json bumped 1.0.0 → 1.0.1 with the marketplace catalogs synced (extended entry + regenerated `marketplace.json`).
- Verified: `grep -ric blocknative plugins/crypto/gas-fee-optimizer` → 0; marketplace validator shows no new findings for the plugin (only the same pre-existing WARN class as siblings); markdownlint clean.

### Commit 2 — `chore(freshie): re-populate the inventory db from the enterprise validator run`

Full marketplace-tier validator sweep via `--populate-db freshie/inventory.sqlite` refreshed `skill_compliance` (3,732 rows), `agent_compliance` (322), and `plugin_compliance` (398) with `validated_at` 2026-07-02, tagged to the latest discovery run. (`discovery_runs.run_date` is only written by `freshie/scripts/rebuild-inventory.py`, so it is unchanged by design.) The sqlite file is git-tracked, so the refreshed DB ships in this PR.

Part of the Wave 1 chores epic (Backlog Zero; needs-human digest #941).

[skip auto-bump]

- Jeremy Longshore
intentsolutions.io