### PR TITLE
fix(sync): unanchored-include lint + one-shot source-change waiver (62ye.6, 62ye.3) [skip auto-bump]

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -27,12 +27,12 @@ plugins/saas-packs/**/skills/**/SKILL.md:pipe-to-shell  documented vendor-CLI in
 plugins/mcp/servicegraph/.mcp.json:mcp-remote  the plugin IS an agent-skills front-end to the remote ServiceGraph MCP server (https://mcp.servicegraph.co, plain HTTP transport, no embedded credentials) — reviewed 2026-07-07, curated mirror pinned at fork SHA df4648a4
 plugins/mcp/servicegraph/README.md:mcp-remote  same remote MCP endpoint documented as the setup step in the upstream README — reviewed 2026-07-07 with the .mcp.json above
 
-# ── TEMPORARY per-PR source-vetting sign-off. sources-change-unscanned is a
-# per-review gate; a persistent line here would auto-waive FUTURE source-list
-# changes too, so each sources PR swaps this line for its own scoped reason and
-# the one-shot-waiver fix (#985 defect 3) retires the convention entirely.
-sources.yaml:sources-change-unscanned  2026-07-10 hyperflow unfreeze PR reviewed: drops curated freeze after upstream merged the frontmatter uplift (Mohammed-Abdelhady/hyperflow#7, HEAD be6ae2d3) — field-parity evidence gate passed (0 regressions across 13 shared skills; amplify/scope/spec removal is upstream-intended merge into plan; unicode hygiene --strict + payload scan clean over all 87 mirror-scope files); include list gains agents/** + scripts/** (v5.x skills dispatch agents/*.md and run scripts/*); relock pins upstream HEAD hashes. No source added or repointed
-sources.lock.json:sources-change-unscanned  2026-07-10 same hyperflow unfreeze PR: the lock diff is the --relock re-baseline itself (hyperflow block only, verified by JSON key diff) pinning upstream HEAD be6ae2d3 hashes after the field-parity + hygiene review above
+# ── sources-change-unscanned is a ONE-SHOT waiver (enforced in code by
+# honoredWaivers, blocker 62ye.3 / #985 defect 3): a line is honored ONLY in the
+# PR whose diff adds it, so it can never persistently waive future source-list
+# changes. Do NOT leave a standing line here — after its PR merges it is inert
+# (the diff-added check ignores it) and only misleads. Each sources PR that needs
+# the sign-off adds its own `sources.yaml:sources-change-unscanned  <reason>`.
 
 # ── hyperflow orchestrator skill: upstream web-research feature. ──
 plugins/ai-agency/hyperflow/skills/hyperflow/SKILL.md:allowed-tools-network  upstream v5.8.x added WebFetch/WebSearch to the orchestrator skill for its web-research feature (skills/hyperflow/web-research.md); mirror content hand-reviewed 2026-07-10 (evidence gate on #1008 + the be6ae2d3->eae6e34c5 delta review) — external mirror, upstream's design, no credential surface

--- a/scripts/scan-synced-content.mjs
+++ b/scripts/scan-synced-content.mjs
@@ -667,7 +667,9 @@ export function parseAllowlist(text) {
     if (!m) continue; // malformed (e.g. missing reason) → ignored, not honored
     const [, pathGlob, rule, reason] = m;
     if (!reason.trim()) continue;
-    out.push({ pathGlob, rule, reason: reason.trim() });
+    // `raw` (the trimmed source line) lets the one-shot waiver check (blocker
+    // 62ye.3) compare a waiver against the lines a PR actually added.
+    out.push({ pathGlob, rule, reason: reason.trim(), raw: line });
   }
   return out;
 }
@@ -690,6 +692,24 @@ export function isWaived(waivers, filePath, ruleId, grade) {
     if (w.pathGlob === filePath || globMatch(w.pathGlob, filePath)) return w.reason;
   }
   return null;
+}
+
+// Rules whose waiver is ONE-SHOT: honored only in the PR that introduces the
+// allowlist line, never persistently after it lands on main. A standing
+// `sources-change-unscanned` line would silently waive EVERY future sources.yaml
+// change and kill the gate (blocker 62ye.3).
+const ONE_SHOT_RULES = new Set(['sources-change-unscanned']);
+
+/**
+ * Drop one-shot waivers that were NOT added in the current PR's diff of the
+ * allowlist. `addedLines` is the set of trimmed lines added to
+ * scripts/scan-allowlist.txt vs the base. All other rules pass through unchanged
+ * — their persistent-allowlist model is intentional. Pure, so it is unit-testable.
+ * Fail-closed by construction: an empty `addedLines` set (diff uncomputable)
+ * removes every one-shot waiver, so the gate re-fires rather than silently waiving.
+ */
+export function honoredWaivers(waivers, addedLines) {
+  return waivers.filter((w) => !ONE_SHOT_RULES.has(w.rule) || (w.raw && addedLines.has(w.raw)));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -750,6 +770,29 @@ function changedFiles(base) {
     ...run(['ls-files', '--others', '--exclude-standard']),
   ]);
   return [...set];
+}
+
+/** Trimmed lines ADDED to scripts/scan-allowlist.txt vs `base` (blocker 62ye.3).
+ * Feeds honoredWaivers so a one-shot waiver counts only in the PR that adds it.
+ * Fail-closed: returns an empty set when the diff can't be computed (e.g. a
+ * missing base ref), so a one-shot waiver is not honored and the gate re-fires. */
+function addedAllowlistLines(base) {
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', ROOT_DIR, 'diff', '--unified=0', base, '--', 'scripts/scan-allowlist.txt'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    return new Set(
+      out
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1).trim())
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set();
+  }
 }
 
 /** Resolve the list of repo-relative files to scan from CLI options. */
