### PR TITLE
feat(jrig): eval→forge_proofs write path — recorder, guarded runner, honest badge copy (#935 Unit 1)

### DIFF
--- a/.github/workflows/jrig-proofs-test.yml
+++ b/.github/workflows/jrig-proofs-test.yml
@@ -1,0 +1,55 @@
+name: JRig Proofs Recorder (unit corpus)
+
+# BLOCKING unit corpus for the eval→forge_proofs write path
+# (scripts/record-jrig-proofs.mjs). The recorder is what lights the
+# JRig-Verified badge on plugin detail pages — a broken upsert/stub-guard
+# would light badges dishonestly, so a failing corpus turns this check red.
+#
+# Zero-install by design: the module and its tests use only node built-ins
+# plus the sqlite3 CLI already present on ubuntu runners.
+#
+# Refs jeremylongshore/claude-code-plugins-plus-skills#935.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/record-jrig-proofs.mjs'
+      - 'scripts/record-jrig-proofs.test.mjs'
+      - 'scripts/run-jrig-eval.sh'
+      - '.github/workflows/jrig-proofs-test.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: jrig-proofs-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jrig-proofs-test:
+    name: record-jrig-proofs unit corpus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Recorder unit corpus (blocking)
+        run: node --test scripts/record-jrig-proofs.test.mjs
+
+      - name: Runner refuses the tracked inventory DB as scratch (blocking)
+        run: |
+          mkdir -p /tmp/guard-skill && touch /tmp/i.db
+          out=$(bash scripts/run-jrig-eval.sh --stub --skill-dir /tmp/guard-skill --plugin x --scratch-db freshie/inventory.sqlite --inventory-db /tmp/i.db 2>&1) && {
+            echo "::error::runner accepted a freshie path as scratch DB — guard broken"
+            exit 1
+          }
+          echo "$out" | grep -q "refusing scratch DB path containing 'freshie'" || {
+            echo "::error::runner exited non-zero but NOT via the freshie guard — got: $out"
+            exit 1
+          }
+          echo "guard holds: freshie scratch path refused with the guard message"

--- a/marketplace/scripts/enrich-jrig-data.mjs
+++ b/marketplace/scripts/enrich-jrig-data.mjs
@@ -162,9 +162,10 @@ function main() {
     warn(
       'forge_proofs exists but has zero passing tier3-jrig rows — no plugin ' +
         'has a completed 7-layer behavioral eval yet, so every JRig-Verified ' +
-        'badge renders "pending". Populate a row with: `j-rig eval <plugin> ' +
-        '--models haiku,sonnet,opus --db freshie/inventory.sqlite` (once the ' +
-        'eval→forge_proofs write path lands).',
+        'badge renders "pending". Populate a row with: `scripts/run-jrig-eval.sh ' +
+        '--skill-dir <dir> --plugin <name> --inventory-db freshie/inventory.sqlite` ' +
+        '(evals against a /dev/shm scratch DB, then records the verdict via ' +
+        'scripts/record-jrig-proofs.mjs — never point j-rig itself at the inventory DB).',
     );
     return;
   }

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -144,7 +144,7 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
             </a>
           )}
           {jrigBadge && (
-            <a href={`/plugins/${plugin.slug || plugin.name}/verification`} class="badge jrig-verified" title={`Behavioral eval: ${jrigBadge.layers} JRig layers passed across Haiku/Sonnet/Opus`}>
+            <a href={`/plugins/${plugin.slug || plugin.name}/verification`} class="badge jrig-verified" title={`Behavioral eval: ${jrigBadge.layers} JRig layers passed across the evaluated model matrix`}>
               {jrigBadge.label} &middot; {jrigBadge.layers} layers
             </a>
           )}

--- a/marketplace/src/pages/plugins/[name]/verification.astro
+++ b/marketplace/src/pages/plugins/[name]/verification.astro
@@ -20,7 +20,7 @@ const jrig = jrigData[plugin.name] ?? null;
 
 const title = `${plugin.name} — JRig Verification | Tons of Skills`;
 const description = jrig?.verified
-  ? `${plugin.name} passed all ${jrig.layers_passed ?? 7} JRig behavioral evaluation layers across Haiku, Sonnet, and Opus. Last verified ${jrig.verified_at ?? 'recently'}.`
+  ? `${plugin.name} passed all ${jrig.layers_passed ?? 7} JRig behavioral evaluation layers across the evaluated model matrix. Last verified ${jrig.verified_at ?? 'recently'}.`
   : `${plugin.name} hasn't yet completed JRig 7-layer behavioral evaluation. Verification status will appear here once a forge or eval run posts results.`;
 
 // 7-layer eval framework — for description, not real per-plugin data.
