### PR TITLE
feat(marketing): kill the skills.sh install-count badge (README + footer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Plugins](https://img.shields.io/badge/plugins-464-blue)](https://tonsofskills.com/explore)
 [![Skills](https://img.shields.io/badge/skills-3661-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
-[![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -478,15 +478,6 @@ const currentPath = Astro.url.pathname;
             text-decoration: underline;
         }
 
-        .footer-badges {
-            margin: 0.5rem 0 0;
-        }
-
-        .footer-badges img {
-            height: 20px;
-            vertical-align: middle;
-        }
-
         .footer-copyright {
             font-size: 0.75rem;
             color: var(--text-3);
@@ -674,7 +665,6 @@ const currentPath = Astro.url.pathname;
 
             <div class="footer-bottom">
                 <p class="footer-blurb">Tons of Skills by <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a>. Marine. Citadel Grad. 20 years ops &rarr; self-taught dev &rarr; AI architect.</p>
-                <p class="footer-badges"><a href="https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills" target="_blank" rel="noopener" aria-label="Install count on skills.sh"><img src="https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills" alt="skills.sh install count" height="20" loading="lazy" decoding="async" /></a></p>
                 <p class="footer-copyright">&copy; {new Date().getFullYear()} Tons of Skills | <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a></p>
             </div>
         </div>


### PR DESCRIPTION
## What

Removes the skills.sh install-count badge from both surfaces #1038 put it on: the README shield row and the tonsofskills.com footer (paragraph + `.footer-badges` styles).

## Why + decision rationale

Owner call, completing the no-badge sweep (#1046 JRig badge, #1047 Verified tiers + Forge pill). The skills.sh **listing** itself is untouched — the `skills/.curated/` mirror, `skills.sh.json`, and the weekly refresh from #1040/#1045 keep working; only the badge display dies. Chose leaving the other README shields (plugin/skill counts, stars, sponsor, buy-me-a-monster) because the instruction named the skills.sh badge; say the word and the whole shield row goes.

## Layers touched

README + marketplace layout only. No data, catalog, or CI change.

## How it works / Verification & evidence

`grep -c 'skills.sh/b/'` → 0 in both files; `footer-badges` class fully removed (markup + styles). CI `marketplace-validation` builds the site on this PR.

## Risk assessment

None beyond cosmetics. Rollback = revert.

## Operational impact

None. Next main deploy drops the footer badge from the live site.

## Follow-up & deferred

None.

## Refs

Refs #1038

- Jeremy Longshore
intentsolutions.io