### PR TITLE
feat: add llm-box external plugin source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1387,3 +1387,32 @@ config:
     {sources}
 
     See `sources.yaml` for configured sources.
+
+  - name: llm-box
+    description: Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.
+    repo: alib8b8/llm-box
+    source_path: .
+    target_path: plugins/community/llm-box
+    author:
+      name: alib8b8
+      github: alib8b8
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - '.claude-plugin/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'skills/llm-box/SKILL.md'
+      - 'skills/setup/SKILL.md'
+      - 'commands/create-workflow.md'
+      - 'commands/run-workflow.md'
+      - 'commands/list-nodes.md'
+      - '.mcp.json'
+      - 'README.md'
+      - 'README.zh-CN.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+      - 'dist/**'
+      - 'contrib/**'

--- a/sources.yaml
+++ b/sources.yaml
@@ -1428,4 +1428,3 @@ config:
     {sources}
 
     See `sources.yaml` for configured sources.
-

--- a/sources.yaml
+++ b/sources.yaml
@@ -1385,7 +1385,6 @@ sources:
       - mcp
     include:
       - '.claude-plugin/plugin.json'
-      - '.claude-plugin/marketplace.json'
       - 'skills/llm-box/SKILL.md'
       - 'skills/setup/SKILL.md'
       - 'commands/create-workflow.md'

--- a/sources.yaml
+++ b/sources.yaml
@@ -1359,6 +1359,48 @@ sources:
       - 'node_modules/**'
       - '.git/**'
       - '*.log'
+
+  # ============================================================
+  # llm-box (alib8b8)
+  # https://github.com/alib8b8/llm-box
+  # ============================================================
+
+  - name: llm-box
+    description: Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.
+    repo: alib8b8/llm-box
+    source_path: .
+    target_path: plugins/community/llm-box
+    author:
+      name: alib8b8
+      github: alib8b8
+    license: MIT
+    category: community
+    verified: false
+    keywords:
+      - workflow
+      - automation
+      - cli
+      - yaml
+      - llm
+      - mcp
+    include:
+      - '.claude-plugin/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'skills/llm-box/SKILL.md'
+      - 'skills/setup/SKILL.md'
+      - 'commands/create-workflow.md'
+      - 'commands/run-workflow.md'
+      - 'commands/list-nodes.md'
+      - '.mcp.json'
+      - 'README.md'
+      - 'README.zh-CN.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+      - 'dist/**'
+      - 'contrib/**'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)
@@ -1388,31 +1430,3 @@ config:
 
     See `sources.yaml` for configured sources.
 
-  - name: llm-box
-    description: Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.
-    repo: alib8b8/llm-box
-    source_path: .
-    target_path: plugins/community/llm-box
-    author:
-      name: alib8b8
-      github: alib8b8
-    license: MIT
-    category: community
-    verified: false
-    include:
-      - '.claude-plugin/plugin.json'
-      - '.claude-plugin/marketplace.json'
-      - 'skills/llm-box/SKILL.md'
-      - 'skills/setup/SKILL.md'
-      - 'commands/create-workflow.md'
-      - 'commands/run-workflow.md'
-      - 'commands/list-nodes.md'
-      - '.mcp.json'
-      - 'README.md'
-      - 'README.zh-CN.md'
-    exclude:
-      - 'node_modules/**'
-      - '.git/**'
-      - '*.log'
-      - 'dist/**'
-      - 'contrib/**'


### PR DESCRIPTION
Add llm-box as an external plugin source for auto-sync via Path B.

## Plugin Info

- **Name**: llm-box
- **Repo**: alib8b8/llm-box
- **Category**: community
- **License**: MIT
- **Author**: alib8b8

## About

Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English descriptions.

### Features
- Generate YAML workflows from natural language
- 20+ built-in nodes (fetch_url, http_request, execute, json_parse, file operations, etc.)
- 15+ LLM providers (Ollama, DeepSeek, OpenAI-compatible, and more)
- Built-in MCP server mode (stdio + HTTP/SSE)
- 3 slash commands: /create-workflow, /run-workflow, /list-nodes
- Safe mode for restricted execution

### Security
- SSRF protection on URL fetching
- Path traversal protection on file operations
- Command injection prevention
- Confirmation gates for destructive operations

### Files Synced
- `.claude-plugin/plugin.json` + `marketplace.json`
- `skills/llm-box/SKILL.md` (workflow skill)
- `skills/setup/SKILL.md` (setup skill)
- `commands/` (3 slash commands)
- `.mcp.json`
- `README.md` + `README.zh-CN.md`

## Validation
- [x] Catalog invariant check passed (456 plugins)