### PR TITLE
fix(notion-pack): clear the five marketplace-tier gate errors

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -9028,7 +9028,7 @@
       "name": "notion-pack",
       "source": "./plugins/saas-packs/notion-pack",
       "description": "Claude Code skill pack for Notion (30 skills)",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": ["notion", "saas", "sdk", "integration"],
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7602,7 +7602,7 @@
       "name": "notion-pack",
       "source": "./plugins/saas-packs/notion-pack",
       "description": "Claude Code skill pack for Notion (30 skills)",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": [
         "notion",

--- a/plugins/saas-packs/notion-pack/.claude-plugin/plugin.json
+++ b/plugins/saas-packs/notion-pack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-pack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code skill pack for Notion (30 skills)",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/saas-packs/notion-pack/skills/notion-content-management/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-content-management/SKILL.md
@@ -144,161 +144,26 @@ async function restorePage(pageId: string) {
 
 ### Step 2: Compose Content with Block Types
 
-Append blocks to an existing page. Each block type has its own shape:
+Append blocks to an existing page with `blocks.children.append`. Each block type has its own payload shape — headings, paragraphs (with rich text annotations), bulleted/numbered lists, to-dos, toggles, code blocks, callouts, quotes, dividers, images, and tables are all supported. The full catalog with the exact shape for every block type is in [the block type catalog](references/block-type-catalog.md).
+
+The minimal pattern:
 
 ```typescript
-async function appendBlocks(pageId: string) {
-  await notion.blocks.children.append({
-    block_id: pageId,
-    children: [
-      // Headings (heading_1, heading_2, heading_3)
-      {
-        heading_1: {
-          rich_text: [{ text: { content: 'Project Overview' } }],
-          is_toggleable: false,
-        },
+await notion.blocks.children.append({
+  block_id: pageId,
+  children: [
+    { heading_2: { rich_text: [{ text: { content: 'Notes' } }] } },
+    {
+      paragraph: {
+        rich_text: [
+          { text: { content: 'Plain and ' } },
+          { text: { content: 'bold' }, annotations: { bold: true } },
+        ],
       },
-
-      // Paragraph with rich text formatting
-      {
-        paragraph: {
-          rich_text: [
-            { text: { content: 'This is ' } },
-            { text: { content: 'bold text' }, annotations: { bold: true } },
-            { text: { content: ' and ' } },
-            { text: { content: 'inline code' }, annotations: { code: true } },
-            { text: { content: '. Visit ' } },
-            {
-              text: { content: 'our docs', link: { url: 'https://example.com' } },
-              annotations: { italic: true },
-            },
-            { text: { content: '.' } },
-          ],
-        },
-      },
-
-      // Bulleted list items
-      {
-        bulleted_list_item: {
-          rich_text: [{ text: { content: 'First bullet point' } }],
-        },
-      },
-      {
-        bulleted_list_item: {
-          rich_text: [{ text: { content: 'Second bullet point' } }],
-        },
-      },
-
-      // Numbered list items
-      {
-        numbered_list_item: {
-          rich_text: [{ text: { content: 'Step one' } }],
-        },
-      },
-      {
-        numbered_list_item: {
-          rich_text: [{ text: { content: 'Step two' } }],
-        },
-      },
-
-      // To-do items
-      {
-        to_do: {
-          rich_text: [{ text: { content: 'Review pull requests' } }],
-          checked: false,
-        },
-      },
-      {
-        to_do: {
-          rich_text: [{ text: { content: 'Update documentation' } }],
-          checked: true,
-        },
-      },
-
-      // Toggle block (collapsible)
-      {
-        toggle: {
-          rich_text: [{ text: { content: 'Click to expand details' } }],
-          children: [
-            {
-              paragraph: {
-                rich_text: [{ text: { content: 'Hidden content inside toggle.' } }],
-              },
-            },
-          ],
-        },
-      },
-
-      // Code block
-      {
-        code: {
-          rich_text: [{ text: { content: 'const x = 42;\nconsole.log(x);' } }],
-          language: 'typescript',
-          caption: [{ text: { content: 'Example snippet' } }],
-        },
-      },
-
-      // Callout
-      {
-        callout: {
-          rich_text: [{ text: { content: 'Important: review before merging.' } }],
-          icon: { emoji: '⚠️' },
-          color: 'yellow_background',
-        },
-      },
-
-      // Quote
-      {
-        quote: {
-          rich_text: [{ text: { content: 'Ship early, ship often.' } }],
-          color: 'gray',
-        },
-      },
-
-      // Divider
-      { divider: {} },
-
-      // Image (external URL)
-      {
-        image: {
-          external: { url: 'https://example.com/diagram.png' },
-          caption: [{ text: { content: 'System architecture diagram' } }],
-        },
-      },
-
-      // Table (3 columns x 2 rows)
-      {
-        table: {
-          table_width: 3,
-          has_column_header: true,
-          has_row_header: false,
-          children: [
-            {
-              table_row: {
-                cells: [
-                  [{ text: { content: 'Feature' } }],
-                  [{ text: { content: 'Status' } }],
-                  [{ text: { content: 'Owner' } }],
-                ],
-              },
-            },
-            {
-              table_row: {
-                cells: [
-                  [{ text: { content: 'Auth' } }],
-                  [{ text: { content: 'Done' } }],
-                  [{ text: { content: 'Alice' } }],
-                ],
-              },
-            },
-          ],
-        },
-      },
-    ],
-  });
-
-  console.log('Blocks appended to page:', pageId);
-}
+    },
+    { to_do: { rich_text: [{ text: { content: 'Review PRs' } }], checked: false } },
+  ],
+});
 ```
 
 ### Step 3: Update and Delete Individual Blocks

--- a/plugins/saas-packs/notion-pack/skills/notion-content-management/references/block-type-catalog.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-content-management/references/block-type-catalog.md
@@ -1,0 +1,162 @@
+# Notion Block Type Catalog
+
+Complete `blocks.children.append` reference covering every common block type
+and its exact payload shape. Notion caps append calls at 100 blocks per
+request — see the "Batch Block Append" example in SKILL.md for chunking.
+
+## All Common Block Types in One Append Call
+
+```typescript
+async function appendBlocks(pageId: string) {
+  await notion.blocks.children.append({
+    block_id: pageId,
+    children: [
+      // Headings (heading_1, heading_2, heading_3)
+      {
+        heading_1: {
+          rich_text: [{ text: { content: 'Project Overview' } }],
+          is_toggleable: false,
+        },
+      },
+
+      // Paragraph with rich text formatting
+      {
+        paragraph: {
+          rich_text: [
+            { text: { content: 'This is ' } },
+            { text: { content: 'bold text' }, annotations: { bold: true } },
+            { text: { content: ' and ' } },
+            { text: { content: 'inline code' }, annotations: { code: true } },
+            { text: { content: '. Visit ' } },
+            {
+              text: { content: 'our docs', link: { url: 'https://example.com' } },
+              annotations: { italic: true },
+            },
+            { text: { content: '.' } },
+          ],
+        },
+      },
+
+      // Bulleted list items
+      {
+        bulleted_list_item: {
+          rich_text: [{ text: { content: 'First bullet point' } }],
+        },
+      },
+      {
+        bulleted_list_item: {
+          rich_text: [{ text: { content: 'Second bullet point' } }],
+        },
+      },
+
+      // Numbered list items
+      {
+        numbered_list_item: {
+          rich_text: [{ text: { content: 'Step one' } }],
+        },
+      },
+      {
+        numbered_list_item: {
+          rich_text: [{ text: { content: 'Step two' } }],
+        },
+      },
+
+      // To-do items
+      {
+        to_do: {
+          rich_text: [{ text: { content: 'Review pull requests' } }],
+          checked: false,
+        },
+      },
+      {
+        to_do: {
+          rich_text: [{ text: { content: 'Update documentation' } }],
+          checked: true,
+        },
+      },
+
+      // Toggle block (collapsible)
+      {
+        toggle: {
+          rich_text: [{ text: { content: 'Click to expand details' } }],
+          children: [
+            {
+              paragraph: {
+                rich_text: [{ text: { content: 'Hidden content inside toggle.' } }],
+              },
+            },
+          ],
+        },
+      },
+
+      // Code block
+      {
+        code: {
+          rich_text: [{ text: { content: 'const x = 42;\nconsole.log(x);' } }],
+          language: 'typescript',
+          caption: [{ text: { content: 'Example snippet' } }],
+        },
+      },
+
+      // Callout
+      {
+        callout: {
+          rich_text: [{ text: { content: 'Important: review before merging.' } }],
+          icon: { emoji: '⚠️' },
+          color: 'yellow_background',
+        },
+      },
+
+      // Quote
+      {
+        quote: {
+          rich_text: [{ text: { content: 'Ship early, ship often.' } }],
+          color: 'gray',
+        },
+      },
+
+      // Divider
+      { divider: {} },
+
+      // Image (external URL)
+      {
+        image: {
+          external: { url: 'https://example.com/diagram.png' },
+          caption: [{ text: { content: 'System architecture diagram' } }],
+        },
+      },
+
+      // Table (3 columns x 2 rows)
+      {
+        table: {
+          table_width: 3,
+          has_column_header: true,
+          has_row_header: false,
+          children: [
+            {
+              table_row: {
+                cells: [
+                  [{ text: { content: 'Feature' } }],
+                  [{ text: { content: 'Status' } }],
+                  [{ text: { content: 'Owner' } }],
+                ],
+              },
+            },
+            {
+              table_row: {
+                cells: [
+                  [{ text: { content: 'Auth' } }],
+                  [{ text: { content: 'Done' } }],
+                  [{ text: { content: 'Alice' } }],
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  console.log('Blocks appended to page:', pageId);
+}
+```

--- a/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/SKILL.md
@@ -28,6 +28,8 @@ compatibility: Designed for Claude Code
 ---
 # Deploy Notion-Integrated Applications
 
+## Overview
+
 Ship Node.js apps that talk to the Notion API to Vercel, Railway, or Fly.io. This skill covers environment variable management, the Notion client singleton pattern for serverless, rate limit handling at 3 req/sec, health check endpoints that verify Notion connectivity, and caching strategies to reduce API calls.
 
 ## Prerequisites
@@ -329,85 +331,7 @@ curl https://my-notion-service.fly.dev/health
 
 ### Step 3 — Monitor Notion API Errors in Production
 
-Set up structured error logging so you can track Notion-specific failures in your monitoring tool (Sentry, Datadog, or platform logs).
-
-```typescript
-// src/notion-error-handler.ts — structured error reporting
-import { isNotionClientError, APIErrorCode, ClientErrorCode } from '@notionhq/client';
-
-interface NotionErrorReport {
-  source: 'notion_api';
-  code: string;
-  status: number;
-  message: string;
-  retryable: boolean;
-  action: string;
-}
-
-export function classifyNotionError(error: unknown): NotionErrorReport {
-  if (!isNotionClientError(error)) {
-    return {
-      source: 'notion_api',
-      code: 'unknown',
-      status: 500,
-      message: error instanceof Error ? error.message : String(error),
-      retryable: false,
-      action: 'investigate — non-Notion error in API path',
-    };
-  }
-
-  const report: NotionErrorReport = {
-    source: 'notion_api',
-    code: error.code,
-    status: error.status,
-    message: error.message,
-    retryable: false,
-    action: '',
-  };
-
-  switch (error.code) {
-    case APIErrorCode.RateLimited:
-      report.retryable = true;
-      report.action = 'back off — increase cache TTL or reduce polling frequency';
-      break;
-    case APIErrorCode.Unauthorized:
-      report.retryable = false;
-      report.action = 'rotate NOTION_TOKEN — token expired or was revoked';
-      break;
-    case APIErrorCode.ObjectNotFound:
-      report.retryable = false;
-      report.action = 'check integration permissions — page/database not shared with integration';
-      break;
-    case APIErrorCode.InternalServerError:
-    case APIErrorCode.ServiceUnavailable:
-      report.retryable = true;
-      report.action = 'retry with exponential backoff — Notion is having issues';
-      break;
-    case APIErrorCode.ValidationError:
-      report.retryable = false;
-      report.action = 'fix request payload — check filter syntax and property names';
-      break;
-    default:
-      report.action = 'check Notion API status page and SDK changelog';
-  }
-
-  return report;
-}
-
-export function logNotionError(error: unknown, context: Record<string, string> = {}): void {
-  const report = classifyNotionError(error);
-  console.error(JSON.stringify({ ...report, ...context, timestamp: new Date().toISOString() }));
-}
-```
-
-Wire this into your API routes:
-
-```typescript
-} catch (error) {
-  logNotionError(error, { route: '/api/notion/query', databaseId });
-  // ... return error response
-}
-```
+Set up structured error logging so you can track Notion-specific failures in your monitoring tool (Sentry, Datadog, or platform logs). The full `classifyNotionError` / `logNotionError` module — which maps every `@notionhq/client` error code to a retryability flag and an operator action, plus the API-route wiring — lives in [production error monitoring](references/production-error-monitoring.md). Copy it to `src/notion-error-handler.ts` and call `logNotionError(error, context)` from every catch block that touches the Notion API.
 
 **Key metrics to monitor:**
 

--- a/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/references/production-error-monitoring.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-deploy-integration/references/production-error-monitoring.md
@@ -1,0 +1,85 @@
+# Production Error Monitoring for Notion Integrations
+
+Structured error logging so you can track Notion-specific failures in your
+monitoring tool (Sentry, Datadog, or platform logs). The classifier maps every
+`@notionhq/client` error to a retryability flag and a concrete operator action.
+
+## Error Classifier Module
+
+```typescript
+// src/notion-error-handler.ts — structured error reporting
+import { isNotionClientError, APIErrorCode, ClientErrorCode } from '@notionhq/client';
+
+interface NotionErrorReport {
+  source: 'notion_api';
+  code: string;
+  status: number;
+  message: string;
+  retryable: boolean;
+  action: string;
+}
+
+export function classifyNotionError(error: unknown): NotionErrorReport {
+  if (!isNotionClientError(error)) {
+    return {
+      source: 'notion_api',
+      code: 'unknown',
+      status: 500,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+      action: 'investigate — non-Notion error in API path',
+    };
+  }
+
+  const report: NotionErrorReport = {
+    source: 'notion_api',
+    code: error.code,
+    status: error.status,
+    message: error.message,
+    retryable: false,
+    action: '',
+  };
+
+  switch (error.code) {
+    case APIErrorCode.RateLimited:
+      report.retryable = true;
+      report.action = 'back off — increase cache TTL or reduce polling frequency';
+      break;
+    case APIErrorCode.Unauthorized:
+      report.retryable = false;
+      report.action = 'rotate NOTION_TOKEN — token expired or was revoked';
+      break;
+    case APIErrorCode.ObjectNotFound:
+      report.retryable = false;
+      report.action = 'check integration permissions — page/database not shared with integration';
+      break;
+    case APIErrorCode.InternalServerError:
+    case APIErrorCode.ServiceUnavailable:
+      report.retryable = true;
+      report.action = 'retry with exponential backoff — Notion is having issues';
+      break;
+    case APIErrorCode.ValidationError:
+      report.retryable = false;
+      report.action = 'fix request payload — check filter syntax and property names';
+      break;
+    default:
+      report.action = 'check Notion API status page and SDK changelog';
+  }
+
+  return report;
+}
+
+export function logNotionError(error: unknown, context: Record<string, string> = {}): void {
+  const report = classifyNotionError(error);
+  console.error(JSON.stringify({ ...report, ...context, timestamp: new Date().toISOString() }));
+}
+```
+
+## Wiring Into API Routes
+
+```typescript
+} catch (error) {
+  logNotionError(error, { route: '/api/notion/query', databaseId });
+  // ... return error response
+}
+```

--- a/plugins/saas-packs/notion-pack/skills/notion-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-reference-architecture/SKILL.md
@@ -17,7 +17,7 @@ description: 'Design and implement a production-ready Notion integration archite
   architecture", "notion service pattern".
 
   '
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Glob, Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -403,6 +403,14 @@ After applying this architecture you will have:
 | `502/503 server errors` | Notion service degradation | Check https://status.notion.so; the retry wrapper auto-recovers with backoff |
 | Stale cache data | Cache TTL too long for write-heavy workloads | Invalidate on writes (shown in `NotionService.createTask`); reduce TTL for volatile databases |
 | Polling misses changes | Poll interval too wide or clock skew | Use 10s intervals; store `last_edited_time` from the most recent page, not system clock |
+
+## Safety Justification
+
+This skill scaffolds a multi-file TypeScript project, so it needs `Write`/`Edit` alongside shell access — a combination that warrants explicit scoping:
+
+- **Bash is scoped, not blanket.** Only `Bash(npm:*)` (install `@notionhq/client`, run `npm test`) and `Bash(npx:*)` (run TypeScript tooling like `npx tsc`/`npx vitest`) are granted — no arbitrary subprocesses, no `curl`-pipe-shell surface.
+- **Write/Edit scope is the project source tree.** The skill creates files only under the layout shown in Step 1 (`src/notion/`, `src/repositories/`, `src/services/`, `src/cache/`, `tests/`); it never writes credentials or touches files outside the project.
+- **No secret handling.** `NOTION_TOKEN` is read from the environment by the generated code at runtime; the skill never echoes, fabricates, or persists token values.
 
 ## Examples
 

--- a/plugins/saas-packs/notion-pack/skills/notion-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-webhooks-events/SKILL.md
@@ -441,6 +441,56 @@ See [scheduled polling and examples](references/scheduled-polling-and-examples.m
 | Content changes not detected | `last_edited_time` only covers properties | Use `blocks.children.list` fingerprinting for page body changes |
 | `databases.query` filter ignored | Wrong filter structure | Use `{ timestamp: 'last_edited_time', last_edited_time: { after: isoString } }` — not a property filter |
 
+## Examples
+
+### Minimal Webhook Receiver (verification + fetch on change)
+
+```typescript
+import express from 'express';
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const app = express();
+app.use(express.json());
+
+app.post('/webhooks/notion', async (req, res) => {
+  // Registration handshake: echo the challenge back
+  if (req.body.type === 'url_verification') {
+    return res.status(200).json({ challenge: req.body.challenge });
+  }
+  res.status(200).json({ ok: true }); // ack fast, process async
+
+  // Webhooks carry no payload — fetch the changed resource
+  if (req.body.type === 'page.properties_updated') {
+    const page = await notion.pages.retrieve({ page_id: req.body.data.id });
+    console.log('Page changed:', 'url' in page ? page.url : page.id);
+  }
+});
+
+app.listen(3000);
+```
+
+### One-Database Change Watcher (polling)
+
+```typescript
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+let since = new Date().toISOString();
+
+setInterval(async () => {
+  const response = await notion.databases.query({
+    database_id: process.env.NOTION_DATABASE_ID!,
+    filter: { timestamp: 'last_edited_time', last_edited_time: { after: since } },
+    sorts: [{ timestamp: 'last_edited_time', direction: 'descending' }],
+  });
+  if (response.results.length > 0) {
+    since = (response.results[0] as any).last_edited_time;
+    console.log(`${response.results.length} row(s) changed since last poll`);
+  }
+}, 60_000); // 60s interval respects the 3 req/s rate limit
+```
+
 ## Resources
 
 - [Notion API Search endpoint](https://developers.notion.com/reference/post-search)


### PR DESCRIPTION
Clears every marketplace-tier validator ERROR in the notion-pack (5 findings across 4 skills). Backlog Zero Wave 1, Phase C.

## The five fixes

1. **notion-webhooks-events** — added a real `## Examples` section: a minimal webhook receiver (verification handshake + fetch-on-change via `@notionhq/client`) and a one-database polling watcher.
2. **notion-deploy-integration** — inserted the missing `## Overview` section between the H1 and Prerequisites, matching the sibling-pack pattern.
3. **notion-deploy-integration** — extracted the production error-monitoring module (`classifyNotionError` / `logNotionError`) to `references/production-error-monitoring.md` with a pointer; body 499 → 423 lines.
4. **notion-content-management** — extracted the full block-type catalog to `references/block-type-catalog.md`, leaving a compact append example + pointer; body 501 → 366 lines (was over the 500-line hard limit).
5. **notion-reference-architecture** — scoped the bare `Bash` grant to `Bash(npm:*), Bash(npx:*)` (what the skill actually needs) and added the `## Safety Justification` section the tool-safety tier requires.

## Validator result

- notion-pack: **32 skills, ZERO errors** at marketplace tier (warnings remain, as allowed)
- New pack average score: **80.84/100**

Note: the 90+-average policy question stays open under the supersession epic — this PR only clears the ERRORS, it does not attempt to lift the pack average to 90+.

Version bumped 1.0.0 → 1.0.1 (plugin.json + marketplace.extended.json, `marketplace.json` regenerated via sync-marketplace).

[skip auto-bump]

Refs jeremylongshore/claude-code-plugins-plus-skills#938

- Jeremy Longshore
intentsolutions.io