### PR TITLE
feat(validator): enforce disallowed-tools shape + allowed/disallowed overlap (schema 3.15.2) [skip auto-bump]

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,55 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.15.2] — 2026-07-12 — `disallowed-tools` cross-field enforcement made real (spec-compliance, additive; closes claude-41c2.2)
+
+**Additive spec-compliance implementation — no change to `ALWAYS_REQUIRED`, the
+tier model, or error-vs-warning semantics.** Autonomous-OK class per
+NON-NEGOTIABLE #6 (implements already-documented behavior; not architectural).
+`disallowed-tools` has been *recognized* since 3.7.0, but its two documented
+rules (repo CLAUDE.md § Optional frontmatter 3.7.0, `000-docs/681`) were never
+actually checked — the field parsed clean regardless of content.
+
+### Added
+
+- **Shape guard:** `disallowed-tools` must be a string or a YAML list (same
+  shapes as `allowed-tools`). A non-string/non-list value (e.g. an int) is now
+  an ERROR: *"'disallowed-tools' must be a list of strings or a space/comma-
+  separated string"*.
+- **Cross-field overlap rule:** a tool pattern MUST NOT appear in both
+  `allowed-tools` and `disallowed-tools` — declaring a tool simultaneously
+  permitted and denied is contradictory and almost always a mis-scoped list.
+  Now an ERROR at **every tier**: *"contradictory tool declaration: […] appears
+  in both allowed-tools and disallowed-tools"*. This mirrors the existing 3.5.0
+  `requires_*` / `fallback_for_*` visibility-overlap rule; both lists normalize
+  through the shared `parse_allowed_tools()` so `Bash(rm:*)` matches whether it
+  was written CSV, space-separated, or as a YAML list.
+
+### Why this is not architectural
+
+The `disallowed-tools` field itself stays **optional** (ALWAYS_REQUIRED is
+untouched); the new errors only fire when the field is present and either
+malformed or self-contradictory. Error-vs-warning semantics for the required
+set are unchanged. This is the "make an already-recognized optional field's
+documented constraints real" class, parallel to how 3.8.0 made `allowed-tools`
+entry validation real.
+
+### Corpus safety
+
+All 26 in-corpus SKILL.md files that declare `disallowed-tools` (the
+penetration-tester pack, defense-in-depth denials of tools NOT in their
+`allowed-tools`) were re-validated: **zero** newly fail on the overlap or shape
+checks.
+
+### Tests
+
+Six regression tests added to `tests/test_validate_skills_schema_frontmatter.py`:
+overlap-is-error (standard + marketplace tiers), disjoint-is-clean, shared-
+normalization overlap (space form vs list form), disallowed-without-allowed is
+clean (guarded), and bad-shape is error.
+
+---
+
 ## [3.15.1] — 2026-07-02 — Body-vs-allowlist regex recognizes kebab/snake MCP server names (spec-compliance bug fix, issue #843)
 
 **Bug fix — no change to `ALWAYS_REQUIRED`, the tier model, or error-vs-warning

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -177,8 +177,20 @@ except ImportError:
 #                       frontmatter `capabilities` BAN (NON-NEGOTIABLE) are all
 #                       unchanged — only `## Capabilities` as a *heading* is credited
 #                       as an Overview synonym.
+# 3.15.2 (2026-07-12) — disallowed-tools (schema 3.7.0) cross-field enforcement
+#                       made real. The field was recognized since 3.7.0 but its
+#                       two rules were never checked: (1) shape — must be a
+#                       string or YAML list (same as allowed-tools); (2) a tool
+#                       pattern MUST NOT appear in both allowed-tools and
+#                       disallowed-tools (contradictory permit+deny), an ERROR at
+#                       every tier, mirroring the 3.5.0 requires_*/fallback_for_*
+#                       overlap rule. Reuses parse_allowed_tools() so both lists
+#                       normalize identically. Spec-compliance implementation of
+#                       already-documented behavior (repo CLAUDE.md + 000-docs/681);
+#                       not an architectural change — ALWAYS_REQUIRED, tiers, and
+#                       error-vs-warning semantics are unchanged. Closes claude-41c2.2.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.15.1"
+SCHEMA_VERSION = "3.15.2"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -2817,6 +2829,36 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
                 f"simultaneously require and be the fallback for the same "
                 f"{scope[:-1] if scope.endswith('s') else scope} identifier."
             )
