### PR TITLE
fix(sources): verified:false on the 27 census-drifted entries (wondelai family + n-skills)

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -31,4 +31,4 @@ plugins/mcp/servicegraph/README.md:mcp-remote  same remote MCP endpoint document
 # per-review gate; a persistent line here would auto-waive FUTURE source-list
 # changes too, so each sources PR swaps this line for its own scoped reason and
 # the one-shot-waiver fix (#985 defect 3) retires the convention entirely.
-sources.yaml:sources-change-unscanned  2026-07-08 glob-anchoring PR reviewed: strictly risk-reducing — anchors the portaljs/llm-box/mnemos include patterns with `/` so the matcher's **/ auto-prefix stops mirroring nested unintended files (#985 defect 6); no source added or repointed
+sources.yaml:sources-change-unscanned  2026-07-08 verified-flag honesty PR reviewed: strictly risk-reducing — flips verified:true to false on the 27 census-drifted entries (wondelai family + n-skills, graded D/F) until upstream fixes land; no source added, repointed, or re-included

--- a/sources.yaml
+++ b/sources.yaml
@@ -46,7 +46,8 @@ sources:
       email: numman.ali@gmail.com
     license: Apache-2.0
     category: community
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     # Files to sync (relative to source_path)
     include:
       - 'SKILL.md'
@@ -69,7 +70,8 @@ sources:
       email: numman.ali@gmail.com
     license: Apache-2.0
     category: community
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'README.md'
@@ -126,7 +128,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -145,7 +148,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -164,7 +168,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -183,7 +188,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -202,7 +208,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -221,7 +228,8 @@ sources:
       github: wondelai
     license: MIT
     category: productivity
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -240,7 +248,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -259,7 +268,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -278,7 +288,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -297,7 +308,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -316,7 +328,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -335,7 +348,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -354,7 +368,8 @@ sources:
       github: wondelai
     license: MIT
     category: productivity
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -373,7 +388,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -392,7 +408,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -411,7 +428,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -430,7 +448,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -449,7 +468,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -468,7 +488,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -487,7 +508,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -506,7 +528,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -525,7 +548,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -544,7 +568,8 @@ sources:
       github: wondelai
     license: MIT
     category: business-tools
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -563,7 +588,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'
@@ -582,7 +608,8 @@ sources:
       github: wondelai
     license: MIT
     category: design
-    verified: true
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
     include:
       - 'SKILL.md'
       - 'references/**'


### PR DESCRIPTION
Honesty fix during the census deadline window: `verified: true` cannot sit on D/F-graded content. Flips 27 entries (wondelai ×25, gastown, zai-cli) to `verified: false` with inline re-earn comments — the flag flips back when their upstream fixes land via the weekly sync (notify issues posted with the 2026-07-22 deadline; still below bar after that → delisting per the fix-or-removed policy).

Refs #984.

- Jeremy Longshore
intentsolutions.io