### PR TITLE
fix(ci): install pyyaml in promote-curated.yml before running the promoter

### DIFF
--- a/.github/workflows/promote-curated.yml
+++ b/.github/workflows/promote-curated.yml
@@ -51,6 +51,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      # promote-to-curated.py hard-exits without pyyaml (it feeds the in-process
+      # re-grade via the canonical validator, which imports yaml). The runner's
+      # bare setup-python has no pyyaml — first dispatch (run 29263338462) failed
+      # exactly here.
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## What

Adds a `pip install pyyaml` step to `promote-curated.yml` between setup-python and the promoter run.

## Why + decision rationale

The first `workflow_dispatch` of the weekly curated-mirror refresh ([run 29263338462](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/29263338462)) failed: `promote-to-curated.py` hard-exits with `ERROR: pyyaml required` because its in-process re-grade imports the canonical validator, which needs yaml, and the runner's bare setup-python ships without it — local runs never hit this because pyyaml is installed system-wide. Chose a one-line pip install over a requirements file because pyyaml is this workflow's only Python dependency.

## Layers touched

CI only (`.github/workflows/promote-curated.yml`). No script, catalog, or mirror change.

## How it works / Verification & evidence

Dispatched the workflow **on this branch** before opening the PR: [run 29264392713](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/29264392713) — **success**, promoter ran to completion, "skills/.curated/ already up to date — no PR" (the expected no-change outcome right after #1040). Bonus verification from the failing run: the Slack-on-fail alert leg fired correctly (`✓ Slack failure alert posted.` to #operation-hired), proving the failure-alerting path end-to-end.

## Risk assessment

Minimal — additive CI step; failure mode is pip network flake, which the existing Slack-on-fail alert catches.

## Operational impact

None. Next Monday 06:00 UTC cron run uses the fixed workflow after merge.

## Follow-up & deferred

None.

## Refs

Refs #1040 (the PR that introduced the workflow)

- Jeremy Longshore
intentsolutions.io