### PR TITLE
fix(ci): make the Slack digest read live npm stats and unjam the writer's PR loop

### DIFF
--- a/.github/workflows/slack-daily-downloads.yml
+++ b/.github/workflows/slack-daily-downloads.yml
@@ -3,6 +3,12 @@ name: Daily Slack download digest
 # Reads the latest marketplace/src/data/npm-stats.json and posts a concise
 # summary to #operation-hired. Runs daily at 18:00 UTC = 1pm Central.
 #
+# Data freshness: update-npm-stats.yml (the writer) refreshes the stats at
+# 00:15 UTC daily on the `automation/npm-stats` branch (main is protected,
+# so fresh data only reaches main when its PR merges). This digest therefore
+# prefers the writer branch's copy and falls back to main's if the branch
+# is absent (e.g. just merged and deleted, in which case main IS fresh).
+#
 # Follows the /slack skill conventions:
 #   - Webhook secret: SLACK_OPERATION_HIRED_WEBHOOK_URL
 #   - Target channel: #operation-hired
@@ -31,6 +37,21 @@ jobs:
           if [ -z "${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}" ]; then
             echo "SLACK_OPERATION_HIRED_WEBHOOK_URL not set; skipping. Configure the repo secret to enable."
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prefer freshest stats from the writer branch
+        if: steps.check.outputs.skip != 'true'
+        # update-npm-stats.yml force-recreates automation/npm-stats from
+        # current main + a fresh fetch every day at 00:15 UTC, so its copy of
+        # npm-stats.json is always at least as fresh as main's. Reading main
+        # alone posted 6-week-stale numbers (estate audit finding F5).
+        run: |
+          set -euo pipefail
+          if git fetch --depth 1 origin automation/npm-stats; then
+            git checkout FETCH_HEAD -- marketplace/src/data/npm-stats.json
+            echo "Using npm-stats.json from automation/npm-stats (writer branch)."
+          else
+            echo "automation/npm-stats branch not found; using main's copy."
           fi
 
       - name: Build Slack payload

--- a/.github/workflows/update-npm-stats.yml
+++ b/.github/workflows/update-npm-stats.yml
@@ -82,7 +82,11 @@ jobs:
 
           git push --force-with-lease origin "$BRANCH"
 
-          if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+          # `gh pr view <branch>` also matches MERGED/CLOSED PRs, so after the
+          # first PR (#786) merged this check always "succeeded" and no new PR
+          # was ever opened — main's npm-stats.json silently froze for 6 weeks
+          # (estate audit finding F5). Only an OPEN PR counts.
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             gh pr create \
               --title "📦 Daily npm download stats refresh" \
               --head "$BRANCH" \


### PR DESCRIPTION
## What

Two root-cause fixes for estate-audit finding **F5** — the daily Slack download digest (`slack-daily-downloads.yml`) posting ~6-week-stale numbers even on a green run:

1. **`slack-daily-downloads.yml` (reader):** new step fetches `automation/npm-stats` (the branch the writer maintains) and prefers its copy of `marketplace/src/data/npm-stats.json`, falling back to main's copy if the branch is absent (right after a merge+delete, when main IS fresh).
2. **`update-npm-stats.yml` (writer):** the "PR already exists" guard used `gh pr view "$BRANCH"`, which also matches **MERGED/CLOSED** PRs. After PR #786 merged on 2026-05-28 the guard always passed, so no new PR was ever opened and main's `npm-stats.json` silently froze while the writer stayed green and force-pushed fresh data to the branch daily. The guard now counts only OPEN PRs (`gh pr list --head "$BRANCH" --state open`).

## Why + decision rationale

The digest was underreporting by ~4x: main's copy said **14,130** monthly downloads (`generatedAt 2026-05-28T01:44Z`) while the writer branch had **57,031** (`generatedAt 2026-07-10T01:31Z`). The writer force-recreates `automation/npm-stats` from current main + a fresh fetch every day at 00:15 UTC, so its copy is always at least as fresh as main's.

**Chose** reading the writer branch **over** re-running `scripts/fetch-npm-stats.mjs` inside the digest **because** the full fetch takes ~33 minutes per writer run (see any `update-npm-stats.yml` run) — a 2-second `git fetch` beats duplicating that daily. **Chose** fixing the writer's guard too (not just the reader) **because** main's stale copy also feeds the README `NPM-STATS` block and the marketplace site data — the reader fix alone would leave those frozen.

## Layer touched

CI/automation only — two GitHub Actions workflow files. No app code, no schema, no deps, no invariant changes.

## How it works

- Digest: after checkout of main, `git fetch --depth 1 origin automation/npm-stats && git checkout FETCH_HEAD -- marketplace/src/data/npm-stats.json`; on fetch failure it logs and keeps main's copy (the existing missing-file fallback to `fetch-npm-stats.mjs` is untouched).
- Writer: `gh pr create` now fires whenever no **open** PR exists for the branch, so after each merge the next daily run re-opens one instead of going silent.

## Verification & evidence

- Webhook side (Part A of the SEV-1): secret `SLACK_OPERATION_HIRED_WEBHOOK_URL` was a placeholder — every scheduled run since 2026-07-06 failed in "Post to Slack" with `curl: (6) Could not resolve host: ***` (run [29114638557](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/29114638557)). After setting the real secret, dispatched run [29120246268](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/29120246268) is **green including "Post to Slack"**.
- Bug proof (live): `gh pr view automation/npm-stats --json number,state` → `{"number":786,"state":"MERGED"}`, exit 0 → writer skipped `pr create` every day since 2026-05-28.
- Fix proof (live): `gh pr list --head automation/npm-stats --state open` → empty → create path fires.
- The new freshness step was executed verbatim in a worktree: yielded `generatedAt 2026-07-10T01:31:43.678Z / totalMonth 57,031` (vs main's `2026-05-28 / 14,130`).
- Both workflow files parse as valid YAML (`python3 yaml.safe_load`).

## Risk assessment

Low. Digest degrades gracefully to today's behavior (main's copy) if the branch fetch fails. Writer change can at most open one PR where previously none was opened — idempotent across re-runs (open-PR check). Neither touches protected-branch rules or secrets.

## Operational impact

None to deploy: workflows take effect on merge. Expect the daily `📦 Daily npm download stats refresh` PR to reappear after the next 00:15 UTC writer run — merging it (or not) no longer affects digest freshness, only README/site data.

## Follow-ups & deferred

- The daily stats PR still needs a human merge for main/README/site freshness; consider auto-merge on green if desired (out of scope here).
- Orchestrator tracks bead/registry updates for this SEV-1 (no bead writes from this PR).

## Refs

Refs intent-solutions-io/intent-os#42

- Jeremy Longshore
intentsolutions.io