### PR TITLE
feat(marketplace): declutter pass 1 — cut decoration, restyle labels to the §4 spec

### DIFF
--- a/marketplace/src/components/DocsTemplate.astro
+++ b/marketplace/src/components/DocsTemplate.astro
@@ -73,7 +73,6 @@ const jsonLd = {
 
         <!-- Header -->
         <header class="docs-header">
-          <span class="section-badge">{sectionLabel}</span>
           <h1 class="docs-title">{title}</h1>
           <p class="docs-description">{description}</p>
         </header>
@@ -194,20 +193,6 @@ const jsonLd = {
       margin-bottom: 2.5rem;
       padding-bottom: 2rem;
       border-bottom: 1px solid var(--border);
-    }
-
-    .section-badge {
-      display: inline-block;
-      background: var(--surface-3);
-      color: var(--primary);
-      padding: 0.3rem 0.7rem;
-      border-radius: 4px;
-      font-size: 0.7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      margin-bottom: 1rem;
-      font-family: 'JetBrains Mono', monospace;
     }
 
     .docs-title {
@@ -427,8 +412,6 @@ const jsonLd = {
     .related-section {
       font-size: 0.65rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
       color: var(--text-3);
       font-family: 'JetBrains Mono', monospace;
     }
@@ -476,8 +459,6 @@ const jsonLd = {
     .nav-label {
       font-size: 0.7rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
       color: var(--text-3);
       font-family: 'JetBrains Mono', monospace;
     }

--- a/marketplace/src/components/PlaybookTemplate.astro
+++ b/marketplace/src/components/PlaybookTemplate.astro
@@ -57,8 +57,6 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
             <span class="meta-item">~{Math.round(wordCount / 200)} min read</span>
             <span class="meta-divider">•</span>
             <span class="meta-item">{wordCount.toLocaleString()} words</span>
-            <span class="meta-divider">•</span>
-            <span class="meta-item">Production-Ready</span>
           </div>
         </div>
       </div>
@@ -143,15 +141,13 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
 
     .category-badge {
       display: inline-block;
-      background: var(--primary-tint, rgba(217, 119, 87, 0.1));
-      color: var(--primary);
-      padding: 0.375rem 0.75rem;
-      border-radius: 0.375rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border: 1px solid var(--primary-border, rgba(217, 119, 87, 0.2));
+      color: var(--ink-2, var(--brand-mid-gray));
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      border: 1px solid var(--rule);
       margin-bottom: 1rem;
     }
 
@@ -197,8 +193,6 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
     .toc-title {
       font-size: 0.875rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       color: var(--text-3, var(--brand-mid-gray));
       margin-bottom: 1rem;
     }
@@ -385,8 +379,6 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
     .nav-label {
       font-size: 0.75rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       color: var(--text-3, var(--brand-mid-gray));
     }
 

--- a/marketplace/src/components/ResearchTemplate.astro
+++ b/marketplace/src/components/ResearchTemplate.astro
@@ -42,8 +42,6 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
             <span class="meta-item">~{readTime} min read</span>
             <span class="meta-divider">&bull;</span>
             <span class="meta-item">{wordCount.toLocaleString()} words</span>
-            <span class="meta-divider">&bull;</span>
-            <span class="meta-item">Data-Driven</span>
           </div>
         </div>
       </div>
@@ -145,17 +143,14 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
 
     .domain-badge {
       display: inline-block;
-      background: rgba(120, 140, 93, 0.1);
-      color: var(--brand-green);
-      padding: 0.375rem 0.75rem;
-      border-radius: 0.375rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border: 1px solid rgba(120, 140, 93, 0.2);
+      color: var(--ink-2, var(--brand-mid-gray));
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-weight: 500;
+      border: 1px solid var(--rule);
       margin-bottom: 1rem;
-      font-family: 'Inter', system-ui, sans-serif;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     }
 
     .research-title {
@@ -213,8 +208,6 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
     .toc-title {
       font-size: 0.875rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       color: var(--brand-mid-gray);
       margin-bottom: 1rem;
       font-family: 'Inter', system-ui, sans-serif;
@@ -390,8 +383,6 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
     .cite-title {
       font-size: 0.875rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       color: var(--brand-mid-gray);
       margin-bottom: 0.75rem;
       font-family: 'Inter', system-ui, sans-serif;

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -392,22 +392,22 @@ const currentPath = Astro.url.pathname;
 
         .footer-signup-form button {
             padding: 0.6rem 1rem;
-            background: var(--signal);
-            color: #0a0a0c;
-            border: none;
-            border-radius: 6px;
+            background: transparent;
+            color: var(--ink);
+            border: 1px solid var(--rule);
+            border-radius: var(--radius-md);
             font-weight: 600;
             font-size: 0.85rem;
             min-height: 44px;
             cursor: pointer;
             font-family: 'Inter', system-ui, sans-serif;
-            transition: all var(--duration-fast);
+            transition: border-color var(--duration-fast);
             white-space: nowrap;
         }
 
         .footer-signup-form button:hover {
-            background: #ffffa1;
-            color: #0a0a0c;
+            border-color: var(--rule-bright);
+            color: var(--ink);
         }
 
         .footer-form-note {

--- a/marketplace/src/pages/404.astro
+++ b/marketplace/src/pages/404.astro
@@ -8,7 +8,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 >
   <section class="not-found">
     <div class="container">
-      <p class="eyebrow">404 · Page Not Found</p>
+      <p class="eyebrow">404</p>
       <h1>That page isn't here.</h1>
       <p class="lede">
         Either the URL is wrong, the page moved, or it never existed. Three good places to try:
@@ -49,24 +49,22 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   .eyebrow {
     font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 0.875rem;
-    letter-spacing: 0.05em;
-    color: var(--slate-400);
+    font-size: 11px;
+    color: var(--ink-3);
     margin: 0 0 1rem;
-    text-transform: uppercase;
   }
 
   h1 {
     font-size: 2.75rem;
     line-height: 1.1;
     margin: 0 0 1.5rem;
-    color: var(--slate-100);
+    color: var(--ink);
   }
 
   .lede {
     font-size: 1.125rem;
     line-height: 1.6;
-    color: var(--slate-300);
+    color: var(--ink-2);
     margin: 0 0 2rem;
   }
 
@@ -74,17 +72,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     list-style: none;
     padding: 0;
     margin: 0 0 3rem;
-    border-top: 1px solid var(--slate-700);
+    border-top: 1px solid var(--rule);
   }
 
   .links li {
     padding: 1.25rem 0;
-    border-bottom: 1px solid var(--slate-700);
-    color: var(--slate-300);
+    border-bottom: 1px solid var(--rule);
+    color: var(--ink-2);
   }
 
   .links a {
-    color: var(--green-400);
+    color: var(--ink-link);
     font-weight: 600;
     text-decoration: none;
   }
@@ -95,11 +93,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   .hint {
     font-size: 0.875rem;
-    color: var(--slate-400);
+    color: var(--ink-3);
     margin: 0;
   }
 
   .hint a {
-    color: var(--slate-200);
+    color: var(--ink);
   }
 </style>

--- a/marketplace/src/pages/collections.astro
+++ b/marketplace/src/pages/collections.astro
@@ -25,21 +25,6 @@ const totalPluginsInCollections = collections.collections.reduce(
       margin-bottom: 3rem;
     }
 
-    .page-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      background: var(--brand-light);
-      border: 1px solid rgba(217, 119, 87, 0.25);
-      padding: 0.5rem 1rem;
-      border-radius: 100px;
-      font-size: 0.85rem;
-      font-weight: 500;
-      color: var(--primary-dark);
-      margin-bottom: 1rem;
-      font-family: 'Inter', system-ui, sans-serif;
-    }
-
     .page-title {
       font-size: clamp(2rem, 5vw, 3rem);
       font-weight: 700;
@@ -97,15 +82,6 @@ const totalPluginsInCollections = collections.collections.reduce(
       font-family: 'Inter', system-ui, sans-serif;
     }
 
-    .section-badge {
-      background: var(--primary);
-      color: #0a0a0c;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 600;
-    }
-
     .install-guide {
       background: var(--brand-light);
       border-radius: 12px;
@@ -137,16 +113,10 @@ const totalPluginsInCollections = collections.collections.reduce(
     }
 
     .step-number {
-      width: 28px;
-      height: 28px;
-      background: var(--primary);
-      color: #0a0a0c;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: 600;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      font-weight: 500;
       font-size: 0.9rem;
+      color: var(--ink-2, var(--brand-mid-gray));
       flex-shrink: 0;
     }
 
@@ -187,7 +157,6 @@ const totalPluginsInCollections = collections.collections.reduce(
 
   <div class="collections-page">
     <header class="page-header">
-      <span class="page-badge">Quick Start</span>
       <h1 class="page-title">Plugin Collections</h1>
       <p class="page-description">
         Pre-built plugin bundles for common workflows. Each collection is curated
@@ -204,16 +173,11 @@ const totalPluginsInCollections = collections.collections.reduce(
         <div class="stat-value">{totalPluginsInCollections}</div>
         <div class="stat-label">Total Plugins</div>
       </div>
-      <div class="stat-item">
-        <div class="stat-value">1-Click</div>
-        <div class="stat-label">Install</div>
-      </div>
     </div>
 
     <section class="collections-section">
       <div class="section-header">
         <h2 class="section-title">Featured Collections</h2>
-        <span class="section-badge">Most Popular</span>
       </div>
       <CollectionsGrid featured={true} />
     </section>
@@ -233,21 +197,21 @@ const totalPluginsInCollections = collections.collections.reduce(
       </p>
       <div class="install-steps">
         <div class="install-step">
-          <span class="step-number">1</span>
+          <span class="step-number">01</span>
           <div class="step-content">
             <strong>Click "Copy Install" on any collection</strong>
             This copies the install commands for all plugins in the bundle.
           </div>
         </div>
         <div class="install-step">
-          <span class="step-number">2</span>
+          <span class="step-number">02</span>
           <div class="step-content">
             <strong>Open Claude Code</strong>
             Launch your Claude Code terminal session.
           </div>
         </div>
         <div class="install-step">
-          <span class="step-number">3</span>
+          <span class="step-number">03</span>
           <div class="step-content">
             <strong>Paste and run the commands</strong>
             Each plugin will be installed from the marketplace.

--- a/marketplace/src/pages/community.astro
+++ b/marketplace/src/pages/community.astro
@@ -354,16 +354,6 @@ function getContributionSummary(plugins: any[]): string {
       overflow: hidden;
     }
 
-    .hof-card::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      background: var(--signal);
-    }
-
     .hof-card:hover {
       border-color: var(--primary);
       transform: translateY(-2px);
@@ -381,12 +371,12 @@ function getContributionSummary(plugins: any[]): string {
       justify-content: center;
       width: 28px;
       height: 28px;
-      background: var(--primary);
-      color: #0a0a0c;
-      font-family: 'Inter Tight', system-ui, sans-serif;
-      font-size: 0.85rem;
-      font-weight: 700;
-      border-radius: 6px;
+      border: 1px solid var(--rule);
+      color: var(--ink);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      border-radius: var(--radius-sm);
     }
 
     .hof-week {
@@ -397,13 +387,11 @@ function getContributionSummary(plugins: any[]): string {
 
     .hof-category {
       font-family: 'JetBrains Mono', monospace;
-      font-size: 0.65rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
+      font-size: 11px;
       color: var(--text-2);
-      background: var(--surface-2);
-      padding: 0.2rem 0.5rem;
-      border-radius: 4px;
+      border: 1px solid var(--rule);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
       margin-left: auto;
     }
 
@@ -500,14 +488,6 @@ function getContributionSummary(plugins: any[]): string {
     </p>
 
     <div class="hero-stats-row">
-      <div class="hero-stat">
-        <span>{contributors.length}</span>
-        Authors
-      </div>
-      <div class="hero-stat">
-        <span>{communityPlugins.length}</span>
-        Community
-      </div>
       <div class="hero-stat">
         <span>{officialPlugins.length}+</span>
         Official

--- a/marketplace/src/pages/compare-marketplaces.astro
+++ b/marketplace/src/pages/compare-marketplaces.astro
@@ -22,13 +22,7 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
         "name": "Tons of Skills (Claude Code Plugins)",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Cross-platform",
-        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "ratingValue": "4.8",
-          "ratingCount": "340",
-          "bestRating": "5"
-        }
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
       }
     })} />
   </Fragment>

--- a/marketplace/src/pages/compare-marketplaces.astro
+++ b/marketplace/src/pages/compare-marketplaces.astro
@@ -173,32 +173,26 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
       <h2>Why Developers Choose Tons of Skills</h2>
       <div class="diff-grid">
         <div class="diff-card">
-          <div class="diff-icon">&#128269;</div>
           <h3>Instant Discovery</h3>
           <p>Fuzzy search across {stats.totalPlugins} plugins and {stats.totalSkills.toLocaleString()} skills. Filter by category, keyword, or tool type. No README scrolling.</p>
         </div>
         <div class="diff-card">
-          <div class="diff-icon">&#128187;</div>
           <h3>CLI-First Install</h3>
           <p>Install any plugin with <code>/plugin install name@claude-code-plugins-plus</code> or use the <code>ccpi</code> CLI. Copy the command right from the explore page.</p>
         </div>
         <div class="diff-card">
-          <div class="diff-icon">&#9989;</div>
           <h3>Quality Validated</h3>
           <p>Every plugin passes CI validation: JSON schema checks, frontmatter validation, secret scanning, and dangerous pattern detection before merge.</p>
         </div>
         <div class="diff-card">
-          <div class="diff-icon">&#128230;</div>
           <h3>Bulk Downloads</h3>
           <p>Download individual plugins, full category bundles, or the entire {stats.totalPlugins}-plugin mega-zip from the Cowork downloads page. Checksums included.</p>
         </div>
         <div class="diff-card">
-          <div class="diff-icon">&#129302;</div>
           <h3>{stats.totalAgents} Custom Agents</h3>
           <p>Pre-built agent definitions for specialized workflows: code review, security auditing, deployment, testing, and more. Ready to drop into your project.</p>
         </div>
         <div class="diff-card">
-          <div class="diff-icon">&#128218;</div>
           <h3>Rich Plugin Pages</h3>
           <p>Every plugin gets a dedicated page with description, skills list, install commands, metadata, and related plugins. Not just a link in a list.</p>
         </div>
@@ -277,8 +271,6 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
     font-family: 'JetBrains Mono', monospace;
     font-size: 0.8rem;
     color: var(--primary);
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
     margin-bottom: 1rem;
   }
   .hero h1 {
@@ -414,10 +406,6 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
     border-color: var(--primary);
     transform: translateY(-2px);
   }
-  .diff-icon {
-    font-size: 2rem;
-    margin-bottom: 0.75rem;
-  }
   .diff-card h3 {
     font-size: 1.15rem;
     font-weight: 600;
@@ -440,21 +428,20 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
   }
   .cat-chip {
     display: inline-block;
-    padding: 0.4rem 1rem;
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 999px;
+    padding: 2px 8px;
+    border: 1px solid var(--rule, var(--border));
+    border-radius: var(--radius-sm);
     color: var(--text-2);
-    font-size: 0.8rem;
+    font-size: 11px;
+    font-family: 'JetBrains Mono', monospace;
     text-decoration: none;
     text-transform: capitalize;
     transition: all 0.2s;
-    font-family: 'Inter', system-ui, sans-serif;
   }
   .cat-chip:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    background: rgba(234, 170, 0, 0.08);
+    border-color: var(--signal-edge);
+    background: var(--signal-tint);
+    color: var(--ink);
   }
 
   /* FAQ */

--- a/marketplace/src/pages/compare.astro
+++ b/marketplace/src/pages/compare.astro
@@ -44,11 +44,6 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
       margin: 2rem 0;
     }
 
-    .empty-icon {
-      font-size: 4rem;
-      margin-bottom: 1rem;
-    }
-
     .empty-title {
       font-size: 1.5rem;
       font-weight: 600;
@@ -146,21 +141,13 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
 
     .plugin-type-badge {
       display: inline-block;
-      padding: 0.2rem 0.6rem;
-      border-radius: 4px;
-      font-size: 0.7rem;
-      font-weight: 600;
-      text-transform: uppercase;
-    }
-
-    .plugin-type-badge.plugin {
-      background: rgba(106, 155, 204, 0.15);
-      color: var(--brand-blue);
-    }
-
-    .plugin-type-badge.skill {
-      background: rgba(217, 119, 87, 0.15);
-      color: var(--primary);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2, var(--brand-mid-gray));
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     }
 
     .plugin-name {
@@ -193,10 +180,12 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
     /* Cell content styles */
     .cell-category {
       display: inline-block;
-      padding: 0.3rem 0.75rem;
-      background: var(--brand-light);
-      border-radius: 20px;
-      font-size: 0.85rem;
+      padding: 2px 8px;
+      border: 1px solid var(--rule);
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      color: var(--ink-2, var(--brand-mid-gray));
       text-transform: capitalize;
     }
 
@@ -214,11 +203,12 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
     }
 
     .tool-tag {
-      background: var(--brand-light);
-      padding: 0.2rem 0.5rem;
-      border-radius: 4px;
-      font-size: 0.75rem;
-      font-family: 'Monaco', 'Menlo', monospace;
+      border: 1px solid var(--rule);
+      color: var(--ink-2, var(--brand-mid-gray));
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
     }
 
     .cell-install {
@@ -369,7 +359,6 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
     </header>
 
     <div id="empty-state" class="empty-state">
-      <div class="empty-icon">⚖️</div>
       <h2 class="empty-title">No plugins selected</h2>
       <p class="empty-text">Browse the explore page and add plugins to compare them side-by-side.</p>
       <a href="/explore/" class="empty-cta">
@@ -445,10 +434,10 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
 
     <div id="compare-actions" class="compare-actions" style="display: none;">
       <button id="share-comparison" class="action-btn secondary">
-        <span>📋</span> Copy Share Link
+        Copy Share Link
       </button>
       <button id="clear-all" class="action-btn secondary">
-        <span>🗑️</span> Clear All
+        Clear All
       </button>
       <a href="/explore/" class="action-btn primary">
         <span>+</span> Add More
@@ -547,7 +536,6 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
       // Header
       headerEl.innerHTML = `
         <div class="plugin-header">
-          <span class="plugin-type-badge ${item.type}">${item.type}</span>
           <a href="${detailUrl}" class="plugin-name">${displayName}</a>
           <button class="remove-btn" onclick="removeItem('${id}')">Remove</button>
         </div>
@@ -591,7 +579,7 @@ const itemsMap = new Map(searchIndex.items.map(item => [item.id || item.name, it
         <div class="cell-install">
           <code class="install-code">${installCmd}</code>
           <button class="copy-btn" onclick="copyToClipboard('${installCmd}')">
-            <span>📋</span> Copy
+            Copy
           </button>
         </div>
       `;

--- a/marketplace/src/pages/cowork.astro
+++ b/marketplace/src/pages/cowork.astro
@@ -28,18 +28,6 @@ const allPlugins = manifest?.plugins || [];
       text-align: center;
     }
 
-    .cowork-hero-badge {
-      display: inline-block;
-      background: rgba(255,255,255,0.15);
-      border: 1px solid rgba(255,255,255,0.3);
-      padding: 0.3rem 1rem;
-      border-radius: 20px;
-      font-size: 0.85rem;
-      font-weight: 600;
-      margin-bottom: 1.5rem;
-      letter-spacing: 0.5px;
-    }
-
     .cowork-hero h1 {
       font-size: clamp(2rem, 5vw, 3rem);
       font-weight: 800;
@@ -117,12 +105,13 @@ const allPlugins = manifest?.plugins || [];
     }
 
     .mega-stat {
-      background: var(--brand-light, #faf9f5);
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: var(--brand-blue, #6a9bcc);
+      border: 1px solid var(--rule, var(--brand-light-gray));
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      color: var(--ink-2, var(--brand-mid-gray));
     }
 
     .mega-download-btn {
@@ -171,8 +160,8 @@ const allPlugins = manifest?.plugins || [];
 
     /* Security section */
     .security-banner {
-      background: var(--surface-2);
-      border: 2px solid #86efac;
+      background: var(--panel, var(--surface-2));
+      border: 1px solid var(--rule, var(--brand-light-gray));
       border-radius: 12px;
       padding: 1.5rem 2rem;
       margin: 2rem auto;
@@ -180,7 +169,7 @@ const allPlugins = manifest?.plugins || [];
     }
 
     .security-banner h3 {
-      color: #166534;
+      color: var(--ink, var(--brand-dark));
       font-size: 1.1rem;
       margin: 0 0 0.75rem;
       font-family: 'Inter', system-ui, sans-serif;
@@ -196,17 +185,8 @@ const allPlugins = manifest?.plugins || [];
     }
 
     .security-list li {
-      color: #15803d;
+      color: var(--ink-2, var(--brand-mid-gray));
       font-size: 0.9rem;
-      padding-left: 1.5rem;
-      position: relative;
-    }
-
-    .security-list li::before {
-      content: '\2713';
-      position: absolute;
-      left: 0;
-      font-weight: 700;
     }
 
     /* Setup guide */
@@ -233,18 +213,11 @@ const allPlugins = manifest?.plugins || [];
     }
 
     .step-number {
-      width: 40px;
-      height: 40px;
-      background: var(--brand-blue, #6a9bcc);
-      color: white;
-      border-radius: 50%;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: 800;
+      color: var(--ink-2, var(--brand-mid-gray));
+      font-weight: 500;
       font-size: 1.1rem;
       margin-bottom: 0.75rem;
-      font-family: 'Inter', system-ui, sans-serif;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     }
 
     .setup-step h4 {
@@ -435,11 +408,11 @@ const allPlugins = manifest?.plugins || [];
 
     /* Prereq banner — above the hero, full-bleed, amber */
     .cowork-prereq {
-      background: #fef3c7;
-      border-top: 4px solid #f59e0b;
-      border-bottom: 1px solid #f59e0b;
+      background: var(--panel, var(--surface-2));
+      border-top: 1px solid var(--rule, var(--brand-light-gray));
+      border-bottom: 1px solid var(--rule, var(--brand-light-gray));
       padding: 0.9rem 1.5rem;
-      color: #78350f;
+      color: var(--ink-2, var(--brand-mid-gray));
       font-size: 0.95rem;
       line-height: 1.5;
     }
@@ -450,18 +423,18 @@ const allPlugins = manifest?.plugins || [];
     }
 
     .cowork-prereq strong {
-      color: #78350f;
+      color: var(--ink, var(--brand-dark));
     }
 
     .cowork-prereq a {
-      color: #78350f;
+      color: var(--ink, var(--brand-dark));
       font-weight: 700;
       text-decoration: underline;
       white-space: nowrap;
     }
 
     .cowork-prereq a:hover {
-      color: #92400e;
+      color: var(--ink-2, var(--brand-mid-gray));
     }
 
     /* Official Cowork resources block */
@@ -527,7 +500,6 @@ const allPlugins = manifest?.plugins || [];
 
   <!-- Hero -->
   <section class="cowork-hero">
-    <span class="cowork-hero-badge">FOR COWORK USERS</span>
     <h1>Download Plugin Packs</h1>
     <p>One-click downloads for Claude Cowork. No terminal needed. Just download, unzip, and drag into your project.</p>
 
@@ -554,8 +526,6 @@ const allPlugins = manifest?.plugins || [];
         <h2>Download Everything</h2>
         <p>All {totalPlugins} plugins and {totalSkills} skills in one zip</p>
         <div class="mega-stats">
-          <span class="mega-stat">{totalPlugins} plugins</span>
-          <span class="mega-stat">{totalSkills} skills</span>
           {megaZip && <span class="mega-stat">{megaZip.sizeFormatted}</span>}
         </div>
       </div>
@@ -564,7 +534,6 @@ const allPlugins = manifest?.plugins || [];
         download
         class="mega-download-btn"
       >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Download All
       </a>
     </div>
@@ -637,22 +606,22 @@ const allPlugins = manifest?.plugins || [];
 
       <div class="setup-steps">
         <div class="setup-step">
-          <div class="step-number">1</div>
+          <div class="step-number">01</div>
           <h4>Download</h4>
           <p>Click any download button above. Your browser will save a .zip file to your Downloads folder.</p>
         </div>
         <div class="setup-step">
-          <div class="step-number">2</div>
+          <div class="step-number">02</div>
           <h4>Unzip</h4>
           <p>Double-click the .zip file to extract it. Keep the unzipped folder somewhere you can find it.</p>
         </div>
         <div class="setup-step">
-          <div class="step-number">3</div>
+          <div class="step-number">03</div>
           <h4>Open Cowork &rarr; Customize</h4>
           <p>In the Claude desktop app, switch to the <strong>Cowork</strong> tab, then click <strong>Customize</strong> in the left sidebar and choose <strong>Browse plugins</strong>. Use the upload-a-custom-plugin option to add your unzipped folder. See <a href="https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork" target="_blank" rel="noopener">Use plugins in Claude Cowork</a> for the canonical walkthrough.</p>
         </div>
         <div class="setup-step">
-          <div class="step-number">4</div>
+          <div class="step-number">04</div>
           <h4>Restart if prompted</h4>
           <p>The plugin's skills, agents, and commands appear in your Cowork workspace once installed.</p>
         </div>
@@ -697,19 +666,15 @@ const allPlugins = manifest?.plugins || [];
       <p>Start with our learning resources to get the most out of your plugins.</p>
       <div class="learning-links">
         <a href="/getting-started" class="learning-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>
           Getting Started Guide
         </a>
         <a href="/learning" class="learning-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 8 3 12 0v-5"/></svg>
           Learning Hub
         </a>
         <a href="/skills" class="learning-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
           Browse Skills
         </a>
         <a href="/explore" class="learning-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
           Explore Plugins
         </a>
       </div>

--- a/marketplace/src/pages/docs/index.astro
+++ b/marketplace/src/pages/docs/index.astro
@@ -43,7 +43,6 @@ const jsonLd = {
     <!-- Hero -->
     <section class="hub-hero">
       <div class="hub-container">
-        <span class="hub-badge">Documentation</span>
         <h1 class="hub-title">
           Learn Claude Code Plugins
         </h1>
@@ -107,20 +106,6 @@ const jsonLd = {
     .hub-hero {
       padding: 4rem 0 3rem;
       text-align: center;
-    }
-
-    .hub-badge {
-      display: inline-block;
-      background: var(--surface-3);
-      color: var(--primary);
-      padding: 0.35rem 0.85rem;
-      border-radius: 5px;
-      font-size: 0.7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      margin-bottom: 1.25rem;
-      font-family: 'JetBrains Mono', monospace;
     }
 
     .hub-title {
@@ -196,16 +181,9 @@ const jsonLd = {
     }
 
     .section-number {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-      background: var(--surface-3);
-      color: var(--primary);
-      border-radius: 8px;
+      color: var(--ink-2, var(--text-2));
       font-size: 0.8rem;
-      font-weight: 700;
+      font-weight: 500;
       flex-shrink: 0;
       font-family: 'JetBrains Mono', monospace;
     }

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -99,7 +99,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
     /* Filters Section */
     .filters-bar {
       background: var(--surface-1);
-      border-bottom: 2px solid var(--border);
+      border-bottom: 1px solid var(--border);
       padding: 1.5rem 4rem;
       position: sticky;
       top: 80px;
@@ -144,7 +144,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
 
     .filter-select {
       padding: 0.6rem 1rem;
-      border: 2px solid var(--brand-light-gray);
+      border: 1px solid var(--brand-light-gray);
       border-radius: 8px;
       font-size: 0.9rem;
       font-family: 'Inter', system-ui, sans-serif;
@@ -384,7 +384,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         <button class="type-btn" data-type="plugin">Plugins</button>
         <button class="type-btn" data-type="skill">Skills</button>
         <button class="type-btn" data-type="docs">Docs</button>
-        <button class="type-btn" data-type="favorites" id="favorites-btn">♡ Favorites</button>
+        <button class="type-btn" data-type="favorites" id="favorites-btn">Favorites</button>
       </div>
 
       <div class="type-toggle author-toggle">
@@ -925,7 +925,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
         const favBtn = document.getElementById('favorites-btn');
         if (favBtn) {
           const count = this.favorites.size;
-          favBtn.textContent = count > 0 ? `♥ Favorites (${count})` : '♡ Favorites';
+          favBtn.textContent = count > 0 ? `Favorites (${count})` : 'Favorites';
         }
       },
 

--- a/marketplace/src/pages/getting-started.astro
+++ b/marketplace/src/pages/getting-started.astro
@@ -20,17 +20,14 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
         <h2>What Are Plugins &amp; Skills?</h2>
         <div class="gs-cards">
           <div class="gs-card">
-            <div class="gs-card-icon">&#x1F4E6;</div>
             <h3>Plugins</h3>
             <p>Packages you install that contain skills, commands, and agents. Think of them like extensions for VS Code &mdash; each one adds new capabilities to Claude.</p>
           </div>
           <div class="gs-card">
-            <div class="gs-card-icon">&#x26A1;</div>
             <h3>Skills</h3>
             <p>Instructions that activate automatically based on context. When you ask Claude to do something a skill covers, it kicks in without you doing anything extra.</p>
           </div>
           <div class="gs-card">
-            <div class="gs-card-icon">&#x2F;</div>
             <h3>Commands</h3>
             <p>Slash commands you type explicitly, like <code>/audit</code> or <code>/deploy</code>. These give you direct control over specific plugin capabilities.</p>
           </div>
@@ -63,23 +60,21 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
         <h2>How Skills Work</h2>
         <div class="gs-steps">
           <div class="gs-step">
-            <div class="gs-step-number">1</div>
+            <div class="gs-step-number">01</div>
             <div class="gs-step-content">
               <h3>Install a plugin</h3>
               <p>Pick a plugin from the marketplace and install it. The plugin's skills are now available to Claude.</p>
             </div>
           </div>
-          <div class="gs-step-arrow">&rarr;</div>
           <div class="gs-step">
-            <div class="gs-step-number">2</div>
+            <div class="gs-step-number">02</div>
             <div class="gs-step-content">
               <h3>Ask Claude anything</h3>
               <p>Just work normally. Ask Claude to review code, write tests, audit security &mdash; whatever you need.</p>
             </div>
           </div>
-          <div class="gs-step-arrow">&rarr;</div>
           <div class="gs-step">
-            <div class="gs-step-number">3</div>
+            <div class="gs-step-number">03</div>
             <div class="gs-step-content">
               <h3>Skills activate automatically</h3>
               <p>Claude detects the right skill for the job and uses it. Better results with zero extra effort from you.</p>
@@ -140,7 +135,6 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
 /* Cards */
 .gs-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:1.5rem}
 .gs-card{background:var(--brand-light-gray);border:1px solid var(--brand-light-gray);border-radius:.5rem;padding:2rem;text-align:center}
-.gs-card-icon{font-size:2rem;margin-bottom:.75rem}
 .gs-card h3{font-size:1.1rem;color:var(--brand-dark);margin-bottom:.5rem}
 .gs-card p{font-size:.9rem;color:var(--brand-mid-gray);line-height:1.6}
 .gs-card code{background:rgba(217,119,87,.1);padding:.15rem .4rem;border-radius:4px;font-size:.85em;color:var(--primary-dark)}
@@ -148,7 +142,7 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
 /* Install paths */
 .gs-install-paths{display:grid;gap:1.5rem}
 .gs-install-path{background:var(--brand-dark);border-radius:.75rem;padding:1.5rem 2rem}
-.gs-path-label{font-family:'Inter', system-ui, sans-serif;font-size:.8rem;font-weight:600;color:var(--primary);text-transform:uppercase;letter-spacing:.1em;margin-bottom:.75rem}
+.gs-path-label{font-family:'JetBrains Mono','SF Mono',monospace;font-size:11px;font-weight:500;color:var(--primary);margin-bottom:.75rem}
 .gs-code-block{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:.75rem 1rem;margin-bottom:.5rem}
 .gs-code-block code{font-family:'SF Mono','Fira Code',monospace;font-size:.95rem;color:var(--brand-light)}
 .gs-note{font-size:.8rem;color:var(--brand-mid-gray);margin:0}
@@ -157,10 +151,9 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
 /* Steps */
 .gs-steps{display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap;justify-content:center}
 .gs-step{flex:1;min-width:200px;background:var(--brand-light-gray);border-radius:.5rem;padding:1.5rem;text-align:center}
-.gs-step-number{width:40px;height:40px;background:var(--primary);color:#0a0a0c;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-family:'Inter', system-ui, sans-serif;font-weight:700;font-size:1.1rem;margin-bottom:.75rem}
+.gs-step-number{color:var(--brand-mid-gray);display:inline-flex;align-items:center;justify-content:center;font-family:'JetBrains Mono','SF Mono',monospace;font-weight:500;font-size:1.1rem;margin-bottom:.75rem}
 .gs-step-content h3{font-size:1rem;color:var(--brand-dark);margin-bottom:.5rem}
 .gs-step-content p{font-size:.85rem;color:var(--brand-mid-gray);line-height:1.6}
-.gs-step-arrow{font-size:1.5rem;color:var(--primary);display:flex;align-items:center;padding-top:1rem}
 
 /* Explore grid */
 .gs-explore-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem}
@@ -177,7 +170,6 @@ const description = 'New to Claude Code plugins? Learn what plugins and skills a
 
 @media(max-width:768px){
   .gs-steps{flex-direction:column}
-  .gs-step-arrow{transform:rotate(90deg);justify-content:center;width:100%}
   .gs-cards{grid-template-columns:1fr}
 }
 </style>

--- a/marketplace/src/pages/grading.astro
+++ b/marketplace/src/pages/grading.astro
@@ -508,28 +508,11 @@ You can configure it with various options.`}</code></pre>
     text-align: center;
     padding: 0.15rem 0;
     border-radius: 4px;
-    font-weight: 700;
+    border: 1px solid var(--rule);
+    color: var(--ink);
+    font-weight: 500;
+    font-size: 11px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
-  }
-  .grading__pill--a {
-    background: oklch(70% 0.18 145);
-    color: #000;
-  }
-  .grading__pill--b {
-    background: oklch(78% 0.14 95);
-    color: #000;
-  }
-  .grading__pill--c {
-    background: oklch(75% 0.15 60);
-    color: #000;
-  }
-  .grading__pill--d {
-    background: oklch(70% 0.18 35);
-    color: #fff;
-  }
-  .grading__pill--f {
-    background: oklch(60% 0.22 25);
-    color: #fff;
   }
   .grading__cat {
     margin: 2rem 0 2.5rem;

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1053,12 +1053,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         "price": "0",
         "priceCurrency": "USD"
       },
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": "4.8",
-        "ratingCount": "258",
-        "bestRating": "5"
-      },
       "description": "295 plugins for Claude Code with 1,537 agent skills, interactive tutorials, and production workflows. Supports 2026 schema.",
       "softwareVersion": "4.14.0",
       "url": "https://tonsofskills.com",

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -213,10 +213,12 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             letter-spacing: 0.12em;
             margin-bottom: 0.55rem;
         }
+        /* Static row per DESIGN.md §4 Partner bar: "Static row, no marquee …
+           never loop on infinite scroll." */
         .hero-sponsor-track {
             display: flex;
-            gap: 3rem;
-            animation: sponsorScroll 11s linear infinite;
+            flex-wrap: wrap;
+            gap: 0.5rem 1.5rem;
         }
         .hero-sponsor-link {
             flex-shrink: 0;
@@ -235,20 +237,13 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         :global([data-theme="light"]) .hero-sponsor-link:hover {
             color: var(--ink);
         }
-        /* Stats marquee (second row, under partners). Visually separated from
-           the partner marquee with a subtle divider + breathing room — they
-           used to stack at margin-top: 0.35rem (~5.6px) which read as one
-           jammed element. Speed bumped from 28s → 16s per design feedback;
-           still slower than partners (11s) because the text strings are longer
-           and need to stay readable. */
+        /* Stats row (second row, under the hero byline). Static per the
+           no-marquee rule; separated with a subtle divider + breathing room. */
         .hero-stats-marquee {
             margin-top: 1.25rem;
             padding-top: 1rem;
             border-top: 1px solid var(--border);
             max-width: 520px;
-        }
-        .hero-stats-marquee .hero-sponsor-track {
-            animation-duration: 16s;
         }
         .hero-stats-link .hero-sponsor-text {
             font-family: 'JetBrains Mono', monospace;
@@ -261,11 +256,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             font-size: 0.95rem;
             letter-spacing: 0.02em;
         }
-        @keyframes sponsorScroll {
-            from { transform: translateX(0); }
-            to { transform: translateX(-50%); }
-        }
-
         /* Spotlight eyebrow pill */
         /* Subtitle */
         .hero-subtitle {
@@ -312,8 +302,8 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         .search-container {
             position: relative;
             background: var(--surface-2);
-            border: 1.5px solid var(--border);
-            border-radius: 12px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
             transition: border-color 0.2s ease;
             cursor: pointer;
         }
@@ -404,92 +394,14 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             color: var(--ink);
         }
 
-        .search-results {
-            position: absolute;
-            top: calc(100% + 0.5rem);
-            left: 0;
-            right: 0;
-            background: var(--surface-2);
-            border: 1.5px solid var(--border);
-            border-radius: 12px;
-            
-            max-height: 400px;
-            overflow-y: auto;
-            z-index: 100;
-        }
-
-        .search-results.hidden {
-            display: none;
-        }
-
-        .search-result-item {
-            padding: 1rem 1.25rem;
-            border-bottom: 1px solid var(--border);
-            cursor: pointer;
-            transition: background 0.15s ease;
-            text-decoration: none;
-            display: block;
-            color: inherit;
-        }
-
-        .search-result-item:last-child {
-            border-bottom: none;
-        }
-
-        .search-result-item:hover {
-            background: var(--surface-3);
-        }
-
-        .result-type-badge {
-            display: inline-block;
-            padding: 0.25rem 0.5rem;
-            border-radius: 4px;
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            margin-bottom: 0.5rem;
-            font-family: 'JetBrains Mono', monospace;
-            letter-spacing: 0.05em;
-        }
-
-        .result-type-badge.plugin {
-            background: rgba(68, 147, 248, 0.15);
-            color: var(--brand-blue);
-        }
-
-        .result-type-badge.skill {
-            background: rgba(234, 170, 0, 0.15);
-            color: var(--primary);
-        }
-
-        .result-name {
-            font-size: 1rem;
-            font-weight: 600;
-            color: var(--text);
-            margin: 0.25rem 0;
-        }
-
-        .result-description {
-            font-size: 0.875rem;
-            color: var(--text-2);
-            margin: 0.25rem 0;
-            line-height: 1.4;
-        }
-
-        .result-plugin-info {
-            font-size: 0.8125rem;
-            color: var(--brand-blue);
-            margin-top: 0.5rem;
-        }
-
         /* Install box */
         .install-box {
             width: 100%;
             max-width: 650px;
             padding: 1.5rem;
             background: var(--surface-2);
-            border: 1.5px solid var(--border);
-            border-radius: 12px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
             animation: fadeInUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.4s forwards;
             opacity: 0;
         }
@@ -626,7 +538,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         .saas-card {
             background: var(--surface-1);
             border: 1px solid var(--border);
-            border-radius: 16px;
+            border-radius: var(--radius-xl);
             padding: 1.5rem;
             transition: transform 0.2s, box-shadow 0.2s;
         }
@@ -643,16 +555,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             margin-bottom: 1rem;
         }
 
-        .saas-icon {
-            width: 48px;
-            height: 48px;
-            border-radius: 12px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-        }
-
         .saas-card h3 {
             color: var(--text);
             margin: 0;
@@ -660,9 +562,9 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         }
 
         .saas-tier {
-            font-size: 0.85rem;
-            font-weight: 600;
-            color: var(--primary);
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--ink-2);
             font-family: 'JetBrains Mono', monospace;
         }
 
@@ -697,13 +599,13 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         }
 
         .saas-cmd.primary {
-            background: rgba(234, 170, 0, 0.1);
-            color: var(--primary);
-            border: 1px solid rgba(234, 170, 0, 0.2);
+            background: transparent;
+            color: var(--ink);
+            border: 1px solid var(--rule);
         }
 
         .saas-cmd.primary:hover {
-            background: rgba(234, 170, 0, 0.18);
+            border-color: var(--rule-bright);
         }
 
         .saas-card.coming-soon {
@@ -714,11 +616,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             justify-content: center;
             align-items: center;
             text-align: center;
-        }
-
-        .coming-soon-icon {
-            font-size: 2.5rem;
-            margin-bottom: 0.75rem;
         }
 
         .saas-card.coming-soon h3 {
@@ -741,20 +638,20 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             display: inline-flex;
             align-items: center;
             gap: 0.5rem;
-            background: white;
-            color: #8B0A2D;
+            background: transparent;
+            color: var(--ink);
+            border: 1px solid var(--rule);
             padding: 0.875rem 1.75rem;
-            border-radius: 8px;
-            font-weight: 700;
+            border-radius: var(--radius-md);
+            font-weight: 600;
             text-decoration: none;
             font-size: 1rem;
             font-family: 'Inter', system-ui, sans-serif;
-            transition: transform 0.2s, box-shadow 0.2s;
+            transition: border-color 0.2s;
         }
 
         .saas-button:hover {
-            transform: translateY(-2px);
-            
+            border-color: var(--rule-bright);
         }
 
         @media (max-width: 768px) {
@@ -804,21 +701,21 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
-            background: var(--accent);
-            color: var(--surface);
+            background: transparent;
+            color: var(--ink);
+            border: 1px solid var(--rule);
             padding: 1rem 2.5rem;
-            border-radius: 10px;
-            font-weight: 700;
+            border-radius: var(--radius-md);
+            font-weight: 600;
             text-decoration: none;
             font-size: 1.1rem;
             font-family: 'Inter', system-ui, sans-serif;
-            transition: transform var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast) var(--ease-out);
+            transition: border-color var(--duration-fast) var(--ease-out);
         }
 
         .cowork-home-button:hover {
-            transform: translateY(-2px);
-            
-            color: var(--surface);
+            border-color: var(--rule-bright);
+            color: var(--ink);
         }
 
         @media (max-width: 768px) {
@@ -970,8 +867,8 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         .level-up-field input,
         .level-up-field textarea {
             background: var(--panel, var(--surface-2));
-            border: 1.5px solid var(--rule, var(--border));
-            border-radius: 8px;
+            border: 1px solid var(--rule, var(--border));
+            border-radius: var(--radius-md);
             padding: 0.75rem 0.9rem;
             font-family: inherit;
             font-size: 1rem;
@@ -1001,20 +898,20 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         }
 
         .level-up-submit {
-            background: var(--signal, var(--accent));
-            color: var(--bg, #0a0a0c);
-            border: none;
-            border-radius: 8px;
+            background: transparent;
+            color: var(--ink, var(--text));
+            border: 1px solid var(--rule, var(--border));
+            border-radius: var(--radius-md);
             padding: 0.75rem 1.5rem;
             font-family: inherit;
             font-size: 0.95rem;
-            font-weight: 700;
+            font-weight: 600;
             cursor: pointer;
-            transition: opacity 0.15s ease;
+            transition: border-color 0.15s ease;
         }
 
         .level-up-submit:hover {
-            opacity: 0.88;
+            border-color: var(--rule-bright, var(--border));
         }
 
         .level-up-submit:disabled {
@@ -1037,240 +934,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         @media (max-width: 768px) {
             .level-up-section {
                 padding: 3rem 1.5rem;
-            }
-        }
-
-        /* ========================================
-           EMAIL SIGNUP SECTION
-           ======================================== */
-        .signup-section {
-            padding: 3rem 2rem;
-            background: var(--surface);
-        }
-
-        .signup-inner {
-            max-width: 600px;
-            margin: 0 auto;
-            text-align: center;
-        }
-
-        .signup-title {
-            margin-left: auto;
-            margin-right: auto;
-        }
-
-        .signup-desc {
-            color: var(--text-2);
-            margin-bottom: 2rem;
-            font-size: 1rem;
-            line-height: 1.6;
-        }
-
-        .signup-form {
-            display: flex;
-            gap: 0.75rem;
-            max-width: 480px;
-            margin: 0 auto;
-        }
-
-        .signup-form input {
-            flex: 1;
-            padding: 0.75rem 1rem;
-            background: var(--surface-2);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            color: var(--text);
-            font-size: 0.95rem;
-            font-family: 'Inter', system-ui, sans-serif;
-            outline: none;
-            transition: border-color 0.2s;
-        }
-
-        .signup-form input:focus {
-            border-color: var(--primary);
-        }
-
-        .signup-form button {
-            padding: 0.75rem 1.5rem;
-            background: var(--primary);
-            color: #0a0a0c;
-            border: none;
-            border-radius: 8px;
-            font-weight: 700;
-            font-size: 0.95rem;
-            cursor: pointer;
-            font-family: 'Inter', system-ui, sans-serif;
-            transition: all 0.2s;
-            white-space: nowrap;
-        }
-
-        .signup-form button:hover {
-            transform: translateY(-1px);
-            
-        }
-
-        .signup-note {
-            margin-top: 1rem;
-            font-size: 0.75rem;
-            color: var(--text-3);
-            font-family: 'JetBrains Mono', monospace;
-        }
-
-        /* ========================================
-           PRODUCTS & SERVICES SECTION
-           ======================================== */
-        .products-section {
-            padding: 3rem 2rem;
-            background: var(--surface);
-        }
-
-        .products-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 2rem;
-            max-width: 1100px;
-            margin: 3rem auto 0;
-        }
-
-        .product-card {
-            background: var(--surface-2);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2rem;
-            position: relative;
-            overflow: hidden;
-            transition: all 0.3s ease;
-        }
-
-        .product-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 3px;
-            background: var(--signal);
-            opacity: 0;
-            transition: opacity 0.3s ease;
-        }
-
-        .product-card.service-card::before {
-            background: var(--positive);
-        }
-
-        .product-card:hover {
-            border-color: rgba(249, 115, 22, 0.3);
-            transform: translateY(-4px);
-            
-        }
-
-        .product-card.service-card:hover {
-            border-color: rgba(63, 185, 80, 0.3);
-            
-        }
-
-        .product-card:hover::before {
-            opacity: 1;
-        }
-
-        .product-card h3 {
-            color: var(--text);
-            font-size: 1.25rem;
-            font-weight: 700;
-            margin-bottom: 0.5rem;
-        }
-
-        .product-price {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-            margin-bottom: 1rem;
-        }
-
-        .product-price .amount {
-            font-size: 1.5rem;
-            font-weight: 800;
-            color: #f97316;
-        }
-
-        .service-card .product-price .amount {
-            color: var(--positive);
-        }
-
-        .product-price .label {
-            font-size: 0.75rem;
-            color: var(--text-3);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            background: rgba(249, 115, 22, 0.15);
-            padding: 2px 8px;
-            border-radius: 4px;
-            font-family: 'JetBrains Mono', monospace;
-        }
-
-        .service-card .product-price .label {
-            background: rgba(63, 185, 80, 0.15);
-        }
-
-        .product-features {
-            list-style: none;
-            padding: 0;
-            margin: 1.25rem 0;
-        }
-
-        .product-features li {
-            color: var(--text-2);
-            font-size: 0.9rem;
-            padding: 0.4rem 0;
-            padding-left: 1.5rem;
-            position: relative;
-        }
-
-        .product-features li::before {
-            content: '\2713';
-            position: absolute;
-            left: 0;
-            color: #f97316;
-            font-weight: 700;
-        }
-
-        .service-card .product-features li::before {
-            color: var(--positive);
-        }
-
-        .product-cta {
-            display: block;
-            width: 100%;
-            padding: 0.75rem 1.5rem;
-            border: none;
-            border-radius: 10px;
-            font-size: 0.95rem;
-            font-weight: 600;
-            cursor: pointer;
-            text-align: center;
-            text-decoration: none;
-            transition: all 0.3s ease;
-            background: var(--signal);
-            color: #0a0a0c;
-        }
-
-        .product-cta:hover {
-            transform: translateY(-1px);
-            
-        }
-
-        .product-cta.service-cta {
-            background: var(--positive);
-            color: #0a0a0c;
-        }
-
-        .product-cta.service-cta:hover {
-            
-        }
-
-        @media (max-width: 768px) {
-            .products-grid {
-                grid-template-columns: 1fr;
             }
         }
 
@@ -1426,18 +1089,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                         {fmtNum(npmMonth)} total downloads · {fmtNum(npmPublished)} packages on npm
                     </span>
                     <div class="hero-sponsor-track">
-                        {npmTop.map((p) => (
-                            <a
-                                href={`https://www.npmjs.com/package/${p.name}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="hero-sponsor-link hero-stats-link"
-                            >
-                                <span class="hero-sponsor-text">
-                                    {p.name.replace(/^@intentsolutionsio\//, '')} · {fmtNum(p.lastMonth)}
-                                </span>
-                            </a>
-                        ))}
                         {npmTop.map((p) => (
                             <a
                                 href={`https://www.npmjs.com/package/${p.name}`}
@@ -1648,12 +1299,9 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- Supabase Pack -->
                 <div class="saas-card" data-accent="#3ECF8E">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #3ECF8E;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-                        </div>
                         <div>
                             <h3>Supabase</h3>
-                            <span class="saas-tier" style="color: #3ECF8E;">30 Skills</span>
+                            <span class="saas-tier">30 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
@@ -1668,9 +1316,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- Vercel Pack -->
                 <div class="saas-card" data-accent="#000">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #333; border: 1px solid var(--border);">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="white"><path d="M12 2L2 19.5h20L12 2z"/></svg>
-                        </div>
                         <div>
                             <h3>Vercel</h3>
                             <span class="saas-tier">30 Skills</span>
@@ -1688,19 +1333,16 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- Sentry Pack -->
                 <div class="saas-card" data-accent="#362D59">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #362D59;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-                        </div>
                         <div>
                             <h3>Sentry</h3>
-                            <span class="saas-tier" style="color: #8b5cf6;">30 Skills</span>
+                            <span class="saas-tier">30 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
                         Error tracking, performance monitoring, release management, and production operations.
                     </p>
                     <div class="saas-commands">
-                        <code class="saas-cmd primary" style="color: #8b5cf6;" onclick="navigator.clipboard.writeText('/plugin install sentry-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install sentry-pack', 2000);">/plugin install sentry-pack</code>
+                        <code class="saas-cmd primary" onclick="navigator.clipboard.writeText('/plugin install sentry-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install sentry-pack', 2000);">/plugin install sentry-pack</code>
                         <code class="saas-cmd" onclick="navigator.clipboard.writeText('npm i @intentsolutionsio/sentry-pack'); this.textContent='Copied!'; setTimeout(() => this.textContent='npm i @intentsolutionsio/sentry-pack', 2000);">npm i @intentsolutionsio/sentry-pack</code>
                     </div>
                 </div>
@@ -1708,19 +1350,16 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- Cursor Pack -->
                 <div class="saas-card" data-accent="#8b5cf6">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #333; border: 1px solid var(--border);">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-                        </div>
                         <div>
                             <h3>Cursor</h3>
-                            <span class="saas-tier" style="color: #8b5cf6;">30 Skills</span>
+                            <span class="saas-tier">30 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
                         AI code editor with completions, chat, composer, rules config, and IDE optimization.
                     </p>
                     <div class="saas-commands">
-                        <code class="saas-cmd primary" style="color: #8b5cf6;" onclick="navigator.clipboard.writeText('/plugin install cursor-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install cursor-pack', 2000);">/plugin install cursor-pack</code>
+                        <code class="saas-cmd primary" onclick="navigator.clipboard.writeText('/plugin install cursor-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install cursor-pack', 2000);">/plugin install cursor-pack</code>
                         <code class="saas-cmd" onclick="navigator.clipboard.writeText('npm i @intentsolutionsio/cursor-skill-md-pack'); this.textContent='Copied!'; setTimeout(() => this.textContent='npm i @intentsolutionsio/cursor-skill-md-pack', 2000);">npm i @intentsolutionsio/cursor-skill-md-pack</code>
                     </div>
                 </div>
@@ -1728,19 +1367,16 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- OpenRouter Pack -->
                 <div class="saas-card" data-accent="#6366f1">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #6366f1;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
-                        </div>
                         <div>
                             <h3>OpenRouter</h3>
-                            <span class="saas-tier" style="color: #6366f1;">30 Skills</span>
+                            <span class="saas-tier">30 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
                         Multi-model LLM gateway with 100+ models, fallbacks, routing, and OpenAI compatibility.
                     </p>
                     <div class="saas-commands">
-                        <code class="saas-cmd primary" style="color: #6366f1;" onclick="navigator.clipboard.writeText('/plugin install openrouter-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install openrouter-pack', 2000);">/plugin install openrouter-pack</code>
+                        <code class="saas-cmd primary" onclick="navigator.clipboard.writeText('/plugin install openrouter-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install openrouter-pack', 2000);">/plugin install openrouter-pack</code>
                         <code class="saas-cmd" onclick="navigator.clipboard.writeText('npm i @intentsolutionsio/openrouter-skill-md-pack'); this.textContent='Copied!'; setTimeout(() => this.textContent='npm i @intentsolutionsio/openrouter-skill-md-pack', 2000);">npm i @intentsolutionsio/openrouter-skill-md-pack</code>
                     </div>
                 </div>
@@ -1748,31 +1384,25 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- Groq Pack -->
                 <div class="saas-card" data-accent="#f55036">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #f55036;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-                        </div>
                         <div>
                             <h3>Groq</h3>
-                            <span class="saas-tier" style="color: #f55036;">24 Skills</span>
+                            <span class="saas-tier">24 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
                         Ultra-fast LPU inference, Groq Cloud deployment, and low-latency AI workflows.
                     </p>
                     <div class="saas-commands">
-                        <code class="saas-cmd primary" style="color: #f55036;" onclick="navigator.clipboard.writeText('/plugin install groq-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install groq-pack', 2000);">/plugin install groq-pack</code>
+                        <code class="saas-cmd primary" onclick="navigator.clipboard.writeText('/plugin install groq-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install groq-pack', 2000);">/plugin install groq-pack</code>
                     </div>
                 </div>
 
                 <!-- LangChain Pack -->
                 <div class="saas-card" data-accent="#1c3c3c">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #1c5c3c;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-                        </div>
                         <div>
                             <h3>LangChain</h3>
-                            <span class="saas-tier" style="color: #3ECF8E;">24 Skills</span>
+                            <span class="saas-tier">24 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
@@ -1786,25 +1416,21 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 <!-- PostHog Pack -->
                 <div class="saas-card" data-accent="#1d4aff">
                     <div class="saas-card-header">
-                        <div class="saas-icon" style="background: #1d4aff;">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg>
-                        </div>
                         <div>
                             <h3>PostHog</h3>
-                            <span class="saas-tier" style="color: #1d4aff;">24 Skills</span>
+                            <span class="saas-tier">24 Skills</span>
                         </div>
                     </div>
                     <p class="saas-desc">
                         Product analytics, feature flags, session replay, and A/B testing.
                     </p>
                     <div class="saas-commands">
-                        <code class="saas-cmd primary" style="color: #1d4aff;" onclick="navigator.clipboard.writeText('/plugin install posthog-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install posthog-pack', 2000);">/plugin install posthog-pack</code>
+                        <code class="saas-cmd primary" onclick="navigator.clipboard.writeText('/plugin install posthog-pack@claude-code-plugins-plus'); this.textContent='Copied!'; setTimeout(() => this.textContent='/plugin install posthog-pack', 2000);">/plugin install posthog-pack</code>
                     </div>
                 </div>
 
                 <!-- View All Packs -->
                 <div class="saas-card coming-soon" style="cursor: pointer;" onclick="window.location.href='/explore?q=pack'">
-                    <div class="coming-soon-icon">🎯</div>
                     <h3>+34 More Packs</h3>
                     <p>
                         Mistral, Perplexity, Clerk, Linear, Obsidian, Firecrawl, and more
@@ -1877,7 +1503,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         </div>
 
         <div style="text-align: center; margin-top: 2rem;">
-            <a href="/collections/" class="primary-button" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: var(--primary); color: #0a0a0c; text-decoration: none; border-radius: 8px; font-weight: 700; font-family: 'Inter', system-ui, sans-serif;">
+            <a href="/collections/" class="primary-button" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: transparent; color: var(--ink); border: 1px solid var(--rule); text-decoration: none; border-radius: var(--radius-md); font-weight: 600; font-family: 'Inter', system-ui, sans-serif;">
                 View All Collections &rarr;
             </a>
         </div>
@@ -1971,7 +1597,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 const text = this.dataset.copy || this.textContent;
                 navigator.clipboard.writeText(text).then(() => {
                     const original = this.textContent;
-                    this.textContent = '✓ Copied to clipboard!';
+                    this.textContent = 'Copied to clipboard!';
                     this.style.color = 'var(--positive)';
                     if (window.trackEvent) {
                         window.trackEvent('install_copied', { plugin_name: text, source: 'homepage_install' });

--- a/marketplace/src/pages/learn/apollo/index.astro
+++ b/marketplace/src/pages/learn/apollo/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/clay/index.astro
+++ b/marketplace/src/pages/learn/clay/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/clerk/index.astro
+++ b/marketplace/src/pages/learn/clerk/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/coderabbit/index.astro
+++ b/marketplace/src/pages/learn/coderabbit/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/cursor/index.astro
+++ b/marketplace/src/pages/learn/cursor/index.astro
@@ -48,17 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      background: #8b5cf615;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -73,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -143,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -238,9 +228,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          ⌨️
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/customerio/index.astro
+++ b/marketplace/src/pages/learn/customerio/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/deepgram/index.astro
+++ b/marketplace/src/pages/learn/deepgram/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/exa/index.astro
+++ b/marketplace/src/pages/learn/exa/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/firecrawl/index.astro
+++ b/marketplace/src/pages/learn/firecrawl/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/fireflies/index.astro
+++ b/marketplace/src/pages/learn/fireflies/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/gamma/index.astro
+++ b/marketplace/src/pages/learn/gamma/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/granola/index.astro
+++ b/marketplace/src/pages/learn/granola/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/groq/index.astro
+++ b/marketplace/src/pages/learn/groq/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/ideogram/index.astro
+++ b/marketplace/src/pages/learn/ideogram/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/index.astro
+++ b/marketplace/src/pages/learn/index.astro
@@ -68,31 +68,13 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
     }
 
     .tier-badge {
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 600;
-      text-transform: uppercase;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: white;
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: white;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     }
 
     .tier-description {
@@ -127,16 +109,6 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
       align-items: center;
       gap: 1rem;
       margin-bottom: 1rem;
-    }
-
-    .vendor-icon {
-      width: 48px;
-      height: 48px;
-      border-radius: 10px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.5rem;
     }
 
     .vendor-name {
@@ -234,14 +206,6 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
             {tierVendors.map(vendor => (
               <a href={`/learn/${vendor.id}/`} class="vendor-card">
                 <div class="vendor-header">
-                  <div class="vendor-icon" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-                    {vendor.icon === 'database' ? '🗄️' :
-                     vendor.icon === 'cloud' ? '☁️' :
-                     vendor.icon === 'alert-triangle' ? '⚠️' :
-                     vendor.icon === 'code' ? '💻' :
-                     vendor.icon === 'layers' ? '🔗' :
-                     vendor.icon === 'video' ? '🎬' : '📦'}
-                  </div>
                   <h3 class="vendor-name">{vendor.name}</h3>
                 </div>
                 <p class="vendor-description">{vendor.description}</p>

--- a/marketplace/src/pages/learn/instantly/index.astro
+++ b/marketplace/src/pages/learn/instantly/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/juicebox/index.astro
+++ b/marketplace/src/pages/learn/juicebox/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/klingai/index.astro
+++ b/marketplace/src/pages/learn/klingai/index.astro
@@ -48,17 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.15);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -73,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -143,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -238,9 +228,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          🎬
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/langchain/index.astro
+++ b/marketplace/src/pages/learn/langchain/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/lindy/index.astro
+++ b/marketplace/src/pages/learn/lindy/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/linear/index.astro
+++ b/marketplace/src/pages/learn/linear/index.astro
@@ -16,37 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F',
-  'target': '\u{1F3AF}',
-  'link': '\u{1F517}',
-  'bot': '\u{1F916}',
-  'file-text': '\u{1F4C4}',
-  'presentation': '\u{1F4CA}',
-  'shield': '\u{1F6E1}\uFE0F',
-  'layout': '\u{1F4CB}',
-  'git-pull-request': '\u{1F500}',
-  'bar-chart': '\u{1F4CA}',
-  'wind': '\u{1F32C}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -84,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -108,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -196,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -290,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/openrouter/index.astro
+++ b/marketplace/src/pages/learn/openrouter/index.astro
@@ -48,17 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.15);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -73,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -143,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -238,9 +228,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          🔀
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/perplexity/index.astro
+++ b/marketplace/src/pages/learn/perplexity/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/posthog/index.astro
+++ b/marketplace/src/pages/learn/posthog/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/replit/index.astro
+++ b/marketplace/src/pages/learn/replit/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/retellai/index.astro
+++ b/marketplace/src/pages/learn/retellai/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/sentry/index.astro
+++ b/marketplace/src/pages/learn/sentry/index.astro
@@ -48,17 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      background: #8b5cf615;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -73,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -143,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -238,9 +228,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          🔍
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/supabase/index.astro
+++ b/marketplace/src/pages/learn/supabase/index.astro
@@ -48,16 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -72,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -142,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -236,9 +227,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          🗄️
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/vastai/index.astro
+++ b/marketplace/src/pages/learn/vastai/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/vercel/index.astro
+++ b/marketplace/src/pages/learn/vercel/index.astro
@@ -48,17 +48,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      background: var(--panel); border: 1px solid var(--rule);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -73,13 +62,13 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
     }
 
@@ -143,11 +132,12 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -238,9 +228,6 @@ const pageDescription = `Complete ${vendor.name} integration with ${vendor.skill
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo">
-          ☁️
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learn/windsurf/index.astro
+++ b/marketplace/src/pages/learn/windsurf/index.astro
@@ -16,27 +16,6 @@ const tierBadgeClass = vendor.tier === 'flagship+' ? 'tier-badge flagship-plus' 
                        vendor.tier === 'flagship' ? 'tier-badge flagship' :
                        vendor.tier === 'pro' ? 'tier-badge pro' : 'tier-badge standard';
 
-const iconMap: Record<string, string> = {
-  'database': '\u{1F5C4}\uFE0F',
-  'cloud': '\u2601\uFE0F',
-  'alert-triangle': '\u26A0\uFE0F',
-  'code': '\u{1F4BB}',
-  'layers': '\u{1F517}',
-  'video': '\u{1F3AC}',
-  'phone': '\u{1F4DE}',
-  'search': '\u{1F50D}',
-  'zap': '\u26A1',
-  'flame': '\u{1F525}',
-  'users': '\u{1F465}',
-  'terminal': '\u{1F4BB}',
-  'cpu': '\u{1F9E0}',
-  'mail': '\u{1F4E7}',
-  'mic': '\u{1F3A4}',
-  'rabbit': '\u{1F430}',
-  'chart': '\u{1F4CA}',
-  'image': '\u{1F5BC}\uFE0F'
-};
-const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
@@ -74,16 +53,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       margin-bottom: 1.5rem;
     }
 
-    .vendor-logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 2.5rem;
-    }
-
     .pack-title {
       font-size: clamp(2rem, 4vw, 2.5rem);
       font-weight: 700;
@@ -98,32 +67,14 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
 
     .tier-badge {
       display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--rule);
+      color: var(--ink-2);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       margin-top: 0.5rem;
-    }
-
-    .tier-badge.flagship-plus {
-      background: var(--signal); color: #0a0a0c;
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.flagship {
-      background: var(--panel-2); border: 1px solid var(--rule); color: var(--ink);
-      color: var(--brand-dark);
-    }
-
-    .tier-badge.pro {
-      background: var(--panel); border: 1px solid var(--rule); color: var(--ink-2);
-      color: var(--ink);
-    }
-
-    .tier-badge.standard {
-      background: var(--ink-link); color: #0a0a0c;
-      color: var(--ink);
     }
 
     .install-section {
@@ -186,11 +137,12 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
     }
 
     .category-badge {
-      background: var(--brand-light-gray);
+      border: 1px solid var(--rule);
       color: var(--brand-mid-gray);
-      font-size: 0.75rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 10px;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
     }
 
     .skills-grid {
@@ -280,9 +232,6 @@ const vendorIcon = iconMap[vendor.icon] || '\u{1F4E6}';
       </div>
 
       <div class="pack-header">
-        <div class="vendor-logo" style={`background: ${vendor.color}15; color: ${vendor.color};`}>
-          {vendorIcon}
-        </div>
         <div>
           <h1 class="pack-title">{vendor.name} Pack</h1>
           <p class="pack-subtitle">{vendor.description}</p>

--- a/marketplace/src/pages/learning/index.astro
+++ b/marketplace/src/pages/learning/index.astro
@@ -101,22 +101,18 @@ const notebooks = {
         <h2 class="section-title">What You'll Learn</h2>
         <div class="learn-grid">
           <div class="learn-card">
-            <div class="learn-icon">📋</div>
             <h3>Test Harness Pattern</h3>
             <p>Understand the mental model behind evidence-based LLM workflows</p>
           </div>
           <div class="learn-card">
-            <div class="learn-icon">🔄</div>
             <h3>Multi-Phase Orchestration</h3>
             <p>Build workflows with strict validation gates between phases</p>
           </div>
           <div class="learn-card">
-            <div class="learn-icon">✅</div>
             <h3>Empirical Verification</h3>
             <p>Use scripts to validate LLM outputs instead of trusting them</p>
           </div>
           <div class="learn-card">
-            <div class="learn-icon">🏗️</div>
             <h3>Production Deployment</h3>
             <p>Take your workflows from learning lab to production systems</p>
           </div>
@@ -167,9 +163,6 @@ const notebooks = {
             {notebooks.skills.map(notebook => (
               <div class="notebook-card">
                 <div class="notebook-header">
-                  <svg class="notebook-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
                   <h4>{notebook.title}</h4>
                 </div>
                 <div class="notebook-actions">
@@ -179,9 +172,6 @@ const notebooks = {
                     rel="noopener noreferrer"
                     class="colab-button"
                   >
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path fill="#F9AB00" d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm4.9 9.9c0 1-.8 1.8-1.8 1.8s-1.8-.8-1.8-1.8.8-1.8 1.8-1.8 1.8.8 1.8 1.8zm-9.8 0c0 1-.8 1.8-1.8 1.8S3.5 10.9 3.5 9.9s.8-1.8 1.8-1.8 1.8.8 1.8 1.8z"/>
-                    </svg>
                     Open in Colab
                   </a>
                   <a
@@ -205,9 +195,6 @@ const notebooks = {
             {notebooks.plugins.map(notebook => (
               <div class="notebook-card">
                 <div class="notebook-header">
-                  <svg class="notebook-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
                   <h4>{notebook.title}</h4>
                 </div>
                 <div class="notebook-actions">
@@ -217,9 +204,6 @@ const notebooks = {
                     rel="noopener noreferrer"
                     class="colab-button"
                   >
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path fill="#F9AB00" d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm4.9 9.9c0 1-.8 1.8-1.8 1.8s-1.8-.8-1.8-1.8.8-1.8 1.8-1.8 1.8.8 1.8 1.8zm-9.8 0c0 1-.8 1.8-1.8 1.8S3.5 10.9 3.5 9.9s.8-1.8 1.8-1.8 1.8.8 1.8 1.8z"/>
-                    </svg>
                     Open in Colab
                   </a>
                   <a
@@ -243,9 +227,6 @@ const notebooks = {
             {notebooks.orchestration.map(notebook => (
               <div class="notebook-card">
                 <div class="notebook-header">
-                  <svg class="notebook-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
                   <h4>{notebook.title}</h4>
                 </div>
                 <div class="notebook-actions">
@@ -255,9 +236,6 @@ const notebooks = {
                     rel="noopener noreferrer"
                     class="colab-button"
                   >
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path fill="#F9AB00" d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm4.9 9.9c0 1-.8 1.8-1.8 1.8s-1.8-.8-1.8-1.8.8-1.8 1.8-1.8 1.8.8 1.8 1.8zm-9.8 0c0 1-.8 1.8-1.8 1.8S3.5 10.9 3.5 9.9s.8-1.8 1.8-1.8 1.8.8 1.8 1.8z"/>
-                    </svg>
                     Open in Colab
                   </a>
                   <a
@@ -282,28 +260,28 @@ const notebooks = {
         <h2 class="section-title">Getting Started</h2>
         <div class="checklist">
           <div class="checklist-item">
-            <span class="checklist-number">1</span>
+            <span class="checklist-number">01</span>
             <div class="checklist-content">
               <h3>Read the Introduction</h3>
               <p>Start with <a href="/learning/start-here">GUIDE 00: Start Here</a> to understand the mental model (5 min)</p>
             </div>
           </div>
           <div class="checklist-item">
-            <span class="checklist-number">2</span>
+            <span class="checklist-number">02</span>
             <div class="checklist-content">
               <h3>Choose Your Path</h3>
               <p>Pick Beginner, Advanced, or Reference based on your experience level</p>
             </div>
           </div>
           <div class="checklist-item">
-            <span class="checklist-number">3</span>
+            <span class="checklist-number">03</span>
             <div class="checklist-content">
               <h3>Try Jupyter Notebooks</h3>
               <p>Launch interactive tutorials in Google Colab - no setup required</p>
             </div>
           </div>
           <div class="checklist-item">
-            <span class="checklist-number">4</span>
+            <span class="checklist-number">04</span>
             <div class="checklist-content">
               <h3>Build Your Own</h3>
               <p>Adapt the reference implementation for your production use case</p>
@@ -385,8 +363,6 @@ const notebooks = {
   .stat-label {
     font-size: 0.875rem;
     color: rgba(255, 255, 255, 0.8);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
   }
 
   /* Sections */
@@ -435,11 +411,6 @@ const notebooks = {
     
   }
 
-  .learn-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-  }
-
   .learn-card h3 {
     font-size: 1.25rem;
     color: var(--brand-dark);
@@ -482,12 +453,12 @@ const notebooks = {
   }
 
   .path-duration {
-    background: var(--brand-light-gray);
+    border: 1px solid var(--rule);
     color: var(--brand-mid-gray);
-    padding: 0.25rem 0.75rem;
-    border-radius: 1rem;
-    font-size: 0.75rem;
-    font-family: 'Inter', system-ui, sans-serif;
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
   }
 
   .path-description {
@@ -573,13 +544,6 @@ const notebooks = {
     margin-bottom: 1rem;
   }
 
-  .notebook-icon {
-    width: 1.5rem;
-    height: 1.5rem;
-    color: var(--brand-blue);
-    flex-shrink: 0;
-  }
-
   .notebook-header h4 {
     font-size: 1rem;
     color: var(--brand-dark);
@@ -608,17 +572,13 @@ const notebooks = {
   }
 
   .colab-button {
-    background: #F9AB00;
+    background: transparent;
+    border: 1px solid var(--rule);
     color: var(--ink);
   }
 
   .colab-button:hover {
-    background: #e09900;
-  }
-
-  .colab-button svg {
-    width: 1.25rem;
-    height: 1.25rem;
+    border-color: var(--rule-bright);
   }
 
   .github-button {
@@ -648,15 +608,9 @@ const notebooks = {
   }
 
   .checklist-number {
-    width: 2.5rem;
-    height: 2.5rem;
-    background: var(--primary);
-    color: #0a0a0c;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
+    font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+    color: var(--ink-2, var(--brand-mid-gray));
+    font-weight: 500;
     font-size: 1.25rem;
     flex-shrink: 0;
   }
@@ -713,8 +667,6 @@ const notebooks = {
     }
 
     .checklist-number {
-      width: 2rem;
-      height: 2rem;
       font-size: 1rem;
     }
   }

--- a/marketplace/src/pages/playbooks/index.astro
+++ b/marketplace/src/pages/playbooks/index.astro
@@ -107,7 +107,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
     <section class="hero">
       <div class="container">
         <div class="hero-content">
-          <span class="hero-badge">Production Engineering</span>
           <h1 class="hero-title">
             <span style="color: var(--primary);">Production Playbooks</span>
           </h1>
@@ -140,7 +139,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
       <div class="container">
         <div class="filter-header">
           <h2 class="filter-cta">Choose Your Focus Area</h2>
-          <p class="filter-subtitle">Select a category to explore production-ready guides</p>
         </div>
         <div class="filter-controls">
           <button class="filter-btn active" data-category="all">All Playbooks</button>
@@ -161,7 +159,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
               <a href={`/playbooks/${playbook.slug}`} class="playbook-card featured-card" data-category={playbook.category}>
                 <div class="card-header">
                   <span class="category-badge">{playbook.category}</span>
-                  <span class="featured-badge">Featured</span>
                 </div>
                 <h3 class="card-title">{playbook.title}</h3>
                 <p class="card-description">{playbook.description}</p>
@@ -238,20 +235,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
       margin: 0 auto;
     }
 
-    .hero-badge {
-      display: inline-block;
-      background: rgba(255, 255, 255, 0.15);
-      color: white;
-      padding: 0.5rem 1rem;
-      border-radius: 0.5rem;
-      font-size: 0.875rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      margin-bottom: 1.5rem;
-    }
-
     .hero-title {
       font-size: clamp(2.5rem, 5vw, 4rem);
       font-weight: 900;
@@ -296,8 +279,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
     .stat-label {
       font-size: 0.875rem;
       color: rgba(255, 255, 255, 0.8);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       font-weight: 600;
     }
 
@@ -325,11 +306,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
       font-weight: 800;
       color: var(--brand-dark);
       margin-bottom: 0.5rem;
-    }
-
-    .filter-subtitle {
-      font-size: 1rem;
-      color: var(--brand-mid-gray);
     }
 
     .filter-controls {
@@ -421,27 +397,13 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
 
     .category-badge {
       display: inline-block;
-      background: rgba(217, 119, 87, 0.1);
-      color: var(--primary);
-      padding: 0.375rem 0.75rem;
-      border-radius: 0.375rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border: 1px solid rgba(217, 119, 87, 0.2);
-    }
-
-    .featured-badge {
-      display: inline-block;
-      background: var(--primary);
-      color: #0a0a0c;
-      padding: 0.375rem 0.75rem;
-      border-radius: 0.375rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+      color: var(--ink-2, var(--brand-mid-gray));
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+      border: 1px solid var(--rule);
     }
 
     .card-title {

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -103,7 +103,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
         {plugin.tagline && <p class="tagline">{plugin.tagline}</p>}
         <div class="meta">
           {plugin.featured && <span class="badge featured">Featured</span>}
-          <span class="badge category">{plugin.category}</span>
           <span class="meta-item">v{plugin.version}</span>
           {plugin.author?.name && <span class="meta-item">by {plugin.author.name}</span>}
         </div>
@@ -174,11 +173,7 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
                       <path d="M4 2 L10 6 L4 10 Z" fill="currentColor"/>
                     </svg>
                   </button>
-                  <svg class="file-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/>
-                  </svg>
                   <span class="gist-filename">{cleanName(skill.name)}</span>
-                  <span class="gist-filetype">SKILL.md</span>
                   <a href={`/skills/${skill.slug}/`} class="gist-view-link">View full skill &rarr;</a>
                 </div>
                 <div class="gist-body">
@@ -433,14 +428,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
     color: #0a0a0c;
   }
 
-  .badge.category {
-    background: var(--brand-green);
-    border-color: var(--brand-green);
-    color: white;
-    text-transform: capitalize;
-  }
-
-
   /* NOI tagline — outcome-speak subtitle (6–10 words) under plugin name */
   .tagline {
     font-size: 1.05rem;
@@ -489,8 +476,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
   .stat-label {
     font-size: 0.7rem;
     color: var(--text-3, var(--brand-mid-gray));
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
   }
 
   .stats-divider {
@@ -707,13 +692,13 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
   }
 
   .component-badge {
-    background: var(--primary);
-    color: #0a0a0c;
-    padding: 0.4rem 1rem;
+    border: 1px solid var(--rule, var(--border));
+    color: var(--ink-2, var(--text-2));
+    padding: 2px 8px;
     border-radius: var(--radius-sm);
-    font-size: 0.9rem;
+    font-size: 11px;
     font-weight: 500;
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
   }
 
   /* Skill Gist Explorer */
@@ -801,11 +786,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
     transition: transform var(--duration-fast) var(--ease-out);
   }
 
-  .file-icon {
-    color: var(--text-3, var(--brand-mid-gray));
-    flex-shrink: 0;
-  }
-
   .gist-filename {
     font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     font-size: 0.85rem;
@@ -814,16 +794,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .gist-filetype {
-    font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
-    font-size: 0.7rem;
-    color: var(--text-3, var(--brand-mid-gray));
-    background: var(--surface-2, var(--brand-light-gray));
-    padding: 0.1rem 0.4rem;
-    border-radius: var(--radius-sm);
-    flex-shrink: 0;
   }
 
   .gist-view-link {
@@ -865,12 +835,11 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
 
   .tool-pill {
     font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
-    font-size: 0.7rem;
-    padding: 0.15rem 0.45rem;
+    font-size: 11px;
+    padding: 2px 8px;
     border-radius: var(--radius-sm);
-    background: rgba(234, 170, 0, 0.1);
-    color: var(--primary);
-    border: 1px solid rgba(234, 170, 0, 0.2);
+    color: var(--ink-2, var(--text-2));
+    border: 1px solid var(--rule, var(--border));
   }
 
   .gist-content {
@@ -928,8 +897,6 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
     font-size: 0.75rem;
     font-weight: 600;
     color: var(--text-3, var(--brand-mid-gray));
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
     font-family: 'Inter', system-ui, sans-serif;
   }
 
@@ -940,10 +907,10 @@ statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
   }
 
   .tag {
-    background: var(--surface-3, var(--brand-light-gray));
-    padding: 0.2rem 0.55rem;
+    border: 1px solid var(--rule, var(--border));
+    padding: 2px 8px;
     border-radius: var(--radius-sm);
-    font-size: 0.72rem;
+    font-size: 11px;
     color: var(--text-2, var(--brand-mid-gray));
     font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
   }

--- a/marketplace/src/pages/research.astro
+++ b/marketplace/src/pages/research.astro
@@ -242,8 +242,6 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
     .stat-label {
       font-size: 0.875rem;
       color: rgba(255, 255, 255, 0.8);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
       font-weight: 600;
       font-family: 'Inter', system-ui, sans-serif;
     }
@@ -293,13 +291,13 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
     }
 
     .domain-count {
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: var(--brand-green);
-      background: rgba(120, 140, 93, 0.1);
-      padding: 0.25rem 0.625rem;
-      border-radius: 0.375rem;
-      font-family: 'Inter', system-ui, sans-serif;
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--ink-2, var(--brand-mid-gray));
+      border: 1px solid var(--rule);
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
       white-space: nowrap;
     }
 

--- a/marketplace/src/pages/skill-enhancers.astro
+++ b/marketplace/src/pages/skill-enhancers.astro
@@ -171,11 +171,6 @@ const collectionSchema = {
   <!-- Hero Section -->
   <section class="hero">
     <div class="container">
-      <div class="hero-badge">
-        <span class="badge-new">NEW CATEGORY</span>
-        <span class="badge-count">5 Plugins</span>
-      </div>
-
       <h1 class="hero-title">
         <span style="color: var(--primary);">Skill Enhancers</span>
         <br />AI Automation for Claude Code
@@ -224,7 +219,6 @@ const collectionSchema = {
 
       <div class="concept-grid">
         <div class="concept-card">
-          <div class="concept-icon">🧠</div>
           <h3 class="concept-title">Claude's Skills</h3>
           <p class="concept-description">
             Built-in capabilities like web_search, file_read, and calendar_read that Claude uses to gather information.
@@ -232,7 +226,6 @@ const collectionSchema = {
         </div>
 
         <div class="concept-card">
-          <div class="concept-icon">+</div>
           <h3 class="concept-title">Automation Layer</h3>
           <p class="concept-description">
             Plugins that intercept Skill results and transform them into actionable outputs automatically.
@@ -240,7 +233,6 @@ const collectionSchema = {
         </div>
 
         <div class="concept-card">
-          <div class="concept-icon">🚀</div>
           <h3 class="concept-title">Automated Output</h3>
           <p class="concept-description">
             GitHub issues, Slack messages, production code, or infrastructure deployments created instantly.
@@ -289,7 +281,7 @@ const collectionSchema = {
             <p class="flow-description">
               Formatted output appears in GitHub, Slack, your codebase, or infrastructure.
             </p>
-            <code class="flow-example">GitHub issue created with sources and checklist ✓</code>
+            <code class="flow-example">GitHub issue created with sources and checklist</code>
           </div>
         </div>
       </div>
@@ -300,7 +292,7 @@ const collectionSchema = {
   <section class="section-featured" id="free-plugin">
     <div class="container">
       <div class="featured-badge">
-        <span class="badge-tier-free">COMMUNITY TIER - FREE</span>
+        <span class="badge-tier-free">Community tier — free</span>
       </div>
 
       <h2 class="section-title">Featured: Web to GitHub Issue</h2>
@@ -315,27 +307,15 @@ const collectionSchema = {
 
           <div class="featured-benefits">
             <div class="benefit">
-              <svg class="benefit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-              </svg>
               <span>Automatic source preservation</span>
             </div>
             <div class="benefit">
-              <svg class="benefit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-              </svg>
               <span>Smart priority detection (CVEs, security)</span>
             </div>
             <div class="benefit">
-              <svg class="benefit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-              </svg>
               <span>Action checklists for next steps</span>
             </div>
             <div class="benefit">
-              <svg class="benefit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-              </svg>
               <span>Related topic extraction</span>
             </div>
           </div>
@@ -356,7 +336,7 @@ const collectionSchema = {
         <div class="featured-demo">
           <div class="demo-card">
             <div class="demo-header">
-              <span class="demo-label">BEFORE</span>
+              <span class="demo-label">Before</span>
               <span class="demo-time">15 minutes</span>
             </div>
             <ol class="demo-steps">
@@ -373,13 +353,12 @@ const collectionSchema = {
 
           <div class="demo-card demo-card-after">
             <div class="demo-header">
-              <span class="demo-label">AFTER</span>
+              <span class="demo-label">After</span>
               <span class="demo-time demo-time-saved">30 seconds (95% saved)</span>
             </div>
             <ol class="demo-steps">
               <li>"Research PostgreSQL indexing and create ticket"</li>
             </ol>
-            <div class="demo-badge">✓ Done automatically</div>
           </div>
         </div>
       </div>
@@ -411,10 +390,6 @@ const collectionSchema = {
             <li>Digest formatting templates</li>
             <li>Thread management</li>
           </ul>
-          <div class="premium-status">
-            <span class="status-label">Status:</span>
-            <span class="status-badge status-roadmap">On Roadmap</span>
-          </div>
         </div>
 
         <!-- Pro Tier Plugin 2 -->
@@ -433,10 +408,6 @@ const collectionSchema = {
             <li>TypeScript type definitions</li>
             <li>Documentation generation</li>
           </ul>
-          <div class="premium-status">
-            <span class="status-label">Status:</span>
-            <span class="status-badge status-roadmap">On Roadmap</span>
-          </div>
         </div>
 
         <!-- Pro Tier Plugin 3 -->
@@ -455,10 +426,6 @@ const collectionSchema = {
             <li>Context gathering</li>
             <li>Follow-up automation</li>
           </ul>
-          <div class="premium-status">
-            <span class="status-label">Status:</span>
-            <span class="status-badge status-roadmap">On Roadmap</span>
-          </div>
         </div>
 
         <!-- Enterprise Tier Plugin -->
@@ -477,16 +444,12 @@ const collectionSchema = {
             <li>Multi-cloud deployment</li>
             <li>Cost estimation</li>
           </ul>
-          <div class="premium-status">
-            <span class="status-label">Status:</span>
-            <span class="status-badge status-roadmap">On Roadmap</span>
-          </div>
         </div>
       </div>
 
       <div class="sponsor-cta">
         <p class="sponsor-text">
-          ⚡🪽 Support development as a design partner and get early access to premium roadmap items as they ship. Pro and Enterprise sponsors influence what gets built and when.
+          Support development as a design partner and get early access to premium roadmap items as they ship. Pro and Enterprise sponsors influence what gets built and when.
         </p>
         <a href="https://buymeacoffee.com/jeremylongshore" class="btn-sponsor" target="_blank" rel="noopener noreferrer">
           Buy me a Red Bull - Give These Plugins Wings →
@@ -667,36 +630,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     border-bottom: 1px solid var(--brand-light-gray);
   }
 
-  .hero-badge {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    justify-content: center;
-    margin-bottom: 2rem;
-  }
-
-  .badge-new {
-    padding: 0.5rem 1rem;
-    background: var(--primary); color: #0a0a0c;
-    color: #0a0a0c;
-    border-radius: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-  }
-
-  .badge-count {
-    padding: 0.5rem 1rem;
-    background: var(--brand-light-gray);
-    color: var(--brand-mid-gray);
-    border: 1px solid var(--brand-light-gray);
-    border-radius: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    font-family: var(--font-mono);
-  }
-
   .hero-title {
     font-size: clamp(2.5rem, 5vw, 4rem);
     font-weight: 800;
@@ -782,8 +715,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
   .stat-label {
     font-size: 0.875rem;
     color: var(--brand-mid-gray);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
     margin-top: 0.5rem;
   }
 
@@ -836,11 +767,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     border-color: var(--primary);
     
     transform: translateY(-4px);
-  }
-
-  .concept-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
   }
 
   .concept-title {
@@ -931,14 +857,13 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
   }
 
   .badge-tier-free {
-    padding: 0.5rem 1rem;
-    background: var(--primary); color: #0a0a0c;
-    color: #0a0a0c;
-    border-radius: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    padding: 2px 8px;
+    border: 1px solid var(--rule, var(--brand-light-gray));
+    color: var(--ink-2, var(--brand-mid-gray));
+    border-radius: 0.25rem;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: var(--font-mono);
   }
 
   .featured-grid {
@@ -980,13 +905,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     align-items: center;
     gap: 0.75rem;
     color: var(--brand-dark);
-  }
-
-  .benefit-icon {
-    width: 1.5rem;
-    height: 1.5rem;
-    color: var(--primary);
-    flex-shrink: 0;
   }
 
   .install-section {
@@ -1051,10 +969,8 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
 
   .demo-label {
     font-size: 0.75rem;
-    font-weight: 700;
+    font-weight: 500;
     color: var(--brand-mid-gray);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
   }
 
   .demo-time {
@@ -1073,18 +989,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     padding-left: 1.5rem;
     color: var(--brand-mid-gray);
     line-height: 1.8;
-  }
-
-  .demo-badge {
-    margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    background: rgba(217, 119, 87, 0.1);
-    border: 1px solid var(--primary-dark);
-    border-radius: 0.5rem;
-    color: var(--primary);
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-align: center;
   }
 
   /* Premium Grid */
@@ -1173,33 +1077,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     left: 0;
     color: var(--primary);
     font-weight: 700;
-  }
-
-  .premium-status {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--brand-light-gray);
-  }
-
-  .status-label {
-    font-size: 0.875rem;
-    color: var(--brand-mid-gray);
-    font-weight: 600;
-  }
-
-  .status-badge {
-    padding: 0.25rem 0.75rem;
-    border-radius: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-  }
-
-  .status-roadmap {
-    background: rgba(234, 179, 8, 0.1);
-    color: var(--yellow-500);
-    border: 1px solid var(--yellow-500);
   }
 
   .sponsor-cta {
@@ -1300,10 +1177,8 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
 
   .comparison-label {
     font-size: 0.75rem;
-    font-weight: 700;
+    font-weight: 500;
     color: var(--brand-mid-gray);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
     margin-bottom: 1rem;
   }
 
@@ -1320,15 +1195,13 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     font-size: 0.875rem;
     color: var(--brand-mid-gray);
     padding: 0.5rem 1rem;
-    background: var(--brand-light);
+    border: 1px solid var(--rule, var(--brand-light-gray));
     border-radius: 0.25rem;
     display: inline-block;
   }
 
   .comparison-time-saved {
     color: var(--primary);
-    background: rgba(217, 119, 87, 0.1);
-    border: 1px solid var(--primary-dark);
     font-weight: 600;
   }
 

--- a/marketplace/src/pages/skills/[slug].astro
+++ b/marketplace/src/pages/skills/[slug].astro
@@ -100,12 +100,6 @@ const cleanTools = (tools: string[]) =>
       gap: 0.5rem;
     }
 
-    .metadata-item svg {
-      width: 18px;
-      height: 18px;
-      color: var(--text-2, var(--brand-mid-gray));
-    }
-
     /* Compatible platforms */
     .platform-pills {
       display: flex;
@@ -115,12 +109,11 @@ const cleanTools = (tools: string[]) =>
 
     .platform-pill {
       font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
-      font-size: 0.75rem;
+      font-size: 11px;
       padding: 0.25rem 0.6rem;
       border-radius: var(--radius-sm);
-      background: var(--surface-3, var(--brand-light-gray));
       color: var(--text-2, var(--brand-mid-gray));
-      border: 1px solid var(--border, var(--brand-light-gray));
+      border: 1px solid var(--rule, var(--border));
     }
 
     /* Stats Bar */
@@ -174,11 +167,6 @@ const cleanTools = (tools: string[]) =>
       
     }
 
-    .section-box.highlight {
-      background: rgba(217, 119, 87, 0.05);
-      border-color: rgba(217, 119, 87, 0.2);
-    }
-
     .section-box.dark {
       background: var(--brand-dark);
       border-color: var(--brand-dark);
@@ -203,13 +191,13 @@ const cleanTools = (tools: string[]) =>
     }
 
     .tool-badge {
-      padding: 0.4rem 0.85rem;
-      background: var(--primary);
-      color: #0a0a0c;
+      padding: 2px 8px;
+      border: 1px solid var(--rule, var(--border));
+      color: var(--ink-2, var(--text-2));
       border-radius: var(--radius-sm);
-      font-size: 0.8rem;
-      font-weight: 600;
-      font-family: 'Inter', system-ui, sans-serif;
+      font-size: 11px;
+      font-weight: 500;
+      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
     }
 
     .plugin-info {
@@ -446,23 +434,6 @@ const cleanTools = (tools: string[]) =>
       opacity: 0.6;
     }
 
-    .skill-footer {
-      margin-top: 2rem;
-      padding-top: 1.5rem;
-      border-top: 1px solid var(--border, var(--brand-light-gray));
-      font-size: 0.8rem;
-      color: var(--text-2, var(--brand-mid-gray));
-    }
-
-    .skill-footer a {
-      color: var(--primary);
-      text-decoration: none;
-    }
-
-    .skill-footer a:hover {
-      text-decoration: underline;
-    }
-
     .related-skills-section {
       margin-top: 2rem;
     }
@@ -517,12 +488,11 @@ const cleanTools = (tools: string[]) =>
 
     .related-tool-pill {
       font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
-      font-size: 0.65rem;
+      font-size: 11px;
       padding: 0.1rem 0.35rem;
       border-radius: 3px;
-      background: rgba(234, 170, 0, 0.1);
-      color: var(--primary);
-      border: 1px solid rgba(234, 170, 0, 0.15);
+      color: var(--ink-2, var(--text-2));
+      border: 1px solid var(--rule, var(--border));
     }
 
     @media (max-width: 768px) {
@@ -579,21 +549,12 @@ const cleanTools = (tools: string[]) =>
 
       <div class="skill-metadata">
         <div class="metadata-item">
-          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
-          </svg>
           <span>v{skill.version}</span>
         </div>
         <div class="metadata-item">
-          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-          </svg>
           <span>{authorName}</span>
         </div>
         <div class="metadata-item">
-          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
-          </svg>
           <span>{skill.license}</span>
         </div>
       </div>
@@ -623,7 +584,7 @@ const cleanTools = (tools: string[]) =>
     )}
 
     <!-- 4. Allowed Tools -->
-    <section class="section-box highlight">
+    <section class="section-box">
       <h2 class="section-title">Allowed Tools</h2>
       <div class="tools-grid">
         {skill.allowedTools.map(tool => (
@@ -694,10 +655,6 @@ const cleanTools = (tools: string[]) =>
       </section>
     )}
 
-    <!-- 10. Footer -->
-    <footer class="skill-footer">
-      <p>Part of <a href={`/plugins/${skill.parentPlugin.name}/`}>{skill.parentPlugin.name}</a></p>
-    </footer>
   </div>
 
   <!-- Copy functionality -->

--- a/marketplace/src/pages/sponsor.astro
+++ b/marketplace/src/pages/sponsor.astro
@@ -393,13 +393,6 @@ const seo = {
         line-height: 1.5;
       }
 
-      .pricing-features li::before {
-        content: "✓";
-        color: var(--brand-green);
-        font-weight: 700;
-        font-size: 1.125rem;
-        flex-shrink: 0;
-      }
 
       .pricing-cta {
         display: block;
@@ -577,8 +570,6 @@ const seo = {
         font-size: 0.75rem;
         font-weight: 700;
         color: var(--brand-orange);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
         margin-bottom: 0.5rem;
       }
 
@@ -818,9 +809,6 @@ const seo = {
         </p>
         <p style="margin: 0; color: var(--brand-mid-gray); font-size: 0.875rem;">
           © 2026 Claude Code Plugins. Open Source under MIT License.
-        </p>
-        <p style="margin: 0.5rem 0 0 0; color: var(--brand-mid-gray); font-size: 0.75rem;">
-          Built with Astro 5 + Tailwind CSS v4
         </p>
       </div>
     </footer>

--- a/marketplace/src/pages/tools.astro
+++ b/marketplace/src/pages/tools.astro
@@ -138,28 +138,6 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         margin-bottom: 1.5rem;
       }
 
-      .tool-icon {
-        width: 48px;
-        height: 48px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 10px;
-        font-size: 1.5rem;
-      }
-
-      .tool-icon.doctor {
-        background: var(--primary);
-      }
-
-      .tool-icon.analytics {
-        background: var(--ink-link);
-      }
-
-      .tool-icon.chats {
-        background: var(--alert);
-      }
-
       .tool-title {
         flex: 1;
       }
@@ -171,22 +149,13 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
       }
 
       .tool-status {
-        font-size: 0.85rem;
-        padding: 0.25rem 0.75rem;
-        border-radius: 999px;
-        font-weight: 600;
-      }
-
-      .status-available {
-        background: rgba(16, 185, 129, 0.2);
-        color: var(--accent);
-        border: 1px solid var(--accent);
-      }
-
-      .status-soon {
-        background: rgba(251, 146, 60, 0.2);
-        color: var(--orange);
-        border: 1px solid var(--orange);
+        font-size: 11px;
+        font-family: 'JetBrains Mono', monospace;
+        padding: 2px 8px;
+        border-radius: 2px;
+        border: 1px solid var(--border);
+        color: var(--text-muted);
+        font-weight: 500;
       }
 
       .tool-description {
@@ -207,13 +176,6 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         margin-bottom: 0.75rem;
         color: var(--text);
         font-size: 0.95rem;
-      }
-
-      .feature-list li::before {
-        content: '✓';
-        color: var(--accent);
-        font-weight: 700;
-        flex-shrink: 0;
       }
 
       .install-box {
@@ -400,10 +362,9 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         <!-- Doctor -->
         <div class="tool-card">
           <div class="tool-header">
-            <div class="tool-icon doctor">🩺</div>
             <div class="tool-title">
               <h2>CCPI Doctor</h2>
-              <span class="tool-status status-available">Available Now</span>
+              <span class="tool-status status-available">Available now</span>
             </div>
           </div>
 
@@ -429,10 +390,9 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         <!-- Analytics -->
         <div class="tool-card">
           <div class="tool-header">
-            <div class="tool-icon analytics">📊</div>
             <div class="tool-title">
               <h2>CCPI Analytics</h2>
-              <span class="tool-status status-soon">Coming Soon</span>
+              <span class="tool-status status-soon">Coming soon</span>
             </div>
           </div>
 
@@ -458,10 +418,9 @@ const CLI_INSTALL = 'npx @claude-code-plugins/ccp doctor';
         <!-- Chats -->
         <div class="tool-card">
           <div class="tool-header">
-            <div class="tool-icon chats">💬</div>
             <div class="tool-title">
               <h2>CCPI Chats</h2>
-              <span class="tool-status status-soon">Coming Soon</span>
+              <span class="tool-status status-soon">Coming soon</span>
             </div>
           </div>
 


### PR DESCRIPTION
## What

Declutter pass 1 over tonsofskills.com, implementing a completed 5-group site audit (catalog · skills/enhancers · shell/home · content hubs · marketing) against the DESIGN.md constitution (§4 badges/tags spec, §7 one-accent, §8 anti-slop reject table).

Note: `[skip auto-bump]` — marketplace UI only, no plugin/package changes.

**Counts**

- **54 safe cuts applied** (of 56 audited): emoji/SVG icons decorating labels (SaaS grid icon boxes, vendor-page emoji logos, learn-card emoji, diff-card emoji, heroicons beside version/author/license), redundant ALL-CAPS pills that repeat adjacent headings/breadcrumbs ("NEW CATEGORY", "Quick Start", "Most Popular", "FOR COWORK USERS", "Documentation", "Production Engineering", "Featured"-inside-Featured-section, DocsTemplate section badge), ✓-checkmark list/chip decorations (tools, sponsor, cowork, skill-enhancers, copy feedback), self-praise meta labels ("Production-Ready", "Data-Driven"), the fake "1-Click Install" stat, the 4x-repeated "Status: On Roadmap" rows, duplicated hero stat chips/boxes (cowork mega-stats, community Authors/Community boxes), one 5th-time-repeated plugin link (skills footer), and ~310 lines of confirmed-dead CSS in `index.astro` (`.products-section`, `.signup-section`, `.search-results` — all verified unreferenced in markup).
- **48 style fixes applied** (of 53 audited; 2 of the 48 partial — see skipped): info-bearing pills/chips/labels restyled to the §4 spec (JetBrains Mono 11px, 1px `var(--rule)` hairline, no background fill, sentence case) — tool pills, component counts, keyword tags, tier/category/domain badges (incl. all 30 `/learn/<vendor>/` pages), grade pills, platform pills, durations, statuses; ALL-CAPS `text-transform` dropped from stat/toc/nav/demo/comparison labels; filled number circles → bare mono kickers (01/02/03…); competing signal-yellow filled CTAs (footer Subscribe, level-up Send, View All Collections, cowork button, saas/colab buttons) → §4 Secondary tier (transparent, 1px hairline) leaving `nav-cta` as the single primary; the hero npm-stats **marquee converted to a static wrapping row** (motion removed, duplicated seamless-loop render deleted — the row itself stays, per the §4 "static row, no marquee" rule); off-palette raw hex (amber prereq banner, green security panel, Colab orange, burgundy button, 404 undefined slate/green tokens) → semantic tokens; hardcoded border-radius values pointed at the token radii; 2px borders → 1px hairlines.
- **7 skipped, with reasons** (all logged, nothing silently dropped):
  1. `collections.astro` "supercharge" wording — banned-vocab **copy rewrite = owner decision** (scope rule: no copy rewording).
  2. `compare-marketplaces.astro` "Ready to Supercharge Your Claude Code?" h2 — same banned-vocab rewrite, owner decision.
  3. `plugins/[name].astro` `.badge`/`.badge.featured` restyle — conditional on the Featured-pill owner decision (cut vs keep).
  4. `skills/[slug].astro` `.stat-label` de-caps — conditional on the stats-bar owner decision.
  5. `skill-enhancers.astro` `.tier-badge` pro/enterprise restyle — pricing pills are an explicit owner decision.
  6. `research.astro` `.hero-badge` + `.coming-badge` restyles — both conditional on their contentDecisions.
  7. Partial skips: the killer-skills subscribe/nomination boxes kept their 12px radii and yellow buttons — that whole surface is the killer-signup owner decision; and `learn/**` skill-card 10px radii were not cited by the audit and were left alone.

## Why

Owner directive: the website has accumulated clutter. `marketplace/DESIGN.md` (Data-Dense Pro, locked 2026-05-06) is the authority — §4 defines the badge/tag spec, §7 caps the page at one signal accent, §8 rejects icon-decorating-a-label, multi-accent, fills, and marquee motion. Every change here either deletes decoration that carries zero information or restyles an information-bearing element to the constitution's spec. Chose surgical in-place edits over a component refactor because the audit's line-item findings map 1:1 to existing markup/CSS and the risk budget for this pass is visual-only.

## Layers touched

Marketplace UI only: `marketplace/src/{pages,components,layouts}` — 54 files. No plugins/**, no skills/**, no scripts/**, no data/**, no DESIGN.md edits, no copy rewording.

## How it works

Each audit `safeCut` was verified against current markup by content (line numbers had drifted) before removal; orphaned CSS was grepped per class and deleted only when truly unreferenced (remaining `featured-badge`/`hero-badge` hits are blog/changelog pages outside audit scope or intentionally-kept contentDecision elements). The 30 near-identical `/learn/<vendor>/` pages were batch-transformed with a per-block count-verified script (each block asserted to match exactly once per file; 3 structural variants handled explicitly). Style fixes reference tokens (`--rule`, `--ink-2`, `--radius-*`, `--signal-tint/edge`) with legacy-alias fallbacks on light-native pages.

## Verification & evidence

- `cd marketplace && npm run build` — full 7-step pipeline (discover-skills → … → astro build) passes; route count and budgets within CI limits (see CI run on this PR).
- Grep assertions all green: zero `.saas-icon`, zero `coming-soon-icon`, zero `.products-section`/`.signup-section`/`.search-results` residue in `index.astro`, and **zero raw hex introduced** (`git diff` added-lines contain no `#hex` colors — the diff only removes hex or replaces it with `var(--token)`).
- Full-diff information-loss review: every removed line is decoration (icons, fills, transforms, dead CSS, duplicate renders); the only removed *text* nodes are the audited redundant labels listed above.

## Risk assessment

Visual-only change; no data, routing, or build-pipeline logic touched. The largest behavioural deltas are the static npm-stats row (was animated marquee) and the de-filled secondary CTAs. Rollback = revert this single commit.

## Operational impact

None beyond the next deploy — static site rebuild picks everything up; no env/migrations/deps/secrets.

## Owner decisions — NOT in this PR

All 24 contentDecisions from the audit are untouched and listed here for the owner to rule on separately:

| File | Element | Tradeoff |
|---|---|---|
| `explore.astro:349` | Hero subtitle repeats the plugin/skill counts shown in the stats row below | De-number the subtitle (recommended) or drop the stats row (loses Categories count + mono readout) |
| `plugins/[name].astro:105` | "Featured" signal-yellow pill in header meta | Real curation data vs accent-budget cost; cut, or keep + §4 restyle |
| `skill-enhancers.astro:401` | "PRO TIER - $19/mo" / "ENTERPRISE TIER - $199/mo" pills | Only pricing signal on the page, but prices roadmap items that don't exist yet |
| `skill-enhancers.astro:199` | Hero stat "95% / Time Saved" | Headline claim vs unverifiable estimate presented as a stat |
| `skill-enhancers.astro:588` | "93.8%" giant aggregate time-saved block | Invented average of estimates styled as a hero stat |
| `skill-enhancers.astro:487` | sponsor-cta pitch near-duplicates the section intro | Two identical sponsor asks; owner picks which sentence survives |
| `skills/[slug].astro:610` | Stats bar (Tools / Plugin / Category) | House-style readout, but every value is triple-stated within one viewport |
| `index.astro:1555` | killer-signup boxed subscribe form | Second email-capture form on the homepage (footer already has one); code comment documents one-form intent |
| `index.astro:1424` | npm-stats row REMOVAL (now static, motion already fixed in this PR) | Per-package downloads are unique data and the only mobile npm surface; removal is the remaining call |
| `BaseLayout.astro:667` | Footer bio "Marine. Citadel Grad. 20 years ops → …" | Founder-story signal on every page vs footer minimalism |
| `index.astro:1888` | "Community-driven, production-ready plugins" h2 | "production-ready" is banned vocab; replacement copy is owner's |
| `learn/index.astro:250` | "View Pack" install-hint in vendor cards | Card's only textual click affordance vs zero-data label |
| `learn/index.astro:259` | "More Packs Coming Soon / 50 vendors" promo box | Public roadmap claim (possibly stale) vs promo chrome |
| `learn/index.astro:209` | Hero stat "4 / Tier Levels" | Own-taxonomy count padding the stat row vs only hint tiers exist |
| `learning/index.astro:89` | Hero stat "5 / Phase System" | Internal-model count vs hero mention of the phase model |
| `research.astro:87` | "Research & Analysis" hero badge | Only on-page element naming the section (h1 is "How We Know What Works") |
| `research.astro:100` | "{totalDocs} Documents" hero stat counts 24 though only 6 are ready | Advertises 4x available content; honest number deflates the stat |
| `research.astro:126` | 18 "Coming Soon" placeholder rows | Genuine public roadmap vs page that is 75% unclickable |
| `playbooks/index.astro:169` | Dual "~N min read • N words" meta | Same fact twice (min-read derived from words) — defensible as data |
| `sponsor.astro:800` | Third identical "Email Me for Details" CTA banner | End-of-scroll conversion prompt vs §7 one-primary-CTA |
| `sponsor.astro:691` | Hardcoded "313 plugins / 1,500+ skills" hero stats | Stale hand-coded numbers; wire to live search-index stats or cut |
| `tools.astro:430` | Two "Coming Soon" tool cards (Analytics, Chats) with dead install boxes | Roadmap visibility vs two-thirds of the page being vaporware chrome |
| `cowork.astro:694` | "New to Claude Code Plugins?" learning-path panel | Nav duplication vs deliberate onboarding hand-off for no-terminal Cowork users |
| `compare-marketplaces.astro:26` | JSON-LD aggregateRating 4.8/340 with no review system | Unearned star snippet vs Google structured-data policy risk — recommend same-day ruling |

## Follow-up & deferred

- The 6 conditional style fixes above activate automatically once the owner rules on their parent contentDecisions.
- Non-clutter observations from the audit, for later passes: `explore.astro` carries dead `.bookmark-btn` JS; `ResearchTemplate.astro` bypasses BaseLayout (no site nav); `sponsor.astro` has ~180 lines of dead CSS; `index.astro:1393` ships its own aggregateRating JSON-LD (4.8/258) — same class of issue as the compare-marketplaces one above.

## Refs

- Constitution: `marketplace/DESIGN.md` §4 / §7 / §8 (+ 2026-05-31 and 2026-06-03 changelog precedents)
- Prior badge-removal passes: #1046, #1047, #1049 (no overlap — verified by the audit)

- Jeremy Longshore
intentsolutions.io
