### PR TITLE
test(marketplace): de-flake the production search specs with deterministic data-ready waits

### DIFF
--- a/marketplace/tests/production/P2-search-flow.spec.ts
+++ b/marketplace/tests/production/P2-search-flow.spec.ts
@@ -49,8 +49,11 @@ test.describe('P2: Search Flow', () => {
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('prettier');
 
-    // Should have at least one result card visible
-    const resultCards = page.locator('a[href*="/plugins/"], a[href*="/skills/"]');
+    // Should have at least one result card visible — scoped to the results
+    // grid so the (mobile-hidden) header nav links can never satisfy this
+    const resultCards = page
+      .locator('#results-grid')
+      .locator('a[href*="/plugins/"], a[href*="/skills/"]');
     await expect(resultCards.first()).toBeVisible({ timeout: 10_000 });
     await expect.poll(() => resultCards.count(), { timeout: 10_000 }).toBeGreaterThan(0);
 
@@ -65,7 +68,11 @@ test.describe('P2: Search Flow', () => {
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('genkit');
 
-    const resultCards = page.locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]');
+    // Scoped to the results grid so the (mobile-hidden) header nav /cowork
+    // link can never satisfy this
+    const resultCards = page
+      .locator('#results-grid')
+      .locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]');
     await expect(resultCards.first()).toBeVisible({ timeout: 10_000 });
     await expect.poll(() => resultCards.count(), { timeout: 10_000 }).toBeGreaterThan(0);
 
@@ -92,7 +99,12 @@ test.describe('P2: Search Flow', () => {
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('security');
 
-    const firstResult = page.locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]').first();
+    // Scoped to the results grid so the (mobile-hidden) header nav /cowork
+    // link can never satisfy this
+    const firstResult = page
+      .locator('#results-grid')
+      .locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]')
+      .first();
     await expect(firstResult).toBeVisible({ timeout: 10_000 });
 
     // Secondary signal: the client-side render updated the results counter

--- a/marketplace/tests/production/P2-search-flow.spec.ts
+++ b/marketplace/tests/production/P2-search-flow.spec.ts
@@ -1,8 +1,21 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * P2: Search Flow — Tests search from homepage through explore page results
  */
+
+/**
+ * The explore page loads fuse.js from jsdelivr (top-level ESM import) and
+ * fetches the ~2.9MB /data/unified-search-index.json before any result can
+ * render (measured 1.4–3.5s against production). When the index is ready the
+ * page sets #results-grid aria-busy="false" and removes #explore-loading —
+ * wait on that deterministic signal instead of sleeping.
+ */
+async function waitForSearchIndex(page: Page): Promise<void> {
+  await page.locator('#results-grid[aria-busy="false"]').waitFor({ timeout: 20_000 });
+}
+
+const RESULTS_INFO_PATTERN = /Showing \d+ of \d+/;
 
 test.describe('P2: Search Flow', () => {
   test('Homepage search redirects to /explore on click', async ({ page }) => {
@@ -31,59 +44,67 @@ test.describe('P2: Search Flow', () => {
 
   test('Search returns results for known plugin', async ({ page }) => {
     await page.goto('/explore');
+    await waitForSearchIndex(page);
 
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('prettier');
-    await page.waitForTimeout(600);
 
     // Should have at least one result card visible
     const resultCards = page.locator('a[href*="/plugins/"], a[href*="/skills/"]');
-    const count = await resultCards.count();
-    expect(count).toBeGreaterThan(0);
+    await expect(resultCards.first()).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => resultCards.count(), { timeout: 10_000 }).toBeGreaterThan(0);
+
+    // Secondary signal: the client-side render updated the results counter
+    await expect(page.locator('#results-info')).toHaveText(RESULTS_INFO_PATTERN);
   });
 
   test('Search returns results for known skill', async ({ page }) => {
     await page.goto('/explore');
+    await waitForSearchIndex(page);
 
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('genkit');
-    await page.waitForTimeout(600);
 
     const resultCards = page.locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]');
-    const count = await resultCards.count();
-    expect(count).toBeGreaterThan(0);
+    await expect(resultCards.first()).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => resultCards.count(), { timeout: 10_000 }).toBeGreaterThan(0);
+
+    // Secondary signal: the client-side render updated the results counter
+    await expect(page.locator('#results-info')).toHaveText(RESULTS_INFO_PATTERN);
   });
 
   test('Empty search query shows no-results state gracefully', async ({ page }) => {
     await page.goto('/explore');
+    await waitForSearchIndex(page);
 
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('xyznonexistent999zzz');
-    await page.waitForTimeout(600);
 
-    // Page should not crash
+    // Page should not crash — the results counter still renders
+    await expect(page.locator('#results-info')).toHaveText(RESULTS_INFO_PATTERN);
     await expect(page).toHaveTitle(/Explore/);
   });
 
   test('Search results link to valid pages', async ({ page }) => {
     await page.goto('/explore');
+    await waitForSearchIndex(page);
 
     const searchInput = page.locator('.hero-search-input').first();
     await searchInput.fill('security');
-    await page.waitForTimeout(600);
 
     const firstResult = page.locator('a[href*="/plugins/"], a[href*="/skills/"], a[href*="/cowork"]').first();
-    const isVisible = await firstResult.isVisible().catch(() => false);
+    await expect(firstResult).toBeVisible({ timeout: 10_000 });
 
-    if (isVisible) {
-      const href = await firstResult.getAttribute('href');
-      expect(href).toBeTruthy();
+    // Secondary signal: the client-side render updated the results counter
+    await expect(page.locator('#results-info')).toHaveText(RESULTS_INFO_PATTERN);
 
-      await firstResult.click();
-      const response = await page.waitForLoadState('networkidle');
-      // Should land on a valid page (not 404)
-      const title = await page.title();
-      expect(title).not.toContain('404');
-    }
+    const href = await firstResult.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    await firstResult.click();
+    await page.waitForLoadState('networkidle');
+    // Should land on a valid page (not 404)
+    const title = await page.title();
+    expect(title).not.toContain('404');
   });
 });

--- a/marketplace/tests/production/P5-cowork-downloads.spec.ts
+++ b/marketplace/tests/production/P5-cowork-downloads.spec.ts
@@ -53,11 +53,12 @@ test.describe('P5: Cowork Downloads', () => {
     }
 
     await searchInput.fill('security');
-    await page.waitForTimeout(400);
 
+    // The count label reads "Showing all N plugins" until the filter runs,
+    // then "Showing X of N plugins" — assert the filtered form with a
+    // retrying web-first assertion instead of a fixed sleep.
     const countLabel = page.locator('#plugin-count');
-    const text = await countLabel.textContent();
-    expect(text).toContain('Showing');
+    await expect(countLabel).toContainText(/Showing \d+ of \d+ plugins/);
   });
 
   test('Setup guide has 4 steps', async ({ page }) => {


### PR DESCRIPTION
## The race

The P2 search-flow count-based production tests did `goto('/explore')` → `fill` → `waitForTimeout(600)` → one-shot `count()`. Before any result card can render, the explore page must (a) resolve the top-level jsdelivr `fuse.js` ESM import and (b) fetch the ~2.9MB `/data/unified-search-index.json` — measured at **1.4–3.5s** against production. A fixed 600ms sleep loses that race routinely, so the counts came back 0 and the specs flaked.

## What replaced the sleep

- **Deterministic data-ready wait before interacting**: the page flips `#results-grid` to `aria-busy="false"` (and removes `#explore-loading`) once the index is fetched and Fuse is built. Tests now wait on `locator('#results-grid[aria-busy="false"]').waitFor({ timeout: 20_000 })` — verified those hooks in `marketplace/src/pages/explore.astro` (lines 438–473).
- **Web-first retrying assertions** instead of sleep + one-shot count: `expect(resultCards.first()).toBeVisible({ timeout: 10_000 })` plus `expect.poll(() => resultCards.count()).toBeGreaterThan(0)`.
- **Secondary signal**: every fixed test also asserts `#results-info` matches `/Showing \d+ of \d+/`, proving the client-side render actually ran (`applyFilters()` unconditionally updates it).

## Scope

- All three count-based P2 tests fixed: *known plugin*, *known skill*, *results link to valid pages* — plus the empty-query test, which shared the identical sleep. *Results link to valid pages* also drops its silent `isVisible().catch(() => false)` escape hatch: with a deterministic data-ready wait, `security` always yields a visible result, so the test asserts it outright.
- `P5-cowork-downloads` *Plugin search filter works* had the trivially identical pattern (`fill` → `waitForTimeout(400)` → one-shot `textContent`) and now uses a retrying `toContainText(/Showing \d+ of \d+ plugins/)` — which additionally stops vacuously matching the pre-filter "Showing all N plugins" server-rendered text. No other production spec uses `waitForTimeout`.
- Test-code-only change; test intent unchanged.

## Verification (against live tonsofskills.com, CI config)

- Full production suite: `npx playwright test --config=playwright.production.config.ts` → **66/66 passed**.
- The two changed specs: **3 consecutive runs with `--retries=0`, 12/12 each** (plus a 4th post-commit confirmation run).

[skip auto-bump]

Refs jeremylongshore/claude-code-plugins-plus-skills#941

- Jeremy Longshore
intentsolutions.io