### PR TITLE
test(ci): VERIFY — stuck-class repro (non-lintable diff) — will be closed, do not merge

### DIFF
--- a/SCRATCH-ci-required-verify.txt
+++ b/SCRATCH-ci-required-verify.txt
@@ -1,0 +1,5 @@
+Scratch file for end-to-end CI verification (PR will be closed, not merged).
+Repro of the #778/#964 stuck class: a diff with NO lintable/path-matched files.
+Under the old 10-context protection, path-filtered required checks never ran and
+the PR hung on "Expected" forever. Expected now: ci-required + gitleaks both
+report and pass.


### PR DESCRIPTION
End-to-end verification of the #778/#964 fix. This diff touches a single non-lintable .txt — under the old 10-context protection the path-filtered required checks never ran and the PR hung on "Expected" forever. Expected now: `ci-required` + `gitleaks` both report and pass, nothing stuck. **Scratch PR — will be closed without merging.**