### PR TITLE
docs: submission paperwork + validation baseline for the content-consistency-validator plugin

### DIFF
--- a/000-docs/702-AA-AUDR-consistency-validator-plugin-baseline-audit-2026-07-07.md
+++ b/000-docs/702-AA-AUDR-consistency-validator-plugin-baseline-audit-2026-07-07.md
@@ -1,0 +1,53 @@
+# Validation baseline audit — 000-jeremy-content-consistency-validator (first-party plugin)
+
+**Date:** 2026-07-07 · **Scope:** full validator pass over
+`plugins/productivity/000-jeremy-content-consistency-validator/` — plugin manifest, skill
+at marketplace tier, command at standard tier, agents directory. **Purpose:** freeze the
+as-is baseline before the #991 multi-agent rebuild, and attach it to the submission
+paperwork (`docs/PRD.md`, `docs/ADR.md`, `docs/ONE-PAGER.md`) filed per the tier→docs
+matrix in `700-DR-GUID-skill-submission-standard.md` (first-party, flagship track).
+
+---
+
+## 1. Layer-by-layer results
+
+| Layer                    | Artifact                                                   | Result                                                                                               |
+| ------------------------ | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Plugin manifest          | `.claude-plugin/plugin.json`                               | Canonical path; complete — `name`, `description`, `version` 2.0.0, `author`, `repository`, `license` |
+| Skill (marketplace tier) | `skills/000-jeremy-content-consistency-validator/SKILL.md` | **Grade A, 100/100 — 0 errors, 6 warnings** (verbatim below)                                         |
+| Command (standard tier)  | `commands/validate-consistency.md`                         | **PASS** — legacy format; Anthropic guidance says new plugins use `skills/`                          |
+| Agents                   | `agents/`                                                  | **Absent** — zero agents exist; `/validate-agent` had nothing to grade                               |
+
+## 2. The 6 marketplace-tier warnings (verbatim)
+
+1. `allowed-tools` declares `Grep` but the body never references it (over-permissive/stale).
+2. `allowed-tools` declares `Read` but the body never references it (over-permissive/stale).
+3. `allowed-tools` declares `WebSearch` but the body never references it (over-permissive/stale).
+4. The `## Report Format` section is a 6-word stub.
+5. Missing conditional field `argument-hint`.
+6. The body carries time-sensitive dates/versions that can go stale.
+
+## 3. Diagnosis — A/100 on paper, hollow in practice (the shadowing defect)
+
+The grade and the product's actual condition diverge, and the mechanism is known
+(epic **#991**): Jeremy invokes `/validate-consistency` constantly, but **skill
+precedence resolves to the global `~/.claude` skill** of the same name — the installed
+plugin is shadowed in its own author's environment. Unexercised, the plugin copy has
+drifted into a **thin shell (682-word SKILL.md)** while the global skill carries the full
+engine: project-type auto-detect, a source-of-truth hierarchy, and deterministic drift
+checks. The warning cluster above is the symptom set of that drift — a stale tool grant
+(warnings 1–3), a stub section (warning 4), and staleness-prone body content (warning 6)
+are what a shadowed, unmaintained copy looks like at A/100.
+
+**Disposition:** a rebuild per Fable's recommendation — multi-agent architecture — is
+scoped in issue **#991**. The current single-pass architecture is recorded honestly in
+`docs/ADR.md` with status "superseded-in-planning"; the rebuild files its own ADR. The
+PRD describes the product contract and holds across the rebuild.
+
+## 4. Cross-references
+
+- Epic: `jeremylongshore/claude-code-plugins-plus-skills#991` (rebuild scope)
+- Umbrella: `#984` (marketplace quality pipeline)
+- Submission standard: `000-docs/700-DR-GUID-skill-submission-standard.md`
+- Paperwork filed with this baseline:
+  `plugins/productivity/000-jeremy-content-consistency-validator/docs/{PRD,ADR,ONE-PAGER}.md`

--- a/plugins/productivity/000-jeremy-content-consistency-validator/docs/ADR.md
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/docs/ADR.md
@@ -1,0 +1,90 @@
+# ADR: 000-jeremy-content-consistency-validator — single-pass read-only skill with a report-only contract
+
+> Filed at `docs/ADR.md` beside the rest of the submission set, per
+> `000-docs/700-DR-GUID-skill-submission-standard.md` §2 ("the same matrix applies to
+> Intent Solutions' own skills"). The ADR template's `000-docs/` filing note is the known
+> alternative reading; the first-party `docs/` convention follows the databricks-pack
+> backfill precedent (PR #989).
+
+**Author:** Jeremy Longshore (Intent Solutions)
+**Date:** 2026-07-07
+**Status:** Accepted — current implementation, **superseded-in-planning** by the #991
+multi-agent rebuild (Fable's recommendation); the rebuild files its own ADR.
+
+## Context
+
+The product contract ([`docs/PRD.md`](PRD.md)) is a cross-surface consistency audit whose
+one non-negotiable is trust: the user must be able to run it against their live website,
+public GitHub repos, and internal docs with zero risk that anything gets modified. The
+comparison itself is not purely mechanical — the README commits to exact, fuzzy
+(90%+ similarity), semantic, and pattern-based matching — so some judgment lives in-model
+rather than in scripts. And the output has to be actionable by a non-participant: every
+finding needs a file path, a line number, a severity, and a recommendation grounded in a
+declared authority order (website > GitHub > local docs). Doing nothing means users
+hand-diff dozens of files across three surfaces after every website change.
+
+## Decision
+
+Ship the validator as a **single-pass, read-only Claude Code skill** — one SKILL.md with
+an eight-step procedure (discover → extract → verify → compare → classify → prioritize →
+report → save) — plus a **legacy `commands/validate-consistency.md` slash command** for
+explicit invocation. No agents, no bundled scripts: source discovery and extraction run
+through narrowly-scoped shell text tools (`Bash(diff:*)`, `Bash(grep:*)`), remote
+surfaces are fetched with WebFetch, and the fuzzy/semantic comparison happens in-context.
+The trust hierarchy (website > GitHub > local docs) is hard-coded into the procedure, and
+the only artifact a run produces is a timestamped Markdown report under
+`consistency-reports/`.
+
+## Alternatives considered
+
+| Alternative                                                                | Why rejected                                                                                                                                                                                           |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Multi-agent pipeline (discovery / extraction / comparison / report agents) | More machinery than the v1 contract needed; a single-pass skill ships with zero orchestration surface. This rejection is now reversed in planning — the #991 rebuild adopts exactly this architecture. |
+| Deterministic script-based comparator (bundled `scripts/`)                 | Pure scripts handle exact and regex matching but not the fuzzy/semantic matching the product claims; staying scriptless also keeps install zero-dependency across hosts.                               |
+| Write-enabled auto-fixer                                                   | Breaks the core trust contract. "You maintain complete control — the plugin only reports, you decide what to fix" is the product's first promise, not an implementation detail.                        |
+| Command-only plugin (no skill)                                             | Loses natural-language auto-activation ("check consistency before I update training materials"). The command was kept alongside the skill instead — see the legacy-format consequence below.           |
+
+## Consequences
+
+**Positive:**
+
+- Zero write risk by construction: no `Write`, no `Edit`, no git mutation anywhere in the
+  declared tool surface — the read-only guarantee is enforceable, not aspirational.
+- Zero-dependency install: no scripts, no runtime, nothing to build; the skill works
+  wherever SKILL.md works (frontmatter declares Claude Code, Codex, OpenClaw).
+- Two invocation paths: natural-language skill activation plus an explicit
+  `/validate-consistency` command.
+- Deterministic report location and structure — timestamped file, fixed sections — so
+  successive runs are comparable.
+
+**Negative / accepted tradeoffs:**
+
+- **Tool-scope debt** (validation baseline, 2026-07-07): `allowed-tools` declares
+  `Grep`, `Read`, and `WebSearch`, but the SKILL.md body never references them —
+  over-permissive/stale scope, flagged as 3 of the 6 marketplace-tier warnings. To be
+  corrected in the #991 rebuild.
+- Single-pass, in-context comparison caps depth: no project-type auto-detection, no
+  deterministic drift checks — the gap that motivated the #991 multi-agent rebuild.
+- The legacy command duplicates the skill's job in the older `commands/` format; it
+  passes standard tier, but Anthropic guidance says new plugins use `skills/`. Two
+  surfaces for one behavior invite drift between them.
+- **Shadowing defect** (epic #991): skill precedence resolves `/validate-consistency` to
+  the global `~/.claude` skill of the same name, so this plugin is shadowed in its own
+  author's environment and has drifted into a thin shell (682-word SKILL.md) relative to
+  the global engine. The single-pass architecture made that thinning easy to miss.
+
+## Tool-permission scope
+
+The frontmatter declares six entries and nothing mutating — no bare `Bash`, no `Write`,
+no `Edit`. Entries marked ✱ are declared but never referenced in the SKILL.md body
+(validation baseline 2026-07-07, warnings 1–3); they are retained here as recorded debt,
+not as justified scope, pending the #991 rebuild.
+
+| Tool           | Why it's needed                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| `Read` ✱       | Intended for loading local docs and build output as comparison sources; body never invokes it.      |
+| `WebFetch`     | Fetch deployed website pages and GitHub raw content when the surface is remote (per Prerequisites). |
+| `WebSearch` ✱  | No use documented in the body; stale grant to be removed or justified in the rebuild.               |
+| `Grep` ✱       | Intended for structured-data extraction across sources; the body uses `Bash(grep:*)` instead.       |
+| `Bash(diff:*)` | Pairwise comparison of extracted fields between sources (step 4 of the procedure).                  |
+| `Bash(grep:*)` | Source discovery and extraction of versions, feature claims, and contact info (steps 1–2).          |

--- a/plugins/productivity/000-jeremy-content-consistency-validator/docs/ONE-PAGER.md
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/docs/ONE-PAGER.md
@@ -1,0 +1,54 @@
+# Content Consistency Validator
+
+**Read-only discrepancy reports that catch messaging drift across your website, GitHub, and internal docs — every finding with a file, a line number, and a severity.**
+
+## Problem
+
+The website gets updated first and everything else lags: the README still shows last
+release's version, internal training still quotes old pricing, and the same product is a
+"plugin" on one surface and an "extension" on another. Catching that drift by hand means
+manually diffing dozens of files across three surfaces after every change.
+
+## Solution
+
+One skill scans all three surfaces — any HTML-based website (static HTML, Hugo, Jekyll,
+WordPress, Next.js, Vue, Gatsby, Docusaurus, and more), GitHub repository docs, and local
+documentation — extracts versions, feature claims, contact info, and terminology, then
+compares every source pair. Discrepancies land in a timestamped Markdown report,
+severity-classified (Critical / Warning / Informational) and resolved against a declared
+trust hierarchy: website > GitHub > local docs. It never modifies a file; the report is
+the only artifact.
+
+## W5
+
+|           |                                                                                                                                                                         |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Who**   | Content managers, documentation teams, technical writers, open-source maintainers — anyone keeping public and internal messaging aligned                                |
+| **What**  | Scans website + GitHub + local docs, compares versions, feature claims, contact info, and terminology, and generates a severity-ranked read-only discrepancy report     |
+| **When**  | Before updating internal docs or training materials; after website updates, releases, or rebrands; any time "does everything still say the same thing?" needs an answer |
+| **Where** | Claude Code — auto-activating skill or explicit `/validate-consistency` command — run locally against the working repo; frontmatter also declares Codex and OpenClaw    |
+| **Why**   | Hand-diffing three surfaces misses drift; this turns every mismatch into a file-and-line action item under a defined authority order, without touching a single file    |
+
+## Stack
+
+| Layer          | Choice                                                                               |
+| -------------- | ------------------------------------------------------------------------------------ |
+| Skill runtime  | Claude Code SKILL.md (single skill, no bundled scripts)                              |
+| Command        | Legacy `/validate-consistency` slash command (`commands/`)                           |
+| Comparison     | In-context analysis + shell text tools scoped to `Bash(diff:*)` and `Bash(grep:*)`   |
+| Remote sources | WebFetch for deployed sites and GitHub raw content                                   |
+| External APIs  | None                                                                                 |
+| Output         | Timestamped Markdown report in `consistency-reports/`                                |
+| Tool scope     | Read-only — no `Write`, no `Edit`, no git mutations anywhere in the declared surface |
+
+## Differentiators
+
+1. **Read-only by contract, not by convention.** The declared tool surface contains
+   nothing that can mutate a file — the "it never changes anything" promise is
+   structurally enforceable, so it's safe to point at production content on day one.
+2. **A built-in authority order.** Website > GitHub > local docs is baked into the
+   procedure, so every conflict comes back with a defined authoritative source and an
+   update flow (website → GitHub → docs) instead of "these two files disagree."
+3. **Findings are assignments, not investigations.** Every discrepancy ships with its
+   file path, line number, severity class, and a concrete recommendation — the report
+   reads as a prioritized fix list someone can be handed.

--- a/plugins/productivity/000-jeremy-content-consistency-validator/docs/PRD.md
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/docs/PRD.md
@@ -1,0 +1,72 @@
+# PRD: 000-jeremy-content-consistency-validator
+
+**Author:** Jeremy Longshore (Intent Solutions)
+**Date:** 2026-07-07
+**Status:** Active
+
+> This PRD describes the product contract — problem, users, success criteria — and holds
+> across the multi-agent rebuild scoped in issue #991. Implementation decisions (and their
+> planned supersession) live in [`docs/ADR.md`](ADR.md).
+
+## Problem
+
+Messaging drifts apart across the surfaces a project publishes to. The website gets
+updated first; GitHub READMEs and internal documentation lag behind — so the public site
+says v1.2.1 while the README still says v1.2.0, the site claims "236 plugins" while the
+docs say "230+", contact info goes stale in training materials, and the same product is
+called a "plugin" on one surface and an "extension" on another. The cost is mixed public
+messaging, customer confusion, and internal materials (SOPs, training, sales collateral)
+that quietly contradict what the website promises. Finding this drift by hand means
+manually diffing dozens of files across three surfaces every time anything changes.
+
+## Target users
+
+| User                                  | Context                                                                      | Primary need                                                           |
+| ------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Content manager / marketing owner     | Website is updated first; internal paperwork lags behind                     | Know exactly what to update in the docs to match the live site         |
+| Documentation team / technical writer | Pre-release and post-rebrand audits across README, docs site, and changelog  | Version and terminology consistency, with file-and-line fix locations  |
+| Open-source maintainer                | README / CONTRIBUTING / docs drift from the published site between releases  | One report listing every file that needs updating, ordered by severity |
+| Trainer / internal-ops owner          | Training materials must match current public pricing, features, and contacts | Pre-update validation so materials are revised against current truth   |
+
+## Success criteria
+
+1. Every reported finding carries its source, file path, and line number — no finding
+   requires the reader to re-search for where the fix goes.
+2. Every discrepancy is severity-classified against the documented classes: Critical
+   (conflicting versions, contradictory feature lists, mismatched contact info, broken
+   cross-references), Warning (inconsistent terminology, missing information, outdated
+   dates), Informational (stylistic and platform-specific variation).
+3. A run mutates nothing: no Write, no Edit, no git operations. The only artifact is the
+   timestamped Markdown report saved to `consistency-reports/YYYY-MM-DD-HH-MM-SS.md`.
+4. Extraction is verified before comparison — at least 3 data points per source — and
+   every source pair (website↔GitHub, website↔docs, GitHub↔docs) appears in the
+   comparison matrix.
+
+## Functional requirements
+
+- **FR-1:** Auto-discover content sources across three surfaces: any HTML-based website
+  (static HTML, Hugo, Astro, Jekyll, WordPress, Next.js/React, Vue/Nuxt, Gatsby,
+  11ty/Eleventy, Docusaurus), GitHub repository docs (README, CONTRIBUTING, `docs/`), and
+  local documentation directories (`docs/`, `claudes-docs/`, `000-docs/`, `internal/`).
+- **FR-2:** Extract structured messaging from each source: version numbers, feature
+  claims, product names and taglines, contact information, URLs, technical requirements,
+  and terminology.
+- **FR-3:** Build a pairwise comparison matrix across all sources and classify each
+  discrepancy as Critical, Warning, or Informational.
+- **FR-4:** Apply the trust hierarchy — website (most authoritative) > GitHub
+  (developer-facing) > local docs (internal) — when recommending which side changes, with
+  the update flow website → GitHub → local docs.
+- **FR-5:** Generate a timestamped read-only Markdown report: executive summary,
+  per-pair comparison tables, terminology consistency matrix, and prioritized action
+  items with file paths and line numbers.
+
+## Out of scope
+
+- **Fixing anything.** The validator never modifies files and never auto-remediates; it
+  reports, the human decides.
+- **Deciding content.** It flags differences against the trust hierarchy; it does not
+  author or arbitrate copy.
+- **Continuous enforcement.** It is an on-demand audit, not a CI gate or a scheduled
+  monitor.
+- **Non-HTML surfaces.** App-store listings, social profiles, and ad copy are not
+  scanned — the surfaces are HTML-based websites, GitHub repositories, and local docs.

--- a/plugins/productivity/000-jeremy-content-consistency-validator/package.json
+++ b/plugins/productivity/000-jeremy-content-consistency-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/000-jeremy-content-consistency-validator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Read-only validator that generates comprehensive discrepancy reports comparing messaging consistency across ANY HTML-based website (WordPress, Hugo, Next.js, React, Vue, static HTML, etc.), GitHub rep",
   "keywords": [
     "documentation",


### PR DESCRIPTION
Files the submission-documents paperwork for the FIRST-PARTY flagship-track plugin `000-jeremy-content-consistency-validator`, per the tier→docs matrix in `000-docs/700-DR-GUID-skill-submission-standard.md` §2 ("the same matrix applies to Intent Solutions' own skills"; `docs/` filing per the databricks-pack backfill precedent, #989).

## The four files

| File | What it is |
|---|---|
| `plugins/productivity/000-jeremy-content-consistency-validator/docs/PRD.md` | The product contract: multi-surface messaging drift (website vs GitHub vs local docs), target users, 4 measurable success criteria, FR-1..FR-5, out-of-scope. Grounded only in what the plugin + its references actually claim; stable across the #991 rebuild. |
| `.../docs/ADR.md` | Honest record of the CURRENT architecture — single-pass read-only skill + legacy command, zero agents — with alternatives, consequences, and the least-privilege tool-scope table. Status: current implementation, **superseded-in-planning** by the #991 multi-agent rebuild (Fable's recommendation); the rebuild files its own ADR. The 3 baseline-flagged unreferenced `allowed-tools` (Grep, Read, WebSearch) are recorded as debt. |
| `.../docs/ONE-PAGER.md` | Pattern A landing view: W5 + stack tables with real values, three differentiators led by the structurally-enforceable read-only contract. |
| `000-docs/702-AA-AUDR-consistency-validator-plugin-baseline-audit-2026-07-07.md` | The validation baseline, verbatim: plugin.json complete at the canonical path; SKILL.md **Grade A, 100/100** at marketplace tier (0 errors, 6 warnings); command passes standard tier in legacy format; `agents/` absent. |

## The finding worth reading

**A/100 on paper, hollow in practice.** The plugin grades clean, but skill precedence resolves `/validate-consistency` to the global `~/.claude` skill of the same name — the plugin is shadowed in its own author's environment and has drifted into a 682-word thin shell while the global skill carries the full engine (project-type auto-detect, source-of-truth hierarchy, deterministic drift checks). The 6 warnings are that drift's symptom set. The multi-agent rebuild is scoped in #991; this PR freezes the baseline and files the paperwork the rebuild starts from.

**Gates:** prettier@3.8.3 `--check` green on all four files; markdownlint-cli2 clean with the repo config; no leftover placeholders or template instruction lines.

Refs #984, #991.



## CI note (fix-up)

`[skip auto-bump]` — third confirmed hit of the auto-bump checkless-head loop (#985 defect 5). Marker added so required checks report at a stable head.

- Jeremy Longshore
intentsolutions.io
