### PR TITLE
fix(marketplace): guard the homepage explore-redirect against WebKit double-navigation

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1644,7 +1644,14 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             });
         });
 
+        // Navigate-once guard: a click on the input fires focus THEN click
+        // (the container handler), so both handlers used to call
+        // location.assign back-to-back — WebKit cancels the second navigation
+        // ("Navigation canceled by policy check") and the redirect dies.
+        let redirected = false;
         const redirectToExplore = () => {
+            if (redirected) return;
+            redirected = true;
             const url = new URL('/explore', window.location.origin);
             if (activeType && activeType !== 'all') url.searchParams.set('type', activeType);
             window.location.assign(url.toString());


### PR DESCRIPTION
## What

A navigate-once flag in the homepage's `redirectToExplore` handler (`marketplace/src/pages/index.astro`, +7 lines) — the only change.

## Why + decision rationale

Clicking the hero search input fires `focus` and then the container `click` handler; both called `location.assign` back-to-back, and WebKit cancels the second navigation ('Navigation canceled by policy check'), killing the redirect. T1's two webkit-mobile E2E tests failed both attempts on main run [29278474728](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/29278474728). The race predates the declutter, but #1050's lighter page made it consistently reproducible. Chose a one-flag guard over deduplicating the two handlers because either handler alone must still work: keyboard focus without a click, and container clicks outside the input.

## Layers touched

Marketplace UI script only (homepage inline script). No catalog, data, CI, or invariant change.

## How it works

First handler to fire sets `redirected = true` and navigates; the second returns early, so only one `location.assign` reaches WebKit's policy delegate. The toggle-button path is untouched — the container handler already skips `.toggle-btn` targets, so toggles never double-fire.

## Verification & evidence

- Failure evidence: run 29278474728 — `T1 › should navigate to /explore when search input is focused (desktop)` and `… tapped (mobile viewport)` failed both attempts on webkit-mobile with 'page.waitForURL: Navigation canceled by policy check'; all other suites green (production-e2e passed).
- Executable proof: the post-merge main E2E run must show T1 green on webkit-mobile — I am watching it and will report.

## Risk assessment

Minimal, user-facing but strictly narrowing: one navigation instead of two identical ones. Worst case is unchanged behavior on browsers that tolerated the double-fire. Rollback = revert the 7-line commit.

## Operational impact

None (no env, deps, migrations, secrets). Ships with the next main deploy.

## Follow-up & deferred

None — if webkit-mobile T1 still flakes after this lands, next step is quarantining the test to retry-on-webkit, tracked via a bead at that point.

## Refs

Refs #1050 #1051

- Jeremy Longshore
intentsolutions.io