### PR TITLE
docs: required tiered submission documents + issue-before-PR intake (the value-proof filter)

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-submission.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yml
@@ -19,6 +19,14 @@ body:
 
         Also worth reading: [CONTRIBUTING.md § Before You Submit](../blob/main/CONTRIBUTING.md#before-you-submit--read-this) and the [PR Pre-screen runbook](../blob/main/000-docs/265-DR-GUID-pr-prescreen-system.md).
 
+        ### This issue comes first
+
+        Every submission starts here — **a PR opened without this issue will be asked to
+        file one before review continues.** The questions below are the PRD essentials;
+        your answers carry straight into the `docs/PRD.md` your PR includes (templates:
+        [`templates/skill-docs/`](../blob/main/templates/skill-docs/README.md), process:
+        [submission standard](../blob/main/000-docs/700-DR-GUID-skill-submission-standard.md)).
+
   - type: input
     id: plugin-name
     attributes:
@@ -44,6 +52,61 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does it solve?
+      description: What hurts, for whom, and how you know. Cite evidence if you have it (an issue link, a benchmark, your own experience).
+      placeholder: "Developers doing X keep hitting Y, which costs them Z..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: target-users
+    attributes:
+      label: Who is it for?
+      description: The 2–4 user types who reach for this, and when.
+      placeholder: |
+        - Backend devs debugging flaky CI — need fast failure triage
+        - Team leads reviewing PRs — need consistent quality signals
+    validations:
+      required: true
+
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success criteria
+      description: 2–4 measurable statements. "Works well" is not measurable; "resolves X without manual edits across the three README examples" is.
+      placeholder: |
+        1. Correctly classifies all three failure classes in the README examples
+        2. Runs end-to-end in under 60 seconds on a typical repo
+    validations:
+      required: true
+
+  - type: textarea
+    id: functional-requirements
+    attributes:
+      label: Top functional requirements
+      description: The top 3–5 things it must do, numbered FR-1… One line each.
+      placeholder: |
+        FR-1: Parse the CI log and extract failing test names
+        FR-2: Map each failure to the owning module
+        FR-3: Produce a triage summary with suggested owners
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Submission tier
+      description: "Determines which docs your PR must include — see the [tier→docs matrix](../blob/main/templates/skill-docs/README.md). Micro-skill: PRD only. Standard plugin: PRD + ADR. Pack/flagship: PRD + ADR + one-pager(s)."
+      options:
+        - micro-skill (single command/skill, no scripts)
+        - standard plugin (skills + scripts/commands)
+        - pack / flagship (multi-skill pack, featured or paid-tier)
+    validations:
+      required: true
+
   - type: dropdown
     id: category
     attributes:
@@ -66,6 +129,8 @@ body:
       label: Checklist (per spec v3.6.0)
       options:
         - label: I have read the [skill spec](../blob/main/000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)
+          required: true
+        - label: I've read the [tier→docs matrix](../blob/main/templates/skill-docs/README.md) and will include the required docs in my PR
           required: true
         - label: Has `plugin.json` + `.claude-plugin/marketplace.json`
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,22 @@
 
 <!-- Link to related issues: Closes #123, Fixes #456 -->
 
+## Submission Standard (plugin & source submissions)
+
+<!-- Required for new plugin/source submissions — see
+     000-docs/700-DR-GUID-skill-submission-standard.md and templates/skill-docs/ -->
+
+- [ ] This PR links its submission issue (`Closes #N` / `Refs #N`) — submissions start
+      as an issue using the plugin-submission template; a PR without one will be asked
+      to file it
+- [ ] The required docs for my declared tier are included (`docs/PRD.md` at minimum —
+      see the [tier→docs matrix](../templates/skill-docs/README.md))
+- [ ] Validator run locally (`python3 scripts/validate-skills-schema.py --marketplace --verbose <plugin-dir>`)
+- [ ] For `feat(sources)` PRs: source vetted per the
+      [external-source vetting playbook](../000-docs/699-DR-GUID-external-source-vetting-playbook.md)
+- [ ] `verified:` / `curated:` flags in `sources.yaml` are honest (no `verified: true`
+      without maintainer vetting; no silently hardened mirrors without `curated: true`)
+
 ## Security
 
 - Related alerts: GHSA-/CVE-

--- a/000-docs/700-DR-GUID-skill-submission-standard.md
+++ b/000-docs/700-DR-GUID-skill-submission-standard.md
@@ -1,0 +1,79 @@
+---
+filing_code: DR-GUID-SKILL-SUBMISSION-STANDARD-2026-07-07
+date: 2026-07-07
+status: active
+scope: The tiered submission-documents standard + issue-before-PR intake for every plugin/source submission — external and Intent Solutions' own
+related:
+  - templates/skill-docs/ (the four fill-in templates + tier matrix)
+  - 000-docs/698-TQ-SECU-external-sync-threat-model.md (threat model for synced sources)
+  - 000-docs/699-DR-GUID-external-source-vetting-playbook.md (source vetting procedure)
+  - STANDARDS.md (8-field marketplace frontmatter rubric)
+  - "GitHub issue #984 — marketplace quality pipeline umbrella"
+---
+
+# Skill Submission Standard (tiered documents + issue-before-PR)
+
+## Purpose
+
+The marketplace already gates *validity* (validators, security scan, 8-field frontmatter).
+This standard gates *value*: every submission arrives with just enough written proof that
+the problem is real, the design was deliberate, and the claim matches the tier. The
+documents are a filter that helps contributors sharpen a submission — not a wall that
+rejects them.
+
+## 1. Issue-before-PR (required)
+
+Every plugin/source submission **starts as a GitHub issue** using the
+[plugin-submission template](../.github/ISSUE_TEMPLATE/plugin-submission.yml), which
+captures the PRD-level answers (problem, target users, success criteria, top functional
+requirements) up front. The PR must link that issue (`Closes #N` / `Refs #N`).
+
+A PR that arrives without a linked submission issue is not rejected — it gets a comment
+asking for one, and review pauses until it exists. (Decision: Jeremy, 2026-07-07.)
+
+## 2. Tier → required documents
+
+Templates: [`templates/skill-docs/`](../templates/skill-docs/). Docs live in the plugin
+directory as `docs/PRD.md`, `docs/ADR.md`, etc. The same matrix applies to Intent
+Solutions' own skills.
+
+| Tier | What it covers | Required docs |
+|------|----------------|---------------|
+| **Micro-skill** | a single command or skill, no scripts | `PRD.md` (short form OK) |
+| **Standard plugin** | skills plus scripts/commands | `PRD.md` + `ADR.md` |
+| **Pack / flagship / featured / paid-tier** | multi-skill packs, featured picks, anything sold | `PRD.md` + `ADR.md` + `ONE-PAGER.md` (+ `CFO-ONE-PAGER.md` where money is the pitch) |
+
+## 3. Eligibility: listing vs featuring
+
+- **Listing** (in the catalog): a valid plugin, an honestly declared tier with the
+  matching docs, and — for synced sources — the source vetted per the
+  [external-source vetting playbook (699)](699-DR-GUID-external-source-vetting-playbook.md).
+- **Featuring** (spotlight, homepage, Hall of Fame): A-grade at marketplace tier
+  (8-field frontmatter per [STANDARDS.md](../STANDARDS.md)) **plus** the full doc set
+  for the pack/flagship tier **plus** an editorial pick. Featuring is earned, and we
+  help authors earn it (see the rubric below).
+
+## 4. Sync-model rubric (case-by-case, the curation doctrine)
+
+How an external plugin's quality improvements flow is decided per source, not by one
+global policy:
+
+| Situation | Model |
+|-----------|-------|
+| Responsive maintainer + thin consumer | **Upstream PR** they own and merge; mirror stays SHA-pinned via `sources.lock.json` |
+| We're featuring it / our name is on its quality / maintainer slow-or-unknown | **Mirror + `curated: true`** — we harden our copy, frozen from sync, author credited |
+| Full adoption (we take over maintenance) | **Vendor** into this repo |
+
+The upstream PR is **always a courtesy, never a blocker** — a stalled or silent upstream
+never delays listing or featuring. Curated copies join a periodic reconcile that pulls
+upstream **security fixes** into the frozen copy so hardening never means falling behind
+on safety.
+
+## 5. Canonical sources (cited, not restated)
+
+- [698 — external-sync threat model](698-TQ-SECU-external-sync-threat-model.md): what the
+  machine layers can and cannot prove about synced content.
+- [699 — external-source vetting playbook](699-DR-GUID-external-source-vetting-playbook.md):
+  the human procedure for listing, reviewing, and suspending sources.
+- [STANDARDS.md](../STANDARDS.md): the 8-field marketplace frontmatter rubric and where
+  the machine-readable source of truth lives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,26 @@ The bar isn't _size_, it's _completeness of what you do ship_. Start from `templ
 
 Read the rest of this doc, then run `./scripts/quick-test.sh` locally before you push. That script runs the same validators CI runs — passing it locally means your PR will pass the hard gates.
 
+## What a submission must include
+
+Two things, and both help you more than they cost you:
+
+**1. The submission issue comes first.** Every plugin/source submission starts as a GitHub issue using the [plugin-submission template](.github/ISSUE_TEMPLATE/plugin-submission.yml) — it captures the PRD essentials (problem, users, success criteria, top requirements) before anyone reads code. Your PR then links that issue (`Closes #N` / `Refs #N`). A PR that arrives without one isn't rejected — you'll just be asked to file the issue before review continues.
+
+**2. The docs that match your tier.** The bar scales with the claim, not the size:
+
+| Tier | What it covers | Required docs |
+|------|----------------|---------------|
+| **Micro-skill** | a single command or skill, no scripts | `PRD.md` (short form OK) |
+| **Standard plugin** | skills plus scripts/commands | `PRD.md` + `ADR.md` |
+| **Pack / flagship / featured / paid-tier** | multi-skill packs, featured picks, anything sold | `PRD.md` + `ADR.md` + `ONE-PAGER.md` (+ `CFO-ONE-PAGER.md` where money is the pitch) |
+
+Fill-in-the-blank templates live in [`templates/skill-docs/`](templates/skill-docs/README.md) — copy the ones your tier needs into your plugin directory as `docs/PRD.md`, `docs/ADR.md`, etc. Your issue answers ARE most of the PRD, so this is minutes, not hours. The same matrix applies to Intent Solutions' own skills — this isn't a hoop for outsiders, it's the house standard. Full process: [`000-docs/700-DR-GUID-skill-submission-standard.md`](000-docs/700-DR-GUID-skill-submission-standard.md).
+
+## Getting featured
+
+Nominate any skill — yours or one you love — via the [killer-skill nomination template](.github/ISSUE_TEMPLATE/killer-skill-nomination.yml). Eligibility for featuring is A-grade at marketplace tier (the 8-field frontmatter per [STANDARDS.md](STANDARDS.md)) plus the pack/flagship doc set, plus an editorial pick. We help you get there — either a PR you own, or a credited hardened mirror (`curated: true`) on our side; a stalled upstream never blocks featuring.
+
 ---
 
 ## Quick Start
@@ -135,6 +155,8 @@ Best when you maintain the plugin in your own repo and want updates to flow to t
 3. After your `sources.yaml` PR merges, the next weekly sync (Mondays 06:00 UTC) pulls your latest content into `plugins/<category>/<name>/` and opens an automated PR. Once that PR merges, your plugin is live on the site.
 4. For an immediate first sync (instead of waiting for Monday), a maintainer can trigger the workflow manually via `gh workflow run sync-external.yml`.
 5. Every subsequent push you make to your own repo gets picked up by the next weekly sync — no further action on your end.
+
+Every listed source is vetted per the [external-source vetting playbook](000-docs/699-DR-GUID-external-source-vetting-playbook.md) and pinned via `sources.lock.json`, and synced content is gated by the payload scanner (`scripts/scan-synced-content.mjs`) before the sync PR lands.
 
 **What `verified:` and `curated:` mean for you as an author.** These two flags are separate and independent:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,12 +144,12 @@ Best when you maintain the plugin in your own repo and want updates to flow to t
      category: community
      verified: true
      include:
-       - "SKILL.md"
-       - "README.md"
-       - "references/**"
+       - 'SKILL.md'
+       - 'README.md'
+       - 'references/**'
      exclude:
-       - "node_modules/**"
-       - ".git/**"
+       - 'node_modules/**'
+       - '.git/**'
    ```
 
 3. After your `sources.yaml` PR merges, the next weekly sync (Mondays 06:00 UTC) pulls your latest content into `plugins/<category>/<name>/` and opens an automated PR. Once that PR merges, your plugin is live on the site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ Two things, and both help you more than they cost you:
 
 **2. The docs that match your tier.** The bar scales with the claim, not the size:
 
-| Tier | What it covers | Required docs |
-|------|----------------|---------------|
-| **Micro-skill** | a single command or skill, no scripts | `PRD.md` (short form OK) |
-| **Standard plugin** | skills plus scripts/commands | `PRD.md` + `ADR.md` |
+| Tier                                       | What it covers                                   | Required docs                                                                        |
+| ------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| **Micro-skill**                            | a single command or skill, no scripts            | `PRD.md` (short form OK)                                                             |
+| **Standard plugin**                        | skills plus scripts/commands                     | `PRD.md` + `ADR.md`                                                                  |
 | **Pack / flagship / featured / paid-tier** | multi-skill packs, featured picks, anything sold | `PRD.md` + `ADR.md` + `ONE-PAGER.md` (+ `CFO-ONE-PAGER.md` where money is the pitch) |
 
 Fill-in-the-blank templates live in [`templates/skill-docs/`](templates/skill-docs/README.md) — copy the ones your tier needs into your plugin directory as `docs/PRD.md`, `docs/ADR.md`, etc. Your issue answers ARE most of the PRD, so this is minutes, not hours. The same matrix applies to Intent Solutions' own skills — this isn't a hoop for outsiders, it's the house standard. Full process: [`000-docs/700-DR-GUID-skill-submission-standard.md`](000-docs/700-DR-GUID-skill-submission-standard.md).
@@ -144,12 +144,12 @@ Best when you maintain the plugin in your own repo and want updates to flow to t
      category: community
      verified: true
      include:
-       - 'SKILL.md'
-       - 'README.md'
-       - 'references/**'
+       - "SKILL.md"
+       - "README.md"
+       - "references/**"
      exclude:
-       - 'node_modules/**'
-       - '.git/**'
+       - "node_modules/**"
+       - ".git/**"
    ```
 
 3. After your `sources.yaml` PR merges, the next weekly sync (Mondays 06:00 UTC) pulls your latest content into `plugins/<category>/<name>/` and opens an automated PR. Once that PR merges, your plugin is live on the site.

--- a/templates/skill-docs/ADR.md
+++ b/templates/skill-docs/ADR.md
@@ -9,29 +9,29 @@
 
 ## Context
 
-*What situation forced a decision — the constraints, the PRD requirement it serves,
-what breaks if you do nothing. 1–2 paragraphs.*
+_What situation forced a decision — the constraints, the PRD requirement it serves,
+what breaks if you do nothing. 1–2 paragraphs._
 
 <Describe the forces at play.>
 
 ## Decision
 
-*The choice, stated as a decision ("We use X to do Y"), not a description of the code.*
+_The choice, stated as a decision ("We use X to do Y"), not a description of the code._
 
 <State the decision.>
 
 ## Alternatives considered
 
-*2–3 alternatives with why each was rejected. If nothing was rejected, no decision was made.*
+_2–3 alternatives with why each was rejected. If nothing was rejected, no decision was made._
 
-| Alternative | Why rejected |
-|-------------|--------------|
+| Alternative     | Why rejected      |
+| --------------- | ----------------- |
 | <alternative 1> | <specific reason> |
 | <alternative 2> | <specific reason> |
 
 ## Consequences
 
-*Both directions. A decision with no negative consequences is a description, not a decision.*
+_Both directions. A decision with no negative consequences is a description, not a decision._
 
 **Positive:**
 
@@ -43,11 +43,11 @@ what breaks if you do nothing. 1–2 paragraphs.*
 
 ## Tool-permission scope
 
-*Which `allowed-tools` the skill declares and why each one is needed. Least privilege:
-`Bash(git:*)` beats bare `Bash`. If a tool can't be justified here, remove it from the
-frontmatter.*
+_Which `allowed-tools` the skill declares and why each one is needed. Least privilege:
+`Bash(git:_)`beats bare`Bash`. If a tool can't be justified here, remove it from the
+frontmatter.\*
 
-| Tool | Why it's needed |
-|------|-----------------|
-| <Read> | <reason> |
-| <Bash(npm:*)> | <reason> |
+| Tool           | Why it's needed |
+| -------------- | --------------- |
+| <Read>         | <reason>        |
+| <Bash(npm:\*)> | <reason>        |

--- a/templates/skill-docs/ADR.md
+++ b/templates/skill-docs/ADR.md
@@ -1,0 +1,53 @@
+# ADR: <skill-slug> — <short decision title>
+
+> In this repo, ADRs are filed per skill in `000-docs/` as `NNN-AT-DECR-<skill-slug>.md`
+> (next free `NNN`). In your own plugin, keep it at `docs/ADR.md` — the sync mirrors it as-is.
+
+**Author:** <your name>
+**Date:** <YYYY-MM-DD>
+**Status:** Proposed | Accepted
+
+## Context
+
+*What situation forced a decision — the constraints, the PRD requirement it serves,
+what breaks if you do nothing. 1–2 paragraphs.*
+
+<Describe the forces at play.>
+
+## Decision
+
+*The choice, stated as a decision ("We use X to do Y"), not a description of the code.*
+
+<State the decision.>
+
+## Alternatives considered
+
+*2–3 alternatives with why each was rejected. If nothing was rejected, no decision was made.*
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| <alternative 1> | <specific reason> |
+| <alternative 2> | <specific reason> |
+
+## Consequences
+
+*Both directions. A decision with no negative consequences is a description, not a decision.*
+
+**Positive:**
+
+- <what gets better>
+
+**Negative / accepted tradeoffs:**
+
+- <what gets worse or harder, and why that's acceptable>
+
+## Tool-permission scope
+
+*Which `allowed-tools` the skill declares and why each one is needed. Least privilege:
+`Bash(git:*)` beats bare `Bash`. If a tool can't be justified here, remove it from the
+frontmatter.*
+
+| Tool | Why it's needed |
+|------|-----------------|
+| <Read> | <reason> |
+| <Bash(npm:*)> | <reason> |

--- a/templates/skill-docs/CFO-ONE-PAGER.md
+++ b/templates/skill-docs/CFO-ONE-PAGER.md
@@ -1,0 +1,47 @@
+# <Skill or Plugin Name> — CFO One-Pager
+
+> Required only for enterprise / flagship / paid-tier skills — anywhere money is the
+> pitch. If the value story is "saves a developer some keystrokes," skip this document.
+
+*Every number here should survive a skeptical reader. Estimates are fine; label them
+as estimates. Delete the italic lines when done.*
+
+## The cost of the problem
+
+*What the problem costs today, in dollars or hours. Name the assumption behind the number.*
+
+<e.g. "Each manual release audit takes ~3 engineer-hours; a missed finding costs a
+patch release (~1 day). Assumption: monthly release cadence.">
+
+## What the skill changes
+
+*The mechanism, one paragraph. What work disappears, what risk shrinks, what becomes possible.*
+
+<What changes operationally when this is installed.>
+
+## Impact per run
+
+*Quantify one invocation. Use the rows that apply; delete the rest.*
+
+| Dimension | Per run |
+|-----------|---------|
+| Time saved | <e.g. ~2.5 hours vs manual> |
+| Risk reduced | <e.g. catches the 3 failure classes that caused past incidents> |
+| Dollars saved | <e.g. ~$400 at a blended $160/hr rate (estimate)> |
+
+## Adoption cost
+
+*What it takes to start. Honest setup time beats an optimistic one.*
+
+| Item | Cost |
+|------|------|
+| Setup time | <e.g. ~15 minutes> |
+| Prerequisites | <e.g. GitHub CLI authed, Node 20+> |
+| Ongoing | <e.g. none / weekly config review> |
+
+## Risk notes
+
+*What could go wrong and what bounds it — permissions, data exposure, failure modes.*
+
+- <Risk 1 and its mitigation>
+- <Risk 2 and its mitigation>

--- a/templates/skill-docs/CFO-ONE-PAGER.md
+++ b/templates/skill-docs/CFO-ONE-PAGER.md
@@ -3,45 +3,45 @@
 > Required only for enterprise / flagship / paid-tier skills — anywhere money is the
 > pitch. If the value story is "saves a developer some keystrokes," skip this document.
 
-*Every number here should survive a skeptical reader. Estimates are fine; label them
-as estimates. Delete the italic lines when done.*
+_Every number here should survive a skeptical reader. Estimates are fine; label them
+as estimates. Delete the italic lines when done._
 
 ## The cost of the problem
 
-*What the problem costs today, in dollars or hours. Name the assumption behind the number.*
+_What the problem costs today, in dollars or hours. Name the assumption behind the number._
 
 <e.g. "Each manual release audit takes ~3 engineer-hours; a missed finding costs a
 patch release (~1 day). Assumption: monthly release cadence.">
 
 ## What the skill changes
 
-*The mechanism, one paragraph. What work disappears, what risk shrinks, what becomes possible.*
+_The mechanism, one paragraph. What work disappears, what risk shrinks, what becomes possible._
 
 <What changes operationally when this is installed.>
 
 ## Impact per run
 
-*Quantify one invocation. Use the rows that apply; delete the rest.*
+_Quantify one invocation. Use the rows that apply; delete the rest._
 
-| Dimension | Per run |
-|-----------|---------|
-| Time saved | <e.g. ~2.5 hours vs manual> |
-| Risk reduced | <e.g. catches the 3 failure classes that caused past incidents> |
-| Dollars saved | <e.g. ~$400 at a blended $160/hr rate (estimate)> |
+| Dimension     | Per run                                                         |
+| ------------- | --------------------------------------------------------------- |
+| Time saved    | <e.g. ~2.5 hours vs manual>                                     |
+| Risk reduced  | <e.g. catches the 3 failure classes that caused past incidents> |
+| Dollars saved | <e.g. ~$400 at a blended $160/hr rate (estimate)>               |
 
 ## Adoption cost
 
-*What it takes to start. Honest setup time beats an optimistic one.*
+_What it takes to start. Honest setup time beats an optimistic one._
 
-| Item | Cost |
-|------|------|
-| Setup time | <e.g. ~15 minutes> |
+| Item          | Cost                               |
+| ------------- | ---------------------------------- |
+| Setup time    | <e.g. ~15 minutes>                 |
 | Prerequisites | <e.g. GitHub CLI authed, Node 20+> |
-| Ongoing | <e.g. none / weekly config review> |
+| Ongoing       | <e.g. none / weekly config review> |
 
 ## Risk notes
 
-*What could go wrong and what bounds it — permissions, data exposure, failure modes.*
+_What could go wrong and what bounds it — permissions, data exposure, failure modes._
 
 - <Risk 1 and its mitigation>
 - <Risk 2 and its mitigation>

--- a/templates/skill-docs/ONE-PAGER.md
+++ b/templates/skill-docs/ONE-PAGER.md
@@ -1,0 +1,44 @@
+# <Skill or Plugin Name>
+
+**<One-line tagline — what it does for whom, no adjectives you can't defend.>**
+
+*The one-pager is the landing-page view: someone deciding whether to install should
+get everything they need from this single screen. Delete the italic lines when done.*
+
+## Problem
+
+*One short paragraph. Same problem as the PRD, compressed for a reader in a hurry.*
+
+<What hurts, for whom.>
+
+## Solution
+
+*One short paragraph. What this ships and how it removes the pain.*
+
+<What it does, in plain language.>
+
+## W5
+
+| | |
+|---|---|
+| **Who** | <who uses it> |
+| **What** | <what it does> |
+| **When** | <when they reach for it> |
+| **Where** | <where it runs — Claude Code, CI, which repos> |
+| **Why** | <why this beats doing it by hand> |
+
+## Stack
+
+| Layer | Choice |
+|-------|--------|
+| <e.g. Skill runtime> | <e.g. Claude Code SKILL.md> |
+| <e.g. Scripts> | <e.g. Bash + jq> |
+| <e.g. External APIs> | <e.g. none / GitHub API> |
+
+## Differentiators
+
+*Exactly three. What makes this the one to install over the adjacent alternatives.*
+
+1. <Differentiator 1>
+2. <Differentiator 2>
+3. <Differentiator 3>

--- a/templates/skill-docs/ONE-PAGER.md
+++ b/templates/skill-docs/ONE-PAGER.md
@@ -2,42 +2,42 @@
 
 **<One-line tagline — what it does for whom, no adjectives you can't defend.>**
 
-*The one-pager is the landing-page view: someone deciding whether to install should
-get everything they need from this single screen. Delete the italic lines when done.*
+_The one-pager is the landing-page view: someone deciding whether to install should
+get everything they need from this single screen. Delete the italic lines when done._
 
 ## Problem
 
-*One short paragraph. Same problem as the PRD, compressed for a reader in a hurry.*
+_One short paragraph. Same problem as the PRD, compressed for a reader in a hurry._
 
 <What hurts, for whom.>
 
 ## Solution
 
-*One short paragraph. What this ships and how it removes the pain.*
+_One short paragraph. What this ships and how it removes the pain._
 
 <What it does, in plain language.>
 
 ## W5
 
-| | |
-|---|---|
-| **Who** | <who uses it> |
-| **What** | <what it does> |
-| **When** | <when they reach for it> |
+|           |                                                |
+| --------- | ---------------------------------------------- |
+| **Who**   | <who uses it>                                  |
+| **What**  | <what it does>                                 |
+| **When**  | <when they reach for it>                       |
 | **Where** | <where it runs — Claude Code, CI, which repos> |
-| **Why** | <why this beats doing it by hand> |
+| **Why**   | <why this beats doing it by hand>              |
 
 ## Stack
 
-| Layer | Choice |
-|-------|--------|
+| Layer                | Choice                      |
+| -------------------- | --------------------------- |
 | <e.g. Skill runtime> | <e.g. Claude Code SKILL.md> |
-| <e.g. Scripts> | <e.g. Bash + jq> |
-| <e.g. External APIs> | <e.g. none / GitHub API> |
+| <e.g. Scripts>       | <e.g. Bash + jq>            |
+| <e.g. External APIs> | <e.g. none / GitHub API>    |
 
 ## Differentiators
 
-*Exactly three. What makes this the one to install over the adjacent alternatives.*
+_Exactly three. What makes this the one to install over the adjacent alternatives._
 
 1. <Differentiator 1>
 2. <Differentiator 2>

--- a/templates/skill-docs/PRD.md
+++ b/templates/skill-docs/PRD.md
@@ -4,29 +4,29 @@
 **Date:** <YYYY-MM-DD>
 **Status:** Draft | Active
 
-*One document, five sections. A micro-skill can keep every section to a sentence or two —
-the bar is honesty, not length. Delete the italic instruction lines when you fill this in.*
+_One document, five sections. A micro-skill can keep every section to a sentence or two —
+the bar is honesty, not length. Delete the italic instruction lines when you fill this in._
 
 ## Problem
 
-*What hurts, for whom, and how you know. Cite evidence where you have it — an issue link,
-a benchmark, your own scar tissue.*
+_What hurts, for whom, and how you know. Cite evidence where you have it — an issue link,
+a benchmark, your own scar tissue._
 
 <Describe the problem: who hits it, when, and what it costs them today.>
 
 ## Target users
 
-*Who reaches for this. 2–4 rows is plenty.*
+_Who reaches for this. 2–4 rows is plenty._
 
-| User | Context | Primary need |
-|------|---------|--------------|
+| User        | Context                           | Primary need                     |
+| ----------- | --------------------------------- | -------------------------------- |
 | <user type> | <when/where they hit the problem> | <what they need from this skill> |
-| <user type> | <context> | <need> |
+| <user type> | <context>                         | <need>                           |
 
 ## Success criteria
 
-*2–4 measurable statements. "Works well" is not measurable; "resolves X without manual
-edits across the three README examples" is.*
+_2–4 measurable statements. "Works well" is not measurable; "resolves X without manual
+edits across the three README examples" is._
 
 1. <Measurable outcome 1>
 2. <Measurable outcome 2>
@@ -34,7 +34,7 @@ edits across the three README examples" is.*
 
 ## Functional requirements
 
-*The top 3–5 things it must do, numbered FR-1… One line each.*
+_The top 3–5 things it must do, numbered FR-1… One line each._
 
 - **FR-1:** <requirement>
 - **FR-2:** <requirement>
@@ -42,7 +42,7 @@ edits across the three README examples" is.*
 
 ## Out of scope
 
-*What this deliberately does NOT do. Saves reviewers guessing and saves you scope creep.*
+_What this deliberately does NOT do. Saves reviewers guessing and saves you scope creep._
 
 - <Non-goal 1>
 - <Non-goal 2>

--- a/templates/skill-docs/PRD.md
+++ b/templates/skill-docs/PRD.md
@@ -1,0 +1,48 @@
+# PRD: <skill-or-plugin-name>
+
+**Author:** <your name>
+**Date:** <YYYY-MM-DD>
+**Status:** Draft | Active
+
+*One document, five sections. A micro-skill can keep every section to a sentence or two —
+the bar is honesty, not length. Delete the italic instruction lines when you fill this in.*
+
+## Problem
+
+*What hurts, for whom, and how you know. Cite evidence where you have it — an issue link,
+a benchmark, your own scar tissue.*
+
+<Describe the problem: who hits it, when, and what it costs them today.>
+
+## Target users
+
+*Who reaches for this. 2–4 rows is plenty.*
+
+| User | Context | Primary need |
+|------|---------|--------------|
+| <user type> | <when/where they hit the problem> | <what they need from this skill> |
+| <user type> | <context> | <need> |
+
+## Success criteria
+
+*2–4 measurable statements. "Works well" is not measurable; "resolves X without manual
+edits across the three README examples" is.*
+
+1. <Measurable outcome 1>
+2. <Measurable outcome 2>
+3. <Measurable outcome 3 (optional)>
+
+## Functional requirements
+
+*The top 3–5 things it must do, numbered FR-1… One line each.*
+
+- **FR-1:** <requirement>
+- **FR-2:** <requirement>
+- **FR-3:** <requirement>
+
+## Out of scope
+
+*What this deliberately does NOT do. Saves reviewers guessing and saves you scope creep.*
+
+- <Non-goal 1>
+- <Non-goal 2>

--- a/templates/skill-docs/README.md
+++ b/templates/skill-docs/README.md
@@ -9,20 +9,20 @@ skills use the same templates and are held to the same standard. Full process:
 
 The bar scales with the tier — a bigger claim carries more paperwork, not a bigger skill.
 
-| Tier | What it covers | Required docs |
-|------|----------------|---------------|
-| **Micro-skill** | a single command or skill, no scripts | `PRD.md` (short form OK) |
-| **Standard plugin** | skills plus scripts/commands | `PRD.md` + `ADR.md` |
+| Tier                                       | What it covers                                   | Required docs                                                                        |
+| ------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| **Micro-skill**                            | a single command or skill, no scripts            | `PRD.md` (short form OK)                                                             |
+| **Standard plugin**                        | skills plus scripts/commands                     | `PRD.md` + `ADR.md`                                                                  |
 | **Pack / flagship / featured / paid-tier** | multi-skill packs, featured picks, anything sold | `PRD.md` + `ADR.md` + `ONE-PAGER.md` (+ `CFO-ONE-PAGER.md` where money is the pitch) |
 
 ## The templates
 
-| Template | What it proves |
-|----------|----------------|
-| [`PRD.md`](PRD.md) | The problem is real, the users exist, success is measurable |
-| [`ADR.md`](ADR.md) | The design was a decision, not an accident — including least-privilege tool scope |
-| [`ONE-PAGER.md`](ONE-PAGER.md) | An installer-in-a-hurry can evaluate it from one screen |
-| [`CFO-ONE-PAGER.md`](CFO-ONE-PAGER.md) | The money claim survives a skeptical reader (enterprise/flagship/paid only) |
+| Template                               | What it proves                                                                    |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| [`PRD.md`](PRD.md)                     | The problem is real, the users exist, success is measurable                       |
+| [`ADR.md`](ADR.md)                     | The design was a decision, not an accident — including least-privilege tool scope |
+| [`ONE-PAGER.md`](ONE-PAGER.md)         | An installer-in-a-hurry can evaluate it from one screen                           |
+| [`CFO-ONE-PAGER.md`](CFO-ONE-PAGER.md) | The money claim survives a skeptical reader (enterprise/flagship/paid only)       |
 
 ## How to use them
 

--- a/templates/skill-docs/README.md
+++ b/templates/skill-docs/README.md
@@ -1,0 +1,42 @@
+# Skill submission documents
+
+Fill-in-the-blank templates for the documents every marketplace submission ships with.
+These are the single source of truth — external contributors and Intent Solutions' own
+skills use the same templates and are held to the same standard. Full process:
+[`000-docs/700-DR-GUID-skill-submission-standard.md`](../../000-docs/700-DR-GUID-skill-submission-standard.md).
+
+## Which docs does my submission need?
+
+The bar scales with the tier — a bigger claim carries more paperwork, not a bigger skill.
+
+| Tier | What it covers | Required docs |
+|------|----------------|---------------|
+| **Micro-skill** | a single command or skill, no scripts | `PRD.md` (short form OK) |
+| **Standard plugin** | skills plus scripts/commands | `PRD.md` + `ADR.md` |
+| **Pack / flagship / featured / paid-tier** | multi-skill packs, featured picks, anything sold | `PRD.md` + `ADR.md` + `ONE-PAGER.md` (+ `CFO-ONE-PAGER.md` where money is the pitch) |
+
+## The templates
+
+| Template | What it proves |
+|----------|----------------|
+| [`PRD.md`](PRD.md) | The problem is real, the users exist, success is measurable |
+| [`ADR.md`](ADR.md) | The design was a decision, not an accident — including least-privilege tool scope |
+| [`ONE-PAGER.md`](ONE-PAGER.md) | An installer-in-a-hurry can evaluate it from one screen |
+| [`CFO-ONE-PAGER.md`](CFO-ONE-PAGER.md) | The money claim survives a skeptical reader (enterprise/flagship/paid only) |
+
+## How to use them
+
+1. **Open the submission issue first.** The
+   [plugin-submission issue template](../../.github/ISSUE_TEMPLATE/plugin-submission.yml)
+   captures the PRD-level answers (problem, users, success criteria, top requirements)
+   before any code review happens. A PR without a linked submission issue will be asked
+   to file one.
+2. **Copy the templates your tier requires** into your plugin directory as
+   `docs/PRD.md`, `docs/ADR.md`, `docs/ONE-PAGER.md`, `docs/CFO-ONE-PAGER.md`.
+3. **Fill them in and delete the italic instruction lines.** Angle-bracket placeholders
+   (`<like this>`) mark every blank.
+4. **Link the issue from your PR** (`Closes #N` or `Refs #N`) with the docs included.
+
+Each template is deliberately short (under ~80 lines). If your filled-in version is
+shorter than the template, that's fine — completeness beats length, same as the rest of
+the marketplace bar.


### PR DESCRIPTION
## What this adds

The **submission-documents standard**: every plugin/source submission arrives with written proof of value — scaled to its tier — captured through an issue-first intake. One standard, four surfaces:

### 1. `templates/skill-docs/` — the four templates (single source of truth)

| Template | What it proves |
|----------|----------------|
| `PRD.md` | The problem is real, the users exist, success is measurable (skeleton lifted from the forge PRDs) |
| `ADR.md` | The design was a decision, not an accident — includes a least-privilege tool-permission scope table |
| `ONE-PAGER.md` | Pattern A: tagline → problem → solution → W5 → stack → 3 differentiators |
| `CFO-ONE-PAGER.md` | The money claim survives a skeptical reader (enterprise/flagship/paid-tier only) |

All YAML-free fill-in-the-blank markdown, `<angle-bracket>` placeholders, one italic instruction line per section, each under ~80 lines. `templates/skill-docs/README.md` carries the tier→docs matrix:

| Tier | Required docs |
|------|---------------|
| micro-skill (single command/skill, no scripts) | PRD only (short form OK) |
| standard plugin (skills + scripts/commands) | PRD + ADR |
| pack / flagship / featured / paid-tier | PRD + ADR + ONE-PAGER (+ CFO-ONE-PAGER where money is the pitch) |

### 2. `000-docs/700-DR-GUID-skill-submission-standard.md` — the process doc (claims number 700)

Issue-before-PR rule (decision: Jeremy, 2026-07-07), the tier matrix, the listing-vs-featuring eligibility bar, and the case-by-case sync-model rubric (upstream PR SHA-pinned / mirror + `curated: true` / vendor — the upstream PR is always a courtesy, never a blocker). Cites 698, 699, and STANDARDS.md rather than restating them.

### 3. Issue-first intake wiring

- `plugin-submission.yml` now captures the PRD essentials (problem, target users, success criteria, top FRs) as required textareas, plus a required tier dropdown and a tier→docs-matrix checkbox — the issue IS the first draft of the PRD. All pre-existing fields/ids preserved; YAML validated.
- `PULL_REQUEST_TEMPLATE.md` gains a Submission Standard checklist: linked submission issue, tier docs included, validator run locally, source vetted per 699 for `feat(sources)` PRs, honest `verified:`/`curated:` flags.

### 4. CONTRIBUTING.md (surgical additions, no rewrites)

- **What a submission must include** — issue-before-PR + the tier matrix, right after the quality-bar section.
- **Getting featured** — killer-skill nomination, A-grade eligibility, and the commitment: we help you get there via a PR you own or a credited hardened mirror (`curated: true`); a stalled upstream never blocks featuring.
- **Path B** — one sentence linking the 699 vetting playbook, `sources.lock.json` pinning, and the `scan-synced-content` payload gate.

## Why

The validators already gate *validity*; nothing gated *value*. This is a quality filter that helps contributors instead of rejecting them: the issue-form answers carry straight into the PRD, a PR without an issue gets asked for one (not closed), and the docs bar scales with the claim, not the size. The same standard applies to Intent Solutions' own skills — it's the house bar, not a hoop for outsiders.

## Verification

- `npx markdownlint-cli2` (repo config) — 0 errors on every added/changed file
- `yaml.safe_load` on `plugin-submission.yml` — valid, 11 body blocks, all existing ids intact
- Diff is exactly 9 files, all additive (416 insertions, 0 deletions)

Refs jeremylongshore/claude-code-plugins-plus-skills#984

- Jeremy Longshore
intentsolutions.io