@@ -79,7 +79,7 @@ const layers = [
 
       <section class="layers">
         <h2>The 7 layers</h2>
-        <p class="lede">JRig evaluates each plugin against seven binary criteria. To pass, every layer must clear the threshold across all three models in the matrix (Haiku, Sonnet, Opus). This is what the JRig-Verified badge represents.</p>
+        <p class="lede">JRig evaluates each plugin against seven binary criteria. To pass, every layer must clear the threshold across every model in the evaluated matrix. This is what the JRig-Verified badge represents.</p>
         <ol class="layer-list">
           {layers.map((layer) => (
             <li class="layer">
@@ -123,8 +123,8 @@ const layers = [
             <h3>Why this plugin isn't verified yet</h3>
             <p>JRig verification is opt-in and runs through one of two paths:</p>
             <ol>
-              <li><strong>Forge generation</strong>: plugins produced by <code>/skill-creator --forge</code> run JRig as the final gate. The Tier 3 verdict is written to <code>forge_proofs</code> automatically.</li>
-              <li><strong>Manual eval</strong>: maintainers can run <code>j-rig eval &lt;skill-dir&gt; --models haiku,sonnet,opus --db freshie/inventory.sqlite</code> to post results.</li>
+              <li><strong>Forge generation</strong>: plugins produced by <code>/skill-creator --forge</code> run JRig as the final gate. The Tier 3 verdict is recorded to <code>forge_proofs</code> via the eval write path (<code>scripts/record-jrig-proofs.mjs</code>).</li>
+              <li><strong>Manual eval</strong>: maintainers can run <code>scripts/run-jrig-eval.sh --skill-dir &lt;dir&gt; --plugin &lt;name&gt; --inventory-db freshie/inventory.sqlite</code>, which evals against a scratch DB and records the verdict.</li>
             </ol>
             <p>Until one of those paths fires, the plugin's grade and Tier 2 production-gate results are still authoritative — JRig adds behavioral verification on top.</p>
           </div>

--- a/scripts/record-jrig-proofs.mjs
+++ b/scripts/record-jrig-proofs.mjs
@@ -122,7 +122,12 @@ export function sqlString(value) {
 
 export function parseArgs(argv) {
   const args = { allowStub: false };
-  const takesValue = { '--db': 'db', '--plugin': 'plugin', '--run-id': 'runId', '--result': 'result' };
+  const takesValue = {
+    '--db': 'db',
+    '--plugin': 'plugin',
+    '--run-id': 'runId',
+    '--result': 'result',
+  };
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
     if (flag === '--allow-stub') {
@@ -139,7 +144,9 @@ export function parseArgs(argv) {
     if (!args[key]) fail(`Missing required argument: ${flag}`);
   }
   if (!/^\d+$/.test(args.runId)) {
-    fail(`--run-id must be a non-negative integer (got: ${args.runId}) — it is part of the UNIQUE(plugin_name, verification_type, run_id) upsert key.`);
+    fail(
+      `--run-id must be a non-negative integer (got: ${args.runId}) — it is part of the UNIQUE(plugin_name, verification_type, run_id) upsert key.`,
+    );
   }
   args.runId = Number(args.runId);
   return args;
@@ -162,19 +169,26 @@ export function extractModelEntries(parsed) {
         (v) => v !== null && typeof v === 'object' && !Array.isArray(v) && 'scoreCard' in v,
       );
   if (entries.length === 0) {
-    fail('No model entries with a scoreCard found in the result JSON — is this really `j-rig eval --json` output?');
+    fail(
+      'No model entries with a scoreCard found in the result JSON — is this really `j-rig eval --json` output?',
+    );
   }
   for (const entry of entries) {
     const sc = entry.scoreCard;
     if (
-      sc === null || typeof sc !== 'object' ||
-      !Number.isInteger(sc.passed) || sc.passed < 0 ||
-      !Number.isInteger(sc.total_criteria) || sc.total_criteria < 0
+      sc === null ||
+      typeof sc !== 'object' ||
+      !Number.isInteger(sc.passed) ||
+      sc.passed < 0 ||
+      !Number.isInteger(sc.total_criteria) ||
+      sc.total_criteria < 0
     ) {
       fail(`Malformed scoreCard (need integer passed/total_criteria >= 0): ${JSON.stringify(sc)}`);
     }
     if (!VALID_DECISIONS.has(entry.decision)) {
-      fail(`Malformed model entry: decision must be one of ${[...VALID_DECISIONS].join('|')} (got: ${JSON.stringify(entry.decision)})`);
+      fail(
+        `Malformed model entry: decision must be one of ${[...VALID_DECISIONS].join('|')} (got: ${JSON.stringify(entry.decision)})`,
+      );
     }
   }
   return entries;
@@ -197,7 +211,9 @@ export function aggregateEntries(entries, { allowStub = false } = {}) {
   }
   const totals = new Set(entries.map((e) => e.scoreCard.total_criteria));
   if (totals.size > 1) {
-    fail(`Model entries disagree on total_criteria (${[...totals].join(', ')}) — same eval spec should yield the same criteria count. Refusing to record an ambiguous row.`);
+    fail(
+      `Model entries disagree on total_criteria (${[...totals].join(', ')}) — same eval spec should yield the same criteria count. Refusing to record an ambiguous row.`,
+    );
   }
   return {
     passed: entries.every((e) => e.decision === 'ship') ? 1 : 0,
@@ -249,7 +265,9 @@ export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
 
   if (!fs.existsSync(args.db)) {
-    fail(`DB not found: ${args.db} — refusing to create a fresh database at an arbitrary path. Point --db at the inventory DB (or a copy of it).`);
+    fail(
+      `DB not found: ${args.db} — refusing to create a fresh database at an arbitrary path. Point --db at the inventory DB (or a copy of it).`,
+    );
   }
   if (!fs.existsSync(args.result)) {
     fail(`Result file not found: ${args.result}`);
@@ -277,7 +295,8 @@ WHERE plugin_name = ${sqlString(args.plugin)}
   AND verification_type = ${sqlString(VERIFICATION_TYPE)}
   AND run_id = ${args.runId};`,
   ).trim();
-  if (!echo) fail('Upsert reported success but the row is not readable back — refusing to report success.');
+  if (!echo)
+    fail('Upsert reported success but the row is not readable back — refusing to report success.');
 
   const written = JSON.parse(echo)[0];
   console.log(

--- a/scripts/record-jrig-proofs.mjs
+++ b/scripts/record-jrig-proofs.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * record-jrig-proofs.mjs — the eval→forge_proofs write path (issue #935).
+ *
+ * Takes a `j-rig eval ... --json` result file and upserts one row into the
+ * `forge_proofs` table of a Freshie-shaped SQLite inventory DB. This is the
+ * missing write end of the "printing press" data flow:
+ *
+ *   j-rig eval → THIS SCRIPT → forge_proofs row
+ *     → marketplace/scripts/enrich-jrig-data.mjs → jrig-data.json
+ *     → JRig-Verified badge on the plugin detail page.
+ *
+ * INPUT SHAPE (what we bind to — inspected from @intentsolutions/jrig-cli
+ * 0.1.2, dist/index.js `registerEvalCommand`): `j-rig eval --json` prints a
+ * map keyed by model name, one entry per `--models` entry:
+ *
+ *   {
+ *     "<model>": {
+ *       "provider":     string,        // e.g. "deepseek" | "stub"
+ *       "model":        string,        // e.g. "deepseek-v4-flash"
+ *       "ground_truth": boolean,       // false when the stub provider ran
+ *       "pkgReport":    { ... },       // Layer 1 package-integrity report
+ *       "scoreCard": {                 // computeScoreCard() output
+ *         "total_criteria":    number,
+ *         "passed":            number,
+ *         "failed":            number,
+ *         "unsure":            number,
+ *         "blocker_failures":  number,
+ *         "sacred_regressions": number,
+ *         "pass_rate":         number
+ *       },
+ *       "decision": "ship" | "warn" | "block" | "obsolete_review",
+ *       "report": { skill_name, timestamp, decision, score, regressions,
+ *                   baseline, blockers, warnings, reasoning }
+ *     }
+ *   }
+ *
+ * A bare single-run object (`{ scoreCard, decision, ... }`) is also accepted.
+ *
+ * ROW CONTRACT (conforms to the real schema in freshie/inventory.sqlite,
+ * created by scripts/validate-skills-schema.py — verified 2026-07-09):
+ *
+ *   CREATE TABLE forge_proofs (
+ *     id INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     plugin_name TEXT NOT NULL,
+ *     run_id INTEGER,
+ *     verification_type TEXT NOT NULL,
+ *     passed INTEGER NOT NULL,
+ *     evidence TEXT,
+ *     layers_passed INTEGER DEFAULT NULL,
+ *     total_layers INTEGER DEFAULT 7,
+ *     baseline_delta REAL DEFAULT NULL,
+ *     verified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE(plugin_name, verification_type, run_id)
+ *   );
+ *
+ *   - verification_type = 'tier3-jrig' (what enrich-jrig-data.mjs selects)
+ *   - passed        = 1 iff EVERY model's rollout decision is "ship"
+ *   - layers_passed = min(scoreCard.passed) across models (conservative)
+ *   - total_layers  = scoreCard.total_criteria (must agree across models)
+ *   - baseline_delta = NULL (standalone eval runs carry no baseline compare)
+ *   - evidence      = JSON: per-model {provider, model, ground_truth,
+ *                     decision, scoreCard, reasoning, timestamp} subset
+ *
+ * Upsert is idempotent: INSERT ... ON CONFLICT(plugin_name,
+ * verification_type, run_id) DO UPDATE. `--run-id` is REQUIRED and must be a
+ * non-negative integer — SQLite treats NULLs as distinct in UNIQUE
+ * constraints, so a NULL run_id would break idempotency.
+ *
+ * STUB GUARD: results produced by the stub provider (`ground_truth: false`)
+ * are refused unless `--allow-stub` is passed — a stub row would light a
+ * JRig-Verified badge with non-ground-truth evidence. `--allow-stub` exists
+ * for pipeline plumbing against scratch DB copies only.
+ *
+ * Uses only node built-ins + the `sqlite3` CLI via child_process (same
+ * pattern as marketplace/scripts/enrich-jrig-data.mjs — no better-sqlite3
+ * native dep for a once-per-run write).
+ *
+ * Usage:
+ *   node scripts/record-jrig-proofs.mjs \
+ *     --db <inventory.sqlite> --plugin <name> --run-id <int> \
+ *     --result <result.json> [--allow-stub]
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VERIFICATION_TYPE = 'tier3-jrig';
+const VALID_DECISIONS = new Set(['ship', 'warn', 'block', 'obsolete_review']);
+
+// Exact DDL from scripts/validate-skills-schema.py so the adapter also works
+// against a fresh scratch DB (CREATE TABLE IF NOT EXISTS is a no-op on the
+// real inventory DB, which already carries the table).
+const FORGE_PROOFS_DDL = `CREATE TABLE IF NOT EXISTS forge_proofs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    plugin_name TEXT NOT NULL,
+    run_id INTEGER,
+    verification_type TEXT NOT NULL,
+    passed INTEGER NOT NULL,
+    evidence TEXT,
+    layers_passed INTEGER DEFAULT NULL,
+    total_layers INTEGER DEFAULT 7,
+    baseline_delta REAL DEFAULT NULL,
+    verified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(plugin_name, verification_type, run_id)
+);
+CREATE INDEX IF NOT EXISTS idx_forge_proofs_plugin ON forge_proofs(plugin_name);
+CREATE INDEX IF NOT EXISTS idx_forge_proofs_passed ON forge_proofs(passed);`;
+
+export function fail(message) {
+  const err = new Error(message);
+  err.isCliFailure = true;
+  throw err;
+}
+
+/** SQLite string literal escaping: double the single quotes. */
+export function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+export function parseArgs(argv) {
+  const args = { allowStub: false };
+  const takesValue = { '--db': 'db', '--plugin': 'plugin', '--run-id': 'runId', '--result': 'result' };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--allow-stub') {
+      args.allowStub = true;
+    } else if (takesValue[flag]) {
+      const value = argv[++i];
+      if (value === undefined) fail(`Missing value for ${flag}`);
+      args[takesValue[flag]] = value;
+    } else {
+      fail(`Unknown argument: ${flag}`);
+    }
+  }
+  for (const [flag, key] of Object.entries(takesValue)) {
+    if (!args[key]) fail(`Missing required argument: ${flag}`);
+  }
+  if (!/^\d+$/.test(args.runId)) {
+    fail(`--run-id must be a non-negative integer (got: ${args.runId}) — it is part of the UNIQUE(plugin_name, verification_type, run_id) upsert key.`);
+  }
+  args.runId = Number(args.runId);
+  return args;
+}
+
+/**
+ * Extract per-model result entries from a parsed `j-rig eval --json` result.
+ * Accepts the canonical model-keyed map or a bare single-run object.
+ */
+export function extractModelEntries(parsed) {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail('Result JSON must be an object (the `j-rig eval --json` model-keyed map).');
+  }
+  if (parsed.error) {
+    fail(`Result JSON records a failed eval run: ${parsed.error}`);
+  }
+  const entries = parsed.scoreCard
+    ? [parsed]
+    : Object.values(parsed).filter(
+        (v) => v !== null && typeof v === 'object' && !Array.isArray(v) && 'scoreCard' in v,
+      );
+  if (entries.length === 0) {
+    fail('No model entries with a scoreCard found in the result JSON — is this really `j-rig eval --json` output?');
+  }
+  for (const entry of entries) {
+    const sc = entry.scoreCard;
+    if (
+      sc === null || typeof sc !== 'object' ||
+      !Number.isInteger(sc.passed) || sc.passed < 0 ||
+      !Number.isInteger(sc.total_criteria) || sc.total_criteria < 0
+    ) {
+      fail(`Malformed scoreCard (need integer passed/total_criteria >= 0): ${JSON.stringify(sc)}`);
+    }
+    if (!VALID_DECISIONS.has(entry.decision)) {
+      fail(`Malformed model entry: decision must be one of ${[...VALID_DECISIONS].join('|')} (got: ${JSON.stringify(entry.decision)})`);
+    }
+  }
+  return entries;
+}
+
+/**
+ * Fold N per-model entries into the single forge_proofs row contract.
+ * Conservative: the row only reads as passed when every model ships, and
+ * layers_passed is the weakest model's count.
+ */
+export function aggregateEntries(entries, { allowStub = false } = {}) {
+  const stubEntries = entries.filter((e) => e.ground_truth === false);
+  if (stubEntries.length > 0 && !allowStub) {
+    fail(
+      `Result contains ${stubEntries.length} stub-provider entr${stubEntries.length === 1 ? 'y' : 'ies'} ` +
+        '(ground_truth: false). Refusing to record non-ground-truth evidence into forge_proofs — ' +
+        'a stub row would light a JRig-Verified badge dishonestly. Pass --allow-stub only for ' +
+        'pipeline plumbing against a scratch DB copy.',
+    );
+  }
+  const totals = new Set(entries.map((e) => e.scoreCard.total_criteria));
+  if (totals.size > 1) {
+    fail(`Model entries disagree on total_criteria (${[...totals].join(', ')}) — same eval spec should yield the same criteria count. Refusing to record an ambiguous row.`);
+  }
+  return {
+    passed: entries.every((e) => e.decision === 'ship') ? 1 : 0,
+    layers_passed: Math.min(...entries.map((e) => e.scoreCard.passed)),
+    total_layers: [...totals][0],
+    baseline_delta: null,
+    evidence: {
+      source: 'j-rig eval --json',
+      recorded_by: 'scripts/record-jrig-proofs.mjs',
+      stub: stubEntries.length > 0,
+      models: entries.map((e) => ({
+        provider: e.provider ?? null,
+        model: e.model ?? null,
+        ground_truth: e.ground_truth ?? null,
+        decision: e.decision,
+        scoreCard: e.scoreCard,
+        reasoning: e.report?.reasoning ?? null,
+        timestamp: e.report?.timestamp ?? null,
+      })),
+    },
+  };
+}
+
+/** Build the idempotent upsert SQL for one forge_proofs row. */
+export function buildUpsertSql({ plugin, runId, row }) {
+  return `${FORGE_PROOFS_DDL}
+INSERT INTO forge_proofs
+  (plugin_name, run_id, verification_type, passed, evidence, layers_passed, total_layers, baseline_delta)
+VALUES
+  (${sqlString(plugin)}, ${runId}, ${sqlString(VERIFICATION_TYPE)}, ${row.passed},
+   ${sqlString(JSON.stringify(row.evidence))}, ${row.layers_passed}, ${row.total_layers}, NULL)
+ON CONFLICT(plugin_name, verification_type, run_id) DO UPDATE SET
+  passed = excluded.passed,
+  evidence = excluded.evidence,
+  layers_passed = excluded.layers_passed,
+  total_layers = excluded.total_layers,
+  baseline_delta = excluded.baseline_delta,
+  verified_at = CURRENT_TIMESTAMP;`;
+}
+
+function runSqlite(dbPath, sql) {
+  const result = spawnSync('sqlite3', ['-batch', dbPath], { input: sql, encoding: 'utf8' });
+  if (result.error) fail(`Failed to spawn sqlite3 CLI: ${result.error.message}`);
+  if (result.status !== 0) fail(`sqlite3 exited ${result.status}: ${result.stderr.trim()}`);
+  return result.stdout;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+
+  if (!fs.existsSync(args.db)) {
+    fail(`DB not found: ${args.db} — refusing to create a fresh database at an arbitrary path. Point --db at the inventory DB (or a copy of it).`);
+  }
+  if (!fs.existsSync(args.result)) {
+    fail(`Result file not found: ${args.result}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(args.result, 'utf8'));
+  } catch (err) {
+    fail(`Result file is not valid JSON (${args.result}): ${err.message}`);
+  }
+
+  const entries = extractModelEntries(parsed);
+  const row = aggregateEntries(entries, { allowStub: args.allowStub });
+
+  runSqlite(args.db, buildUpsertSql({ plugin: args.plugin, runId: args.runId, row }));
+
+  // Read the row back so the log line is evidence, not hope.
+  const echo = runSqlite(
+    args.db,
+    `.mode json
+SELECT plugin_name, run_id, verification_type, passed, layers_passed, total_layers, baseline_delta, verified_at
+FROM forge_proofs
+WHERE plugin_name = ${sqlString(args.plugin)}
+  AND verification_type = ${sqlString(VERIFICATION_TYPE)}
+  AND run_id = ${args.runId};`,
+  ).trim();
+  if (!echo) fail('Upsert reported success but the row is not readable back — refusing to report success.');
+
+  const written = JSON.parse(echo)[0];
+  console.log(
+    `[record-jrig-proofs] Upserted ${VERIFICATION_TYPE} row for '${args.plugin}' (run_id=${args.runId}): ` +
+      `passed=${written.passed}, layers=${written.layers_passed}/${written.total_layers}, ` +
+      `models=${row.evidence.models.map((m) => m.model).join(',')}${row.evidence.stub ? ' [STUB — not ground truth]' : ''}`,
+  );
+  return written;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`[record-jrig-proofs] ERROR: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/record-jrig-proofs.test.mjs
+++ b/scripts/record-jrig-proofs.test.mjs
@@ -1,0 +1,259 @@
+/**
+ * record-jrig-proofs.test.mjs — unit tests for the eval→forge_proofs write
+ * path (issue #935).
+ *
+ * Covers:
+ *   (a) fresh insert — a well-formed `j-rig eval --json` result lands as one
+ *       tier3-jrig row with the contracted column bindings;
+ *   (b) idempotent re-run — same (plugin, run_id) upserts in place, never
+ *       duplicates; changed scorecards update the existing row;
+ *   (c) malformed result JSON — rejected loudly with a non-zero exit;
+ *   (d) runner freshie-path guard — scripts/run-jrig-eval.sh refuses any
+ *       j-rig scratch DB path containing 'freshie' (and non-/dev/shm paths);
+ *   (e) stub guard — ground_truth:false results are refused without
+ *       --allow-stub.
+ *
+ * Run: node --test scripts/record-jrig-proofs.test.mjs
+ * Needs the `sqlite3` CLI on PATH (same requirement as the script itself and
+ * marketplace/scripts/enrich-jrig-data.mjs).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RECORD_SCRIPT = path.join(__dirname, 'record-jrig-proofs.mjs');
+const RUNNER_SCRIPT = path.join(__dirname, 'run-jrig-eval.sh');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'record-jrig-test-'));
+}
+
+/** Minimal fixture matching the `j-rig eval --json` model-keyed map shape. */
+function fixtureResult({ passed = 7, total = 7, decision = 'ship', groundTruth = true, model = 'deepseek-v4-flash' } = {}) {
+  return {
+    [model]: {
+      provider: groundTruth ? 'deepseek' : 'stub',
+      model,
+      ground_truth: groundTruth,
+      pkgReport: { summary: { passed: 5, errors: 0 } },
+      scoreCard: {
+        total_criteria: total,
+        passed,
+        failed: total - passed,
+        unsure: 0,
+        blocker_failures: 0,
+        sacred_regressions: 0,
+        pass_rate: total > 0 ? passed / total : 0,
+      },
+      decision,
+      report: {
+        skill_name: 'fixture-skill',
+        timestamp: '2026-07-09T00:00:00.000Z',
+        decision,
+        blockers: [],
+        warnings: [],
+        reasoning: `${passed}/${total} criteria passed.`,
+      },
+    },
+  };
+}
+
+function writeFixture(dir, name, value) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, typeof value === 'string' ? value : JSON.stringify(value, null, 2));
+  return file;
+}
+
+function freshDb(dir) {
+  // A zero-length file is a valid empty SQLite database; the script's
+  // CREATE TABLE IF NOT EXISTS provisions forge_proofs.
+  const db = path.join(dir, 'inventory-copy.sqlite');
+  fs.writeFileSync(db, '');
+  return db;
+}
+
+function record(args) {
+  return execFileSync(process.execPath, [RECORD_SCRIPT, ...args], { encoding: 'utf8' });
+}
+
+function recordExpectFail(args) {
+  const result = spawnSync(process.execPath, [RECORD_SCRIPT, ...args], { encoding: 'utf8' });
+  assert.notEqual(result.status, 0, `expected non-zero exit, got ${result.status}\nstdout: ${result.stdout}`);
+  return result.stderr;
+}
+
+function queryRows(db, sql) {
+  const out = execFileSync('sqlite3', ['-batch', '-json', db, sql], { encoding: 'utf8' }).trim();
+  return out ? JSON.parse(out) : [];
+}
+
+test('(a) fresh insert lands one tier3-jrig row with the contracted bindings', () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+  const result = writeFixture(dir, 'result.json', fixtureResult({ passed: 6, total: 7, decision: 'warn' }));
+
+  const stdout = record(['--db', db, '--plugin', 'coreweave-pack', '--run-id', '42', '--result', result]);
+  assert.match(stdout, /Upserted tier3-jrig row for 'coreweave-pack' \(run_id=42\)/);
+
+  const rows = queryRows(db, 'SELECT * FROM forge_proofs;');
+  assert.equal(rows.length, 1);
+  const row = rows[0];
+  assert.equal(row.plugin_name, 'coreweave-pack');
+  assert.equal(row.run_id, 42);
+  assert.equal(row.verification_type, 'tier3-jrig');
+  assert.equal(row.passed, 0); // decision 'warn' !== 'ship'
+  assert.equal(row.layers_passed, 6); // scoreCard.passed
+  assert.equal(row.total_layers, 7); // scoreCard.total_criteria
+  assert.equal(row.baseline_delta, null);
+  assert.ok(row.verified_at);
+
+  const evidence = JSON.parse(row.evidence);
+  assert.equal(evidence.source, 'j-rig eval --json');
+  assert.equal(evidence.stub, false);
+  assert.equal(evidence.models.length, 1);
+  assert.equal(evidence.models[0].model, 'deepseek-v4-flash');
+  assert.equal(evidence.models[0].scoreCard.passed, 6);
+});
+
+test('(a2) all-ship multi-model result records passed=1 with the weakest layer count', () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+  const multi = {
+    ...fixtureResult({ passed: 7, total: 7, model: 'deepseek-v4-flash' }),
+    ...fixtureResult({ passed: 5, total: 7, model: 'other-model' }),
+  };
+  const result = writeFixture(dir, 'result.json', multi);
+
+  record(['--db', db, '--plugin', 'multi-pack', '--run-id', '1', '--result', result]);
+
+  const [row] = queryRows(db, "SELECT * FROM forge_proofs WHERE plugin_name='multi-pack';");
+  assert.equal(row.passed, 1); // both decisions are 'ship'
+  assert.equal(row.layers_passed, 5); // min across models
+  assert.equal(row.total_layers, 7);
+  assert.equal(JSON.parse(row.evidence).models.length, 2);
+});
+
+test('(b) idempotent re-run: same run_id upserts in place, never duplicates', () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+  const first = writeFixture(dir, 'r1.json', fixtureResult({ passed: 7, total: 7, decision: 'ship' }));
+  const second = writeFixture(dir, 'r2.json', fixtureResult({ passed: 4, total: 7, decision: 'block' }));
+
+  record(['--db', db, '--plugin', 'plane', '--run-id', '100', '--result', first]);
+  record(['--db', db, '--plugin', 'plane', '--run-id', '100', '--result', first]); // identical re-run
+  let rows = queryRows(db, "SELECT * FROM forge_proofs WHERE plugin_name='plane';");
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].passed, 1);
+  assert.equal(rows[0].layers_passed, 7);
+
+  record(['--db', db, '--plugin', 'plane', '--run-id', '100', '--result', second]); // changed verdict, same key
+  rows = queryRows(db, "SELECT * FROM forge_proofs WHERE plugin_name='plane';");
+  assert.equal(rows.length, 1, 'still exactly one row for the key');
+  assert.equal(rows[0].passed, 0);
+  assert.equal(rows[0].layers_passed, 4);
+
+  record(['--db', db, '--plugin', 'plane', '--run-id', '101', '--result', first]); // new run_id = new row
+  rows = queryRows(db, "SELECT * FROM forge_proofs WHERE plugin_name='plane' ORDER BY run_id;");
+  assert.equal(rows.length, 2);
+});
+
+test('(c) malformed result JSON is rejected loudly with a non-zero exit', () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+
+  // Not JSON at all.
+  const garbage = writeFixture(dir, 'garbage.json', 'this is not json {');
+  let stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', garbage]);
+  assert.match(stderr, /not valid JSON/);
+
+  // Valid JSON, wrong shape (no scoreCard anywhere).
+  const wrongShape = writeFixture(dir, 'wrong.json', { hello: 'world' });
+  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', wrongShape]);
+  assert.match(stderr, /No model entries with a scoreCard/);
+
+  // scoreCard present but non-integer fields.
+  const badCard = fixtureResult();
+  badCard['deepseek-v4-flash'].scoreCard.passed = 'seven';
+  const badCardFile = writeFixture(dir, 'badcard.json', badCard);
+  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', badCardFile]);
+  assert.match(stderr, /Malformed scoreCard/);
+
+  // Invalid decision.
+  const badDecision = fixtureResult();
+  badDecision['deepseek-v4-flash'].decision = 'maybe';
+  const badDecisionFile = writeFixture(dir, 'baddecision.json', badDecision);
+  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', badDecisionFile]);
+  assert.match(stderr, /decision must be one of/);
+
+  // Non-integer run-id (would break the UNIQUE upsert key).
+  const ok = writeFixture(dir, 'ok.json', fixtureResult());
+  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', 'abc', '--result', ok]);
+  assert.match(stderr, /--run-id must be a non-negative integer/);
+
+  // Nothing was written by any failing invocation.
+  const rows = queryRows(db, "SELECT COUNT(*) AS n FROM sqlite_master WHERE type='table' AND name='forge_proofs';");
+  assert.equal(rows[0].n, 0, 'failing runs must not touch the DB');
+});
+
+test('(e) stub results (ground_truth:false) are refused without --allow-stub', () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+  const stub = writeFixture(dir, 'stub.json', fixtureResult({ groundTruth: false }));
+
+  const stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '7', '--result', stub]);
+  assert.match(stderr, /Refusing to record non-ground-truth evidence/);
+
+  // Opting in records the row and marks the evidence as stub.
+  record(['--db', db, '--plugin', 'p', '--run-id', '7', '--result', stub, '--allow-stub']);
+  const [row] = queryRows(db, "SELECT * FROM forge_proofs WHERE plugin_name='p';");
+  assert.equal(JSON.parse(row.evidence).stub, true);
+});
+
+test("(d) runner guard refuses j-rig scratch DB paths containing 'freshie'", () => {
+  const dir = tmpDir();
+  const db = freshDb(dir);
+  const skillDir = path.join(dir, 'skill');
+  fs.mkdirSync(skillDir);
+
+  // Guard fires before any sops/pnpm/j-rig work, so this is spend-free.
+  const result = spawnSync(
+    'bash',
+    [
+      RUNNER_SCRIPT,
+      '--skill-dir', skillDir,
+      '--plugin', 'p',
+      '--inventory-db', db,
+      '--scratch-db', '/dev/shm/freshie-scratch.db',
+      '--stub',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /refusing scratch DB path containing 'freshie'/);
+
+  // Scratch DBs outside /dev/shm are refused too.
+  const outside = spawnSync(
+    'bash',
+    [
+      RUNNER_SCRIPT,
+      '--skill-dir', skillDir,
+      '--plugin', 'p',
+      '--inventory-db', db,
+      '--scratch-db', path.join(dir, 'scratch.db'),
+      '--stub',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(outside.status, 0);
+  assert.match(outside.stderr, /scratch DB must live under \/dev\/shm/);
+
+  // Static belt-and-suspenders: the guard text exists in the runner source.
+  const source = fs.readFileSync(RUNNER_SCRIPT, 'utf8');
+  assert.match(source, /\*freshie\*\)/, 'freshie case-glob guard present in run-jrig-eval.sh');
+});

--- a/scripts/record-jrig-proofs.test.mjs
+++ b/scripts/record-jrig-proofs.test.mjs
@@ -35,7 +35,13 @@ function tmpDir() {
 }
 
 /** Minimal fixture matching the `j-rig eval --json` model-keyed map shape. */
-function fixtureResult({ passed = 7, total = 7, decision = 'ship', groundTruth = true, model = 'deepseek-v4-flash' } = {}) {
+function fixtureResult({
+  passed = 7,
+  total = 7,
+  decision = 'ship',
+  groundTruth = true,
+  model = 'deepseek-v4-flash',
+} = {}) {
   return {
     [model]: {
       provider: groundTruth ? 'deepseek' : 'stub',
@@ -84,7 +90,11 @@ function record(args) {
 
 function recordExpectFail(args) {
   const result = spawnSync(process.execPath, [RECORD_SCRIPT, ...args], { encoding: 'utf8' });
-  assert.notEqual(result.status, 0, `expected non-zero exit, got ${result.status}\nstdout: ${result.stdout}`);
+  assert.notEqual(
+    result.status,
+    0,
+    `expected non-zero exit, got ${result.status}\nstdout: ${result.stdout}`,
+  );
   return result.stderr;
 }
 
@@ -96,9 +106,22 @@ function queryRows(db, sql) {
 test('(a) fresh insert lands one tier3-jrig row with the contracted bindings', () => {
   const dir = tmpDir();
   const db = freshDb(dir);
-  const result = writeFixture(dir, 'result.json', fixtureResult({ passed: 6, total: 7, decision: 'warn' }));
+  const result = writeFixture(
+    dir,
+    'result.json',
+    fixtureResult({ passed: 6, total: 7, decision: 'warn' }),
+  );
 
-  const stdout = record(['--db', db, '--plugin', 'coreweave-pack', '--run-id', '42', '--result', result]);
+  const stdout = record([
+    '--db',
+    db,
+    '--plugin',
+    'coreweave-pack',
+    '--run-id',
+    '42',
+    '--result',
+    result,
+  ]);
   assert.match(stdout, /Upserted tier3-jrig row for 'coreweave-pack' \(run_id=42\)/);
 
   const rows = queryRows(db, 'SELECT * FROM forge_proofs;');
@@ -142,8 +165,16 @@ test('(a2) all-ship multi-model result records passed=1 with the weakest layer c
 test('(b) idempotent re-run: same run_id upserts in place, never duplicates', () => {
   const dir = tmpDir();
   const db = freshDb(dir);
-  const first = writeFixture(dir, 'r1.json', fixtureResult({ passed: 7, total: 7, decision: 'ship' }));
-  const second = writeFixture(dir, 'r2.json', fixtureResult({ passed: 4, total: 7, decision: 'block' }));
+  const first = writeFixture(
+    dir,
+    'r1.json',
+    fixtureResult({ passed: 7, total: 7, decision: 'ship' }),
+  );
+  const second = writeFixture(
+    dir,
+    'r2.json',
+    fixtureResult({ passed: 4, total: 7, decision: 'block' }),
+  );
 
   record(['--db', db, '--plugin', 'plane', '--run-id', '100', '--result', first]);
   record(['--db', db, '--plugin', 'plane', '--run-id', '100', '--result', first]); // identical re-run
@@ -169,7 +200,16 @@ test('(c) malformed result JSON is rejected loudly with a non-zero exit', () => 
 
   // Not JSON at all.
   const garbage = writeFixture(dir, 'garbage.json', 'this is not json {');
-  let stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', garbage]);
+  let stderr = recordExpectFail([
+    '--db',
+    db,
+    '--plugin',
+    'p',
+    '--run-id',
+    '1',
+    '--result',
+    garbage,
+  ]);
   assert.match(stderr, /not valid JSON/);
 
   // Valid JSON, wrong shape (no scoreCard anywhere).
@@ -181,14 +221,32 @@ test('(c) malformed result JSON is rejected loudly with a non-zero exit', () => 
   const badCard = fixtureResult();
   badCard['deepseek-v4-flash'].scoreCard.passed = 'seven';
   const badCardFile = writeFixture(dir, 'badcard.json', badCard);
-  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', badCardFile]);
+  stderr = recordExpectFail([
+    '--db',
+    db,
+    '--plugin',
+    'p',
+    '--run-id',
+    '1',
+    '--result',
+    badCardFile,
+  ]);
   assert.match(stderr, /Malformed scoreCard/);
 
   // Invalid decision.
   const badDecision = fixtureResult();
   badDecision['deepseek-v4-flash'].decision = 'maybe';
   const badDecisionFile = writeFixture(dir, 'baddecision.json', badDecision);
-  stderr = recordExpectFail(['--db', db, '--plugin', 'p', '--run-id', '1', '--result', badDecisionFile]);
+  stderr = recordExpectFail([
+    '--db',
+    db,
+    '--plugin',
+    'p',
+    '--run-id',
+    '1',
+    '--result',
+    badDecisionFile,
+  ]);
   assert.match(stderr, /decision must be one of/);
 
   // Non-integer run-id (would break the UNIQUE upsert key).
@@ -197,7 +255,10 @@ test('(c) malformed result JSON is rejected loudly with a non-zero exit', () => 
   assert.match(stderr, /--run-id must be a non-negative integer/);
 
   // Nothing was written by any failing invocation.
-  const rows = queryRows(db, "SELECT COUNT(*) AS n FROM sqlite_master WHERE type='table' AND name='forge_proofs';");
+  const rows = queryRows(
+    db,
+    "SELECT COUNT(*) AS n FROM sqlite_master WHERE type='table' AND name='forge_proofs';",
+  );
   assert.equal(rows[0].n, 0, 'failing runs must not touch the DB');
 });
 
@@ -226,10 +287,14 @@ test("(d) runner guard refuses j-rig scratch DB paths containing 'freshie'", () 
     'bash',
     [
       RUNNER_SCRIPT,
-      '--skill-dir', skillDir,
-      '--plugin', 'p',
-      '--inventory-db', db,
-      '--scratch-db', '/dev/shm/freshie-scratch.db',
+      '--skill-dir',
+      skillDir,
+      '--plugin',
+      'p',
+      '--inventory-db',
+      db,
+      '--scratch-db',
+      '/dev/shm/freshie-scratch.db',
       '--stub',
     ],
     { encoding: 'utf8' },
@@ -242,10 +307,14 @@ test("(d) runner guard refuses j-rig scratch DB paths containing 'freshie'", () 
     'bash',
     [
       RUNNER_SCRIPT,
-      '--skill-dir', skillDir,
-      '--plugin', 'p',
-      '--inventory-db', db,
-      '--scratch-db', path.join(dir, 'scratch.db'),
+      '--skill-dir',
+      skillDir,
+      '--plugin',
+      'p',
+      '--inventory-db',
+      db,
+      '--scratch-db',
+      path.join(dir, 'scratch.db'),
       '--stub',
     ],
     { encoding: 'utf8' },

--- a/scripts/run-jrig-eval.sh
+++ b/scripts/run-jrig-eval.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# run-jrig-eval.sh — run a j-rig behavioral eval and record the verdict into
+# the forge_proofs table (issue #935, the eval→forge_proofs write path).
+#
+# Flow:
+#   1. Decrypt DEEPSEEK_API_KEY via SOPS, in-memory only (never written to
+#      disk; the only disk artifacts live under /dev/shm and are removed by
+#      the cleanup trap).
+#   2. Run `pnpm exec j-rig eval` against a SCRATCH SQLite DB under /dev/shm.
+#      j-rig writes its own run tables into whatever --db it is given, so it
+#      must NEVER be pointed at the tracked freshie/inventory.sqlite — the
+#      guard below refuses any scratch path containing 'freshie'.
+#   3. Feed the --json result to scripts/record-jrig-proofs.mjs, which
+#      upserts the tier3-jrig row into the REAL inventory DB (passed
+#      separately via --inventory-db).
+#
+# Usage:
+#   scripts/run-jrig-eval.sh --skill-dir <dir> --plugin <catalog-name> \
+#     --inventory-db freshie/inventory.sqlite \
+#     [--run-id <int>] [--models <csv>] [--provider <name>] [--spec <path>] \
+#     [--scratch-db <path-under-/dev/shm>] [--stub]
+#
+# Defaults: --provider deepseek, --models deepseek-v4-flash,
+#           --run-id $(date +%s), scratch DB under /dev/shm.
+#
+# --stub runs the j-rig stub provider (J_RIG_ALLOW_STUB=1, no API key, no
+# spend) and passes --allow-stub to the recorder. Stub results are NOT ground
+# truth — only use against a scratch copy of the inventory DB.
+#
+# Env overrides:
+#   JRIG_BIN       — j-rig binary to use instead of `pnpm exec j-rig`
+#   JRIG_SOPS_ENV  — SOPS dotenv file carrying DEEPSEEK_API_KEY
+
+set -euo pipefail
+
+die() {
+  echo "[run-jrig-eval] ERROR: $*" >&2
+  exit 1
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+skill_dir=""
+plugin=""
+inventory_db=""
+run_id="$(date +%s)"
+models="deepseek-v4-flash"
+provider="deepseek"
+spec=""
+scratch_db=""
+stub=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skill-dir)    skill_dir="${2:?--skill-dir needs a value}"; shift 2 ;;
+    --plugin)       plugin="${2:?--plugin needs a value}"; shift 2 ;;
+    --inventory-db) inventory_db="${2:?--inventory-db needs a value}"; shift 2 ;;
+    --run-id)       run_id="${2:?--run-id needs a value}"; shift 2 ;;
+    --models)       models="${2:?--models needs a value}"; shift 2 ;;
+    --provider)     provider="${2:?--provider needs a value}"; shift 2 ;;
+    --spec)         spec="${2:?--spec needs a value}"; shift 2 ;;
+    --scratch-db)   scratch_db="${2:?--scratch-db needs a value}"; shift 2 ;;
+    --stub)         stub=1; shift ;;
+    *)              die "Unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$skill_dir" ] || die "--skill-dir is required"
+[ -n "$plugin" ] || die "--plugin is required"
+[ -n "$inventory_db" ] || die "--inventory-db is required"
+[ -d "$skill_dir" ] || die "--skill-dir does not exist: $skill_dir"
+[ -f "$inventory_db" ] || die "--inventory-db does not exist: $inventory_db"
+case "$run_id" in
+  ''|*[!0-9]*) die "--run-id must be a non-negative integer (got: $run_id)" ;;
+esac
+
+# Scratch workspace: everything transient lives under /dev/shm (tmpfs — no
+# plaintext or eval artifacts ever touch persistent disk) and dies with the
+# trap below.
+scratch_dir="$(mktemp -d /dev/shm/jrig-eval.XXXXXX)"
+cleanup() {
+  unset DEEPSEEK_API_KEY || true
+  rm -rf "$scratch_dir"
+  # sqlite WAL/SHM siblings of a user-supplied --scratch-db live next to it.
+  if [ -n "$scratch_db" ]; then
+    rm -f "$scratch_db" "$scratch_db-wal" "$scratch_db-shm"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [ -z "$scratch_db" ]; then
+  scratch_db="$scratch_dir/jrig-scratch.db"
+fi
+
+# --- GUARDS: j-rig must never write into the tracked inventory DB ----------
+case "$scratch_db" in
+  *freshie*) die "refusing scratch DB path containing 'freshie' ($scratch_db) — j-rig writes its own run tables and must never touch the tracked inventory DB. Use a /dev/shm scratch path." ;;
+  /dev/shm/*) : ;;
+  *) die "scratch DB must live under /dev/shm (got: $scratch_db)" ;;
+esac
+if [ "$scratch_db" = "$inventory_db" ]; then
+  die "scratch DB and inventory DB must be different files"
+fi
+# ----------------------------------------------------------------------------
+
+result_json="$scratch_dir/result.json"
+jrig_bin="${JRIG_BIN:-}"
+
+run_jrig() {
+  if [ -n "$jrig_bin" ]; then
+    "$jrig_bin" "$@"
+  else
+    pnpm exec j-rig "$@"
+  fi
+}
+
+jrig_args=(eval "$skill_dir" --models "$models" --db "$scratch_db" --json)
+if [ -n "$spec" ]; then
+  jrig_args+=(--spec "$spec")
+fi
+
+if [ "$stub" -eq 1 ]; then
+  echo "[run-jrig-eval] STUB MODE — no API key, no spend, results are NOT ground truth" >&2
+  export J_RIG_ALLOW_STUB=1
+  jrig_args+=(--provider stub)
+else
+  # Decrypt the DeepSeek key via SOPS into the environment only — the
+  # anchored sed keeps comment/blank lines out and never writes plaintext to
+  # disk (per the SOPS standard in the estate CLAUDE.md).
+  sops_env="${JRIG_SOPS_ENV:-$HOME/000-projects/intent-eval-platform/intent-eval-lab/.env.sops}"
+  [ -f "$sops_env" ] || die "SOPS env file not found: $sops_env"
+  DEEPSEEK_API_KEY="$(sops -d --input-type dotenv --output-type dotenv "$sops_env" | sed -nE 's/^DEEPSEEK_API_KEY=(.*)$/\1/p' | head -n1)"
+  [ -n "$DEEPSEEK_API_KEY" ] || die "DEEPSEEK_API_KEY not found in $sops_env"
+  export DEEPSEEK_API_KEY
+  jrig_args+=(--provider "$provider")
+fi
+
+echo "[run-jrig-eval] j-rig eval: skill=$skill_dir models=$models provider=$([ "$stub" -eq 1 ] && echo stub || echo "$provider") scratch=$scratch_db" >&2
+run_jrig "${jrig_args[@]}" > "$result_json" || die "j-rig eval failed (see output above)"
+
+[ -s "$result_json" ] || die "j-rig eval produced no JSON output"
+
+record_args=(--db "$inventory_db" --plugin "$plugin" --run-id "$run_id" --result "$result_json")
+if [ "$stub" -eq 1 ]; then
+  record_args+=(--allow-stub)
+fi
+
+node "$repo_root/scripts/record-jrig-proofs.mjs" "${record_args[@]}"
+
+echo "[run-jrig-eval] Done — tier3-jrig row recorded for '$plugin' (run_id=$run_id) in $inventory_db" >&2


### PR DESCRIPTION
## What

Unit 1 (no-spend) of #935: the missing write path from a j-rig eval verdict into the `forge_proofs` table that drives JRig-Verified badges.

- `scripts/record-jrig-proofs.mjs` — idempotent upsert adapter (node built-ins + sqlite3 CLI, the enrich-jrig-data prior-art pattern; `UNIQUE(plugin_name, verification_type, run_id)` conflict target; `layers_passed=scoreCard.passed`, `total_layers=scoreCard.total_criteria`, `baseline_delta=NULL`, evidence = per-model scorecard JSON; multi-model rule = min across models, all-ship required for `passed=1`).
- `scripts/run-jrig-eval.sh` — runner: SOPS-decrypts `DEEPSEEK_API_KEY` to env only, evals against a `/dev/shm` scratch DB, then records into the real inventory DB. **Refuses any scratch path containing `freshie`** — j-rig writes its own run tables and must never touch the tracked CMDB.
- Stub-guard: the recorder refuses `ground_truth:false` rows unless `--allow-stub` (a stub row must never light a badge; implements j-rig's own CI-consumer rule).
- Badge copy fixes: removed the false "written to forge_proofs automatically" claim and the actively harmful documented command `j-rig eval ... --db freshie/inventory.sqlite` (which pollutes the CMDB — exactly what the new guard forbids); model-matrix copy made model-neutral.
- `.github/workflows/jrig-proofs-test.yml` — blocking unit corpus (zero-install, sync-lockfile-test pattern) + a guard-message assertion.

## Why + decision rationale

forge_proofs rows exist only from historical forge runs; nothing recorded new evals, so badges could never update. Chose sqlite3-CLI over better-sqlite3 because scripts must run without the native build step (`pnpm rebuild better-sqlite3` is not auto-run on install).

## Layers touched

scripts (new write path), marketplace render copy, CI (new advisory-to-required-candidate workflow). No schema change — the adapter conforms to the existing `forge_proofs` DDL exactly.

## How it works / Verification & evidence

- Recorder corpus: **6/6 pass** (`node --test scripts/record-jrig-proofs.test.mjs`).
- shellcheck clean on the runner.
- **Stub end-to-end dry-run (zero spend)**: j-rig 0.1.2's real stub provider (`--provider stub`, `J_RIG_ALLOW_STUB=1`) driven through the actual runner against a COPY of the inventory DB using `coreweave-fabric-diagnostics` (ships eval-spec.yaml) → row landed (passed=1, 10/10 layers, `evidence.stub=true`) → `enrich-jrig-data.mjs` against that copy emits non-empty badge data for the pack. The badge pipeline provably picks up recorder rows.
- Guard assertion verified locally verbatim (message-matched, not just exit-code).

## Risk assessment

Low: additive scripts + copy edits; no behavior change to build or publish. The tracked `freshie/inventory.sqlite` is untouched (byte-identical; dry-run used a copy). Rollback = revert.

## Operational impact

None now. Unit 2 (gated spend ~$8–20: real DeepSeek pilot on `plane` + 3 spec-ready skills, committed DB rows + jrig-data) follows as its own PR and will carry `Closes #935`.

## Follow-up & deferred

Unit 2 as above; tracked under #935.

Refs #935

- Jeremy Longshore
intentsolutions.io