+
+    # ── disallowed-tools cross-field rule (schema 3.7.0) ─────────────────
+    # disallowed-tools (kebab-case denylist) removes tools from the model while
+    # the skill is active — defense-in-depth parallel to allowed-tools, not a
+    # replacement. Shape mirrors allowed-tools: a space/comma-separated string
+    # OR a YAML list. Two rules, both enforced here:
+    #   1. shape: must be a string or a list (same as allowed-tools);
+    #   2. cross-field: a tool pattern MUST NOT appear in both allowed-tools and
+    #      disallowed-tools — declaring the same tool permitted AND denied is
+    #      contradictory and almost always a mis-scoped list. Error at every tier
+    #      (the fields are optional, but if both are present they must agree).
+    # Mirrors the visibility-gating overlap rule above.
+    if "disallowed-tools" in fm:
+        dt_val = fm["disallowed-tools"]
+        if not isinstance(dt_val, (list, str)):
+            errors.append(
+                f"[frontmatter] 'disallowed-tools' must be a list of strings or a "
+                f"space/comma-separated string, got: {type(dt_val).__name__}"
+            )
+        elif "allowed-tools" in fm:
+            allowed_set = set(parse_allowed_tools(fm.get("allowed-tools")))
+            disallowed_set = set(parse_allowed_tools(dt_val))
+            tool_overlap = allowed_set & disallowed_set
+            if tool_overlap:
+                errors.append(
+                    f"[frontmatter] contradictory tool declaration: "
+                    f"{sorted(tool_overlap)} appears in both allowed-tools and "
+                    f"disallowed-tools. A tool cannot be simultaneously permitted "
+                    f"and denied — remove it from one list."
+                )
 
     # ── Self-declared config surface (schema 3.6.0) ──────────────────────
     # required_environment_variables — list of objects describing each env

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -348,3 +348,70 @@ def test_843_end_to_end_validate_agent_surfaces_check3(tmp_path):
     )
     result = validator.validate_agent(agent)
     assert any("CHECK 3" in e for e in result["errors"]), result["errors"]
+
+
+# =========================================================================
+# schema 3.7.0 / 3.15.2 — disallowed-tools cross-field enforcement
+#   (claude-41c2.2): shape guard + allowed-tools ∩ disallowed-tools overlap
+#   is an ERROR at every tier, mirroring the 3.5.0 requires_*/fallback_for_*
+#   overlap rule. Both lists normalize through parse_allowed_tools().
+# =========================================================================
+
+
+def test_allowed_disallowed_tool_overlap_is_error():
+    fm = {
+        "name": "my-skill", "description": GOOD_DESC,
+        "allowed-tools": "Read, Bash(rm:*)",
+        "disallowed-tools": "Bash(rm:*)",
+    }
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("contradictory tool declaration" in e and "Bash(rm:*)" in e for e in errors), errors
+
+
+def test_overlap_is_error_at_marketplace_tier_too():
+    fm = {
+        "name": "my-skill", "description": GOOD_DESC,
+        "allowed-tools": ["Read", "Write"],
+        "disallowed-tools": ["Write"],
+    }
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("contradictory tool declaration" in e and "Write" in e for e in errors), errors
+
+
+def test_disjoint_allowed_disallowed_is_clean():
+    # Defense-in-depth: disallow a tool NOT in allowed-tools (the intended use).
+    fm = {
+        "name": "my-skill", "description": GOOD_DESC,
+        "allowed-tools": "Read, Write",
+        "disallowed-tools": "Bash(rm:*), Bash(curl:*)",
+    }
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert not any("contradictory tool declaration" in e for e in errors), errors
+
+
+def test_overlap_detection_uses_shared_normalization():
+    # Space-separated allowed-tools vs the same token in disallowed-tools must
+    # still overlap — both go through parse_allowed_tools().
+    fm = {
+        "name": "my-skill", "description": GOOD_DESC,
+        "allowed-tools": "Read Bash(rm:*)",
+        "disallowed-tools": ["Bash(rm:*)"],
+    }
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("contradictory tool declaration" in e for e in errors), errors
+
+
+def test_disallowed_tools_without_allowed_tools_is_clean():
+    # The overlap check is guarded on allowed-tools also being present.
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Bash(rm:*)"}
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert not any("contradictory tool declaration" in e for e in errors), errors
+
+
+def test_disallowed_tools_bad_shape_is_error():
+    fm = {
+        "name": "my-skill", "description": GOOD_DESC,
+        "allowed-tools": "Read", "disallowed-tools": 123,
+    }
+    errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
+    assert any("'disallowed-tools' must be" in e for e in errors), errors


