### PR TITLE
fix(validator): recognize kebab/snake MCP server names in the body-vs-allowlist check

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,59 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.15.1] — 2026-07-02 — Body-vs-allowlist regex recognizes kebab/snake MCP server names (spec-compliance bug fix, issue #843)
+
+**Bug fix — no change to `ALWAYS_REQUIRED`, the tier model, or error-vs-warning
+semantics.** Autonomous-OK class per NON-NEGOTIABLE #6 (spec-compliance
+technical-correctness fix); PR gated for review per the Backlog Zero campaign
+governance rule (validator changes wait for Jeremy).
+
+### Fixed
+
+- **`_RE_MCP_FQ` (the #843 body-vs-allowlist scanner) now matches MCP server
+  names containing hyphens or underscores.** The old pattern
+  `mcp__[a-zA-Z0-9]+__[a-zA-Z0-9_]+` only accepted a bare-alnum server segment,
+  so real-world fully-qualified refs like `mcp__semantic-scholar__paper_search`
+  (kebab) and `mcp__plugin_automate_kobiton__getApp` (snake) never matched at
+  all. A declared-and-used tool with such a server name was therefore invisible
+  to the body scan and falsely warned as *"declares MCP tool … but the body never
+  references it — over-declared privilege"*. New pattern:
+  `mcp__[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*__[a-zA-Z0-9_]+`.
+- **Separator-ambiguity choice (deliberate):** the server segment is alnum runs
+  joined by a SINGLE `-`/`_`, and each joiner must be followed by an alnum char —
+  so the segment can never swallow the `__` separator (whose second char is `_`,
+  not alnum). `mcp__a_b__c` parses as server `a_b` + tool `c`, deterministically.
+  The charset mirrors the existing `RE_MCP_TOOL_REF` (allowed-tools permission
+  form, which already accepted `mcp__database-explorer__query_database`) minus
+  its `^…$` anchors — `_RE_MCP_FQ` was the lone outlier. The tool segment is
+  unchanged (`[a-zA-Z0-9_]+`, underscores already allowed).
+
+### Tests
+
+Five regression tests added to the #843 section of
+`tests/test_validate_skills_schema_frontmatter.py`: kebab declared+used clean,
+snake declared+used clean, undeclared kebab body ref still a CHECK 1 error,
+over-declared kebab tool still warns, and the `mcp__a_b__c` separator guard.
+
+### Backward compatibility
+
+Non-breaking for correct agents: anything that passed at 3.15.0 with a truthful
+allowlist still passes at 3.15.1 with same or fewer warnings. Repo-wide
+marketplace run at landing (old vs new validator, same tree):
+
+- **−4 false over-declared warnings** — `mcp__dolt-mcp-vcs__{query,list_databases}`,
+  declared AND genuinely used in agent bodies, previously invisible to the scan.
+- **+2 previously-invisible TRUE-positive CHECK 3 errors** —
+  `plugins/community/sprint/agents/{nextjs-diagnostics-agent,ui-test-agent}.md`
+  reference `mcp__next-devtools__*` / `mcp__claude-in-chrome__*` in their bodies
+  while declaring zero `mcp__*` tools. These are genuine #843 defects (every
+  call runtime-blocked) that the old regex could not see — the check working
+  as designed, not a regression. Both files are pre-existing on `main` and
+  outside this PR's diff; no blocking CI lane runs a full-tree marketplace
+  pass, so no gate flips. Fix tracked as ordinary agent-file remediation.
+
+---
+
 ## [3.15.0] — 2026-07-01 — Enterprise body-section checks credit equivalent heading names (iel-62j fairness, additive)
 
 **Additive MINOR — no change to `ALWAYS_REQUIRED`, the tier model, or

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -178,7 +178,7 @@ except ImportError:
 #                       unchanged — only `## Capabilities` as a *heading* is credited
 #                       as an Overview synonym.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.15.0"
+SCHEMA_VERSION = "3.15.1"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -1900,8 +1900,13 @@ _MCP_VERB_PREFIXES = (
     "start",
     "stop",
 )
-# Fully-qualified MCP tool reference: mcp__<server>__<tool>
-_RE_MCP_FQ = re.compile(r"mcp__[a-zA-Z0-9]+__[a-zA-Z0-9_]+")
+# Fully-qualified MCP tool reference: mcp__<server>__<tool>.
+# The server segment accepts kebab/snake names (mcp__semantic-scholar__paper_search,
+# mcp__plugin_automate_kobiton__getApp): alnum runs joined by a SINGLE `-`/`_`.
+# Each joiner must be followed by an alnum char, so the segment can never swallow
+# the `__` separator (whose second char is `_`, not alnum) — deliberate
+# disambiguation. Charset mirrors RE_MCP_TOOL_REF, minus its ^…$ anchors.
+_RE_MCP_FQ = re.compile(r"mcp__[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*__[a-zA-Z0-9_]+")
 # Backtick-quoted verbCamelCase short names commonly tool-call-shaped.
 _RE_BACKTICK_VERB = re.compile(r"`([a-z][a-zA-Z0-9_]*)`")
 

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -261,6 +261,61 @@ def test_843_check2_shortname_mention_warns_not_errors():
     assert any("CHECK 2" in w and "reserveDevice" in w for w in warnings), warnings
 
 
