### PR TITLE
fix(ci): repair trufflehog, gitleaks, and Slack-digest scheduled jobs

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -37,8 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
-          GITLEAKS_ENABLE_COMMENTS: "true"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+          GITLEAKS_ENABLE_COMMENTS: 'true'
+          GITLEAKS_ENABLE_SUMMARY: 'true'
 
   trufflehog:
     # Verified-credentials scan — runs only on schedule or manual dispatch.
@@ -56,7 +56,13 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          extra_args: --only-verified --fail
+          # The trufflehog action already appends `--fail` to the underlying
+          # `trufflehog git ... --fail --no-update --github-actions ${ARGS}`
+          # invocation. Passing `--fail` again here made trufflehog abort with
+          # `flag 'fail' cannot be repeated` (exit 2) BEFORE scanning — every
+          # scheduled run failed this way since ~2026-04-26. Pass only the
+          # scan-scoping flag; let the action supply `--fail`.
+          extra_args: --only-verified
 
       - name: Notify Slack on failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/slack-daily-downloads.yml
+++ b/.github/workflows/slack-daily-downloads.yml
@@ -13,8 +13,8 @@ name: Daily Slack download digest
 
 on:
   schedule:
-    - cron: '0 18 * * *'  # 18:00 UTC daily = 1pm America/Chicago
-  workflow_dispatch:       # manual fire for testing
+    - cron: '0 18 * * *' # 18:00 UTC daily = 1pm America/Chicago
+  workflow_dispatch: # manual fire for testing
 
 permissions:
   contents: read
@@ -91,9 +91,11 @@ jobs:
           WEBHOOK: ${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}
           PAYLOAD: ${{ steps.build.outputs.payload }}
         run: |
-          # --fail so non-2xx aborts the job with a clear signal
+          # --fail so non-2xx aborts the job with a clear signal.
+          # `--` ends option parsing so a malformed webhook value (e.g. the
+          # placeholder '-') is treated as the URL argument, not a curl flag.
           curl --silent --show-error --fail \
             --header "Content-Type: application/json" \
             --data "$PAYLOAD" \
