### PR TITLE
fix(prescreen): actually scan the PR tree — validator anchors its root to its own script path

### DIFF
--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -143,13 +143,24 @@ jobs:
           CI: 'true'
         run: |
           set -euo pipefail
-          # We deliberately run the validator FROM the PR tree so the schema
-          # version + rubric matches what the PR ships against. The validator
-          # is pure read — no exec, no install. If the PR ships a malicious
-          # validator script, the catalog check below will flag it as a
-          # structural concern (validator path modified).
-          python3 ../base/scripts/validate-skills-schema.py --marketplace --json \
+          # SCAN-ROOT FIX (2026-07): the validator anchors its scan root to ITS
+          # OWN location (Path(__file__).resolve().parents[1]), NOT the cwd. The
+          # previous invocation (`python3 ../base/scripts/...` from cwd=pr) made
+          # parents[1] == base/, so prescreen graded MAIN's pristine tree and any
+          # PR that broke a skill's frontmatter got a false PASS (verified live:
+          # a SKILL.md with `version` removed scored errors:0 from base vs
+          # errors:1 against the PR tree).
+          #
+          # Fix: copy the BASE-authored validator INTO the PR tree (overwriting
+          # anything a malicious PR may have planted at that path), then run the
+          # copy so parents[1] == the PR tree. We still execute ONLY
+          # base-authored bytes — never PR-authored code (pull_request_target
+          # safety). The validator is pure read — no exec, no install.
+          install -m 0644 ../base/scripts/validate-skills-schema.py \
+            ./scripts/.prescreen-validator.py
+          python3 scripts/.prescreen-validator.py --marketplace --json \
             > /tmp/validator-results.json 2>/tmp/validator.log || true
+          rm -f ./scripts/.prescreen-validator.py
           echo "Validator stderr/info:" >&2
           tail -50 /tmp/validator.log >&2 || true
           # Filter to only changed plugin paths (if any). Otherwise we pass
@@ -334,8 +345,13 @@ jobs:
             CHANGES_REQUESTED|HARD_BLOCK) STATE=failure ;;
             *) STATE=error ;;
           esac
-          # GitHub caps a status description at 140 chars.
-          DESC="$(printf '%s: %s' "$VERDICT" "$SUMMARY" | cut -c1-138)"
+          # GitHub caps a status description at 140 chars. classify.py's summary
+          # already leads with the verdict ("PASS: …"), so don't prefix it again;
+          # only prepend when the summary doesn't carry it.
+          case "$SUMMARY" in
+            "$VERDICT"*) DESC="$(printf '%s' "$SUMMARY" | cut -c1-138)" ;;
+            *) DESC="$(printf '%s: %s' "$VERDICT" "$SUMMARY" | cut -c1-138)" ;;
+          esac
           gh api "repos/${REPO}/statuses/${SHA}" \
             -f state="$STATE" \
             -f context='prescreen-grade' \


### PR DESCRIPTION
**Found by the end-to-end verification** (scratch PR #978): prescreen has been grading **main's pristine tree**, not the PR's content — a latent false-PASS hole.

## Root cause
`validate-skills-schema.py` computes its scan root as `Path(__file__).resolve().parents[1]` — from the **script's location**, not the cwd. Prescreen invoked `python3 ../base/scripts/validate-skills-schema.py` (cwd=`pr/`), so `parents[1] == base/` and every sweep scanned base. Live proof: #978 removes `version` from a cataloged skill → CI prescreen graded `errors:0 / score:99 / PASS`; the same validator against the PR tree reports `errors:1 / score:98` (`Missing required field: 'version' (marketplace)`). Latent since the wiring landed; became visible the moment #976 surfaced verdicts on the PR.

## Fix (pure wiring — validator untouched, kernel discipline intact)
Copy the **base-authored** validator into the PR tree as `scripts/.prescreen-validator.py` (overwriting anything a malicious PR planted at that path), run the copy so `parents[1] ==` the PR tree, then remove it. Only base-authored bytes are ever executed — `pull_request_target` safety preserved.

Verified locally with a two-tree simulation: buggy invocation → grades base (`errors:0`); fixed invocation → grades the PR tree (`errors:1`).

Also fixes the cosmetic `PASS: PASS: …` status description (classify's summary already leads with the verdict).

**Post-merge verification plan:** `workflow_dispatch` prescreen against #978 (still broken) → expect `CHANGES_REQUESTED`, a failure `prescreen-grade` status, and the marker comment; then push the frontmatter fix to #978 → status flips to success.