### PR TITLE
ci: surface agent-frontmatter + .mcp.json findings on every PR (new pinned-validator invocations)

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -54,6 +54,23 @@ jobs:
       - name: Enforce CI deadlines (no report-only rot)
         run: python3 scripts/check-ci-deadlines.py
 
+      # Agent-frontmatter validation — surfaces agent.md schema findings on every
+      # PR (previously ungated). REPORT-ONLY for now: the agent corpus is
+      # unbaselined (currently has pre-existing errors), so this reports without
+      # walling merges; flip to a blocking gate once the corpus is curated.
+      # REPORT-ONLY-UNTIL: 2026-10-31 (agent corpus unbaselined; flip to blocking once curated)
+      - name: Validate agent frontmatter (report-only)
+        run: |
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml || true
+          python3 scripts/validate-skills-schema.py --agents-only || true
+
+      # .mcp.json advisory validation — surfaces MCP-config findings on every PR.
+      # (kernel-shadow-validation runs this same validator, but only when the
+      # validator itself changes.) ADVISORY ONLY — never pass --strict here; the
+      # promotion to a blocking gate is the DR-049 soak checklist's call.
+      - name: Validate .mcp.json configs (advisory)
+        run: node scripts/validate-mcp-config.mjs || true
+
       # Design-tell gate (VibeCheck 25/100 regression guard, 2026-05-31).
       # Fails on chrome gradients, glassmorphism, purple/indigo/violet
       # utilities, or em-dash density >12 in visible chrome.


### PR DESCRIPTION
Stage 2 of the CI/CD repair — adds two previously-ungated surfaces to the `validate` job. Both are **new invocations of the already-pinned validators**; no validator logic is touched (kernel discipline preserved).

## Agents — `validate-skills-schema.py --agents-only` (report-only)
Agent `.md` frontmatter had no real gate. Now runs on every PR, **REPORT-ONLY**: `|| true` plus a tracked `# REPORT-ONLY-UNTIL: 2026-10-31` marker (enforced by `check-ci-deadlines.py`, verified 116 days out). The corpus is unbaselined (3 pre-existing errors today), so it reports without walling merges — flip to blocking once curated. A lightweight `import yaml` guard installs pyyaml only if the runner lacks it (the validate job has no `setup-python`).

## MCP — `validate-mcp-config.mjs` (advisory)
`.mcp.json` findings now surface on every PR. **ADVISORY ONLY** — never `--strict` here; promotion to a blocking gate is the DR-049 soak checklist's call. `ajv`/`ajv-formats` are root deps the validate job's install already provides. `kernel-shadow-validation` runs the same validator, but only when the validator itself changes — this makes findings visible on every PR.

`actionlint` clean; `check-ci-deadlines.py` green; YAML parses.