### PR TITLE
fix(sources): anchor thin-mirror include globs (stop the **/ auto-prefix over-mirroring)

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -31,4 +31,4 @@ plugins/mcp/servicegraph/README.md:mcp-remote  same remote MCP endpoint document
 # per-review gate; a persistent line here would auto-waive FUTURE source-list
 # changes too, so each sources PR swaps this line for its own scoped reason and
 # the one-shot-waiver fix (#985 defect 3) retires the convention entirely.
-sources.yaml:sources-change-unscanned  2026-07-07 curated-vendoring PR reviewed: adds servicegraph (nostrband/ServiceGraph, nomination #828) + schedule-after-usage-reset (lemondepat/schedule-after-usage-reset, nomination #830) as curated frozen mirrors vetted per 699 — both MIT, 8/8 fields, content pinned to the reviewed fork SHAs df4648a4/a83ea165
+sources.yaml:sources-change-unscanned  2026-07-08 glob-anchoring PR reviewed: strictly risk-reducing — anchors the portaljs/llm-box/mnemos include patterns with `/` so the matcher's **/ auto-prefix stops mirroring nested unintended files (#985 defect 6); no source added or repointed

--- a/sources.yaml
+++ b/sources.yaml
@@ -1360,10 +1360,10 @@ sources:
     category: community
     verified: false
     include:
-      - '.claude-plugin/plugin.json'
-      - '.claude/skills/mnemos/SKILL.md'
-      - 'README.md'
-      - 'LICENSE'
+      - '/.claude-plugin/plugin.json'
+      - '/.claude/skills/mnemos/SKILL.md'
+      - '/README.md'
+      - '/LICENSE'
     exclude:
       - '.git/**'
       - 'node_modules/**'
@@ -1390,12 +1390,12 @@ sources:
     category: community
     verified: false
     include:
-      - '.claude-plugin/**'
-      - 'skills/**'
-      - 'README.md'
+      - '/.claude-plugin/**'
+      - '/skills/**'
+      - '/README.md'
       # upstream stores its license file as lowercase `license`; the sync
       # glob match is case-sensitive, so the casing must match theirs
-      - 'license'
+      - '/license'
     exclude:
       - 'node_modules/**'
       - '.git/**'
@@ -1425,15 +1425,15 @@ sources:
       - llm
       - mcp
     include:
-      - '.claude-plugin/plugin.json'
-      - 'skills/llm-box/SKILL.md'
-      - 'skills/setup/SKILL.md'
-      - 'commands/create-workflow.md'
-      - 'commands/run-workflow.md'
-      - 'commands/list-nodes.md'
-      - '.mcp.json'
-      - 'README.md'
-      - 'README.zh-CN.md'
+      - '/.claude-plugin/plugin.json'
+      - '/skills/llm-box/SKILL.md'
+      - '/skills/setup/SKILL.md'
+      - '/commands/create-workflow.md'
+      - '/commands/run-workflow.md'
+      - '/commands/list-nodes.md'
+      - '/.mcp.json'
+      - '/README.md'
+      - '/README.zh-CN.md'
     exclude:
       - 'node_modules/**'
       - '.git/**'


### PR DESCRIPTION
Root cause of #994's ci-required failure: the sync matcher auto-prefixes `**/` to unanchored patterns, so the vetted includes for portaljs/llm-box/mnemos were silently recursive — `README.md` mirrored every README upstream, pulling unvetted `examples/` + `giftless/` content whose placeholder URLs failed marketplace-validation. Anchors all three entries with `/`. Strictly risk-reducing; next sync orphan-prunes the extras.

Filed as **#985 defect 6**: 699 vetting reviews globs as least-privilege while the matcher un-anchors them — anchored-by-default (or a lint) is the real fix.

After merge: re-dispatch sync with relock=all (the #994 re-baseline never reached main) — the fresh sync PR supersedes #994.

Refs #984, #985.

- Jeremy Longshore
intentsolutions.io