### PR TITLE
feat(scripts): local census-watch.mjs for the 2026-07-22 delist deadline (claude-ss50.8)

### DIFF
--- a/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
+++ b/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
@@ -319,4 +319,3 @@ The meta-lesson is the method itself. Six independent lenses, each forced to **v
   "articleSection": "Architecture"
 }
 </script>
-

--- a/scripts/census-watch.mjs
+++ b/scripts/census-watch.mjs
@@ -119,10 +119,16 @@ function main() {
     byRepo.get(s.repo).push(s.name);
   }
 
-  const prev = fs.existsSync(STATE_FILE)
-    ? JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'))
-    : { repos: {} };
-  const firstRun = !fs.existsSync(STATE_FILE);
+  // Read prior state by attempting the read directly (no existsSync check first) —
+  // an existsSync-then-readFileSync pair is a time-of-check/time-of-use race (CWE-367).
+  let prev = { repos: {} };
+  let firstRun = true;
+  try {
+    prev = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+    firstRun = false;
+  } catch {
+    // No readable prior state (file missing or unparseable) → treat as first run.
+  }
 
   const now = new Date();
   const daysLeft = Math.ceil((new Date(`${DEADLINE}T23:59:59Z`) - now) / 86_400_000);

--- a/scripts/census-watch.mjs
+++ b/scripts/census-watch.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * census-watch.mjs — local watcher for the 2026-07-08 whole-catalog quality census.
+ *
+ * WHY THIS EXISTS (and why it runs locally, not as a cloud routine):
+ *   The 2026-07-08 census graded 27 marketplace source-entries D/F and put them on a
+ *   delist clock (deadline 2026-07-22 — see the `# census 2026-07-08 … deadline 2026-07-22`
+ *   comments in sources.yaml and bead claude-ss50.8). Those sources live in cross-owner
+ *   upstream repos (datopian/*, wondelai/*, numman-ali/*, …). A previous cloud routine
+ *   tried to watch them but its sandboxed GitHub-App session was scoped to a single owner
+ *   (jeremylongshore), so every cross-owner read was blocked (add_repo cross-tier rejected,
+ *   raw api.github.com intercepted). This script runs on the dev box where `gh` has
+ *   unrestricted cross-owner read access, so it can actually do the job.
+ *
+ * WHAT IT DOES:
+ *   1. Parses sources.yaml, selecting the entries carrying the census delist-deadline marker.
+ *   2. Collapses them to unique upstream repos (n-skills / wondelai are monorepos → many
+ *      source-entries share one repo).
+ *   3. For each upstream, reads the default-branch HEAD (sha + commit date) via `gh api`.
+ *   4. Classifies each: GONE (repo deleted/archived → auto-delist), MOVED (pushed since the
+ *      census date → the maintainer MAY have landed the fix → re-grade candidate), or
+ *      DORMANT (no activity since census → delist candidate on the deadline).
+ *   5. Diffs against the previous run's state so subsequent runs surface *new* movement,
+ *      and rewrites the state file. First run initializes the baseline.
+ *
+ * OUTPUT: a human report to stdout + a machine state file. A cron wrapper can diff the
+ *   printed summary or read the state JSON to decide whether to ping Slack.
+ *
+ * Zero runtime deps (no js-yaml) on purpose: a local cron must run without `npm install`.
+ * sources.yaml has a stable 2-space list indent, so raw block parsing is reliable.
+ *
+ * Usage:  node scripts/census-watch.mjs [--json]
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SOURCES_FILE = path.join(__dirname, '..', 'sources.yaml');
+const STATE_DIR = path.join(os.homedir(), '.local', 'state', 'census-watch');
+const STATE_FILE = path.join(STATE_DIR, 'state.json');
+
+const CENSUS_DATE = '2026-07-08'; // the whole-catalog census that set the clock
+const DEADLINE = '2026-07-22'; // delist deadline for sources still failing
+const DEADLINE_MARKER = `deadline ${DEADLINE}`; // stable comment string in sources.yaml
+const JSON_OUT = process.argv.includes('--json');
+
+/** Parse sources.yaml by raw 2-space list blocks; return the census-marked entries. */
+function onClockSources() {
+  const raw = fs.readFileSync(SOURCES_FILE, 'utf8');
+  // Split on the top-level list-item delimiter. slice(1) drops the file header.
+  const blocks = raw.split(/\n  - name:/).slice(1);
+  const out = [];
+  for (const b of blocks) {
+    if (!b.includes(DEADLINE_MARKER)) continue;
+    const name = (b.match(/^\s*(\S.*)$/m) || [, '(unknown)'])[1].trim();
+    const repoM = b.match(/\n\s*repo:\s*(\S+)/);
+    if (!repoM) continue;
+    out.push({ name, repo: repoM[1].trim() });
+  }
+  return out;
+}
+
+/** Read the default-branch HEAD of an upstream repo via gh. Returns null on 404/gone. */
+function upstreamHead(repo) {
+  let meta;
+  try {
+    meta = JSON.parse(
+      execFileSync('gh', ['api', `repos/${repo}`, '--jq',
+        '{default_branch, archived, pushed_at}'], { encoding: 'utf8' }),
+    );
+  } catch {
+    return { gone: true };
+  }
+  if (meta.archived) return { gone: true, archived: true, pushedAt: meta.pushed_at };
+  let head;
+  try {
+    const line = execFileSync('gh', ['api',
+      `repos/${repo}/commits/${meta.default_branch}`, '--jq',
+      '.sha + "|" + .commit.committer.date'], { encoding: 'utf8' }).trim();
+    const [sha, date] = line.split('|');
+    head = { sha: sha.slice(0, 12), date };
+  } catch {
+    head = { sha: null, date: meta.pushed_at };
+  }
+  return { gone: false, defaultBranch: meta.default_branch, headSha: head.sha, headDate: head.date };
+}
+
+function classify(info) {
+  if (info.gone) return info.archived ? 'GONE-ARCHIVED' : 'GONE-DELETED';
+  if (!info.headDate) return 'DORMANT';
+  return new Date(info.headDate) > new Date(`${CENSUS_DATE}T00:00:00Z`) ? 'MOVED' : 'DORMANT';
+}
+
+function main() {
+  const sources = onClockSources();
+  // repo -> [source names]
+  const byRepo = new Map();
+  for (const s of sources) {
+    if (!byRepo.has(s.repo)) byRepo.set(s.repo, []);
+    byRepo.get(s.repo).push(s.name);
+  }
+
+  const prev = fs.existsSync(STATE_FILE)
+    ? JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'))
+    : { repos: {} };
+  const firstRun = !fs.existsSync(STATE_FILE);
+
+  const now = new Date();
+  const daysLeft = Math.ceil((new Date(`${DEADLINE}T23:59:59Z`) - now) / 86_400_000);
+
+  const results = [];
+  for (const [repo, names] of [...byRepo.entries()].sort()) {
+    const info = upstreamHead(repo);
+    const cls = classify(info);
+    const before = prev.repos[repo];
+    let delta;
+    if (firstRun || !before) delta = 'init';
+    else if (before.headSha !== info.headSha) delta = 'CHANGED-since-last-run';
+    else delta = 'same';
+    results.push({ repo, sources: names, class: cls, headSha: info.headSha || null, headDate: info.headDate || null, delta });
+  }
+
+  const state = {
+    generatedAt: now.toISOString(),
+    censusDate: CENSUS_DATE,
+    deadline: DEADLINE,
+    daysLeft,
+    repos: Object.fromEntries(results.map((r) => [r.repo, { headSha: r.headSha, headDate: r.headDate, class: r.class }])),
+  };
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2) + '\n');
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ ...state, results }, null, 2));
+    return;
+  }
+
+  const moved = results.filter((r) => r.class === 'MOVED');
+  const dormant = results.filter((r) => r.class === 'DORMANT');
+  const gone = results.filter((r) => r.class.startsWith('GONE'));
+  const changed = results.filter((r) => r.delta === 'CHANGED-since-last-run');
+
+  const sourceCount = sources.length;
+  console.log(`\n  Census watch — ${CENSUS_DATE} D/F cohort · delist deadline ${DEADLINE} (${daysLeft} days left)`);
+  console.log(`  ${sourceCount} source-entries on the clock across ${byRepo.size} upstream repos`);
+  console.log(`  state: ${STATE_FILE}${firstRun ? '  (initialized this run)' : ''}\n`);
+
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(`  ${pad('UPSTREAM REPO', 34)}${pad('CLASS', 15)}${pad('HEAD DATE', 22)}${pad('Δ', 10)}SOURCES`);
+  console.log(`  ${'-'.repeat(96)}`);
+  for (const r of results) {
+    console.log(`  ${pad(r.repo, 34)}${pad(r.class, 15)}${pad((r.headDate || '—').slice(0, 19), 22)}${pad(r.delta === 'init' ? 'init' : r.delta === 'same' ? '·' : '⚑ NEW', 10)}${r.sources.join(', ')}`);
+  }
+
+  console.log(`\n  SUMMARY`);
+  console.log(`   • ${moved.length} upstream(s) MOVED since ${CENSUS_DATE} → RE-GRADE candidates (a fix may have landed):`);
+  moved.forEach((r) => console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`));
+  console.log(`   • ${dormant.length} upstream(s) DORMANT → DELIST candidates on ${DEADLINE} unless re-graded:`);
+  dormant.forEach((r) => console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`));
+  if (gone.length) {
+    console.log(`   • ${gone.length} upstream(s) GONE → auto-delist:`);
+    gone.forEach((r) => console.log(`       ${r.repo}  [${r.class}]`));
+  }
+  if (!firstRun && changed.length) {
+    console.log(`   • ${changed.length} upstream(s) CHANGED since last watch → re-grade now:`);
+    changed.forEach((r) => console.log(`       ${r.repo}`));
+  }
+  console.log(`\n  Next: re-grade the MOVED upstreams (validator), flip verified:true on any that now pass,`);
+  console.log(`  and on ${DEADLINE} delist whatever is still DORMANT/failing (bead claude-ss50.8).\n`);
+}
+
+main();

