### PR TITLE
feat(ci): emit signed gate-result evidence manifest for the labs dashboard

### DIFF
--- a/.github/workflows/emit-evidence.yml
+++ b/.github/workflows/emit-evidence.yml
@@ -1,0 +1,176 @@
+# ── Emit this repo's own signed testing evidence for the labs dashboard ──
+#
+# PURELY ADDITIVE workflow: no existing workflow, gate, or branch-protection
+# context changes. It is NOT a PR check and never reports a status context —
+# the required gate stays {ci-required, gitleaks}.
+#
+# Why push-to-main (not tag/release triggered):
+#   (a) release.yml here is workflow_dispatch-only and pushes its tags/releases
+#       with GITHUB_TOKEN — and GITHUB_TOKEN-created refs SUPPRESS downstream
+#       workflow triggers, so a tag/release-triggered emit could never fire;
+#   (b) a dispatched release runs at refs/heads/main anyway, so a branch-ref
+#       OIDC subject is what the identity would pin to regardless;
+#   (c) per-package npm releases pollute `releases/latest` (100/100 recent),
+#       so the manifest lives on a FIXED rolling prerelease (`evidence-latest`)
+#       instead — prerelease so it never becomes the repo's `latest`.
+#
+# What it does (fail-closed at every step):
+#   1. re-runs two of the repo's REAL blocking CI gates (both are steps of the
+#      `validate` job that `ci-required` needs): catalog-invariants +
+#      unicode-hygiene;
+#   2. shapes each outcome into a kernel gate-result/v1 row wrapped in a kernel
+#      EvidenceBundle, validated against @intentsolutions/core@0.9.0 — the
+#      EXACT version the dashboard verifies with (ci/emit-evidence/);
+#   3. keyless-signs each bundle's canonical bytes with cosign (Fulcio OIDC +
+#      production Rekor), then verifies every signature back in-repo;
+#   4. assembles report-manifest.json and uploads it onto the rolling
+#      `evidence-latest` prerelease (--clobber).
+#
+# The dashboard fetches:
+#   releases/download/evidence-latest/report-manifest.json
+# and pins these OIDC claims for the `ccp` row:
+#   issuer      https://token.actions.githubusercontent.com
+#   subject     repo:jeremylongshore/claude-code-plugins-plus-skills:ref:refs/heads/main
+#   workflowRef jeremylongshore/claude-code-plugins-plus-skills/.github/workflows/emit-evidence.yml@refs/heads/main
+name: Emit signed evidence manifest
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # activation / re-emit without waiting for a push
+
+concurrency:
+  group: emit-evidence
+  cancel-in-progress: true
+
+permissions: {} # default-deny; the job grants exactly what it needs
+
+jobs:
+  emit:
+    name: Emit signed gate-result evidence for the dashboard
+    # Claims must pin refs/heads/main — a dispatch from any other ref would
+    # produce an unverifiable manifest, so guard instead of emitting one.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # create/upload the rolling evidence-latest release
+      id-token: write # cosign keyless (Fulcio OIDC)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          # Node >= 22.6 — the emit scripts run under --experimental-strip-types
+          # (TS without a build step), which Node 20 does NOT support.
+          node-version: 22
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Standalone install (NOT a workspace member): pins the kernel validators
+      # to the exact version the dashboard verifies with, via the committed
+      # ci/emit-evidence/pnpm-lock.yaml. Root workspace + publish surfaces are
+      # untouched.
+      - name: Install kernel validators (standalone, frozen lockfile)
+        working-directory: ci/emit-evidence
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Emit-evidence self-check (kernel-valid + canonical-stable)
+        run: node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --self-check
+
+      # Runs the two real gates (python3 stdlib only), builds + kernel-validates
+      # the gate-result/v1 rows and EvidenceBundles. Fail-closed: a failing
+      # gate emits a FAIL row (honest evidence); a malformed artifact aborts.
+      - name: Emit gate-result/v1 EvidenceBundle(s)
+        run: node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --out build/evidence --ref "${GITHUB_REF}"
+
+      - name: Sign each EvidenceBundle (cosign keyless -> production Rekor)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          signed=0
+          for bundle in build/evidence/bundle-*.json; do
+            case "$bundle" in *.sigstore.json) continue;; esac
+            sig="${bundle%.json}.sigstore.json"
+            echo "::group::cosign sign-blob $bundle"
+            cosign sign-blob --yes --new-bundle-format --bundle "$sig" "$bundle"
+            echo "::endgroup::"
+            signed=$((signed + 1))
+          done
+          if [ "$signed" -eq 0 ]; then
+            echo "::error::no EvidenceBundles were produced to sign"
+            exit 1
+          fi
+          echo "signed $signed bundle(s)"
+
+      # Verify each signature back, in-repo, before publishing — a signature
+      # nobody in the producing pipeline checks is not a verified chain. The
+      # pinned identity is the SAME claim pair the manifest skeleton records
+      # and the dashboard re-checks at ingest.
+      - name: Verify each EvidenceBundle signature (cosign verify-blob; fail-closed)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          cert_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/emit-evidence.yml@${GITHUB_REF}"
+          cert_issuer="https://token.actions.githubusercontent.com"
+          echo "verifying against identity: ${cert_identity}"
+          verified=0
+          for bundle in build/evidence/bundle-*.json; do
+            case "$bundle" in *.sigstore.json) continue;; esac
+            sig="${bundle%.json}.sigstore.json"
+            if [ ! -s "$sig" ]; then
+              echo "::error::expected signature ${sig} for ${bundle} but it is missing/empty"
+              exit 1
+            fi
+            echo "::group::cosign verify-blob $bundle"
+            cosign verify-blob \
+              --new-bundle-format \
+              --bundle "$sig" \
+              --certificate-identity "$cert_identity" \
+              --certificate-oidc-issuer "$cert_issuer" \
+              "$bundle"
+            echo "::endgroup::"
+            verified=$((verified + 1))
+          done
+          if [ "$verified" -eq 0 ]; then
+            echo "::error::no signed EvidenceBundles were found to verify"
+            exit 1
+          fi
+          echo "verified $verified signed bundle(s) — emit->sign->verify chain closed in-repo"
+
+      - name: Assemble report-manifest.json (fail-closed on shape mismatch)
+        run: node --experimental-strip-types ci/emit-evidence/assemble-manifest.ts --dir build/evidence --out build/evidence/report-manifest.json
+
+      # Fixed rolling prerelease: created once (idempotent), then only the
+      # attached manifest asset moves. Prerelease => never shadows the repo's
+      # `latest` (which the per-package npm releases already own).
+      - name: Ensure rolling evidence-latest prerelease exists (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view evidence-latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "evidence-latest release already exists"
+          else
+            gh release create evidence-latest \
+              --repo "${GITHUB_REPOSITORY}" \
+              --prerelease \
+              --title "Evidence manifest (rolling)" \
+              --notes "Rolling signed-evidence manifest for the labs.intentsolutions.io reports hub (repo row key: ccp). The only meaningful artifact is the attached report-manifest.json, re-uploaded (--clobber) by .github/workflows/emit-evidence.yml on every push to main. Verify: cosign verify-blob against the OIDC identity pinned in the manifest's signing block."
+          fi
+
+      - name: Publish report-manifest.json onto evidence-latest (--clobber)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload evidence-latest build/evidence/report-manifest.json \
+            --repo "${GITHUB_REPOSITORY}" --clobber
+          echo "report-manifest.json published to the evidence-latest rolling prerelease"

--- a/ci/emit-evidence/assemble-manifest.ts
+++ b/ci/emit-evidence/assemble-manifest.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * ci/emit-evidence/assemble-manifest.ts — combine the emit skeleton with the
+ * cosign-produced sigstore bundles into the final `report-manifest.json` the
+ * intent-eval-dashboard fetches for the `ccp` row.
+ *
+ * Runs AFTER `ci/emit-evidence/emit-evidence.ts` (which wrote the skeleton +
+ * canonical bundle files) and AFTER CI has signed each `bundle-<i>.json` with
+ * `cosign sign-blob --bundle bundle-<i>.sigstore.json`. For each skeleton row
+ * it reads back the canonical bundle object + its sigstore bundle and
+ * assembles:
+ *
+ *   { repo, signing, rows: [ { bundle, sigstoreBundle, sourceSha, gateResults } ] }
+ *
+ * This is EXACTLY the shape the dashboard's `isReportManifestShape` accepts:
+ * each row carries `bundle` + `sigstoreBundle` + a string `sourceSha`. The
+ * extra `gateResults` field is additive — the current ingest ignores it; the
+ * gate-row resolver consumes it.
+ *
+ * Fail-closed: a missing bundle file, a missing sigstore bundle, or a
+ * structural mismatch aborts (exit 1) rather than publishing a half-built
+ * manifest.
+ *
+ * Usage:
+ *   node --experimental-strip-types ci/emit-evidence/assemble-manifest.ts \
+ *     [--dir build/evidence] [--out build/evidence/report-manifest.json]
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+interface SkeletonRow {
+  readonly bundleFile: string;
+  readonly gateResults: readonly unknown[];
+  readonly sourceSha: string;
+}
+interface Skeleton {
+  readonly repo: string;
+  readonly signing: {
+    readonly issuer: string;
+    readonly subject: string;
+    readonly workflowRef: string;
+  };
+  readonly rows: readonly SkeletonRow[];
+}
+
+interface ManifestRow {
+  readonly bundle: unknown;
+  readonly sigstoreBundle: unknown;
+  readonly sourceSha: string;
+  readonly gateResults: readonly unknown[];
+}
+interface ReportManifest {
+  readonly repo: string;
+  readonly signing: Skeleton['signing'];
+  readonly rows: readonly ManifestRow[];
+}
+
+/** Mirror of the dashboard's `isReportManifestShape` (kept in sync by review). */
+function isReportManifestShape(value: unknown): value is ReportManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v['repo'] !== 'string') return false;
+  const signing = v['signing'];
+  if (typeof signing !== 'object' || signing === null) return false;
+  const s = signing as Record<string, unknown>;
+  if (typeof s['issuer'] !== 'string') return false;
+  if (typeof s['subject'] !== 'string') return false;
+  if (typeof s['workflowRef'] !== 'string') return false;
+  if (!Array.isArray(v['rows'])) return false;
+  return v['rows'].every((r) => {
+    if (typeof r !== 'object' || r === null) return false;
+    const row = r as Record<string, unknown>;
+    return 'bundle' in row && 'sigstoreBundle' in row && typeof row['sourceSha'] === 'string';
+  });
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function assemble(dir: string): ReportManifest {
+  const skeletonPath = join(dir, 'manifest-skeleton.json');
+  if (!existsSync(skeletonPath)) {
+    throw new Error(`missing ${skeletonPath} — run ci/emit-evidence/emit-evidence.ts first`);
+  }
+  const skeleton = readJson(skeletonPath) as Skeleton;
+
+  const rows: ManifestRow[] = skeleton.rows.map((row) => {
+    const bundlePath = join(dir, row.bundleFile);
+    const sigPath = join(dir, `${basename(row.bundleFile, '.json')}.sigstore.json`);
+    if (!existsSync(bundlePath)) throw new Error(`missing bundle file ${bundlePath}`);
+    if (!existsSync(sigPath)) {
+      throw new Error(
+        `missing sigstore bundle ${sigPath} — was cosign sign-blob run for ${row.bundleFile}?`,
+      );
+    }
+    return {
+      bundle: readJson(bundlePath),
+      sigstoreBundle: readJson(sigPath),
+      sourceSha: row.sourceSha,
+      gateResults: row.gateResults,
+    };
+  });
+
+  const manifest: ReportManifest = { repo: skeleton.repo, signing: skeleton.signing, rows };
+  if (!isReportManifestShape(manifest)) {
+    throw new Error(
+      'assembled manifest failed the report-manifest shape check (would be rejected at ingest)',
+    );
+  }
+  return manifest;
+}
+
+function parseArgs(argv: readonly string[]): { dir: string; out: string } {
+  let dir = 'build/evidence';
+  let out = '';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--dir') {
+      dir = argv[i + 1] ?? dir;
+      i++;
+    } else if (argv[i] === '--out') {
+      out = argv[i + 1] ?? out;
+      i++;
+    }
+  }
+  if (out === '') out = join(dir, 'report-manifest.json');
+  return { dir, out };
+}
+
+const invokedDirectly = process.argv[1]?.endsWith('assemble-manifest.ts') === true;
+if (invokedDirectly) {
+  try {
+    const { dir, out } = parseArgs(process.argv.slice(2));
+    const manifest = assemble(dir);
+    writeFileSync(out, JSON.stringify(manifest), 'utf8');
+    console.log(`assemble-manifest OK: ${manifest.rows.length} signed row(s) -> ${out}`);
+    process.exit(0);
+  } catch (err: unknown) {
+    console.error(
+      'assemble-manifest FAILED (fail-closed):',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  }
+}

--- a/ci/emit-evidence/emit-evidence.ts
+++ b/ci/emit-evidence/emit-evidence.ts
@@ -1,0 +1,480 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * ci/emit-evidence/emit-evidence.ts — produce this repo's own signed-ready
+ * testing evidence for the intent-eval-dashboard reports hub
+ * (labs.intentsolutions.io, repo row key `ccp`).
+ *
+ * ── Why this lives in `ci/emit-evidence/`, NOT `scripts/` ──
+ *
+ * `scripts/` is the repo's operational toolbox (validators, sync, publish
+ * helpers) and is linted/formatted under the root gates. This emitter is a
+ * CI-only artifact producer with its own pinned dependency
+ * (`@intentsolutions/core` — the kernel validators, pinned to the EXACT
+ * version the dashboard verifies with). It has its own private, non-workspace
+ * `package.json` + lockfile so the root workspace, the publish surfaces
+ * (`plugins/**`, `packages/**`, pnpm-workspace globs), and the published npm
+ * packages are all untouched. Nothing under `ci/` ships anywhere.
+ *
+ * This is the DETERMINISTIC half of the emit. It runs two of the repo's real,
+ * blocking, deterministic CI gates (both live inside the `validate` job that
+ * the `ci-required` aggregate needs), shapes each outcome into a kernel
+ * `gate-result/v1` body, wraps each in a kernel `EvidenceBundle`, and writes:
+ *
+ *   build/evidence/bundle-<i>.json          — CANONICAL EvidenceBundle bytes
+ *   build/evidence/gate-result-<i>.json     — the gate-result/v1 predicate body
+ *   build/evidence/manifest-skeleton.json   — for ci/emit-evidence/assemble-manifest.ts
+ *
+ * Signing + Rekor + final report-manifest.json assembly happen in CI
+ * (.github/workflows/emit-evidence.yml). This script does NO crypto and
+ * writes only to the gitignored `build/` dir.
+ *
+ * ── Gate selection (honest, no fake evidence) ──
+ *
+ * Chosen (both are blocking steps of the `validate` job → `ci-required`):
+ *   - catalog-invariants  — scripts/validate-catalog-invariants.py
+ *                           (plugin FS path == catalog category, entry parity)
+ *   - unicode-hygiene     — scripts/validate-unicode-hygiene.py
+ *                           (invisible tag chars / Trojan Source / zero-width
+ *                           defense; blocks on BLOCKER findings)
+ *
+ * Deliberately excluded after recon (would be fake/degraded evidence):
+ *   - `audit-harness verify`     — its hash-pinning surface is currently EMPTY
+ *                                  in this repo (see validate-plugins.yml
+ *                                  comment), so it trivially exits 0: no signal.
+ *   - full-corpus skill grading  — report-only with hundreds of known errors;
+ *                                  not a pass/fail gate on main.
+ *   - kernel-shadow / vendor-hash lanes — advisory by design (soak), never
+ *                                  blocking; unfit for SIGNED pass evidence.
+ *
+ * ── Contract (matches the dashboard ingest, verified against its source) ──
+ *
+ *   - Each `bundle` validates against `EvidenceBundleSchema` (kernel pinned to
+ *     the EXACT version the dashboard verifies with).
+ *   - Canonical bytes use the dashboard's `stableStringify` so cosign's
+ *     signature round-trips through the dashboard's re-canonicalisation.
+ *   - `signing_mode: 'rekor_production'`, `rekor_log_indices: []` (real index
+ *     lives in the sigstore Bundle the dashboard's Rekor check verifies).
+ *
+ * Usage:
+ *   node --experimental-strip-types ci/emit-evidence/emit-evidence.ts \
+ *     [--out build/evidence] [--ref refs/heads/main] [--self-check]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  GateResultV1Schema,
+  GATE_RESULT_V1_URI,
+} from '@intentsolutions/core/validators/v1/gate-result-v1';
+import { EvidenceBundleSchema } from '@intentsolutions/core/validators/v1/evidence-bundle';
+
+const GITHUB_REPO = 'jeremylongshore/claude-code-plugins-plus-skills';
+const REPO_KEY = 'ccp';
+
+/** The two gate scripts whose bytes ARE the policy this emit attests under. */
+const POLICY_FILES = [
+  'scripts/validate-catalog-invariants.py',
+  'scripts/validate-unicode-hygiene.py',
+] as const;
+
+interface GateOutcome {
+  readonly gateName: string;
+  readonly gateVersion: string;
+  readonly decision: 'pass' | 'fail' | 'advisory' | 'error';
+  readonly reasons: readonly string[];
+  readonly dimensionsEvaluated: readonly string[];
+  readonly dimensionsSkipped: readonly string[];
+  readonly advisorySeverity?: 'info' | 'warn' | 'error';
+  readonly failureMode?: string;
+}
+
+interface EmitContext {
+  readonly nowIso: string;
+  readonly nowMs: number;
+  readonly commitSha: string;
+  readonly sourceSha: string;
+  readonly policyHash: string;
+  readonly runnerVersion: string;
+  readonly rand16: () => Uint8Array;
+}
+
+// ── Canonicalisation (MUST match the dashboard's content-address.ts) ──
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => [k, sortDeep(v)] as const);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+/** Canonical JSON string (sorted keys, no whitespace) — dashboard-identical. */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+
+function sha256Hex(s: string): string {
+  return createHash('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
+}
+
+/** Generate a kernel-valid UUIDv7 from a 16-byte source + ms timestamp. */
+export function uuidv7(nowMs: number, rand: Uint8Array): string {
+  const b = Buffer.from(rand.slice(0, 16));
+  const ts = BigInt(nowMs);
+  b[0] = Number((ts >> 40n) & 0xffn);
+  b[1] = Number((ts >> 32n) & 0xffn);
+  b[2] = Number((ts >> 24n) & 0xffn);
+  b[3] = Number((ts >> 16n) & 0xffn);
+  b[4] = Number((ts >> 8n) & 0xffn);
+  b[5] = Number(ts & 0xffn);
+  b[6] = (b[6]! & 0x0f) | 0x70; // version 7
+  b[8] = (b[8]! & 0x3f) | 0x80; // variant 10
+  const h = b.toString('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+}
+
+/** A built row: the kernel-valid bundle + its canonical bytes + the gate body. */
+export interface EmitRow {
+  readonly bundle: unknown;
+  readonly canonicalBundle: string;
+  readonly gateResult: unknown;
+  readonly sourceSha: string;
+}
+
+/**
+ * Build + kernel-validate a gate-result/v1 body for one outcome. Throws (fail
+ * closed) if the result is not kernel-schema-valid.
+ */
+export function buildGateResult(o: GateOutcome, ctx: EmitContext): Record<string, unknown> {
+  const gateId = `${REPO_KEY}:ci:${o.gateName}`;
+  const inputHash = `sha256:${sha256Hex(`${ctx.commitSha}:${o.gateName}:${ctx.policyHash}`)}`;
+  const body: Record<string, unknown> = {
+    gate_id: gateId,
+    gate_name: o.gateName,
+    gate_version: o.gateVersion,
+    gate_decision: o.decision,
+    gate_reasons: [...o.reasons],
+    coverage: {
+      dimensions_evaluated: [...o.dimensionsEvaluated],
+      dimensions_skipped: [...o.dimensionsSkipped],
+    },
+    policy_ref: `${ctx.policyHash}:${POLICY_FILES.join('+')}`,
+    policy_hash: ctx.policyHash,
+    input_hash: inputHash,
+    evaluated_at: ctx.nowIso,
+    runner: `ccpi-emit@${ctx.runnerVersion}`,
+    commit_sha: ctx.commitSha,
+    ...(o.advisorySeverity !== undefined ? { advisory_severity: o.advisorySeverity } : {}),
+    ...(o.failureMode !== undefined ? { failure_mode: o.failureMode } : {}),
+  };
+  GateResultV1Schema.parse(body); // fail-closed
+  return body;
+}
+
+/**
+ * Wrap a gate-result body in a kernel EvidenceBundle. Throws if the bundle is
+ * not kernel-schema-valid.
+ */
+export function buildEvidenceBundle(
+  gateResult: Record<string, unknown>,
+  ctx: EmitContext,
+): Record<string, unknown> {
+  const grHashHex = sha256Hex(stableStringify(gateResult));
+  const inputHash = String(gateResult['input_hash']);
+  const subjectDigest = inputHash.startsWith('sha256:')
+    ? inputHash.slice('sha256:'.length)
+    : inputHash;
+  const bundle: Record<string, unknown> = {
+    id: uuidv7(ctx.nowMs, ctx.rand16()),
+    eval_run_id: uuidv7(ctx.nowMs, ctx.rand16()),
+    created_at: ctx.nowIso,
+    predicate_uri_set: [GATE_RESULT_V1_URI],
+    row_count: 1,
+    subject_set: [{ name: String(gateResult['gate_id']), digest: { sha256: subjectDigest } }],
+    storage_key: `sha256:${grHashHex}`,
+    signing_mode: 'rekor_production',
+    rekor_log_indices: [], // real index lives in the sigstore Bundle (see header)
+    verification_status: 'unverified', // the dashboard re-verifies; we don't self-attest
+    verification_last_checked_at: ctx.nowIso,
+  };
+  EvidenceBundleSchema.parse(bundle); // fail-closed
+  return bundle;
+}
+
+/** Build all rows from outcomes. */
+export function buildRows(outcomes: readonly GateOutcome[], ctx: EmitContext): EmitRow[] {
+  return outcomes.map((o) => {
+    const gateResult = buildGateResult(o, ctx);
+    const bundle = buildEvidenceBundle(gateResult, ctx);
+    return {
+      bundle,
+      canonicalBundle: stableStringify(bundle),
+      gateResult,
+      sourceSha: ctx.sourceSha,
+    };
+  });
+}
+
+/** The manifest skeleton CI signs + assembles into the final report-manifest.json. */
+export interface ManifestSkeleton {
+  readonly repo: string;
+  readonly signing: {
+    readonly issuer: string;
+    readonly subject: string;
+    readonly workflowRef: string;
+  };
+  readonly rows: readonly {
+    readonly bundleFile: string;
+    readonly gateResults: readonly unknown[];
+    readonly sourceSha: string;
+  }[];
+}
+
+/**
+ * Compute the OIDC signing claims this CI run will assert. The emit workflow
+ * runs on push to main (plus a main-only workflow_dispatch guard), so `ref` is
+ * always `refs/heads/main` in CI — these are exactly the claims the dashboard
+ * pins for the `ccp` row:
+ *   issuer      https://token.actions.githubusercontent.com
+ *   subject     repo:jeremylongshore/claude-code-plugins-plus-skills:ref:refs/heads/main
+ *   workflowRef jeremylongshore/claude-code-plugins-plus-skills/.github/workflows/emit-evidence.yml@refs/heads/main
+ */
+export function signingClaims(ref: string): ManifestSkeleton['signing'] {
+  return {
+    issuer: 'https://token.actions.githubusercontent.com',
+    subject: `repo:${GITHUB_REPO}:ref:${ref}`,
+    workflowRef: `${GITHUB_REPO}/.github/workflows/emit-evidence.yml@${ref}`,
+  };
+}
+
+/** Write all emit artifacts under `outDir`. Returns the skeleton written. */
+export function writeEmit(rows: readonly EmitRow[], ref: string, outDir: string): ManifestSkeleton {
+  mkdirSync(outDir, { recursive: true });
+  const skeletonRows = rows.map((row, i) => {
+    const bundleFile = `bundle-${i}.json`;
+    writeFileSync(join(outDir, bundleFile), row.canonicalBundle, 'utf8');
+    writeFileSync(join(outDir, `gate-result-${i}.json`), stableStringify(row.gateResult), 'utf8');
+    return { bundleFile, gateResults: [row.gateResult], sourceSha: row.sourceSha };
+  });
+  const skeleton: ManifestSkeleton = {
+    repo: REPO_KEY,
+    signing: signingClaims(ref),
+    rows: skeletonRows,
+  };
+  writeFileSync(join(outDir, 'manifest-skeleton.json'), JSON.stringify(skeleton, null, 2), 'utf8');
+  return skeleton;
+}
+
+// ── Gate collection (CI-run; runs the repo's real blocking gates) ──
+
+function run(cmd: string, args: readonly string[]): { ok: boolean; out: string } {
+  try {
+    const out = execFileSync(cmd, args as string[], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, out };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    return { ok: false, out: `${e.stdout ?? ''}${e.stderr ?? ''}${e.message ?? ''}` };
+  }
+}
+
+/**
+ * Catalog invariant gate: every catalog entry's filesystem path matches its
+ * declared category (and entry parity holds). Real, deterministic, stdlib-only
+ * Python; a blocking step of the `validate` job on main.
+ */
+function catalogInvariantsOutcome(): GateOutcome {
+  const r = run('python3', ['scripts/validate-catalog-invariants.py']);
+  return {
+    gateName: 'catalog-invariants',
+    gateVersion: '1.0.0',
+    decision: r.ok ? 'pass' : 'fail',
+    reasons: r.ok
+      ? [firstLines(r.out, 1) || 'catalog invariant check passed']
+      : [firstLines(r.out, 8) || 'catalog invariants violated'],
+    dimensionsEvaluated: ['catalog-path-category-parity'],
+    dimensionsSkipped: [],
+    ...(r.ok ? {} : { failureMode: 'catalog-invariant-violation' }),
+  };
+}
+
+/**
+ * Unicode-hygiene gate: invisible tag characters (Socket TrapDoor vector),
+ * bidi overrides (Trojan Source), zero-width/format chars, mixed-script
+ * identifiers. Blocks on BLOCKER findings. Real, deterministic, stdlib-only
+ * Python; a blocking step of the `validate` job on main.
+ */
+function unicodeHygieneOutcome(): GateOutcome {
+  const r = run('python3', ['scripts/validate-unicode-hygiene.py']);
+  return {
+    gateName: 'unicode-hygiene',
+    gateVersion: '1.0.0',
+    decision: r.ok ? 'pass' : 'fail',
+    reasons: r.ok
+      ? ['no BLOCKER-severity unicode findings (tag chars, bidi overrides)']
+      : [firstLines(r.out, 8) || 'BLOCKER-severity unicode findings present'],
+    dimensionsEvaluated: ['invisible-tag-chars', 'bidi-overrides', 'zero-width-format-chars'],
+    dimensionsSkipped: [],
+    ...(r.ok ? {} : { failureMode: 'unicode-hygiene-blocker' }),
+  };
+}
+
+function firstLines(s: string, n: number): string {
+  return s
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .slice(0, n)
+    .join(' ')
+    .slice(0, 500);
+}
+
+function gitSha(): string {
+  const r = run('git', ['rev-parse', 'HEAD']);
+  return r.ok ? r.out.trim() : '0'.repeat(40);
+}
+
+/**
+ * policy_hash = sha256 over the raw bytes of the two gate scripts (in fixed
+ * order, filename-delimited). The policy an emitted row attests under IS the
+ * validator source at this commit — recomputable by any auditor from the tree.
+ */
+function gatePolicyHash(): string {
+  const h = createHash('sha256');
+  for (const f of POLICY_FILES) {
+    h.update(Buffer.from(`${f}\n`, 'utf8'));
+    h.update(readFileSync(join(process.cwd(), f)));
+  }
+  return `sha256:${h.digest('hex')}`;
+}
+
+// ── Self-check (locally-runnable correctness proof) ──
+
+function selfCheck(): void {
+  const ctx = synthCtx();
+  const outcomes: GateOutcome[] = [
+    {
+      gateName: 'catalog-invariants',
+      gateVersion: '1.0.0',
+      decision: 'pass',
+      reasons: ['catalog invariant check passed (462 plugins)'],
+      dimensionsEvaluated: ['catalog-path-category-parity'],
+      dimensionsSkipped: [],
+    },
+    {
+      gateName: 'unicode-hygiene',
+      gateVersion: '1.0.0',
+      decision: 'fail',
+      reasons: ['BLOCKER: U+E0041 invisible tag character in install command'],
+      dimensionsEvaluated: ['invisible-tag-chars', 'bidi-overrides', 'zero-width-format-chars'],
+      dimensionsSkipped: [],
+      failureMode: 'unicode-hygiene-blocker',
+    },
+  ];
+  const rows = buildRows(outcomes, ctx); // throws if any artifact is kernel-invalid
+  for (const row of rows) {
+    if (stableStringify(JSON.parse(row.canonicalBundle)) !== row.canonicalBundle) {
+      throw new Error('canonical bundle is not stable under re-canonicalisation');
+    }
+  }
+  if (rows.length !== 2) throw new Error('expected 2 rows');
+  console.log(`self-check OK: ${rows.length} kernel-valid, canonical-stable rows built`);
+}
+
+function synthCtx(): EmitContext {
+  let n = 0;
+  return {
+    nowIso: '2026-07-08T00:00:00.000Z',
+    nowMs: 1783209600000,
+    commitSha: 'a'.repeat(40),
+    sourceSha: 'a'.repeat(40),
+    policyHash: `sha256:${'b'.repeat(64)}`,
+    runnerVersion: '4.33.0',
+    // Deterministic, non-random 16-byte source so self-check output is stable.
+    rand16: () => {
+      n += 1;
+      return Uint8Array.from(Array.from({ length: 16 }, (_v, i) => (n * 31 + i) & 0xff));
+    },
+  };
+}
+
+function packageVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+      version?: string;
+    };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function ciCtx(): EmitContext {
+  const sha = gitSha();
+  return {
+    nowIso: new Date().toISOString(),
+    nowMs: Date.now(),
+    commitSha: sha,
+    sourceSha: sha,
+    policyHash: gatePolicyHash(),
+    runnerVersion: packageVersion(),
+    rand16: () => Uint8Array.from(randomBytes(16)),
+  };
+}
+
+function parseArgs(argv: readonly string[]): { out: string; selfCheck: boolean; ref: string } {
+  let out = 'build/evidence';
+  let ref = process.env['GITHUB_REF'] ?? 'refs/heads/main';
+  let sc = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--out') {
+      out = argv[i + 1] ?? out;
+      i++;
+    } else if (argv[i] === '--ref') {
+      ref = argv[i + 1] ?? ref;
+      i++;
+    } else if (argv[i] === '--self-check') {
+      sc = true;
+    }
+  }
+  return { out, selfCheck: sc, ref };
+}
+
+function main(argv: readonly string[]): number {
+  const args = parseArgs(argv);
+  if (args.selfCheck) {
+    selfCheck();
+    return 0;
+  }
+  const ctx = ciCtx();
+  mkdirSync(args.out, { recursive: true });
+  const outcomes: GateOutcome[] = [catalogInvariantsOutcome(), unicodeHygieneOutcome()];
+  const rows = buildRows(outcomes, ctx);
+  writeEmit(rows, args.ref, args.out);
+  console.log(
+    `emit-evidence OK: ${rows.length} kernel-valid gate-result/v1 row(s) written to ${args.out}\n` +
+      `  decisions: ${outcomes.map((o) => `${o.gateName}=${o.decision}`).join(', ')}\n` +
+      `  next (CI): cosign sign-blob each bundle-<i>.json -> assemble-manifest.ts -> report-manifest.json`,
+  );
+  return 0;
+}
+
+// Only run when invoked directly (not when imported by a sibling assembler).
+const invokedDirectly = process.argv[1]?.endsWith('emit-evidence.ts') === true;
+if (invokedDirectly) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (err: unknown) {
+    console.error(
+      'emit-evidence FAILED (fail-closed):',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  }
+}

