### PR TITLE
feat(marketing): embed the skills.sh install-count badge on README + tonsofskills.com [skip auto-bump]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Plugins](https://img.shields.io/badge/plugins-431-blue)](https://tonsofskills.com/explore)
 [![Skills](https://img.shields.io/badge/skills-2%2C754-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
+[![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -478,6 +478,15 @@ const currentPath = Astro.url.pathname;
             text-decoration: underline;
         }
 
+        .footer-badges {
+            margin: 0.5rem 0 0;
+        }
+
+        .footer-badges img {
+            height: 20px;
+            vertical-align: middle;
+        }
+
         .footer-copyright {
             font-size: 0.75rem;
             color: var(--text-3);
@@ -665,6 +674,7 @@ const currentPath = Astro.url.pathname;
 
             <div class="footer-bottom">
                 <p class="footer-blurb">Tons of Skills by <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a>. Marine. Citadel Grad. 20 years ops &rarr; self-taught dev &rarr; AI architect.</p>
+                <p class="footer-badges"><a href="https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills" target="_blank" rel="noopener" aria-label="Install count on skills.sh"><img src="https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills" alt="skills.sh install count" height="20" loading="lazy" decoding="async" /></a></p>
                 <p class="footer-copyright">&copy; {new Date().getFullYear()} Tons of Skills | <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a></p>
             </div>
         </div>


### PR DESCRIPTION
## What

Embeds the **official skills.sh install-count badge** (`https://skills.sh/b/<owner>/<repo>`) — a live SVG served by skills.sh showing this repo's total install count (**~49.3K across 1,877 indexed skills**) — in two places:

- **README.md** — a new badge in the existing shields row, linking to the skills.sh repo page.
- **marketplace/src/layouts/BaseLayout.astro** — the `footer-bottom`, so it shows site-wide on **tonsofskills.com** (+ a small `.footer-badges` CSS rule).

## Why + decision rationale

**Chose the official skills.sh badge over a homemade shields-endpoint badge** (I'd started one — a script summing `/api/search` installs into a committed JSON + a weekly refresh workflow) because skills.sh ships a first-class live badge endpoint (per `skills.sh/docs/api`): zero maintenance, always current, no committed JSON or scheduled action to keep fresh. Removed the half-built homemade tooling.

## Layer(s) touched

Docs (README) + the marketplace site layout. No plugin/skill/CI-runtime change.

## Verification & evidence

- Badge endpoint returns **HTTP 200, `image/svg+xml`, rendering "Skills 49.3K"** (`curl https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills`).
- The stat matches the API: `?q=<source>&limit=3000` returns exactly the **1,877 skills** for this source → **49,250 installs**.
- Footer edit is a plain `<img>` in `<p>` + a CSS rule; CI `marketplace-validation` builds the site.

## Risk assessment

The badge is an **external image** from skills.sh. On tonsofskills.com it renders only if the VPS Caddy CSP allows `img-src` from `skills.sh` — **if it doesn't display on the live site, add `https://skills.sh` to the Caddy `img-src`** (one line). It does not affect the build, and the README badge (GitHub-rendered) is unaffected.

## Operational impact

None at build/deploy time. Possible one-line Caddy `img-src` addition on the VPS if the live badge is CSP-blocked.

## Follow-up & deferred

- (If needed) allow `skills.sh` in the VPS Caddy CSP `img-src`.

## Governance links

skills.sh badge docs: <https://www.skills.sh/docs/api>. Repo on skills.sh: <https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills>.