### PR TITLE
fix(freshie): make batch-remediate --fix-compatible-with actually work (juoz.6) [skip auto-bump]

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -109,10 +109,11 @@ jobs:
       # Dolt history) and the Freshie Dolt exporter's dialect translation. Both
       # are security/data-critical, stdlib-only, and were previously runnable but
       # ungated. safety-eval.yaml cites tests/test_sql_classifier.py as this gate.
-      - name: Test Dolt safety suites (SQL classifier + Freshie exporter)
+      - name: Test Freshie + Dolt tooling suites (classifier, exporter, remediator)
         run: |
           python3 -m unittest tests.test_sql_classifier -v
           python3 -m unittest tests.test_dolt_sync -v
+          python3 -m unittest tests.test_batch_remediate_compat -v
 
       # Reject PRs that reformat .claude-plugin/marketplace.extended.json beyond
       # the line budget implied by added/modified entries. Prevents prettier or

--- a/freshie/scripts/batch-remediate.py
+++ b/freshie/scripts/batch-remediate.py
@@ -17,7 +17,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import shutil
@@ -30,7 +29,7 @@ from typing import NamedTuple
 # Configuration
 # ---------------------------------------------------------------------------
 
-REPO_ROOT = Path("/home/jeremy/000-projects/claude-code-plugins")
+REPO_ROOT = Path(__file__).resolve().parents[2]  # worktree-safe (freshie/scripts/ -> repo root)
 DB_PATH = REPO_ROOT / "freshie" / "inventory.sqlite"
 PLUGINS_ROOT = REPO_ROOT / "plugins"
 
@@ -356,7 +355,13 @@ def add_tags_to_file(file_path: Path, dry_run: bool) -> tuple[bool, str | None]:
 
 def add_compatible_with_to_file(file_path: Path, dry_run: bool) -> tuple[bool, str | None]:
     """
-    Add `compatible-with: claude-code` if the field is missing.
+    Add the modern `compatibility` free-text field if it is missing.
+
+    `compatibility` (free-text) is the canonical required field; `compatible-with`
+    (CSV list) is the deprecated IS-invented predecessor — see the validator's
+    DEPRECATED_FIELDS and `scripts/batch-remediate.py --migrate-compatible-with`.
+    Skip when EITHER field is already present: a file that still carries the
+    legacy `compatible-with` is left for the migrate tool, not double-stamped.
     """
     try:
         content = file_path.read_text(encoding="utf-8")
