### PR TITLE
test(ci): VERIFY — prescreen respond leg (broken frontmatter) — will be closed, do not merge

### DIFF
--- a/plugins/devops/git-commit-smart/skills/generating-smart-commits/SKILL.md
+++ b/plugins/devops/git-commit-smart/skills/generating-smart-commits/SKILL.md
@@ -8,6 +8,7 @@ description: 'Execute use when generating conventional commit messages from stag
 
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*)
+version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/plugins/devops/git-commit-smart/skills/generating-smart-commits/SKILL.md
+++ b/plugins/devops/git-commit-smart/skills/generating-smart-commits/SKILL.md
@@ -8,7 +8,6 @@ description: 'Execute use when generating conventional commit messages from stag
 
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*)
-version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:
@@ -90,3 +89,5 @@ BREAKING CHANGE: description (if applicable)
 - Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/
 - Angular commit guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
 - Git commit best practices: https://cbea.ms/git-commit/
+
+Scratch line for end-to-end prescreen verification (PR will be closed).


### PR DESCRIPTION
End-to-end verification of the pr-prescreen respond leg (#976). Removes `version` from git-commit-smart's SKILL.md (marketplace-tier ERROR) → expect an advisory `prescreen-grade` **failure** commit status + ONE marker comment. A follow-up push restores it → expect the status to flip to **success** with no comment spam. **Scratch PR — will be closed without merging.**

[skip auto-bump]