--- a/ci/emit-evidence/package.json
+++ b/ci/emit-evidence/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ccpi-emit-evidence-ci",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CI-only signed-evidence emitter for the intent-eval-dashboard reports hub (repo row key: ccp). Not a workspace package, never published; installed standalone in .github/workflows/emit-evidence.yml via `pnpm install --ignore-workspace`.",
+  "type": "module",
+  "dependencies": {
+    "@intentsolutions/core": "0.9.0"
+  }
+}

--- a/ci/emit-evidence/pnpm-lock.yaml
+++ b/ci/emit-evidence/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@intentsolutions/core':
+        specifier: 0.9.0
+        version: 0.9.0
+
+packages:
+
+  '@intentsolutions/core@0.9.0':
+    resolution: {integrity: sha512-XGF3rR/FFgRz1qkiXMEXLijmPX3/9layH9e2wqykMitkl2gX/JREpS6ilRXB1tVnkdcHnDdfAxWstpW/UoGKsA==}
+    engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@intentsolutions/core@0.9.0':
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## What this adds

A **purely additive** signed-evidence emit for the labs.intentsolutions.io reports hub (intent-eval-dashboard): one new workflow (`.github/workflows/emit-evidence.yml`) plus a CI-only emitter under `ci/emit-evidence/`. **Zero existing files are touched** — no `validate-plugins.yml`, no `release.yml`, no branch-protection change. The workflow never reports a PR status context; the required gate stays `{ci-required, gitleaks}`.

