### PR TITLE
fix(ci): make auto-bump idempotent + prescreen fail-closed (62ye.5, 62ye.4) [skip auto-bump]

### DIFF
--- a/.github/workflows/auto-bump-test.yml
+++ b/.github/workflows/auto-bump-test.yml
@@ -1,0 +1,46 @@
+name: Auto-bump idempotency (unit corpus)
+
+# Unit corpus for the auto-bump decision engine (scripts/auto-bump-changed-plugins.mjs).
+# Before blocker 62ye.5, the workflow re-derived a plugin's patch bump from the
+# CURRENT local version on every PR `synchronize` and only checked "did a source
+# file change vs base" (true for the whole PR), so it walked the version forward
+# endlessly — each bump pushing a checkless GITHUB_TOKEN head that left the PR
+# BLOCKED on unreported required contexts. bumpDecision() keys the bump on the
+# version at the PR base, so a second run is a no-op. This corpus pins that
+# contract (including the new-plugin case, where the base version is null).
+#
+# Path-filtered + advisory, matching the sibling script-unit workflows
+# (sync-lockfile-test.yml, jrig-proofs-test.yml). Refs claude-62ye.5.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/auto-bump-changed-plugins.mjs'
+      - 'scripts/auto-bump-changed-plugins.test.mjs'
+      - '.github/workflows/auto-bump-test.yml'
+
+# Read-only — pure unit tests, no writes.
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-bump-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-bump-test:
+    name: auto-bump idempotency unit corpus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Zero-install: the module and its tests use only node built-ins
+      # (node:test, node:assert) by design.
+      - name: Auto-bump decision unit corpus
+        run: node --test scripts/auto-bump-changed-plugins.test.mjs

--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -158,9 +158,15 @@ jobs:
           # safety). The validator is pure read — no exec, no install.
           install -m 0644 ../base/scripts/validate-skills-schema.py \
             ./scripts/.prescreen-validator.py
+          # A non-zero exit is NORMAL (marketplace-tier errors make it exit
+          # non-zero), so we must not abort here — but capture the code instead
+          # of blindly `|| true`-swallowing it, so a genuine crash is visible in
+          # the log and the empty-results guard below can fail closed.
+          VALIDATOR_EXIT=0
           python3 scripts/.prescreen-validator.py --marketplace --json \
-            > /tmp/validator-results.json 2>/tmp/validator.log || true
+            > /tmp/validator-results.json 2>/tmp/validator.log || VALIDATOR_EXIT=$?
           rm -f ./scripts/.prescreen-validator.py
+          echo "Validator exit: $VALIDATOR_EXIT" >&2
           echo "Validator stderr/info:" >&2
           tail -50 /tmp/validator.log >&2 || true
           # Filter to only changed plugin paths (if any). Otherwise we pass
@@ -168,9 +174,25 @@ jobs:
           # PRs that don't touch plugin dirs.
           python3 - <<'PY'
           import json, pathlib
-          all_results = json.loads(pathlib.Path('/tmp/validator-results.json').read_text() or '[]')
+          raw = pathlib.Path('/tmp/validator-results.json').read_text()
+          try:
+              all_results = json.loads(raw or '[]')
+          except json.JSONDecodeError:
+              all_results = []
           changed_lines = pathlib.Path('/tmp/changed-plugins.txt').read_text().splitlines()
           changed = [c.strip() for c in changed_lines if c.strip()]
+          # Fail-closed guard (blocker 62ye.4). The validator sweeps the WHOLE
+          # corpus, so an empty/unparseable result set means it crashed (or the
+          # output was truncated) — NOT a clean PR. Without this, a plugin-touching
+          # PR whose validator run died would filter to [] and the classifier would
+          # emit a silent PASS ("no plugin paths matched"). Append an internal-error
+          # signal (the Classify step concatenates /tmp/diff-step-signals.txt) so the
+          # verdict surfaces the failure instead of a false PASS.
+          if not all_results:
+              with pathlib.Path('/tmp/diff-step-signals.txt').open('a') as fh:
+                  fh.write('prescreen-internal-error: validator sweep produced 0 results '
+                           '(crash or truncated output; see /tmp/validator.log)\n')
+              print('::error::pr-prescreen internal: validator produced no results — failing closed')
           # If the PR doesn't touch any plugins/ dir, we have nothing to
           # pre-screen. Emit an empty list — the classifier reports PASS
           # with "no plugin paths matched", which is the correct signal.

--- a/scripts/auto-bump-changed-plugins.mjs
+++ b/scripts/auto-bump-changed-plugins.mjs
@@ -42,11 +42,12 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const SCOPE = '@intentsolutionsio/';
 
