### PR TITLE
docs(databricks-pack): backfill the submission-doc set for databricks-cost-leak-hunter (first first-party skill on the tier matrix)

### DIFF
--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines (v1, DEPRECATED — rebuilt as 5 live-detection skills + MCP in v2.0.0)",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/databricks-pack/package.json
+++ b/plugins/saas-packs/databricks-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/databricks-pack",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Claude Code skill pack for Databricks - 24 skills covering lakehouse platform, Spark, and ML pipelines (v1, DEPRECATED — rebuilt as 5 live-detection skills + MCP in v2.0.0)",
   "main": "README.md",
   "type": "module",

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/ADR.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/ADR.md
@@ -1,0 +1,97 @@
+# ADR: databricks-cost-leak-hunter — billing-table dollars, deterministic ranking, two data planes
+
+> Filed at `docs/ADR.md` beside the rest of the submission set, per
+> `000-docs/700-DR-GUID-skill-submission-standard.md` §2 ("the same matrix applies to
+> Intent Solutions' own skills") — keeping the four docs atomic and inside the
+> markdownlint-gated `plugins/**` tree. The ADR template's `000-docs/` filing note is the
+> known alternative reading; the divergence is called out in the backfill PR.
+
+**Author:** Jeremy Longshore (Intent Solutions)
+**Date:** 2026-07-07
+**Status:** Accepted
+
+## Context
+
+A cost report is only worth shipping if a finance owner can trust every number in it and
+act on every line. Three forces shaped the design. (1) Generic waste estimates get
+discounted on sight — a credible figure must be computed from the customer's own billing
+rows, and Databricks exposes exactly that in `system.billing.usage` joined to
+`system.billing.list_prices`, but behind a metastore-admin grant chain that is the single
+most common failure. (2) An LLM eyeballing arithmetic is a nonstarter when the output is a
+money claim — the math must be reproducible and auditable. (3) A billing row says how much
+but not _why_: turning a leak into a fix requires live control-plane evidence (the
+auto-termination setting, the cluster source, the autoscale floor, the runtime engine)
+that the billing tables do not carry.
+
+## Decision
+
+We compute every confirmed dollar figure from the customer's own `system.billing.usage`
+joined to `system.billing.list_prices` through the **Databricks CLI Statement Execution
+API** — never an estimate — and we corroborate each leak's root cause on a second data
+plane, the **`databricks-workspace-mcp`** control-plane tools, so each report line lands
+as a single verified config change. All arithmetic runs in the **deterministic ranker**
+(`scripts/rank-and-report.py`): it sums per-category figures by `kind`
+(`confirmed` / `estimated` / `at-risk`), ranks by monthly dollar impact, annualizes the
+headline and #1 line, and keeps confirmed and unconfirmed dollars split — the LLM does
+not do the arithmetic. Step 1 probes the billing grant chain and fails fast with the
+exact missing `GRANT` statements; if the MCP server is absent, the dollar half still runs
+and corroboration degrades to pasted config rather than failing silently.
+
+## Alternatives considered
+
+| Alternative                                                    | Why rejected                                                                                                                                                                                                             |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Model waste from published industry rates (e.g. cloud-waste %) | An estimate a skeptical CFO can dismiss. The skill's contract is confirmed dollars from the workspace's own billing rows; published rates survive only as labeled framing in the illustrative sample output.             |
+| Let the LLM compute and rank the dollar figures inline         | Money arithmetic must be reproducible. The deterministic ranker produces the same report from the same inputs and is auditable line-by-line; "the LLM does NOT do the arithmetic" is a stated invariant of the pipeline. |
+| A single data plane — SQL only, or the workspace REST/MCP only | The REST control plane cannot produce billed dollars; the billing tables cannot confirm today's live config. Either half alone loses the dollar figure or loses the verified single-config-change fix.                   |
+
+A fourth rejection is baked into the output contract: a single blended headline number.
+Summing confirmed spend with modeled (estimated/at-risk) amounts under one verb is
+forbidden by the skill's Output rules and enforced as the regression-critical eval
+criterion `splits-confirmed-vs-estimated`.
+
+## Consequences
+
+**Positive:**
+
+- Confirmed figures are billed dollars attributed to `system.billing.usage` — the
+  strongest evidence class available, and the `dollars-from-billing-not-estimates` eval
+  criterion holds the skill to it.
+- Same inputs, same report: the ranker's sums, ranking, and annualization are
+  deterministic and reviewable in `scripts/rank-and-report.py`.
+- Every leak ships with corroborated live config, so each fix is one named setting
+  (auto-termination, Jobs Compute, autoscale floor, `runtime_engine`).
+- The grant-chain probe converts the most common failure into an upfront, verbatim
+  `GRANT`-chain report instead of a mid-flow crash.
+
+**Negative / accepted tradeoffs:**
+
+- Hard prerequisites: Premium/Enterprise with Unity Catalog, a metastore-admin grant
+  chain, and a running SQL warehouse (`DATABRICKS_WAREHOUSE_ID`). No grants, no report —
+  accepted, because an unverifiable number is worse than no number.
+- Two authentication surfaces (CLI host+token; the MCP's own PAT/U2M/M2M) mean more
+  setup. Accepted as the price of two-plane evidence.
+- Two of the four categories (overprovisioning `est_*`, Photon at-risk) are modeled and
+  never join the confirmed headline, so the report undersells the total against a blended
+  number. Accepted by design — that is the point.
+- Without the MCP server, corroboration relies on pasted config: weaker evidence, clearly
+  labeled, still dollar-accurate.
+
+## Tool-permission scope
+
+No bare `Bash`: shell access is scoped to exactly two binaries. The five MCP tools are
+all read-only `get`/`list` calls; nothing in the tool set can mutate workspace config.
+
+| Tool                                                 | Why it's needed                                                                                                                                      |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Read`                                               | Load the on-demand `references/*.md` knowledge (leak-category SQL, CFO format, grant-chain setup, DLT tiers) and per-category `leak-*.json` results. |
+| `Write`                                              | Write the rendered report and per-leak detail artifacts to the runtime working dir (`$OUT`) — never into the skill package.                          |
+| `Edit`                                               | Rescale the headline spend in the rendered report when the user asks.                                                                                |
+| `Bash(databricks:*)`                                 | The CLI Statement Execution API calls (`databricks api post /api/2.0/sql/statements`) that run the Step-1 grant probe and every dollar query.        |
+| `Bash(jq:*)`                                         | Parse statement-execution JSON, inject `warehouse_id` into the SQL template, and assemble the per-category results fed to the ranker.                |
+| `Glob`                                               | Collect the per-category `leak-*.json` outputs for the ranking step.                                                                                 |
+| `mcp__databricks-workspace-mcp__clusters_get`        | Confirm live `autotermination_minutes`, `autoscale.min_workers`/`max_workers`, `cluster_source`, and `runtime_engine` for a flagged cluster.         |
+| `mcp__databricks-workspace-mcp__clusters_events`     | Measure the actual idle gap between `RUNNING` and `TERMINATING` events on never-terminating clusters.                                                |
+| `mcp__databricks-workspace-mcp__clusters_list`       | Enumerate clusters and confirm compute type when validating the jobs-on-All-Purpose leak.                                                            |
+| `mcp__databricks-workspace-mcp__instance_pools_list` | Detect the idle-pool overprovisioning variant (`min_idle_instances` + `stats.idle_count`) — pool waste is not a billing row.                         |
+| `mcp__databricks-workspace-mcp__pipelines_get`       | Check DLT pipeline Photon/serverless/edition settings (`spec.photon`) when the Photon leak touches DLT.                                              |

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/CFO-ONE-PAGER.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/CFO-ONE-PAGER.md
@@ -1,0 +1,65 @@
+# Databricks Cost Leak Hunter — CFO One-Pager
+
+> This document is required for this skill: `databricks-pack` is the 2026-W27 featured
+> pick and money is the pitch (per the `templates/skill-docs/README.md` tier matrix).
+> Numbers discipline, inherited from the skill itself: confirmed (billed) dollars and
+> modeled (estimated/at-risk) dollars are presented separately and never summed under one
+> figure.
+
+## The cost of the problem
+
+On the skill's worked example — a **$100K/month** Databricks workspace — the four leak
+categories account for **~$19,000/month of confirmed billed waste (~$228K/year)**, plus
+**up to ~$8,000/month flagged for review (~$96K/year)**. The $100K/month workspace spend
+is the only assumed input; on a live run, every confirmed figure is computed from your
+own `system.billing.usage` joined to `system.billing.list_prices`. The mechanics behind
+the leaks are published rates, not house numbers — e.g. All-Purpose Compute bills
+~$0.55/DBU against ~$0.15/DBU on Jobs Compute, so a scheduled job on the wrong tier pays
+roughly 2–3× for identical work, and Photon carries a ~2× DBU premium that only pays off
+when the job actually runs faster.
+
+## What the skill changes
+
+One invocation replaces a manual FinOps audit. It verifies billing-table access upfront
+(and, if access is missing, reports the exact grants to request instead of failing
+halfway), runs four detection scans over the workspace's own billing rows, corroborates
+each finding against the live cluster/pool/pipeline configuration, and hands the results
+to a deterministic ranker — the LLM never does the arithmetic. The output is a
+dollar-ranked report designed to be read by a non-engineer in ~90 seconds, where every
+line is a single config change an engineer can be assigned: idle clusters that never shut
+off, scheduled jobs on the premium tier, oversized clusters, and Photon premium paid
+without the speedup.
+
+## Impact per run
+
+| Dimension     | Per run                                                                                                                                                                                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Time saved    | Replaces manual billing-table SQL plus per-cluster config archaeology; the report itself is built to a ~90-second CFO read — a blocking criterion in the skill's eval spec.                                                                                                 |
+| Risk reduced  | Confirmed vs Estimated vs At-risk labeling prevents booking modeled savings as recoverable dollars; the upfront grant check prevents half-run analyses.                                                                                                                     |
+| Dollars saved | Worked example ($100K/month workspace): ~$19K/month confirmed (~$228K/yr) + up to ~$8K/month pending review (~$96K/yr); the #1 line alone (idle clusters, confirmed) is ~$144K/yr, fixed in one setting. Live runs compute your actual figures from `system.billing.usage`. |
+
+## Adoption cost
+
+| Item          | Cost                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setup time    | Minutes if billing grants already exist; otherwise gated on a metastore admin running a four-statement `GRANT` chain — the skill checks upfront and prints exactly what is missing.                                                                                                                                                                                   |
+| Prerequisites | Databricks Premium or Enterprise with Unity Catalog; metastore-admin grant chain on `system.billing` (and `system.compute` for corroboration); Databricks CLI authenticated; `jq`; `DATABRICKS_WAREHOUSE_ID` pointing at a running SQL warehouse; `databricks-workspace-mcp` registered (own PAT/U2M/M2M auth) — optional, the dollar analysis still runs without it. |
+| Ongoing       | None required; re-run per billing review — every report stamps its trailing-30-day window.                                                                                                                                                                                                                                                                            |
+
+## Risk notes
+
+- **Read-only against Databricks.** The workspace access is billing `SELECT`s plus
+  read-only `get`/`list` config calls; the skill changes no workspace configuration —
+  every fix is a recommendation applied by your engineer.
+- **Permissions bound the blast radius.** Billing access requires an explicit Unity
+  Catalog grant chain; the MCP server authenticates separately; no secrets are hardcoded
+  — all auth comes from the environment or the registered MCP server.
+- **Modeled numbers are fenced.** Overprovisioning figures are estimates (labeled
+  `est_*`); the Photon premium is at-risk pending a runtime-gain review; neither is ever
+  counted in the confirmed headline.
+- **Negotiated pricing can diverge from list prices.** The price join matches
+  `sku_name` and `usage_unit` within the price-effective window; if it returns NULL, the
+  skill falls back to your contracted rate card rather than guessing.
+- **Degraded mode is explicit.** If the workspace MCP is absent, dollar figures still
+  compute and config corroboration relies on pasted config — weaker evidence, clearly
+  labeled, never a silent failure.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/ONE-PAGER.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/ONE-PAGER.md
@@ -1,0 +1,54 @@
+# Databricks Cost Leak Hunter
+
+**Finds the real-dollar cost leaks in a Databricks workspace and reports them as a dollar-ranked, CFO-grokkable fix list — computed from the customer's own billing tables.**
+
+## Problem
+
+Databricks spend leaks through four recurring configurations — clusters that never
+auto-terminate, scheduled jobs on All-Purpose Compute (~$0.55/DBU) instead of Jobs
+Compute (~$0.15/DBU), clusters sized for peak that idle below 25% CPU, and a ~2× Photon
+premium on jobs it doesn't accelerate. The bill says how much but not where or why, and
+DBU-denominated analysis needs an engineer to translate before a CFO can act.
+
+## Solution
+
+A detect → compute → rank → report pipeline. SQL over the workspace's own
+`system.billing.usage` joined to `system.billing.list_prices` (via the Databricks CLI
+Statement Execution API) produces the dollars; the `databricks-workspace-mcp`
+control-plane tools corroborate the live config that explains each leak; a deterministic
+Python ranker does all the arithmetic; and the output is a CFO-grokkable report — a split
+confirmed-vs-pending-review headline, a ranked leak table with a Confidence column, and a
+single-config-change fix per line. A Step-1 grant-chain probe fails fast if billing
+access is missing.
+
+## W5
+
+|           |                                                                                                                                         |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Who**   | CFO / FinOps owners and the data-platform engineers who answer to them                                                                  |
+| **What**  | Audits a workspace for four named leak categories and emits a dollar-ranked FinOps report with Confirmed / Estimated / At-risk labels   |
+| **When**  | The bill spikes, the monthly FinOps review, or any "why is my Databricks bill so high?" moment                                          |
+| **Where** | Claude Code (also Codex-compatible), against a Databricks Premium/Enterprise + Unity Catalog workspace                                  |
+| **Why**   | Dollars come from the workspace's own billing rows and a deterministic ranker — never LLM guesswork — and each fix is one config change |
+
+## Stack
+
+| Layer             | Choice                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| Skill runtime     | Claude Code `SKILL.md` (compatibility: Codex)                                                     |
+| Dollar data plane | Databricks CLI Statement Execution API over `system.billing.usage` × `system.billing.list_prices` |
+| Config data plane | `databricks-workspace-mcp` — five read-only cluster/pool/pipeline tools                           |
+| Arithmetic        | Deterministic Python ranker (`scripts/rank-and-report.py`) + `jq`                                 |
+| Knowledge         | `references/*.md` loaded on demand (leak-category SQL, CFO format, grant-chain setup, DLT tiers)  |
+
+## Differentiators
+
+1. **Confirmed dollars, never estimates** — every confirmed figure is computed from the
+   customer's own `system.billing.usage` joined to `list_prices`; the two modeled
+   categories are explicitly labeled Estimated and At-risk and never blended in.
+2. **The LLM never does the arithmetic** — a deterministic ranker sums, ranks, and
+   annualizes, and the headline never sums confirmed and unconfirmed dollars under one
+   verb (a regression-critical eval criterion).
+3. **Every leak is one config change** — the second data plane corroborates live config
+   (`auto_termination_minutes`, `cluster_source`, autoscale floor, `runtime_engine`), so
+   each report line names the exact setting to flip.

--- a/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/PRD.md
+++ b/plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/PRD.md
@@ -1,0 +1,79 @@
+# PRD: databricks-cost-leak-hunter
+
+**Author:** Jeremy Longshore (Intent Solutions)
+**Date:** 2026-07-07
+**Status:** Active
+
+> Backfilled 2026-07-07 from the shipped skill (SKILL.md v0.1.0, `eval-spec.yaml`, and the
+> pack's design-review record) to the `templates/skill-docs/` submission standard — the
+> first first-party skill held to the pack/flagship tier of the doc matrix. Refs #984.
+
+## Problem
+
+Databricks bills climb without an explanation a finance owner can act on. The waste hides
+in four recurring configurations: clusters that never auto-terminate and bill around the
+clock for idle compute; scheduled jobs running on All-Purpose Compute (~$0.55/DBU) instead
+of Jobs Compute (~$0.15/DBU) — 2–3× the cost for identical work; clusters sized for peak
+that idle below 25% CPU; and the ~2× Photon DBU premium paid on jobs it doesn't
+accelerate. The native billing data can prove all four, but it lives in `system.*` tables
+behind a metastore-admin grant chain and speaks in DBUs — so cost reviews either stall on
+access, or arrive as engineering jargon a CFO can't act on, or fall back to generic
+industry waste estimates that a skeptical reader can dismiss.
+
+## Target users
+
+| User                       | Context                                                                                       | Primary need                                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| CFO / FinOps owner         | Monthly spend review, or the Databricks bill just spiked                                      | A dollar-ranked report readable in ~90 seconds and actionable without an engineer to translate        |
+| Data-platform engineer     | Asked "why is our Databricks bill so high?" and needs defensible numbers, not vibes           | Deterministic detection SQL over `system.billing.usage` plus a ranked list of one-config-change fixes |
+| Databricks workspace admin | Recurring cost-hygiene sweeps (idle clusters, wrong-SKU jobs, oversized floors, Photon usage) | A repeatable detect → compute → rank → report pipeline with confirmed-vs-estimated labeling           |
+
+## Success criteria
+
+Criteria 1–3 are enforced verbatim by the skill's `eval-spec.yaml` judge criteria.
+
+1. Triggers on Databricks cost questions ("why is my databricks bill", "find wasted
+   spend", "cost leak") and does not trigger on unrelated prompts — eval criterion
+   `triggers-on-cost-question` (blocker) plus the two should-not-trigger control cases.
+2. A CFO with no Databricks engineering knowledge can read the output in ~90 seconds and
+   say "we are wasting $X here, fix it" without an engineer — eval criterion
+   `produces-cfo-grokkable-report` (blocker).
+3. Confirmed and estimated/at-risk dollars are never summed under one figure, and every
+   leak carries a Confidence label (Confirmed / Estimated / At-risk) — eval criterion
+   `splits-confirmed-vs-estimated` (regression-critical), with confirmed figures
+   attributed to `system.billing.usage` (`dollars-from-billing-not-estimates`).
+4. A workspace missing the billing grant chain is reported upfront with the exact missing
+   `GRANT` statements — Step 1 fails fast instead of dying mid-analysis (eval criterion
+   `checks-grant-chain-upfront`).
+
+## Functional requirements
+
+- **FR-1:** Verify the metastore-admin grant chain on `system.billing` before any
+  analysis; on failure, report the exact missing grants verbatim and stop.
+- **FR-2:** Detect the four named leak categories with SQL over `system.billing.usage`
+  joined to `system.billing.list_prices` via the CLI Statement Execution API: idle
+  clusters (`auto_termination_minutes = 0`), scheduled jobs on `ALL_PURPOSE`,
+  overprovisioned clusters (<25% CPU from `system.compute.node_timeline`), and the Photon
+  premium (`sku_name ILIKE '%PHOTON%'`).
+- **FR-3:** Corroborate each leak's live configuration through `databricks-workspace-mcp`
+  (`clusters_get`, `clusters_events`, `clusters_list`, `instance_pools_list`,
+  `pipelines_get`); if the MCP server is absent, still produce the dollar figures and
+  accept pasted config instead of failing.
+- **FR-4:** Do all dollar arithmetic in the deterministic ranker
+  (`scripts/rank-and-report.py`) — the LLM never eyeballs a number; every leak carries a
+  `kind` of `confirmed` / `estimated` / `at-risk`.
+- **FR-5:** Render the CFO report per `references/cfo-output-format.md`: a split headline
+  that never sums confirmed and unconfirmed dollars under one verb, a trailing-30-day
+  window stamp, a ranked table with a Confidence column, and a #1-line annualized callout
+  — each fix a single config change.
+
+## Out of scope
+
+- Authoring cost-control policy (cluster policies, spot configs) — that is the sibling
+  `databricks-cost-tuning` skill; this skill detects and reports.
+- Applying any fix — every remediation is a recommendation for a human-approved config
+  change; the skill never mutates workspace configuration.
+- Estimating spend when the billing tables are unreadable — no grant chain, no report
+  (fail fast at Step 1 rather than substitute guesses).
+- Standard-tier / non-Unity-Catalog workspaces — the `system.*` tables are UC-governed
+  and unavailable there.


### PR DESCRIPTION
## What

Backfills the full submission-document set for our own `databricks-cost-leak-hunter` skill — the first **first-party** skill held to the `templates/skill-docs/` tier→docs matrix. The standard applies to "even the ones we make, so they are all the same."

New files (all under `plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/`):

- `PRD.md` — problem, target users, success criteria mapped 1:1 to `eval-spec.yaml` judge criteria, FR-1..FR-5, out-of-scope (incl. the `databricks-cost-tuning` sibling boundary)
- `ADR.md` — billing-table dollars / deterministic ranking / two data planes, 3 rejected alternatives, consequences both directions, and a tool-permission table justifying **exactly** the frontmatter `allowed-tools` (2 scoped Bash binaries + 5 read-only MCP tools, no bare Bash)
- `ONE-PAGER.md` — tagline, problem/solution, W5, stack, exactly three differentiators
- `CFO-ONE-PAGER.md` — money is the pitch here, so the fourth doc is required

## Why this tier

Per the tier matrix in [`templates/skill-docs/README.md`](../blob/main/templates/skill-docs/README.md) and `000-docs/700-DR-GUID-skill-submission-standard.md` §2–3: **Pack / flagship / featured / paid-tier → PRD + ADR + ONE-PAGER (+ CFO-ONE-PAGER where money is the pitch)**, and §3 makes the full set a **featuring requirement**. `databricks-cost-leak-hunter` is the 2026-W27 Hall of Fame featured skill with a dollar headline — it was featured before the standard existed, so this backfill closes the compliance gap. No pack sibling ships any per-skill docs, so this also sets the first in-tree precedent for the `docs/` layout (the only filled example so far is `templates/skill-docs/examples/mnemos/`).

## Placement decision (resolving the known ambiguity)

`700-DR-GUID` §2 says docs live **in the plugin directory** as `docs/PRD.md`, `docs/ADR.md`, etc., and that "the same matrix applies to Intent Solutions' own skills." The `ADR.md` template's blockquote says the opposite for this repo: "In this repo, ADRs are filed per skill in `000-docs/` as `NNN-AT-DECR-<skill-slug>.md`."

**Chosen reading: all four docs at the skill's `docs/` dir** (`plugins/saas-packs/databricks-pack/skills/databricks-cost-leak-hunter/docs/`), because:

1. §2 of the guide is the canonical process doc and explicitly extends the matrix to first-party skills;
2. it keeps the four-doc set atomic and inside the `plugins/**` tree that the **blocking** markdownlint CI job covers (`000-docs/**` is lint-ignored);
3. skill-scoped (not pack-root) `docs/` is the defensible reading for a 24-skill pack — this doc set describes one skill, not the pack.

The divergence from the ADR template's blockquote is noted in the ADR itself; if maintainers prefer the `000-docs/702-AT-DECR-…` filing, moving one file is trivial. Follow-up worth considering: reconcile the ADR template blockquote with 700-GUID §2 so the next first-party backfill doesn't face the same fork.

## Numbers discipline

Every figure traces to the shipped skill: the SKILL.md worked example ($100K/month workspace → **~$19,000/month confirmed** (~$228K/yr) **plus up to ~$8,000/month pending review** (~$96K/yr); $12K idle / $7K All-Purpose jobs / $5K overprovision (Estimated) / $3K Photon (At-risk); #1 line ~$144K/yr), the ~$0.55 vs ~$0.15/DBU rate gap, and the W27 spotlight copy. Per the skill's own Output rule and the `regression_critical` eval criterion `splits-confirmed-vs-estimated`, the CFO one-pager **never** presents a blended ~$27K total — the confirmed/pending split is preserved everywhere.

## Gates

- `npx -y markdownlint-cli2` with the repo config (the blocking CI job; `plugins/**/*.md` is covered and databricks-pack is not in the sync-ignore list): **0 errors**
- `npx -y prettier@3.8.3 --check` with the repo config: **clean** (`plugins/` is prettier-ignored by `.prettierignore`; the four files were additionally formatted to prettier style so they'd pass even without the ignore)

Refs #984



## CI note (fix-up)

`[skip auto-bump]` — the auto-bump workflow re-bumps this docs-only PR on every synchronize event and pushes a checkless bot-actor head (same non-idempotence as on #990; tracked in #985). Marker added so required checks can report at a stable head.

- Jeremy Longshore
intentsolutions.io