+def test_843_kebab_server_name_declared_and_used_is_clean():
+    # Regression (schema 3.15.1): server segment with hyphens was invisible to
+    # _RE_MCP_FQ, so a declared-and-used tool falsely warned as over-declared.
+    errors, warnings = _body_check(
+        ["Read", "mcp__semantic-scholar__paper_search"],
+        "Call `mcp__semantic-scholar__paper_search` to find candidate papers.",
+    )
+    assert errors == [], errors
+    assert not any("over-declared" in w for w in warnings), warnings
+
+
+def test_843_snake_server_name_declared_and_used_is_clean():
+    # Regression (schema 3.15.1): underscores in the server segment collided
+    # with the `__` separator and the ref was never matched at all.
+    errors, warnings = _body_check(
+        ["Read", "mcp__plugin_automate_kobiton__getApp"],
+        "Fetch metadata with `mcp__plugin_automate_kobiton__getApp` first.",
+    )
+    assert errors == [], errors
+    assert not any("over-declared" in w for w in warnings), warnings
+
+
+def test_843_kebab_server_undeclared_body_ref_still_errors():
+    # True positive must survive the regex widening: an undeclared kebab-server
+    # FQ ref in the body is still a CHECK 1 error.
+    errors, _ = _body_check(
+        ["Read", "mcp__semantic-scholar__paper_search"],
+        "Then call `mcp__semantic-scholar__author_search` for the author list.",
+    )
+    assert any("CHECK 1" in e and "mcp__semantic-scholar__author_search" in e for e in errors), errors
+
+
+def test_843_overdeclared_kebab_server_tool_still_warns():
+    # True positive must survive: a declared kebab-server tool the body never
+    # references is still flagged as over-declared privilege.
+    errors, warnings = _body_check(
+        ["Read", "mcp__semantic-scholar__paper_search"],
+        "Summarize the papers already collected in the notes file.",
+    )
+    assert errors == []
+    assert any("over-declared" in w and "mcp__semantic-scholar__paper_search" in w for w in warnings), warnings
+
+
+def test_843_server_segment_cannot_swallow_separator():
+    # Separator-ambiguity guard: in mcp__a_b__c the server segment must stop
+    # at `a_b` (single-underscore joiner) and leave `__` as the separator, so
+    # the exact declared string matches and no over-declared warning fires.
+    errors, warnings = _body_check(
+        ["Read", "mcp__a_b__c"],
+        "Invoke `mcp__a_b__c` to run the check.",
+    )
+    assert errors == [], errors
+    assert not any("over-declared" in w for w in warnings), warnings
+
+
 def test_843_check2_suppressed_for_non_mcp_agent():
     # A code-focused agent with no MCP involvement: backtick `getStaticProps`
     # is prose, not a tool call — must not warn (the known-FP guard).


### PR DESCRIPTION
**GOVERNANCE: validator change — awaiting Jeremy review, do not auto-merge**

`[skip auto-bump]`

Refs jeremylongshore/claude-code-plugins-plus-skills#941

## Defect

`_RE_MCP_FQ` (scripts/validate-skills-schema.py, the #843 body-vs-allowlist scanner) was `mcp__[a-zA-Z0-9]+__[a-zA-Z0-9_]+` — a bare-alnum server segment. Real MCP server names containing hyphens or underscores (`mcp__semantic-scholar__paper_search`, `mcp__plugin_automate_kobiton__getApp`) never matched at all, so:

- declared-and-used tools with such server names were invisible to the body scan and **falsely warned as over-declared privilege**;
- undeclared body refs with such server names **escaped CHECK 1/3 entirely**.

## Fix

```
mcp__[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*__[a-zA-Z0-9_]+
```

**Separator-ambiguity choice (deliberate):** the server segment is alnum runs joined by a SINGLE `-`/`_`; each joiner must be followed by an alnum char, so the segment can never swallow the `__` separator (whose second char is `_`, not alnum). `mcp__a_b__c` parses deterministically as server `a_b` + tool `c`. The charset mirrors the sibling `RE_MCP_TOOL_REF` (allowed-tools permission form, which already accepted kebab/snake) minus its `^…$` anchors — `_RE_MCP_FQ` was the lone outlier. Tool segment unchanged (`[a-zA-Z0-9_]+`).

`SCHEMA_VERSION` 3.15.0 → 3.15.1 + SCHEMA_CHANGELOG entry. Bug fix — autonomous-OK class per NON-NEGOTIABLE #6 (spec-compliance technical correctness); PR gated for review per campaign governance rule. No change to `ALWAYS_REQUIRED`, the tier model, or error-vs-warning semantics.

## Test evidence

5 regression cases added to the existing #843 section of `tests/test_validate_skills_schema_frontmatter.py`:

- kebab server declared + used → clean (was: false over-declared warning)
- snake server declared + used → clean (was: invisible)
- undeclared kebab body ref → still a CHECK 1 error (true positive survives)
- over-declared kebab tool never referenced → still warns (true positive survives)
- `mcp__a_b__c` separator guard → exact-string match, no ambiguity

31/31 pass in the file; 54/54 across all validator test suites.

## Warning delta (repo-wide `--marketplace`, old vs new validator, same tree)

- **Warnings 35,122 → 35,118 (−4):** all four were false over-declared warnings on `mcp__dolt-mcp-vcs__{query,list_databases}` — declared AND genuinely used.
- **Errors 8,752 → 8,754 (+2):** previously-invisible TRUE-positive CHECK 3 errors on `plugins/community/sprint/agents/{nextjs-diagnostics-agent,ui-test-agent}.md`, whose bodies reference `mcp__next-devtools__*` / `mcp__claude-in-chrome__*` while declaring zero `mcp__*` tools. Genuine #843 defects the old regex could not see — the check working as designed, not a regression. Both files pre-exist on `main`, are outside this diff, and no blocking CI lane runs a full-tree marketplace pass, so no gate flips.

- Jeremy Longshore
intentsolutions.io