### PR TITLE
docs: add STANDARDS.md and SUPPORT.md (repo credibility surface)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -87,7 +87,8 @@
     "CHANGELOG.md",
     "AGENTS.md",
     "RELEASING.md",
-    "SECURITY.md"
+    "SECURITY.md",
+    "STANDARDS.md"
   ],
   "ignores": [
     "node_modules/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -88,7 +88,8 @@
     "AGENTS.md",
     "RELEASING.md",
     "SECURITY.md",
-    "STANDARDS.md"
+    "STANDARDS.md",
+    "SUPPORT.md"
   ],
   "ignores": [
     "node_modules/**",

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,102 @@
+# Standards
+
+This page states which specifications this repository follows, where it deliberately
+goes beyond them, and where the machine-readable source of truth lives. It links the
+canonical documents instead of restating them — when this page and a linked document
+disagree, the linked document wins.
+
+## The floor: open specs we follow
+
+Two upstream specifications define baseline validity for every skill in this repo:
+
+1. [agentskills.io/specification](https://agentskills.io/specification) — the open
+   Agent Skills standard that Claude Code follows. Requires only `name` and
+   `description`; documents `license`, `compatibility`, `metadata`, and
+   `allowed-tools` as optional.
+2. [code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills) — Anthropic's
+   Claude Code skills reference, the primary source for frontmatter field semantics.
+   (API surface: [platform.claude.com Agent Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).)
+
+Both are intentionally permissive. Everything valid under this repo's rules is also
+valid under both upstream specs — the overlay below is additive, never subtractive.
+
+## The overlay: where we deliberately diverge
+
+The Intent Solutions marketplace tier is intentionally stricter than the upstream
+floor. The divergences, all documented in the
+[schema changelog's NON-NEGOTIABLES](000-docs/SCHEMA_CHANGELOG.md) and the
+[master spec](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md):
+
+- **8 required frontmatter fields**, not 2:
+  `name`, `description`, `allowed-tools`, `version`, `author`, `license`,
+  `compatibility`, `tags` (the `ALWAYS_REQUIRED` set). Upstream treats most of these
+  as optional; the marketplace requires them for trust signals, downstream pinning,
+  and legal clarity.
+- **Missing required fields are ERRORS at marketplace tier**, not warnings. The gate
+  is `scripts/validate-skills-schema.py`, run in CI by
+  [`validate-plugins.yml`](.github/workflows/validate-plugins.yml).
+- **`capabilities` as a frontmatter field is banned** (a `## Capabilities` _heading_
+  is fine and is credited as an `## Overview` equivalent).
+- **Heading-equivalence fairness for external contributors** — standard-but-different
+  section names (`## Usage` for `## Instructions`, `## Troubleshooting` for
+  `## Error Handling`, etc.) are credited, per the
+  [mirror-by-default decision record](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md).
+
+Changes to the required-field set, the tier model, or error-vs-warning semantics are
+architectural and require explicit approval before landing — see the schema
+changelog's "How we got here" section for why that rule exists.
+
+## The direction: kernel single source of truth
+
+The validator's hand-rolled field sets are converging on a machine-readable kernel:
+the `authoring/v1` schema family in
+[`@intentsolutions/core`](https://github.com/jeremylongshore/intent-eval-core)
+(pinned exactly in `package.json`). The kernel's
+[`schemas/authoring/v1/CHANGELOG.md`](https://github.com/jeremylongshore/intent-eval-core/blob/main/schemas/authoring/v1/CHANGELOG.md)
+is canonical for authoring-contract semantics; this repo's schema changelog cites it
+rather than duplicating rationale.
+
+The conformance signal for that cutover is
+[`kernel-shadow-validation.yml`](.github/workflows/kernel-shadow-validation.yml): it
+runs the kernel's published JSON Schema over the same SKILL.md corpus the prose-spec
+validator grades and reports the per-file AGREE/DISAGREE deviation rate. It is
+**advisory by design** — report-only, not in the required-status set, and it never
+blocks a merge. Promotion to a blocking gate is a separate, later cutover step.
+
+## The catalog: two files, one source of truth
+
+| File                                       | Role                                    | Hand-edit? |
+| ------------------------------------------ | --------------------------------------- | ---------- |
+| `.claude-plugin/marketplace.extended.json` | Source of truth for every catalog entry | Yes        |
+| `.claude-plugin/marketplace.json`          | CLI-compatible catalog, auto-generated  | Never      |
+
+`pnpm run sync-marketplace` regenerates `marketplace.json`, missing
+`plugins/**/package.json` files, and the README AUTO-TOC block. The pre-commit hook
+runs it automatically when the extended catalog is staged, and CI fails if any
+derived file drifts. Authoring workflow: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## External plugins: mirror by default
+
+Externally-synced plugins (registered in `sources.yaml`, a small minority of the
+catalog) follow **mirror by default · upstream improvements · never clobber**, per
+the [decision record](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md):
+
+- The contributor's own repo is the source of truth; the weekly sync mirrors it and
+  opens a PR a human reviews. We do not locally edit a pure mirror.
+- Quality improvements are **upstreamed** to the contributor's repo, not forked into
+  a divergent local copy. A locally-hardened source is frozen with `curated: true`
+  until the improvement lands upstream.
+- Mirrored paths self-register their lint exclusions: the managed
+  `sync-lint-ignores` block in `.markdownlint-cli2.jsonc` is generated from
+  `sources.yaml` (via `scripts/sync-lint-ignores.mjs`), because upstream markdown
+  style is the upstream maintainer's choice, not ours.
+
+## Canonical documents
+
+| Topic                                | Document                                                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Required fields, tier model, history | [000-docs/SCHEMA_CHANGELOG.md](000-docs/SCHEMA_CHANGELOG.md)                                                                   |
+| Full skills standard (master spec)   | [000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)               |
+| External-sync policy                 | [000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md) |
+| Contribution requirements            | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                             |
+| Security policy                      | [SECURITY.md](SECURITY.md)                                                                                                     |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,61 @@
+# Support
+
+How to get help with this repository, what response time to expect, and what is
+fully supported versus best-effort.
+
+## Where to ask
+
+| I want to…                        | Go to                                                                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ask a usage question              | [GitHub Discussions — Q&A](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/q-a)                     |
+| Propose or discuss an idea        | [GitHub Discussions — Ideas](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/ideas)                 |
+| Show off something you built      | [GitHub Discussions — Show and tell](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/show-and-tell) |
+| Request a new plugin pack         | [Plugin Pack Request discussion template](.github/DISCUSSION_TEMPLATE/plugin-pack-request.yml)                                                |
+| Report a bug or request a feature | [Open an issue](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/new/choose)                                         |
+| Submit a plugin                   | The plugin-submission issue template, then follow [CONTRIBUTING.md](CONTRIBUTING.md)                                                          |
+| Report a security vulnerability   | [SECURITY.md](SECURITY.md) — **never a public issue**                                                                                         |
+
+Issue templates exist for bug reports, feature requests, documentation problems,
+questions, plugin submissions, and killer-skill nominations — the
+[issue chooser](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/new/choose)
+routes you to the right one.
+
+## Triage SLA
+
+**First response within 72 hours** on new Issues and Discussions. That first
+response is triage — an acknowledgment, a label, a question back, or a routing
+decision — not necessarily a fix. Complex fixes land on their own schedule and are
+tracked in the issue thread.
+
+## Security reports
+
+Follow [SECURITY.md](SECURITY.md): report privately via
+[GitHub Security Advisories](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/security/advisories/new)
+or email `jeremy@intentsolutions.io`. Security reports get acknowledged within
+24 hours with a remediation timeline within 72 hours — faster than the general
+triage SLA above.
+
+## What's supported vs best-effort
+
+This repo follows the mirror-by-default model for externally-synced plugins (see
+[STANDARDS.md](STANDARDS.md) and the
+[decision record](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md)),
+which determines where a fix can actually land:
+
+- **Intent Solutions–authored plugins and skills** (the large in-repo majority),
+  the catalog tooling, the `ccpi` CLI, and the marketplace site are **fully
+  supported here** — bugs in them are ours to fix, under the SLA above.
+- **Mirrored external plugins** (registered in `sources.yaml`) are **best-effort**.
+  Their upstream repo is the source of truth and we deliberately do not carry local
+  patches, so a bug in a mirrored plugin's own code belongs in the upstream
+  maintainer's tracker. Open an issue here anyway if you're not sure — triage will
+  identify the upstream repo and point you (or the report) at it. Problems with
+  _how we mirror or catalog_ an external plugin are ours and fully supported.
+
+## Before you post
+
+- Check [README.md](README.md) and [CONTRIBUTING.md](CONTRIBUTING.md) — most
+  install, catalog, and submission questions are answered there.
+- Search existing issues and discussions; duplicates get closed with a pointer.
+- Interactions in every support channel are governed by the
+  [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Two root-level reference docs under the Backlog Zero Wave 1 credibility epic, as two commits on one branch.

## STANDARDS.md — the repo's spec posture in one page

States which specs this repo follows (agentskills.io + Anthropic's skills docs as the floor), where it deliberately diverges (the IS marketplace 8-field `ALWAYS_REQUIRED` overlay with errors-not-warnings tier semantics, per the schema changelog NON-NEGOTIABLES and the master spec), the kernel SSoT direction (`@intentsolutions/core` authoring/v1, with `kernel-shadow-validation.yml` as the advisory conformance signal — the CI half is already covered there and is not duplicated), the two-catalog system (`marketplace.extended.json` source of truth → `marketplace.json` generated), and the mirror-by-default external-plugin model per `000-docs/694-AT-DECR`. Links canonical docs rather than restating them.

## SUPPORT.md — support surface and the 72h triage SLA

Routes questions to Discussions (Q&A / Ideas / Show-and-tell — verified enabled — plus the plugin-pack-request discussion template), bugs/features to the issue-template chooser, and vulnerabilities to SECURITY.md (private advisories, 24h ack). States a 72-hour first-response triage SLA on Issues + Discussions and draws the supported-vs-best-effort line: IS-authored plugins/tooling fully supported here; bugs inside mirrored external plugins belong upstream.

Both files are registered in the `.markdownlint-cli2.jsonc` root-doc globs so they hold the same lint bar as the other root docs. Docs-only — no workflow, validator, or catalog changes.

[skip auto-bump]

Refs jeremylongshore/claude-code-plugins-plus-skills#941

- Jeremy Longshore
intentsolutions.io