### PR TITLE
fix(sync): anchored include patterns were dead code — strip the '/' when compiling

### DIFF
--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -215,13 +215,20 @@ function walkFiles(baseDir, relPrefix = '') {
  * the strict match dropped real files. Auto-prefixing fixes that without
  * needing every sources.yaml entry rewritten.
  */
-function matchesPattern(filePath, patterns) {
+export function matchesPattern(filePath, patterns) {
   if (!patterns || patterns.length === 0) return true;
 
   return patterns.some((rawPattern) => {
-    // Auto-prefix `**/` unless the pattern already starts with `**` or `/`
-    const pattern =
-      rawPattern.startsWith('**') || rawPattern.startsWith('/') ? rawPattern : `**/${rawPattern}`;
+    // Auto-prefix `**/` unless the pattern already starts with `**` or `/`.
+    // A leading `/` means "anchored to the source root": skip the auto-prefix
+    // AND strip the slash, because candidate paths are root-relative (a
+    // pattern compiled to ^/skills/... could never match 'skills/...' — the
+    // anchor form was dead code until 2026-07-08, #985 defect 6).
+    const pattern = rawPattern.startsWith('**')
+      ? rawPattern
+      : rawPattern.startsWith('/')
+        ? rawPattern.slice(1)
+        : `**/${rawPattern}`;
 
     // Order matters: handle `?` (single-char glob) BEFORE we insert any
     // literal `?` chars (like `(?:.*/)?`) into the regex pattern. Then
@@ -956,7 +963,14 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error('Fatal error:', error);
-  process.exit(1);
-});
+// Only run when executed directly (node scripts/sync-external.mjs …) —
+// the unit corpus imports matchesPattern from this module and must not
+// trigger a live sync on import.
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/scripts/sync-lockfile.test.mjs
+++ b/scripts/sync-lockfile.test.mjs
@@ -258,3 +258,42 @@ test('buildLockEntry: null resolved ref is preserved as null (bootstrap has no c
   assert.equal(e.locked_at, '2026-07-06T00:00:00Z');
   assert.match(e.files['a.md'], /^sha256:[0-9a-f]{64}$/);
 });
+
+// ── matchesPattern — include/exclude glob semantics (sync-external.mjs) ──
+// Added 2026-07-08 with the anchored-pattern fix (#985 defect 6): a leading
+// `/` anchors a pattern to the source root; anything else is auto-prefixed
+// `**/` (recursive by design, for nested contributor layouts). The anchored
+// form was dead code before this corpus existed — these tests keep it alive.
+import { matchesPattern } from './sync-external.mjs';
+
+test('anchored /README.md matches only the root README', () => {
+  assert.equal(matchesPattern('README.md', ['/README.md']), true);
+  assert.equal(matchesPattern('examples/portaljs-catalog/README.md', ['/README.md']), false);
+  assert.equal(matchesPattern('giftless/cloudflare/README.md', ['/README.md']), false);
+});
+
+test('anchored exact deep path matches itself and nothing nested above it', () => {
+  assert.equal(matchesPattern('skills/llm-box/SKILL.md', ['/skills/llm-box/SKILL.md']), true);
+  assert.equal(
+    matchesPattern('contrib/skills/llm-box/SKILL.md', ['/skills/llm-box/SKILL.md']),
+    false,
+  );
+});
+
+test('anchored /skills/** matches the root skills tree only', () => {
+  assert.equal(matchesPattern('skills/a/SKILL.md', ['/skills/**']), true);
+  assert.equal(matchesPattern('skills/deep/nested/ref.md', ['/skills/**']), true);
+  assert.equal(matchesPattern('nested/skills/a/SKILL.md', ['/skills/**']), false);
+});
+
+test('unanchored patterns stay recursive (the documented auto-prefix default)', () => {
+  assert.equal(matchesPattern('README.md', ['README.md']), true);
+  assert.equal(matchesPattern('examples/x/README.md', ['README.md']), true);
+  assert.equal(matchesPattern('skills/tools/x/skills/x/SKILL.md', ['skills/**']), true);
+});
+
+test('single-star stays single-segment; ? stays single-char', () => {
+  assert.equal(matchesPattern('docs/a.md', ['/docs/*.md']), true);
+  assert.equal(matchesPattern('docs/sub/a.md', ['/docs/*.md']), false);
+  assert.equal(matchesPattern('a.md', ['?.md']), true);
+});


### PR DESCRIPTION
The '/' anchor opt-out in matchesPattern() skipped the auto-prefix but never stripped the slash: `^/skills/...$` can never match root-relative `skills/...`, so every anchored pattern matched nothing. That's why sync PR #996 mirrored only generated artifacts after #995 anchored the thin-mirror includes.

Fix: strip the leading '/' at compile; export the function behind a new main-guard; 5 new corpus tests (anchored root/deep/glob + preserved recursive default). 24/24 pass.

After merge: re-dispatch sync with relock=all — the fresh sync PR supersedes #996 with the correctly-scoped mirrors.

Refs #984, #985 (defect 6).

- Jeremy Longshore
intentsolutions.io