### PR TITLE
ci: fix release.yml dead-script calls + stop catalog-data churn triggering E2E

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,10 @@ on:
       - 'marketplace/src/styles/**'
       - 'marketplace/src/scripts/**'
       - 'marketplace/public/**'
+      # Regenerated catalog data (JSON) is not a UI change — excluding it stops
+      # every plugin PR (which touches this dir via sync-marketplace) from
+      # triggering the ~14-min Playwright E2E. Honors this workflow's own policy.
+      - '!marketplace/public/data/**'
       - 'marketplace/astro.config.mjs'
       - 'marketplace/playwright.config.ts'
       - 'marketplace/playwright.production.config.ts'
@@ -40,6 +44,10 @@ on:
       - 'marketplace/src/styles/**'
       - 'marketplace/src/scripts/**'
       - 'marketplace/public/**'
+      # Regenerated catalog data (JSON) is not a UI change — excluding it stops
+      # every plugin PR (which touches this dir via sync-marketplace) from
+      # triggering the ~14-min Playwright E2E. Honors this workflow's own policy.
+      - '!marketplace/public/data/**'
       - 'marketplace/astro.config.mjs'
       - 'marketplace/playwright.config.ts'
       - 'marketplace/playwright.production.config.ts'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,14 @@ jobs:
       - name: Run validation tests
         if: ${{ !inputs.skip_tests }}
         run: |
-          echo "Running plugin validation..."
-          chmod +x scripts/*.sh scripts/*.py
-          ./scripts/validate-all.sh plugins
-
-          echo "Testing git-commit-smart installation..."
-          ./scripts/test-installation.sh plugins/devops/git-commit-smart
+          # scripts/validate-all.sh + test-installation.sh were removed; the full
+          # gate now runs in CI (the ci-required aggregate on every PR + on push
+          # to main, which is where releases are cut from). This step re-runs the
+          # two deterministic, self-contained validators as a release smoke check.
+          echo "Running plugin schema validation (standard tier)…"
+          python3 scripts/validate-skills-schema.py --standard
+          echo "Validating catalog invariants…"
+          python3 scripts/validate-catalog-invariants.py
 
       - name: Get current version
         id: current_version


### PR DESCRIPTION
Two independent CI-wiring fixes (Stage 2 of the CI/CD repair).

## `release.yml` — dead script calls
The "Run validation tests" step called `scripts/validate-all.sh` and `scripts/test-installation.sh`, **both deleted** — a real release run would fail there. Replaced with the two self-contained validators that still exist:
- `validate-skills-schema.py --standard`
- `validate-catalog-invariants.py`

as a release smoke check. The full gate already runs in CI (the `ci-required` aggregate on every PR **and** on push to main, which is where releases are cut).

## `e2e-tests.yml` — catalog-data churn
Added `- '!marketplace/public/data/**'` under **both** the `push` and `pull_request` `paths:` filters. Regenerated catalog JSON (written by `sync-marketplace` on nearly every plugin PR) is not a UI change, yet it was triggering the ~14-min Playwright E2E on plugin PRs. This honors the workflow's own stated policy (run on UI changes).

Validated: `actionlint` clean, YAML parses. First PR under the new 2-context required gate (`ci-required` + `gitleaks`).