--- a/scripts/census-watch.mjs
+++ b/scripts/census-watch.mjs
@@ -52,11 +52,11 @@ const JSON_OUT = process.argv.includes('--json');
 function onClockSources() {
   const raw = fs.readFileSync(SOURCES_FILE, 'utf8');
   // Split on the top-level list-item delimiter. slice(1) drops the file header.
-  const blocks = raw.split(/\n  - name:/).slice(1);
+  const blocks = raw.split(/\n {2}- name:/).slice(1);
   const out = [];
   for (const b of blocks) {
     if (!b.includes(DEADLINE_MARKER)) continue;
-    const name = (b.match(/^\s*(\S.*)$/m) || [, '(unknown)'])[1].trim();
+    const name = (b.match(/^\s*(\S.*)$/m)?.[1] || '(unknown)').trim();
     const repoM = b.match(/\n\s*repo:\s*(\S+)/);
     if (!repoM) continue;
     out.push({ name, repo: repoM[1].trim() });
@@ -69,8 +69,11 @@ function upstreamHead(repo) {
   let meta;
   try {
     meta = JSON.parse(
-      execFileSync('gh', ['api', `repos/${repo}`, '--jq',
-        '{default_branch, archived, pushed_at}'], { encoding: 'utf8' }),
+      execFileSync(
+        'gh',
+        ['api', `repos/${repo}`, '--jq', '{default_branch, archived, pushed_at}'],
+        { encoding: 'utf8' },
+      ),
     );
   } catch {
     return { gone: true };
@@ -78,15 +81,27 @@ function upstreamHead(repo) {
   if (meta.archived) return { gone: true, archived: true, pushedAt: meta.pushed_at };
   let head;
   try {
-    const line = execFileSync('gh', ['api',
-      `repos/${repo}/commits/${meta.default_branch}`, '--jq',
-      '.sha + "|" + .commit.committer.date'], { encoding: 'utf8' }).trim();
+    const line = execFileSync(
+      'gh',
+      [
+        'api',
+        `repos/${repo}/commits/${meta.default_branch}`,
+        '--jq',
+        '.sha + "|" + .commit.committer.date',
+      ],
+      { encoding: 'utf8' },
+    ).trim();
     const [sha, date] = line.split('|');
     head = { sha: sha.slice(0, 12), date };
   } catch {
     head = { sha: null, date: meta.pushed_at };
   }
-  return { gone: false, defaultBranch: meta.default_branch, headSha: head.sha, headDate: head.date };
+  return {
+    gone: false,
+    defaultBranch: meta.default_branch,
+    headSha: head.sha,
+    headDate: head.date,
+  };
 }
 
 function classify(info) {
@@ -121,7 +136,14 @@ function main() {
     if (firstRun || !before) delta = 'init';
     else if (before.headSha !== info.headSha) delta = 'CHANGED-since-last-run';
     else delta = 'same';
-    results.push({ repo, sources: names, class: cls, headSha: info.headSha || null, headDate: info.headDate || null, delta });
+    results.push({
+      repo,
+      sources: names,
+      class: cls,
+      headSha: info.headSha || null,
+      headDate: info.headDate || null,
+      delta,
+    });
   }
 
   const state = {
@@ -129,7 +151,9 @@ function main() {
     censusDate: CENSUS_DATE,
     deadline: DEADLINE,
     daysLeft,
-    repos: Object.fromEntries(results.map((r) => [r.repo, { headSha: r.headSha, headDate: r.headDate, class: r.class }])),
+    repos: Object.fromEntries(
+      results.map((r) => [r.repo, { headSha: r.headSha, headDate: r.headDate, class: r.class }]),
+    ),
   };
   fs.mkdirSync(STATE_DIR, { recursive: true });
   fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2) + '\n');
@@ -145,22 +169,36 @@ function main() {
   const changed = results.filter((r) => r.delta === 'CHANGED-since-last-run');
 
   const sourceCount = sources.length;
-  console.log(`\n  Census watch — ${CENSUS_DATE} D/F cohort · delist deadline ${DEADLINE} (${daysLeft} days left)`);
+  console.log(
+    `\n  Census watch — ${CENSUS_DATE} D/F cohort · delist deadline ${DEADLINE} (${daysLeft} days left)`,
+  );
   console.log(`  ${sourceCount} source-entries on the clock across ${byRepo.size} upstream repos`);
   console.log(`  state: ${STATE_FILE}${firstRun ? '  (initialized this run)' : ''}\n`);
 
   const pad = (s, n) => String(s).padEnd(n);
-  console.log(`  ${pad('UPSTREAM REPO', 34)}${pad('CLASS', 15)}${pad('HEAD DATE', 22)}${pad('Δ', 10)}SOURCES`);
+  console.log(
+    `  ${pad('UPSTREAM REPO', 34)}${pad('CLASS', 15)}${pad('HEAD DATE', 22)}${pad('Δ', 10)}SOURCES`,
+  );
   console.log(`  ${'-'.repeat(96)}`);
   for (const r of results) {
-    console.log(`  ${pad(r.repo, 34)}${pad(r.class, 15)}${pad((r.headDate || '—').slice(0, 19), 22)}${pad(r.delta === 'init' ? 'init' : r.delta === 'same' ? '·' : '⚑ NEW', 10)}${r.sources.join(', ')}`);
+    console.log(
+      `  ${pad(r.repo, 34)}${pad(r.class, 15)}${pad((r.headDate || '—').slice(0, 19), 22)}${pad(r.delta === 'init' ? 'init' : r.delta === 'same' ? '·' : '⚑ NEW', 10)}${r.sources.join(', ')}`,
+    );
   }
 
   console.log(`\n  SUMMARY`);
-  console.log(`   • ${moved.length} upstream(s) MOVED since ${CENSUS_DATE} → RE-GRADE candidates (a fix may have landed):`);
-  moved.forEach((r) => console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`));
-  console.log(`   • ${dormant.length} upstream(s) DORMANT → DELIST candidates on ${DEADLINE} unless re-graded:`);
-  dormant.forEach((r) => console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`));
+  console.log(
+    `   • ${moved.length} upstream(s) MOVED since ${CENSUS_DATE} → RE-GRADE candidates (a fix may have landed):`,
+  );
+  moved.forEach((r) =>
+    console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`),
+  );
+  console.log(
+    `   • ${dormant.length} upstream(s) DORMANT → DELIST candidates on ${DEADLINE} unless re-graded:`,
+  );
+  dormant.forEach((r) =>
+    console.log(`       ${r.repo}  (${r.sources.length} skill(s): ${r.sources.join(', ')})`),
+  );
   if (gone.length) {
     console.log(`   • ${gone.length} upstream(s) GONE → auto-delist:`);
     gone.forEach((r) => console.log(`       ${r.repo}  [${r.class}]`));
@@ -169,8 +207,12 @@ function main() {
     console.log(`   • ${changed.length} upstream(s) CHANGED since last watch → re-grade now:`);
     changed.forEach((r) => console.log(`       ${r.repo}`));
   }
-  console.log(`\n  Next: re-grade the MOVED upstreams (validator), flip verified:true on any that now pass,`);
-  console.log(`  and on ${DEADLINE} delist whatever is still DORMANT/failing (bead claude-ss50.8).\n`);
+  console.log(
+    `\n  Next: re-grade the MOVED upstreams (validator), flip verified:true on any that now pass,`,
+  );
+  console.log(
+    `  and on ${DEADLINE} delist whatever is still DORMANT/failing (bead claude-ss50.8).\n`,
+  );
 }
 
 main();


### PR DESCRIPTION
## What
Adds `scripts/census-watch.mjs` — a **local** watcher for the 2026-07-08 whole-catalog quality census. It reads `sources.yaml`, selects the entries on the `deadline 2026-07-22` delist clock, collapses them to unique upstream repos, reads each upstream's default-branch HEAD via `gh`, and classifies **MOVED** (activity since the census → re-grade candidate) / **DORMANT** (delist candidate) / **GONE**, diffing against a local state file so later runs surface *new* movement.

## Why
Enforcing the census delist deadline (bead `claude-ss50.8` — "re-grade every notified cluster and delist what still fails") means watching **cross-owner** upstream repos. A prior cloud routine tried this and structurally couldn't: its sandboxed GitHub-App session was scoped to a single owner (`jeremylongshore`), so every cross-owner read was blocked (`add_repo` cross-tier rejected, raw `api.github.com` intercepted). It ran daily and did nothing.

**Chose a local dev-box script over re-scoping the cloud routine** because cloud-routine sessions are hard-scoped to one owner, whereas `gh` on the dev box has unrestricted cross-owner read access and the reads (default-branch HEAD + one file) are trivial. **Zero runtime deps** (raw-block parse, not `js-yaml`) so a local cron runs without `npm install`.

## How it works / layers touched
Read-only tooling (`scripts/`). Two `gh api` calls per unique upstream. State persisted at `~/.local/state/census-watch/state.json` (outside the repo). No change to sync, catalog, or any plugin.

## Verification & evidence
First run initialized state and resolved the **27 delist-clock source-entries to 2 upstream repos** — `numman-ali/n-skills` (gastown, zai-cli) and `wondelai/skills` (25 skills) — **both DORMANT** (no default-branch activity since the 2026-07-08 census), 13 days to deadline. The 2-repo / 27-entry resolution matches an independent grep of the `deadline 2026-07-22` markers. (Notable: the prior routine's hardcoded 12-upstream watch-list was over-broad — the other ~10 were killer-skill *nominations*, a resolved track, not delist-clock sources.)

## Risk
Read-only; no secrets; no network writes; state lives outside the repo. Safe to run repeatedly.

## Follow-up
- Wire a dev-box daily cron until 2026-07-22 (optionally Slack-on-change via the existing notify-lib pattern) — deferred pending channel choice.
- The dead single-owner cloud routine should be retired (a `/schedule` action).

Refs claude-ss50.8.

- Jeremy Longshore
intentsolutions.io