@@ -369,10 +374,10 @@ def add_compatible_with_to_file(file_path: Path, dry_run: bool) -> tuple[bool, s
 
     opening, fm_text, rest = parts
 
-    if _has_field(fm_text, "compatible-with"):
+    if _has_field(fm_text, "compatibility") or _has_field(fm_text, "compatible-with"):
         return False, None
 
-    compat_line = "compatible-with: claude-code\n"
+    compat_line = "compatibility: Designed for Claude Code\n"
     new_fm = _insert_field_line(fm_text, compat_line)
     new_content = _reconstruct(opening, new_fm, rest)
 
@@ -433,16 +438,35 @@ def _open_db() -> sqlite3.Connection | None:
         return None
 
 
+def _skill_md_from_row(path_str: str) -> Path:
+    """Resolve a `skill_compliance.skill_path` DB value to the SKILL.md file.
+
+    The DB stores the skill *directory* (repo-relative), e.g.
+    `plugins/.../skills/foo` — not the file. Left as-is, `Path(row).read_text()`
+    hits the directory and raises IsADirectoryError, which the fixers count as a
+    skip (why the DB-mode fixers silently `Added: 0`). Join `/SKILL.md` and make
+    it absolute against REPO_ROOT so it resolves regardless of the cwd."""
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    if p.is_dir():
+        p = p / "SKILL.md"
+    return p
+
+
 def get_skills_missing_tags(db: sqlite3.Connection) -> list[Path]:
     cur = db.cursor()
     cur.execute("SELECT skill_path FROM skill_compliance WHERE missing_fields LIKE '%tags%'")
-    return [Path(row[0]) for row in cur.fetchall()]
+    return [_skill_md_from_row(row[0]) for row in cur.fetchall()]
 
 
 def get_skills_missing_compatible_with(db: sqlite3.Connection) -> list[Path]:
+    # The canonical required field is `compatibility` (free-text); the DB records
+    # it in missing_fields under that name. The old query matched the DEPRECATED
+    # `compatible-with`, which never appears -> a silent 0-row no-op.
     cur = db.cursor()
-    cur.execute("SELECT skill_path FROM skill_compliance WHERE missing_fields LIKE '%compatible-with%'")
-    return [Path(row[0]) for row in cur.fetchall()]
+    cur.execute("SELECT skill_path FROM skill_compliance WHERE missing_fields LIKE '%compatibility%'")
+    return [_skill_md_from_row(row[0]) for row in cur.fetchall()]
 
 
 def get_agents_with_invalid_fields(db: sqlite3.Connection) -> list[Path]:
@@ -481,7 +505,13 @@ def _skills_missing_tags_from_fs() -> list[Path]:
 
 
 def _skills_missing_compat_from_fs() -> list[Path]:
-    return [p for p in _walk_skill_files() if not _file_has_field(p, "compatible-with")]
+    # Select files that have NEITHER the modern `compatibility` nor the legacy
+    # `compatible-with`; without the `compatibility` clause the walk re-selected
+    # ~2,857 already-compliant files and stamped a second, deprecated field.
+    return [
+        p for p in _walk_skill_files()
+        if not _file_has_field(p, "compatibility") and not _file_has_field(p, "compatible-with")
+    ]
 
 
 def _agents_with_invalid_fields_from_fs() -> list[Path]:
@@ -574,7 +604,7 @@ def run_fix_compatible_with(paths: list[Path], dry_run: bool, verbose: bool) -> 
             added += 1
             if verbose:
                 action = "DRY-RUN" if dry_run else "FIXED"
-                print(f"  {action} compatible-with: {p}")
+                print(f"  {action} compatibility: {p}")
         else:
             skipped += 1
     return added, skipped, errors
@@ -634,7 +664,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--fix-compatible-with",
         action="store_true",
-        help="Add missing compatible-with: claude-code to SKILL.md files.",
+        help="Add the missing `compatibility` free-text field to SKILL.md files.",
     )
     parser.add_argument(
         "--fix-agents",
@@ -721,13 +751,13 @@ def main() -> int:
 
     # --- Fix compatible-with ---
     if fix_compat:
-        print("[2/3] Fixing missing compatible-with...")
+        print("[2/3] Fixing missing compatibility...")
         if use_db and db is not None:
             compat_paths = get_skills_missing_compatible_with(db)
-            print(f"      DB reports {len(compat_paths)} skills missing compatible-with.")
+            print(f"      DB reports {len(compat_paths)} skills missing compatibility.")
         else:
             compat_paths = _skills_missing_compat_from_fs()
-            print(f"      Filesystem walk found {len(compat_paths)} skills missing compatible-with.")
+            print(f"      Filesystem walk found {len(compat_paths)} skills missing compatibility.")
 
         compat_paths = _filter_by_pack(compat_paths, args.pack)
         added, skipped, errors = run_fix_compatible_with(compat_paths, dry_run, args.verbose)
@@ -761,7 +791,7 @@ def main() -> int:
     # --- Summary ---
     print("=== BATCH REMEDIATION REPORT ===")
     print(f"Tags added:                {total_tags_added:>6,}")
-    print(f"Compatible-with added:     {total_compat_added:>6,}")
+    print(f"Compatibility added:       {total_compat_added:>6,}")
     print(f"Agent fields removed:      {total_agent_fields_removed:>6,}")
     print(f"Files modified:            {total_files_modified:>6,}")
     print(f"Files skipped (compliant): {total_skipped:>6,}")

--- a/tests/test_batch_remediate_compat.py
+++ b/tests/test_batch_remediate_compat.py
@@ -1,0 +1,175 @@
+"""Regression tests for freshie/scripts/batch-remediate.py --fix-compatible-with
+(bead claude-juoz.6).
+
+Four defects fixed and pinned here:
+  1. DB query matched the DEPRECATED `compatible-with` (never in missing_fields)
+     instead of the canonical `compatibility` -> a silent 0-row no-op in DB mode.
+  2. The writer emitted the deprecated `compatible-with: claude-code` field.
+  3. The fs-walk selector only checked `compatible-with`, so ~2,857 already-
+     compliant files were re-selected and double-stamped.
+  4. DB `skill_compliance.skill_path` is a skill DIRECTORY, not the SKILL.md file;
+     `Path(row).read_text()` hit the directory (IsADirectoryError -> counted as a
+     skip), so even the tags fixer added nothing in DB mode.
+
+Run: python3 -m unittest tests.test_batch_remediate_compat -v
+
+Fully self-contained: builds a tmp skill tree + a tmp sqlite `skill_compliance`,
+monkeypatches the module's REPO_ROOT / PLUGINS_ROOT / DB_PATH at that tree, and
+never touches the real repo or freshie/inventory.sqlite.
+"""
+
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "freshie" / "scripts" / "batch-remediate.py"
+_spec = importlib.util.spec_from_file_location("batch_remediate", SCRIPT)
+br = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(br)
+
+MISSING = """\
+---
+name: needs-compat
+description: A skill that is missing the compatibility field entirely.
+tags: [test]
+---
+# Body
+"""
+
+HAS_COMPAT = """\
+---
+name: has-compat
+description: A skill that already declares the modern compatibility field.
+compatibility: Designed for Claude Code
+tags: [test]
+---
+# Body
+"""
+
+HAS_LEGACY = """\
+---
+name: has-legacy
+description: A skill that still carries the deprecated compatible-with field.
+compatible-with: claude-code
+tags: [test]
+---
+# Body
+"""
+
+
+class BatchRemediateCompatTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.root = root
+        plugins = root / "plugins"
+        # skill directories (the DB stores the DIRECTORY, not the SKILL.md path)
+        self.missing_dir = plugins / "cat" / "p" / "skills" / "needs-compat"
+        self.compat_dir = plugins / "cat" / "p" / "skills" / "has-compat"
+        self.legacy_dir = plugins / "cat" / "p" / "skills" / "has-legacy"
+        for d, body in (
+            (self.missing_dir, MISSING),
+            (self.compat_dir, HAS_COMPAT),
+            (self.legacy_dir, HAS_LEGACY),
+        ):
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(body, encoding="utf-8")
+
+        # tmp DB with the same shape the real skill_compliance uses: skill_path =
+        # a repo-relative DIRECTORY, missing_fields = a JSON list string.
+        self.db_path = root / "inv.sqlite"
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE skill_compliance (skill_path TEXT, missing_fields TEXT)")
+        conn.execute(
+            "INSERT INTO skill_compliance VALUES (?, ?)",
+            (str(self.missing_dir.relative_to(root)), '["compatibility", "tags"]'),
+        )
+        conn.execute(
+            "INSERT INTO skill_compliance VALUES (?, ?)",
+            (str(self.compat_dir.relative_to(root)), '["author"]'),
+        )
+        conn.commit()
+        conn.close()
+
+        # Point the module at the tmp tree. Functions read these module globals
+        # at call time, so patching the attributes is sufficient.
+        self._orig = {k: getattr(br, k) for k in ("REPO_ROOT", "PLUGINS_ROOT", "DB_PATH")}
+        br.REPO_ROOT = root
+        br.PLUGINS_ROOT = plugins
+        br.DB_PATH = self.db_path
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            setattr(br, k, v)
+        self._tmp.cleanup()
+
+    # ── defect 4: directory-row -> SKILL.md resolver ────────────────────
+    def test_skill_md_from_row_resolves_directory_to_file(self):
+        rel = str(self.missing_dir.relative_to(self.root))
+        resolved = br._skill_md_from_row(rel)
+        self.assertEqual(resolved, self.missing_dir / "SKILL.md")
+        self.assertTrue(resolved.is_file())
+
+    # ── defect 1: DB query uses `compatibility`, resolver returns the file ──
+    def test_db_query_finds_missing_compatibility_as_skill_md(self):
+        conn = sqlite3.connect(self.db_path)
+        paths = br.get_skills_missing_compatible_with(conn)
+        conn.close()
+        # only the row whose missing_fields contains 'compatibility', resolved to
+        # the actual SKILL.md file (not the bare directory).
+        self.assertEqual(paths, [self.missing_dir / "SKILL.md"])
+
+    def test_old_deprecated_field_name_would_have_matched_nothing(self):
+        # Proves the original bug: the DB never records the deprecated name.
+        conn = sqlite3.connect(self.db_path)
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM skill_compliance WHERE missing_fields LIKE '%compatible-with%'"
+        ).fetchone()[0]
+        conn.close()
+        self.assertEqual(rows, 0)
+
+    # ── defect 2: writes the modern field, never the deprecated one ─────
+    def test_writes_modern_compatibility_field(self):
+        changed, err = br.add_compatible_with_to_file(self.missing_dir / "SKILL.md", dry_run=False)
+        self.assertTrue(changed)
+        self.assertIsNone(err)
+        text = (self.missing_dir / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("compatibility: Designed for Claude Code", text)
+        self.assertNotIn("compatible-with:", text)
+
+    def test_dry_run_does_not_write(self):
+        before = (self.missing_dir / "SKILL.md").read_text(encoding="utf-8")
+        changed, _ = br.add_compatible_with_to_file(self.missing_dir / "SKILL.md", dry_run=True)
+        self.assertTrue(changed)
+        self.assertEqual((self.missing_dir / "SKILL.md").read_text(encoding="utf-8"), before)
+
+    # ── defect 3: no double-stamping ────────────────────────────────────
+    def test_skips_file_that_already_has_compatibility(self):
+        before = (self.compat_dir / "SKILL.md").read_text(encoding="utf-8")
+        changed, err = br.add_compatible_with_to_file(self.compat_dir / "SKILL.md", dry_run=False)
+        self.assertFalse(changed)
+        self.assertIsNone(err)
+        self.assertEqual((self.compat_dir / "SKILL.md").read_text(encoding="utf-8"), before)
+
+    def test_skips_file_with_legacy_compatible_with(self):
+        # A file still carrying the deprecated field is left for the migrate tool,
+        # not double-stamped with the modern field.
+        before = (self.legacy_dir / "SKILL.md").read_text(encoding="utf-8")
+        changed, err = br.add_compatible_with_to_file(self.legacy_dir / "SKILL.md", dry_run=False)
+        self.assertFalse(changed)
+        self.assertIsNone(err)
+        after = (self.legacy_dir / "SKILL.md").read_text(encoding="utf-8")
+        self.assertEqual(after, before)
+        self.assertNotIn("compatibility:", after)
+
+    def test_fs_walk_excludes_files_that_already_have_either_field(self):
+        found = set(br._skills_missing_compat_from_fs())
+        self.assertIn(self.missing_dir / "SKILL.md", found)
+        self.assertNotIn(self.compat_dir / "SKILL.md", found)   # has compatibility
+        self.assertNotIn(self.legacy_dir / "SKILL.md", found)   # has compatible-with
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`freshie/scripts/batch-remediate.py --fix-compatible-with` was a **silent no-op in DB mode** and a **deprecated-field writer in fs-walk mode**. Four defects, all fixed. The canonical required frontmatter field is `compatibility` (free-text); `compatible-with` is the deprecated IS-invented predecessor (validator `DEPRECATED_FIELDS`).

1. **DB query** matched `missing_fields LIKE '%compatible-with%'` — a name the DB never records → 0 rows → silent no-op. Now `%compatibility%`. Empirically **0 → 2460 rows**.
2. **Writer** emitted `compatible-with: claude-code` (deprecated) → now writes `compatibility: Designed for Claude Code`, and skips when **either** field is already present (a legacy `compatible-with` file is left for `--migrate-compatible-with`, never double-stamped).
3. **fs-walk selector** only excluded `compatible-with`, so ~2,857 already-compliant files were re-selected and would get a second deprecated field → now excludes files with either field.
4. **Shared latent bug:** DB `skill_compliance.skill_path` is a skill *directory*, not the SKILL.md file, so `Path(row).read_text()` hit the directory (`IsADirectoryError` → counted as a skip) — why every DB-mode fixer, including `--fix-tags`, added **0**. New `_skill_md_from_row()` joins `/SKILL.md` and anchors to `REPO_ROOT`.

Also: `REPO_ROOT` is now `__file__`-relative (worktree-safe, matching last session's `rebuild-inventory.py` fix) since the new resolver depends on it; removed a pre-existing dead `import json`; corrected user-facing strings (help, progress, report label).

## Why · decision rationale

**Skip-on-either-field over skip-on-modern-only:** prevents double-stamping in both directions and keeps a clean division of labor with `--migrate-compatible-with` (which translates legacy→modern) instead of the two tools fighting over the same files. Today the chain is actively harmful — the freshie tool writes the deprecated field and the migrate tool then has to undo it.

## Layer(s) touched

Freshie remediation tooling only (`freshie/scripts/batch-remediate.py`) + its new test + one CI wiring line. No validator, catalog, or plugin change. This PR fixes the **tool**; it does not run the mass remediation (that's `claude-juoz.5`, a separate reviewed change).

## Verification & evidence

```
$ python3 -m unittest tests.test_batch_remediate_compat
Ran 8 tests in 0.16s
OK

$ python3 freshie/scripts/batch-remediate.py --fix-compatible-with --dry-run
[2/3] Fixing missing compatibility...
      DB reports 2460 skills missing compatibility.    # was: 0 missing compatible-with
      Added: 866  Skipped: 1594  Errors: 0             # was: Added: 0
```
- 8 new tests (`tests/test_batch_remediate_compat.py`): directory→SKILL.md resolver, DB query returns the resolved file, writes-modern-not-deprecated, dry-run writes nothing, no-double-stamp when `compatibility` OR `compatible-with` present, fs-walk exclusion. Self-contained (tmp tree + tmp sqlite; never touches the real repo or `inventory.sqlite`). **Wired into `validate-plugins.yml`** (flows into `ci-required`).
- `ruff check` clean; working tree confirmed unchanged after the dry-run (no accidental writes).

## Risk assessment

Low. The tool defaults to dry-run (writes only with `--execute`); this PR does not execute a mass remediation. The behavior change is: DB mode now finds real work and writes the *correct* field. No public API/contract; internal tooling only.

## Operational impact

None at merge. When later run with `--execute` (under `claude-juoz.5`), it will add `compatibility` to skills genuinely missing it — the intended remediation.

## Follow-up & deferred

- `claude-dgpl` (filed): the tags half of the 500 top-level numbered skills needs a separate `infer_tags`/`_category_from_path`/`TAG_MAP` generalization (those skills live under `skills/`, outside `plugins/`, so category inference returns `None`). This PR unblocks the **compatibility** half of `claude-juoz.5` for the full 530-skill cohort.

## Rollback

Revert this commit; the tool returns to its prior (broken) behavior. No data/state migration.

Refs `claude-juoz.6`.

- Jeremy Longshore
intentsolutions.io