@@ -891,7 +934,11 @@ function main() {
         snippet: trustFiles.join(', ').slice(0, 100),
         file: trustFiles[0],
       };
-      f.waivedReason = isWaived(waivers, f.file, f.id, f.grade);
+      // One-shot (blocker 62ye.3): honor a sources-change-unscanned waiver only
+      // if its allowlist line was added in THIS PR — a standing line on main
+      // would waive every future sources.yaml change and silently kill the gate.
+      const fresh = honoredWaivers(waivers, addedAllowlistLines(opts.base || 'origin/main'));
+      f.waivedReason = isWaived(fresh, f.file, f.id, f.grade);
       perFile.push({ rel: f.file, findings: [f] });
       all = all.concat(f);
     }

--- a/scripts/scan-synced-content.test.mjs
+++ b/scripts/scan-synced-content.test.mjs
@@ -20,6 +20,7 @@ import {
   decideExit,
   parseAllowlist,
   isWaived,
+  honoredWaivers,
   concatCollapse,
   normalizeLines,
   fileClass,
@@ -387,6 +388,46 @@ test('allowlist: REFUSE is NEVER waivable', () => {
   for (const x of f)
     x.waivedReason = isWaived(waivers, 'plugins/community/evil/x.sh', x.id, x.grade);
   assert.equal(decideExit(f), 2, 'REFUSE must still block despite a waiver line');
+});
+
+// ── honoredWaivers — sources-change-unscanned is ONE-SHOT (blocker 62ye.3) ──
+test('one-shot: a sources-change-unscanned waiver is dropped when its line was NOT added in the PR', () => {
+  const waivers = parseAllowlist('sources.yaml:sources-change-unscanned  reviewed the new source');
+  const added = new Set(); // empty = this line is standing on main, not diff-added
+  const fresh = honoredWaivers(waivers, added);
+  assert.equal(fresh.length, 0, 'a standing (not-added) one-shot waiver must not survive');
+  // …so the CHALLENGE is NOT waived and the gate re-fires.
+  assert.equal(isWaived(fresh, 'sources.yaml', 'sources-change-unscanned', GRADE.CHALLENGE), null);
+});
+
+test('one-shot: the waiver IS honored in the PR whose diff adds its line', () => {
+  const line = 'sources.yaml:sources-change-unscanned  reviewed the new source';
+  const waivers = parseAllowlist(line);
+  const added = new Set([line]); // the reviewer added exactly this line in the PR
+  const fresh = honoredWaivers(waivers, added);
+  assert.equal(fresh.length, 1);
+  assert.equal(
+    isWaived(fresh, 'sources.yaml', 'sources-change-unscanned', GRADE.CHALLENGE),
+    'reviewed the new source',
+  );
+});
+
+test('one-shot filter leaves OTHER (persistent) rules untouched', () => {
+  const waivers = parseAllowlist(
+    'plugins/**/README.md:pipe-to-shell  installer docs\n' +
+      'sources.yaml:sources-change-unscanned  one-shot line',
+  );
+  const fresh = honoredWaivers(waivers, new Set()); // nothing added this PR
+  // pipe-to-shell (persistent) survives; sources-change-unscanned (one-shot) is dropped.
+  assert.deepEqual(
+    fresh.map((w) => w.rule),
+    ['pipe-to-shell'],
+  );
+});
+
+test('one-shot fail-closed: an empty added-set (uncomputable diff) drops the waiver', () => {
+  const waivers = parseAllowlist('sources.lock.json:sources-change-unscanned  relock reviewed');
+  assert.equal(honoredWaivers(waivers, new Set()).length, 0);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/sync-external.mjs
+++ b/scripts/sync-external.mjs
@@ -47,6 +47,7 @@ import {
   buildLockEntry,
   diffSource,
   matchesPattern,
+  unanchoredIncludes,
 } from './sync-lockfile.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -519,6 +520,19 @@ async function syncSource(source, config, lock) {
           colors.red,
         );
       }
+    }
+
+    // Anchoring lint (blocker 62ye.6): an include that starts with neither `/`
+    // nor `**` is silently auto-prefixed `**/` and matches at ANY depth, not the
+    // root the vetter likely intended. Warn so intent is explicit — the fix is a
+    // one-char edit in sources.yaml (`/README.md` root-only, or `**/README.md`
+    // to keep it recursive on purpose). Advisory only; the matcher is unchanged.
+    for (const pat of unanchoredIncludes(source.include)) {
+      log(
+        `   ⚠️  Unanchored include "${pat}" is auto-prefixed **/ (matches at any depth) — ` +
+          `anchor as "/${pat}" for root-only, or write "**/${pat}" to make the recursion explicit`,
+        colors.yellow,
+      );
     }
     const filteredFiles = files.filter((file) => {
       const included = matchesPattern(file.path, source.include);

--- a/scripts/sync-lockfile.mjs
+++ b/scripts/sync-lockfile.mjs
@@ -270,3 +270,20 @@ export function matchesPattern(filePath, patterns) {
     return regex.test(filePath);
   });
 }
