### PR TITLE
ci: fix fork-PR event wiring (plane-sync close-out, auto-bump note, scoped CodeQL PR)

### DIFF
--- a/.github/workflows/auto-bump-on-pr.yml
+++ b/.github/workflows/auto-bump-on-pr.yml
@@ -28,6 +28,15 @@ name: Auto-bump changed plugin patch versions
 #   - PR head branch starts with `automation/` (avoids self-bumping the
 #     automation/npm-stats and similar generated PRs).
 #   - PR title or body contains `[skip auto-bump]`.
+#
+# Runs on `pull_request` (NOT pull_request_target) BY DESIGN: the bump needs a
+# write token to commit back to the PR branch, and pull_request_target would hand
+# that token to fork-PR code — a code-execution-with-secrets risk not worth a
+# patch bump. The accepted cost is that a first-time fork contributor's run sits
+# in the "Approve and run" queue until a maintainer approves it; since the job
+# skips forks anyway (first skip condition above), approving it just lets it
+# no-op cleanly. Fixing the queue entry would require raising the CI blast
+# radius, so it stays.
 
 on:
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,17 @@ name: "CodeQL Security Analysis"
 on:
   push:
     branches: [ "main" ]
-  # pull_request trigger removed 2026-05-16 — was firing false-positive alerts on PRs
-  # for code that's documented as known-safe (release/, scripts/). Coverage on main
-  # is preserved via the push trigger; PRs merging to main get scanned at merge time.
-  # Closes #652.
+  # pull_request re-added 2026-07 but SCOPED to first-party app/library code only.
+  # The 2026-05-16 disable (#652) was because CodeQL fired false positives on PRs
+  # for release/ + scripts/ (documented known-safe). Those dirs are outside this
+  # scope, and plugin PRs (plugins/**) don't match either — so this adds no fan-out
+  # to plugin PRs while restoring real PR-time coverage of the code CodeQL is good
+  # at. Advisory only — never a required status check.
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'packages/**'
+      - 'marketplace/src/**'
   # schedule disabled — burns Actions minutes
   # - cron: '0 6 * * 1'
 

--- a/.github/workflows/plane-sync.yml
+++ b/.github/workflows/plane-sync.yml
@@ -3,7 +3,13 @@ name: Plane Sync (quiet mode)
 on:
   issues:
     types: [opened]
-  pull_request:
+  # pull_request_target (not pull_request) so the close-out fires with repo
+  # secrets on FORK PRs too — fork pull_request runs get no PLANE_API_KEY, so the
+  # Plane issue never flipped Done when a fork PR merged. SAFE here ONLY because
+  # no job below checks out or executes PR code: they read the PR title/body from
+  # the event context into quoted env vars and curl to Plane. NEVER add an
+  # `actions/checkout` of the PR head to this workflow.
+  pull_request_target:
     types: [closed]
 
 env:
@@ -51,7 +57,7 @@ jobs:
           echo "::notice::created $PLANE_IDENTIFIER-${SEQ:-?} from GH issue #${{ github.event.issue.number }}"
 
   pr-closes-plane-issue:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Parse closing references


### PR DESCRIPTION
Stage 2 of the CI/CD repair — three fork-PR / event-wiring fixes.

## `plane-sync.yml` — close-out never fired on fork PRs
The `pr-closes-plane-issue` job triggered on `pull_request`, so a **fork** PR's merge ran without repo secrets (no `PLANE_API_KEY`) → the Plane issue never flipped Done. Switched to **`pull_request_target`** (base-repo context, has secrets) and updated the job `if:` to `github.event_name == 'pull_request_target'`.

**Safe** only because no job here checks out or executes PR code — they read the PR title/body from the event context into quoted env vars and `curl` to Plane. Added a header comment forbidding an `actions/checkout` of the PR head in this workflow.

## `auto-bump-on-pr.yml` — documented the fork approval-queue tradeoff
Kept on `pull_request` (not `pull_request_target`) **by design**: the bump needs a write token to commit back, and `pull_request_target` would grant that to fork code (code-exec-with-secrets). Accepted cost: a first-time fork contributor's run sits in the "Approve and run" queue; the job skips forks anyway, so approving it just no-ops. Documented in the header.

## `codeql.yml` — restored a *scoped* PR trigger
Re-added `pull_request` scoped to `packages/**` + `marketplace/src/**`. The 2026-05-16 disable (#652) was over false positives in `release/` + `scripts/` — outside this scope, and plugin PRs (`plugins/**`) don't match, so **no fan-out to plugin PRs**. Advisory, never a required check.

`actionlint` clean on all three.