### PR TITLE
fix(openrouter-pack): clear the standing marketplace-tier gate errors

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -5870,7 +5870,7 @@
       "name": "openrouter-pack",
       "source": "./plugins/saas-packs/openrouter-pack",
       "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": [
         "openrouter",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5343,7 +5343,7 @@
       "name": "openrouter-pack",
       "source": "./plugins/saas-packs/openrouter-pack",
       "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "saas-packs",
       "keywords": [
         "openrouter",

--- a/plugins/saas-packs/openrouter-pack/.claude-plugin/plugin.json
+++ b/plugins/saas-packs/openrouter-pack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openrouter-pack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Flagship+ skill pack for OpenRouter - 30 skills for multi-model routing, fallbacks, and LLM gateway mastery",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-audit-logging/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-audit-logging/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement audit logging for OpenRouter API calls. Use when buildin
   openrouter requests''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(sqlite3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Every OpenRouter API call returns a generation ID and metadata that enables comprehensive audit logging. The generation endpoint (`GET /api/v1/generation?id=`) provides exact cost, token counts, provider used, and latency -- data that the initial response doesn't always include. This skill covers structured logging, cost tracking, PII redaction, and compliance-ready audit trails.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK and `requests` (`pip install openai requests`) — the audit wrapper fetches exact cost from the generation endpoint with `requests`
+- SQLite: the Python stdlib `sqlite3` module writes the audit table; the `sqlite3` CLI runs the Audit Queries against `openrouter_audit.db`
+- Optional: a SIEM destination (Splunk, Datadog, ELK) if you ship the structured JSON log lines downstream
+
+## Instructions
+
+1. Export your key and wire `audited_completion()` from Core: Generation Metadata Retrieval — it hashes the prompt (SHA-256), times the call, and fetches exact cost via `GET /api/v1/generation?id=` after each request.
+2. Create the append-only store with `init_audit_db()` per Structured Log Storage, then persist every `AuditEntry` with `write_audit()` — `INSERT OR IGNORE` keeps retries from double-writing a `generation_id`.
+3. Run `redact_pii()` from PII Redaction Before Logging over any prompt preview before it touches a log: emails, phones, SSNs, card numbers, and `sk-or-v1-` keys are scrubbed, and raw prompts are never stored (hashes only).
+4. Answer operational questions with the Audit Queries SQL: daily cost by model, error rate per model over the last 24 hours, and top spenders by `user_id`.
+5. If the generation fetch 404s or `total_cost` comes back missing, apply the fixes in Error Handling (fetch within 30 minutes; retry after 1-2 seconds).
+6. Harden per Enterprise Considerations: append-only storage (SQLite WAL, S3), retention policy (90 days operational, 7 years financial), and SIEM shipping.
 
 ## Core: Generation Metadata Retrieval
 
@@ -201,6 +217,33 @@ GROUP BY model_requested;
 SELECT user_id, COUNT(*) as requests, SUM(total_cost) as total_cost
 FROM audit_log GROUP BY user_id ORDER BY total_cost DESC LIMIT 10;
 ```
+
+## Output
+
+- One structured JSON `AuditEntry` per request: `timestamp`, `generation_id`, `model_requested` vs `model_used`, prompt/completion token counts, exact `total_cost`, `latency_ms`, `status`, `user_id`, and a 16-char `prompt_hash`
+- An append-only SQLite `audit_log` table (`openrouter_audit.db`) indexed on `timestamp` and `user_id`, protected against duplicate writes by `INSERT OR IGNORE`
+- SQL report rows from the Audit Queries: per-day per-model cost, 24-hour error percentage per model, and the top-10 spenders by `user_id`
+
+## Examples
+
+Wrap a call with the JSONL `AuditLogger` variant from the references and read back the entry it appends:
+
+```python
+result = audited_completion("user-123", "What is machine learning?")
+# [Audit] user=user-123 tokens=97 latency=450ms
+```
+
+The corresponding line in `audit.jsonl`:
+
+```json
+{"timestamp": "2026-03-17T10:00:00Z", "user_id": "user-123",
+ "model": "openai/gpt-3.5-turbo", "prompt_hash": "a1b2c3d4e5f6g7h8",
+ "prompt_preview": "What is machine learning?", "prompt_tokens": 12,
+ "completion_tokens": 85, "total_tokens": 97, "status": "success",
+ "latency_ms": 450, "generation_id": "gen-abc123"}
+```
+
+More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-caching-strategy/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-caching-strategy/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement caching for OpenRouter API responses to reduce cost and 
   ''reduce openrouter cost''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter charges per token, so caching identical or similar requests can dramatically cut costs. Deterministic requests (`temperature=0`) with the same model and messages produce identical outputs -- these are safe to cache. This skill covers in-memory caching, persistent caching with TTL, and Anthropic prompt caching via OpenRouter.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK, plus the `redis` client package for the persistent cache; Node.js 18+ with the OpenAI SDK for the TypeScript variant in the references
+- A Redis server reachable at `localhost:6379` for Persistent Cache with Redis (the in-memory `LLMCache` needs no infrastructure)
+- Deterministic request settings — caching is only safe at `temperature=0`
+
+## Instructions
+
+1. Confirm the requests you want to cache are deterministic (`temperature=0`); non-zero temperatures produce different outputs each call and must never be cached.
+2. Start with the In-Memory Cache: `LLMCache` plus `cached_completion()` gives you TTL expiry and hit/miss counters in a single process.
+3. For multi-instance deployments, switch to Persistent Cache with Redis — `redis_cached_completion()` stores results under `or:<sha256>` keys with `r.setex` TTL expiry and falls through to a direct API call on a miss.
+4. Build keys per Cache Key Design: include the model ID (with variants like `:floor`), messages, temperature, max_tokens, and top_p; exclude `stream` and the HTTP-Referer/X-Title headers.
+5. For large static system prompts (RAG context), add `cache_control: {"type": "ephemeral"}` per Anthropic Prompt Caching via OpenRouter — cache reads bill at 0.1x the input rate.
+6. Wire the Cache Invalidation table: flush per-model keys on model version updates, flush everything on system prompt changes, and let TTL handle the rest.
 
 ## In-Memory Cache
 
@@ -163,6 +179,25 @@ def cache_key(model: str, messages: list, **params) -> str:
 | System prompt change | Flush all keys | Output semantics changed |
 | TTL expiry | Automatic eviction | Prevents stale data |
 | Manual purge | `r.delete(key)` or clear by prefix | Debugging or policy change |
+
+## Output
+
+- Cached completion payloads returned without an API round-trip: `{"content", "model", "usage"}` from the in-memory cache or `{"content", "model", "tokens"}` from Redis
+- Redis keys of the form `or:<sha256-of-canonical-request>` that expire automatically via TTL
+- Hit/miss counters and a `hit_rate` figure you can use to justify the caching infrastructure
+- On Anthropic models, `cache_creation_input_tokens` billed at 1.25x on the first call and `cache_read_input_tokens` at 0.1x (90% savings) on subsequent hits
+
+## Examples
+
+Two identical deterministic calls through the `ResponseCache` from the references — the second returns instantly from cache:
+
+```python
+result1 = cached_completion("What is Python?")   # [Cache MISS] key=3f8a92c1... (stored)
+result2 = cached_completion("What is Python?")   # [Cache HIT] key=3f8a92c1...
+print(f"Hit rate: {cache.hit_rate:.0%}")         # Hit rate: 50%
+```
+
+More worked examples, including a TypeScript Redis-style cache: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-common-errors/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-common-errors/SKILL.md
@@ -5,7 +5,7 @@ description: 'Diagnose and fix common OpenRouter API errors. Use when encounteri
   error'', ''openrouter 401'', ''openrouter 429'', ''openrouter 402'', ''fix openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter returns standard HTTP error codes plus OpenRouter-specific error codes in the response body. The most common: 401 (auth), 402 (credits), 429 (rate limit), 400 (bad request), and 5xx (upstream provider errors). Each error includes a `code` field and a human-readable `message`. This skill covers every common error, its root cause, and the exact fix.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` to run the Diagnostic Script
+- Python 3.8+ with the OpenAI SDK for the categorized error handler; Node.js 18+ for the TypeScript typed-error classifier in the references
+- The `requests` package if you use the Prevention Middleware's pre-flight model check
+
+## Instructions
+
+1. Identify the failure by HTTP status and `code` using the Complete Error Reference table (400/401/402/403/408/429/5xx each map to a specific fix).
+2. Inspect the body per Error Response Format — `error.code`, `error.message`, and `error.metadata.provider_name` tell you whether OpenRouter or the upstream provider failed.
+3. Run the Diagnostic Script: it checks auth via `GET /api/v1/auth/key`, computes remaining credits, verifies the model exists in `/api/v1/models`, and fires a minimal 1-token completion.
+4. Wrap production calls with `safe_completion()` from Python Error Handler — `max_retries=3` auto-retries 429 and 5xx, and each exception class raises with its exact remedy.
+5. Add `validate_before_send()` from Prevention Middleware to catch bad model IDs (with suggestions), malformed messages, and context overflows before spending money on a 400.
+6. If errors persist across retries and providers, check [status.openrouter.ai](https://status.openrouter.ai) per the Error Handling table.
 
 ## Complete Error Reference
 
@@ -172,6 +188,26 @@ def validate_before_send(model: str, messages: list, max_tokens: int = 1024):
     if errors:
         raise ValueError("Pre-flight validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
 ```
+
+## Output
+
+- A four-line diagnostic report: auth OK/FAIL, dollars of credit remaining, model availability in `/api/v1/models`, and the HTTP status of a minimal live request
+- Categorized exceptions from `safe_completion()` — auth failures exit pointing at the key, 402s point at credit top-up, context overflows raise `ValueError` naming the model to trim for
+- Pre-flight `ValueError`s from `validate_before_send()` listing every problem found (unknown model with suggested IDs, missing `role`/`content` fields, estimated-token overflow) before any API call is made
+
+## Examples
+
+A healthy integration produces this from the Diagnostic Script:
+
+```text
+=== OpenRouter Error Diagnostics ===
+1. Auth: OK
+2. Credits: $46.58 remaining
+3. Model: openai/gpt-4o-mini available
+4. Request: OK
+```
+
+Any FAIL line maps straight to a row in the Complete Error Reference table — e.g. `1. Auth: FAIL (HTTP 401)` means regenerating the key at openrouter.ai/keys. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-compliance-review/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-compliance-review/SKILL.md
@@ -6,7 +6,7 @@ description: 'Review OpenRouter integration for regulatory compliance (SOC2, GDP
   soc2'', ''openrouter data residency''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter is a proxy that routes requests to upstream providers (OpenAI, Anthropic, Google, etc.). Compliance depends on both OpenRouter's data handling and the selected provider's policies. Key considerations: data transit through OpenRouter infrastructure, provider-specific data retention, model selection for regulated data, and audit trail requirements.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK for provider-pinned requests and the automated checker in the references
+- `curl` and `jq` to run the Compliance Audit Script
+- An existing OpenRouter integration to review — the audit script scans its source tree for hardcoded `sk-or-v1-` keys
+- Knowledge of which regimes apply (SOC2, GDPR, HIPAA) and how your data is classified
+
+## Instructions
+
+1. Work through the four areas of the Compliance Checklist — `data_handling`, `access_control`, `audit_trail`, and `provider_selection` — recording pass/fail per item.
+2. Classify each workload with the Data Classification Matrix (Public → Internal → Confidential → Restricted/PHI) to determine allowed providers and required controls.
+3. Pin regulated traffic per Provider Routing for Compliance: set `provider.order` plus `allow_fallbacks: False`, then verify `response.model` confirms the approved provider actually served the request.
+4. For data-sovereignty requirements, configure BYOK per BYOK for Data Sovereignty so inference runs on your own provider account and OpenRouter only routes.
+5. Run the Compliance Audit Script: key label/limit check via `GET /api/v1/auth/key`, a free-tier warning (free tier is unsuitable for regulated data), and the hardcoded-key scan.
+6. Document the data flow for auditors — client → OpenRouter (routing) → provider (inference) — per Enterprise Considerations.
 
 ## Compliance Checklist
 
@@ -136,6 +153,28 @@ IS_FREE=$(curl -s https://openrouter.ai/api/v1/auth/key \
 FOUND=$(grep -r "sk-or-v1-" --include="*.py" --include="*.ts" --include="*.js" . 2>/dev/null | grep -v node_modules | wc -l)
 echo "Hardcoded keys found: $FOUND"
 ```
+
+## Output
+
+- A pass/fail/warn compliance report from the automated checker in the references, one line per control (API key storage, HTTPS enforcement, max_tokens, error handling, audit logging)
+- Key-configuration JSON (`label`, `limit`, `is_free_tier`) plus a free-tier warning and a count of hardcoded keys found in source, from the Compliance Audit Script
+- A provider-pinned client configuration (`provider.order` + `allow_fallbacks: False`) that cannot route regulated data to unapproved providers
+- A filled-in markdown compliance checklist (template in the references) covering security, data privacy, reliability, observability, and cost controls
+
+## Examples
+
+Running `run_compliance_review()` from the references against a healthy integration:
+
+```text
+Compliance: 5/5 passed, 0 failed, 0 warnings
+  [OK] api_key_storage: Key loaded from environment variable
+  [OK] https_enforcement: HTTPS enforced
+  [OK] max_tokens: max_tokens set to 500
+  [OK] error_handling: Error handling present
+  [OK] audit_logging: Audit logging configured
+```
+
+Any `[FAIL]` line maps to a checklist item above — fix it and re-run until clean. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-context-optimization/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-context-optimization/SKILL.md
@@ -6,7 +6,7 @@ description: 'Optimize context window usage for OpenRouter models to reduce cost
   token limit'', ''reduce tokens openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter models have varying context windows (4K to 1M+ tokens). Since pricing is per-token, stuffing unnecessary context wastes money and can degrade output quality. This skill covers context window lookup, token estimation, conversation trimming, chunking strategies, and Anthropic prompt caching for large contexts.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK and `requests` for model-metadata lookup; `tiktoken` for exact token counting per the references
+- `curl` and `jq` to query context windows and pricing from `/api/v1/models`
+- Node.js 18+ if you use the TypeScript context-budget calculator in the references
+
+## Instructions
+
+1. Run the Query Context Limits one-liner — it returns `context_length` and prompt price per 1M tokens for each candidate model, so you know the real budget before writing code.
+2. Estimate input size (~4 characters per token, or exactly with `tiktoken` per the references) and pick a model with `select_model_for_context()` from Context-Aware Model Selection — it applies an 80% safety margin and falls back through gpt-4o-mini (128K) → Claude 3.5 Sonnet (200K) → Gemini 2.0 Flash (1M).
+3. Keep long conversations inside budget with `trim_conversation()` per Conversation Trimming: system prompt plus the last N messages, with a trim-marker note injected where history was dropped.
+4. For documents that exceed any window, use `chunk_and_process()` per Chunking for Large Documents — 8,000-char chunks with 500-char overlap, analyzed independently at `temperature=0` and then synthesized.
+5. Mark large static blocks with `cache_control: {"type": "ephemeral"}` per Prompt Caching for Repeated Context to cut repeated input cost by 90% on Anthropic models.
+6. Monitor `prompt_tokens` on every response (Enterprise Considerations) to catch context bloat before it becomes a 400 `context_length_exceeded`.
 
 ## Query Context Limits
 
@@ -172,6 +188,25 @@ response = client.chat.completions.create(
 # First request: cache_creation_input_tokens at 1.25x rate
 # Subsequent: cache_read_input_tokens at 0.1x rate (90% savings)
 ```
+
+## Output
+
+- A jq-formatted listing of model IDs with `context_length` and per-1M prompt pricing from `/api/v1/models`
+- A model ID selected to fit the estimated token count within an 80% safety margin, or a `ValueError` when nothing fits
+- A trimmed message list containing the system prompt, a `[Previous N messages trimmed for context limits]` note, and the most recent turns
+- A single synthesized answer assembled from per-chunk analyses of an oversized document
+
+## Examples
+
+Multi-turn chat with the references' `prune_conversation()` holding a 2,000-token budget — oldest messages drop as the conversation grows:
+
+```text
+[Pruned] 9 -> 7 messages (1876 tokens)
+Q: What about class-based decorators?...
+Tokens: 412
+```
+
+The pruner always keeps the system message and removes the oldest non-system turns first. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-cost-controls/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-cost-controls/SKILL.md
@@ -5,7 +5,7 @@ description: 'Implement cost controls for OpenRouter API usage. Use when setting
   ''openrouter cost limit'', ''openrouter spending'', ''control openrouter cost''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*), Bash(curl:*), Bash(jq:*), Bash(bc:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter provides per-key credit limits, a credit balance API, and per-generation cost queries. Combined with client-side budget middleware, you can enforce hard spending caps at the key level and soft caps in your application. This skill covers key-level limits, per-request cost tracking, budget enforcement middleware, and alert systems.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK and `requests`; Node.js 18+ for the TypeScript per-request cost logger in the references
+- `curl`, `jq`, and `bc` for the balance check and the Budget Alert Script
+- An OpenRouter management key exported as `OPENROUTER_MGMT_KEY` if you provision per-key credit limits via `POST /api/v1/keys`
+
+## Instructions
+
+1. Query `GET /api/v1/auth/key` per Check Credit Balance to see credits used, the key's limit, remaining balance, free-tier status, and rate limit.
+2. Provision scoped keys per Per-Key Credit Limits — `POST /api/v1/keys` with a dollar `limit` (e.g. $50 for `backend-prod`) using the management key, then list keys to review usage against limits per service.
+3. Deploy the `BudgetEnforcer` from Budget Enforcement Middleware: `check_budget()` rejects any request whose pre-flight estimate exceeds the per-request or daily cap, and `record_cost()` books the exact spend from `GET /api/v1/generation?id=`.
+4. Cut unit cost with Cost-Saving Model Variants: `:floor` picks the cheapest provider, `:free` costs nothing where available, and the task-based `ROUTING` table sends classification to gpt-4o-mini and simple Q&A to Llama 3.1 8B.
+5. Schedule the Budget Alert Script (cron) so a balance drop below the threshold fires an alert to Slack or PagerDuty.
+6. Set `max_tokens` on every request and enable auto-topup per Enterprise Considerations to cap completion cost without risking an outage.
 
 ## Check Credit Balance
 
@@ -173,6 +189,31 @@ if (( $(echo "$REMAINING < $THRESHOLD" | bc -l) )); then
   # Send to Slack, PagerDuty, etc.
 fi
 ```
+
+## Output
+
+- A credit-balance JSON summary: `credits_used`, `credit_limit`, `remaining`, `is_free_tier`, and `rate_limit` for the active key
+- Newly provisioned API keys with hard dollar limits, plus a per-key `usage / limit` listing from the management API
+- `ValueError` rejections from the middleware when a request would exceed the per-request or daily budget, and a running daily-spend total booked from actual generation costs
+- Alert lines such as `ALERT: OpenRouter credits low: $4.87 remaining` whenever the balance crosses the configured threshold
+
+## Examples
+
+Check what's left on a key before turning on traffic:
+
+```bash
+curl -s https://openrouter.ai/api/v1/auth/key \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  | jq '{used: .data.usage, limit: .data.limit, remaining: (.data.limit - .data.usage)}'
+```
+
+Expected output:
+
+```json
+{"used": 3.42, "limit": 50, "remaining": 46.58}
+```
+
+More worked examples, including thread-safe budget middleware and a TypeScript cost logger: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-data-privacy/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-data-privacy/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement data privacy controls for OpenRouter API usage. Use when
   handling''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 When sending data through OpenRouter to upstream LLM providers, you're responsible for ensuring prompts don't leak PII inappropriately. OpenRouter itself does not train on API data, but each upstream provider has its own data retention and training policies. This skill covers PII detection and redaction, placeholder substitution, provider selection for privacy, and consent tracking.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK (`pip install openai`) — every pattern in this skill is Python
+- A sensitivity classification for your workloads (`public` / `standard` / `sensitive`) so `privacy_aware_completion()` can route each one
+- A list of providers your org approves for sensitive data, to plug into `provider.order` with `allow_fallbacks: False`
+
+## Instructions
+
+1. Start with PII Detection and Redaction: adapt `PII_RULES` (email, phone, SSN, credit card, `sk-or-v1-` API keys, IPs) to your data, then run `scan_and_redact()` on representative inputs and review the `findings` for false positives.
+2. When downstream code needs the original values back, use the Placeholder Substitution Pattern instead of plain redaction — `PrivacyProxy.anonymize()` before the API call, `deanonymize()` on the model's reply.
+3. Classify each workload and route it via Provider Selection for Privacy: `privacy_aware_completion()` maps sensitivity to a model plus a `provider` block (`order: ["Anthropic"]`, `allow_fallbacks: False` for standard/sensitive).
+4. Wire the Privacy Middleware into every call path, choosing `block_on_pii=True` (raise on detection) or `auto_redact=True` (scrub and continue) per workload.
+5. Apply the Enterprise Considerations: hash logged prompts (SHA-256) for GDPR right-to-erasure, and use BYOK for the most sensitive workloads.
 
 ## PII Detection and Redaction
 
@@ -184,6 +199,28 @@ class PrivacyMiddleware:
             processed.append(msg)
         return processed
 ```
+
+## Output
+
+The privacy flows in this skill produce:
+
+- A `PiiScanResult` per scan: `clean_text` with placeholders substituted, `findings` (PII type + first-4-chars value prefix per match), and a `has_pii` flag
+- Anonymized prompts like `"Contact [EMAIL_0] or call [PHONE_1]"` plus the placeholder→original map that `deanonymize()` uses to restore values in the response
+- Chat completions served only by approved providers when the `provider.order` + `allow_fallbacks: False` config is applied
+- A `ValueError` listing the detected PII types when `PrivacyMiddleware` runs with `block_on_pii=True`
+
+## Examples
+
+Scanning a support message before it leaves your infrastructure:
+
+```python
+result = scan_and_redact("Contact john@example.com or call 555-123-4567")
+print(result.clean_text)  # Contact [EMAIL] or call [PHONE]
+print(result.has_pii)     # True
+print(result.findings)    # [{'type': 'email', 'value_prefix': 'john...'}, {'type': 'phone', ...}]
+```
+
+To keep the values recoverable, run the same input through `PrivacyProxy.anonymize()` instead, send the placeholder version to the model, then `deanonymize()` the reply. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-debug-bundle/SKILL.md
@@ -6,7 +6,7 @@ description: 'Create debug bundles for troubleshooting OpenRouter API issues. Us
   issue''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(curl:*), Bash(jq:*), Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -27,6 +27,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 When an OpenRouter request fails or returns unexpected results, you need a structured debug bundle: the exact request, response, headers, generation metadata, and environment info. The generation ID (`gen-*` prefix in `response.id`) is the key correlator -- it lets you look up exact cost, provider used, and latency via `GET /api/v1/generation?id=`.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for the quick-debug flow and the Common Debug Checks
+- Python 3.8+ with the `openai` and `requests` packages for the Debug Bundle Generator
+- A failing or suspect request you can reproduce — its `gen-*` generation ID is what everything else correlates on
+
+## Instructions
+
+1. Rule out environment problems first with the Common Debug Checks: verify the key via `/api/v1/auth/key`, confirm the model exists in `/api/v1/models`, and check `status.openrouter.ai`.
+2. Reproduce the failure with the Quick Debug: curl command — `curl -v ... | tee /tmp/openrouter-debug.txt` captures request headers, response headers, and body in one transcript.
+3. Extract the generation ID (`jq -r '.id'`) and query `GET /api/v1/generation?id=$GEN_ID` to get exact cost, token counts, `generation_time`, and `provider_name`.
+4. For failures inside an application, call `debug_request()` from the Python Debug Bundle Generator to capture the same request/response/error/latency/environment data as a `DebugBundle` and save it with `bundle.save("debug_bundle.json")`.
+5. Match the symptoms against the Error Handling table (missing generation ID, 502/503, `model_not_found`, slow TTFT).
+6. Before sharing a bundle, redact API keys per Enterprise Considerations (`sk-or-v1-...` -> `sk-or-v1-[REDACTED]`) and include the generation ID in any OpenRouter support request.
 
 ## Quick Debug: curl
 
@@ -193,6 +209,35 @@ curl -s https://openrouter.ai/api/v1/models | jq --arg m "$MODEL" '.data[] | sel
 # 3. Check OpenRouter status
 curl -s https://status.openrouter.ai/api/v2/status.json | jq '.status'
 ```
+
+## Output
+
+Running these flows leaves you with concrete debug artifacts:
+
+- `/tmp/openrouter-debug.txt` — the full verbose curl transcript (request/response headers plus the completion JSON) from the quick-debug step
+- A generation-metadata JSON from `/api/v1/generation`: `model`, `total_cost`, `tokens_prompt`, `tokens_completion`, `generation_time`, and `provider_name`
+- `debug_bundle.json` — the serialized `DebugBundle`: timestamp, generation ID, request model/messages/params, response status and content, error type/message/code, `latency_ms`, generation metadata, and environment info (Python version, platform, SDK version)
+- One-line JSON results from the three Common Debug Checks (key label/usage/limit, model existence, OpenRouter status)
+
+## Examples
+
+Looking up a request you just sent by its generation ID:
+
+```bash
+curl -s "https://openrouter.ai/api/v1/generation?id=$GEN_ID" \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" | jq '.data | {model, total_cost, generation_time, provider: .provider_name}'
+```
+
+```json
+{
+  "model": "openai/gpt-4o-mini",
+  "total_cost": 0.000021,
+  "generation_time": 412,
+  "provider": "OpenAI"
+}
+```
+
+If the metadata comes back empty, wait 1-2 seconds and retry with the same key that made the request. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-fallback-config/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-fallback-config/SKILL.md
@@ -6,7 +6,7 @@ description: 'Configure automatic model fallbacks for high availability on OpenR
   backup model''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter supports native model fallbacks: pass multiple model IDs and OpenRouter tries each in order until one succeeds. You can also use `provider.order` to control which provider serves a specific model. This skill covers native fallbacks, provider routing, client-side fallback chains, and timeout configuration.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK (`pip install openai`) for the fallback patterns; `curl` and `jq` for the Testing Fallbacks step
+- A ranked list of acceptable models for your workload, matched by capability (tool calling, vision, context length) so a fallback never silently drops a feature you depend on
+
+## Instructions
+
+1. Start with Native Model Fallback (Server-Side): pass a `models` array plus `route: "fallback"` in `extra_body` and let OpenRouter try each model in order.
+2. Log `response.model` after every call — it tells you which model actually served the request, which is how you detect that a fallback fired.
+3. If you need the *same* model from specific vendors (e.g., Claude via Anthropic direct vs AWS Bedrock), use Provider Fallback with `provider.order` and `allow_fallbacks`.
+4. For per-model timeouts and custom error handling, implement the Client-Side Fallback Chain: `resilient_completion()` walks `FALLBACK_CHAIN` (primary → secondary → budget-fallback → last-resort) and raises once every entry fails.
+5. Pick chains per feature with Fallback with Capability Matching — `CAPABILITY_CHAINS` keeps tool-calling, vision, long-context, and budget workloads on models that actually support them.
+6. Verify the behavior with Testing Fallbacks: send the curl request with an invalid primary model and confirm the response comes back from `openai/gpt-4o-mini`.
 
 ## Native Model Fallback (Server-Side)
 
@@ -165,6 +180,34 @@ curl -s https://openrouter.ai/api/v1/chat/completions \
   }' | jq '{model: .model, content: .choices[0].message.content}'
 # Should succeed with openai/gpt-4o-mini
 ```
+
+## Output
+
+A configured fallback setup produces:
+
+- Chat completions whose `response.model` field reveals the model that actually served each request — the primary when healthy, a chain entry when a fallback fired
+- Log lines from `resilient_completion()`: `Served by primary: anthropic/claude-3.5-sonnet` on success, `primary failed (anthropic/claude-3.5-sonnet): ...` warnings per failed hop
+- A `RuntimeError("All fallbacks exhausted. Last error: ...")` when every model in `FALLBACK_CHAIN` fails — the signal to alert on
+- From the Testing Fallbacks curl: a `{model, content}` JSON showing the request survived an invalid primary model
+
+## Examples
+
+Force a fallback by putting an invalid model first in the `models` array:
+
+```bash
+curl -s https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "invalid/model-name", "messages": [{"role": "user", "content": "test"}],
+       "max_tokens": 10, "models": ["invalid/model-name", "openai/gpt-4o-mini"], "route": "fallback"}' \
+  | jq '{model: .model, content: .choices[0].message.content}'
+```
+
+```json
+{"model": "openai/gpt-4o-mini", "content": "Test received!"}
+```
+
+The `model` field proves the fallback chain worked. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-function-calling/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-function-calling/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement function/tool calling with OpenRouter models. Use when b
   openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter supports OpenAI-compatible tool/function calling across multiple providers. Define tools as JSON Schema, send them with your request, and the model returns structured `tool_calls` instead of free text. This works with GPT-4o, Claude 3.5, Gemini, and other tool-capable models via the same API. The key difference from direct provider APIs: OpenRouter normalizes the tool calling interface, so the same code works across providers.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ or Node.js 18+ with the OpenAI SDK (`pip install openai` / `npm install openai`)
+- A tool-capable model — check the Model Compatibility table below or query `/api/v1/models` (e.g., `openai/gpt-4o`, `anthropic/claude-3.5-sonnet`)
+- Real function implementations to dispatch tool calls to (the `execute_tool()` dispatcher below stubs `get_weather` and `search_database`)
+
+## Instructions
+
+1. Pick a model from the Model Compatibility table that supports the features you need (tool calling, JSON mode, parallel tools).
+2. Define your tools as JSON Schema per Basic Tool Calling and send them with `tool_choice="auto"` (or `"required"` to force a call, or a specific function name).
+3. Read `response.choices[0].message.tool_calls` — each entry carries `function.name` and JSON-encoded `function.arguments` to parse with `json.loads()`.
+4. For agents, wire the Multi-Turn Tool Loop: append the assistant message, execute each tool via `execute_tool()`, append `role: "tool"` results keyed by `tool_call_id`, and loop until the model returns plain text (bounded by `max_rounds`).
+5. Use the TypeScript Tool Calling section for the identical flow in Node — same schema, same `tool_calls` shape.
+6. When you only need structured data (no function execution), skip tools and use Structured Output (JSON Mode) with `response_format={"type": "json_object"}`.
+7. Handle failures per the Error Handling table: force `tool_choice: "required"` for extraction pipelines and validate arguments server-side before executing.
 
 ## Basic Tool Calling
 
@@ -203,6 +220,27 @@ data = json.loads(response.choices[0].message.content)
 | `anthropic/claude-3.5-sonnet` | Yes | Via system prompt | Sequential |
 | `google/gemini-2.0-flash-001` | Yes | Yes | Yes |
 | `meta-llama/llama-3.1-70b-instruct` | Yes (varies) | Via prompt | No |
+
+## Output
+
+The tool-calling flows produce:
+
+- `message.tool_calls` entries — each with a `function.name` and JSON-encoded `function.arguments` (e.g., `get_weather` with `{"location": "Tokyo", "unit": "celsius"}`) plus a `tool_call_id` for pairing results
+- The final assistant text once the Multi-Turn Tool Loop resolves — or the `"Max tool rounds exceeded"` sentinel if it hits `max_rounds`
+- From JSON Mode: a parseable JSON object matching your system-prompt schema (e.g., `{"name": "Jane Smith", "email": "jane@acme.co", "company": "Acme Corp"}`)
+
+## Examples
+
+Asking a weather question with the `get_weather` tool registered:
+
+```python
+message = response.choices[0].message
+for tc in message.tool_calls:
+    print(tc.function.name, json.loads(tc.function.arguments))
+# get_weather {'location': 'Tokyo', 'unit': 'celsius'}
+```
+
+Feed that result back as a `role: "tool"` message and the next completion returns prose ("It's currently 22°C and sunny in Tokyo..."). More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-hello-world/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-hello-world/SKILL.md
@@ -6,7 +6,7 @@ description: 'Send your first OpenRouter API request and understand the response
   quickstart''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(curl:*), Bash(python3:*), Bash(node:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Send a minimal chat completion request through OpenRouter, understand the response format, try different models, and verify the full round-trip works. All requests go to the single endpoint `POST https://openrouter.ai/api/v1/chat/completions`.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for the command-line request, or Python 3.8+ / Node.js 18+ with the OpenAI SDK (`pip install openai` / `npm install openai`)
+- A free-tier model works for every step here (no credits required for `:free` models)
+
+## Instructions
+
+1. Export your key: `export OPENROUTER_API_KEY="sk-or-v1-..."`.
+2. Send the minimal cURL request below and confirm you get a `choices[0].message.content` back.
+3. Read the Response Format section to identify the four key fields (`id`, `model`, `usage`, `finish_reason`).
+4. Repeat the same request from your app language using the Python or TypeScript example.
+5. Swap model IDs per Try Different Models to confirm multi-model access works with the same code.
+6. Query `GET /api/v1/generation?id=gen-...` per Check Generation Cost to verify cost tracking on the request you just sent.
 
 ## Minimal Request (cURL)
 
@@ -151,6 +166,33 @@ curl -s "https://openrouter.ai/api/v1/generation?id=gen-abc123xyz" \
     total_cost: .data.total_cost
   }'
 ```
+
+## Output
+
+A successful round-trip produces:
+
+- A chat completion JSON with `choices[0].message.content` holding the model's reply, a `gen-...` request `id`, the `model` that actually served the request, and `usage` token counts
+- Console output from the Python/TypeScript examples: the reply text plus model name and prompt/completion token counts
+- A cost record from the generation endpoint: `tokens_prompt`, `tokens_completion`, and `total_cost` for the request
+
+## Examples
+
+End-to-end run with the minimal cURL request:
+
+```text
+$ curl -s https://openrouter.ai/api/v1/chat/completions ... | jq .choices[0].message.content
+"Hello! Bonjour! Hola!"
+```
+
+The Python and TypeScript sections above are the same request in SDK form; expected console output:
+
+```text
+OpenRouter is a unified API gateway that routes requests to 400+ LLMs.
+Model: google/gemma-2-9b-it:free
+Tokens: 21 prompt + 17 completion
+```
+
+More worked examples (cURL with full expected response, SDK variants): `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-install-auth/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-install-auth/SKILL.md
@@ -6,7 +6,7 @@ description: 'Set up OpenRouter API authentication and configure API keys. Use w
   ''sk-or key''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*), Bash(pip:*), Bash(npm:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -30,7 +30,7 @@ Set up OpenRouter API credentials, configure the OpenAI-compatible client, verif
 - Python 3.8+ or Node.js 18+
 - OpenAI SDK (`pip install openai` or `npm install openai`)
 
-## Quick Setup
+## Instructions
 
 ### 1. Generate an API Key
 
@@ -127,6 +127,29 @@ print(f"Tokens: {response.usage.prompt_tokens} in / {response.usage.completion_t
 | Standard key | `sk-or-v1-...` | API access (chat completions, models) |
 | Management key | `sk-or-v1-...` | Key provisioning only (cannot call completions) |
 | BYOK provider key | Varies by provider | Bring-your-own-key for direct provider access |
+
+## Output
+
+A completed setup leaves you with:
+
+- `OPENROUTER_API_KEY` set in your environment (or a gitignored `.env` file), holding the `sk-or-v1-...` key from [openrouter.ai/keys](https://openrouter.ai/keys)
+- A configured OpenAI-SDK client pointed at `https://openrouter.ai/api/v1` with `HTTP-Referer` and `X-Title` headers for dashboard attribution
+- An auth-verification printout from `/api/v1/auth/key`: key label, credits used, credit limit, free-tier flag, and rate limit
+- A test completion from the free model (`google/gemma-2-9b-it:free`) with its reply text and prompt/completion token counts
+
+## Examples
+
+Running the step-4 verification against a fresh key prints something like:
+
+```text
+Key: my-app-dev
+Credits used: $0.0000
+Credit limit: unlimited
+Free tier: True
+Rate limit: 10 req / 10s
+```
+
+Then the step-5 test request returns a greeting plus `Tokens: 9 in / 12 out`, confirming the key can call completions end-to-end. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-known-pitfalls/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-known-pitfalls/SKILL.md
@@ -5,7 +5,7 @@ description: 'Avoid common OpenRouter integration mistakes and gotchas. Use proa
   pitfalls'', ''openrouter gotchas'', ''openrouter mistakes'', ''openrouter best practices''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 A curated list of real-world mistakes developers make when integrating OpenRouter, each with the specific API behavior that causes the problem and the exact fix. These are not theoretical -- they come from production incidents and support requests.
+
+## Prerequisites
+
+- An existing (or in-progress) OpenRouter integration to audit against the 10 pitfalls below
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK (`pip install openai`) to run the validation snippets (e.g., the startup check against `/api/v1/models`)
+- Grep access to the codebase to hunt hardcoded `sk-or-v1-` keys and scattered model IDs
+
+## Instructions
+
+1. Audit request format first: every model ID uses the `provider/model` form (Pitfall 1), and model IDs live in one `MODELS` config validated against `/api/v1/models` at startup instead of being scattered through the code (Pitfall 3).
+2. Check cost controls: `max_tokens` is set on every request (Pitfall 2) and no `:free` models are used in production, where the 50-1000 req/day limits will 429 you (Pitfall 5).
+3. Review routing: sensitive-data requests pin `provider.order` with `allow_fallbacks: False` (Pitfall 4), and `response.model` is logged on every call to catch unexpected fallbacks (Pitfall 6).
+4. Inspect client hygiene: one shared client instance with connection pooling (Pitfall 7) configured with `timeout` and `max_retries` (Pitfall 9).
+5. Sweep for secrets: grep for hardcoded `sk-or-v1-` strings and move any hits to env vars or a secrets manager, rotating the exposed keys (Pitfall 8).
+6. Verify caching only stores deterministic `temperature=0` responses (Pitfall 10).
+7. Finish by walking the Quick Checklist (`PITFALL_CHECKLIST`) top to bottom — it condenses all 10 pitfalls into a code-review pass.
 
 ## Pitfall 1: Missing Provider Prefix on Model ID
 
@@ -215,6 +232,29 @@ PITFALL_CHECKLIST = [
     "Only deterministic responses (temp=0) are cached",
 ]
 ```
+
+## Output
+
+An audit pass with this skill produces:
+
+- A pitfall-by-pitfall verdict on your integration — each of the 10 items either confirmed clean or flagged with the exact fix from its section
+- Startup validation output from the Pitfall 3 snippet: `WARNING: primary model 'anthropic/claude-3.5-sonnet' not available!` for any config entry missing from `/api/v1/models`
+- Fallback-detection log lines from Pitfall 6: `Fallback triggered: requested claude-3.5-sonnet, got <response.model>`
+- The completed `PITFALL_CHECKLIST` — a 10-line review artifact to attach to the integration PR
+
+## Examples
+
+Validating your centralized model config at startup (Pitfall 3):
+
+```python
+available = {m["id"] for m in requests.get("https://openrouter.ai/api/v1/models").json()["data"]}
+for name, model_id in MODELS.items():
+    if model_id not in available:
+        print(f"WARNING: {name} model '{model_id}' not available!")
+# WARNING: primary model 'anthropic/claude-3-opus' not available!
+```
+
+A warning here means a rename or removal upstream — update the one `MODELS` entry instead of chasing hardcoded IDs across the codebase. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-load-balancing/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-load-balancing/SKILL.md
@@ -6,7 +6,7 @@ description: 'Distribute OpenRouter requests across multiple keys and models for
   openrouter requests'', ''multiple api keys''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 A single OpenRouter API key has rate limits (requests/minute and tokens/minute). To scale beyond those limits, distribute requests across multiple keys. OpenRouter also provides server-side load balancing via provider routing and the `:nitro` variant for low-latency inference. This skill covers multi-key rotation, health-based routing, circuit breakers, and concurrent request patterns.
+
+## Prerequisites
+
+- Two or more OpenRouter API keys exported as `OPENROUTER_KEY_1`, `OPENROUTER_KEY_2`, `OPENROUTER_KEY_3` so the `KeyPool` has keys to rotate — see the `openrouter-install-auth` skill for creating and exporting keys
+- `OPENROUTER_API_KEY` exported for the single-key concurrent-processing pattern
+- Python 3.8+ with the OpenAI SDK and `requests` (`pip install openai requests`) — the concurrent example uses `AsyncOpenAI` from the same package
+- Adequate credits on every key in the pool; per-key quota is visible via `GET /api/v1/auth/key`
+
+## Instructions
+
+1. Export your pool keys and build the `KeyPool` from Multi-Key Round Robin — it round-robins across keys, trips a circuit breaker after 3 consecutive errors, and auto-recovers a key after a 60s cooldown.
+2. Send traffic through `balanced_completion()`: on `RateLimitError` it calls `pool.mark_error(key)` and retries with the next healthy key.
+3. For batch workloads, use `parallel_completions()` from Concurrent Request Processing — an `asyncio.Semaphore` (`max_concurrent=3-5`) caps in-flight requests against a single key.
+4. Layer on server-side distribution per Provider-Level Load Balancing: pass `extra_body={"provider": {"order": [...], "allow_fallbacks": True}}` so OpenRouter spreads the same model across Anthropic, AWS Bedrock, and GCP Vertex.
+5. Monitor quota per key with `check_rate_limits()` (`GET /api/v1/auth/key`) from Rate Limit Awareness, and when 429s hit all keys simultaneously, apply the fixes in Error Handling (more keys, request queuing).
 
 ## Multi-Key Round Robin
 
@@ -175,6 +190,26 @@ for key in pool.keys:
     limits = check_rate_limits(key)
     print(f"Key {key[:12]}...: {limits}")
 ```
+
+## Output
+
+- Chat completion responses served through whichever pool key was healthy at send time, plus per-key health state: error counts, `healthy` flags, and log lines like `Key sk-or-v1-abc... marked unhealthy after 3 errors`
+- An ordered list of completion strings from `parallel_completions()` — one per input prompt, gathered concurrently
+- Rate-limit status dicts per key from `check_rate_limits()`: `requests_limit`, `interval`, `credits_used`, `credits_limit`
+
+## Examples
+
+Six requests through a two-key pool split evenly, and the pool's stats confirm the distribution:
+
+```python
+for i in range(6):
+    balanced_completion(f"Request {i}: Hello!")
+print(pool.get_stats())
+# {'sk-or-v1-abc': {'requests': 3, 'errors': 0},
+#  'sk-or-v1-def': {'requests': 3, 'errors': 0}}
+```
+
+Zero errors means no key tripped the circuit breaker; a nonzero `errors` count on one key with requests skewing to the other shows health-based routing doing its job. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-availability/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-availability/SKILL.md
@@ -5,7 +5,7 @@ description: 'Monitor OpenRouter model availability and implement health checks.
   model status'', ''is model available'', ''openrouter health check'', ''model availability''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter's `/api/v1/models` endpoint is the source of truth for model availability. Models can be temporarily unavailable, have degraded performance, or be permanently removed. This skill covers querying model status, building health probes, tracking availability over time, and automating failover.
+
+## Prerequisites
+
+- An OpenRouter API key exported as `OPENROUTER_API_KEY` for live probes (the catalog query itself needs no auth) — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for the catalog status queries and the cron monitoring script
+- Python 3.8+ with the OpenAI SDK and `requests` (`pip install openai requests`) for the health-check service
+- A small credit balance — each `max_tokens: 1` probe costs roughly $0.0001
+
+## Instructions
+
+1. Confirm your models exist in the catalog with `curl -s https://openrouter.ai/api/v1/models | jq ...` per Query Model Status — pull `context_length` and per-million pricing without spending any tokens.
+2. For a zero-cost existence check inside code, use `check_model_exists()` from Catalog-Based Availability Check; on a miss it calls `find_similar()` to suggest same-provider replacements.
+3. Probe live health with `probe_model()` from Health Check Service — a `max_tokens: 1` request that returns a `HealthStatus` with `available`, `latency_ms`, and `checked_at`.
+4. Sweep your critical set with `check_critical_models()`, which logs `OK`/`FAIL` plus latency per model.
+5. Automate via the Availability Monitoring Script as a `*/5 * * * *` cron job appending timestamped status lines to `/var/log/openrouter-health.log`.
+6. Tune alerting per Error Handling — require 2-3 consecutive failures before marking a model down to avoid false positives.
 
 ## Query Model Status
 
@@ -157,6 +173,24 @@ for MODEL in "${MODELS[@]}"; do
   echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $STATUS $MODEL $HTTP_CODE ${LATENCY}ms" >> "$LOG_FILE"
 done
 ```
+
+## Output
+
+- `HealthStatus` records per probed model: `available`, `latency_ms`, an ISO-8601 `checked_at` timestamp, and the error string when a model is down
+- Catalog check dicts: `{"exists": True, "context_length": ..., "pricing": ...}` on a hit, or `{"exists": False, "suggestion": [...]}` listing similar model IDs on a miss
+- Append-only log lines from the cron script, e.g. `2026-07-02T14:05:01Z OK anthropic/claude-3.5-sonnet 200 842ms`, one per critical model every 5 minutes
+
+## Examples
+
+Check that a critical model is still in the catalog before spending tokens on a probe:
+
+```bash
+curl -s https://openrouter.ai/api/v1/models | jq '[.data[] | select(
+  .id == "anthropic/claude-3.5-sonnet") | {id, context_length}]'
+# [{"id": "anthropic/claude-3.5-sonnet", "context_length": 200000}]
+```
+
+Then run the Python health sweep — `run_health_checks()` in `references/examples.md` prints `[OK] anthropic/claude-3.5-sonnet: 842.3ms` per model, a `3/3 models healthy` summary, and the mapped fallback (e.g. `openai/gpt-4-turbo`) for any failure. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-catalog/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-catalog/SKILL.md
@@ -5,7 +5,7 @@ description: 'Query, filter, and select from OpenRouter''s 400+ model catalog. U
   models'', ''list models'', ''model catalog'', ''compare models'', ''available models''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Query the `GET /api/v1/models` endpoint to browse 400+ models, filter by capabilities, compare pricing, and check provider endpoints. No API key required for the models endpoint.
+
+## Prerequisites
+
+- `curl` and `jq` for the command-line catalog queries — `GET /api/v1/models` itself requires no auth
+- An OpenRouter API key exported as `OPENROUTER_API_KEY` only for the Special Routers completion example — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with `requests` for filtering, plus the OpenAI SDK for the `openrouter/auto` example (`pip install requests openai`)
+
+## Instructions
+
+1. List the catalog per List All Models: `curl -s https://openrouter.ai/api/v1/models | jq '.data | length'`; add `?supported_parameters=tools` to filter to tool-calling models.
+2. Read Model Object Shape to interpret each entry — `pricing.prompt`/`pricing.completion` are per token (multiply by 1M for readable rates), plus `context_length`, `top_provider.max_completion_tokens`, and `architecture.modality`.
+3. Filter programmatically per Python: Query and Filter — free models, tool-calling models, cheapest paid models sorted by prompt price, and 128K+ context models.
+4. Compare per-provider pricing and quantization for a single model via `GET /api/v1/models/{id}/endpoints` per List Providers for a Model.
+5. Pick behavior with a suffix per Model Variants (`:free`, `:nitro`, `:floor`, `:extended`, `:thinking`), or delegate selection entirely to `openrouter/auto` per Special Routers.
+6. Sanity-check choices against the Popular Model Quick Reference, but always verify live pricing via `/api/v1/models` — prices change frequently.
 
 ## List All Models
 
@@ -153,6 +168,27 @@ print(f"Auto-selected: {response.model}")  # Shows which model was chosen
 | `openai/o1` | 200K | $15.00 / $60.00 |
 
 *Prices change frequently. Always verify via `/api/v1/models`.*
+
+## Output
+
+- Raw catalog JSON: one object per model with `id`, `context_length`, `pricing`, `top_provider`, and `architecture` fields
+- Filtered console listings, e.g. counts of free / tool-calling / 128K+ models and cheapest-paid lines like `$0.06/M tokens — meta-llama/llama-3.1-8b-instruct (128K ctx)`
+- Per-provider endpoint rows for one model: `provider_name`, prompt/completion pricing, `context_length`, `quantization`
+- For `openrouter/auto` requests, `response.model` reveals which model the router actually selected
+
+## Examples
+
+Fetch the catalog once, then slice it three ways with the filters from Python: Query and Filter:
+
+```python
+models = requests.get("https://openrouter.ai/api/v1/models").json()["data"]
+free = [m for m in models if m["pricing"]["prompt"] == "0"]
+large = [m for m in models if m["context_length"] >= 128_000]
+print(f"Total: {len(models)}, free: {len(free)}, 128K+: {len(large)}")
+# Total: 267, free: 12, 128K+: 45   (counts drift as the catalog changes)
+```
+
+The same pass sorted by prompt price surfaces the cheapest paid options — `meta-llama/llama-3-8b-instruct: $0.05/1M prompt tokens` leads the list in the worked run. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-model-routing/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-model-routing/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement intelligent model routing to optimize cost, quality, and
   ''model selection openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter gives you access to 100+ models through one API. The key to cost efficiency is routing each request to the right model based on task complexity, required capabilities, cost budget, and latency requirements. This skill covers task-based routing, complexity classification, cost-aware selection, and OpenRouter's native routing features.
+
+## Prerequisites
+
+- An OpenRouter API key exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK and `requests` (`pip install openai requests`)
+- A rough inventory of your task mix (classification, summarization, code generation, deep reasoning, ...) to seed the `TASK_ROUTING` table
+- Credits sized for the tiers you route to — the premium tier (`openai/o1`) runs $15/$60 per 1M tokens, 250x the budget tier
+
+## Instructions
+
+1. Define your tiers per Task-Based Router: the `MODELS` dict (free → budget → mid → standard → premium) and the `TASK_ROUTING` map, then send requests through `route_request()`, which returns `content`, the serving `model`, `tier`, and token count.
+2. When callers can't label tasks, switch to the Complexity-Based Auto-Router — `classify_complexity()` scores word count, code, reasoning, and math markers to pick a tier inside `auto_route()`.
+3. Add resilience per OpenRouter Native Routing: `extra_body={"models": [...], "route": "fallback"}` tries models in order, `provider.order` controls which provider serves, and the `:floor` variant picks the cheapest provider automatically.
+4. Keep pricing current per Cost-Aware Router — `get_model_pricing()` pulls live per-1M rates from `GET /api/v1/models`, and `cheapest_model_for_task()` selects under context/tooling constraints.
+5. Log every routing decision (task type, tier, model, cost) and tune per Error Handling and Enterprise Considerations — escalate the tier on quality regressions and cap per-request cost with `max_tokens`.
 
 ## Task-Based Router
 
@@ -171,6 +186,26 @@ def cheapest_model_for_task(pricing: dict, min_context: int = 4096,
     candidates.sort(key=lambda x: x[1]["prompt"] + x[1]["completion"])
     return candidates[0][0] if candidates else "openai/gpt-4o-mini"
 ```
+
+## Output
+
+- Routed completion dicts from `route_request()`: the reply `content`, the actual `model` that served, the `tier` chosen, and total `tokens` consumed
+- Router decision traces per request, e.g. `[Router] Task=code -> Model=anthropic/claude-3.5-sonnet`, giving you an audit trail to tune the routing table against
+- A live pricing map from `get_model_pricing()` keyed by model ID: per-1M `prompt`/`completion` cost plus `context` length for cost-aware selection
+
+## Examples
+
+The same router sends trivial and demanding prompts to opposite ends of the cost spectrum:
+
+```python
+print(routed_completion("What is 2+2?"))
+# [Router] Task=simple -> Model=google/gemma-2-9b-it:free
+
+print(routed_completion("Write a Python function to merge two sorted lists."))
+# [Router] Task=code -> Model=anthropic/claude-3.5-sonnet
+```
+
+The 4-word arithmetic prompt lands on the free tier while the code request escalates to Claude 3.5 Sonnet — the spread between those two decisions is where the cost savings live. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-multi-provider/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-multi-provider/SKILL.md
@@ -6,7 +6,7 @@ description: 'Use multiple AI providers (OpenAI, Anthropic, Google, Meta) throug
   provider'', ''openrouter openai anthropic'', ''compare models openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter's unified API lets you access models from OpenAI, Anthropic, Google, Meta, Mistral, and others with a single API key and endpoint. Model IDs use `provider/model-name` format. The same OpenAI SDK code works for any provider by simply changing the model ID. This skill covers provider comparison, cross-provider routing, feature normalization, and BYOK (Bring Your Own Key).
+
+## Prerequisites
+
+- A single OpenRouter API key exported as `OPENROUTER_API_KEY` — it covers every provider (OpenAI, Anthropic, Google, Meta, Mistral); see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for the provider-landscape query
+- Python 3.8+ with the OpenAI SDK (`pip install openai`)
+- For BYOK only: your own provider API key (e.g. an OpenAI key) added in the OpenRouter dashboard under Settings > Integrations > Add Provider Key
+
+## Instructions
+
+1. Survey what's on offer per Provider Landscape: `curl -s https://openrouter.ai/api/v1/models | jq ...` groups model IDs by their `provider/` prefix and sorts by model count.
+2. Benchmark candidates with `compare_models()` from Cross-Provider Comparison — the same prompt at `temperature=0` across Anthropic, OpenAI, Google, and Meta, capturing latency, tokens, and the actual serving endpoint (`response.model`).
+3. Shortlist by task using the Provider Strength Matrix — Anthropic for analysis/long context, OpenAI for code and tool calling, Google for multimodal and 1M context, Meta for budget work, Mistral for European data residency.
+4. Pin or fail over per Provider-Specific Routing: `provider.order` with `allow_fallbacks: False` forces one provider (e.g. for regulated data); `allow_fallbacks: True` fails across providers such as Anthropic → AWS Bedrock.
+5. For high-volume production, configure BYOK — requests route to your own provider key with the first 1M requests/month free, then 5% of normal provider cost.
+6. Smooth capability gaps with `normalized_completion()` per Feature Normalization — JSON mode uses `response_format` natively on `openai/` models and a system-prompt instruction elsewhere.
 
 ## Provider Landscape
 
@@ -163,6 +179,25 @@ def normalized_completion(messages, model, **kwargs):
 
     return client.chat.completions.create(model=model, messages=messages, **kwargs)
 ```
+
+## Output
+
+- Comparison result rows per model: `served_by` (the endpoint that actually answered), truncated `content`, token totals, `latency_ms`, and `status` (`ok` or the error)
+- A provider census from the jq query: `{provider, models}` objects sorted by model count, showing which namespaces dominate the catalog
+- Completions attributed to their exact serving provider via `response.model` — the raw material for cost/quality attribution across providers
+
+## Examples
+
+One prompt — "Explain what an API gateway is in 2 sentences." — fanned across four providers through the same client produces a directly comparable scoreboard:
+
+```text
+[OpenAI] 450ms, 65 tokens — ok
+[Anthropic] 380ms, 58 tokens — ok
+[Google] 620ms, 71 tokens — ok
+[Meta] 510ms, 63 tokens — ok
+```
+
+Anthropic answered fastest with the fewest tokens on this run; the point is that switching providers cost zero code changes beyond the model ID. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-openai-compat/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-openai-compat/SKILL.md
@@ -6,7 +6,7 @@ description: 'Migrate from OpenAI to OpenRouter with minimal code changes. Use w
   migration''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter implements the OpenAI Chat Completions API specification (`/v1/chat/completions`). Existing OpenAI SDK code works with OpenRouter by changing two values: `base_url` and `api_key`. This gives you access to 400+ models from all providers through the same SDK interface.
+
+## Prerequisites
+
+- An existing OpenAI SDK integration to migrate — Python or TypeScript code calling `chat.completions.create`
+- An OpenRouter API key exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the `openai` package, or Node.js 18+ with the `openai` npm package — the same SDK you already use, no new dependency
+- Optionally keep `OPENAI_API_KEY` exported too, so the Dual-Provider Pattern can switch back to direct OpenAI
+
+## Instructions
+
+1. Apply The Two-Line Migration: point `base_url` at `https://openrouter.ai/api/v1` and swap `api_key` to `OPENROUTER_API_KEY`; optionally add the `HTTP-Referer` / `X-Title` headers for app attribution.
+2. Prefix every model string per Model ID Mapping — `gpt-4o` becomes `openai/gpt-4o`, `o1` becomes `openai/o1` — and try a non-OpenAI model (`anthropic/claude-3.5-sonnet`) through the same client.
+3. Confirm your feature usage against What Works Identically (streaming, `tools`, JSON mode, `stop`, `n`) and adjust per What Differs — remove the `organization` param, plan around limited embeddings, and check `logprobs` support per model via `/api/v1/models`.
+4. Layer in OpenRouter-Only Features through `extra_body`: ordered fallback model lists with `"route": "fallback"`, provider preferences with `sort: "price"`, or the `plugins: [{"id": "web"}]` web-search plugin.
+5. Keep the migration reversible with the Dual-Provider Pattern — `create_client()` switches between direct OpenAI and OpenRouter off the `LLM_PROVIDER` environment variable.
 
 ## The Two-Line Migration
 
@@ -183,6 +198,30 @@ def create_client(provider: str = "openrouter") -> OpenAI:
 # Switch providers without changing application code
 client = create_client(os.environ.get("LLM_PROVIDER", "openrouter"))
 ```
+
+## Output
+
+- Standard OpenAI-SDK `ChatCompletion` objects — `choices[0].message.content`, `usage` token counts, and `model` reporting the provider-prefixed ID that actually served the request
+- The identical code path returning completions from non-OpenAI models (Claude, Gemini) with only the model string changed
+- A provider-switchable client from `create_client()` — flipping `LLM_PROVIDER` moves traffic between direct OpenAI and OpenRouter with zero application-code changes
+
+## Examples
+
+After the two-line change, the untouched OpenAI SDK call round-trips through OpenRouter:
+
+```python
+client = OpenAI(base_url="https://openrouter.ai/api/v1",
+                api_key=os.environ["OPENROUTER_API_KEY"])
+response = client.chat.completions.create(
+    model="openai/gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    max_tokens=100,
+)
+print(response.choices[0].message.content)  # The capital of France is Paris.
+print(response.model)                        # openai/gpt-3.5-turbo
+```
+
+Swap the model string to `anthropic/claude-3.5-sonnet` and the same code returns Claude's answer — that swap is the entire multi-provider story. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-performance-tuning/SKILL.md
@@ -6,7 +6,7 @@ description: 'Optimize OpenRouter request latency and throughput. Use when build
   throughput''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter adds minimal overhead (~50-100ms) to direct provider calls. Most latency comes from the upstream model. Key levers: model selection (smaller = faster), streaming (lower TTFT), parallel requests, prompt size reduction, and provider routing to faster infrastructure. This skill covers benchmarking, streaming optimization, concurrent processing, and connection tuning.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK (`openai` package) — the examples use both the sync `OpenAI` client and `AsyncOpenAI` for parallel processing
+- Credits on the key if you benchmark paid models like `anthropic/claude-3.5-sonnet`; a `:free` model is enough to validate the benchmark harness itself
+- `HTTP-Referer` / `X-Title` header values for your app (set in every client constructor here)
+
+## Instructions
+
+1. Establish a baseline: run `benchmark_model()` from Benchmark Latency against your candidate models (e.g. `openai/gpt-4o-mini` vs `anthropic/claude-3.5-sonnet`) and record p50/p95.
+2. Check the results against the Model Speed Tiers table to confirm each candidate sits in the right tier for your latency budget (200-500ms TTFT fastest tier; 5-30s for reasoning models).
+3. Switch user-facing paths to `stream_completion()` per Streaming for Lower TTFT and verify `ttft_ms` drops (typically 2-10x).
+4. Move batch workloads to `parallel_completions()` per Parallel Request Processing, capping concurrency with `asyncio.Semaphore` (`max_concurrent=5-10`).
+5. Apply Connection Optimization — one shared client with `timeout=30.0` and `max_retries=2` instead of a new client per request.
+6. Work through the Performance Optimization Checklist (set `max_tokens`, shrink prompts, consider `:nitro` variants and provider routing), then re-run the benchmark to quantify each change.
 
 ## Benchmark Latency
 
@@ -169,6 +185,27 @@ client = OpenAI(
 for prompt in prompts:
     client.chat.completions.create(...)  # Reuses HTTP connection
 ```
+
+## Output
+
+- A latency benchmark table per model from `benchmark_model()`: `p50_ms`, `p95_ms`, `avg_ms`, `min_ms`, `max_ms` over N sample requests
+- Streaming metrics from `stream_completion()`: the full `content` plus `ttft_ms` and `total_ms` for each request
+- A list of completions from `parallel_completions()` produced in roughly one request's wall-clock time instead of N sequential round-trips
+- A prioritized tuning plan drawn from the Performance Optimization Checklist (lever, expected impact, effort)
+
+## Examples
+
+Benchmark two fastest-tier candidates before committing to one:
+
+```python
+for model in ["openai/gpt-4o-mini", "anthropic/claude-3-haiku"]:
+    r = benchmark_model(model, n=5)
+    print(f"{r['model']}: p50={r['p50_ms']}ms p95={r['p95_ms']}ms avg={r['avg_ms']}ms")
+# openai/gpt-4o-mini: p50=430ms p95=610ms avg=455ms
+# anthropic/claude-3-haiku: p50=395ms p95=580ms avg=418ms
+```
+
+Both land in the fastest tier (200-500ms typical TTFT), so choose on cost or quality — then `stream_completion()` cuts perceived latency further for user-facing paths. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-pricing-basics/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-pricing-basics/SKILL.md
@@ -6,7 +6,7 @@ description: 'Understand OpenRouter pricing, calculate costs, and optimize spend
   much does openrouter cost''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter charges per token with separate rates for prompt (input) and completion (output) tokens. Prices are listed per token in the models API (multiply by 1M for per-million rates). Credits are prepaid with a 5.5% processing fee ($0.80 minimum). Free models are available for testing and low-volume use.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for the model-pricing and credit-balance queries
+- Python 3.8+ with the OpenAI SDK plus the `requests` package for the cost-calculation and generation-endpoint snippets
+- Prepaid credits for paid models — the public models/pricing endpoint needs no auth, but real completions require credits or a `:free` model
+
+## Instructions
+
+1. Read How Pricing Works: prepaid credits (5.5% fee, $0.80 minimum) are drawn down per request as `(prompt_tokens * prompt_rate) + (completion_tokens * completion_rate)`.
+2. Query per-token rates via `GET /api/v1/models` per Query Model Pricing, and place candidate models in the Cost Tiers table (free → premium).
+3. Estimate spend before committing: run `estimate_cost()` from Calculate Request Cost with your expected prompt/completion token counts.
+4. After sending real traffic, fetch the exact charge with `GET /api/v1/generation?id=` per Track Actual Cost Per Request.
+5. Watch the balance via `GET /api/v1/auth/key` per Check Credit Balance, and enable auto-topup for production keys.
+6. Cut costs with the `:floor` and `:free` variants per Save Money with Variants, and check Special Pricing for reasoning tokens, image inputs, per-request fees, and BYOK.
 
 ## How Pricing Works
 
@@ -134,6 +150,27 @@ response = client.chat.completions.create(
 | **Per-request fee** | Some models charge a flat fee per request (`pricing.request`) |
 | **BYOK** | First 1M requests/month free; then 5% of normal provider cost |
 | **Free model limits** | 50 req/day (free users), 1000 req/day (with $10+ credits) |
+
+## Output
+
+- A per-model pricing record from the models API: `prompt_per_M`, `completion_per_M`, `context` (e.g. $3 / $15 per 1M tokens for `anthropic/claude-3.5-sonnet`)
+- A pre-request dollar estimate from `estimate_cost()` and the exact post-request figures from the generation endpoint: `total_cost`, `tokens_prompt`, `tokens_completion`
+- A credit-balance snapshot from `/api/v1/auth/key`: `credits_used`, `credit_limit`, `remaining`, `is_free_tier`
+
+## Examples
+
+Check remaining credits before a batch job:
+
+```bash
+curl -s https://openrouter.ai/api/v1/auth/key \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" | jq '{
+    credits_used: .data.usage,
+    remaining: ((.data.limit // 0) - .data.usage)
+  }'
+# {"credits_used": 2.34, "remaining": 47.66}
+```
+
+Estimating first keeps surprises out: 1,000 prompt + 500 completion tokens on `anthropic/claude-3.5-sonnet` comes to roughly $0.0105 via `estimate_cost()`, and the generation endpoint then confirms the exact charge. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-prod-checklist/SKILL.md
@@ -5,7 +5,7 @@ description: 'Validate production readiness of your OpenRouter integration. Use 
   ''openrouter launch'', ''production checklist openrouter'', ''openrouter deploy''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 A comprehensive production readiness checklist for OpenRouter integrations covering security, reliability, observability, cost management, and operational procedures. Each item includes the specific API endpoint or configuration needed to verify compliance.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- A working OpenRouter integration ready to launch — this skill validates an existing integration, it doesn't build one
+- `curl` and `jq` for the pre-launch validation script and the auth/credit-limit checks
+- Python 3.8+ if you turn the checklist dicts (`SECURITY`, `RELIABILITY`, `OBSERVABILITY`) into automated CI checks
+- A secret scanner in CI (gitleaks or trufflehog) — the security checklist verifies its presence
+
+## Instructions
+
+1. Work through the Security Checklist: keys in a secrets manager, 90-day rotation, per-key credit limits (`GET /api/v1/auth/key` → `.data.limit`), secret scanning in CI, HTTPS-only endpoints.
+2. Verify the Reliability Checklist: a fallback chain (`models` array + `route: "fallback"`), SDK `max_retries=3` with built-in backoff, `timeout=30.0`, a circuit breaker on the primary model, and `max_tokens` on every request.
+3. Confirm the Observability Checklist: structured logs carrying `generation_id`/model/latency/tokens/cost, error-rate alerts (>5% over 5 min), P50/P95 latency per model, daily cost tracking via `GET /api/v1/generation?id=`, and credit-balance alerts.
+4. Run the Pre-Launch Validation Script — it exercises auth, credit limit, primary-model availability, a live test request, and a hardcoded-key scan.
+5. Fix every FAIL and re-run until the script prints `READY FOR PRODUCTION`, then wire it into CI as a pre-deploy gate per Enterprise Considerations.
 
 ## Security Checklist
 
@@ -153,6 +169,30 @@ echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ $FAIL -eq 0 ] && echo "READY FOR PRODUCTION" || echo "FIX FAILURES BEFORE LAUNCH"
 ```
+
+## Output
+
+- A pass/fail pre-launch validation report: five numbered checks, a `Results: N passed, M failed` summary, and a final `READY FOR PRODUCTION` / `FIX FAILURES BEFORE LAUNCH` verdict
+- A completed three-part readiness checklist (security, reliability, observability) with the verify command or API endpoint recorded per item
+- A hardcoded-key scan result — zero `sk-or-v1-` matches in source outside `.env` and `node_modules`
+
+## Examples
+
+A correctly configured production key produces a clean run of the Pre-Launch Validation Script:
+
+```text
+=== OpenRouter Production Readiness ===
+1. API Authentication: PASS (my-app-prod)
+2. Credit Limit: PASS ($100)
+3. Primary Model Available: PASS (anthropic/claude-3.5-sonnet)
+4. Test Request: PASS
+5. No Hardcoded Keys: PASS
+
+Results: 5 passed, 0 failed
+READY FOR PRODUCTION
+```
+
+A key with no credit limit instead shows `WARN (no limit set)` on check 2 and counts as a failure — set a per-key limit to bound blast radius before launch. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-rate-limits/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-rate-limits/SKILL.md
@@ -5,7 +5,7 @@ description: 'Understand and handle OpenRouter rate limits. Use when hitting 429
   rate limit'', ''openrouter 429'', ''openrouter throttle'', ''rate limiting openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter rate limits are per-key, not per-account. Free tier keys get lower limits; paid keys get higher limits that scale with credit balance. The OpenAI SDK has built-in retry with exponential backoff for 429 responses. Check your current limits via `GET /api/v1/auth/key`. Rate limit headers are returned on every response.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- `curl` and `jq` for querying your key's limits from `GET /api/v1/auth/key`
+- Python 3.8+ with the OpenAI SDK (sync `OpenAI` and `AsyncOpenAI`) plus the `requests` package for reading rate-limit headers directly
+- Awareness of your tier: free keys get 20 req/10s, keys with any credits 200 req/10s (see Rate Limit Tiers)
+
+## Instructions
+
+1. Query your key's limits via `GET /api/v1/auth/key` per Check Your Rate Limits — note `rate_limit.requests` and `rate_limit.interval`.
+2. Place yourself in the Rate Limit Tiers table, remembering free models carry separate daily caps (50 req/day free, 1000 req/day with $10+ credits).
+3. Inspect live headroom with `check_rate_headers()` per Read Rate Limit Headers — watch `x-ratelimit-remaining` and `retry-after`.
+4. Configure SDK retries per Retry Strategy with OpenAI SDK: `max_retries=5`, `timeout=60.0`; the SDK catches 429s and backs off with jitter automatically.
+5. Add the client-side `TokenBucket` limiter from Custom Rate Limiter, set below the server limit (e.g. 150 per 10s under a 200/10s cap) so you rarely hit 429 at all.
+6. For bulk jobs, use `batch_with_rate_limit()` per Batch Processing with Rate Awareness — staggered starts plus semaphore-capped concurrency instead of bursts.
 
 ## Check Your Rate Limits
 
@@ -182,6 +198,25 @@ async def batch_with_rate_limit(prompts: list[str], model="openai/gpt-4o-mini",
 
     return await asyncio.gather(*[process(p, i) for i, p in enumerate(prompts)])
 ```
+
+## Output
+
+- A key-limit snapshot from `/api/v1/auth/key`: `label`, `rate_limit` (requests + interval), `is_free_tier`, and credit usage
+- Per-request header readings from `check_rate_headers()`: `x-ratelimit-limit`, `x-ratelimit-remaining`, `x-ratelimit-reset`, `retry-after`
+- A rate-limited client: SDK auto-retry on 429 plus a `TokenBucket` that blocks (up to a timeout) instead of erroring
+- Ordered batch results from `batch_with_rate_limit()` produced without triggering a retry storm
+
+## Examples
+
+Read your server-side limit, then size the client-side limiter under it:
+
+```bash
+curl -s https://openrouter.ai/api/v1/auth/key \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" | jq '.data.rate_limit'
+# {"requests": 200, "interval": "10s"}
+```
+
+With that 200/10s ceiling, configure `TokenBucket(rate=150, interval=10.0)` so steady-state traffic stays ~25% below the limit, and let the SDK's `max_retries=5` absorb whatever bursts through. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-reference-architecture/SKILL.md
@@ -6,7 +6,7 @@ description: 'Design production architectures using OpenRouter as the LLM gatewa
   at scale'', ''llm gateway architecture''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,21 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter serves as a unified LLM gateway, abstracting provider complexity. A production architecture wraps it with caching, rate limiting, cost controls, observability, and async processing. This skill provides three reference architectures: simple (single service), standard (microservice), and enterprise (event-driven).
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK; FastAPI + Pydantic for Architecture 2's AI service, and a Redis instance (with the `redis` package) for Architecture 2's cache and Architecture 3's queue/results store
+- SQLite or Postgres if you implement Architecture 2's budget enforcer
+- Your scale numbers — team size, requests/day, and latency needs drive the decision in Choosing an Architecture
+
+## Instructions
+
+1. Score your system against the Choosing an Architecture table: team size, requests/day, latency needs, budget-tracking granularity, failure handling, observability.
+2. Start with Architecture 1 (Simple): one shared client (`max_retries=3`, `timeout=30.0`) behind the logging `complete()` wrapper.
+3. When you need task routing, caching, and per-user budgets, move to Architecture 2 (Standard): a FastAPI `/v1/complete` endpoint with the `ROUTING_TABLE`, cache-first lookup, budget check, and a fallback chain (`models` + `route: "fallback"`).
+4. At 100K+ requests/day or mixed sync/async workloads, adopt Architecture 3 (Enterprise): queue (Redis/SQS) → auto-scaling workers running `worker_loop()` → results store, with OTEL metrics feeding dashboards and alerts.
+5. Whichever tier you land on, route every call through the same OpenRouter client wrapper per Enterprise Considerations — consistent logging, cost tracking, and no budget bypass.
 
 ## Architecture 1: Simple (Single Service)
 
@@ -200,6 +215,26 @@ def worker_loop():
 | Budget tracking | Basic | Per-user | Per-user + department |
 | Failure handling | SDK retries | Fallback chain | Queue + retry + DLQ |
 | Observability | Logging | Metrics + logging | Full OTEL tracing |
+
+## Output
+
+- An architecture selection (Simple / Standard / Enterprise) justified line-by-line against the Choosing an Architecture criteria
+- Architecture 1: a logging `complete()` wrapper that records the serving model and prompt+completion token counts on every call
+- Architecture 2: a `/v1/complete` FastAPI endpoint returning `{content, model, tokens}` — or `{content, cached: true}` on a cache hit — with task-type routing and budget enforcement applied
+- Architecture 3: worker-produced result records `{id, content, model, status}` pushed to `ai:results:{id}` with a one-hour TTL
+
+## Examples
+
+Route a code task through the Architecture 2 microservice:
+
+```python
+# POST /v1/complete  (Architecture 2)
+req = CompletionRequest(prompt="Refactor this function...", task_type="code", user_id="u42")
+# ROUTING_TABLE maps "code" -> anthropic/claude-3.5-sonnet, with openai/gpt-4o-mini as fallback
+# -> {"content": "...", "model": "anthropic/claude-3.5-sonnet", "tokens": 348}
+```
+
+Repeating the identical request returns `{"content": "...", "cached": true}` straight from the TTL cache without touching OpenRouter or the budget. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-routing-rules/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-routing-rules/SKILL.md
@@ -5,7 +5,7 @@ description: 'Define custom routing rules for OpenRouter requests based on user 
   rules'', ''custom routing openrouter'', ''conditional model selection''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Beyond simple task-based model selection, production systems need configurable routing rules that consider user tier, cost budget, time of day, model availability, and feature requirements. This skill covers building a rules engine for OpenRouter model selection with config-driven rules, dynamic conditions, and override capabilities.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK — the rules engine itself is stdlib (`dataclasses`, `json`, `random`) layered on top
+- Per-request metadata available in your app: user tier, task type, remaining budget, tool/vision needs, latency SLA (the `RoutingContext` fields)
+- Budget tracking wired up (see `openrouter-cost-controls`) if you use budget-conditioned rules like `low-budget`
+
+## Instructions
+
+1. Model each request's metadata as a `RoutingContext` (user tier, task type, budget remaining, tools/vision flags, latency SLA) per Rules Engine.
+2. Define `RoutingRule` entries in priority order — free-tier first, then budget, capability (tools/vision), task type, latency, and always a `priority=99` default catch-all.
+3. Resolve the winning rule with `evaluate_rules(ctx)`: first match by ascending priority wins; failing conditions return False instead of raising.
+4. Execute through `routed_completion()` per Routed Completion — it applies the rule's model, fallback chain (`models` + `route: "fallback"`), and `max_tokens`.
+5. To make rules hot-reloadable, express them as JSON per Config-Driven Rules and match with `match_config_rule()` instead of lambdas.
+6. Validate any rule change on a slice of traffic with `ab_test_routing()` per A/B Testing Rules before full rollout.
 
 ## Rules Engine
 
@@ -240,6 +256,26 @@ def ab_test_routing(ctx: RoutingContext, test_name: str, variant_b_pct: float = 
         )
     return rule
 ```
+
+## Output
+
+- A resolved `RoutingRule` per request — name, model, fallbacks, `max_tokens` — from `evaluate_rules()`
+- A completion result dict from `routed_completion()`: `{content, model, rule, tokens}`; the `rule` field makes every routing decision auditable
+- A JSON rules config (Config-Driven Rules) that can be hot-reloaded without redeployment
+- A/B variant assignments (`<rule-name>:variant-b`) for a configurable percentage of traffic
+
+## Examples
+
+A pro-tier code request falls through the free-tier, budget, tools, and vision rules and matches `code-tasks`:
+
+```python
+ctx = RoutingContext(user_tier="pro", task_type="code", budget_remaining=50.0)
+result = routed_completion([{"role": "user", "content": "Refactor this function..."}], ctx=ctx)
+print(f"Rule: {result['rule']}, Model: {result['model']}")
+# Rule: code-tasks, Model: anthropic/claude-3.5-sonnet
+```
+
+The same context with `user_tier="free"` matches the priority-1 `free-tier` rule instead, landing on `google/gemma-2-9b-it:free` capped at 512 tokens. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-sdk-patterns/SKILL.md
@@ -5,7 +5,7 @@ description: 'Build reusable OpenRouter client wrappers with retries, typing, an
   ''openrouter client wrapper'', ''openrouter patterns'', ''openrouter library''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -21,6 +21,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Build production-grade OpenRouter client wrappers using the OpenAI SDK. The OpenAI Python/TypeScript SDKs work natively with OpenRouter by changing `base_url` to `https://openrouter.ai/api/v1`. This skill covers typed wrappers, retry strategies, middleware, and reusable patterns.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK plus `requests` (used for the `/auth/key` credits check and `/generation` cost lookups), or Node.js 18+ with the OpenAI SDK
+- Optional: `tenacity` if you want the custom retry decorator beyond the SDK's built-in backoff
+- An app name and URL to send as `HTTP-Referer` / `X-Title` default headers for dashboard attribution
+
+## Instructions
+
+1. Start from the Python: Production Client Wrapper (or the TypeScript variant): point the OpenAI SDK at `base_url="https://openrouter.ai/api/v1"`, read `OPENROUTER_API_KEY` from the environment, and set the `HTTP-Referer` / `X-Title` default headers in the constructor.
+2. Return typed results from every call — the `CompletionResult` dataclass/interface captures `content`, the served `model`, `prompt_tokens`/`completion_tokens`, `generation_id`, and `latency_ms`.
+3. Tune the SDK's built-in retries per the Retry Strategy section (`max_retries`, `timeout` in the constructor); add the `tenacity` decorator only when you need retry behavior beyond the SDK's 429/5xx/connection handling.
+4. Layer cross-cutting concerns via the Middleware Pattern — `with_cost_tracking` queries `GET /api/v1/generation?id=` after each request and accumulates a session cost total.
+5. Surface remaining credits and rate limits with `check_credits()`, which calls `GET /api/v1/auth/key` with the same key.
+6. Map SDK exceptions using the Error Handling table, then apply the Enterprise Considerations (single central wrapper, dependency injection for tests, SLA-based `max_retries`).
 
 ## Python: Production Client Wrapper
 
@@ -250,6 +266,26 @@ def with_cost_tracking(fn: Callable) -> Callable:
     wrapper.total_cost = total_cost
     return wrapper
 ```
+
+## Output
+
+- A typed `CompletionResult` per call: `content`, the `model` that actually served the request, `prompt_tokens`/`completion_tokens`, the `gen-...` `generation_id`, and `latency_ms`
+- A structured log line per request, e.g. `[openai/gpt-4o-mini] 12+87 tokens, 843.2ms`
+- Cost-tracking middleware output: per-request cost plus a running session total, e.g. `Request cost: $0.000123 | Session total: $0.0045`
+- A credits dict from `check_credits()` with usage and limit data from `/api/v1/auth/key`
+
+## Examples
+
+Instantiate the wrapper once and make a typed call:
+
+```python
+or_client = OpenRouterClient(app_name="my-saas")
+result = or_client.complete("Explain recursion", model="openai/gpt-4o-mini", max_tokens=200)
+print(f"{result.model} | {result.latency_ms}ms | {result.prompt_tokens}+{result.completion_tokens} tokens")
+# openai/gpt-4o-mini | 812.4ms | 11+142 tokens
+```
+
+The reference implementation also shows task helpers (`summarize`, `classify`) built on the same wrapper. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-streaming-setup/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-streaming-setup/SKILL.md
@@ -6,7 +6,7 @@ description: 'Implement streaming responses with OpenRouter for real-time UIs. U
   openrouter'', ''real-time openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter supports Server-Sent Events (SSE) streaming via `stream: true`, compatible with the OpenAI SDK. Streaming returns tokens as they're generated, reducing time-to-first-token (TTFT) from seconds to milliseconds. Usage stats are available via `stream_options: {include_usage: true}` in the final chunk. This skill covers Python and TypeScript streaming, SSE forwarding to browsers, and error recovery.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ or Node.js 18+ with the OpenAI SDK (the async example uses `AsyncOpenAI` from the same Python package)
+- FastAPI if you plan to forward the SSE stream to browsers per the SSE Forwarding section
+- A streaming-appropriate client timeout (e.g. 120s) — longer than for non-streaming requests
+
+## Instructions
+
+1. Start with Python: Basic Streaming — pass `stream=True` plus `stream_options={"include_usage": True}` so the final chunk carries token counts, and print each `chunk.choices[0].delta.content` as it arrives.
+2. Wrap that loop in the Python: Streaming with Metrics generator to capture TTFT and total time per request; the metrics dict is available after the generator is exhausted.
+3. For Node services, use the TypeScript: Streaming `for await` loop over the same `stream: true` request.
+4. To reach a browser UI, expose the FastAPI endpoint in SSE Forwarding to Browser — it re-emits each token as a `data: {"token": ...}` SSE line and terminates with `data: [DONE]`.
+5. Consume that endpoint with the Browser Client (JavaScript) reader loop, appending tokens to the DOM as they decode.
+6. In async web frameworks, switch to the Async Streaming pattern built on `AsyncOpenAI`.
+7. Handle mid-stream failures (cut-offs, missing `usage`, keep-alive pings, `finish_reason: "length"`) per the Error Handling table.
 
 ## Python: Basic Streaming
 
@@ -216,6 +233,30 @@ async def async_stream(messages, model="openai/gpt-4o-mini", **kwargs):
         if chunk.choices and chunk.choices[0].delta.content:
             yield chunk.choices[0].delta.content
 ```
+
+## Output
+
+- Token-by-token console output as the model generates, followed by usage counts from the final chunk (`Tokens: 14 in + 132 out`)
+- A metrics dict after the generator is exhausted: `ttft_ms`, `total_ms`, `usage` token counts, and the `model` used
+- A FastAPI SSE endpoint emitting `data: {"token": ...}` lines and a terminating `data: [DONE]` for browser consumption
+- Incrementally rendered text in the browser as the JavaScript reader loop decodes each SSE line
+
+## Examples
+
+Stream with metrics and inspect TTFT after the tokens finish printing:
+
+```python
+for token in stream_with_metrics(
+    [{"role": "user", "content": "Write a haiku about programming"}],
+    model="openai/gpt-4o-mini", max_tokens=60,
+):
+    print(token, end="", flush=True)
+print(f"\nMetrics: {stream_with_metrics.last_metrics}")
+# Code flows like a stream / bugs surface then sink away / green tests light the dawn
+# Metrics: {'ttft_ms': 412, 'total_ms': 1875, 'usage': {'prompt_tokens': 14, 'completion_tokens': 21}, 'model': 'openai/gpt-4o-mini'}
+```
+
+More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-team-setup/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-team-setup/SKILL.md
@@ -5,7 +5,7 @@ description: 'Configure OpenRouter for multi-user teams with per-user keys, budg
   ''openrouter organization'', ''team api keys openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -22,6 +22,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter supports team usage through per-user API keys with individual credit limits, management keys for programmatic key provisioning, and usage attribution via headers. This skill covers key provisioning, per-user budgets, usage tracking, and governance policies for multi-user deployments.
+
+## Prerequisites
+
+- A management key (`sk-or-v1-...`) with provisioning rights exported as `OPENROUTER_MGMT_KEY` — created separately at openrouter.ai/keys; it can create/list/delete API keys but cannot call completions
+- A regular OpenRouter API key exported as `OPENROUTER_API_KEY` for the shared-key attribution pattern — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK and `requests`; `sqlite3` (stdlib) backs the per-user budget database
+- `curl` and `jq` for the Team Key Dashboard Script
+
+## Instructions
+
+1. Create a management key at openrouter.ai/keys and export it as `OPENROUTER_MGMT_KEY`.
+2. Provision one key per team member via Key Provisioning via Management API — `create_team_key(name, credit_limit)` posts to `/api/v1/keys`; record the one-time `key` value and keep the `key_hash` for later listing/revocation.
+3. Alternatively, keep a single shared key and attribute usage per user with the Shared Key with User Attribution pattern (`X-Title: my-app:{user_id}` header shows each user in the dashboard).
+4. Enforce spend locally with Per-User Budget Enforcement — initialize the `user_usage` / `user_budgets` sqlite tables, call `check_user_budget` before each request and `record_user_usage` after.
+5. Gate expensive models per tier with the Model Governance allowlists (`enforce_model_policy` downgrades disallowed requests).
+6. Monitor continuously: run the Team Key Dashboard Script (curl + jq against `/api/v1/keys`) and generate the weekly Team Usage Report from the sqlite DB.
+7. Revoke keys for departed members with `delete_team_key(key_hash)` (`DELETE /api/v1/keys/{hash}`).
 
 ## Key Provisioning via Management API
 
@@ -223,6 +240,28 @@ def enforce_model_policy(user_tier: str, requested_model: str) -> str:
     # Downgrade to best allowed model
     return allowlist[-1]
 ```
+
+## Output
+
+- Per-member API keys (`sk-or-v1-...`, shown once at creation) plus `key_hash` records carrying name, usage, and credit limit
+- A `team_usage.db` sqlite database with per-user daily `total_cost` and `request_count` rows plus per-user budgets and model allowlists
+- A columnar key dashboard from the curl + jq script: key name, spend, and limit per row, plus a total-spend line
+- A weekly team usage report list sorted by `weekly_cost`, one dict per user with requests and daily limit
+
+## Examples
+
+Provision keys for three team members with a $50 credit limit each:
+
+```python
+for member in ["alice-backend", "bob-frontend", "carol-ml"]:
+    key_info = create_team_key(member, credit_limit=50.0)
+    print(f"Created key for {member}: {key_info['key'][:20]}...")
+# Created key for alice-backend: sk-or-v1-a1b2c3d4e5...
+# Created key for bob-frontend: sk-or-v1-f6a7b8c9d0...
+# Created key for carol-ml: sk-or-v1-e1f2a3b4c5...
+```
+
+Each key value is only returned once — store it securely and keep the hash for revocation. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-upgrade-migration/SKILL.md
@@ -5,7 +5,7 @@ description: 'Migrate to OpenRouter from direct provider APIs or upgrade between
   openrouter'', ''migrate from openai to openrouter''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(node:*), Bash(npm:*), Bash(pip:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -26,6 +26,23 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 Migrating to OpenRouter from a direct provider API (OpenAI, Anthropic) is minimal: change `base_url` and `api_key`, add two headers. The OpenAI SDK works natively with OpenRouter. This skill covers migrating from direct APIs, switching between models, upgrading SDK versions, and running comparison tests.
+
+## Prerequisites
+
+- An existing direct OpenAI or Anthropic integration to migrate — the Current State block above checks your installed `openai` SDK via `npm list openai` / `pip show openai`
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ or Node.js 18+ with the OpenAI SDK (Anthropic SDK users switch to the OpenAI SDK as part of the migration)
+- The old provider key (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) kept active during migration for comparison tests and quick rollback
+
+## Instructions
+
+1. Confirm your installed SDK versions from the Current State output at the top of this skill.
+2. Apply the 3-line change per Migration from Direct OpenAI, Migration from Direct Anthropic, or TypeScript Migration: swap `base_url` to `https://openrouter.ai/api/v1`, switch to `OPENROUTER_API_KEY`, and add the `HTTP-Referer` / `X-Title` headers. Anthropic migrations also change response parsing to `.choices[0].message.content`.
+3. Prefix every model ID with its provider per the Model ID Migration Map (e.g. `gpt-4o` → `openai/gpt-4o`).
+4. Work through the Migration Checklist — config, code, testing, and operations items — before flipping traffic.
+5. Run the Comparison Test Script on your critical prompts (`temperature=0`) to compare content, tokens, and latency against the old backend.
+6. Roll out gradually with the Feature Flag Migration pattern (`USE_OPENROUTER` env var plus `get_model_id` mapping), moving 10% → 50% → 100%.
+7. Watch for post-migration failures (401, `model_not_found`, response-format drift, +50–100ms latency) per the Error Handling table.
 
 ## Migration from Direct OpenAI
 
@@ -217,6 +234,32 @@ def get_model_id(model: str) -> str:
         return MODEL_MAP.get(model, f"openai/{model}")
     return model
 ```
+
+## Output
+
+- Migrated client initialization code: 3 changed lines (`base_url`, `api_key`, headers) plus provider-prefixed model IDs across routes/configs
+- A comparison test JSON per prompt with the served `model`, a content preview, combined token count, and `latency_ms`
+- A four-category migration checklist (config / code / testing / operations) to track cutover readiness
+- A feature-flagged `get_llm_client()` that flips between direct OpenAI and OpenRouter via the `USE_OPENROUTER` env var
+
+## Examples
+
+Verify a migrated model on the same prompt before flipping traffic:
+
+```python
+result = compare_migration("What is 2+2?", old_model="gpt-4o", new_model="openai/gpt-4o")
+print(json.dumps(result, indent=2))
+# {
+#   "openrouter": {
+#     "model": "openai/gpt-4o",
+#     "content": "2 + 2 = 4",
+#     "tokens": 21,
+#     "latency_ms": 934
+#   }
+# }
+```
+
+Expect OpenRouter latency to run ~50-100ms above the direct API. More worked examples: `references/examples.md`.
 
 ## Error Handling
 

--- a/plugins/saas-packs/openrouter-pack/skills/openrouter-usage-analytics/SKILL.md
+++ b/plugins/saas-packs/openrouter-pack/skills/openrouter-usage-analytics/SKILL.md
@@ -6,7 +6,7 @@ description: 'Track and analyze OpenRouter API usage patterns, costs, and perfor
   openrouter spend''.
 
   '
-allowed-tools: Read, Write, Edit, Bash, Grep
+allowed-tools: Read, Write, Edit, Grep, Bash(python3:*), Bash(curl:*), Bash(jq:*)
 version: 2.0.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
@@ -23,6 +23,22 @@ compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
 ## Overview
 
 OpenRouter provides usage data through three endpoints: `GET /api/v1/auth/key` (credit balance and rate limits), `GET /api/v1/generation?id=` (per-request cost and metadata), and response `usage` fields (token counts). This skill covers collecting metrics from these sources, building analytics pipelines, cost reporting, and performance dashboards.
+
+## Prerequisites
+
+- An OpenRouter API key (`sk-or-v1-...`) exported as `OPENROUTER_API_KEY` — see the `openrouter-install-auth` skill for setup
+- Python 3.8+ with the OpenAI SDK plus `requests` (used to fetch exact per-request cost from the generation endpoint); `sqlite3` (stdlib) backs the analytics database
+- `curl` and `jq` for the Credit Balance Monitoring one-liner
+- `HTTP-Referer` / `X-Title` headers set on the client if you also want OpenRouter dashboard attribution
+
+## Instructions
+
+1. Route completions through `tracked_completion` (Collect Per-Request Metrics) — it times each call, then fetches the exact `total_cost` from `GET /api/v1/generation?id=` and emits a JSON metric with tokens, latency, and `model_requested` vs `model_used`.
+2. Initialize `openrouter_analytics.db` with `init_analytics_db` (Analytics Database) and persist every metric via `store_metric` — the `generation_id` unique constraint plus `INSERT OR IGNORE` deduplicates retries.
+3. Query the store with the Analytics Queries: daily cost summary, cost by model, top users by spend, hourly request pattern, and 30-day cost trend.
+4. Watch remaining credits with the Credit Balance Monitoring snippet — curl + jq against `/api/v1/auth/key` reports `credits_used`, `credit_limit`, and `remaining`.
+5. Generate the Weekly Report Generator output for stakeholders (totals plus top 5 models by cost).
+6. Apply the retention and alerting policies from Enterprise Considerations (aggregate raw rows after 30 days, alert when daily cost exceeds 2x the historical average).
 
 ## Collect Per-Request Metrics
 
@@ -210,6 +226,28 @@ Top Models by Cost:
 
     return report
 ```
+
+## Output
+
+- A JSON-logged metric per request: timestamp, `generation_id`, `model_requested` vs `model_used`, prompt/completion tokens, exact `total_cost`, `latency_ms`, and `user_id`
+- An `openrouter_analytics.db` sqlite store with an indexed `metrics` table ready for the daily/model/user/hourly queries
+- A credit-status JSON from the curl + jq snippet: `credits_used`, `credit_limit`, and `remaining`
+- A weekly text report with request count, total cost, average latency, total tokens, avg cost/request, and the top 5 models by cost
+
+## Examples
+
+Track a single call and read the captured metric:
+
+```python
+response, metric = tracked_completion(
+    [{"role": "user", "content": "Summarize HTTP/2 in one line"}],
+    model="openai/gpt-4o-mini", user_id="alice", max_tokens=60,
+)
+print(metric["model_used"], metric["total_cost"], metric["latency_ms"])
+# openai/gpt-4o-mini 8.4e-05 912.3
+```
+
+After a week of stored metrics, `print(weekly_report(conn))` renders the `=== OpenRouter Weekly Report ===` block with totals and top models. More worked examples: `references/examples.md`.
 
 ## Error Handling
 


### PR DESCRIPTION
Clears all 179 standing marketplace-tier validator ERRORs across openrouter-pack's 30 skills — the worst pack in the repo. These errors persisted on main because pr-prescreen only gates changed dirs.

## Buckets

| Bucket | Before | After | Fix |
|---|---|---|---|
| Unscoped `Bash` in allowed-tools | 30 | 0 | Scoped per-skill to what the body actually invokes (`Bash(curl:*)`, `Bash(python3:*)`, `Bash(node:*)`, `Bash(jq:*)`, ...) |
| tier2 tool-safety (unscoped Bash + Write/WebFetch) | 30 | 0 | Cleared by scoping Bash — no Safety Justification section needed |
| Missing `## Instructions` | 30 | 0 | Numbered workflows sequencing each skill's own existing sections |
| Missing `## Output` | 30 | 0 | Concrete artifacts grounded in each skill's response shapes/scripts |
| Missing `## Examples` | 30 | 0 | Worked examples grounded in body + `references/examples.md` |
| Missing `## Prerequisites` | 29 | 0 | Real per-skill dependencies (keys, SDKs, Redis, mgmt keys, ...) |
| **Total ERRORs** | **179** | **0** | |

## Scores

Pack average marketplace score: **84.5 → 94.2** — all 30 skills now grade A (range 92–97).

Note: the 90+-average policy question remains a separate open decision — this PR clears ERRORS only.

`openrouter-pack` bumped `1.0.0 → 1.0.1`, mirrored in `marketplace.extended.json`, and `pnpm run sync-marketplace` regenerated `marketplace.json`.

[skip auto-bump]

Refs jeremylongshore/claude-code-plugins-plus-skills#938

- Jeremy Longshore
intentsolutions.io