### PR TITLE
feat(spotlight): mnemos W28 Killer Skill + first worked example of the submission standard

### DIFF
--- a/000-docs/701-AA-AUDR-marketplace-legitimacy-report-2026-07-07.md
+++ b/000-docs/701-AA-AUDR-marketplace-legitimacy-report-2026-07-07.md
@@ -1,0 +1,92 @@
+# Marketplace legitimacy report — open PRs + Killer-Skill nominations
+
+**Date:** 2026-07-07 · **Evidence basis:** required gates (`ci-required` + `gitleaks` + pinned validator + `scan-synced-content`) actually executed on every open PR (stalled `action_required` runs approved at latest heads; #960 given a fresh post-rebuild event via update-branch; #965 superseding sync dispatched). Nomination evidence gathered read-only from upstream HEADs via GitHub API. Nothing merged, no contributor-surface comments posted.
+
+---
+
+## Part 1 — Open PRs (5)
+
+### Gate execution proof
+
+| PR | head | ci-required | gitleaks | scan-synced-content | validator (`validate`) |
+|---|---|---|---|---|---|
+| #981 portaljs | `f4c54cab` | **FAIL** (scan only) | **PASS** | CHALLENGE ×1 | PASS |
+| #983 llm-box | `bfaa6e71` | **FAIL** (format + scan) | **PASS** | CHALLENGE ×1 | PASS |
+| #964 agent-safety-preflight | `d77a5d67` | **FAIL** (4 real findings) | **PASS** | CHALLENGE ×1 | **FAIL** (catalog churn) |
+| #960 walkie-talkie | `79678fe2` (fresh event) | pending→fail | **PASS** | CHALLENGE ×1 | PASS |
+| #965 bot sync | `2622c2da` (stale) | n/a | — | superseding run **REFUSE-blocked** | — |
+
+The common `scan-synced-content` CHALLENGE on the three `feat(sources)` PRs is the **designed human-sign-off gate** (`sources-change-unscanned`): a source-list change requires a reviewed waiver line in `scripts/scan-allowlist.txt` after the 699 vetting checklist. That's the system working, not a defect.
+
+### Verdicts
+
+**#981 portaljs (datopian, 2,304★, MIT, pushed today) — LEGIT, one-line fix.**
+The contributor's original entry had `include: 'license'` (lowercase — **correct**: upstream file is lowercase, no uppercase variant exists). Greptile's P1 suggestion claimed the opposite and the contributor applied it via web UI at `f4c54cab` → current head has `'LICENSE'`, which silently fails to match on the case-sensitive sync runner. **Greptile's applied "fix" introduced the exact bug it warned about**, and the thread is misleadingly marked resolved. Everything else verified: `.claude-plugin/` + `skills/**` resolve upstream, `verified: false` honest, all other gates green.
+→ **Action: revert to `- 'license'` + add the vetted waiver line → merge.** Strongest source in the batch.
+
+**#983 llm-box (alib8b8, 4★, MIT, active today) — LEGIT, two mechanical fixes.**
+All 9 include globs verified to exist upstream; narrow include list (deliberately excludes `.grok-plugin/`, `contrib/` etc. — good sign); contributor made two corrective pushes same-day (moved the entry out of the `config:` block; dropped a wrong `marketplace.json` include). Remaining: `format-check` (prettier on sources.yaml) + the waiver line. `verified: false` correctly reflects thin adoption. Note: ships an `.mcp.json` → payload scanner gets its say at sync time.
+→ **Action: prettier-format + waiver → merge.**
+
+**#964 agent-safety-preflight (el-zachariah) — LEGIT code, needs 4 mechanical fixes + one maintainer call.**
+Confirmed at head: **no SKILL.md anywhere** — plugin.json + one command + Python scanner + tests. All 7 substantive Greptile/Gemini security findings resolved with matching fix commits. CI found (all real, all small):
+1. `ruff` E401 — `import argparse, json, os, re, subprocess` on one line (`agent_preflight_lite.py:4`)
+2. `markdownlint` ×3 — MD031/MD032 blank-line issues in `commands/agent-preflight.md`
+3. `validate` — catalog churn **+1,592 lines** for 1 added entry (a formatter pass rewrote `marketplace.json`'s load-bearing layout; must be reverted)
+4. `scan-synced-content` CHALLENGE — **meta false-positive**: it flagged the plugin's own `curl|wget` *detection regex* as an outbound network call. The plugin makes no network calls. Narrow waiver.
+→ **Action: request-changes with the concrete list** + Jeremy's call: accept commands-only (below the 8-field SKILL.md marketplace tier by design) or require a SKILL.md.
+
+**#960 walkie-talkie (MulhamAnalytics → walkie-talkie-skill/walkie-talkie, 0★, 5 days old) — HOLD (upstream-blocked).**
+Upstream SKILL.md frontmatter **provably unparseable** at HEAD `0b74f4d3` (`ScannerError` at the unquoted `Triggers:` in `description`). Jeremy's fix issue walkie-talkie#1: open, 0 comments, no push since repo-creation day. PR author ≠ upstream org (relationship unverified). Entry also missing `verified:` flag. Fresh-event CI: gitleaks/validate/format all PASS; scan = the standard sources CHALLENGE.
+→ **Action: hold; one status comment (nudge #1, note the two gaps). Not merge-eligible until upstream YAML parses.**
+
+**#965 bot sync PR — superseded-in-principle, blocked by a real catch.**
+The superseding sync run (28886237377) was **hard-blocked by the supply-chain gate**: `plugins/community/mytradeledger-skills/…/mtl.py:52 [REFUSE] secret-exfil-cooccur` + 8 urllib CHALLENGEs, same file. Code review of upstream (`trpsbill/skills`, 0★, MIT): it's a **standard API client** — reads its own skill-local `.env` (`MTL_URL`/`MTL_TOKEN`) and sends the token as a Bearer header to its own configured service (default `https://mytradeledger.com`). Not exfiltration — dual-use pattern the scanner is rightly paranoid about.
+→ **Action needed (Jeremy):** narrow waiver for mtl.py (recommended — reviewed, own-service client) **or** drop the source. Then re-dispatch sync → fresh PR auto-closes #965.
+
+---
+
+## Part 2 — Killer-Skill nominations (6)
+
+| # | Repo | ★ | pushed | YAML | 8-field | Call |
+|---|---|---|---|---|---|---|
+| **833** | polyxmedia/mnemos | 20 | 07-02 | ✓ | **8/8** | **FEATURE-READY — W28** |
+| 828 | nostrband/ServiceGraph | **68** | 06-02 | ✓ | 3/8 | Mirror + `curated:true` (fix staged: fork `skill-frontmatter-spec` @ `df4648a4`, 1 ahead, covers all 18 SKILL.md) |
+| 834 | tonone-ai/tonone | 56 | 06-17 | ✓ | 6/8 | **Already curated on main** (`curated: true`, ~100 agents A-graded locally) — feature-viable now; upstream offer #107 still open, 0 response |
+| 830 | lemondepat/schedule-after-usage-reset | 1 | 05-23 | ✓ | 2/8 | Fix staged (fork @ `a83ea165`) — but 1★, upstream dead since day one. Editorial: weak feature candidate |
+| 829 | ggrigo/align | 0 | 07-02 | ✓ | 2/8 | Park/decline — author iterates (0.5.3→0.8.2) but zero adoption, stub frontmatter |
+| 832 | rhinehart514/founder-os | 3 | 05-25 | **✗ root parse FAIL** | 4/8 | **Decline-with-invite** (broken as shipped, idle upstream) — same treatment as #831 |
+
+**Hygiene (confirmed):**
+1. Three outreach artifacts silently self-closed 2026-07-07 ~02:16 UTC with **zero maintainer engagement ever**: `ServiceGraph#2` (not_planned), `schedule-after-usage-reset#2` (not_planned), `tonone#108` (PR, closed unmerged). Nominations #828/#830/#834 still link them as live → each needs a one-line status note.
+2. The #830 triage claim "YAML parse break" **does not reproduce** at upstream HEAD (parses clean; upstream unchanged since 05-23) — triage record needs correcting.
+3. tonone now has **616** SKILL.md files upstream (triage said 402).
+
+**Recurring gaps across the pool** (feeds the submission standard): missing `compatibility`+`tags` (5/6), missing `author`/`license`/`version` (4/6), YAML breaks from unquoted colon-bearing descriptions (founder-os live; walkie-talkie in the PR queue; #831 rejected for same).
+
+---
+
+## Part 3 — Decisions needed
+
+1. **#981 + #983:** push the tiny fixes to contributor branches ourselves (`maintainerCanModify: true` on both) + vetted waiver lines, then merge — or comment and wait. (Recommend: push + merge; credit the contributor in the merge message.)
+2. **#964:** accept commands-only plugin (no SKILL.md, below marketplace tier by design) or require a SKILL.md in the request-changes ask?
+3. **mytradeledger REFUSE:** narrow reviewed waiver (recommend) or drop the source? Unblocks all future syncs either way.
+4. Contributor-surface comment drafts (#964 request-changes, #960 status note, 3 nomination status notes) follow for wording sign-off per AGENTS.md.
+
+---
+
+## Part 4 — Outcomes (same day, 2026-07-07)
+
+Applied after Jeremy's checkpoint approval (push-fixes-and-merge / require-SKILL.md / resolve-the-REFUSE):
+
+| Item | Outcome |
+|---|---|
+| #981 portaljs | **MERGED** `c70f4388` — casing reverted to upstream's lowercase `license`, vetting waiver, full gate green |
+| #983 llm-box | **MERGED** `87d006ea` — prettier fix + main merged in (conflict resolved), full gate green |
+| #987 sources hygiene | **MERGED** `d6d307ee` — REFUSEd mytradeledger removed (rule-fidelity gap, not malware; #985 defect 1), mnemos W28 pinned mirror added (#833), waiver line swapped |
+| #964 preflight | Request-changes drafted (4 mechanical fixes + require SKILL.md per maintainer call) — awaiting wording sign-off |
+| #960 walkie-talkie | Hold note drafted — upstream YAML still unparseable; awaiting wording sign-off |
+| #965 bot sync | Still open — superseding sync (run 28889050755) cleared the REFUSE but hit the **first lock-baseline reconcile**: 39 pure-mirror sources drift-quarantined by sources.lock.json (#968 working as designed; sync stalled for weeks so upstreams legitimately moved). Relock decision pending |
+| Gate defects | Filed as #985 / four beads: own-service REFUSE fidelity, REFUSE-walls-sync, waiver persistence, prescreen path filter |
+| Submission standard | PR #986: templates/skill-docs/ ×4 + tier→docs matrix + issue-before-PR intake + 000-docs/700 + CONTRIBUTING sections |
+| Backlog | #789–794 collapsed under #795 (decision 2026-08-04); dispositions on #935/#859/#796/#938; #941's 15 policy calls surfaced |

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Or use Claude's built-in command:
 
 <!-- KILLER-SKILL:START — do not edit; run `node scripts/render-spotlight.mjs` -->
 
-> **Killer Skill of the Week** — [databricks-pack](https://tonsofskills.com/plugins/databricks-pack) by [Jeremy Longshore](https://github.com/jeremylongshore)
+> **Killer Skill of the Week** — [mnemos](https://github.com/polyxmedia/mnemos) by [Polyx Media](https://github.com/polyxmedia)
 >
-> **Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess**
+> **Persistent memory for Claude Code that actually gets written — measured, not promised**
 >
-> The databricks-cost-leak-hunter skill audits a workspace for real-dollar cost leaks and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure is computed from the customer's own system.billing.usage joined to list_prices — never an estimate. Four named leaks — idle clusters that never auto-terminate, scheduled jobs on All-Purpose compute (2–3× overpay), overprovisioned clusters, and the Photon premium paid without the speedup — each tagged confirmed / estimated / at-risk so a CFO never confuses billed waste with modeled savings. A deterministic Python ranker does the arithmetic (the LLM never eyeballs a number), and the databricks-workspace-mcp control plane turns each leak into a single-config-change fix. One of 24 skills in the Databricks pack.
+> The mnemos skill closes the loop most memory tools leave open: getting anything recorded at all. A SessionStart hook prewarms a token-budgeted context block and a UserPromptSubmit hook pattern-matches correction-shaped prompts into a non-skippable capture directive — upstream measured capture jumping from a 7% baseline to 53%, with a +40% behavior lift on paired Claude runs. Corrections persist as structured tried/wrong_because/fix records, and three that cluster auto-promote into a skill deterministically, no LLM in the loop. The engine is a dependency-free single Go binary (~15 MB, pure-Go SQLite) keeping everything local. MIT-licensed, with all 8/8 required frontmatter fields verified at upstream HEAD.
 >
-> _"A $100K/month Databricks workspace is likely burning ~$27,000/month — and every line is one config change."_ — Jeremy Longshore
+> _"A memory layer for AI coding agents — because Claude Code keeps forgetting, and that gets old fast."_ — Polyx Media
 >
-> Grade: A | Week of June 30, 2026 (W27) | [Browse on Marketplace](https://tonsofskills.com/plugins/databricks-pack)
+> Grade: A | Week of July 7, 2026 (W28) | [View on GitHub](https://github.com/polyxmedia/mnemos)
 >
-> Previous picks: [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate), [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
+> Previous picks: [databricks-pack](https://tonsofskills.com/plugins/databricks-pack), [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate), [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
 
 <!-- KILLER-SKILL:END -->
 

--- a/marketplace/src/data/spotlights.json
+++ b/marketplace/src/data/spotlights.json
@@ -1,19 +1,32 @@
 {
-  "week": "2026-W27",
+  "week": "2026-W28",
   "title": "Killer Skill of the Week",
   "spotlight": {
-    "pluginSlug": "databricks-pack",
-    "headline": "Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess",
-    "whyKiller": "The databricks-cost-leak-hunter skill audits a workspace for real-dollar cost leaks and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure is computed from the customer's own system.billing.usage joined to list_prices — never an estimate. Four named leaks — idle clusters that never auto-terminate, scheduled jobs on All-Purpose compute (2–3× overpay), overprovisioned clusters, and the Photon premium paid without the speedup — each tagged confirmed / estimated / at-risk so a CFO never confuses billed waste with modeled savings. A deterministic Python ranker does the arithmetic (the LLM never eyeballs a number), and the databricks-workspace-mcp control plane turns each leak into a single-config-change fix. One of 24 skills in the Databricks pack.",
-    "author": "Jeremy Longshore",
-    "authorGithub": "jeremylongshore",
+    "pluginSlug": "mnemos",
+    "headline": "Persistent memory for Claude Code that actually gets written — measured, not promised",
+    "whyKiller": "The mnemos skill closes the loop most memory tools leave open: getting anything recorded at all. A SessionStart hook prewarms a token-budgeted context block and a UserPromptSubmit hook pattern-matches correction-shaped prompts into a non-skippable capture directive — upstream measured capture jumping from a 7% baseline to 53%, with a +40% behavior lift on paired Claude runs. Corrections persist as structured tried/wrong_because/fix records, and three that cluster auto-promote into a skill deterministically, no LLM in the loop. The engine is a dependency-free single Go binary (~15 MB, pure-Go SQLite) keeping everything local. MIT-licensed, with all 8/8 required frontmatter fields verified at upstream HEAD.",
+    "author": "Polyx Media",
+    "authorGithub": "polyxmedia",
     "grade": "A",
-    "skillCount": 24,
-    "category": "saas-packs",
-    "link": "/plugins/databricks-pack",
-    "quote": "A $100K/month Databricks workspace is likely burning ~$27,000/month — and every line is one config change."
+    "skillCount": 1,
+    "category": "community",
+    "link": "https://github.com/polyxmedia/mnemos",
+    "quote": "A memory layer for AI coding agents — because Claude Code keeps forgetting, and that gets old fast."
   },
   "hallOfFame": [
+    {
+      "week": "2026-W27",
+      "pluginSlug": "databricks-pack",
+      "headline": "Find the ~$27K/month leaking out of a $100K Databricks workspace — from the billing table, not a guess",
+      "whyKiller": "The databricks-cost-leak-hunter skill audits a workspace for real-dollar cost leaks and emits a CFO-grokkable, dollar-ranked FinOps report. Every confirmed figure is computed from the customer's own system.billing.usage joined to list_prices — never an estimate. Four named leaks — idle clusters that never auto-terminate, scheduled jobs on All-Purpose compute (2–3× overpay), overprovisioned clusters, and the Photon premium paid without the speedup — each tagged confirmed / estimated / at-risk so a CFO never confuses billed waste with modeled savings. A deterministic Python ranker does the arithmetic (the LLM never eyeballs a number), and the databricks-workspace-mcp control plane turns each leak into a single-config-change fix. One of 24 skills in the Databricks pack.",
+      "author": "Jeremy Longshore",
+      "authorGithub": "jeremylongshore",
+      "grade": "A",
+      "skillCount": 24,
+      "category": "saas-packs",
+      "link": "/plugins/databricks-pack",
+      "quote": "A $100K/month Databricks workspace is likely burning ~$27,000/month — and every line is one config change."
+    },
     {
       "week": "2026-W21",
       "pluginSlug": "kobiton-automate",
@@ -126,8 +139,8 @@
     }
   ],
   "meta": {
-    "version": "2.5.0",
-    "lastUpdated": "2026-06-30",
+    "version": "2.6.0",
+    "lastUpdated": "2026-07-07",
     "curatedBy": "Jeremy Longshore"
   }
 }

--- a/templates/skill-docs/examples/mnemos/ADR.md
+++ b/templates/skill-docs/examples/mnemos/ADR.md
@@ -1,0 +1,84 @@
+# ADR: mnemos — dependency-free Go binary, hook-driven capture, local-first storage
+
+> Worked example: this decision record is reconstructed from the upstream
+> `polyxmedia/mnemos` repository (README "Design" and "Architecture" sections, SKILL.md,
+> and decisions the store itself records) — the design as shipped, read back as the
+> decision it was.
+
+**Author:** André Figueira (Polyx Media)
+**Date:** 2026-07-07
+**Status:** Accepted
+
+## Context
+
+A memory layer for coding agents only works if it is present at every session start with
+near-zero friction, if anything actually gets _written_ to it, and if what is written can
+be trusted when it re-enters context later. Three forces shape the design: (1) the engine
+must install and run identically across five agent hosts (Claude Code, Claude Desktop,
+Cursor, Windsurf, Codex CLI) on Linux/macOS/Windows without a language runtime on the
+user's machine; (2) agents skip optional tool calls — upstream measured a 7% baseline
+capture rate, so prompting alone demonstrably does not produce a learning loop; (3) a
+memory store is a write-time prompt-injection attack surface, and anything non-local or
+non-deterministic makes the pipeline unauditable.
+
+## Decision
+
+Ship the engine as a **single static, CGO-free Go binary** (~15 MB) exposing MCP tools
+over stdio, with state in a **local SQLite + FTS5 database** (`~/.mnemos/mnemos.db`,
+pure-Go `modernc.org/sqlite` driver, bi-temporal schema). Make capture **structural, not
+optional**: a Claude Code SessionStart hook (`mnemos prewarm`) injects a token-budgeted
+context block and opens the session, and a UserPromptSubmit hook pattern-matches
+correction-shaped prompts and emits a `[mnemos: capture required]` directive. This
+SKILL.md is the behavioral layer that tells the agent which tool answers which signal.
+Consolidation (three clustered corrections → one promoted skill) is deterministic
+clustering + templating — no LLM inside the memory layer. Nothing leaves the machine by
+default.
+
+## Alternatives considered
+
+| Alternative                                       | Why rejected                                                                                                                                                                                                                                 |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Node or Python MCP server                         | Adds a language runtime + dependency tree to every user machine; install friction and version drift defeat "memory is always there." A static binary wired by `mnemos init` needs neither.                                                   |
+| Skill/prompt-only capture (no hooks)              | Measured insufficient: capture sat at 7% baseline and tuning trigger phrases gained only a few points. The UserPromptSubmit directive — a structural fix — moved it to 53%.                                                                  |
+| LLM-in-the-loop consolidation and memory curation | Non-deterministic and unauditable: a model deciding "what counts as similar enough" gives different skills from the same corrections. Deterministic clustering + templating yields the same output for the same input, end-to-end auditable. |
+
+Within the binary itself, the CGO SQLite driver (`mattn/go-sqlite3`) was also rejected —
+the repo records this decision verbatim: the pure-Go driver "keeps the binary CGO-free
+and cross-compilable to linux/darwin/windows without a toolchain on the install path";
+zero-CGO is a hard invariant.
+
+## Consequences
+
+**Positive:**
+
+- One-command install (curl script or Homebrew), one binary serving five agent hosts;
+  `mnemos update` self-updates with sha256 verification.
+- Capture becomes structural: the hook path raised recorded corrections from 7% to 53%,
+  and the paired-run behavior harness shows +40% overall lift (25/25 vs 15/25).
+- Deterministic, auditable pipeline — same corrections always promote the same skill; the
+  write-time prompt-injection scanner sanitizes or flags hostile content before it can
+  re-enter context.
+- Local-first by default: no network calls unless the user opts into OpenAI embeddings or
+  the HTTP transport.
+
+**Negative / accepted tradeoffs:**
+
+- The hook mechanism is Claude Code-specific; other hosts fall back to skill-instructed
+  `mnemos_session_start`, a weaker capture path. Accepted: Claude Code is the primary
+  target and the MCP tools still work everywhere.
+- Capture is not solved — 53% overall, and architectural decisions buried inside larger
+  task prompts still sit at 0/3 even with the directive. Accepted and documented openly
+  upstream as an open problem.
+- Pure-Go SQLite trades some raw performance against the CGO driver; cross-compilation
+  without a toolchain was judged worth more.
+- Retrieval falls back to pure FTS5 (BM25) when Ollama is unreachable, so paraphrased
+  queries rank worse without embeddings. Accepted: fine for most projects.
+
+## Tool-permission scope
+
+The skill's frontmatter declares exactly one entry — least privilege in its strictest
+form: no `Bash`, no `Read`/`Write`, no filesystem or shell access at all.
+
+| Tool          | Why it's needed                                                                                                                                                                                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp__mnemos` | The entire skill surface is the mnemos MCP server's tools (`mnemos_session_start/end`, `mnemos_save`, `mnemos_correct`, `mnemos_convention`, `mnemos_search`, `mnemos_ruminate_*`, …). All persistence crosses the MCP boundary, where the write-time prompt-injection scanner runs — the skill never touches disk or shell directly. |

--- a/templates/skill-docs/examples/mnemos/ONE-PAGER.md
+++ b/templates/skill-docs/examples/mnemos/ONE-PAGER.md
@@ -1,0 +1,57 @@
+# mnemos
+
+**Persistent memory for Claude Code — corrections, conventions, and decisions that survive the session, with a harness that measures the lift instead of claiming it.**
+
+## Problem
+
+Claude Code forgets conventions, corrections, and architectural decisions between
+sessions, and even with a memory store wired in as MCP tools, agents almost never record
+to it on their own — upstream measured a 7% baseline capture rate. The store sits empty,
+and every session starts blind.
+
+## Solution
+
+The mnemos skill is the behavioral layer over the mnemos memory engine (a single static
+Go binary serving MCP tools). A SessionStart hook prewarms a token-budgeted context block
+of conventions, corrections, and hot files; a UserPromptSubmit hook turns
+correction-shaped prompts into a non-skippable capture directive; the skill tells the
+agent which tool answers which signal — record corrections as structured
+tried / wrong_because / fix entries, save decisions, close sessions with summaries, and
+hostile-review stale rules through the rumination workflow. Three clustered corrections
+auto-promote into a skill deterministically, so the next session starts smarter.
+
+## W5
+
+|           |                                                                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Who**   | Claude Code users running the mnemos MCP server (the same server also works in Claude Desktop, Cursor, Windsurf, and Codex CLI)                                       |
+| **What**  | Makes the agent actually use its memory: open/reuse sessions, record corrections, conventions, and decisions, close with summaries, and review flagged rules          |
+| **When**  | Every session — at start (reuse the prewarm session ID), on any genuine correction or architectural call, and at session end                                          |
+| **Where** | Claude Code with `mnemos serve` wired by `mnemos init`; all state local in `~/.mnemos/mnemos.db` (SQLite), nothing leaves the machine by default                      |
+| **Why**   | Agents skip optional memory calls (7% capture baseline); the skill + hooks raise recorded corrections to 53% and deliver a measured +40% behavior lift on paired runs |
+
+## Stack
+
+| Layer         | Choice                                                                                          |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| Skill runtime | Claude Code SKILL.md (single skill, no bundled scripts)                                         |
+| Memory engine | mnemos — single static, CGO-free Go binary (~15 MB), MCP over stdio                             |
+| Storage       | SQLite + FTS5 via pure-Go `modernc.org/sqlite`, bi-temporal schema, local `~/.mnemos/mnemos.db` |
+| Capture hooks | Claude Code SessionStart (`mnemos prewarm`) + UserPromptSubmit capture directive                |
+| Retrieval     | BM25 + optional cosine similarity via Reciprocal Rank Fusion (Ollama auto-detected)             |
+| External APIs | None by default (opt-in: Ollama/OpenAI embeddings, HTTP transport)                              |
+| Tool scope    | `mcp__mnemos` only — no Bash, no filesystem tools                                               |
+
+## Differentiators
+
+1. **Measured, not claimed.** Ships `mnemos verify`: Claude run twice on a fixed scenario
+   set, on vs off — 25/25 vs 15/25 behavior compliance (+40%), capture 7% → 53%. The
+   fixtures and runner are in the repo; the numbers are reproducible, including the ones
+   that are still ugly (architectural-decision capture: 0/3).
+2. **Deterministic learning loop.** Three corrections clustering on the same agent,
+   project, and topic promote into a skill by clustering + templating — no LLM inside the
+   memory layer, same input always yields the same output — and revising a flagged rule
+   requires stating a new falsifiable prediction (a Popperian guard at the tool boundary).
+3. **Zero-dependency and local-first.** One curl or brew install, no runtime, five agent
+   hosts wired by `mnemos init`; a write-time prompt-injection scanner guards the store,
+   and no network calls happen unless you opt in.

--- a/templates/skill-docs/examples/mnemos/PRD.md
+++ b/templates/skill-docs/examples/mnemos/PRD.md
@@ -1,0 +1,70 @@
+# PRD: mnemos
+
+**Author:** André Figueira (Polyx Media)
+**Date:** 2026-07-07
+**Status:** Active
+
+> Worked example: reconstructed by the marketplace maintainers from the upstream
+> `polyxmedia/mnemos` SKILL.md, README, and plugin.json at HEAD. Every number below is an
+> upstream-published measurement, not a marketplace claim.
+
+## Problem
+
+AI coding agents forget conventions, corrections, and architectural decisions between
+sessions, so users re-teach the same fixes over and over. Worse: even when a persistent
+memory store is available as MCP tools, agents almost never record to it unprompted —
+upstream measured a 7% baseline capture rate for correction-shaped signals, and the store
+itself contains a recorded correction about the exact failure mode ("agent skipped
+`mnemos_session_start` on editing tasks"). Without a behavioral layer that forces the
+learning loop, the memory store sits empty and every session starts blind.
+
+## Target users
+
+| User                                           | Context                                                                                  | Primary need                                                                        |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Solo developer on a long-lived repo            | Multi-session Claude Code work where the same corrections and conventions keep repeating | Record a correction once, have it surface automatically next session                |
+| Claude Code user with mnemos already installed | The `mnemos_*` MCP tools are wired but the agent silently edits and never calls them     | An external nudge that makes the agent actually record and recall                   |
+| Developer working across MCP hosts             | Same project rules re-taught to Claude Code, Cursor, Windsurf, and Codex CLI separately  | One local store the same MCP server serves to every host, plus portable skill packs |
+
+## Success criteria
+
+1. On the upstream `mnemos verify behavior` harness (Claude Code, n=5 paired runs), the
+   skill-on arm matches the published result: 25/25 scenario compliance vs 15/25 with
+   mnemos off — a +40% overall lift, concentrated on project-specific conventions and the
+   recursive "agent forgets to use its own memory tools" case.
+2. On `mnemos verify capture`, correction-shaped signals in user prompts are recorded at
+   the published 53% (8/15) rate with the UserPromptSubmit capture directive — against
+   the 7% baseline without it.
+3. No dangling sessions: `mnemos_stats` at the top of a new session shows zero open
+   sessions left behind by a skill-guided prior session (every opened session is closed
+   via `mnemos_session_end` with a summary and status).
+4. The prewarm context block stays inside its 500-token default budget (upstream measured
+   ~20 tokens on an empty store, ~460 populated).
+
+## Functional requirements
+
+- **FR-1:** At session start, reuse the `mnemos_session_id` injected by the SessionStart
+  prewarm hook; call `mnemos_session_start(project, goal)` only when no ID is present and
+  real work is about to happen.
+- **FR-2:** Record durable signals with the matching tool: `mnemos_correct`
+  (tried / wrong_because / fix) for genuine corrections, `mnemos_convention` for
+  project-forever rules, `mnemos_save` for decisions, patterns, and architecture calls.
+- **FR-3:** Close every session on a done signal via `mnemos_session_end` with a one-to-two
+  sentence summary and a status of `ok` / `failed` / `blocked` / `abandoned`.
+- **FR-4:** Run the rumination workflow when stored rules are flagged —
+  `mnemos_ruminate_list` → `mnemos_ruminate_pack` → resolve (with a falsifiable
+  `why_better`) or dismiss (with an honest reason); never close a candidate silently.
+- **FR-5:** Fail loudly when `mnemos_*` tools are not visible: direct the user to
+  `mnemos doctor` / `mnemos init` rather than silently proceeding without memory.
+
+## Out of scope
+
+- The memory engine itself — storage, ranking, consolidation, the prompt-injection
+  scanner, and the verify harness ship in the separate mnemos Go binary / MCP server, not
+  in this skill.
+- Installing the binary or wiring agent hosts — `mnemos init` and the installer own that;
+  the skill only points at `mnemos doctor` when tools are missing.
+- Ephemeral within-session notes — the skill explicitly forbids saving running commentary
+  ("I'm reading X now") to the store.
+- Retrieval tuning (hybrid alpha, embedding providers, token budgets) — configuration
+  surface of the engine, not skill behavior.


### PR DESCRIPTION
Promotes mnemos to the 2026-W28 spotlight (databricks-pack → Hall of Fame), ships the first worked example of the submission-documents standard at `templates/skill-docs/examples/mnemos/` (PRD + ADR + ONE-PAGER, every metric traced to upstream's own verify-harness numbers), and files the Phase-0 legitimacy report as `000-docs/701-AA-AUDR`.

Sequencing note: the mnemos source entry is already on main (#987); the mirrored plugin content lands with the next successful sync (currently pending the 39-source lock-baseline relock decision). The spotlight links to the upstream repo (skyvern precedent), so nothing renders broken in the interim.

Refs #984, #833.

- Jeremy Longshore
intentsolutions.io