### PR TITLE
feat(sources): swap REFUSEd mytradeledger for the mnemos W28 pinned mirror + waiver hygiene

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -23,7 +23,8 @@ plugins/ai-ml/ollama-local-ai/**:pipe-to-shell  official Ollama installer is the
 plugins/mcp/slack-channel/**:pipe-to-shell  documented Bun/Claude install steps in slack-channel setup docs
 plugins/saas-packs/**/skills/**/SKILL.md:pipe-to-shell  documented vendor-CLI install step inside a SaaS-pack skill
 
-# ── TEMPORARY per-PR source-vetting sign-off (remove after merge — tracked in the
-# sources-hygiene follow-up PR). sources-change-unscanned is a per-review gate;
-# leaving this line on main would auto-waive FUTURE source-list changes too.
-sources.yaml:sources-change-unscanned  portaljs vetted 2026-07-07 per 699 playbook: datopian/portaljs (2.3k-star, MIT, active), least-privilege include globs verified upstream, verified:false tier
+# ── TEMPORARY per-PR source-vetting sign-off. sources-change-unscanned is a
+# per-review gate; a persistent line here would auto-waive FUTURE source-list
+# changes too, so each sources PR swaps this line for its own scoped reason and
+# the one-shot-waiver fix (#985 defect 3) retires the convention entirely.
+sources.yaml:sources-change-unscanned  2026-07-07 sources-hygiene PR reviewed: removes REFUSEd mytradeledger source (risk-reducing) + adds mnemos pinned mirror vetted per 699 (polyxmedia/mnemos, 8/8 fields, MIT, 20-star, least-privilege globs)

--- a/sources.yaml
+++ b/sources.yaml
@@ -1332,33 +1332,43 @@ sources:
       - '.git/**'
       - '*.log'
 
+  # NOTE (2026-07-07): mytradeledger-skills (trpsbill/skills) was removed
+  # from this list. Its mtl.py trips the unwaivable secret-exfil-cooccur
+  # REFUSE at sync time (run 28886237377) — code review shows an own-service
+  # API client (own .env token → own configured MTL_URL), i.e. a rule-fidelity
+  # gap, not malware. Re-add once the rule distinguishes own-service clients
+  # from foreign-credential exfil. Tracked in #985 (defect 1).
+
   # ============================================================
-  # MyTradeLedger Skills (trpsbill)
-  # https://github.com/trpsbill/skills
-  # MyTradeLedger REST API skill — journaled crypto trades,
-  # account balances / realized P&L, CSV export, asset registry.
+  # mnemos (Polyx Media)
+  # https://github.com/polyxmedia/mnemos
+  # Persistent memory for Claude Code — 2026-W28 featured skill.
+  # Killer-skill nomination #833: 8/8 required frontmatter fields
+  # at upstream HEAD, MIT, active. Pure pinned mirror (no local
+  # hardening needed — upstream is already A-grade).
   # ============================================================
 
-  - name: mytradeledger-skills
-    description: Access and manage MyTradeLedger journaled crypto trades via the REST API — ledger entries (CRUD + bulk-import + P&L recompute), account balances and realized P&L, CSV export, asset registry, entry metadata, and personal access token management.
-    repo: trpsbill/skills
+  - name: mnemos
+    description: Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.
+    repo: polyxmedia/mnemos
     source_path: .
-    target_path: plugins/community/mytradeledger-skills
+    target_path: plugins/community/mnemos
     author:
-      name: trpsbill
-      github: trpsbill
-      email: trpsbill@gmail.com
+      name: Polyx Media
+      github: polyxmedia
     license: MIT
     category: community
     verified: false
     include:
       - '.claude-plugin/plugin.json'
-      - 'skills/**'
+      - '.claude/skills/mnemos/SKILL.md'
+      - 'README.md'
       - 'LICENSE'
     exclude:
-      - 'node_modules/**'
       - '.git/**'
+      - 'node_modules/**'
       - '*.log'
+
   # ============================================================
   # PortalJS (Datopian)
   # https://github.com/datopian/portaljs


### PR DESCRIPTION
Three coupled trust-surface changes with one reviewed sign-off (evidence: #984, defects: #985):

1. **Remove `mytradeledger-skills`** — its `mtl.py` hard-blocks every sync run on the unwaivable `secret-exfil-cooccur` REFUSE (run 28886237377). Code review: own-service API client (own `.env` token → own configured `MTL_URL`, default mytradeledger.com) — a rule-fidelity gap, not malware. REFUSE is fail-closed by design, so the source leaves the list until the rule can tell own-service clients from foreign-credential exfil (#985 defect 1). Inline NOTE marks the re-add condition. **This unblocks the weekly sync pipeline** (currently walled — #985 defect 2).
2. **Add `mnemos` (polyxmedia/mnemos) as a pure pinned mirror** — killer-skill nomination #833, verified 8/8 required frontmatter fields at upstream HEAD, MIT, 20★, active. The 2026-W28 featured-skill candidate. Least-privilege globs: plugin.json + the one SKILL.md + README + LICENSE; the duplicate `.agents/` copy and nested `marketplace.json` deliberately excluded.
3. **Swap the temporary `sources-change-unscanned` waiver line** — the portaljs line (PR #981, merged) is replaced by this PR's scoped sign-off, keeping exactly one clearly-marked temporary line on main until the one-shot-waiver fix (#985 defect 3) retires the convention.

After merge: re-dispatch `sync-external` → the fresh sync PR supersedes and auto-closes #965.

Refs #984, #985. Nomination: #833.

- Jeremy Longshore
intentsolutions.io
