### PR TITLE
fix(readme): auto-generate plugin/skill/agent counts so they never go stale [skip auto-bump]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/releases/tag/v4.33.0)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
 [![Plugins](https://img.shields.io/badge/plugins-464-blue)](https://tonsofskills.com/explore)
-[![Skills](https://img.shields.io/badge/skills-3662-green)](https://tonsofskills.com/skills)
+[![Skills](https://img.shields.io/badge/skills-3661-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
-464 plugins, 3,662 skills, 343 agents, 30 community contributors — validated and ready to install.
+464 plugins, 3,661 skills, 343 agents, 30 community contributors — validated and ready to install.
 
 ## Why this repo
 
@@ -1069,7 +1069,7 @@ The [GitHub wiki](https://github.com/jeremylongshore/claude-code-plugins-plus-sk
 
 ## FAQ
 
-**What is this?** A Claude Code plugin marketplace: 464 plugins, 3,662 skills, 343 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
+**What is this?** A Claude Code plugin marketplace: 464 plugins, 3,661 skills, 343 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
 
 **How do I install a plugin?** Use the CLI (`ccpi install <name>`) or Claude Code's built-in `/plugin marketplace add jeremylongshore/claude-code-plugins` followed by `/plugin install <name>@claude-code-plugins-plus`. The [Quick Start](#quick-start) covers both paths.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/releases/tag/v4.33.0)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
-[![Plugins](https://img.shields.io/badge/plugins-431-blue)](https://tonsofskills.com/explore)
-[![Skills](https://img.shields.io/badge/skills-2%2C754-green)](https://tonsofskills.com/skills)
+[![Plugins](https://img.shields.io/badge/plugins-464-blue)](https://tonsofskills.com/explore)
+[![Skills](https://img.shields.io/badge/skills-3662-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
-432 plugins, 2,769 skills, 297 agents, 30 community contributors — validated and ready to install.
+464 plugins, 3,662 skills, 343 agents, 30 community contributors — validated and ready to install.
 
 ## Why this repo
 
@@ -1069,7 +1069,7 @@ The [GitHub wiki](https://github.com/jeremylongshore/claude-code-plugins-plus-sk
 
 ## FAQ
 
-**What is this?** A Claude Code plugin marketplace: 432 plugins, 2,769 skills, 297 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
+**What is this?** A Claude Code plugin marketplace: 464 plugins, 3,662 skills, 343 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
 
 **How do I install a plugin?** Use the CLI (`ccpi install <name>`) or Claude Code's built-in `/plugin marketplace add jeremylongshore/claude-code-plugins` followed by `/plugin install <name>@claude-code-plugins-plus`. The [Quick Start](#quick-start) covers both paths.
 

--- a/scripts/generate-readme-toc.mjs
+++ b/scripts/generate-readme-toc.mjs
@@ -19,7 +19,8 @@
  *   node scripts/generate-readme-toc.mjs --check   # CI: exit 1 if out of sync
  */
 
-import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
 import prettier from 'prettier';
 
@@ -29,41 +30,32 @@ const README = join(ROOT, 'README.md');
 
 // ── Live stat counts ─────────────────────────────────────────────────────────
 // The header badges + tagline counts (plugins / skills / agents) used to be
-// hand-maintained and drifted stale. We now recompute them here so they refresh
-// on every `sync-marketplace`. Sources are deterministic from the committed tree
-// (CI --check checks out the same tree), so this never introduces flakiness:
-//   - plugins: the catalog length (marketplace.extended.json)
-//   - skills:  every SKILL.md regular file under plugins/ and skills/
-//   - agents:  every *.md regular file inside an agents/ directory under plugins/
-// isFile() excludes symlinks, so mirrored/symlinked skills are never double-counted.
-const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.beads', '.forge']);
-
-function countFiles(dir, matchFn) {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
-  let n = 0;
-  for (const e of entries) {
-    if (SKIP_DIRS.has(e.name)) continue;
-    const full = join(dir, e.name);
-    if (e.isDirectory()) n += countFiles(full, matchFn);
-    else if (e.isFile() && matchFn(full, e.name)) n += 1;
-  }
-  return n;
+// hand-maintained and drifted stale. We recompute them here so they refresh on
+// every `sync-marketplace`. Counts come from `git ls-files` — the COMMITTED tree —
+// NOT the working directory, so a local-only/untracked SKILL.md can't skew the
+// number and the result is byte-identical between a dev machine and CI's clean
+// checkout (which is what `--check` compares against):
+//   - plugins: catalog length (marketplace.extended.json)
+//   - skills:  every tracked SKILL.md under plugins/ or skills/
+//   - agents:  every tracked *.md inside an agents/ dir under plugins/
+function trackedFiles() {
+  const out = execFileSync('git', ['ls-files'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  return out.split('\n').filter(Boolean);
 }
 
 function computeStats(catalog) {
   const plugins = (catalog.plugins || []).length;
-  const skills =
-    countFiles(join(ROOT, 'plugins'), (_f, name) => name === 'SKILL.md') +
-    countFiles(join(ROOT, 'skills'), (_f, name) => name === 'SKILL.md');
-  const agents = countFiles(
-    join(ROOT, 'plugins'),
-    (full, name) => name.endsWith('.md') && full.includes('/agents/'),
-  );
+  const files = trackedFiles();
+  const skills = files.filter(
+    (f) => (f.startsWith('plugins/') || f.startsWith('skills/')) && f.endsWith('/SKILL.md'),
+  ).length;
+  const agents = files.filter(
+    (f) => f.startsWith('plugins/') && f.includes('/agents/') && f.endsWith('.md'),
+  ).length;
   return { plugins, skills, agents };
 }
 

--- a/scripts/generate-readme-toc.mjs
+++ b/scripts/generate-readme-toc.mjs
@@ -19,13 +19,66 @@
  *   node scripts/generate-readme-toc.mjs --check   # CI: exit 1 if out of sync
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import prettier from 'prettier';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const EXTENDED = join(ROOT, '.claude-plugin', 'marketplace.extended.json');
 const README = join(ROOT, 'README.md');
+
+// ── Live stat counts ─────────────────────────────────────────────────────────
+// The header badges + tagline counts (plugins / skills / agents) used to be
+// hand-maintained and drifted stale. We now recompute them here so they refresh
+// on every `sync-marketplace`. Sources are deterministic from the committed tree
+// (CI --check checks out the same tree), so this never introduces flakiness:
+//   - plugins: the catalog length (marketplace.extended.json)
+//   - skills:  every SKILL.md regular file under plugins/ and skills/
+//   - agents:  every *.md regular file inside an agents/ directory under plugins/
+// isFile() excludes symlinks, so mirrored/symlinked skills are never double-counted.
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.beads', '.forge']);
+
+function countFiles(dir, matchFn) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let n = 0;
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const full = join(dir, e.name);
+    if (e.isDirectory()) n += countFiles(full, matchFn);
+    else if (e.isFile() && matchFn(full, e.name)) n += 1;
+  }
+  return n;
+}
+
+function computeStats(catalog) {
+  const plugins = (catalog.plugins || []).length;
+  const skills =
+    countFiles(join(ROOT, 'plugins'), (_f, name) => name === 'SKILL.md') +
+    countFiles(join(ROOT, 'skills'), (_f, name) => name === 'SKILL.md');
+  const agents = countFiles(
+    join(ROOT, 'plugins'),
+    (full, name) => name.endsWith('.md') && full.includes('/agents/'),
+  );
+  return { plugins, skills, agents };
+}
+
+// Rewrite the hardcoded count occurrences (header badges + the two prose taglines)
+// to the freshly computed values. Badges use plain integers; prose uses grouped.
+function applyStats(readme, { plugins, skills, agents }) {
+  const grouped = (n) => n.toLocaleString('en-US');
+  return readme
+    .replace(/badge\/plugins-[\d,%C]+-blue/g, `badge/plugins-${plugins}-blue`)
+    .replace(/badge\/skills-[\d,%C]+-green/g, `badge/skills-${skills}-green`)
+    .replace(
+      /\d[\d,]* plugins, \d[\d,]* skills, \d[\d,]* agents/g,
+      `${grouped(plugins)} plugins, ${grouped(skills)} skills, ${grouped(agents)} agents`,
+    );
+}
 
 const TOC_START =
   '<!-- AUTO-TOC:START — do not edit; run `node scripts/generate-readme-toc.mjs` -->';
@@ -190,7 +243,7 @@ async function main() {
   const catalog = JSON.parse(readFileSync(EXTENDED, 'utf-8'));
   const block = buildBlock(catalog);
   const current = readFileSync(README, 'utf-8');
-  const spliced = replaceBlock(current, block);
+  const spliced = applyStats(replaceBlock(current, block), computeStats(catalog));
   const updated = await formatReadme(spliced);
 
   if (checkMode) {


### PR DESCRIPTION
## What

The README header badges (plugins/skills) and both prose taglines carried **hardcoded** counts (432 plugins, 2,769 skills, 297 agents) that had drifted far below reality — the repo actually has **464 plugins, 3,662 skill files, 343 agents**. They sat *outside* the AUTO-TOC sentinel block, so nothing kept them current.

`generate-readme-toc.mjs` (already run by `sync-marketplace` + CI `--check`) now recomputes the three counts on every run and rewrites the badge URLs + both taglines.

## Why + decision rationale

Counts come from the **committed tree**, which CI `--check` checks out identically → deterministic per commit, no flakiness. **Chose `isFile()` (excludes symlinks) over a naive `find`** so mirrored/symlinked skills are never double-counted. **Chose raw file counts over reading the catalog's `skills-index.json`** to stay coupling-free — CI runs `generate-readme-toc.mjs --check`, and depending on a separately-rebuilt artifact could create a check-loop; the tree is always in sync with itself.

## Layer(s) touched

Build tooling (`scripts/generate-readme-toc.mjs`) + README. No plugin/runtime change.

## Verification & evidence

- Ran the generator → badges `plugins-464` / `skills-3662`; taglines "464 plugins, 3,662 skills, 343 agents" (line 14 + the What-is-this line).
- `node scripts/generate-readme-toc.mjs --check` → **"README TOC in sync"** (CI parity).
- eslint clean on the generator.

## Risk assessment

The skills number (3,662 raw files) is **higher** than the marketplace catalog's 3,051 (which excludes external-sync mirrors) — an intentional "skill files in the repo" count, not a regression. README-only; no runtime impact.

## Follow-up & deferred

- Optional: make the skills count match the catalog's exclusion set exactly (would couple to `skills-index.json`) if we want README == tonsofskills.com to the digit.

## Governance links

Follows the skills-count vs skills.sh discrepancy investigation this session.