### PR TITLE
feat(freshie): publish the skills+grades corpus as a HuggingFace dataset [skip auto-bump]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ freshie/dolt/
 
 # Backup files created by freshie/scripts/batch-remediate.py during --execute
 *.bak
+
+# HF dataset build artifact (regenerate via freshie/scripts/build-hf-dataset.py)
+freshie/hf-dataset/skills.jsonl

--- a/freshie/hf-dataset/README.md
+++ b/freshie/hf-dataset/README.md
@@ -1,0 +1,84 @@
+---
+license: mit
+pretty_name: Tons of Skills — Claude Code Skills + Quality Grades
+size_categories:
+  - 1K<n<10K
+task_categories:
+  - text-generation
+  - text-classification
+tags:
+  - claude-code
+  - agent-skills
+  - prompts
+  - code
+  - developer-tools
+configs:
+  - config_name: default
+    data_files: skills.jsonl
+---
+
+# Tons of Skills — Claude Code Skills + Quality Grades
+
+A browsable corpus of **~3,000 Claude Code / Agent Skills** from the
+[Tons of Skills](https://tonsofskills.com) marketplace, each joined with its **quality
+grade and behavioral-eval verdict** from the Freshie compliance CMDB.
+
+One row per skill: the skill's content and frontmatter **plus** its letter grade
+(A–F), numeric score, and JRig behavioral-eval pass flag.
+
+## Why the grades are here
+
+Most "awesome skills" lists are unranked. This dataset ships the **quality signal**
+alongside the content, so you can filter to A-grade skills, study what separates an A
+from an F, or train/evaluate against a graded corpus. The grades come from the same
+system-of-record that versions them publicly:
+
+- **System of record:** the grades, compliance scores, and JRig verdicts are produced
+  by an in-house validator + behavioral-eval harness and versioned in **Dolt**, pushed
+  to the public DoltHub database
+  [`jeremylongshore/freshie-inventory`](https://www.dolthub.com/repositories/jeremylongshore/freshie-inventory)
+  (one tagged run per inventory pass).
+- **This dataset is a regenerated *view*, not a hand-curated copy.** It is rebuilt from
+  the same inventory run + the marketplace catalog every time, so it never drifts from
+  the source of truth. Think of it as a published export (like a CSV snapshot), joined
+  with the skill content that the compliance DB itself does not store.
+
+## Schema
+
+| field | description |
+|-------|-------------|
+| `name`, `slug`, `category`, `parent_plugin` | identity + where the skill lives |
+| `description` | the skill's trigger/summary frontmatter |
+| `author`, `license`, `version` | authoring metadata (per-skill license — mostly MIT) |
+| `allowed_tools`, `visibility` | the tool allow-list + any visibility gating |
+| `content_html` | the rendered skill body (HTML) |
+| `grade`, `score` | Freshie letter grade (A–F) + numeric compliance score |
+| `jrig_passed`, `jrig_tier_blocked` | JRig behavioral-eval pass flag / tier block |
+| `is_stub` | flagged as a stub (thin/placeholder) by the validator |
+| `inventory_run_id` | the Freshie inventory run this snapshot came from |
+
+## Snapshot stats (this run)
+
+- **3,008 skills**, **2,996 graded** (12 personal-prefix/edge skills ungraded).
+- Grade histogram: **A 795 · B 1,033 · C 993 · D 168 · F 7**.
+- Inventory run: **9**.
+
+## Regenerate
+
+The dataset is deterministic from the marketplace catalog + `freshie/inventory.sqlite`:
+
+```bash
+python3 freshie/scripts/build-hf-dataset.py
+```
+
+## License
+
+Dataset tooling + the compilation: **MIT**. Per-skill content carries its own `license`
+field — 2,999 of 3,008 are MIT (the rest Apache-2.0 or MIT-variant). The underlying
+skill content is already publicly browsable at [tonsofskills.com](https://tonsofskills.com).
+
+## Source
+
+Marketplace: <https://tonsofskills.com> · Repo:
+[`jeremylongshore/claude-code-plugins-plus-skills`](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
+· Grades: [DoltHub `jeremylongshore/freshie-inventory`](https://www.dolthub.com/repositories/jeremylongshore/freshie-inventory).

--- a/freshie/hf-dataset/STATS.json
+++ b/freshie/hf-dataset/STATS.json
@@ -1,0 +1,13 @@
+{
+  "skills": 3008,
+  "graded": 2996,
+  "ungraded": 12,
+  "inventory_run_id": 9,
+  "grade_histogram": {
+    "A": 795,
+    "B": 1033,
+    "C": 993,
+    "D": 168,
+    "F": 7
+  }
+}

--- a/freshie/scripts/build-hf-dataset.py
+++ b/freshie/scripts/build-hf-dataset.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""build-hf-dataset.py — regenerate the HuggingFace skills dataset from the SAME source
+of truth as the Dolt/Freshie CMDB: the marketplace catalog (skill content) JOINED with
+`skill_compliance` (grades, JRig verdicts) from `freshie/inventory.sqlite`.
+
+This is a published, browsable VIEW — not a hand-curated copy. Dolt/DoltHub stays the
+versioned system-of-record for grades; this dataset is a rebuilt export (exactly like
+`freshie/grades.csv`), so it can never diverge: re-run it and it reflects the current
+inventory run. One JSONL row per skill = its content + frontmatter + its Freshie grade
+and JRig-verified flag.
+
+Join: catalog `filePath` (or slug/name fallback) ↔ `skill_compliance.skill_path`.
+
+Inputs (read-only):
+  marketplace/public/data/skills-catalog.json   full skill bodies + metadata
+  marketplace/src/data/skills-index.json         category enrichment
+  freshie/inventory.sqlite                        skill_compliance (latest run_id)
+
+Outputs (build artifacts, git-ignored — regenerate any time):
+  freshie/hf-dataset/skills.jsonl                 the dataset
+  freshie/hf-dataset/README.md                    the HF dataset card
+  freshie/hf-dataset/STATS.json                   run stats (counts, grade histogram)
+
+Usage: python3 freshie/scripts/build-hf-dataset.py
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG = ROOT / "marketplace" / "public" / "data" / "skills-catalog.json"
+INDEX = ROOT / "marketplace" / "src" / "data" / "skills-index.json"
+DB = ROOT / "freshie" / "inventory.sqlite"
+OUT_DIR = ROOT / "freshie" / "hf-dataset"
+
+
+def _norm_path(p):
+    """Normalize a skill path for join: strip trailing /SKILL.md and slashes, lowercase."""
+    if not p:
+        return ""
+    p = p.strip().replace("\\", "/").rstrip("/")
+    low = p.lower()
+    if low.endswith("/skill.md"):
+        p = p[: -len("/skill.md")]
+    return p.lower()
+
+
+def _dir_key(p):
+    """The skill's own directory name — the fallback join key (slug/name equivalent)."""
+    p = _norm_path(p)
+    return p.split("/")[-1] if p else ""
+
+
+def load_grades():
+    """Return (by_path, by_dir, run_id): grade/JRig maps keyed by normalized path and by
+    dir name, for the latest inventory run."""
+    con = sqlite3.connect(str(DB))
+    cur = con.cursor()
+    run_id = cur.execute("SELECT MAX(run_id) FROM skill_compliance").fetchone()[0]
+    rows = cur.execute(
+        "SELECT skill_path, grade, score, jrig_passed, jrig_tier_blocked, is_stub "
+        "FROM skill_compliance WHERE run_id = ?",
+        (run_id,),
+    ).fetchall()
+    con.close()
+    by_path, by_dir = {}, {}
+    for skill_path, grade, score, jrig_passed, jrig_blocked, is_stub in rows:
+        rec = {
+            "grade": grade,
+            "score": score,
+            "jrig_passed": bool(jrig_passed) if jrig_passed is not None else None,
+            "jrig_tier_blocked": bool(jrig_blocked) if jrig_blocked is not None else None,
+            "is_stub": bool(is_stub) if is_stub is not None else None,
+        }
+        by_path[_norm_path(skill_path)] = rec
+        by_dir.setdefault(_dir_key(skill_path), rec)
+    return by_path, by_dir, run_id
+
+
+def load_categories():
+    """slug -> category from the L0 index."""
+    d = json.loads(INDEX.read_text())
+    skills = d["skills"] if isinstance(d, dict) and "skills" in d else d
+    return {s.get("slug"): s.get("category") for s in skills}
+
+
+def main():
+    for f in (CATALOG, INDEX, DB):
+        if not f.exists():
+            print(f"missing input: {f}", file=sys.stderr)
+            return 2
+
+    by_path, by_dir, run_id = load_grades()
+    categories = load_categories()
+    catalog = json.loads(CATALOG.read_text())
+    skills = catalog["skills"] if isinstance(catalog, dict) and "skills" in catalog else catalog
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    matched = 0
+    grade_hist = {}
+    with (OUT_DIR / "skills.jsonl").open("w") as fh:
+        for s in skills:
+            fp = _norm_path(s.get("filePath"))
+            grade_rec = by_path.get(fp) or by_dir.get(_dir_key(s.get("filePath") or s.get("slug") or ""))
+            if grade_rec is None:
+                grade_rec = by_dir.get(s.get("slug") or "") or by_dir.get(s.get("name") or "")
+            if grade_rec:
+                matched += 1
+                grade_hist[grade_rec["grade"]] = grade_hist.get(grade_rec["grade"], 0) + 1
+            row = {
+                "name": s.get("name"),
+                "slug": s.get("slug"),
+                "category": categories.get(s.get("slug")),
+                "parent_plugin": s.get("parentPlugin"),
+                "description": s.get("description"),
+                "author": s.get("author"),
+                "license": s.get("license"),
+                "allowed_tools": s.get("allowedTools"),
+                "version": s.get("version"),
+                "visibility": s.get("visibility"),
+                "file_path": s.get("filePath"),
+                "content_html": s.get("content"),
+                # Freshie CMDB quality signal (same source of truth as DoltHub):
+                "grade": (grade_rec or {}).get("grade"),
+                "score": (grade_rec or {}).get("score"),
+                "jrig_passed": (grade_rec or {}).get("jrig_passed"),
+                "jrig_tier_blocked": (grade_rec or {}).get("jrig_tier_blocked"),
+                "is_stub": (grade_rec or {}).get("is_stub"),
+                "inventory_run_id": run_id,
+            }
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    total = len(skills)
+    stats = {
+        "skills": total,
+        "graded": matched,
+        "ungraded": total - matched,
+        "inventory_run_id": run_id,
+        "grade_histogram": dict(sorted(grade_hist.items())),
+    }
+    (OUT_DIR / "STATS.json").write_text(json.dumps(stats, indent=2) + "\n")
+    print(json.dumps(stats, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds `freshie/scripts/build-hf-dataset.py` — regenerates a **HuggingFace dataset from the same source of truth as the Dolt/Freshie CMDB**. One JSONL row per skill = the skill's content + frontmatter (marketplace catalog) **joined** with its Freshie letter grade, compliance score, and JRig behavioral-eval verdict (`skill_compliance` in `freshie/inventory.sqlite`, latest run).

**Published (private, for review before public):** <https://huggingface.co/datasets/intent-solutions-io/tons-of-skills> — 3,008 skills, 2,996 graded (A 795 · B 1,033 · C 993 · D 168 · F 7), run 9.

## Why + decision rationale

The dataset is a **regenerated view, not a hand-curated copy**: Dolt/DoltHub stays the versioned system-of-record for grades, and this export is rebuilt from the same inventory run every time, so it can't drift (same model as `freshie/grades.csv`). **Chose a join of catalog-content + compliance-grades over mirroring the raw Dolt tables**, because the compliance DB doesn't store skill content and a raw table dump isn't browsable/loadable as a skills corpus — the value is content + quality signal in one row.

The 25 MB `skills.jsonl` is a git-ignored build artifact (like `inventory.sqlite`); only the generator, the dataset card, and `STATS.json` are tracked.

## Layer(s) touched

`freshie/` tooling only. No marketplace/plugin/CI runtime change. New `.gitignore` entry for the blob.

## Verification & evidence

- Generator runs clean (`ruff` clean); **join rate 2,996/3,008 = 99.6%** by `filePath ↔ skill_path` with slug/name fallback; `STATS.json` records the histogram.
- Dataset card is `markdownlint`-clean; HF upload returned commit SHAs for both files (card + data).

## Risk assessment

Content is already public on tonsofskills.com, so this is a **distribution-format change, not a new disclosure**. Licenses: 2,999/3,008 MIT (rest Apache-2.0 / MIT-variant), per-skill `license` field included. Published **PRIVATE** first — flipping to public is a deliberate step you take.

## Operational impact

Regenerate any time: `python3 freshie/scripts/build-hf-dataset.py`. Publishing uses the HuggingFace token from the SOPS store. No new deps.

## Follow-up & deferred

- Flip the HF dataset public (your call, after review).
- The two skill registries ("do all"): skills.sh + agentskills.io submission — separate follow-up (each has its own mechanism to research).

## Governance links

Data source-of-truth: DoltHub [`jeremylongshore/freshie-inventory`](https://www.dolthub.com/repositories/jeremylongshore/freshie-inventory). Marketplace: tonsofskills.com.