### PR TITLE
feat(marketplace): include the docs section in unified search

### DIFF
--- a/marketplace/scripts/generate-unified-search.mjs
+++ b/marketplace/scripts/generate-unified-search.mjs
@@ -20,6 +20,7 @@ const OUTPUT_FILE = path.join(DATA_DIR, 'unified-search-index.json');
 
 const PLUGINS_DIR = path.resolve(ROOT_DIR, '..', 'plugins');
 const EXTENDED_CATALOG_FILE = path.resolve(ROOT_DIR, '..', '.claude-plugin', 'marketplace.extended.json');
+const DOCS_DIR = path.join(ROOT_DIR, 'src/content/docs');
 
 console.log('🔍 Generating unified search index...\n');
 
@@ -171,6 +172,84 @@ const skills = skillsData.skills.map(skill => ({
   searchText: `${skill.name} ${skill.description || ''} ${skill.parentPlugin.category} ${(skill.allowedTools || []).join(' ')} ${(skill.compatibleWith || []).join(' ')}`.toLowerCase()
 }));
 
+// Transform docs for search — walk src/content/docs/**/*.md and index the
+// documentation section alongside plugins and skills. URLs mirror the Astro
+// content-collection routing in src/pages/docs/[...slug].astro, where the
+// entry id is the file path relative to the collection root minus `.md`.
+function walkDocFiles(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const ent of entries) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...walkDocFiles(full));
+    } else if (ent.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Minimal frontmatter parser for the docs schema (title, description,
+// section: scalar strings; keywords: block list of strings). Nested object
+// lists (officialLinks) are ignored — only scalar and string-list fields
+// referenced below are consumed.
+function parseDocFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const fm = {};
+  let currentKey = null;
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (kv) {
+      currentKey = kv[1];
+      const value = kv[2].trim();
+      if (value === '') {
+        fm[currentKey] = []; // block list (or nested structure) follows
+      } else {
+        fm[currentKey] = value.replace(/^["']|["']$/g, '');
+      }
+      continue;
+    }
+    const item = line.match(/^\s*-\s+(.*)$/);
+    if (item && currentKey && Array.isArray(fm[currentKey])) {
+      const entry = item[1].trim().replace(/^["']|["']$/g, '');
+      // Skip object-list entries (e.g. officialLinks `- title: ...`)
+      if (!/^[A-Za-z][A-Za-z0-9_-]*:\s/.test(entry)) fm[currentKey].push(entry);
+    }
+  }
+  return fm;
+}
+
+const docs = walkDocFiles(DOCS_DIR)
+  .map(file => {
+    const fm = parseDocFrontmatter(fs.readFileSync(file, 'utf8'));
+    if (!fm || !fm.title) {
+      console.warn(`   ⚠ Skipping doc without frontmatter title: ${path.relative(ROOT_DIR, file)}`);
+      return null;
+    }
+    const slug = path.relative(DOCS_DIR, file).replace(/\\/g, '/').replace(/\.md$/, '');
+    const keywords = Array.isArray(fm.keywords) ? fm.keywords : [];
+    return {
+      type: 'docs',
+      id: `docs/${slug}`,
+      slug,
+      name: fm.title,
+      description: typeof fm.description === 'string' ? fm.description : '',
+      category: typeof fm.section === 'string' ? fm.section : 'docs',
+      keywords,
+      url: `/docs/${slug}/`,
+      searchText: `${fm.title} ${fm.description || ''} ${fm.section || ''} ${keywords.join(' ')}`.toLowerCase()
+    };
+  })
+  .filter(Boolean)
+  .sort((a, b) => a.slug.localeCompare(b.slug));
+
 // Combine into unified index
 const unifiedIndex = {
   meta: {
@@ -181,7 +260,10 @@ const unifiedIndex = {
   stats: {
     totalPlugins: plugins.length,
     totalSkills: skills.length,
-    totalItems: plugins.length + skills.length,
+    totalDocs: docs.length,
+    totalItems: plugins.length + skills.length + docs.length,
+    // Docs sections are intentionally excluded — this drives the plugin/skill
+    // category filter dropdown and the "N categories" marketing copy.
     categories: [...new Set([...plugins.map(p => p.category), ...skills.map(s => s.category)])].sort(),
     skillTools: skillsData.allowedToolsUsed || [],
     allKeywords: [...new Set(plugins.flatMap(p => p.keywords || []))].sort(),
@@ -193,7 +275,7 @@ const unifiedIndex = {
     communityPlugins: plugins.filter(p => p.authorType === 'community').length,
     communityContributors: [...new Set(plugins.filter(p => p.authorType === 'community').map(p => p.author?.name || 'Unknown'))].length
   },
-  items: [...plugins, ...skills]
+  items: [...plugins, ...skills, ...docs]
 };
 
 // Write unified index
@@ -203,6 +285,7 @@ console.log('✅ Unified search index generated!\n');
 console.log(`📊 Statistics:`);
 console.log(`   Plugins: ${plugins.length}`);
 console.log(`   Skills: ${skills.length}`);
+console.log(`   Docs: ${docs.length}`);
 console.log(`   Total searchable items: ${unifiedIndex.stats.totalItems}`);
 console.log(`   Categories: ${unifiedIndex.stats.categories.length}`);
 console.log(`   Skill tools: ${unifiedIndex.stats.skillTools.length}`);

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -383,6 +383,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         <button class="type-btn active" data-type="all">All</button>
         <button class="type-btn" data-type="plugin">Plugins</button>
         <button class="type-btn" data-type="skill">Skills</button>
+        <button class="type-btn" data-type="docs">Docs</button>
         <button class="type-btn" data-type="favorites" id="favorites-btn">♡ Favorites</button>
       </div>
 
@@ -581,13 +582,21 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       const displayName = escHtml(item.type === 'plugin' && item.displayName ? item.displayName : item.name);
       const href = item.type === 'plugin'
         ? `/plugins/${escHtml(item.name)}/`
-        : (item.parentPlugin ? `/cowork` : `/skills/${escHtml(item.slug)}/`);
+        : item.type === 'docs'
+          ? escHtml(item.url || `/docs/${item.slug}/`)
+          : (item.parentPlugin ? `/cowork` : `/skills/${escHtml(item.slug)}/`);
       const installName = item.type === 'plugin' ? item.name : (item.parentPlugin?.name || item.name);
-      const installCmd = `/plugin install ${escHtml(installName)}@claude-code-plugins-plus`;
+      // Docs are pages, not installables — no install command on their cards.
+      const installHtml = item.type === 'docs'
+        ? ''
+        : `<code>/plugin install ${escHtml(installName)}@claude-code-plugins-plus</code>`;
 
       const metaParts = [];
       if (item.type === 'skill' && item.parentPlugin) {
         metaParts.push(`<span>Provided by ${escHtml(item.parentPlugin.name)}</span>`);
+      }
+      if (item.type === 'docs') {
+        metaParts.push(`<span>Docs · ${escHtml(item.category)}</span>`);
       }
       if (item.skillCount > 0) {
         metaParts.push(`<span>${item.skillCount} skills</span>`);
@@ -605,7 +614,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
           <a class="pcard" href="${href}">
             <h3>${displayName}</h3>
             <p>${escHtml(item.description)}</p>
-            <code>${installCmd}</code>
+            ${installHtml}
             ${metaHtml}
           </a>
         </div>`;
@@ -645,7 +654,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
       const typeParam = urlParams.get('type');
       const searchParam = urlParams.get('q');
 
-      if (typeParam && ['all', 'plugin', 'skill'].includes(typeParam)) {
+      if (typeParam && ['all', 'plugin', 'skill', 'docs'].includes(typeParam)) {
         activeFilters.type = typeParam;
         document.querySelectorAll('.type-btn').forEach(b => b.classList.remove('active'));
         const targetBtn = document.querySelector(`.type-btn[data-type="${typeParam}"]`);

--- a/marketplace/tests/T2-search-results.spec.ts
+++ b/marketplace/tests/T2-search-results.spec.ts
@@ -44,8 +44,9 @@ test.describe('Search Results', () => {
     // Wait for results
     await page.waitForTimeout(500);
 
-    // Find first plugin result link (look for any link containing /plugins/)
-    const pluginLink = page.locator('a[href*="/plugins/"]').first();
+    // Find first plugin result link (anchored to the /plugins/ prefix so
+    // docs URLs like /docs/concepts/plugins/ don't substring-match)
+    const pluginLink = page.locator('a[href^="/plugins/"]').first();
 
     // Click if found, otherwise skip this assertion
     const isVisible = await pluginLink.isVisible({ timeout: 2000 }).catch(() => false);
@@ -89,8 +90,9 @@ test.describe('Search Results', () => {
     // Wait for results
     await page.waitForTimeout(500);
 
-    // Find first skill result link (look for any link containing /skills/)
-    const skillLink = page.locator('a[href*="/skills/"]').first();
+    // Find first skill result link (anchored to the /skills/ prefix so
+    // docs URLs like /docs/concepts/skills/ don't substring-match)
+    const skillLink = page.locator('a[href^="/skills/"]').first();
 
     // Click if found
     const isVisible = await skillLink.isVisible({ timeout: 2000 }).catch(() => false);


### PR DESCRIPTION
Backlog Zero Wave 1 — epic: tonsofskills docs follow-ups. Single commit.

## What

`generate-unified-search.mjs` indexed only `type:'plugin'` and `type:'skill'`. It now runs a third pass over `marketplace/src/content/docs/**/*.md` (24 pages) and emits `type:'docs'` entries:

- **title** from frontmatter → `name`; **description** from frontmatter; `category` = the docs `section` (concepts / guides / reference / ecosystem / getting-started); frontmatter `keywords` carried through
- **url** = `/docs/<slug>/`, where the slug mirrors the Astro content-collection routing in `src/pages/docs/[...slug].astro` (path relative to the collection root minus `.md`)
- `stats.totalDocs` added; `stats.totalItems` now includes docs; `stats.categories` deliberately stays plugin/skill-only so the category dropdown and the "N categories" marketing copy do not absorb docs sections

## Consumer wiring

`/explore` (the unified-search UI) filters by `item.type`, so without handling, docs entries would never render. Added:

- a **Docs** toggle button in the type filter row
- `'docs'` accepted in the `?type=` URL-param whitelist
- `renderCard` support: docs cards link to their page, drop the install-command line (docs are pages, not installables), and show a `Docs · <section>` meta line

Fuse.js keys (`name`, `description`, `category`, `keywords`, `searchText`) already cover the docs fields, so fuzzy search picks them up with no config change.

## Verification

- Generator run: 448 plugins / 3008 skills / **24 docs** = 3480 items; sample entry checked (`docs/concepts/agents` → `/docs/concepts/agents/`)
- `cd marketplace && npm run build` — pass, 4217 pages
- `node scripts/lint-design-tells.mjs` — pass

[skip auto-bump]

- Jeremy Longshore
intentsolutions.io