### PR TITLE
feat(security): add agent-safety-preflight plugin (recreated from #964, full credit to @el-zachariah)

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -10612,6 +10612,30 @@
         "agents": 0,
         "total": 1
       }
+    },
+    {
+      "name": "agent-safety-preflight",
+      "source": "./plugins/security/agent-safety-preflight",
+      "description": "Local Claude Code command that generates a repo-risk receipt before AI-agent edits.",
+      "version": "1.0.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "claude-code",
+        "agent-safety",
+        "preflight",
+        "repo-risk",
+        "mcp",
+        "hooks",
+        "ai-agent"
+      ],
+      "author": {
+        "name": "el-zachariah",
+        "url": "https://github.com/el-zachariah"
+      },
+      "homepage": "https://github.com/el-zachariah/ai-agent-safety-starter-pack#readme",
+      "repository": "https://github.com/el-zachariah/ai-agent-safety-starter-pack",
+      "license": "MIT"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9042,6 +9042,30 @@
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       }
+    },
+    {
+      "name": "agent-safety-preflight",
+      "source": "./plugins/security/agent-safety-preflight",
+      "description": "Local Claude Code command that generates a repo-risk receipt before AI-agent edits.",
+      "version": "1.0.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "claude-code",
+        "agent-safety",
+        "preflight",
+        "repo-risk",
+        "mcp",
+        "hooks",
+        "ai-agent"
+      ],
+      "author": {
+        "name": "el-zachariah",
+        "url": "https://github.com/el-zachariah"
+      },
+      "homepage": "https://github.com/el-zachariah/ai-agent-safety-starter-pack#readme",
+      "repository": "https://github.com/el-zachariah/ai-agent-safety-starter-pack",
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | ⚡  | [Performance](#performance)                        |      25 |
 | ✅  | [Productivity](#productivity)                      |      31 |
 | 🎁  | [SaaS Skill Packs](#saas-skill-packs)              |     106 |
-| 🔐  | [Security](#security)                              |      26 |
+| 🔐  | [Security](#security)                              |      27 |
 | ✨  | [Skill Enhancers](#skill-enhancers)                |       9 |
 | 🧪  | [Testing](#testing)                                |      28 |
 | 📁  | [Analytics](#analytics)                            |       1 |
@@ -676,11 +676,12 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 
 ### Security
 
-🔐 **26 plugins** · category slug: `security`
+🔐 **27 plugins** · category slug: `security`
 
 | Plugin                             | Description                                                                                                                              |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `access-control-auditor`           | Audit access control implementations                                                                                                     |
+| `agent-safety-preflight`           | Local Claude Code command that generates a repo-risk receipt before AI-agent edits.                                                      |
 | `authentication-validator`         | Validate authentication implementations                                                                                                  |
 | `compliance-report-generator`      | Generate compliance reports                                                                                                              |
 | `cors-policy-validator`            | Validate CORS policies                                                                                                                   |

--- a/plugins/security/agent-safety-preflight/.claude-plugin/plugin.json
+++ b/plugins/security/agent-safety-preflight/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-safety-preflight",
+  "version": "1.0.0",
+  "description": "Generate a local repo-risk receipt before Claude Code or other AI-agent edits",
+  "author": {
+    "name": "el-zachariah",
+    "url": "https://github.com/el-zachariah"
+  },
+  "repository": "https://github.com/el-zachariah/ai-agent-safety-starter-pack",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "claude-code",
+    "agent-safety",
+    "preflight",
+    "repo-risk",
+    "mcp",
+    "hooks",
+    "ai-agent",
+    "agent-skills"
+  ]
+}

--- a/plugins/security/agent-safety-preflight/LICENSE
+++ b/plugins/security/agent-safety-preflight/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 el-zachariah
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/security/agent-safety-preflight/README.md
+++ b/plugins/security/agent-safety-preflight/README.md
@@ -1,0 +1,46 @@
+# Agent Safety Preflight
+
+Claude Code command plugin for generating a lightweight repository risk receipt before AI-agent edits.
+
+Use it when a maintainer, teammate, or agent operator needs a quick green/yellow/red preflight before allowing Claude Code, Codex, Cursor, MCP-backed agents, or other coding agents to change a real repository.
+
+## Installation
+
+```bash
+/plugin install agent-safety-preflight@claude-code-plugins-plus
+```
+
+## Usage
+
+```bash
+/agent-preflight
+# or shortcut
+/apf
+```
+
+## What it checks
+
+- Git working-tree state and uncommitted-change risk.
+- Files commonly used for agent authority, hooks, MCP routing, CI, and dangerous automation.
+- High-risk command patterns such as destructive recursive deletion, shell-to-network install chains, credential writes, and agent authority config.
+- A clear decision receipt: Green, Yellow, or Red, with the reason to stop or proceed.
+
+## Privacy and safety
+
+The bundled command is local-first. It does not require secrets, API keys, network access, KYC, payment credentials, or security testing against third-party systems. It is intended as a preflight receipt before routine AI-agent coding work, not as a vulnerability scanner.
+
+## Open-source upstream
+
+This marketplace package wraps the free command/scanner workflow from:
+
+<https://github.com/el-zachariah/ai-agent-safety-starter-pack>
+
+## Files
+
+- `commands/agent-preflight.md` — Claude Code slash-command instructions.
+- `scripts/agent_preflight_lite.py` — dependency-free local scanner used by the command.
+- `tests/test_agent_preflight_lite.py` — basic parser/decision tests.
+
+## License
+
+MIT

--- a/plugins/security/agent-safety-preflight/commands/agent-preflight.md
+++ b/plugins/security/agent-safety-preflight/commands/agent-preflight.md
@@ -1,0 +1,92 @@
+---
+name: agent-preflight
+description: Generate a lightweight repository risk receipt before AI-agent edits
+shortcut: apf
+---
+# Agent Safety Preflight
+
+Generate a local, auditable preflight receipt before Claude Code or another AI coding agent changes a repository.
+
+## What You Do
+
+1. Identify the repository root. Use the current workspace unless the user supplied a path.
+2. Run the bundled lightweight scanner when possible. Do not assume the current working directory is the plugin package; the user is usually inside the repo being checked.
+
+Use this local-only bootstrap:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import subprocess
+import sys
+
+repo = Path.cwd()
+trusted_roots = [Path.home() / ".claude", Path.home() / ".config" / "claude"]
+patterns = (
+    "**/agent-safety-preflight/scripts/agent_preflight_lite.py",
+    "**/agent_preflight_lite.py",
+)
+candidates = []
+seen = set()
+for root in trusted_roots:
+    if not root.exists():
+        continue
+    try:
+        trusted_root = root.resolve()
+    except OSError:
+        continue
+    for pattern in patterns:
+        for scanner in root.glob(pattern):
+            try:
+                resolved = scanner.resolve()
+            except OSError:
+                continue
+            if not resolved.is_relative_to(trusted_root) or resolved in seen:
+                continue
+            seen.add(resolved)
+            candidates.append(resolved)
+
+for scanner in candidates:
+    if scanner.is_file():
+        raise SystemExit(subprocess.call([sys.executable, str(scanner), "--repo", str(repo), "--format", "markdown"]))
+
+print("Bundled agent_preflight_lite.py was not found from this workspace.")
+print("Use the manual decision rules in this command; do not claim an automated scan ran.")
+PY
+```
+
+If the scanner cannot be located, use the manual decision rules below instead of sending code, secrets, or repository contents anywhere.
+
+Then continue:
+
+1. Inspect the receipt and classify the repo as Green, Yellow, or Red.
+2. Tell the user the decision, the evidence, and the next safe action before making edits.
+
+## Decision Rules
+
+- **Green**: clean git state and no high-risk automation markers found. Routine agent edits can proceed after the user confirms scope.
+- **Yellow**: uncommitted changes or medium-risk hooks/agent config are present. Ask for a checkpoint or narrower scope before broad edits.
+- **Red**: destructive command patterns, credential-writing automation, or risky shell/network install chains appear in agent-controlled paths. Stop and ask for human review before editing.
+
+## Output Format
+
+```markdown
+## Agent Safety Preflight Receipt
+
+- Decision: Green | Yellow | Red
+- Repository: <path>
+- Git state: <clean/dirty/unavailable>
+- Risk buckets: <bullets>
+- Evidence: <file/path markers>
+- Next safe action: <proceed/checkpoint/stop>
+```
+
+## Safety Boundaries
+
+This command is local-first and read-only. Do not exfiltrate files, secrets, tokens, private source, payment credentials, or environment variables. Do not perform security testing against third-party systems.
+
+## More Complete Free Workflow
+
+For the full open-source scanner, sample receipts, and maintainer handoff examples, use:
+
+<https://github.com/el-zachariah/ai-agent-safety-starter-pack>

--- a/plugins/security/agent-safety-preflight/package.json
+++ b/plugins/security/agent-safety-preflight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/agent-safety-preflight",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate a local repo-risk receipt before Claude Code or other AI-agent edits",
   "keywords": [
     "security",

--- a/plugins/security/agent-safety-preflight/package.json
+++ b/plugins/security/agent-safety-preflight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/agent-safety-preflight",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate a local repo-risk receipt before Claude Code or other AI-agent edits",
   "keywords": [
     "security",

--- a/plugins/security/agent-safety-preflight/package.json
+++ b/plugins/security/agent-safety-preflight/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@intentsolutionsio/agent-safety-preflight",
+  "version": "1.0.0",
+  "description": "Generate a local repo-risk receipt before Claude Code or other AI-agent edits",
+  "keywords": [
+    "security",
+    "claude-code",
+    "agent-safety",
+    "preflight",
+    "repo-risk",
+    "mcp",
+    "hooks",
+    "ai-agent",
+    "agent-skills",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/security/agent-safety-preflight"
+  },
+  "homepage": "https://tonsofskills.com/plugins/agent-safety-preflight",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "el-zachariah",
+    "url": "https://github.com/el-zachariah"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills",
+    "commands",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install agent-safety-preflight\\\\n  or /plugin install agent-safety-preflight@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/security/agent-safety-preflight/scripts/agent_preflight_lite.py
+++ b/plugins/security/agent-safety-preflight/scripts/agent_preflight_lite.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Dependency-free repo preflight scanner for the agent-safety-preflight Claude Code command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+DELETE_PATTERN = r"\brm\s+-" + r"rf\b|Remove-Item\s+-Recurse\s+-Force"
+RISK_PATTERNS = [
+    ("destructive-recursive-delete", re.compile(DELETE_PATTERN, re.I)),
+    ("shell-network-install", re.compile(r"curl\b[^\n|;]*(\||>)|wget\b[^\n|;]*(\||>)", re.I)),
+    (
+        "credential-write",
+        re.compile(
+            r"(?:^|[\n{,])\s*['\"]?(?:AWS_SECRET_ACCESS_KEY|GITHUB_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|STRIPE_SECRET|PAYPAL_(?:CLIENT_ID|CLIENT_SECRET|SECRET|ACCESS_TOKEN|API_KEY))['\"]?\s*[:=]",
+            re.I,
+        ),
+    ),
+    (
+        "agent-authority",
+        re.compile(
+            r"(mcpServers|(?:claude|cursor|agent)[-_ ]?hooks|hooks\s*[:=]\s*(\[|\{|['\"]?(pre|post|tool|agent|command))|allowedTools|dangerously|autoApprove|agent[-_ ]?permissions|tool[-_ ]?permissions|permissions['\"]?\s*[:=]\s*(?:['\"]?(?:write|admin|danger|allow)|\[[^\]\n]*(?:write|admin|danger|allow)))",
+            re.I,
+        ),
+    ),
+]
+INTERESTING_NAMES = {
+    ".claude",
+    ".mcp.json",
+    "mcp.json",
+    "claude_desktop_config.json",
+    "settings.json",
+    "package.json",
+    "Makefile",
+    "justfile",
+    "Dockerfile",
+}
+INTERESTING_SUFFIXES = {".sh", ".bash", ".zsh", ".ps1", ".yaml", ".yml", ".json", ".toml", ".md"}
+SKIP_DIRS = {".git", "node_modules", ".venv", "venv", "__pycache__", "dist", "build"}
+MAX_SCAN_BYTES = 120_000
+SAFE_ENV_SUFFIXES = (".example", ".sample", ".template")
+
+
+def is_credential_filename(name: str) -> bool:
+    return name == ".env" or (name.startswith(".env.") and not name.endswith(SAFE_ENV_SUFFIXES))
+
+
+def read_sample(path: Path) -> str:
+    with path.open("rb") as handle:
+        return handle.read(MAX_SCAN_BYTES).decode("utf-8", errors="ignore")
+
+
+def git_state(repo: Path) -> str:
+    try:
+        cp = subprocess.run(["git", "status", "--porcelain"], cwd=repo, text=True, capture_output=True, timeout=5)
+    except Exception:
+        return "unavailable"
+    if cp.returncode != 0:
+        return "unavailable"
+    return "dirty" if cp.stdout.strip() else "clean"
+
+
+def iter_files(repo: Path):
+    for root, dirs, files in os.walk(repo):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        root_path = Path(root)
+        for name in files:
+            p = root_path / name
+            rel = p.relative_to(repo)
+            if (
+                any(part in {".claude", ".cursor", ".github"} for part in rel.parts)
+                or name in INTERESTING_NAMES
+                or is_credential_filename(name)
+                or p.suffix in INTERESTING_SUFFIXES
+            ):
+                yield p
+
+
+def scan(repo: Path):
+    findings = []
+    for path in iter_files(repo):
+        rel = str(path.relative_to(repo))
+        if is_credential_filename(path.name):
+            findings.append({"bucket": "credential-write", "path": rel})
+        try:
+            text = read_sample(path)
+        except Exception:
+            continue
+        for bucket, pattern in RISK_PATTERNS:
+            if pattern.search(text):
+                findings.append({"bucket": bucket, "path": rel})
+    state = git_state(repo)
+    buckets = sorted({f["bucket"] for f in findings})
+    if any(b in buckets for b in ["destructive-recursive-delete", "credential-write", "shell-network-install"]):
+        decision = "Red"
+    elif state in {"dirty", "unavailable"} or buckets:
+        decision = "Yellow"
+    else:
+        decision = "Green"
+    return {
+        "decision": decision,
+        "repository": str(repo),
+        "git_state": state,
+        "risk_buckets": buckets,
+        "findings": findings[:50],
+    }
+
+
+def as_markdown(result: dict) -> str:
+    lines = [
+        "## Agent Safety Preflight Receipt",
+        "",
+        f"- Decision: {result['decision']}",
+        f"- Repository: {result['repository']}",
+        f"- Git state: {result['git_state']}",
+    ]
+    lines.append("- Risk buckets: " + ", ".join(result["risk_buckets"] or ["none"]))
+    lines.append("")
+    lines.append("### Evidence")
+    if result["findings"]:
+        for item in result["findings"][:20]:
+            lines.append(f"- `{item['bucket']}` in `{item['path']}`")
+    else:
+        lines.append("- No high-risk markers found by the lightweight scanner.")
+    lines.append("")
+    next_action = (
+        "proceed with scoped edits"
+        if result["decision"] == "Green"
+        else ("checkpoint and narrow scope" if result["decision"] == "Yellow" else "stop for human review")
+    )
+    lines.append(f"- Next safe action: {next_action}")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
+    args = parser.parse_args()
+    repo = Path(args.repo).resolve()
+    result = scan(repo)
+    print(json.dumps(result, indent=2) if args.format == "json" else as_markdown(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/security/agent-safety-preflight/skills/agent-safety-preflight/SKILL.md
+++ b/plugins/security/agent-safety-preflight/skills/agent-safety-preflight/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: agent-safety-preflight
+description: |
+  Generate a local repository risk receipt before Claude Code or other AI-agent edits.
+  Use when the user asks to prepare a repository for agent changes, check for risky
+  hooks or credential-writing automation, or run the /agent-preflight command.
+  Trigger with "run agent preflight", "check this repo before agent edits", or
+  "/agent-preflight".
+argument-hint: "[repo-path]"
+allowed-tools: Read, Bash(git:*), Bash(python3:*)
+version: 1.0.0
+author: Signal Loom Works <194151508+el-zachariah@users.noreply.github.com>
+license: MIT
+compatibility: Designed for Claude Code, also compatible with Codex and OpenClaw
+tags:
+  - security
+  - agent-safety
+  - claude-code
+  - preflight
+---
+
+# Agent Safety Preflight
+
+## Overview
+
+Agent Safety Preflight helps Claude inspect a local repository before making AI-agent-assisted edits. It produces a compact Green, Yellow, or Red risk receipt from local files only, with special attention to destructive shell patterns, credential-writing automation, agent authority surfaces, uncommitted changes, and unavailable git state.
+
+The skill pairs with the `/agent-preflight` command in this plugin. Prefer the bundled lightweight scanner when it is available from a trusted Claude install root, then explain the decision and next safe action before editing.
+
+## Prerequisites
+
+- A local repository or workspace path to inspect.
+- Python 3 available for the bundled `agent_preflight_lite.py` scanner.
+- Git available when the workspace is a git repository.
+- Permission to read the target workspace locally.
+
+Do not send source, secrets, tokens, private repository contents, payment credentials, or environment variables to external services while using this skill.
+
+## Instructions
+
+1. Confirm the target repository path. Use the current workspace unless the user supplied a path.
+2. Use `Read` only for local documentation or configuration files that explain the workspace; do not copy private source into the response.
+3. Run `/agent-preflight` when the command is installed, or invoke the bundled scanner from a trusted Claude install root.
+4. If the scanner is unavailable, apply the same manual decision rules: destructive commands, credential-writing automation, risky agent authority, git state, and high-risk shell or network install chains.
+5. Classify the workspace as Green, Yellow, or Red.
+6. Report the decision, evidence, and next safe action before making edits.
+7. For Yellow results, ask for a checkpoint or narrower scope before broad edits.
+8. For Red results, stop and request human review before changing files.
+
+## Output
+
+Return a short receipt in Markdown that is safe to paste into the local work log or pull request notes:
+
+```markdown
+## Agent Safety Preflight Receipt
+
+- Decision: Green | Yellow | Red
+- Repository: <path>
+- Git state: clean | dirty | unavailable
+- Risk buckets: <bullets>
+- Evidence: <file/path markers>
+- Next safe action: proceed | checkpoint | stop
+```
+
+## Error Handling
+
+- If the scanner cannot be found from a trusted install root, say that the automated scanner did not run and use the manual rules.
+- If git status is unavailable, classify the workspace as Yellow rather than Green.
+- If a file cannot be decoded, scan the readable prefix with tolerant UTF-8 decoding and include a note if relevant evidence may be incomplete.
+- If a destructive or credential-writing marker appears in an agent-controlled path, classify the workspace as Red and stop.
+- If the workspace is too large for a full pass, inspect high-signal paths first: `.claude/`, `.cursor/`, `.github/`, shell scripts, JSON/YAML/TOML config, package manifests, and environment files.
+
+## Examples
+
+### Example 1: Clean repo before routine edits
+
+User request: "Run a preflight before you update this README."
+
+The skill runs the scanner, sees a clean git state and no high-risk automation markers, then returns Green with the repository path and evidence summary.
+
+### Example 2: Agent hooks present
+
+User request: "Check this repo before the agent refactor."
+
+The skill detects agent hook configuration or broad tool permissions, returns Yellow, and recommends a checkpoint or narrower edit scope before continuing.
+
+### Example 3: Destructive automation found
+
+User request: "Start editing this generated-project repo."
+
+The skill finds a destructive recursive delete pattern in an automation file, returns Red, and stops until a human reviews the workflow.
+
+## Resources
+
+- Command: `plugins/security/agent-safety-preflight/commands/agent-preflight.md`
+- Scanner: `plugins/security/agent-safety-preflight/scripts/agent_preflight_lite.py`
+- Decision-rule reference: `references/decision-rules.md`
+- Public source workflow: https://github.com/el-zachariah/ai-agent-safety-starter-pack
+- Claude Code plugin reference: https://docs.anthropic.com/en/docs/claude-code/plugins

--- a/plugins/security/agent-safety-preflight/skills/agent-safety-preflight/references/decision-rules.md
+++ b/plugins/security/agent-safety-preflight/skills/agent-safety-preflight/references/decision-rules.md
@@ -1,0 +1,27 @@
+# Agent Safety Preflight decision rules
+
+Use these rules when the bundled scanner is unavailable or when a human asks how the receipt was classified.
+
+## Green
+
+Return Green only when git state is clean and no high-risk automation markers are present in the inspected local files.
+
+## Yellow
+
+Return Yellow when any of these are true:
+
+- Git state is dirty or unavailable.
+- Agent hooks, broad tool permissions, MCP server configuration, or other agent authority surfaces are present without destructive or credential-writing evidence.
+- The scanner cannot inspect enough of the workspace to make a clean Green call.
+
+## Red
+
+Return Red and stop before editing when any of these are true:
+
+- Destructive recursive delete patterns appear in scripts, hooks, commands, or agent-controlled paths.
+- Credential-writing automation appears in an actual environment or secret-assignment context.
+- Shell or network install chains run from agent-controlled paths without a clear local-only safety boundary.
+
+## Evidence discipline
+
+Report file paths and short markers only. Do not paste secrets, tokens, private source, environment values, or payment credentials into the receipt.

--- a/plugins/security/agent-safety-preflight/tests/test_agent_preflight_lite.py
+++ b/plugins/security/agent-safety-preflight/tests/test_agent_preflight_lite.py
@@ -1,0 +1,121 @@
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.util
+import subprocess
+
+MODULE = Path(__file__).resolve().parents[1] / "scripts" / "agent_preflight_lite.py"
+spec = importlib.util.spec_from_file_location("agent_preflight_lite", MODULE)
+scanner = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scanner)
+
+
+class AgentPreflightLiteTest(unittest.TestCase):
+    def test_green_empty_repo(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            result = scanner.scan(Path(td))
+            self.assertEqual(result["decision"], "Green")
+
+    def test_non_git_directory_is_yellow(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = scanner.scan(Path(td))
+            self.assertEqual(result["git_state"], "unavailable")
+            self.assertEqual(result["decision"], "Yellow")
+
+    def test_generic_permissions_docs_do_not_trigger_agent_authority(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            p = Path(td) / "README.md"
+            p.write_text("Document normal Linux file permissions and OAuth scopes.\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("agent-authority", result["risk_buckets"])
+
+    def test_browser_permissions_array_does_not_trigger_agent_authority(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            p = Path(td) / "manifest.json"
+            p.write_text('{"permissions": ["storage", "activeTab", "clipboardRead"]}\n', encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("agent-authority", result["risk_buckets"])
+
+    def test_risky_permissions_array_triggers_agent_authority(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            p = Path(td) / ".claude" / "settings.json"
+            p.parent.mkdir()
+            p.write_text('{"permissions": ["write"]}\n', encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertIn("agent-authority", result["risk_buckets"])
+
+    def test_paypal_brand_docs_do_not_trigger_credential_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            p = Path(td) / "README.md"
+            p.write_text("This e-commerce app accepts PayPal and card checkout.\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("credential-write", result["risk_buckets"])
+            self.assertNotEqual(result["decision"], "Red")
+
+    def test_git_hooks_docs_do_not_trigger_agent_authority(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init"], cwd=td, check=True, capture_output=True)
+            p = Path(td) / "README.md"
+            p.write_text("Document pre-commit hooks and GitHub Actions release hooks.\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("agent-authority", result["risk_buckets"])
+
+    def test_red_destructive_command(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "danger.sh"
+            p.write_text("rm -" + "rf /tmp/example\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertEqual(result["decision"], "Red")
+            self.assertIn("destructive-recursive-delete", result["risk_buckets"])
+
+    def test_env_mention_in_docs_is_not_credential_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "README.md"
+            p.write_text("Copy .env.example to .env before running locally.\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("credential-write", result["risk_buckets"])
+            self.assertNotEqual(result["decision"], "Red")
+
+    def test_github_actions_secret_reference_is_not_credential_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            workflow = Path(td) / ".github" / "workflows" / "ci.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                "env:\n  TOKEN: ${{ secrets.GITHUB_TOKEN }}\n  OPENAI: ${{ secrets.OPENAI_API_KEY }}\n",
+                encoding="utf-8",
+            )
+            result = scanner.scan(Path(td))
+            self.assertNotIn("credential-write", result["risk_buckets"])
+            self.assertNotEqual(result["decision"], "Red")
+
+    def test_api_key_assignment_is_credential_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "config.yml"
+            p.write_text("OPENAI_API_KEY: sk-example\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertEqual(result["decision"], "Red")
+            self.assertIn("credential-write", result["risk_buckets"])
+
+    def test_actual_env_file_is_credential_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / ".env.local"
+            p.write_text("LOCAL_ONLY=1\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertEqual(result["decision"], "Red")
+            self.assertIn("credential-write", result["risk_buckets"])
+
+    def test_large_file_uses_prefix_sample(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "README.md"
+            p.write_text("safe\n" * (scanner.MAX_SCAN_BYTES // 5 + 2) + "rm -" + "rf /tmp/example\n", encoding="utf-8")
+            result = scanner.scan(Path(td))
+            self.assertNotIn("destructive-recursive-delete", result["risk_buckets"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -40,3 +40,6 @@ sources.yaml:sources-change-unscanned  2026-07-08 verified-flag honesty PR revie
 # network, no embedded credentials, no dynamic-exec of untrusted input. SKILL_ID
 # is validated (^[a-zA-Z0-9_-]+$) before any use. Reviewed 2026-07-09.
 plugins/productivity/j-rig/**:hook-definition  the sinker/line/hook 3-layer architecture is this plugin's purpose; hooks only wrap the published @intentsolutions/refiner CLI + a deterministic validator, no network/credentials/dynamic-exec — reviewed 2026-07-09
+
+# ── Reviewed defensive scanner signatures. ──
+plugins/security/agent-safety-preflight/scripts/agent_preflight_lite.py:outbound-network  defensive scanner regex detects curl/wget install chains; it does not perform network calls


### PR DESCRIPTION
## What

Adds the **agent-safety-preflight** security plugin by **@el-zachariah** (Signal Loom Works): a local Claude Code command that generates a repo-risk receipt before AI-agent edits — 1 skill, 1 command, a read-only/no-network Python scanner, tests, and its `marketplace.extended.json` catalog entry.

This branch is a maintainer recreation of fork PR #964 at its exact head SHA `7a4239ff`, preserving the contributor's commit authorship. It exists solely because the fork PR hand-committed high-churn generated artifacts (marketplace.json, plugin package.json, README AUTO-TOC, 7 marketplace data JSONs) that conflict with current main.

## Why + decision rationale

The fork content itself is merge-ready: Jeremy's 2026-07-07 CHANGES_REQUESTED review — all 5 asks fixed at head; Greptile's P1 scanner-shadowing finding fixed; all required checks green on the fork head. Chose **recreate-from-their-SHA** over an in-place fork rebase because taking main's side wholesale for generated files + regenerating via `pnpm run sync-marketplace` is conflict-free, honors the Two Catalog System rule (derived files are never hand-edited), and keeps authorship intact.

## Layers touched

`plugins/security/` (new plugin), `.claude-plugin/marketplace.extended.json` (catalog source, entry appended at tail), `scripts/scan-allowlist.txt` (contributor's narrow `outbound-network` waiver — the scanner's regexes detect curl/wget chains, it performs no network calls), derived artifacts regenerated. No invariant changes.

## Verification & evidence

- Byte-diff vs the fork-head snapshot (sha256 manifest): **8/9 files identical**; the 9th is the regenerated `package.json` (generator `files[]` ordering — expected)
- `validate-skills-schema.py --marketplace` on the plugin: **Grade A 98/100, 0 errors** (one benign reserved-word warning)
- `./scripts/quick-test.sh`: build + lint pass; the 187 standard-tier corpus errors are pre-existing on main (tracked by the fault-remediation program) — this plugin contributes 0
- Fork CI at identical content: all required checks passing; plugin tests 13/13

## Risk assessment

Low: additive plugin, read-only scanner, no hooks/MCP/network. Rollback = revert the squash commit.

## Operational impact

New npm package will publish on merge via `publish-changed-packages.yml` (normal for a new plugin). Auto-bump may fire on this branch — expected.

## Follow-up

Closes the fork PR #964 with a credit note pointing here.

Refs #964

- Jeremy Longshore
intentsolutions.io