+
+/**
+ * Include patterns that matchesPattern will silently auto-prefix with `**\/`
+ * — i.e. those that start with neither `/` (root-anchored) nor `**` (explicitly
+ * recursive). Blocker 62ye.6: a vetter reading `README.md` per the source-
+ * vetting playbook believes it mirrors the ROOT README, but the auto-prefix
+ * makes it `**\/README.md`, admitting every README at any depth (unvetted
+ * examples/, vendored dirs, …). Returning the offenders lets the sync flow warn
+ * the vetter so intent is explicit — anchor with `/README.md` or write the
+ * recursion out as `**\/README.md`. Pure (no side effects) so it is unit-testable;
+ * NON-breaking — matchesPattern's behavior is unchanged, this only surfaces it.
+ */
+export function unanchoredIncludes(patterns) {
+  return (patterns || []).filter(
+    (p) => typeof p === 'string' && !p.startsWith('/') && !p.startsWith('**'),
+  );
+}

--- a/scripts/sync-lockfile.test.mjs
+++ b/scripts/sync-lockfile.test.mjs
@@ -264,7 +264,7 @@ test('buildLockEntry: null resolved ref is preserved as null (bootstrap has no c
 // `/` anchors a pattern to the source root; anything else is auto-prefixed
 // `**/` (recursive by design, for nested contributor layouts). The anchored
 // form was dead code before this corpus existed — these tests keep it alive.
-import { matchesPattern } from './sync-lockfile.mjs';
+import { matchesPattern, unanchoredIncludes } from './sync-lockfile.mjs';
 
 test('anchored /README.md matches only the root README', () => {
   assert.equal(matchesPattern('README.md', ['/README.md']), true);
@@ -296,4 +296,37 @@ test('single-star stays single-segment; ? stays single-char', () => {
   assert.equal(matchesPattern('docs/a.md', ['/docs/*.md']), true);
   assert.equal(matchesPattern('docs/sub/a.md', ['/docs/*.md']), false);
   assert.equal(matchesPattern('a.md', ['?.md']), true);
+});
+
+// ── unanchoredIncludes — the anchoring lint (blocker 62ye.6) ──
+// Flags includes that matchesPattern will silently auto-prefix `**/` so the
+// vetter is warned they admit files at ANY depth, not just the root.
+test('unanchoredIncludes flags bare (auto-prefixed) includes', () => {
+  assert.deepEqual(unanchoredIncludes(['README.md', 'references/**']), [
+    'README.md',
+    'references/**',
+  ]);
+});
+
+test('unanchoredIncludes does not flag anchored or explicitly-recursive includes', () => {
+  assert.deepEqual(unanchoredIncludes(['/README.md', '**/SKILL.md', '/skills/**']), []);
+});
+
+test('unanchoredIncludes on mixed list returns only the offenders', () => {
+  assert.deepEqual(unanchoredIncludes(['/README.md', 'SKILL.md', '**/x.md', 'docs/**']), [
+    'SKILL.md',
+    'docs/**',
+  ]);
+});
+
+test('unanchoredIncludes tolerates empty / missing input', () => {
+  assert.deepEqual(unanchoredIncludes([]), []);
+  assert.deepEqual(unanchoredIncludes(undefined), []);
+  assert.deepEqual(unanchoredIncludes(null), []);
+});
+
+// The lint pairs with the real hazard: a bare include IS recursive today.
+test('a bare README.md include silently matches a deep README (the hazard being linted)', () => {
+  assert.equal(matchesPattern('examples/x/README.md', ['README.md']), true);
+  assert.ok(unanchoredIncludes(['README.md']).length === 1);
 });


### PR DESCRIPTION
## What

Two more external-sync gate defects from the 2026-07-07 quality-pipeline audit (epic `claude-62ye`).

**62ye.6 — unanchored includes silently match at any depth.** `matchesPattern` auto-prefixes `**/` to any include not starting with `/` or `**`. A vetter following the source-vetting playbook reads `README.md` and believes it mirrors the **root** README, but it actually matches `**/README.md` — admitting every README at any depth (unvetted `examples/`, vendored dirs), which is how portaljs (#994) pulled in placeholder-URL files that broke marketplace-validation.

**62ye.3 — the `sources-change-unscanned` waiver was persistent, not one-shot.** A `sources.yaml:sources-change-unscanned  <reason>` line in `scan-allowlist.txt` kept waiving the F6/F7 trust-surface CHALLENGE on **every future** `sources.yaml` PR after it landed on main — the gate died after first use.

## How it works

**62ye.6** — new pure exported `unanchoredIncludes()` in `sync-lockfile.mjs`, wired into `sync-external.mjs`'s existing discovery warning loop, flags each offender so intent is explicit (`/README.md` root-only, or `**/README.md` recursive-on-purpose). **Advisory only — `matchesPattern`'s behavior is unchanged.**

**62ye.3** — one-shot: honored only when its allowlist line was **added in the current PR's diff**. New pure exported `honoredWaivers(waivers, addedLines)` drops one-shot-rule waivers not in the added set; `addedAllowlistLines(base)` reads `git diff --unified=0 base -- scan-allowlist.txt`. **Fail-closed** — an empty added-set (uncomputable diff) removes the waiver so the gate re-fires. Removed the two stale standing hyperflow waivers (now inert) and replaced the TEMPORARY comment with one describing the code-enforced mechanism.

## Decision rationale (chose X over Y)

- **Lint over default-flip (62ye.6):** 213 unanchored includes — many legitimately recursive for nested contributor layouts — depend on the auto-prefix; a blind flip drops real files. Surface intent first, convert, flip later (a phased step).
- **Extracted pure functions** (`unanchoredIncludes`, `honoredWaivers`) over inline checks, so the logic is unit-testable without git/fs.

## Layer(s) touched · invariant

External-sync engine + supply-chain scanner. **62ye.3 tightens the `ci-required` `scan-synced-content` gate** (a standing waiver can no longer silently pass a source-list change) — it can only turn a silent pass into a correct fail, and fails closed. 62ye.6 changes no gate (advisory warning).

## Verification & evidence

```
$ node --test scripts/sync-lockfile.test.mjs        # → 29 pass (5 new)
$ node --test scripts/scan-synced-content.test.mjs  # → 54 pass (4 new)
```
- 62ye.6 tests: flags bare includes, ignores anchored/`**`, mixed-list offenders, empty/null input, the hazard pairing (a bare `README.md` DOES match a deep README today).
- 62ye.3 tests: standing waiver dropped, added-line honored, persistent rules (e.g. `pipe-to-shell`) untouched, fail-closed on empty added-set. **`scan-synced-content.test.mjs` is in `ci-required`, so the one-shot logic gates.**
- `node --check` on all changed `.mjs`; `eslint` clean; live `scan --changed-only` runs without crash and the allowlist still parses.

## Risk assessment

Low. 62ye.6 is advisory (a warning line) — zero matcher behavior change. 62ye.3 only makes the scan gate stricter and fails closed; it cannot newly-pass anything. No public API/contract change.

## Operational impact

None. No deps/env/secrets/migrations. Future `sources.yaml` PRs must add a **fresh** `sources-change-unscanned` line to clear the gate (the intended one-shot behavior) — documented in the refreshed allowlist comment.

## Follow-up & deferred

Remaining `claude-62ye` child: `.2` (REFUSE per-source quarantine — sync-engine rework) — separate PR.

## Rollback

Revert the commit; the matcher lint and the one-shot check both drop out cleanly. No state/data migration.

Refs `claude-62ye.6`, `claude-62ye.3`.

- Jeremy Longshore
intentsolutions.io