### PR TITLE
feat(scripts): census-watch --enforce — local enforcement of the 2026-07-22 census delist deadline [skip auto-bump]

### DIFF
--- a/scripts/census-watch.mjs
+++ b/scripts/census-watch.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * census-watch.mjs — local watcher for the 2026-07-08 whole-catalog quality census.
+ * census-watch.mjs — local watcher + deadline enforcer for the 2026-07-08
+ * whole-catalog quality census.
  *
  * WHY THIS EXISTS (and why it runs locally, not as a cloud routine):
  *   The 2026-07-08 census graded 27 marketplace source-entries D/F and put them on a
@@ -10,9 +11,12 @@
  *   tried to watch them but its sandboxed GitHub-App session was scoped to a single owner
  *   (jeremylongshore), so every cross-owner read was blocked (add_repo cross-tier rejected,
  *   raw api.github.com intercepted). This script runs on the dev box where `gh` has
- *   unrestricted cross-owner read access, so it can actually do the job.
+ *   unrestricted cross-owner read access, so it can actually do the job. The deadline
+ *   ENFORCEMENT (below) moved here for the same reason: the cloud one-shot that was meant
+ *   to enforce on 2026-07-23 could not reach the cross-owner census upstreams either
+ *   (disabled 2026-07-10; its semantics are replicated by --enforce).
  *
- * WHAT IT DOES:
+ * WATCH MODE (default — daily cron):
  *   1. Parses sources.yaml, selecting the entries carrying the census delist-deadline marker.
  *   2. Collapses them to unique upstream repos (n-skills / wondelai are monorepos → many
  *      source-entries share one repo).
@@ -23,34 +27,87 @@
  *   5. Diffs against the previous run's state so subsequent runs surface *new* movement,
  *      and rewrites the state file. First run initializes the baseline.
  *