-            "$WEBHOOK" > /dev/null
+            -- "$WEBHOOK" > /dev/null
           echo "✓ Slack message posted."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -72,6 +72,36 @@ paths = [
     # strings as if they were keys. Allowlist the file so the detector
     # library is not re-read as a leak surface.
     '''^plugins/security/penetration-tester/skills/scanning-for-hardcoded-secrets/scripts/scan_secrets\.py$''',
+
+    # --- Documentation / illustrative-example surfaces (2026-07-09 audit) ---
+    # The weekly full-history scan (fetch-depth: 0) surfaced 87 findings, all
+    # illustrative example creds in prose/templates — no real credential. Each
+    # pattern below is grounded in a real finding from run 28731012059.
+    #
+    # Home-level security guides carry `API_KEY="sk-..."` teaching examples
+    # (generic-api-key, stripe-access-token hits in 000-docs/*.md incl. the
+    # 6767-d extensions-schema and 071 user-security guide).
+    '''^000-docs/.*\.md$''',
+    '''^SECURITY\.md$''',
+    '''^CREDENTIAL-MIGRATION-READY\.md$''',
+    # Prior path of the user-security guide (renamed into 000-docs/); still
+    # reachable via history on the full-depth scan.
+    '''^docs/USER_SECURITY_GUIDE\.md$''',
+    # Plugin documentation surfaces — command/agent/plugin-docs markdown and
+    # skill-adapter example assets hold curl-auth-header / generic-api-key /
+    # jwt teaching examples (security-scanner, penetration-tester, crypto
+    # audit, api-* generators, on-chain-analytics, etc.). These are prose docs
+    # and generated example templates, not executable secrets; real plugin
+    # code (.py/.ts/.js/.sh) stays in scope.
+    '''^plugins/.*/commands/.*\.md$''',
+    '''^plugins/.*/agents/.*\.md$''',
+    '''^plugins/.*/docs/.*\.md$''',
+    '''^plugins/.*/skills/skill-adapter/assets/.*''',
+    # Deleted `backups/` tree — a snapshot of plugin docs removed from HEAD but
+    # still reachable through git history under fetch-depth: 0. It re-tripped
+    # ~60 of the 87 findings every scheduled run. The tree no longer exists in
+    # the working copy; scope it out of the history scan so it stops re-firing.
+    '''^backups/.*''',
 ]
 
 regexes = [
@@ -85,4 +115,15 @@ regexes = [
     '''placeholder''',
     '''replace[-_]me''',
     '''example\.com''',
+    # Firebase Web (browser) API key from the now-retired Firebase-hosted
+    # version of marketplace/src/layouts/BaseLayout.astro (the single
+    # gcp-api-key hit at commit 44933759:52; the firebaseConfig block has since
+    # been removed — the current site uses Umami, no Firebase). Firebase Web
+    # API keys are public by design: Google ships them in client-side config
+    # and documents that they are safe to commit (access is gated by Security
+    # Rules + App Check, not by key secrecy). The default gcp-api-key rule
+    # flags the AIzaSy… shape regardless. Allowlist the exact value, NOT the
+    # .astro path, so a real server key ever added to an .astro file still
+    # surfaces.
+    '''AIzaSyAUbgBuoMCtcjEdRcYzqu08kuVFVDeiHsM''',
 ]


### PR DESCRIPTION
## Summary

Three scheduled CI jobs had been failing silently. All three were surfaced by the **2026-07-09 estate automation audit** and every fix here is grounded in the actual failing run logs (secret-scan run `28731012059`; slack-digest schedule runs), not guesses.

| # | Job | Severity | Symptom | Root cause |
|---|-----|----------|---------|------------|
| 1 | `secret-scan.yml` → trufflehog | **CRITICAL** | 11/11 scheduled runs failed since ~2026-04-26 | duplicated `--fail` flag |
| 2 | `secret-scan.yml` → gitleaks | HIGH | every scheduled run red (87 findings) | example creds + deleted `backups/` history + 1 FP |
| 3 | `slack-daily-downloads.yml` | MEDIUM | digest silent 54 days | curl missing `--` separator |

## 1. trufflehog — duplicated `--fail` (CRITICAL)

The trufflehog action already builds `trufflehog git … --fail --no-update --github-actions ${ARGS}` and appends `--fail` itself. Our `extra_args: --only-verified --fail` passed it a second time, so trufflehog aborted **before scanning**:

```
trufflehog: error: flag 'fail' cannot be repeated, try --help   (exit 2)
```

Every weekly verified-credentials scan has failed this way for 10+ weeks. **Fix:** drop the redundant `--fail`, keep `--only-verified`; let the action supply `--fail`.

## 2. gitleaks — example creds + deleted `backups/` tree + one FP (HIGH)

The weekly full-history scan (`fetch-depth: 0`) reported **87 findings, none a real leak**. Every allowlist entry added to `.gitleaks.toml` is grounded in a real finding from run `28731012059`:

- **Documentation / illustrative-example surfaces** — `000-docs/*.md`, `SECURITY.md`, `CREDENTIAL-MIGRATION-READY.md`, `docs/USER_SECURITY_GUIDE.md` (renamed path, history-only), and plugin doc surfaces (`plugins/**/{commands,agents,docs}/*.md` + `skills/skill-adapter/assets/*`). These hold `API_KEY="sk-…"` / curl-auth-header / jwt teaching examples. **Real plugin code (`.py`/`.ts`/`.js`/`.sh`) stays in scope.**
- **Deleted `backups/` tree** — ~60 of the 87 findings live in a snapshot removed from HEAD but still reachable through git history under `fetch-depth: 0`. Scoped out with `^backups/.*` so it stops re-firing.
- **The one `gcp-api-key` hit at `BaseLayout.astro:52` is NOT the Umami UUID the audit assumed.** At commit `44933759` it is a **Firebase Web (browser) API key** (`AIzaSy…`) inside a `firebaseConfig` block from the retired Firebase-hosted version of the site (block since removed; the current site uses Umami only). Firebase Web keys are [public by design](https://firebase.google.com/docs/projects/api-keys) (access gated by Security Rules + App Check, not key secrecy). Allowlisted **by exact value, NOT by a blanket `.astro` path** — verified that with the value allowlisted a *different* `AIzaSy…` key still trips the scanner, so real keys still surface.

### Verification

- `actionlint` + `python3 yaml.safe_load` clean on both workflows; `.gitleaks.toml` parses as TOML.
- Full-history `gitleaks detect` with the new config: **87 → clean** for the CI ruleset. (The only residual local hits are `generic-api-key` false positives on `Ed25519KeyPair` **type annotations** — `keypair:` / `signingKey:` — in `plugins/mcp/slack-channel/*.ts`; these appear **only** under the older local gitleaks 8.18.4 ruleset and are **absent from CI's 8.24.3 finding set**, so they do not affect this job. Left untouched rather than blanket-allowlisting source `.ts`.)

## 3. Slack daily download digest — missing `--` (MEDIUM)

The digest to `#operation-hired` has posted nothing for 54 days. The `curl` to Slack lacked a `--` end-of-options separator, so the malformed webhook value was parsed as a curl flag. **Fix:** add `--` immediately before `"$WEBHOOK"`.

## ⚠️ Still needs Jeremy (blocks the digest from actually posting)

The `--` fix stops curl from mis-parsing the value, but the digest still will not post until the **`SLACK_OPERATION_HIRED_WEBHOOK_URL` repo secret is reset to the real Slack webhook URL** — it is currently a placeholder (`'-'`). That reset requires the real webhook URL, which only Jeremy has; this PR intentionally does **not** touch the secret value.

```
gh secret set SLACK_OPERATION_HIRED_WEBHOOK_URL --repo jeremylongshore/claude-code-plugins-plus-skills   # paste real https://hooks.slack.com/services/… URL
```

## Files changed
- `.github/workflows/secret-scan.yml` — remove duplicate `--fail` from trufflehog `extra_args`
- `.github/workflows/slack-daily-downloads.yml` — add `--` before `"$WEBHOOK"` in the curl
- `.gitleaks.toml` — allowlist example-cred paths, scope out deleted `backups/` history, allowlist the historical Firebase Web API key by value

Source: 2026-07-09 estate automation audit.

- Jeremy Longshore
intentsolutions.io
