### PR TITLE
docs: add the AI-authorship disclosure policy (000-docs 697) [skip auto-bump]

### DIFF
--- a/000-docs/697-BL-POLI-ai-authorship-disclosure-policy.md
+++ b/000-docs/697-BL-POLI-ai-authorship-disclosure-policy.md
@@ -1,0 +1,89 @@
+# AI-Authorship Disclosure Policy
+
+**Filing:** 697-BL-POLI · **Effective:** 2026-07-02 · **Status:** Active
+**Scope:** this repository (`claude-code-plugins-plus-skills`) and the plugins,
+skills, agents, and documentation published from it.
+
+## Purpose
+
+This repository publishes a large catalog of Claude Code plugins and skills.
+Users and contributors deserve a plain statement of how that content is
+authored, who is accountable for it, and what gates it passes before it ships.
+This document is that statement. It is factual disclosure, not marketing.
+
+## 1. Intent Solutions-authored content is AI-assisted, human-directed
+
+Plugins, skills, agents, and docs authored by Intent Solutions in this repo are
+built **AI-assisted under human direction and review**. Concretely, that means:
+
+- **A human decides what gets built and why.** AI tooling drafts and iterates;
+  it does not choose the roadmap, the required-field standards, or what merges.
+- **Deterministic validator gates.** Every skill and agent is checked by the
+  in-repo validator (`scripts/validate-skills-schema.py`) at marketplace tier,
+  where missing required fields are errors, not warnings.
+- **CI checks on every pull request.** Plugin validation, markdown/shell/Python/
+  TypeScript lint, secret scanning, CodeQL, actionlint, link checks, and test
+  suites run in `.github/workflows/` and gate the merge.
+- **Behavioral evals via j-rig.** Beyond static checks, skills can be exercised
+  through the j-rig behavioral-eval harness before being graded
+  production-ready; graded artifacts record their eval evidence.
+- **Human merge decisions.** No AI-drafted change lands on `main` without a
+  human owning the merge. Automated pipelines *propose* (e.g. sync PRs); a
+  human *disposes*.
+
+AI assistance is a production tool here, the same way a compiler or linter is.
+Accountability for what ships stays with the human maintainer.
+
+## 2. Mirrored external plugins keep their upstream authorship
+
+A minority of the catalog is externally sourced and mirrored from the original
+authors' repositories under the **mirror-by-default** model (decision record
+`000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md`):
+
+- Mirrored plugins carry their **upstream authors' provenance**. We do not
+  re-attribute, re-badge, or claim authorship of mirrored work.
+- Whether an upstream author used AI in their own work is their disclosure to
+  make, not ours. We disclose our pipeline; we do not speak for theirs.
+- When we want a mirrored plugin raised to this repo's standard, the
+  improvement is offered **upstream** to the original author rather than held
+  as a silently divergent local copy.
+
+## 3. Commit and pull-request attribution
+
+- Commits and pull requests in this repository are signed by the **human
+  repository owner**. The repo does not use AI-model co-author trailers
+  (no `Co-Authored-By: <model>` lines) — the human signature is the
+  accountability line, per this policy and the review gates above.
+- Automated pipelines that open PRs (external-plugin sync, dependency and
+  version bumps) are labeled as automation and still require human review
+  before merge.
+
+## 4. Where the quality bar lives
+
+The standards that AI-assisted work must clear are written down and versioned:
+
+- **`000-docs/SCHEMA_CHANGELOG.md`** — the validator's changelog, including the
+  NON-NEGOTIABLES section: the required-field set, the errors-not-warnings
+  marketplace tier, and the rule that architectural changes to those semantics
+  need explicit human approval before landing.
+- **Marketplace-tier validation** — the strictest validator tier, applied to
+  content published to the marketplace; it sits intentionally above the
+  permissive upstream floor.
+- **CI as enforcement** — the gates travel with the repo, so a fork or fresh
+  clone reproduces the same checks.
+
+Changes to the quality bar itself are recorded in the schema changelog and are
+never made silently by AI tooling.
+
+## 5. Questions and contact
+
+Questions about this policy, a specific plugin's provenance, or a suspected
+attribution error: open an issue on this repository (see the README for the
+issue tracker and community links; security-sensitive reports go through
+`SECURITY.md`).
+
+## Review
+
+This policy is reviewed when the authoring pipeline materially changes (new
+eval harness, new sync model, new attribution convention). Amendments are
+committed as edits to this file with the change visible in git history.


### PR DESCRIPTION
## What

Adds `000-docs/697-BL-POLI-ai-authorship-disclosure-policy.md` — a public, factual AI-authorship disclosure policy for this repository (Backlog Zero Wave 1, governance-hygiene cluster).

## Contents

- IS-authored plugins are built AI-assisted under human direction and review: deterministic validator gates (marketplace tier), CI checks, j-rig behavioral evals, and human merge decisions.
- Mirrored external plugins keep their upstream authors' provenance under the mirror-by-default model (694-AT-DECR) — no re-attribution.
- Commit/PR attribution convention: signed by the human repository owner; no AI-model co-author trailers.
- The quality bar is versioned in `000-docs/SCHEMA_CHANGELOG.md` (NON-NEGOTIABLES) + marketplace-tier validation.
- Effective 2026-07-02; contact via the repo issue tracker (README) / `SECURITY.md` for sensitive reports.

Doc-only change; file force-added per the 000-docs blanket-ignore precedent (124 tracked files). No workflows, validator, or CLAUDE.md touched. Does not create or edit STANDARDS.md/SUPPORT.md (concurrent builder owns those).

Refs jeremylongshore/claude-code-plugins-plus-skills#941

- Jeremy Longshore
intentsolutions.io