### PR TITLE
chore(reviewers): disable Gemini Code Assist — Greptile is the single AI reviewer

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,17 +1,21 @@
 # Gemini Code Assist GitHub App configuration.
 # https://developers.google.com/gemini-code-assist/docs/customize-review-github
 #
-# 2026-06-25: re-enabled. Greptile (the 2026-06-23 replacement) is paused after
-# exhausting its 50-review/month quota, so Gemini Code Assist is the active AI
-# reviewer again. `comment_severity_threshold: HIGH` is kept to hold down the
-# review noise that originally motivated disabling it — only HIGH-severity
-# findings are posted; the deterministic CI checks remain the merge gate.
+# 2026-07: DISABLED. Greptile is the single repo-controlled AI reviewer; running
+# Gemini alongside it gave contributors up to two overlapping bot reviews. The
+# consumer version of Gemini Code Assist is also being sunset (all review activity
+# ceases 2026-07-17), so this is retired ahead of that. The deterministic CI
+# checks (the ci-required aggregate + gitleaks) remain the authoritative gate.
+#
+# NOTE: setting `disable: true` here stops config-driven reviews, but fully
+# removing Gemini requires UNINSTALLING the Gemini Code Assist GitHub App from the
+# org (a UI/admin action — deleting in-repo config does not uninstall an App).
 #
 # This is NOT the same as the run-gemini-cli action (which used to live in
 # .github/workflows/gemini-code-review.yml and was deleted in PR #721).
 
 have_fun: false
 code_review:
-  disable: false
+  disable: true
   comment_severity_threshold: HIGH
   pull_opened_summary: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ Run `./scripts/quick-test.sh` locally to catch most issues before pushing.
 ### What happens when you open the PR
 
 1. GitHub runs all 15+ validators (`validate-plugins.yml`). **These required checks are the gate** — your PR is mergeable once they're green.
-2. An AI reviewer posts inline comments when it's active on the PR. Treat its findings like any review: address them, or reply if you think it got something wrong and a human will weigh in.
+2. **Greptile** (the repo's AI reviewer) posts inline comments. Treat its findings like any review: address them, or reply if you think it got something wrong and a human will weigh in. If you've installed your own Codex connector on your fork it may also comment — that's contributor-side, not repo-controlled, so maintainers don't act on it.
 3. A maintainer gets a Slack ping and follows up.
 4. Push fixes; the required checks re-run on each push.
 5. Once the required checks pass and any review threads are resolved, a maintainer reviews and merges.


### PR DESCRIPTION
Stage 3 of the CI/CD repair (decision: **Greptile-only**).

- `.gemini/config.yaml`: `code_review.disable: true`. Stops contributors getting two overlapping bot reviews (Greptile + Gemini). Gemini's consumer review product is being sunset (activity ceases **2026-07-17**), so this retires it ahead of that.
- `CONTRIBUTING.md`: names **Greptile** as the repo's AI reviewer and clarifies that a contributor's own **Codex** connector (if installed on their fork) is contributor-side / not repo-controlled — maintainers don't act on it.

## ⚠️ Two operational heads-ups (belt-and-suspenders)

1. **Fully removing Gemini is a UI/admin action.** Deleting/flipping in-repo config does **not** uninstall a GitHub App — please **uninstall the Gemini Code Assist App** from `jeremylongshore` + `intent-solutions-io` to stop it entirely. Until then a stray `gemini-code-assist[bot]` thread may still appear on older PRs. Noted in the config header too.
2. **Confirm Greptile's quota/subscription is active.** The prior config note (2026-06-25) said Gemini was re-enabled *because Greptile had exhausted its 50-review/month quota*. With Gemini off, if Greptile is quota-paused, PRs get **no** AI review until it resets. The deterministic CI gate (`ci-required` + `gitleaks`) still holds regardless, but worth confirming Greptile is live so the AI-review layer isn't silently gone.