### PR TITLE
feat(jrig): light the JRig-Verified badge for databricks-pack from recorded ground-truth proofs

### DIFF
--- a/marketplace/src/data/jrig-data.json
+++ b/marketplace/src/data/jrig-data.json
@@ -1,1 +1,9 @@
-{}
+{
+  "databricks-pack": {
+    "verified": true,
+    "layers_passed": 11,
+    "total_layers": 11,
+    "baseline_delta": null,
+    "verified_at": "2026-07-13 16:02:05"
+  }
+}


### PR DESCRIPTION
## What

First verified entry in `marketplace/src/data/jrig-data.json`: **databricks-pack** (11/11 layers, tier3-jrig). Lights the JRig-Verified badge on the databricks-pack detail page — the execution half of #935.

## Why + decision rationale

The 2026-07-12 databricks-pack v2 rebuild ran **real deepseek-v4-flash ground-truth evals** — j-rig SHIP on cluster-forensics (11/11), streaming-guardian (14/14), bundle-medic (12/12) — but those runs printed human-readable output only; no `--json` artifact ever reached `record-jrig-proofs.mjs`, so `forge_proofs` stayed empty and the badge stayed dark despite genuine passing evals. The verdicts survive in the inventory DB's **native j-rig tables** (`runs` 2/4/5 + `run_summaries` scores 1.0 + 51 `criterion_results` rows, completed timestamps 2026-07-12). Chose transcribing those surviving rows through the canonical writer over re-running the evals: the verdicts are genuine and re-running spends API budget to reproduce data we already hold. Each transcription's `report.reasoning` discloses the reconstruction (run_id, date, why the raw artifact is absent).

## Layers touched

Data only: `marketplace/src/data/jrig-data.json` (committed build input). No code, no schema, no invariant change. The write path (#935 code) shipped earlier and is untouched.

## How it works

`record-jrig-proofs.mjs` (sole writer, blocking CI `jrig-proofs-test.yml`) upserted 3 `tier3-jrig` rows → `enrich-jrig-data.mjs` regenerated this file (`passed=1` collapse per plugin_name) → plugin detail page renders the badge at build time.

## Verification & evidence

- DB before: `SELECT COUNT(*) FROM forge_proofs` → 0; after: 3 rows (`databricks-pack | tier3-jrig | run_id 2/4/5 | passed=1`).
- Source verdicts verified directly against `runs`/`run_summaries`: run 2 = 11/11 (score 1.0), run 4 = 14/14 (1.0), run 5 = 12/12 (1.0), all `deepseek-v4-flash`, completed 2026-07-12.
- `enrich-jrig-data.mjs` output: `Wrote 1 JRig-verified plugin entries`.
- Freshie system of record: `forge_proofs` versioned in Dolt and pushed to [DoltHub jeremylongshore/freshie-inventory](https://www.dolthub.com/repositories/jeremylongshore/freshie-inventory) tag `run-9.1`; `grades.csv` regenerated byte-identical (no curated-mirror impact).

## Risk assessment

Low. Additive JSON data; CI's `enrich-jrig-data.mjs` preserves the committed file when the local DB is absent, so the build pipeline is unaffected. Rollback = revert this one-file commit.

## Operational impact

None (no env, deps, migrations, secrets). Badge appears on the next marketplace deploy.

## Follow-up & deferred

- 2 of 5 v2 skills (cost-leak-hunter, uc-migration-pilot) have no surviving eval evidence; a fresh ~2-min eval each via `scripts/run-jrig-eval.sh` would cover them — deferred, opt-in spend.
- Retain `--json` artifacts on future eval runs so recording never needs transcription again.

## Refs

Closes #935

- Jeremy Longshore
intentsolutions.io