- * OUTPUT: a human report to stdout + a machine state file. A cron wrapper can diff the
- *   printed summary or read the state JSON to decide whether to ping Slack.
+ * ENFORCE MODE (--enforce — fired ONCE by the cron wrapper when the deadline passes):
+ *   Replicates the disabled cloud one-shot's semantics against the LIVE delist clock
+ *   (sources.yaml on origin/main at run time — never a frozen list; entries fixed or
+ *   removed since notify day simply are not on the clock any more):
+ *   1. For each delist-clock cluster (unique upstream repo), validates every notified
+ *      skill at UPSTREAM default-branch HEAD with validate-skills-schema.py
+ *      --marketplace --json. Cluster PASSES only if ALL its skills have 0 errors.
+ *      Deleted/private/archived upstream = FAIL. Partial pass = FAIL. Upstream is truth —
+ *      the mirror may lag or be quarantined, so grading the mirror would be wrong.
+ *   2. For still-failing clusters, builds branch fix/census-deadline-removals off
+ *      origin/main in its own temp clone (never disturbs the invoking checkout) with ONE
+ *      commit: remove each failing cluster's sources.yaml entries (dated NOTE comment
+ *      with the notify-issue link + re-listing-welcome), delete their mirror dirs under
+ *      plugins/, drop their catalog entries from marketplace.extended.json + regenerate
+ *      the derived artifacts (marketplace.json, plugin package.jsons, README AUTO-TOC —
+ *      otherwise validate-catalog-invariants.py fails the PR on catalog entries whose
+ *      source dir no longer exists), and swap the scan-allowlist.txt TEMPORARY
+ *      sources-change-unscanned line for this PR's scoped reason. sources.yaml is
+ *      yaml.safe_load-validated and prettier-checked before commit.
+ *   3. Opens ONE PR ([skip auto-bump], results table, DO NOT MERGE — Jeremy merges;
+ *      this script never calls merge).
+ *   4. Posts the results table on the census tracking issue (#984) and one closing
+ *      comment per still-open notify issue (thank-you-verified on PASS,
+ *      removed-with-PR-link + re-listing-welcome on FAIL). Courtesy-tier repos
+ *      (Skyvern, x-twitter-scraper) and kobiton are NEVER touched.
+ *   5. Idempotent: if the branch/PR already exists it is detected and reported, never
+ *      duplicated; every comment carries a hidden marker and is skipped when present,
+ *      so a partially-failed run can be safely retried the next day.
+ *
+ *   --enforce --dry-run does everything READ-ONLY (upstream validation + would-remove
+ *   report; no clone, no branch, no PR, no comments, no state writes). Live --enforce
+ *   additionally refuses to run before the deadline has passed (defense-in-depth on
+ *   top of the wrapper's days-left gate).
+ *
+ * OUTPUT: a human report to stdout + a machine state file. With --json the machine
+ *   payload goes to stdout and the human report to stderr (so wrappers can jq it).
  *
  * Zero runtime deps (no js-yaml) on purpose: a local cron must run without `npm install`.
  * sources.yaml has a stable 2-space list indent, so raw block parsing is reliable.
  *
  * Usage:  node scripts/census-watch.mjs [--json]
+ *         node scripts/census-watch.mjs --enforce --dry-run [--json]
+ *         node scripts/census-watch.mjs --enforce [--json]
  */
 
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SOURCES_FILE = path.join(__dirname, '..', 'sources.yaml');
+const REPO_ROOT = path.join(__dirname, '..');
+const SOURCES_FILE = path.join(REPO_ROOT, 'sources.yaml');
+const VALIDATOR = path.join(__dirname, 'validate-skills-schema.py');
 const STATE_DIR = path.join(os.homedir(), '.local', 'state', 'census-watch');
 const STATE_FILE = path.join(STATE_DIR, 'state.json');
+const ENFORCE_RESULT_FILE = path.join(STATE_DIR, 'enforce-result.json');
 
 const CENSUS_DATE = '2026-07-08'; // the whole-catalog census that set the clock
 const DEADLINE = '2026-07-22'; // delist deadline for sources still failing
 const DEADLINE_MARKER = `deadline ${DEADLINE}`; // stable comment string in sources.yaml
-const JSON_OUT = process.argv.includes('--json');
 
-/** Parse sources.yaml by raw 2-space list blocks; return the census-marked entries. */
-function onClockSources() {
-  const raw = fs.readFileSync(SOURCES_FILE, 'utf8');
+// Enforcement surface (marketplace repo, tracking issue, removal branch).
+const MARKETPLACE_REPO = 'jeremylongshore/claude-code-plugins-plus-skills';
+const MARKETPLACE_OWNER = 'jeremylongshore'; // author of the 2026-07-08 notify issues
+const RESULTS_ISSUE = 984; // census tracking issue — gets the results table
+const ENFORCE_BRANCH = 'fix/census-deadline-removals';
+// Hidden idempotency marker planted in every comment this script posts.
+const COMMENT_MARKER = '<!-- census-enforce:2026-07-22 -->';
+// Courtesy-tier / partner-channel repos: NEVER acted on, even if a deadline
+// marker somehow appears against them in sources.yaml.
+const NEVER_TOUCH = [/skyvern/i, /x-twitter/i, /kobiton/i];
+const SIGNATURE = '- Jeremy Longshore\nintentsolutions.io';
+
+const JSON_OUT = process.argv.includes('--json');
+const ENFORCE = process.argv.includes('--enforce');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/** Parse a sources.yaml text by raw 2-space list blocks; return census-marked entries. */
+export function parseOnClockSources(raw) {
   // Split on the top-level list-item delimiter. slice(1) drops the file header.
   const blocks = raw.split(/\n {2}- name:/).slice(1);
   const out = [];
@@ -59,9 +116,18 @@ function onClockSources() {
     const name = (b.match(/^\s*(\S.*)$/m)?.[1] || '(unknown)').trim();
     const repoM = b.match(/\n\s*repo:\s*(\S+)/);
     if (!repoM) continue;
-    out.push({ name, repo: repoM[1].trim() });
+    out.push({
+      name,
+      repo: repoM[1].trim(),
+      sourcePath: (b.match(/\n\s*source_path:\s*(\S+)/)?.[1] || '').trim(),
+      targetPath: (b.match(/\n\s*target_path:\s*(\S+)/)?.[1] || '').trim(),
+    });
   }
   return out;
+}
+
+function onClockSources() {
+  return parseOnClockSources(fs.readFileSync(SOURCES_FILE, 'utf8'));
 }
 
 /** Read the default-branch HEAD of an upstream repo via gh. Returns null on 404/gone. */
@@ -110,6 +176,716 @@ function classify(info) {
   return new Date(info.headDate) > new Date(`${CENSUS_DATE}T00:00:00Z`) ? 'MOVED' : 'DORMANT';
 }
 
+function daysLeftAt(now) {
+  return Math.ceil((new Date(`${DEADLINE}T23:59:59Z`) - now) / 86_400_000);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enforce mode — pure decision/transform logic (exported for the fixture tests
+// in census-watch.test.mjs; no network, no fs).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** True when the delist deadline has fully passed (enforcement is due). */
+export function enforcementDue(now) {
+  return daysLeftAt(now) <= 0;
+}
+
+/** Courtesy-tier / partner guard — repos and source names we never act on. */
+export function isNeverTouch(s) {
+  return NEVER_TOUCH.some((re) => re.test(String(s)));
+}
+
+/**
+ * Cluster verdict per the fix-or-removed policy.
+ *   cluster = {
+ *     upstream: { gone, archived? },
+ *     skills:   [{ name, found, errors }],   // one row per notified source-entry
+ *   }
+ * PASS only if the upstream exists AND every notified skill was found AND every
+ * one has 0 validator errors at upstream HEAD. Anything else — deleted/private/
+ * archived upstream, a missing skill, a partial pass — is FAIL.
+ */
+export function clusterVerdict(cluster) {
+  const reasons = [];
+  if (cluster.upstream?.gone) {
+    reasons.push(
+      cluster.upstream.archived
+        ? 'upstream repo is archived'
+        : 'upstream repo is deleted or private',
+    );
+    return { verdict: 'FAIL', reasons };
+  }
+  if (!cluster.skills || cluster.skills.length === 0) {
+    return { verdict: 'FAIL', reasons: ['no notified skills resolvable at upstream HEAD'] };
+  }
+  for (const s of cluster.skills) {
+    if (!s.found) reasons.push(`${s.name}: SKILL.md not found at upstream HEAD`);
+    else if (s.errors > 0)
+      reasons.push(`${s.name}: ${s.errors} validator error(s) at upstream HEAD`);
+  }
+  return reasons.length ? { verdict: 'FAIL', reasons } : { verdict: 'PASS', reasons: [] };
+}
+
+/**
+ * Remove source entries from a sources.yaml text, leaving one dated NOTE
+ * comment block per removal group at the position of its first removed entry.
+ *   removals = [{ names: [entry names], noteLines: [plain text lines] }]
+ * Entry blocks are the `  - name:` line plus following lines indented >= 4
+ * (or blank); trailing blank lines stay so spacing survives. Returns
+ * { text, removedNames }.
+ */
+export function buildSourcesRemoval(raw, removals) {
+  const lines = raw.split('\n');
+  const isEntryStart = (l) => /^ {2}- name:\s*\S/.test(l);
+  const blocks = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!isEntryStart(lines[i])) continue;
+    let end = i + 1;
+    while (end < lines.length && (lines[end].trim() === '' || /^ {4,}/.test(lines[end]))) end++;
+    while (end > i + 1 && lines[end - 1].trim() === '') end--; // leave trailing blanks in place
+    blocks.push({ name: lines[i].replace(/^ {2}- name:\s*/, '').trim(), start: i, end });
+  }
+  const groupOf = new Map();
+  removals.forEach((r, gi) => r.names.forEach((n) => groupOf.set(n, gi)));
+  const keep = new Array(lines.length).fill(true);
+  const inserts = new Map();
+  const noteDone = new Set();
+  const removedNames = [];
+  for (const b of blocks) {
+    const gi = groupOf.get(b.name);
+    if (gi === undefined) continue;
+    removedNames.push(b.name);
+    for (let i = b.start; i < b.end; i++) keep[i] = false;
+    if (!noteDone.has(gi)) {
+      noteDone.add(gi);
+      inserts.set(
+        b.start,
+        removals[gi].noteLines.map((l) => `  # ${l}`.trimEnd()),
+      );
+    }
+  }
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (inserts.has(i)) out.push(...inserts.get(i));
+    if (keep[i]) out.push(lines[i]);
+  }
+  // Collapse runs of blank lines left by the removals (prettier-yaml friendly).
+  const collapsed = [];
+  for (const l of out) {
+    if (l.trim() === '' && collapsed.length && collapsed[collapsed.length - 1].trim() === '')
+      continue;
+    collapsed.push(l);
+  }
+  return { text: collapsed.join('\n'), removedNames };
+}
+
+/**
+ * scan-allowlist.txt temp-line convention (see that file's comments): at most
+ * ONE TEMPORARY sources-change-unscanned waiver may exist; each sources PR
+ * swaps the previous PR's line(s) for its own scoped reason. Replaces every
+ * existing `sources.yaml:`/`sources.lock.json:` sources-change-unscanned line
+ * with `newLine` at the first one's position (appends if none existed).
+ */
+export function swapAllowlistTempLine(raw, newLine) {
+  const lines = raw.split('\n');
+  const isTemp = (l) => /^sources(\.yaml|\.lock\.json):sources-change-unscanned(\s|$)/.test(l);
+  const firstIdx = lines.findIndex(isTemp);
+  const kept = lines.filter((l) => !isTemp(l));
+  if (firstIdx === -1) {
+    while (kept.length && kept[kept.length - 1].trim() === '') kept.pop();
+    kept.push('', newLine, '');
+  } else {
+    kept.splice(firstIdx, 0, newLine); // no temp line precedes firstIdx, so the index maps 1:1
+  }
+  return kept.join('\n');
+}
+
+/** Title matcher for the 2026-07-08 upstream notify issues. */
+export function isNotifyIssueTitle(title) {
+  return /2026-07-22|delist/i.test(String(title));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enforce mode — impure helpers (gh / fs / subprocess).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ghJson(apiPath, extraArgs = []) {
+  return JSON.parse(
+    execFileSync('gh', ['api', apiPath, ...extraArgs], { encoding: 'utf8', maxBuffer: 64e6 }),
+  );
+}
+
+/** The LIVE sources.yaml — origin/main via the API, independent of any local checkout state. */
+function fetchLiveSourcesRaw() {
+  const resp = ghJson(`repos/${MARKETPLACE_REPO}/contents/sources.yaml?ref=main`);
+  return Buffer.from(resp.content, 'base64').toString('utf8');
+}
+
+function assertSaneRepoSlug(repo) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error(`refusing to act on malformed repo slug: ${JSON.stringify(repo)}`);
+  }
+}
+
+/** Download + extract an upstream repo tarball at `ref`; returns the extracted root dir. */
+function downloadUpstream(repo, ref, workDir) {
+  assertSaneRepoSlug(repo);
+  const tarPath = path.join(workDir, `${repo.replace('/', '__')}.tar.gz`);
+  const outDir = path.join(workDir, repo.replace('/', '__'));
+  fs.mkdirSync(outDir, { recursive: true });
+  const tarball = execFileSync('gh', ['api', `repos/${repo}/tarball/${ref}`], {
+    maxBuffer: 512e6,
+  });
+  fs.writeFileSync(tarPath, tarball);
+  execFileSync('tar', ['-xzf', tarPath, '-C', outDir]);
+  const entries = fs
+    .readdirSync(outDir)
+    .filter((e) => fs.statSync(path.join(outDir, e)).isDirectory());
+  if (entries.length !== 1) throw new Error(`unexpected tarball layout for ${repo}: [${entries}]`);
+  return path.join(outDir, entries[0]);
+}
+
+/** Locate the notified skill's SKILL.md(s) under sourcePath at upstream HEAD. */
+function findSkillFiles(extractedRoot, sourcePath) {
+  const base = path.join(extractedRoot, sourcePath);
+  const direct = path.join(base, 'SKILL.md');
+  try {
+    if (fs.statSync(direct).isFile()) return [direct];
+  } catch {
+    /* fall through to the recursive search (upstream may have restructured) */
+  }
+  const found = [];
+  const walk = (dir, depth) => {
+    if (depth > 6) return;
+    let items;
+    try {
+      items = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const it of items) {
+      if (it.name === 'node_modules' || it.name === '.git') continue;
+      const p = path.join(dir, it.name);
+      if (it.isDirectory()) walk(p, depth + 1);
+      else if (it.name === 'SKILL.md') found.push(p);
+    }
+  };
+  walk(base, 0);
+  return found.sort();
+}
+
+/** Run the marketplace validator on one SKILL.md; return its error count. */
+function validateSkillFile(absPath) {
+  const res = spawnSync('python3', [VALIDATOR, '--marketplace', '--json', absPath], {
+    encoding: 'utf8',
+    maxBuffer: 64e6,
+  });
+  // Non-zero exit is EXPECTED when the file has errors — read the JSON regardless.
+  let parsed;
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    throw new Error(
+      `validator produced no parseable JSON for ${absPath} (exit ${res.status}): ${String(
+        res.stdout || res.stderr,
+      ).slice(0, 300)}`,
+    );
+  }
+  const fileRows = parsed.filter((r) => r && typeof r === 'object' && 'path' in r);
+  if (fileRows.length === 0) throw new Error(`validator returned no file row for ${absPath}`);
+  return fileRows.reduce((n, r) => n + (r.errors?.length || 0), 0);
+}
+
+/** Find the still-open 2026-07-08 notify issue we filed on an upstream repo. */
+function findNotifyIssue(repo) {
+  try {
+    const issues = ghJson(
+      `repos/${repo}/issues?state=open&creator=${MARKETPLACE_OWNER}&per_page=100`,
+    );
+    const hit = issues.find((i) => isNotifyIssueTitle(i.title));
+    return hit ? { number: hit.number, url: hit.html_url, title: hit.title } : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Post a comment once (skips when the idempotency marker is already present). */
+function ensureIssueComment(repoSlug, issueNumber, body) {
+  const comments = ghJson(`repos/${repoSlug}/issues/${issueNumber}/comments?per_page=100`);
+  if (comments.some((c) => (c.body || '').includes(COMMENT_MARKER))) return 'already-posted';
+  execFileSync(
+    'gh',
+    ['api', '-X', 'POST', `repos/${repoSlug}/issues/${issueNumber}/comments`, '-f', `body=${body}`],
+    { encoding: 'utf8' },
+  );
+  return 'posted';
+}
+
+function closeIssue(repoSlug, issueNumber) {
+  try {
+    execFileSync(
+      'gh',
+      ['api', '-X', 'PATCH', `repos/${repoSlug}/issues/${issueNumber}`, '-f', 'state=closed'],
+      { encoding: 'utf8' },
+    );
+    return 'closed';
+  } catch {
+    return 'close-failed (left open)';
+  }
+}
+
+function existingEnforcePR() {
+  try {
+    const prs = JSON.parse(
+      execFileSync(
+        'gh',
+        [
+          'pr',
+          'list',
+          '--repo',
+          MARKETPLACE_REPO,
+          '--head',
+          ENFORCE_BRANCH,
+          '--state',
+          'all',
+          '--json',
+          'number,url,state',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    return prs[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function remoteBranchExists() {
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', REPO_ROOT, 'ls-remote', '--heads', 'origin', ENFORCE_BRANCH],
+      { encoding: 'utf8' },
+    );
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', maxBuffer: 64e6, ...opts });
+}
+
+/**
+ * Build the removal branch + PR in an isolated temp clone (the invoking
+ * checkout is shared with other sessions and is never touched). Returns the PR URL.
+ */
+function buildRemovalPR({ failing, today, resultsTable }) {
+  const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'census-removal-'));
+  try {
+    const originUrl = run('git', ['-C', REPO_ROOT, 'remote', 'get-url', 'origin']).trim();
+    run('git', ['clone', '--quiet', '--depth', '50', '--branch', 'main', originUrl, cloneDir]);
+    run('git', ['-C', cloneDir, 'checkout', '-q', '-b', ENFORCE_BRANCH]);
+
+    // 1. sources.yaml — remove the failing clusters' entries, leave dated NOTEs.
+    const srcPath = path.join(cloneDir, 'sources.yaml');
+    const rawSources = fs.readFileSync(srcPath, 'utf8');
+    const removals = failing.map((c) => ({
+      names: c.sources.map((s) => s.name),
+      noteLines: [
+        `NOTE ${today}: ${c.sources.length} source(s) from ${c.repo} removed per the`,
+        `2026-07-08 quality-census fix-or-removed policy (deadline ${DEADLINE}) — still failing`,
+        `the marketplace validator at upstream HEAD ${c.upstream.headSha || '(gone)'}.`,
+        `Notify issue: ${c.notifyIssue?.url || '(not found at enforcement time)'}`,
+        `Re-listing is welcome once the skills pass scripts/validate-skills-schema.py --marketplace.`,
+      ],
+    }));
+    const { text: newSources, removedNames } = buildSourcesRemoval(rawSources, removals);
+    const expected = failing.reduce((n, c) => n + c.sources.length, 0);
+    if (removedNames.length !== expected) {
+      throw new Error(
+        `sources.yaml removal mismatch: expected ${expected} entries, matched ${removedNames.length} — aborting before any write`,
+      );
+    }
+    fs.writeFileSync(srcPath, newSources);
+    run('python3', ['-c', 'import sys, yaml; yaml.safe_load(open(sys.argv[1]))', srcPath]);
+
+    // 2. Mirror directories under plugins/.
+    const removedDirs = [];
+    for (const c of failing) {
+      for (const s of c.sources) {
+        if (!s.targetPath.startsWith('plugins/')) {
+          throw new Error(`refusing to delete non-plugins path: ${s.targetPath}`);
+        }
+        const abs = path.join(cloneDir, s.targetPath);
+        if (fs.existsSync(abs)) {
+          fs.rmSync(abs, { recursive: true });
+          removedDirs.push(s.targetPath);
+        }
+      }
+    }
+
+    // 3. Catalog entries (marketplace.extended.json) for the removed mirrors —
+    //    required, or validate-catalog-invariants.py fails the PR.
+    const extPath = path.join(cloneDir, '.claude-plugin', 'marketplace.extended.json');
+    const ext = JSON.parse(fs.readFileSync(extPath, 'utf8'));
+    const removedSourceSet = new Set(
+      failing.flatMap((c) => c.sources.map((s) => `./${s.targetPath}`)),
+    );
+    const beforeCount = ext.plugins.length;
+    ext.plugins = ext.plugins.filter((p) => !removedSourceSet.has(p.source));
+    const removedCatalog = beforeCount - ext.plugins.length;
+    fs.writeFileSync(extPath, JSON.stringify(ext, null, 2) + '\n');
+
+    // 4. Derived artifacts. sync-marketplace.cjs needs the kernel and
+    //    generate-readme-toc.mjs needs prettier — reuse the invoking checkout's
+    //    node_modules (same commit family), else install fresh.
+    const localNM = path.join(REPO_ROOT, 'node_modules');
+    const cloneNM = path.join(cloneDir, 'node_modules');
+    if (fs.existsSync(path.join(localNM, '@intentsolutions', 'core'))) {
+      fs.symlinkSync(localNM, cloneNM, 'dir');
+    } else {
+      run('pnpm', ['install', '--frozen-lockfile', '--filter', 'claude-code-plugins-monorepo'], {
+        cwd: cloneDir,
+      });
+    }
+    const prettierBin = path.join(cloneNM, '.bin', 'prettier');
+    run(prettierBin, ['--write', extPath], { cwd: cloneDir });
+    run('node', [path.join(cloneDir, 'scripts', 'sync-marketplace.cjs')], { cwd: cloneDir });
+    run('node', [path.join(cloneDir, 'scripts', 'generate-plugin-package-jsons.mjs')], {
+      cwd: cloneDir,
+    });
+    run('node', [path.join(cloneDir, 'scripts', 'generate-readme-toc.mjs')], { cwd: cloneDir });
+
+    // 5. scan-allowlist.txt — swap the TEMPORARY sources-change-unscanned line
+    //    for this PR's scoped reason (one temp line max, per that file's rules).
+    const allowPath = path.join(cloneDir, 'scripts', 'scan-allowlist.txt');
+    const failRepos = failing.map((c) => c.repo).join(', ');
+    fs.writeFileSync(
+      allowPath,
+      swapAllowlistTempLine(
+        fs.readFileSync(allowPath, 'utf8'),
+        `sources.yaml:sources-change-unscanned  ${today} census-deadline enforcement PR: removes the still-failing census clusters (${failRepos}) per the 2026-07-08 fix-or-removed policy — every notified skill re-validated at upstream default-branch HEAD by census-watch --enforce before removal; entries removed only, no source added or repointed`,
+      ),
+    );
+
+    // 6. Gate the tree the same way CI will: sources.yaml must stay prettier-clean.
+    const check = spawnSync(prettierBin, ['--check', 'sources.yaml'], {
+      cwd: cloneDir,
+      encoding: 'utf8',
+    });
+    if (check.status !== 0) {
+      run(prettierBin, ['--write', 'sources.yaml'], { cwd: cloneDir });
+      run(prettierBin, ['--check', 'sources.yaml'], { cwd: cloneDir }); // throws if still dirty
+    }
+
+    // Drop the node_modules symlink before committing (gitignored, but be explicit).
+    try {
+      fs.unlinkSync(cloneNM);
+    } catch {
+      /* real dir from pnpm install — gitignored, leave it */
+    }
+
+    // 7. ONE commit + push + ONE PR. NEVER merged by automation — Jeremy merges.
+    const removedEntries = removedNames.length;
+    const commitMsg = [
+      `fix(census): remove ${removedEntries} still-failing source entries at the ${DEADLINE} census deadline`,
+      '',
+      `The 2026-07-08 whole-catalog quality census put these sources on a fix-or-removed`,
+      `clock (notify issues filed upstream, deadline ${DEADLINE}). census-watch --enforce`,
+      `re-validated every notified skill at upstream default-branch HEAD with`,
+      `validate-skills-schema.py --marketplace on ${today}; these clusters still fail, so their`,
+      `sources.yaml entries (dated NOTE comments left in place), mirror dirs under plugins/,`,
+      `and catalog entries are removed. Derived artifacts regenerated via sync-marketplace.`,
+      `Re-listing is welcome once the skills pass the validator.`,
+      '',
+      `Clusters removed: ${failRepos}`,
+      '',
+      SIGNATURE,
+    ].join('\n');
+    run('git', ['-C', cloneDir, 'add', '-A']);
+    run('git', ['-C', cloneDir, 'commit', '-q', '-m', commitMsg]);
+    run('git', ['-C', cloneDir, 'push', '-q', 'origin', `HEAD:refs/heads/${ENFORCE_BRANCH}`]);
+
+    const prBody = [
+      '## DO NOT MERGE — human review required (Jeremy merges)',
+      '',
+      `Automated census-deadline enforcement (\`scripts/census-watch.mjs --enforce\`, fired ${today}).`,
+      `The 2026-07-08 quality census set a fix-or-removed deadline of ${DEADLINE}; per the`,
+      'owner-set policy, external authors fix their own content or their listing is removed —',
+      'we never fix it for them. Every notified skill was re-validated at UPSTREAM',
+      'default-branch HEAD (`validate-skills-schema.py --marketplace --json`) before removal;',
+      'the live sources.yaml delist clock was read at run time, so anything fixed or already',
+      'removed since notify day is untouched.',
+      '',
+      '### Results at upstream HEAD',
+      '',
+      resultsTable,
+      '',
+      '### What this PR does (one commit)',
+      '',
+      `- Removes ${removedEntries} \`sources.yaml\` entries (${failing.length} cluster(s)) with dated NOTE comments (notify-issue link + re-listing-welcome).`,
+      `- Deletes ${removedDirs.length} mirror dir(s) under \`plugins/\`.`,
+      `- Drops ${removedCatalog} catalog entries from \`marketplace.extended.json\` and regenerates the derived artifacts (\`marketplace.json\`, plugin package.jsons, README AUTO-TOC) so \`validate-catalog-invariants.py\` stays green.`,
+      "- Swaps the TEMPORARY `sources-change-unscanned` line in `scripts/scan-allowlist.txt` for this PR's scoped reason (per that file's one-temp-line convention).",
+      '- `sources.yaml` validated with `yaml.safe_load` + prettier-checked.',
+      '',
+      'Sources are removed, never edited — re-listing is welcome once the skills pass the',
+      'marketplace validator. `sources.lock.json` entries for removed sources become inert',
+      'and can be pruned by the next `--relock` (left untouched here to keep the lock canonical).',
+      '',
+      '[skip auto-bump]',
+      '',
+      SIGNATURE,
+    ].join('\n');
+    const prUrl = run(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--repo',
+        MARKETPLACE_REPO,
+        '--base',
+        'main',
+        '--head',
+        ENFORCE_BRANCH,
+        '--title',
+        `fix(census): remove still-failing census clusters at the ${DEADLINE} deadline [skip auto-bump]`,
+        '--body',
+        prBody,
+      ],
+      { cwd: cloneDir },
+    ).trim();
+    return { prUrl, removedEntries, removedDirs, removedCatalog };
+  } finally {
+    fs.rmSync(cloneDir, { recursive: true, force: true });
+  }
+}
+
+function renderResultsTable(clusters) {
+  const rows = [
+    '| Cluster (upstream) | Notified skills | Found at HEAD | Errors at HEAD | Verdict |',
+    '|---|---|---|---|---|',
+  ];
+  for (const c of clusters) {
+    const found = c.skills.filter((s) => s.found).length;
+    const errs = c.skills.reduce((n, s) => n + (s.errors || 0), 0);
+    const verdict =
+      c.verdict === 'PASS' ? 'PASS — listing retained' : `FAIL — ${c.reasons[0] || 'removed'}`;
+    rows.push(
+      `| ${c.repo}${c.upstream.headSha ? ` @ \`${c.upstream.headSha}\`` : ''} | ${c.skills.length} | ${found} | ${errs} | ${verdict} |`,
+    );
+  }
+  return rows.join('\n');
+}
+
+/**
+ * The enforcement run. Read-only when dryRun; otherwise builds the removal PR,
+ * posts the #984 results comment, and closes the still-open notify issues.
+ */
+function runEnforce({ dryRun }) {
+  const say = (msg) => (JSON_OUT ? console.error(msg) : console.log(msg));
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const daysLeft = daysLeftAt(now);
+
+  if (!dryRun && !enforcementDue(now)) {
+    console.error(
+      `census-watch --enforce: refusing to run live enforcement before the deadline has passed ` +
+        `(${DEADLINE}, ${daysLeft} day(s) left). Use --dry-run for a read-only rehearsal.`,
+    );
+    process.exit(2);
+  }
+
+  say(`\n  Census-deadline enforcement${dryRun ? ' (DRY RUN — read-only)' : ''}`);
+  say(`  policy: fix-or-removed · deadline ${DEADLINE} · days left ${daysLeft}`);
+
+  // LIVE clock: sources.yaml on origin/main at run time — never a frozen list.
+  const liveRaw = fetchLiveSourcesRaw();
+  const allEntries = parseOnClockSources(liveRaw);
+  const entries = [];
+  for (const e of allEntries) {
+    if (isNeverTouch(e.repo) || isNeverTouch(e.name)) {
+      say(`  SKIP (never-touch guard): ${e.name} (${e.repo})`);
+      continue;
+    }
+    entries.push(e);
+  }
+  say(
+    `  live delist clock: ${entries.length} source-entries across ${new Set(entries.map((e) => e.repo)).size} upstream repo(s)\n`,
+  );
+
+  const result = {
+    mode: dryRun ? 'enforce-dry-run' : 'enforce',
+    ok: true,
+    generatedAt: now.toISOString(),
+    deadline: DEADLINE,
+    daysLeft,
+    clusters: [],
+    actions: { pr: null, prExisted: false, resultsComment: null, notifyIssues: [] },
+    slackSummary: '',
+  };
+
+  if (entries.length === 0) {
+    say(
+      '  The delist clock is EMPTY — every census source was fixed or already removed. Nothing to enforce.',
+    );
+    if (!dryRun) {
+      const body = `${COMMENT_MARKER}\n**Census-deadline enforcement (${DEADLINE}) — clock empty.** At enforcement time the live \`sources.yaml\` carried zero delist-clock entries: every 2026-07-08 census source was either fixed upstream or already removed. No removal PR needed.\n\n${SIGNATURE}`;
+      result.actions.resultsComment = ensureIssueComment(MARKETPLACE_REPO, RESULTS_ISSUE, body);
+      fs.mkdirSync(STATE_DIR, { recursive: true });
+      fs.writeFileSync(ENFORCE_RESULT_FILE, JSON.stringify(result, null, 2) + '\n');
+    }
+    result.slackSummary = 'census clock empty — nothing to enforce; #984 updated';
+    if (JSON_OUT) console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Group into clusters by upstream repo and validate at upstream HEAD.
+  const byRepo = new Map();
+  for (const e of entries) {
+    if (!byRepo.has(e.repo)) byRepo.set(e.repo, []);
+    byRepo.get(e.repo).push(e);
+  }
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'census-enforce-'));
+  const clusters = [];
+  try {
+    for (const [repo, sources] of [...byRepo.entries()].sort()) {
+      say(`  validating ${repo} (${sources.length} skill(s)) at upstream HEAD ...`);
+      const upstream = upstreamHead(repo);
+      const skills = [];
+      if (!upstream.gone) {
+        const root = downloadUpstream(repo, upstream.headSha || upstream.defaultBranch, workDir);
+        for (const s of sources) {
+          const files = findSkillFiles(root, s.sourcePath);
+          if (files.length === 0) {
+            skills.push({ name: s.name, found: false, errors: null });
+            say(`      ${s.name}: SKILL.md NOT FOUND under ${s.sourcePath}/`);
+          } else {
+            const errors = files.reduce((n, f) => n + validateSkillFile(f), 0);
+            skills.push({ name: s.name, found: true, errors });
+            say(`      ${s.name}: ${errors} error(s)`);
+          }
+        }
+      } else {
+        say(`      upstream GONE${upstream.archived ? ' (archived)' : ' (deleted/private)'}`);
+      }
+      const { verdict, reasons } = clusterVerdict({ upstream, skills });
+      const notifyIssue = findNotifyIssue(repo);
+      clusters.push({ repo, sources, upstream, skills, verdict, reasons, notifyIssue });
+      say(`    → ${verdict}${reasons.length ? ` (${reasons.length} reason(s))` : ''}\n`);
+    }
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+
+  const failing = clusters.filter((c) => c.verdict === 'FAIL');
+  const passing = clusters.filter((c) => c.verdict === 'PASS');
+  const resultsTable = renderResultsTable(clusters);
+  result.clusters = clusters.map((c) => ({
+    repo: c.repo,
+    verdict: c.verdict,
+    reasons: c.reasons,
+    headSha: c.upstream.headSha || null,
+    skills: c.skills,
+    sources: c.sources.map((s) => s.name),
+    notifyIssue: c.notifyIssue?.url || null,
+  }));
+
+  say(`  VERDICTS: ${passing.length} PASS / ${failing.length} FAIL`);
+  say(resultsTable.replace(/^/gm, '  '));
+
+  if (dryRun) {
+    const wouldRemove = failing.flatMap((c) => c.sources.map((s) => s.name));
+    say(
+      `\n  DRY RUN — would remove ${wouldRemove.length} source entr(ies) across ${failing.length} cluster(s):`,
+    );
+    for (const c of failing) {
+      say(
+        `    ${c.repo}: ${c.sources.length} entries + ${c.sources.length} mirror dir(s); notify issue ${c.notifyIssue?.url || '(not found)'}`,
+      );
+    }
+    say(
+      `  Would open ONE PR on branch ${ENFORCE_BRANCH} (DO NOT MERGE), comment on #${RESULTS_ISSUE},`,
+    );
+    say(`  and post a closing comment on each still-open notify issue. No side effects taken.\n`);
+    result.slackSummary = `dry-run: ${failing.length} cluster(s) would be removed (${wouldRemove.length} sources), ${passing.length} would pass`;
+    if (JSON_OUT) console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // ── LIVE side effects ──────────────────────────────────────────────────────
+  // Idempotency: one branch, one PR, ever. Detect + reuse, never duplicate.
+  const prior = existingEnforcePR();
+  if (failing.length > 0) {
+    if (prior) {
+      say(`  Removal PR already exists (${prior.url}, ${prior.state}) — not duplicating.`);
+      result.actions.pr = prior.url;
+      result.actions.prExisted = true;
+    } else if (remoteBranchExists()) {
+      say(
+        `  Branch ${ENFORCE_BRANCH} already exists on origin without a PR — not rebuilding; open the PR manually or delete the branch and rerun.`,
+      );
+      result.actions.pr = null;
+      result.actions.prExisted = true;
+    } else {
+      const { prUrl } = buildRemovalPR({ failing, today, resultsTable });
+      say(`  Opened removal PR: ${prUrl}  (DO NOT MERGE — Jeremy merges)`);
+      result.actions.pr = prUrl;
+    }
+  } else {
+    say('  Every cluster PASSED — no removal PR needed.');
+  }
+
+  // Results comment on the census tracking issue.
+  const prLine = result.actions.pr
+    ? `\n\nRemoval PR: ${result.actions.pr} — **DO NOT MERGE without review** (Jeremy merges).`
+    : failing.length === 0
+      ? '\n\nEvery cluster passed at upstream HEAD — **no removal PR needed**.'
+      : '';
+  const resultsBody = `${COMMENT_MARKER}\n**Census-deadline enforcement (${DEADLINE}) — results at upstream default-branch HEAD** (\`census-watch.mjs --enforce\`, ${today}; live \`sources.yaml\` clock, validator \`--marketplace\`)\n\n${resultsTable}${prLine}\n\n${SIGNATURE}`;
+  result.actions.resultsComment = ensureIssueComment(MARKETPLACE_REPO, RESULTS_ISSUE, resultsBody);
+  say(`  #${RESULTS_ISSUE} results comment: ${result.actions.resultsComment}`);
+
+  // One short closing comment per still-open notify issue.
+  for (const c of clusters) {
+    if (!c.notifyIssue) {
+      result.actions.notifyIssues.push({ repo: c.repo, status: 'no-open-notify-issue' });
+      continue;
+    }
+    const body =
+      c.verdict === 'PASS'
+        ? `${COMMENT_MARKER}\nVerified at the ${DEADLINE} deadline: the notified skills now pass the marketplace validator at your default-branch HEAD — thank you for fixing them. The listing stays live. Closing this out.\n\n${SIGNATURE}`
+        : `${COMMENT_MARKER}\nThe ${DEADLINE} deadline passed with the notified skills still failing the marketplace validator at your default-branch HEAD, so the listing has been removed per the fix-or-removed policy (removal PR: ${result.actions.pr || 'pending'}). Re-listing is welcome any time once the skills pass — just open an issue or PR on the marketplace repo. Closing this out.\n\n${SIGNATURE}`;
+    const posted = ensureIssueComment(c.repo, c.notifyIssue.number, body);
+    const closed =
+      posted === 'posted' ? closeIssue(c.repo, c.notifyIssue.number) : 'already-handled';
+    result.actions.notifyIssues.push({
+      repo: c.repo,
+      issue: c.notifyIssue.url,
+      comment: posted,
+      close: closed,
+    });
+    say(`  notify issue ${c.notifyIssue.url}: comment ${posted}, ${closed}`);
+  }
+
+  result.slackSummary =
+    failing.length === 0
+      ? `all ${clusters.length} census cluster(s) PASSED at upstream HEAD — no removals; #${RESULTS_ISSUE} updated`
+      : `${failing.length} cluster(s) removed (${failing.reduce((n, c) => n + c.sources.length, 0)} sources) via ${result.actions.pr || 'existing PR/branch'} — DO NOT MERGE without review; ${passing.length} passed; #${RESULTS_ISSUE} + notify issues updated`;
+
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(ENFORCE_RESULT_FILE, JSON.stringify(result, null, 2) + '\n');
+  say(`\n  Enforcement complete. Result: ${ENFORCE_RESULT_FILE}\n`);
+  if (JSON_OUT) console.log(JSON.stringify(result, null, 2));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Watch mode (the original daily report — unchanged behavior).
+// ─────────────────────────────────────────────────────────────────────────────
+
 function main() {
   const sources = onClockSources();
   // repo -> [source names]
@@ -131,7 +907,7 @@ function main() {
   }
 
   const now = new Date();
-  const daysLeft = Math.ceil((new Date(`${DEADLINE}T23:59:59Z`) - now) / 86_400_000);
+  const daysLeft = daysLeftAt(now);
 
   const results = [];
   for (const [repo, names] of [...byRepo.entries()].sort()) {
@@ -221,4 +997,10 @@ function main() {
   );
 }
 
-main();
+// Entry guard: only dispatch when executed directly (the fixture tests in
+// census-watch.test.mjs import this module and must not trigger a run).
+const isEntry = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntry) {
+  if (ENFORCE) runEnforce({ dryRun: DRY_RUN });
+  else main();
+}

--- a/scripts/census-watch.test.mjs
+++ b/scripts/census-watch.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * census-watch.test.mjs — fixture corpus for the --enforce decision logic.
+ *
+ * Covers the pure functions the enforcement run is built on (clusterVerdict,
+ * parseOnClockSources, buildSourcesRemoval, swapAllowlistTempLine, guards) with
+ * in-memory fixtures — NO network, NO gh, NO validator subprocess. The verdict
+ * table below is the executable form of the fix-or-removed policy from the
+ * retired cloud one-shot: PASS only when every notified skill has 0 validator
+ * errors at upstream HEAD; deleted/private/archived upstream = FAIL; partial
+ * pass = FAIL.
+ *
+ * Run: node --test scripts/census-watch.test.mjs
+ * (Deliberately not wired into CI: census-watch is a dev-box cron script that
+ * retires after 2026-07-22; the test runs locally as the enforce-mode evidence.)
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  clusterVerdict,
+  parseOnClockSources,
+  buildSourcesRemoval,
+  swapAllowlistTempLine,
+  isNeverTouch,
+  isNotifyIssueTitle,
+  enforcementDue,
+} from './census-watch.mjs';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// clusterVerdict — the fix-or-removed policy table.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('verdict: all skills 0 errors → PASS', () => {
+  const r = clusterVerdict({
+    upstream: { gone: false },
+    skills: [
+      { name: 'a', found: true, errors: 0 },
+      { name: 'b', found: true, errors: 0 },
+    ],
+  });
+  assert.equal(r.verdict, 'PASS');
+  assert.equal(r.reasons.length, 0);
+});
+
+test('verdict: one failing skill among passing ones → partial pass = cluster FAIL', () => {
+  const r = clusterVerdict({
+    upstream: { gone: false },
+    skills: [
+      { name: 'a', found: true, errors: 0 },
+      { name: 'b', found: true, errors: 7 },
+      { name: 'c', found: true, errors: 0 },
+    ],
+  });
+  assert.equal(r.verdict, 'FAIL');
+  assert.equal(r.reasons.length, 1);
+  assert.match(r.reasons[0], /b: 7 validator error/);
+});
+
+test('verdict: a notified skill missing at upstream HEAD → FAIL', () => {
+  const r = clusterVerdict({
+    upstream: { gone: false },
+    skills: [
+      { name: 'a', found: true, errors: 0 },
+      { name: 'b', found: false, errors: null },
+    ],
+  });
+  assert.equal(r.verdict, 'FAIL');
+  assert.match(r.reasons[0], /b: SKILL\.md not found/);
+});
+
+test('verdict: deleted/private upstream → FAIL', () => {
+  const r = clusterVerdict({ upstream: { gone: true }, skills: [] });
+  assert.equal(r.verdict, 'FAIL');
+  assert.match(r.reasons[0], /deleted or private/);
+});
+
+test('verdict: archived upstream → FAIL (distinct reason)', () => {
+  const r = clusterVerdict({ upstream: { gone: true, archived: true }, skills: [] });
+  assert.equal(r.verdict, 'FAIL');
+  assert.match(r.reasons[0], /archived/);
+});
+
+test('verdict: upstream alive but zero resolvable skills → FAIL', () => {
+  const r = clusterVerdict({ upstream: { gone: false }, skills: [] });
+  assert.equal(r.verdict, 'FAIL');
+  assert.match(r.reasons[0], /no notified skills resolvable/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseOnClockSources — live-clock selection from sources.yaml text.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXTURE_SOURCES = `# header comment
+sources:
+  # ============================================================
+  # Some Upstream (author)
+  # ============================================================
+
+  - name: on-clock-one
+    description: first flagged skill
+    repo: someone/some-repo
+    source_path: skills/one
+    target_path: plugins/community/on-clock-one
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
+    include:
+      - 'SKILL.md'
+
+  - name: clean-entry
+    description: not on the clock
+    repo: fine/repo
+    source_path: .
+    target_path: plugins/devops/clean-entry
+    verified: true
+    include:
+      - 'SKILL.md'
+
+  - name: on-clock-two
+    description: second flagged skill
+    repo: someone/some-repo
+    source_path: skills/two
+    target_path: plugins/community/on-clock-two
+    # census 2026-07-08: graded D/F — verified flips back to true when the upstream fix lands (deadline 2026-07-22)
+    verified: false
+    include:
+      - 'SKILL.md'
+`;
+
+test('parseOnClockSources: selects only deadline-marked entries, with paths', () => {
+  const entries = parseOnClockSources(FIXTURE_SOURCES);
+  assert.deepEqual(
+    entries.map((e) => e.name),
+    ['on-clock-one', 'on-clock-two'],
+  );
+  assert.equal(entries[0].repo, 'someone/some-repo');
+  assert.equal(entries[0].sourcePath, 'skills/one');
+  assert.equal(entries[0].targetPath, 'plugins/community/on-clock-one');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildSourcesRemoval — the sources.yaml edit the removal PR ships.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('buildSourcesRemoval: removes the cluster entries, keeps the clean entry, plants one NOTE', () => {
+  const { text, removedNames } = buildSourcesRemoval(FIXTURE_SOURCES, [
+    {
+      names: ['on-clock-one', 'on-clock-two'],
+      noteLines: ['NOTE 2026-07-23: removed per census deadline', 'notify issue: <url>'],
+    },
+  ]);
+  assert.deepEqual(removedNames, ['on-clock-one', 'on-clock-two']);
+  assert.ok(!text.includes('- name: on-clock-one'), 'first entry removed');
+  assert.ok(!text.includes('- name: on-clock-two'), 'second entry removed');
+  assert.ok(text.includes('- name: clean-entry'), 'unflagged entry retained');
+  assert.ok(text.includes('  # NOTE 2026-07-23: removed per census deadline'), 'NOTE planted');
+  assert.equal(
+    (text.match(/# NOTE 2026-07-23/g) || []).length,
+    1,
+    'exactly one NOTE per removal group',
+  );
+  assert.ok(!/\n\s*\n\s*\n/.test(text), 'no blank-line pileups left behind');
+  // The surviving entry's fields are intact (no partial-block bleed).
+  assert.ok(text.includes('repo: fine/repo'));
+  assert.ok(text.includes('verified: true'));
+});
+
+test('buildSourcesRemoval: names not present in the file remove nothing', () => {
+  const { text, removedNames } = buildSourcesRemoval(FIXTURE_SOURCES, [
+    { names: ['ghost-entry'], noteLines: ['NOTE: n/a'] },
+  ]);
+  assert.deepEqual(removedNames, []);
+  assert.ok(text.includes('- name: on-clock-one'), 'nothing removed on a no-match');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// swapAllowlistTempLine — the one-temp-line convention in scan-allowlist.txt.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXTURE_ALLOWLIST = `# scan-synced-content.mjs — CHALLENGE / FLAG waivers
+plugins/**/README.md:pipe-to-shell  documented upstream installer
+
+# TEMPORARY per-PR source-vetting sign-off block
+sources.yaml:sources-change-unscanned  2026-07-10 previous PR reason
+sources.lock.json:sources-change-unscanned  2026-07-10 previous PR lock reason
+
+plugins/security/scanner.py:outbound-network  defensive scanner regex
+`;
+
+test('swapAllowlistTempLine: replaces all stale temp lines with exactly one new line, in place', () => {
+  const newLine =
+    'sources.yaml:sources-change-unscanned  2026-07-23 census-deadline enforcement PR';
+  const out = swapAllowlistTempLine(FIXTURE_ALLOWLIST, newLine);
+  assert.ok(!out.includes('previous PR reason'), 'old sources.yaml temp line gone');
+  assert.ok(!out.includes('previous PR lock reason'), 'old sources.lock.json temp line gone');
+  assert.equal(
+    out.split('\n').filter((l) => l.startsWith('sources.yaml:sources-change-unscanned')).length,
+    1,
+    'exactly one temp line remains',
+  );
+  assert.ok(out.includes(newLine));
+  assert.ok(out.includes('plugins/**/README.md:pipe-to-shell'), 'permanent waivers untouched');
+  assert.ok(
+    out.includes('plugins/security/scanner.py:outbound-network'),
+    'permanent waivers untouched',
+  );
+  // New line sits where the old temp block was (before the scanner waiver).
+  assert.ok(out.indexOf(newLine) < out.indexOf('plugins/security/scanner.py'));
+});
+
+test('swapAllowlistTempLine: appends when no temp line exists', () => {
+  const base = '# waivers\nplugins/**/README.md:pipe-to-shell  reason\n';
+  const newLine = 'sources.yaml:sources-change-unscanned  2026-07-23 reason';
+  const out = swapAllowlistTempLine(base, newLine);
+  assert.equal(
+    out.split('\n').filter((l) => l.startsWith('sources.yaml:sources-change-unscanned')).length,
+    1,
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guards.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('isNeverTouch: courtesy-tier and partner repos are protected', () => {
+  assert.ok(isNeverTouch('Skyvern-AI/skyvern'));
+  assert.ok(isNeverTouch('someone/x-twitter-scraper'));
+  assert.ok(isNeverTouch('kobiton/some-repo'));
+  assert.ok(!isNeverTouch('wondelai/skills'));
+  assert.ok(!isNeverTouch('numman-ali/n-skills'));
+});
+
+test('isNotifyIssueTitle: matches the 2026-07-08 notify wave titles', () => {
+  assert.ok(
+    isNotifyIssueTitle(
+      'Action needed: your claude-code-plugins marketplace listing is below the A-grade bar — fix by 2026-07-22 or it will be delisted',
+    ),
+  );
+  assert.ok(!isNotifyIssueTitle('Bug: something unrelated'));
+});
+
+test('enforcementDue: false before the deadline, true after it passes', () => {
+  assert.equal(enforcementDue(new Date('2026-07-10T12:00:00Z')), false);
+  assert.equal(
+    enforcementDue(new Date('2026-07-22T12:00:00Z')),
+    false,
+    'deadline day itself is still fix time',
+  );
+  assert.equal(
+    enforcementDue(new Date('2026-07-23T08:23:00Z')),
+    true,
+    'enforcement fires the morning after',
+  );
+});


### PR DESCRIPTION
## What

Adds `--enforce` (+ `--dry-run`) to `scripts/census-watch.mjs` — LOCAL enforcement of the 2026-07-08 quality census's fix-or-removed deadline (2026-07-22) — plus `scripts/census-watch.test.mjs`, a `node --test` fixture corpus for the enforce decision logic. `[skip auto-bump]`

## Why + decision rationale

The cloud one-shot that was meant to enforce on 2026-07-23 was single-owner-scoped and could not reach the cross-owner census upstreams (`wondelai/*`, `numman-ali/*`) — it was disabled 2026-07-10. Enforcement follows the data: the local watcher (PR #1013) already reads those upstreams via `gh` on the dev box, so the enforce semantics move into it. Chose extending `census-watch.mjs` over a new script because enforce reuses the same delist-clock parser and `upstreamHead` reader, and the daily cron wrapper already invokes this file.

## Layer

Repo automation scripts only (`scripts/`). No plugin, catalog, CI-workflow, or validator change. The validator (`validate-skills-schema.py`) is consumed as-is, single-file `--marketplace --json` mode.

## How it works

- **Live clock, never a frozen list:** reads `sources.yaml` from `origin/main` via the API at run time; entries fixed/removed since notify day are simply off the clock.
- **Verdicts:** per cluster (unique upstream repo), every notified skill is validated at UPSTREAM default-branch HEAD. PASS only if ALL skills have 0 errors; deleted/private/archived upstream = FAIL; partial pass = FAIL.
- **Removal PR (still-failing clusters only):** ONE branch `fix/census-deadline-removals` off `origin/main`, built in its own temp clone (never the invoking checkout), ONE commit: `sources.yaml` entries removed with a dated NOTE comment (notify-issue link + re-listing-welcome), mirror dirs under `plugins/` deleted, `marketplace.extended.json` entries dropped + derived artifacts regenerated (`sync-marketplace.cjs`, plugin package.jsons, README AUTO-TOC — otherwise `validate-catalog-invariants.py` fails on catalog entries whose source dir is gone), `scan-allowlist.txt` TEMPORARY `sources-change-unscanned` line swapped for this PR's scoped reason, `yaml.safe_load` + prettier checks before commit. The PR body says **DO NOT MERGE**; the script never calls merge — Jeremy merges.
- **Comms:** results table comment on #984; one closing comment per still-open upstream notify issue (thank-you-verified on PASS, removed-with-PR-link + re-listing-welcome on FAIL). Courtesy-tier repos (Skyvern, x-twitter-scraper) and kobiton are never touched.
- **Dry-run:** `--enforce --dry-run` does everything read-only (validation + would-remove report; no clone/branch/PR/comments/state writes).

## Verification & evidence

`node --test scripts/census-watch.test.mjs` → **14/14 pass** (fixtures only, no network): verdict table (pass / partial-fail / missing-skill / deleted / archived / zero-skills), clock parsing, sources.yaml removal transform (NOTE planting, no partial-block bleed, no blank pileups), allowlist temp-line swap, never-touch + notify-title guards, deadline gate.

Real `--enforce --dry-run` against live upstreams (2026-07-10, zero side effects):

```
  Census-deadline enforcement (DRY RUN — read-only)
  policy: fix-or-removed · deadline 2026-07-22 · days left 13
  live delist clock: 27 source-entries across 2 upstream repo(s)

  VERDICTS: 0 PASS / 2 FAIL
  | Cluster (upstream) | Notified skills | Found at HEAD | Errors at HEAD | Verdict |
  |---|---|---|---|---|
  | numman-ali/n-skills @ `a518c67eab71` | 2 | 2 | 23 | FAIL — gastown: 12 validator error(s) at upstream HEAD |
  | wondelai/skills @ `326b3801223a` | 25 | 25 | 275 | FAIL — wondelai-blue-ocean-strategy: 11 validator error(s) at upstream HEAD |

  DRY RUN — would remove 27 source entr(ies) across 2 cluster(s):
    numman-ali/n-skills: 2 entries + 2 mirror dir(s); notify issue https://github.com/numman-ali/n-skills/issues/34
    wondelai/skills: 25 entries + 25 mirror dir(s); notify issue https://github.com/wondelai/skills/issues/19
```

Also verified: live `--enforce` before the deadline **exits 2 with a refusal**; watch-mode output unchanged; eslint + prettier clean.

## Risk assessment

- **Fires twice / partial failure:** three guards — the wrapper's one-shot state file (`~/.local/state/census-watch/enforce-fired`, touched only on success), existing-branch/PR detection (reuses, never duplicates), and hidden idempotency markers on every comment (safe daily retry until success).
- **Misreads sources.yaml:** the removal transform is fixture-tested, and the live run cross-checks matched-entry count against the expected count and **aborts before any write** on mismatch; `yaml.safe_load` + prettier gate the result; the never-touch guard excludes courtesy/partner repos even if mismarked.
- **Premature enforcement:** live mode refuses while the deadline hasn't passed (wrapper gate + in-script gate).
- **Removal PR CI:** derived artifacts are regenerated with the repo's pinned toolchain (reuses the invoking checkout's `node_modules`, falls back to `pnpm install --frozen-lockfile`), so `validate-catalog-invariants` / sync-drift / prettier gates on that PR stay green. `sources.lock.json` is deliberately untouched (entries become inert; next `--relock` prunes).

## Operational impact

- **This PR alone changes nothing operationally** — nothing invokes `--enforce` yet.
- **After merge (dev box, outside this repo):** `~/bin/census-watch-daily.sh` (the 08:23 cron wrapper) gets the trigger: when the watcher reports days-left ≤ 0, invoke `--enforce` exactly once, guarded by `~/.local/state/census-watch/enforce-fired`; success → marketplace Slack + touch guard; failure → #cron-failures, no guard (retries next day). The wrapper runs the script from the shared checkout's `main`, so merged main must be pulled there (`git -C ~/000-projects/claude-code-plugins pull --ff-only`) as the deployment step.
- No env/migration/secret changes. Whole surface retires after the deadline settles (cron line + wrapper + this mode).

## Follow-ups & deferred

- Post-merge: wrapper edit + shared-checkout pull (above), then a final pre-deadline `--enforce --dry-run` rehearsal before 07-22.
- Post-deadline: retire the cron line, wrapper, and watcher per the wrapper's RETIRE note.
- Test file is deliberately not wired into CI (dev-box cron script retiring in ~2 weeks); it runs via `node --test` locally.

## Refs

Refs intent-solutions-io/intent-os#42 · Refs #984 · builds on #1013 (the watcher) · bead claude-ss50.8

- Jeremy Longshore
intentsolutions.io