On each push to `main` it re-runs two of this repo's real blocking gates, shapes each outcome into a kernel `gate-result/v1` row wrapped in a kernel `EvidenceBundle` (validated fail-closed against `@intentsolutions/core@0.9.0` — the exact version the dashboard verifies with), cosign-keyless-signs each bundle's canonical bytes (Fulcio OIDC + production Rekor), verifies every signature back in-repo, assembles `report-manifest.json`, and uploads it onto a fixed rolling prerelease.

## Why push-to-main + a rolling prerelease (design constraints)

- **GITHUB_TOKEN suppression:** `release.yml` here is `workflow_dispatch`-only and pushes its tags/releases with `GITHUB_TOKEN`, and GITHUB_TOKEN-created refs suppress downstream workflow triggers — so a tag/release-triggered emit could never fire.
- **Dispatch runs at main anyway:** a dispatched release executes at `refs/heads/main`, so a branch-ref OIDC subject is what the signing identity would pin to regardless.
- **`releases/latest` pollution:** per-package npm releases own `releases/latest` (100/100 recent), so the manifest lives on a **fixed rolling prerelease** tagged `evidence-latest` (created once, idempotently; prerelease so it never becomes the repo's `latest`; asset re-uploaded with `--clobber`). The dashboard fetches `releases/download/evidence-latest/report-manifest.json`.

## The two honest gates (and what was rejected)

Chosen — both are **blocking steps of the `validate` job that `ci-required` needs**, deterministic, stdlib-Python-only, and verified passing standalone in a clean `origin/main` worktree before this PR:

| gate_id | What it proves | Local run |
|---|---|---|
| `ccp:ci:catalog-invariants` | plugin FS path == catalog category + entry parity (`scripts/validate-catalog-invariants.py`) | PASS — "Catalog invariant check passed (462 plugins)", ~0.2 s |
| `ccp:ci:unicode-hygiene` | invisible tag chars (TrapDoor), bidi overrides (Trojan Source), zero-width/format chars (`scripts/validate-unicode-hygiene.py`) | PASS — exit 0 (blocks on BLOCKER; known MAJOR findings are non-blocking by design), ~12 s |

Rejected as evidence sources:

- **`pnpm exec audit-harness verify`** — its hash-pinning surface is currently **empty** in this repo (per the comment in `validate-plugins.yml`), so it trivially exits 0: signing that would be fake signal.
- **Full-corpus skill validation** — report-only with hundreds of known errors; not a pass/fail gate on main.
- **kernel-shadow / kernel-vendor-hash lanes** — advisory by design (soak); unfit for signed pass evidence.

Nothing is `|| true`'d; a failing gate emits an honest FAIL row, and a malformed artifact aborts the job.

## OIDC claims the dashboard pins (embedded in the manifest signing block)

```
issuer      https://token.actions.githubusercontent.com
subject     repo:jeremylongshore/claude-code-plugins-plus-skills:ref:refs/heads/main
workflowRef jeremylongshore/claude-code-plugins-plus-skills/.github/workflows/emit-evidence.yml@refs/heads/main
```

The job carries an `if: github.ref == 'refs/heads/main'` guard so a dispatch from any other ref no-ops instead of emitting an unverifiable manifest, and CI `cosign verify-blob`s every bundle against this exact identity before publishing.

## Repo-hygiene checks done

- `ci/emit-evidence/` is outside every publish surface: root package is private, the pnpm-workspace globs don't include it, `publish-changed-packages.yml` detection scans `plugins/` only, and `typescript-coverage-audit` roots at `plugins/`.
- pnpm-only policy respected: the emitter has its own private non-workspace `package.json` + committed `pnpm-lock.yaml`, installed in CI via `pnpm install --frozen-lockfile --ignore-workspace` (no npm, no root lockfile drift; `scripts/check-package-manager.mjs` passes with these files in the tree).
- Local verification: emitter self-check + full dry run (both gates + bundle build + kernel validation, cosign skipped) green; assembler fail-closed and happy paths exercised; `actionlint` clean on the new workflow; `pnpm run lint:root` (ESLint picks up the new TS files) clean; `pnpm run format:check` clean.

## Activation

First run fires on the merge push to `main`; it is also manually dispatchable (`workflow_dispatch`) for re-emit/testing. Expected runtime well under 3 minutes (gates ~12 s + cosign round-trips).

This closes the **design half** of the deferred coordination bead for the labs dashboard `ccp` row (the CCPI entry in the reports hub); the dashboard-side row wiring (fetch URL + pinned claims above) is the other half.

- Jeremy Longshore
intentsolutions.io
