### PR TITLE
chore(reviewers): sources.yaml-is-a-pointer rule + note to automated reviewers (review to our specs, not web searches)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,10 +1,17 @@
 {
   "strictness": 3,
-  "commentTypes": ["logic", "syntax"],
+  "commentTypes": [
+    "logic",
+    "syntax"
+  ],
   "triggerOnUpdates": true,
   "fixWithAI": true,
-  "confidenceScoreSection": { "included": true },
-  "sequenceDiagramSection": { "included": true },
+  "confidenceScoreSection": {
+    "included": true
+  },
+  "sequenceDiagramSection": {
+    "included": true
+  },
   "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\npnpm-lock.yaml\npackage-lock.json\n*.min.js\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite",
   "rules": [
     {
@@ -15,13 +22,20 @@
     {
       "id": "marketplace-json-is-generated",
       "severity": "high",
-      "scope": [".claude-plugin/marketplace.json", "**/package.json", "README.md"],
+      "scope": [
+        ".claude-plugin/marketplace.json",
+        "**/package.json",
+        "README.md"
+      ],
       "rule": "`.claude-plugin/marketplace.json` is AUTO-GENERATED from `.claude-plugin/marketplace.extended.json` by `pnpm run sync-marketplace`; the same step regenerates plugin package.json files and the README AUTO-TOC block. Never hand-edit a generated file. A diff that edits marketplace.json directly (without the corresponding marketplace.extended.json change) is a bug — CI's drift gate rejects it."
     },
     {
       "id": "required-fields-authoritative",
       "severity": "high",
-      "scope": ["scripts/validate-skills-schema.py", "000-docs/SCHEMA_CHANGELOG.md"],
+      "scope": [
+        "scripts/validate-skills-schema.py",
+        "000-docs/SCHEMA_CHANGELOG.md"
+      ],
       "rule": "The IS 8-field ALWAYS_REQUIRED set (name, description, allowed-tools, version, author, license, compatibility, tags) is authoritative; at marketplace tier a missing required field is an ERROR, not a warning. Do not suggest reducing the required set, demoting marketplace errors to warnings, or realigning to Anthropic's permissive floor. Changes to required-fields / tier model / error-vs-warning semantics are approval-gated (see SCHEMA_CHANGELOG NON-NEGOTIABLES)."
     },
     {
@@ -32,7 +46,11 @@
     {
       "id": "agent-vs-skill-tool-fields",
       "severity": "medium",
-      "scope": ["plugins/**/agents/*.md", "plugins/**/skills/**/SKILL.md", "agents/*.md"],
+      "scope": [
+        "plugins/**/agents/*.md",
+        "plugins/**/skills/**/SKILL.md",
+        "agents/*.md"
+      ],
       "rule": "Agents use `tools` (allowlist) + `disallowedTools` (camelCase denylist); skills use `allowed-tools` (kebab allowlist) + optional `disallowed-tools` (kebab denylist). Flag camelCase `disallowedTools` on a skill or kebab `disallowed-tools` on an agent — the validator rejects the mismatch. Authored agents are kernel-strict; banned fields (capabilities, expertise_level, activation_priority, type, category, compatible-with, when_to_use) are errors. An agent body invoking an `mcp__server__tool` not in its `tools` allowlist is an error."
     },
     {
@@ -48,7 +66,9 @@
     {
       "id": "marketplace-design-and-build-invariants",
       "severity": "medium",
-      "scope": ["marketplace/**"],
+      "scope": [
+        "marketplace/**"
+      ],
       "rule": "Marketplace CSS uses OKLCH colors only — never hex/rgb (marketplace/DESIGN.md). Reject gradients on cards, glassmorphism, drop-shadow stacks, hover:scale on whole cards. `compressHTML` stays disabled in astro.config.mjs (iOS Safari fails on lines > 5000 chars; CI-enforced). Respect the performance budgets (40MB gzipped, 1MB largest file, 2800-4000 routes)."
     },
     {
@@ -60,6 +80,14 @@
       "id": "no-generated-artifacts-committed",
       "severity": "medium",
       "rule": "Do not commit generated artifacts: marketplace/public/downloads/ (gitignored, rebuilt in CI from the catalog), marketplace/dist/, or the derived .claude-plugin/marketplace.json. CI rebuilds these from source; committing them leaks local state to prod."
+    },
+    {
+      "id": "sources-yaml-is-a-pointer",
+      "severity": "medium",
+      "scope": [
+        "sources.yaml"
+      ],
+      "rule": "A sources.yaml entry is a POINTER to an external repo, not the plugin itself, and it is validated at SYNC time, not PR time: the weekly sync-external.mjs --strict clones the upstream and runs scripts/validate-skills-schema.py before mirroring into plugins/community/. When reviewing a sources.yaml diff, check the ENTRY schema (name, description, repo, source_path, target_path, include/exclude, license, category) against the established format. Do NOT assert whether the upstream repo exists, is reachable, or has valid frontmatter based on a web search: repo existence is time-sensitive and non-deterministic at review time (a repo can be created minutes later), and the --strict clone plus validate-skills-schema.py are the deterministic gates. If you flag upstream risk, phrase it as 'the sync will verify this at clone time', never 'the repo does not exist'."
     }
   ]
 }

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -30,3 +30,10 @@ This repo is the **Tons of Skills** marketplace for Claude Code plugins and skil
 ## Related repos (multi-repo context)
 
 This repo depends on **`@intentsolutions/core`** (the authoring-schema kernel SSoT — a separate package/repo) and deploys to tonsofskills.com via the **intentsolutions-vps-runbook** repo. Greptile's current config schema does not expose a multi-repo `patternRepositories` key, so these are noted here for reviewer context rather than wired into `config.json`.
+
+## Reviewing a `sources.yaml` entry
+
+A `sources.yaml` entry is a **pointer** to an external repo, not the plugin, and it is validated at **sync time, not PR time**: the weekly `sync-external.mjs --strict` clones the upstream and runs it through `scripts/validate-skills-schema.py` before mirroring into `plugins/community/`.
+
+- **Review the entry's schema** (`name`, `description`, `repo`, `source_path`, `target_path`, `include`/`exclude`, `license`, `category`) against the established format.
+- **Do NOT assert whether the upstream repo exists, is reachable, or has valid frontmatter from a web search.** Repo existence is time-sensitive (a repo can be created minutes after review) and non-deterministic; the `--strict` clone and `validate-skills-schema.py` are the real gates. If you flag upstream risk, say "the sync will verify this at clone time," not "the repo does not exist."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,15 @@ The decision record for this model is `000-docs/694-AT-DECR`; the earlier shared
 
 <!-- BEGIN BEADS INTEGRATION -->
 
+## Note to automated PR reviewers
+
+If you are an AI PR reviewer (Codex, Greptile, or similar), review against **this repo's specs**, not general priors or a web search:
+
+- **The deterministic gate is `scripts/validate-skills-schema.py`** plus the required CI checks. Ground any skill / plugin / agent frontmatter finding in the validator and `000-docs/SCHEMA_CHANGELOG.md` (the 8-field `ALWAYS_REQUIRED` set; at marketplace tier a missing required field is an ERROR, not a warning). If the validator would accept it, do not invent a frontmatter objection.
+- **A `sources.yaml` entry is a pointer**, validated at weekly-sync time by `sync-external.mjs --strict` plus the validator, not at PR time. Do **not** assert whether an upstream repo exists, is reachable, or has valid frontmatter from a web search; repo existence is time-sensitive and non-deterministic at review time. Phrase any upstream risk as "the sync will verify at clone time," never "the repo does not exist."
+- **Defer style** (naming, formatting, import order) to eslint / prettier / ruff / markdownlint / shellcheck. Prioritize correctness, security, and gate integrity.
+- **Never suggest weakening a gate** (a threshold, test, assertion, security check, or required field) unless the same PR replaces it with a stronger equivalent. See `CLAUDE.md` and `.greptile/rules.md`.
+
 ## Issue Tracking with bd (beads)
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.


### PR DESCRIPTION
## What

Teaches the Greptile reviewer how to review a `sources.yaml` entry: it is a **pointer** to an external repo, validated at **sync time** (not PR time) by `sync-external.mjs --strict` + `scripts/validate-skills-schema.py`.

Adds one rule to `.greptile/config.json` (`sources-yaml-is-a-pointer`) and a matching section to `.greptile/rules.md`.

## Why

On #960 the reviewer fired a stale, web-search-based **"the upstream repo does not exist"** review on a repo that was in fact public (`walkie-talkie-skill/walkie-talkie`, HTTP 200). Repo existence is time-sensitive and non-deterministic at review time. The deterministic gate is the weekly `--strict` clone and the validator, which run when the source is actually mirrored.

The rule tells the reviewer to:
- check the **entry schema** (name / description / repo / source_path / target_path / include-exclude / license / category), and
- **not** assert upstream existence / reachability / frontmatter validity from a web search. If flagging upstream risk, phrase it as "the sync will verify at clone time."

## Notes
- Config-only change; no behavior change to CI or the sync.
- Codex's review cadence is a ChatGPT-cloud setting (not in-repo), so it is out of scope here.
