### PR TITLE
fix(supabase-pack): clear the standing marketplace-tier gate findings

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -5652,7 +5652,7 @@
       "name": "supabase-pack",
       "source": "./plugins/saas-packs/supabase-pack",
       "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": [
         "supabase",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5188,7 +5188,7 @@
       "name": "supabase-pack",
       "source": "./plugins/saas-packs/supabase-pack",
       "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": [
         "supabase",

--- a/plugins/saas-packs/supabase-pack/.claude-plugin/plugin.json
+++ b/plugins/saas-packs/supabase-pack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "supabase-pack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code skill pack for Supabase (30 skills)",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/saas-packs/supabase-pack/skills/supabase-architecture-variants/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-architecture-variants/SKILL.md
@@ -53,11 +53,13 @@ Different application architectures require fundamentally different Supabase `cr
 - TypeScript project with generated database types (`supabase gen types typescript`)
 - For mobile: React Native with Expo or bare workflow
 
-## Step 1 — Next.js SSR (App Router with Server and Client Components)
+## Instructions
+
+### Step 1 — Next.js SSR (App Router with Server and Client Components)
 
 Next.js App Router requires **two separate clients**: a server-side client using cookies for auth (with `@supabase/ssr`) and a browser client for client components. Never expose `service_role` to the client.
 
-### Server-Side Client (for Server Components, Route Handlers, Server Actions)
+#### Server-Side Client (for Server Components, Route Handlers, Server Actions)
 
 ```typescript
 // lib/supabase/server.ts
@@ -105,7 +107,7 @@ export function createSupabaseAdmin() {
 }
 ```
 
-### Client-Side Client (for Client Components)
+#### Client-Side Client (for Client Components)
 
 ```typescript
 // lib/supabase/client.ts
@@ -128,7 +130,7 @@ export function createSupabaseBrowser() {
 }
 ```
 
-### Middleware for Auth Session Refresh
+#### Middleware for Auth Session Refresh
 
 ```typescript
 // middleware.ts
@@ -170,7 +172,7 @@ export const config = {
 }
 ```
 
-### Server Component Usage
+#### Server Component Usage
 
 ```typescript
 // app/dashboard/page.tsx
@@ -200,7 +202,7 @@ export default async function DashboardPage() {
 }
 ```
 
-### Server Action with Admin Client
+#### Server Action with Admin Client
 
 ```typescript
 // app/actions/admin.ts
@@ -225,9 +227,9 @@ export async function deleteUserAccount(userId: string) {
 }
 ```
 
-## Step 2 — SPA (React/Vue) and Mobile (React Native)
+### Step 2 — SPA (React/Vue) and Mobile (React Native)
 
-### SPA Architecture (React with Vite)
+#### SPA Architecture (React with Vite)
 
 SPAs use a single browser client with the anon key. All authorization is enforced via RLS. The service_role key is never present in the SPA bundle.
 
@@ -262,7 +264,7 @@ supabase.auth.onAuthStateChange((event, session) => {
 })
 ```
 
-### React Hook for Auth-Protected Queries
+#### React Hook for Auth-Protected Queries
 
 ```typescript
 // src/hooks/useSupabaseQuery.ts
@@ -305,7 +307,7 @@ export function useCreateTodo() {
 }
 ```
 
-### Mobile Architecture (React Native with Expo)
+#### Mobile Architecture (React Native with Expo)
 
 React Native needs `AsyncStorage` for session persistence and deep link handling for OAuth.
 
@@ -329,7 +331,7 @@ export const supabase = createClient<Database>(
 )
 ```
 
-### Mobile OAuth with Deep Links
+#### Mobile OAuth with Deep Links
 
 ```typescript
 // lib/auth.ts (React Native)
@@ -371,7 +373,7 @@ export async function signInWithGoogle() {
 }
 ```
 
-### App.json Deep Link Configuration (Expo)
+#### App.json Deep Link Configuration (Expo)
 
 ```json
 {
@@ -389,7 +391,7 @@ export async function signInWithGoogle() {
 }
 ```
 
-## Step 3 — Serverless (Edge Functions) and Multi-Tenant
+### Step 3 — Serverless (Edge Functions) and Multi-Tenant
 
 See [serverless and multi-tenant patterns](references/serverless-and-multi-tenant.md) for Edge Function per-request clients, admin operation escalation, RLS-based multi-tenant isolation with schema, and tenant-scoped SDK queries.
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
@@ -26,6 +26,8 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ---
 # Supabase Debug Bundle
 
+## Overview
+
 Collect a comprehensive, redacted diagnostic bundle from a Supabase project. Tests connectivity, auth, Realtime, Storage, RLS policy behavior, and database health — then packages everything into a single archive safe for sharing with Supabase support.
 
 ## Current State

--- a/plugins/saas-packs/supabase-pack/skills/supabase-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-known-pitfalls/SKILL.md
@@ -48,11 +48,13 @@ The twelve most common Supabase mistakes, ranked by severity: **security** (serv
 - `@supabase/supabase-js` v2+ installed
 - Basic understanding of Row Level Security (RLS)
 
-## Step 1 — Security Pitfalls (Critical)
+## Instructions
+
+### Step 1 — Security Pitfalls (Critical)
 
 These mistakes can expose all your data to any user with browser dev tools.
 
-### Pitfall 1: Exposing service_role Key in Client Code
+#### Pitfall 1: Exposing service_role Key in Client Code
 
 ```typescript
 // BAD: service_role key in a NEXT_PUBLIC_ variable — shipped to every browser
@@ -92,7 +94,7 @@ grep -rn 'SERVICE_ROLE' --include="*.tsx" --include="*.jsx" --include="*.ts" src
 grep -rn 'NEXT_PUBLIC.*SERVICE_ROLE' .env* *.ts *.tsx
 ```
 
-### Pitfall 2: Tables Without RLS Enabled
+#### Pitfall 2: Tables Without RLS Enabled
 
 ```sql
 -- BAD: table created without enabling RLS
@@ -129,7 +131,7 @@ AND rowsecurity = false
 AND tablename NOT LIKE '\_%';
 ```
 
-### Pitfall 3: Overly Permissive RLS Policies
+#### Pitfall 3: Overly Permissive RLS Policies
 
 ```sql
 -- BAD: lets any authenticated user read ALL messages
@@ -152,7 +154,7 @@ CREATE POLICY "update_own_profile" ON public.profiles
   FOR UPDATE USING (id = auth.uid());
 ```
 
-### Pitfall 4: Not Using Connection Pooling in Serverless
+#### Pitfall 4: Not Using Connection Pooling in Serverless
 
 ```typescript
 // BAD: direct connection string in a serverless function
@@ -165,11 +167,11 @@ const connectionString = 'postgresql://postgres.xxx:pass@aws-0-us-east-1.pooler.
 // Required for serverless (Vercel, Netlify, Cloudflare Workers, AWS Lambda)
 ```
 
-## Step 2 — Data Integrity Pitfalls (High)
+### Step 2 — Data Integrity Pitfalls (High)
 
 These mistakes cause silent data loss, null pointer errors, and inconsistent state.
 
-### Pitfall 5: Not Handling { data, error }
+#### Pitfall 5: Not Handling { data, error }
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
@@ -190,7 +192,7 @@ if (error) {
 console.log(data.id)
 ```
 
-### Pitfall 6: Missing .select() After Insert/Update/Upsert
+#### Pitfall 6: Missing .select() After Insert/Update/Upsert
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
@@ -212,7 +214,7 @@ if (error) throw new Error(`Insert failed: ${error.message}`)
 console.log(data)  // { id: '...', title: 'Buy milk', is_complete: false, ... }
 ```
 
-### Pitfall 7: .single() on Empty or Multiple Results
+#### Pitfall 7: .single() on Empty or Multiple Results
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
@@ -245,9 +247,9 @@ const { data, error } = await supabase
 // neither        — use when you expect an array of results
 ```
 
-## Step 3 — Performance and Maintainability Pitfalls (Medium/Low)
+### Step 3 — Performance and Maintainability Pitfalls (Medium/Low)
 
-### Pitfall 8: select('*') Everywhere
+#### Pitfall 8: select('*') Everywhere
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
@@ -268,7 +270,7 @@ const { data } = await supabase
 // Benefits: smaller payload, typed results, index-friendly, no data leakage
 ```
 
-### Pitfall 9: N+1 Query Pattern
+#### Pitfall 9: N+1 Query Pattern
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
@@ -305,7 +307,7 @@ const { data: allTasks } = await supabase
 // Total: 2 queries regardless of N
 ```
 
-### Pitfall 10: Missing Indexes on Foreign Key Columns
+#### Pitfall 10: Missing Indexes on Foreign Key Columns
 
 ```sql
 -- BAD: foreign key without index
@@ -351,7 +353,7 @@ AND tc.table_schema = 'public'
 AND pi.indexname IS NULL;
 ```
 
-### Pitfall 11: Creating Multiple Client Instances
+#### Pitfall 11: Creating Multiple Client Instances
 
 ```typescript
 // BAD: new client in every file — wastes memory, breaks auth state
@@ -387,7 +389,7 @@ export const supabase = createClient<Database>(
 // import { supabase } from '@/lib/supabase'
 ```
 
-### Pitfall 12: Not Using Generated Types
+#### Pitfall 12: Not Using Generated Types
 
 ```typescript
 // BAD: manual types that drift from the actual database schema

--- a/plugins/saas-packs/supabase-pack/skills/supabase-load-scale/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-load-scale/SKILL.md
@@ -48,11 +48,13 @@ Supabase scaling operates at six layers: **read replicas** (offload analytics an
 - Database access via `psql` or Supabase SQL Editor
 - TypeScript project with generated database types
 
-## Step 1 — Read Replicas and Connection Pooling
+## Instructions
+
+### Step 1 — Read Replicas and Connection Pooling
 
 Read replicas let you route read-heavy queries (dashboards, reports, search) to replica databases while keeping writes on the primary. Supabase uses **Supavisor** (their pgBouncer replacement) for connection pooling with two modes: **transaction** (default, shares connections between requests) and **session** (holds a connection per client session, needed for prepared statements).
 
-### Configure the Read Replica Client
+#### Configure the Read Replica Client
 
 ```typescript
 // lib/supabase.ts
@@ -89,7 +91,7 @@ export const supabaseAdmin = createClient<Database>(
 )
 ```
 
-### Direct Postgres Connections via Supavisor Pooling
+#### Direct Postgres Connections via Supavisor Pooling
 
 ```bash
 # Transaction mode (default, port 6543) — best for serverless/short-lived connections
@@ -104,7 +106,7 @@ psql "postgresql://postgres.[project-ref]:[password]@aws-0-us-east-1.pooler.supa
 psql "postgresql://postgres:[password]@db.[project-ref].supabase.co:5432/postgres"
 ```
 
-### Route Queries to the Right Target
+#### Route Queries to the Right Target
 
 ```typescript
 // services/analytics.ts
@@ -138,7 +140,7 @@ export async function createOrder(order: OrderInsert) {
 }
 ```
 
-### Monitor Connection Pool Usage
+#### Monitor Connection Pool Usage
 
 ```sql
 -- Check active connections by source (run in SQL Editor)
@@ -158,9 +160,9 @@ SHOW max_connections;
 -- Micro: 60, Small: 90, Medium: 120, Large: 160, XL: 240, 2XL: 380, 4XL: 480
 ```
 
-## Step 2 — Compute Upgrades, CDN for Storage, and Edge Function Regions
+### Step 2 — Compute Upgrades, CDN for Storage, and Edge Function Regions
 
-### Compute Size Selection Guide
+#### Compute Size Selection Guide
 
 | Tier | vCPU | RAM | Max Connections | Best For |
 |------|------|-----|----------------|----------|
@@ -180,7 +182,7 @@ supabase projects update --experimental --compute-size small  # or medium, large
 supabase projects list
 ```
 
-### CDN Caching for Storage Buckets
+#### CDN Caching for Storage Buckets
 
 Public buckets are automatically served through Supabase's CDN. Optimize cache behavior with proper headers and transforms.
 
@@ -244,7 +246,7 @@ async function uploadVersionedAsset(bucket: string, file: Buffer, ext: string) {
 }
 ```
 
-### Edge Function Regional Deployment
+#### Edge Function Regional Deployment
 
 ```bash
 # Deploy to a specific region (closer to your users)
@@ -291,7 +293,7 @@ Deno.serve(async (req) => {
 })
 ```
 
-## Step 3 — Database Table Partitioning
+### Step 3 — Database Table Partitioning
 
 See [table partitioning patterns](references/table-partitioning.md) for range partitioning by date, automated partition creation via `pg_cron`, SDK query patterns with partition key filters, and partition drop for data retention.
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
@@ -50,9 +50,11 @@ Organizational governance for Supabase at scale: a **shared RLS policy library**
 - Database access via `psql` or Supabase SQL Editor
 - Pro plan recommended for cost alerts and usage API
 
-## Step 1 — Shared RLS Policy Library and Naming Conventions
+## Instructions
 
-### RLS Policy Templates
+### Step 1 — Shared RLS Policy Library and Naming Conventions
+
+#### RLS Policy Templates
 
 Create reusable RLS policy templates that teams apply to new tables. This prevents each developer from writing ad-hoc policies and ensures consistent access control.
 
@@ -164,7 +166,7 @@ $$ LANGUAGE plpgsql;
 -- SELECT public.rls_public_read_auth_write('blog_posts', 'author_id');
 ```
 
-### Naming Conventions
+#### Naming Conventions
 
 ```sql
 -- supabase/migrations/00000000000001_naming_convention_check.sql
@@ -228,7 +230,7 @@ $$ LANGUAGE plpgsql;
 -- Run: SELECT * FROM public.validate_naming_conventions();
 ```
 
-### Naming Convention Reference
+#### Naming Convention Reference
 
 | Object | Convention | Example |
 |--------|-----------|---------|
@@ -242,7 +244,7 @@ $$ LANGUAGE plpgsql;
 | Indexes | `idx_{table}_{columns}` | `idx_orders_user_id_created_at` |
 | Migrations | `{timestamp}_{verb}_{description}` | `20250322000000_create_orders_table.sql` |
 
-## Step 2 — Migration Review Process with CI Checks
+### Step 2 — Migration Review Process with CI Checks
 
 See [CI checks, cost alerts, and security audits](references/ci-cost-security.md) for GitHub Actions migration guardrails (RLS enforcement, naming checks, destructive operation blocks), pre-commit hooks, cost monitoring with Slack alerts, security audit scripts, and scheduled Edge Function audits.
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-rate-limits/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-rate-limits/SKILL.md
@@ -13,7 +13,7 @@ description: 'Manage Supabase rate limits and quotas across all plan tiers.
   "supabase quota", "supabase connection pool", "supabase too many requests".
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(node:*), Bash(npx:*), Grep
 version: 1.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>

--- a/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
@@ -46,11 +46,13 @@ Production Supabase apps need six reliability layers: **circuit breakers** (stop
 - For offline queue: browser environment with IndexedDB or server with Redis
 - For dual-write: secondary data store (Redis, DynamoDB, or local SQLite)
 
-## Step 1 — Circuit Breaker and Retry with Exponential Backoff
+## Instructions
+
+### Step 1 — Circuit Breaker and Retry with Exponential Backoff
 
 A circuit breaker tracks failures per Supabase service (database, auth, storage) and stops making calls when a threshold is exceeded. Combined with retry logic, it prevents both cascading failures and unnecessary retries during extended outages.
 
-### Circuit Breaker Implementation
+#### Circuit Breaker Implementation
 
 ```typescript
 // lib/circuit-breaker.ts
@@ -147,7 +149,7 @@ export const storageCircuit = new CircuitBreaker({
 })
 ```
 
-### Retry with Exponential Backoff and Jitter
+#### Retry with Exponential Backoff and Jitter
 
 ```typescript
 // lib/retry.ts
@@ -202,7 +204,7 @@ export async function withRetry<T>(
 }
 ```
 
-### Combining Circuit Breaker + Retry
+#### Combining Circuit Breaker + Retry
 
 ```typescript
 // services/todo-service.ts
@@ -247,7 +249,7 @@ export const TodoService = {
 }
 ```
 
-## Step 2 — Offline Queue and Graceful Degradation
+### Step 2 — Offline Queue and Graceful Degradation
 
 See [offline queue, graceful degradation, health checks, and dual-write](references/offline-degradation-health-dualwrite.md) for IndexedDB offline queue with auto-flush, cached fallback patterns, health check endpoints monitoring database/auth/storage, dual-write for critical data with Redis backup, and reconciliation jobs.
 
@@ -271,6 +273,32 @@ See [offline queue, graceful degradation, health checks, and dual-write](referen
 | Dual-write divergence | Network partition | Run reconciliation job every 5 min; alert on divergence count |
 | Health check false positive | Transient network blip | Require 3 consecutive failures before marking unhealthy |
 | Retry storm | All clients retry simultaneously | Jitter prevents thundering herd; circuit breaker stops retries when open |
+
+## Examples
+
+**Example 1 — List todos with outage fallback.** During a Supabase outage the circuit opens after 5 failures and the fallback serves an empty list instead of cascading errors:
+
+```typescript
+import { TodoService } from './services/todo-service'
+
+const { data, error } = await TodoService.list(userId)
+// Healthy: data from Supabase (transient errors retried with backoff).
+// Circuit OPEN: fallback returns { data: [], error: null } — UI renders
+// an empty state instead of crashing.
+```
+
+**Example 2 — Check circuit state before an expensive operation:**
+
+```typescript
+import { dbCircuit, storageCircuit } from './lib/circuit-breaker'
+
+const { state, failures } = dbCircuit.currentState
+if (state === 'OPEN') {
+  console.warn(`Database circuit OPEN (${failures} failures) — deferring bulk import`)
+} else if (storageCircuit.currentState.state !== 'OPEN') {
+  await runBulkImport()
+}
+```
 
 ## Resources
 

--- a/plugins/saas-packs/supabase-pack/skills/supabase-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-webhooks-events/SKILL.md
@@ -44,11 +44,13 @@ Supabase offers four complementary event mechanisms: **Database Webhooks** (trig
 - `@supabase/supabase-js` v2+ installed for client-side patterns
 - Edge Functions deployed for webhook receiver patterns
 
-## Step 1 — Database Webhooks with `pg_net` and Trigger Functions
+## Instructions
+
+### Step 1 — Database Webhooks with `pg_net` and Trigger Functions
 
 Database webhooks fire HTTP requests when rows change. Under the hood, Supabase uses the `pg_net` extension to make async, non-blocking HTTP calls from within PostgreSQL.
 
-### Enable pg_net and Create the Trigger Function
+#### Enable pg_net and Create the Trigger Function
 
 ```sql
 -- Enable the pg_net extension (one-time)
@@ -76,7 +78,7 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 ```
 
-### Attach Triggers for INSERT, UPDATE, DELETE
+#### Attach Triggers for INSERT, UPDATE, DELETE
 
 ```sql
 -- Fire on new rows
@@ -109,7 +111,7 @@ CREATE TRIGGER on_order_status_changed
   FOR EACH ROW EXECUTE FUNCTION public.notify_order_status_changed();
 ```
 
-### Using `supabase_functions.http_request()` (Built-in Helper)
+#### Using `supabase_functions.http_request()` (Built-in Helper)
 
 Supabase provides a built-in wrapper that simplifies calling Edge Functions from triggers without managing headers manually:
 
@@ -128,7 +130,7 @@ CREATE TRIGGER on_profile_updated
   );
 ```
 
-### Inspect pg_net Responses
+#### Inspect pg_net Responses
 
 ```sql
 -- Check recent HTTP responses (retained for 6 hours)
@@ -144,9 +146,9 @@ WHERE status_code >= 400
 ORDER BY created DESC;
 ```
 
-## Step 2 — Edge Function Webhook Receivers with Signature Verification
+### Step 2 — Edge Function Webhook Receivers with Signature Verification
 
-### Webhook Receiver with Signature Verification
+#### Webhook Receiver with Signature Verification
 
 ```typescript
 // supabase/functions/on-order-created/index.ts
@@ -247,7 +249,7 @@ serve(async (req) => {
 });
 ```
 
-### Idempotent Event Processing
+#### Idempotent Event Processing
 
 Webhooks may be delivered more than once. Use an idempotency table to prevent duplicate processing:
 
@@ -307,9 +309,9 @@ DELETE FROM public.processed_events
 WHERE processed_at < now() - interval '7 days';
 ```
 
-## Step 3 — Postgres LISTEN/NOTIFY and Realtime as Event Source
+### Step 3 — Postgres LISTEN/NOTIFY and Realtime as Event Source
 
-### Postgres LISTEN/NOTIFY for Lightweight Pub/Sub
+#### Postgres LISTEN/NOTIFY for Lightweight Pub/Sub
 
 LISTEN/NOTIFY is PostgreSQL's built-in pub/sub. It does not persist messages and is best for ephemeral notifications between database functions or connected clients:
 
@@ -350,7 +352,7 @@ client.on("notification", (msg) => {
 });
 ```
 
-### Realtime `postgres_changes` as Client-Side Event Source
+#### Realtime `postgres_changes` as Client-Side Event Source
 
 Supabase Realtime lets frontend clients subscribe to database changes without polling. Enable Realtime on your table first (Dashboard > Database > Replication).
 
@@ -400,7 +402,7 @@ const channel = supabase
 // await supabase.removeChannel(channel);
 ```
 
-### Event-Driven Architecture: Combining Patterns
+#### Event-Driven Architecture: Combining Patterns
 
 Use database triggers for server-side workflows and Realtime for client-side UI updates:
 


### PR DESCRIPTION
Clears every marketplace-tier validator ERROR in the supabase-pack (10 findings across 8 skills). Backlog Zero Wave 1, Phase C. This was the closest pack to the bar (avg 87.67 before this PR).

## The findings and fixes

| Skill | Finding | Fix |
|---|---|---|
| supabase-policy-guardrails | Missing `## Instructions` | Inserted `## Instructions`; demoted the existing `## Step N` regions one heading level under it (pure reorganization, content unchanged) |
| supabase-reliability-patterns | Missing `## Instructions` | Same restructure |
| supabase-reliability-patterns | Missing `## Examples` | Added two compact examples grounded in the skill's own code: `TodoService.list` fallback during an open circuit, and a `dbCircuit.currentState` pre-flight check |
| supabase-load-scale | Missing `## Instructions` | Same restructure |
| supabase-known-pitfalls | Missing `## Instructions` | Same restructure |
| supabase-webhooks-events | Missing `## Instructions` | Same restructure |
| supabase-architecture-variants | Missing `## Instructions` | Same restructure |
| supabase-debug-bundle | Missing `## Overview` | Promoted the existing intro paragraph under a new `## Overview` heading (matches the rate-limits sibling layout) |
| supabase-rate-limits | Unscoped `Bash` in allowed-tools | Scoped to `Bash(supabase:*), Bash(node:*), Bash(npx:*)` |
| supabase-rate-limits | tier2:tool-safety — unscoped Bash + Write without a Safety Justification | Cleared by the scoping above (the combo rule only fires on a bare `Bash` grant) |

The restructure matches the pattern already used by the pack's passing skills (supabase-debug-bundle, supabase-rate-limits): `## Instructions` with `### Step N` children. Fence-aware demotion — headings inside code blocks untouched.

## Validator result

- supabase-pack: **30 skills, ZERO errors** at marketplace tier (warnings remain, as allowed)
- New pack average score: **87.87/100** (up from 87.67)

Note: the 90+-average policy question stays open under the supersession epic — this PR only clears the ERRORS, it does not attempt to lift the pack average to 90+. The 3 skills without `references/` dirs were left alone (WARN-level only, no ERROR demanded them).

Version bumped 1.0.0 → 1.0.1 (plugin.json + marketplace.extended.json, `marketplace.json` regenerated via sync-marketplace).

[skip auto-bump]

Refs jeremylongshore/claude-code-plugins-plus-skills#938

- Jeremy Longshore
intentsolutions.io