### PR DESCRIPTION
## What

`disallowed-tools` has been **recognized** by the validator since schema 3.7.0 (2026-05-28), but its two documented rules were never actually checked — the field parsed clean regardless of content. This PR makes them real. It's the remaining acceptance criterion of `claude-41c2.2` (the field-registration + `SCHEMA_VERSION` halves were already done; the validator is at 3.15.1).

- **Shape guard** — `disallowed-tools` must be a string or YAML list (same shapes as `allowed-tools`). A non-string/non-list value is now an **ERROR**.
- **Cross-field overlap** — a tool pattern MUST NOT appear in both `allowed-tools` and `disallowed-tools` (contradictory permit+deny). Now an **ERROR at every tier**. Both lists normalize through the shared `parse_allowed_tools()`, so `Bash(rm:*)` matches whether written CSV, space-separated, or as a YAML list.
- `SCHEMA_VERSION` 3.15.1 → **3.15.2**; validator header + `000-docs/SCHEMA_CHANGELOG.md` entry.

## Why · decision rationale

Every dangerous surface a skill can reach is governed by these two lists; a tool declared both allowed and disallowed is a real mis-scope that today ships silently. Modeled the check on the **existing 3.5.0 `requires_*`/`fallback_for_*` visibility-overlap ERROR** (same "cross-field rule" block, same function) rather than a new mechanism — one consistent pattern for "two fields that must not contradict." Reused `parse_allowed_tools()` over a second parser so both token lists normalize identically (a divergent parser would let an overlap slip through on a formatting difference).

## Layer(s) touched · **new ERROR condition (reviewer note)**

`scripts/validate-skills-schema.py` frontmatter validation. This introduces a **new blocking ERROR** for a self-contradictory optional field — flagging it explicitly for review even though it is autonomous-OK class.

## Governance

**Additive spec-compliance implementation of already-documented behavior** (repo CLAUDE.md § Optional frontmatter 3.7.0 + `000-docs/681`), **NOT architectural**: `ALWAYS_REQUIRED`, the tier model, and required-field error-vs-warning semantics are all unchanged. `disallowed-tools` stays **optional**; the new errors fire only when the field is present and either malformed or self-contradictory. Autonomous-OK per `SCHEMA_CHANGELOG.md` NON-NEGOTIABLE #6 (parallel to how 3.8.0 made `allowed-tools` entry validation real).

## Verification & evidence

```
$ python3 -m pytest tests/test_validate_skills_schema_frontmatter.py -q
37 passed in 0.15s
```
- 6 new regression tests: overlap-is-error (standard **and** marketplace tiers), disjoint-is-clean, shared-normalization overlap (space form vs list form), disallowed-without-allowed guarded-clean, bad-shape error.
- **Corpus safety:** all 26 in-corpus SKILL.md files that declare `disallowed-tools` (the penetration-tester pack — defense-in-depth denials of tools *not* in their `allowed-tools`) were re-validated → **zero** newly fail on the overlap or shape checks. No existing skill is broken.

## Risk assessment

Low. The new errors cannot fire on any current corpus skill (verified). For external contributors, a genuinely contradictory `allowed`/`disallowed` pair now fails fast with a clear message instead of shipping a mis-scoped permission set — the intended effect. No public-API/contract change; `disallowed-tools` remains optional.

## Operational impact

None. No deps, env, migrations, or secrets. Validator output changes only for skills that are already misconfigured.

## Follow-up & rollback

Rollback = revert this commit (validator falls back to recognizing `disallowed-tools` without checking it). No data or state to migrate. `claude-41c2.2` closes on merge.

Refs `claude-41c2.2`.

- Jeremy Longshore
intentsolutions.io