### PR TITLE
fix(gitignore): root-anchor the .mcp.json ignore — plugin MCP configs were silently untrackable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,11 @@
 .idea/
 .lycheecache
 .lycheecache/
-.mcp.json
+# Root-anchored: ignore ONLY the repo-root local MCP config. Plugin-shipped
+# .mcp.json files under plugins/** are product content and MUST be tracked —
+# the unanchored form here silently re-ignored them (last-match-wins beat the
+# !plugins/**/.mcp.json negations above; #985, llm-box casualty in sync #998).
+/.mcp.json
 .project
 .pytest_cache/
 .settings/


### PR DESCRIPTION
Last-match-wins: the unanchored `.mcp.json` near the bottom of .gitignore beat the `!plugins/**/.mcp.json` negations at the top, so every new plugin MCP config was silently ignored (the 9 tracked ones were force-adds). Concrete casualty: the sync dropped llm-box's vetted `.mcp.json` (#998 log: 'GIT-IGNORED — will NOT be committed'). Root-anchors the ignore to `/.mcp.json`; verified with git check-ignore both ways.

Refs #984, #985.

- Jeremy Longshore
intentsolutions.io