### PR TITLE
test(e2e): drop the cowork hero-badge assertion after declutter pass 1

### DIFF
--- a/marketplace/tests/T8-cowork-page.spec.ts
+++ b/marketplace/tests/T8-cowork-page.spec.ts
@@ -19,13 +19,8 @@ test.describe('Cowork Downloads Page', () => {
       });
     });
 
-    test('should display hero with badge, heading, and stats', async ({ page }) => {
+    test('should display hero with heading and stats', async ({ page }) => {
       await page.goto('/cowork');
-
-      // Badge
-      const badge = page.locator('.cowork-hero-badge');
-      await expect(badge).toBeVisible();
-      await expect(badge).toContainText('FOR COWORK USERS');
 
       // H1
       const heading = page.locator('.cowork-hero h1');


### PR DESCRIPTION
## What

Removes T8's assertions on `.cowork-hero-badge` / `FOR COWORK USERS` (a pill #1050 deliberately cut) and renames the test to match; heading + stat assertions stay.

## Why one-line

The E2E suite on main red-failed (run 29276622329) asserting decoration the declutter intentionally removed; the test follows the product, not the other way around. T1's webkit-mobile failure in the same run is the known `location.assign` policy-check flake (passed on retry) — untouched.

## Refs

Refs #1050

- Jeremy Longshore
intentsolutions.io