-function parseVersion(v) {
+export function parseVersion(v) {
   if (!v || typeof v !== 'string') return null;
   const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
   if (!m) return null;
@@ -59,6 +60,50 @@ function fmtVersion(p) {
 
 function bumpPatch(v) {
   return { major: v.major, minor: v.minor, patch: v.patch + 1 };
+}
+
+// Compare two parsed versions. >0 if a>b, 0 if equal, <0 if a<b.
+export function compareVersion(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+// Idempotency decision (blocker 62ye.5). Given a plugin's declared (local)
+// version and its version on the PR base (null when the plugin is absent on
+// base), decide whether to bump. Returns { bump: true } or { skip: reason }.
+// Pure — no git, no fs — so the loop-prevention logic is unit-testable.
+export function bumpDecision(declared, base) {
+  if (!base) {
+    // New plugin (absent on base): initial version is author-set and
+    // publish-changed-packages handles the first release. Bumping it would also
+    // loop forever — base stays null on every re-run.
+    return { skip: 'new plugin (absent on base) — initial version left as authored' };
+  }
+  if (compareVersion(declared, base) > 0) {
+    // Already ahead of base → a prior auto-bump run on this PR bumped it (or the
+    // author set a deliberate minor/major bump, which we must not walk further).
+    return {
+      skip: `already bumped in this PR (base ${fmtVersion(base)} → local ${fmtVersion(declared)})`,
+    };
+  }
+  return { bump: true };
+}
+
+// The plugin's version on the PR base ref, or null when the package.json is
+// absent there (a brand-new plugin) or unparseable. Argv-form git (shell:false);
+// baseRef is already validated by SAFE_REF_RE in detectBaseRef and dir comes
+// from pluginDirFor (repo-relative), so nothing untrusted reaches a shell.
+function baseVersion(baseRef, dir) {
+  const res = spawnSync('git', ['show', `${baseRef}:${dir}/package.json`], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    shell: false,
+  });
+  if (res.status !== 0) return null;
+  try {
+    return parseVersion(JSON.parse(res.stdout).version);
+  } catch {
+    return null;
+  }
 }
 
 // Map a changed file to its plugin/package directory, or null if it's not
@@ -204,6 +249,17 @@ function main() {
       });
       continue;
     }
+    // Idempotency across re-runs (blocker 62ye.5). Every `synchronize` event
+    // re-runs this workflow, and the triggering source file is still in the
+    // PR's diff, so without a base-version check the plugin gets re-bumped each
+    // time — 0.2.1 → 0.2.2 → 0.2.3 … — and each bump pushes a GITHUB_TOKEN head
+    // that fires no checks, leaving the PR BLOCKED on unreported required
+    // contexts. Decision is keyed on the plugin's version at the PR base.
+    const decision = bumpDecision(declared, baseVersion(baseRef, dir));
+    if (decision.skip) {
+      skips.push({ dir, reason: decision.skip });
+      continue;
+    }
     const next = bumpPatch(declared);
     bumps.push({
       dir,
@@ -247,9 +303,13 @@ function main() {
   console.log(`no-op:  ${skips.length}`);
 }
 
-try {
-  main();
-} catch (err) {
-  console.error(err.message || err);
-  process.exit(1);
+// Run only when invoked directly (`node scripts/auto-bump-changed-plugins.mjs`),
+// not when imported by the test suite — importing must have no side effects.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message || err);
+    process.exit(1);
+  }
 }

--- a/scripts/auto-bump-changed-plugins.test.mjs
+++ b/scripts/auto-bump-changed-plugins.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * auto-bump-changed-plugins.test.mjs — the idempotency contract (blocker 62ye.5).
+ *
+ * The auto-bump workflow re-runs on every PR `synchronize`. Before the fix it
+ * re-derived the bump from the CURRENT local version and only checked "did a
+ * source file change vs base" — which stays true for the whole PR — so it
+ * walked the version forward on every run (0.2.1 → 0.2.2 → …), each bump pushing
+ * a GITHUB_TOKEN head that fires no checks and leaves the PR BLOCKED on
+ * unreported required contexts. bumpDecision() keys the decision on the version
+ * at the PR base, making a second run a no-op.
+ *
+ * Run: node --test scripts/auto-bump-changed-plugins.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseVersion, compareVersion, bumpDecision } from './auto-bump-changed-plugins.mjs';
+
+const v = (s) => parseVersion(s);
+
+test('compareVersion orders by major, then minor, then patch', () => {
+  assert.ok(compareVersion(v('1.0.0'), v('0.9.9')) > 0);
+  assert.ok(compareVersion(v('0.2.0'), v('0.1.9')) > 0);
+  assert.ok(compareVersion(v('0.2.1'), v('0.2.0')) > 0);
+  assert.equal(compareVersion(v('1.2.3'), v('1.2.3')), 0);
+  assert.ok(compareVersion(v('1.2.3'), v('1.2.4')) < 0);
+});
+
+test('at base version → bump (first run on the PR)', () => {
+  const d = bumpDecision(v('0.2.0'), v('0.2.0'));
+  assert.equal(d.bump, true);
+  assert.equal(d.skip, undefined);
+});
+
+test('already ahead of base → skip (idempotent: the loop-stopper)', () => {
+  // Second synchronize event: local is 0.2.1, base is still 0.2.0.
+  const d = bumpDecision(v('0.2.1'), v('0.2.0'));
+  assert.ok(d.skip);
+  assert.match(d.skip, /already bumped in this PR/);
+  assert.equal(d.bump, undefined);
+});
+
+test('deliberate manual minor/major bump is not walked further', () => {
+  // Author set 0.3.0 by hand; base is 0.2.5 → treated as "already ahead", skip.
+  const d = bumpDecision(v('0.3.0'), v('0.2.5'));
+  assert.ok(d.skip);
+});
+
+test('new plugin (absent on base) → skip, never bumped', () => {
+  // base=null means the package.json does not exist on the PR base. Bumping it
+  // would loop forever (base stays null every run), so it must skip.
+  const d = bumpDecision(v('0.1.0'), null);
+  assert.ok(d.skip);
+  assert.match(d.skip, /new plugin/);
+  assert.equal(d.bump, undefined);
+});
+
+test('a full two-run sequence converges (bump once, then no-op)', () => {
+  const base = v('0.4.2');
+  // Run 1: local == base → bump. Simulate applying it.
+  const run1 = bumpDecision(v('0.4.2'), base);
+  assert.equal(run1.bump, true);
+  const afterBump = v('0.4.3');
+  // Run 2: local is now ahead of the unchanged base → skip. No endless walk.
+  const run2 = bumpDecision(afterBump, base);
+  assert.ok(run2.skip);
+});


### PR DESCRIPTION
## What

Two external-sync gate defects from the 2026-07-07 quality-pipeline audit (epic `claude-62ye`).

**62ye.5 — auto-bump re-bumped on every `synchronize` (the checkless-head loop).** `scripts/auto-bump-changed-plugins.mjs` derived a plugin's patch bump from the **current local** version and gated only on "a source file changed vs base" — true for the whole life of the PR. So each `synchronize` event re-bumped (0.2.1 → 0.2.2 → …), and because the push uses `GITHUB_TOKEN` (which never triggers workflows), each bot head had **zero check runs** and the PR sat `BLOCKED` on unreported required contexts (seen on #989/#990).

**62ye.4 — prescreen could silently PASS a plugin PR on a validator crash.** `pr-prescreen.yml` ran the validator with `... || true`, swallowing a crash into an empty results file; the filter produced `[]` and the classifier emitted a silent PASS ("no plugin paths matched"). The scan-root bug behind the *original* false-PASS is already fixed (#980); this closes the residual crash-swallow class.

## How it works

**62ye.5** — new pure, exported `bumpDecision(declared, base)` keyed on the plugin's version **at the PR base**:
- `base` null (plugin absent on base = brand-new) → **skip** (initial version is author-set; publish handles it; bumping would also loop since base stays null every run);
- `declared > base` → **skip** (a prior run bumped it, or the author set a deliberate minor/major bump we must not walk);
- `declared == base` → **bump once**.

**62ye.4** — capture the validator exit for the log (a non-zero exit is *normal* — marketplace errors — so it can't abort the step), and **fail closed when the whole-corpus sweep returns 0 results** (impossible unless it crashed) by appending a `prescreen-internal-error` signal the Classify step surfaces.

## Decision rationale

Extracted the bump logic into a **pure exported function** (+ exported `parseVersion`/`compareVersion`) and guarded `main()` behind an `import.meta.url` check so the module imports side-effect-free — chose this over a subprocess/temp-git integration test because the loop-prevention logic *is* the whole bug and is now directly unit-tested.

## Layer(s) touched · safety

CI automation only. **62ye.4 stays within `pull_request_target` safety** — it reads only computed values + base-authored validator output, and executes no PR-authored code (the base validator is copied into the PR tree and run from there, per #980).

## Verification & evidence

```
$ node --test scripts/auto-bump-changed-plugins.test.mjs
# tests 6   # pass 6   # fail 0
```
6 cases: compareVersion ordering; at-base bumps; ahead-of-base skips; manual minor/major not walked; new-plugin skips; a two-run sequence converges. New advisory workflow `auto-bump-test.yml` (path-filtered, mirrors `sync-lockfile-test.yml`) runs it in CI.
- Module verified importable side-effect-free **and** still runnable directly (`BASE_REF=origin/main node … --dry-run`).
- `pr-prescreen.yml` + `auto-bump-test.yml` parse as YAML; embedded prescreen Python parses; `actionlint` clean; `eslint` clean.

## Risk assessment

Low. `auto-bump` is not in `ci-required` (advisory automation) — the change only makes it stop over-bumping. `prescreen` is advisory (never a required context) — the guard can only turn a silent PASS into a visible internal-error, never block a merge. No public API/contract change.

## Operational impact

None. No deps/env/secrets/migrations. Triggers unchanged (`auto-bump` stays on `pull_request`, never `pull_request_target`).

## Follow-up & deferred

Remaining `claude-62ye` children: `.6` (unanchored-include lint), `.3` (waiver one-shot), `.2` (REFUSE per-source quarantine) — separate PRs.

## Rollback

Revert the commit; both files return to prior behavior. No state/data migration.

Refs `claude-62ye.5`, `claude-62ye.4`.

- Jeremy Longshore
intentsolutions.io