### PR TITLE
test(ci): VERIFY — sources.yaml-only diff fails loudly (will be closed, do not merge)

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -22,3 +22,4 @@ plugins/**/README.md:pipe-to-shell  documented upstream one-line installer (olla
 plugins/ai-ml/ollama-local-ai/**:pipe-to-shell  official Ollama installer is the documented setup path for this skill
 plugins/mcp/slack-channel/**:pipe-to-shell  documented Bun/Claude install steps in slack-channel setup docs
 plugins/saas-packs/**/skills/**/SKILL.md:pipe-to-shell  documented vendor-CLI install step inside a SaaS-pack skill
+sources.yaml:sources-change-unscanned  end-to-end verification of the documented waiver path (scratch PR #979, will be closed)

--- a/sources.yaml
+++ b/sources.yaml
@@ -1387,3 +1387,5 @@ config:
     {sources}
 
     See `sources.yaml` for configured sources.
+
+# scratch: end-to-end verify of the sources-change-unscanned fail-loud gate (PR will be closed)


### PR DESCRIPTION
End-to-end verification of the F6/F7 fail-loud gate (#969) through the `ci-required` aggregate (#971). This diff touches ONLY `sources.yaml` — it used to scan 0 files and pass silently green. Expected now: `scan-synced-content` emits a waivable `sources-change-unscanned` CHALLENGE (exit 1) → `ci-required` goes **red** → merge blocked. A follow-up push adds the documented allowlist waiver → gate turns green. **Scratch PR — will be closed without merging.**