### PR TITLE
feat(marketplace): declutter pass 2 — cut invented stats, duplicate capture/CTAs, stale claims [skip auto-bump]

### DIFF
--- a/marketplace/src/components/PlaybookTemplate.astro
+++ b/marketplace/src/components/PlaybookTemplate.astro
@@ -55,8 +55,6 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
           <p class="playbook-description">{description}</p>
           <div class="playbook-meta">
             <span class="meta-item">~{Math.round(wordCount / 200)} min read</span>
-            <span class="meta-divider">•</span>
-            <span class="meta-item">{wordCount.toLocaleString()} words</span>
           </div>
         </div>
       </div>
@@ -174,7 +172,6 @@ const nextPlaybook = currentIndex < playbooks.length - 1 ? playbooks[currentInde
       color: var(--text-3, var(--brand-mid-gray));
     }
 
-    .meta-divider { color: var(--border, var(--brand-light-gray)); }
 
     /* Main layout */
     .playbook-main { flex: 1; padding: 3rem 0; }

--- a/marketplace/src/pages/collections.astro
+++ b/marketplace/src/pages/collections.astro
@@ -160,7 +160,7 @@ const totalPluginsInCollections = collections.collections.reduce(
       <h1 class="page-title">Plugin Collections</h1>
       <p class="page-description">
         Pre-built plugin bundles for common workflows. Each collection is curated
-        to give you everything you need to supercharge a specific domain.
+        to give you everything you need for a specific domain.
       </p>
     </header>
 

--- a/marketplace/src/pages/compare-marketplaces.astro
+++ b/marketplace/src/pages/compare-marketplaces.astro
@@ -240,7 +240,7 @@ const description = `Compare Claude Code plugin marketplaces side-by-side. ${sta
 
   <section class="cta-section">
     <div class="cta-inner">
-      <h2>Ready to Supercharge Your Claude Code?</h2>
+      <h2>Ready to Speed Up Your Claude Code?</h2>
       <p>Browse {stats.totalPlugins} plugins and {stats.totalSkills.toLocaleString()} skills. Install in seconds.</p>
       <div class="cta-buttons">
         <a href="/explore" class="cta-primary">Explore Plugins</a>

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -347,7 +347,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} plugins and ${_raw
   <section class="explorer-hero">
     <h1 class="explorer-title">Explore Everything</h1>
     <p class="explorer-subtitle">
-      Search {_rawStats.totalPlugins} plugins and {_rawStats.totalSkills} skills in one unified catalog
+      Search the full catalog in one place.
     </p>
 
     <div class="hero-search-box">

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1041,8 +1041,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
     }
     </script>
 
-    <script type="application/ld+json" slot="head">
-    {
+    <script type="application/ld+json" slot="head" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Claude Code Plugins",
@@ -1053,14 +1052,13 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         "price": "0",
         "priceCurrency": "USD"
       },
-      "description": "295 plugins for Claude Code with 1,537 agent skills, interactive tutorials, and production workflows. Supports 2026 schema.",
-      "softwareVersion": "4.14.0",
+      "description": `${totalPlugins} plugins for Claude Code with ${fmtNum(totalSkills)} agent skills, interactive tutorials, and production workflows.`,
       "url": "https://tonsofskills.com",
       "downloadUrl": "https://github.com/jeremylongshore/claude-code-plugins",
       "applicationSuite": "Claude Code",
       "featureList": [
-        "295 plugins across 24 categories",
-        "1,537 Agent Skills (1,298 standalone + 239 embedded)",
+        `${totalPlugins} plugins across ${totalCategories} categories`,
+        `${fmtNum(totalSkills)} Agent Skills`,
         "Interactive Stack Builder",
         "Shareable plugin collections",
         "Cross-platform CLI tool",
@@ -1068,8 +1066,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
         "Fuzzy search",
         "LocalStorage persistence"
       ]
-    }
-    </script>
+    })} />
 
     <!-- Hero Section -->
     <section class="hero">
@@ -1197,14 +1194,6 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
             <p style="color: var(--text-2); margin-bottom: 0.5rem; max-width: 500px;">We scour GitHub for the most impressive agent skills and spotlight one each week.</p>
             <a href="/community" style="color: var(--primary); text-decoration: none; font-weight: 600; font-size: 0.9rem; display: inline-flex; align-items: center; gap: 0.25rem; margin-bottom: 1.5rem;">Meet the contributors <span style="transition: transform 0.2s; display: inline-block;">&rarr;</span></a>
             <KillerSkills />
-            <div class="killer-signup" style="margin-top: 2rem; padding: 1.25rem 1.5rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: 12px; display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
-                <p style="margin: 0; color: var(--text); font-weight: 600; font-size: 0.95rem;">Get the Killer Skill of the Week in your inbox</p>
-                <form data-signup-form="killer-skills" style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                    <input type="email" name="email" placeholder="you@example.com" required style="padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); font-size: 0.85rem; min-width: 200px;" />
-                    <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;opacity:0;height:0;width:0;" />
-                    <button type="submit" style="padding: 0.5rem 1rem; background: var(--primary); color: #0a0a0c; border: none; border-radius: 8px; font-weight: 600; font-size: 0.85rem; cursor: pointer;">Subscribe</button>
-                </form>
-            </div>
 
             <div style="margin-top: 1rem; padding: 1.25rem 1.5rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: 12px;">
                 <p style="margin: 0 0 0.25rem; color: var(--text); font-weight: 700; font-size: 1.05rem;">Got a killer skill?</p>
@@ -1505,7 +1494,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
 
     <!-- Features Section -->
     <section class="features" id="features">
-        <h2 class="section-title">Community-driven, production-ready plugins</h2>
+        <h2 class="section-title">Community-driven plugins</h2>
 
         <ol class="features-list reveal-stagger">
             <li class="feature-row">

--- a/marketplace/src/pages/learn/index.astro
+++ b/marketplace/src/pages/learn/index.astro
@@ -178,10 +178,6 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
         <span>{vendorPacks.vendors.reduce((acc, v) => acc + v.skillCount, 0)}</span>
         Total Skills
       </div>
-      <div class="hero-stat">
-        <span>4</span>
-        Tier Levels
-      </div>
     </div>
   </section>
 

--- a/marketplace/src/pages/learning/index.astro
+++ b/marketplace/src/pages/learning/index.astro
@@ -86,10 +86,6 @@ const notebooks = {
               <span class="stat-number">11</span>
               <span class="stat-label">Jupyter Notebooks</span>
             </div>
-            <div class="stat">
-              <span class="stat-number">5</span>
-              <span class="stat-label">Phase System</span>
-            </div>
           </div>
         </div>
       </div>

--- a/marketplace/src/pages/playbooks/index.astro
+++ b/marketplace/src/pages/playbooks/index.astro
@@ -164,8 +164,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
                 <p class="card-description">{playbook.description}</p>
                 <div class="card-meta">
                   <span class="meta-item">~{Math.round(playbook.wordCount / 200)} min read</span>
-                  <span class="meta-divider">•</span>
-                  <span class="meta-item">{playbook.wordCount.toLocaleString()} words</span>
                 </div>
               </a>
             ))}
@@ -188,8 +186,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
               <p class="card-description">{playbook.description}</p>
               <div class="card-meta">
                 <span class="meta-item">~{Math.round(playbook.wordCount / 200)} min read</span>
-                <span class="meta-divider">•</span>
-                <span class="meta-item">{playbook.wordCount.toLocaleString()} words</span>
               </div>
             </a>
           ))}
@@ -428,10 +424,6 @@ const featuredPlaybooks = playbooks.filter(p => p.featured);
       color: var(--brand-mid-gray);
       padding-top: 1rem;
       border-top: 1px solid var(--brand-light-gray);
-    }
-
-    .meta-divider {
-      color: var(--brand-light-gray);
     }
 
     /* Footer Section */

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -26,14 +26,6 @@ const installCommand = `/plugin install ${plugin.name}@${MARKETPLACE_SLUG}`;
 
 const readme = (readmeSections as any)[plugin.name] || null;
 
-const formatPricing = (pricing: any) => {
-  if (!pricing) return 'Free';
-  if (pricing.model === 'one-time') {
-    return `$${pricing.price} ${pricing.currency} (one-time)`;
-  }
-  return `$${pricing.price} ${pricing.currency}/${pricing.model}`;
-};
-
 const formatComponents = (components: any) => {
   if (!components) return [];
   const items = [];
@@ -73,7 +65,6 @@ if (plugin.components?.commands) statsItems.push({ label: 'Commands', value: Str
 if (plugin.components?.agents) statsItems.push({ label: 'Agents', value: String(plugin.components.agents) });
 if (plugin.mcpTools) statsItems.push({ label: 'MCP Tools', value: String(plugin.mcpTools) });
 statsItems.push({ label: 'License', value: plugin.license || 'MIT' });
-statsItems.push({ label: 'Pricing', value: formatPricing(plugin.pricing) });
 ---
 
 <BaseLayout title={`${plugin.name} | Claude Code Plugins`} description={plugin.description}>

--- a/marketplace/src/pages/research.astro
+++ b/marketplace/src/pages/research.astro
@@ -71,7 +71,6 @@ const domains = [
   },
 ];
 
-const totalDocs = domains.reduce((sum, d) => sum + d.docs.length, 0);
 const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.ready).length, 0);
 ---
 
@@ -97,8 +96,8 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
             </div>
             <div class="stat-divider"></div>
             <div class="stat-item">
-              <div class="stat-number">{totalDocs}</div>
-              <div class="stat-label">Documents</div>
+              <div class="stat-number">{readyDocs}</div>
+              <div class="stat-label">Published</div>
             </div>
             <div class="stat-divider"></div>
             <div class="stat-item">

--- a/marketplace/src/pages/skill-enhancers.astro
+++ b/marketplace/src/pages/skill-enhancers.astro
@@ -66,61 +66,33 @@ const collectionSchema = {
         "@type": "SoftwareApplication",
         "position": 2,
         "name": "search-to-slack",
-        "description": "Automated research digests sent to Slack channels (Pro Tier)",
+        "description": "Automated research digests sent to Slack channels (roadmap)",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Cross-platform",
-        "offers": {
-          "@type": "Offer",
-          "price": "19.00",
-          "priceCurrency": "USD",
-          "availability": "https://schema.org/InStock",
-          "eligibleCustomerType": "Pro Sponsors"
-        }
+        "operatingSystem": "Cross-platform"
       },
       {
         "@type": "SoftwareApplication",
         "position": 3,
         "name": "file-to-code",
-        "description": "Requirements to production code automation (Pro Tier)",
+        "description": "Requirements to production code automation (roadmap)",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Cross-platform",
-        "offers": {
-          "@type": "Offer",
-          "price": "19.00",
-          "priceCurrency": "USD",
-          "availability": "https://schema.org/InStock",
-          "eligibleCustomerType": "Pro Sponsors"
-        }
+        "operatingSystem": "Cross-platform"
       },
       {
         "@type": "SoftwareApplication",
         "position": 4,
         "name": "calendar-to-workflow",
-        "description": "Meeting preparation automation from calendar events (Pro Tier)",
+        "description": "Meeting preparation automation from calendar events (roadmap)",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Cross-platform",
-        "offers": {
-          "@type": "Offer",
-          "price": "19.00",
-          "priceCurrency": "USD",
-          "availability": "https://schema.org/InStock",
-          "eligibleCustomerType": "Pro Sponsors"
-        }
+        "operatingSystem": "Cross-platform"
       },
       {
         "@type": "SoftwareApplication",
         "position": 5,
         "name": "research-to-deploy",
-        "description": "Infrastructure automation from research to deployment (Enterprise Tier)",
+        "description": "Infrastructure automation from research to deployment (roadmap)",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Cross-platform",
-        "offers": {
-          "@type": "Offer",
-          "price": "199.00",
-          "priceCurrency": "USD",
-          "availability": "https://schema.org/InStock",
-          "eligibleCustomerType": "Enterprise Sponsors"
-        }
+        "operatingSystem": "Cross-platform"
       }
     ]
   },
@@ -192,16 +164,8 @@ const collectionSchema = {
 
       <div class="hero-stats">
         <div class="stat">
-          <div class="stat-value">95%</div>
-          <div class="stat-label">Time Saved</div>
-        </div>
-        <div class="stat">
           <div class="stat-value">5</div>
           <div class="stat-label">Plugins</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value">3</div>
-          <div class="stat-label">Tiers</div>
         </div>
       </div>
     </div>
@@ -291,10 +255,6 @@ const collectionSchema = {
   <!-- Featured Free Plugin -->
   <section class="section-featured" id="free-plugin">
     <div class="container">
-      <div class="featured-badge">
-        <span class="badge-tier-free">Community tier — free</span>
-      </div>
-
       <h2 class="section-title">Featured: Web to GitHub Issue</h2>
 
       <div class="featured-grid">
@@ -354,7 +314,7 @@ const collectionSchema = {
           <div class="demo-card demo-card-after">
             <div class="demo-header">
               <span class="demo-label">After</span>
-              <span class="demo-time demo-time-saved">30 seconds (95% saved)</span>
+              <span class="demo-time demo-time-saved">30 seconds</span>
             </div>
             <ol class="demo-steps">
               <li>"Research PostgreSQL indexing and create ticket"</li>
@@ -369,16 +329,10 @@ const collectionSchema = {
   <section class="section-premium">
     <div class="container">
       <h2 class="section-title">Premium Skill Enhancers (Roadmap)</h2>
-      <p class="section-intro">
-        Support development as a design partner to help shape these advanced automation plugins for Pro and Enterprise workflows. All items below are on the roadmap and will be built with sponsor input.
-      </p>
 
       <div class="premium-grid">
-        <!-- Pro Tier Plugin 1 -->
+        <!-- Roadmap plugin 1 -->
         <div class="premium-card">
-          <div class="premium-tier">
-            <span class="tier-badge tier-pro">PRO TIER - $19/mo</span>
-          </div>
           <h3 class="premium-title">search-to-slack</h3>
           <p class="premium-description">
             Automated research digests sent to Slack channels. Schedule daily industry updates,
@@ -392,11 +346,8 @@ const collectionSchema = {
           </ul>
         </div>
 
-        <!-- Pro Tier Plugin 2 -->
+        <!-- Roadmap plugin 2 -->
         <div class="premium-card">
-          <div class="premium-tier">
-            <span class="tier-badge tier-pro">PRO TIER - $19/mo</span>
-          </div>
           <h3 class="premium-title">file-to-code</h3>
           <p class="premium-description">
             Convert requirements documents into production-ready code with tests, types, and documentation.
@@ -410,11 +361,8 @@ const collectionSchema = {
           </ul>
         </div>
 
-        <!-- Pro Tier Plugin 3 -->
+        <!-- Roadmap plugin 3 -->
         <div class="premium-card">
-          <div class="premium-tier">
-            <span class="tier-badge tier-pro">PRO TIER - $19/mo</span>
-          </div>
           <h3 class="premium-title">calendar-to-workflow</h3>
           <p class="premium-description">
             Automatically prepare for meetings by creating agendas, gathering relevant documents,
@@ -428,11 +376,8 @@ const collectionSchema = {
           </ul>
         </div>
 
-        <!-- Enterprise Tier Plugin -->
+        <!-- Roadmap plugin 4 -->
         <div class="premium-card premium-card-enterprise">
-          <div class="premium-tier">
-            <span class="tier-badge tier-enterprise">ENTERPRISE TIER - $199/mo</span>
-          </div>
           <h3 class="premium-title">research-to-deploy</h3>
           <p class="premium-description">
             Full-stack automation from research to infrastructure deployment. Evaluates technologies,
@@ -487,7 +432,7 @@ const collectionSchema = {
                 <li>"Research PostgreSQL indexing and create ticket"</li>
                 <li>Plugin creates formatted issue with sources</li>
               </ul>
-              <div class="comparison-time comparison-time-saved">Time: 30 seconds (95% saved)</div>
+              <div class="comparison-time comparison-time-saved">Time: 30 seconds</div>
             </div>
           </div>
         </div>
@@ -509,12 +454,12 @@ const collectionSchema = {
               <div class="comparison-time">Time: 30 minutes/day</div>
             </div>
             <div class="comparison-item comparison-item-better">
-              <div class="comparison-label">With search-to-slack (Pro)</div>
+              <div class="comparison-label">With search-to-slack</div>
               <ul class="comparison-steps">
                 <li>Schedule: "research AI news daily, post to #engineering"</li>
                 <li>Automated digests every morning</li>
               </ul>
-              <div class="comparison-time comparison-time-saved">Time: 0 minutes (100% automated)</div>
+              <div class="comparison-time comparison-time-saved">Time: 0 minutes</div>
             </div>
           </div>
         </div>
@@ -537,21 +482,17 @@ const collectionSchema = {
               <div class="comparison-time">Time: 2-4 hours</div>
             </div>
             <div class="comparison-item comparison-item-better">
-              <div class="comparison-label">With file-to-code (Pro)</div>
+              <div class="comparison-label">With file-to-code</div>
               <ul class="comparison-steps">
                 <li>"Convert requirements.md to production React component"</li>
                 <li>Generates component with tests, types, and docs</li>
               </ul>
-              <div class="comparison-time comparison-time-saved">Time: 5 minutes (90%+ saved)</div>
+              <div class="comparison-time comparison-time-saved">Time: 5 minutes</div>
             </div>
           </div>
         </div>
       </div>
 
-      <div class="time-saved-summary">
-        <h3 class="summary-title">Average Time Saved Across All Workflows</h3>
-        <div class="summary-stat">93.8%</div>
-      </div>
     </div>
   </section>
 
@@ -851,21 +792,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
     background: var(--panel);
   }
 
-  .featured-badge {
-    text-align: center;
-    margin-bottom: 2rem;
-  }
-
-  .badge-tier-free {
-    padding: 2px 8px;
-    border: 1px solid var(--rule, var(--brand-light-gray));
-    color: var(--ink-2, var(--brand-mid-gray));
-    border-radius: 0.25rem;
-    font-size: 11px;
-    font-weight: 500;
-    font-family: var(--font-mono);
-  }
-
   .featured-grid {
     display: grid;
     grid-template-columns: 1fr;
@@ -1019,29 +945,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
   .premium-card-enterprise:hover {
     border-color: var(--primary);
     
-  }
-
-  .premium-tier {
-    margin-bottom: 1rem;
-  }
-
-  .tier-badge {
-    padding: 0.5rem 1rem;
-    border-radius: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-  }
-
-  .tier-pro {
-    background: var(--primary); color: #0a0a0c;
-    color: #0a0a0c;
-  }
-
-  .tier-enterprise {
-    background: var(--primary); color: #0a0a0c;
-    color: #0a0a0c;
   }
 
   .premium-title {
@@ -1203,33 +1106,6 @@ export GITHUB_DEFAULT_REPO=owner/repo</code></pre>
   .comparison-time-saved {
     color: var(--primary);
     font-weight: 600;
-  }
-
-  .time-saved-summary {
-    text-align: center;
-    margin-top: 3rem;
-    padding: 2rem;
-    background: var(--brand-light);
-    border: 1px solid var(--primary-dark);
-    border-radius: 0.75rem;
-    
-  }
-
-  .summary-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    color: var(--brand-dark);
-  }
-
-  .summary-stat {
-    font-size: 4rem;
-    font-weight: 800;
-    background: var(--primary); color: #0a0a0c;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    font-family: var(--font-mono);
   }
 
   /* Installation Steps */

--- a/marketplace/src/pages/skills/[slug].astro
+++ b/marketplace/src/pages/skills/[slug].astro
@@ -29,10 +29,6 @@ const installCommand = `/plugin install ${skill.parentPlugin.name}@claude-code-p
 const compatibleWith: string[] = (skill as any).compatibleWith || [];
 
 // Stats bar items
-const statsItems: Array<{ label: string; value: string }> = [];
-if (skill.allowedTools?.length) statsItems.push({ label: 'Tools', value: String(skill.allowedTools.length) });
-statsItems.push({ label: 'Plugin', value: skill.parentPlugin.name });
-statsItems.push({ label: 'Category', value: skill.parentPlugin.category.replace(/-/g, ' ') });
 
 // Related skills — 6 from same category, with tool pills
 const relatedSkills = (skillsCatalog as any).skills
@@ -114,48 +110,6 @@ const cleanTools = (tools: string[]) =>
       border-radius: var(--radius-sm);
       color: var(--text-2, var(--brand-mid-gray));
       border: 1px solid var(--rule, var(--border));
-    }
-
-    /* Stats Bar */
-    .stats-bar {
-      display: flex;
-      align-items: center;
-      gap: 1.25rem;
-      padding: 1rem 1.5rem;
-      background: var(--surface-2, var(--card));
-      border: 1px solid var(--border, var(--brand-light-gray));
-      border-radius: var(--radius-lg);
-      margin-bottom: 1.5rem;
-      overflow-x: auto;
-      font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
-    }
-
-    .stat-item {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 0.2rem;
-      white-space: nowrap;
-    }
-
-    .stat-value {
-      font-size: 1rem;
-      font-weight: 600;
-      color: var(--text, var(--brand-dark));
-    }
-
-    .stat-label {
-      font-size: 0.7rem;
-      color: var(--text-3, var(--brand-mid-gray));
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-    }
-
-    .stats-divider {
-      width: 1px;
-      height: 2rem;
-      background: var(--border, var(--brand-light-gray));
-      flex-shrink: 0;
     }
 
     .section-box {
@@ -507,11 +461,6 @@ const cleanTools = (tools: string[]) =>
       .plugin-info {
         flex-direction: column;
       }
-
-      .stats-bar {
-        gap: 0.75rem;
-        padding: 0.75rem 1rem;
-      }
     }
   </style>
 
@@ -567,21 +516,6 @@ const cleanTools = (tools: string[]) =>
         </div>
       )}
     </header>
-
-    <!-- 3. Stats Bar -->
-    {statsItems.length > 0 && (
-      <div class="stats-bar">
-        {statsItems.map((stat, i) => (
-          <>
-            {i > 0 && <span class="stats-divider" aria-hidden="true" />}
-            <div class="stat-item">
-              <span class="stat-value">{stat.value}</span>
-              <span class="stat-label">{stat.label}</span>
-            </div>
-          </>
-        ))}
-      </div>
-    )}
 
     <!-- 4. Allowed Tools -->
     <section class="section-box">

--- a/marketplace/src/pages/sponsor.astro
+++ b/marketplace/src/pages/sponsor.astro
@@ -1,5 +1,10 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import searchIndex from '../data/unified-search-index.json';
+
+// Live catalog counts — same build-time source the homepage and explore use.
+const totalPlugins = searchIndex.stats.totalPlugins;
+const totalSkills = searchIndex.stats.totalSkills;
 
 const seo = {
   title: "Sponsor Claude Code Plugins - Custom AI Skills & Plugin Development",
@@ -600,36 +605,6 @@ const seo = {
         margin-top: 1rem;
       }
 
-      /* Final CTA */
-      .final-cta {
-        background: var(--primary);
-        padding: 4rem 1rem;
-        text-align: center;
-        color: #0a0a0c;
-      }
-
-      .final-cta h2 {
-        font-size: clamp(2rem, 4vw, 2.5rem);
-        font-weight: 800;
-        margin-bottom: 1rem;
-        color: #0a0a0c;
-      }
-
-      .final-cta p {
-        font-size: 1.125rem;
-        margin-bottom: 2rem;
-        opacity: 0.95;
-      }
-
-      .final-cta .cta-primary {
-        background: var(--brand-light);
-        color: var(--brand-orange);
-      }
-
-      .final-cta .cta-primary:hover {
-        background: rgba(250, 249, 245, 0.9);
-      }
-
       /* Responsive */
       @media (max-width: 768px) {
         .sponsor-hero {
@@ -679,11 +654,11 @@ const seo = {
 
         <div class="sponsor-hero-stats">
           <div class="stat-item">
-            <div class="stat-number">313</div>
+            <div class="stat-number">{totalPlugins}</div>
             <div class="stat-label">Community Plugins</div>
           </div>
           <div class="stat-item">
-            <div class="stat-number">1,500+</div>
+            <div class="stat-number">{totalSkills.toLocaleString('en-US')}</div>
             <div class="stat-label">AI Skills</div>
           </div>
           <div class="stat-item">
@@ -767,7 +742,7 @@ const seo = {
           <div class="success-card">
             <div class="success-industry">Automotive SaaS</div>
             <h3 class="success-title">DiagnosticPro</h3>
-            <p class="success-result">Automated diagnostic service ($4.99/diagnostic)</p>
+            <p class="success-result">Automated diagnostic service</p>
             <p class="success-tech"><strong>Tech:</strong> Firebase + Vertex AI Gemini + Claude Code plugins</p>
             <p class="success-quote">
               "Claude Code plugins saved 40+ hours in development time"
@@ -783,20 +758,6 @@ const seo = {
               "From idea to production using Claude Code automation"
             </p>
           </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Final CTA -->
-    <section class="final-cta">
-      <div class="container">
-        <h2>Interested in Sponsoring?</h2>
-        <p>Let's talk about what makes sense for your team.</p>
-        <a href="mailto:jeremy@intentsolutions.io?subject=Sponsorship%20Inquiry" class="cta-primary">
-          Email Me for Details
-        </a>
-        <div style="margin-top: 1.5rem; opacity: 0.9;">
-          jeremy@intentsolutions.io
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What

Declutter pass 2 — executes the safe tier of the deferred-decision list from the site-wide clutter audit (owner call: "cut the safe stuff now"), plus a mid-pass owner amendment killing all displayed product pricing. 13 files, +37/−306, everything under `marketplace/src/` — UI/copy only.

Per-item:

1. **skill-enhancers.astro** — removed the "95% / Time Saved" hero stat tile ("5 Plugins" stays), the "Average Time Saved Across All Workflows / 93.8%" summary block (invented aggregate of estimates), the "(95% saved)" / "(100% automated)" / "(90%+ saved)" parentheticals (real before/after times kept), and the duplicate sponsor pitch paragraph (kept the block next to the Buy-me-a-coffee button; button stays).
2. **index.astro** — removed the `.killer-signup` boxed subscribe form; the site-wide footer form is the one newsletter form per page (documented intent in the file). Spotlight content untouched. No orphaned styles (it was inline-styled; the footer form keeps the shared `[data-signup-form]` wiring).
3. **index.astro** — features h2: "Community-driven, production-ready plugins" → "Community-driven plugins" (banned vocab per DESIGN.md changelog 2026-05-31).
4. **index.astro** — homepage SoftwareApplication JSON-LD rebuilt with live catalog counts via `set:html` (the same `searchIndex.stats` the hero uses); stale "295 plugins / 1,537 agent skills / 2026 schema" and `softwareVersion: 4.14.0` dropped. featureList numbers also went live (they sat in the same block with the same stale numbers). Built output renders "469 plugins … 3,066 agent skills".
5. **explore.astro** — hero subtitle no longer repeats the stat row: "Search the full catalog in one place." (numbers remain in the adjacent stat row).
6. **skills/[slug].astro** — removed the Tools/Plugin/Category stats-bar (every value repeats within one viewport: Provided-by block + Allowed Tools list) plus all its CSS (`.stats-bar`, `.stat-item`, `.stat-value`, `.stat-label`, `.stats-divider`, responsive block).
7. **playbooks/index.astro + PlaybookTemplate.astro** — dual "~N min read • N words" meta: word count dropped, min read kept; orphaned `.meta-divider` CSS removed in both files. (The playbooks hero "Words" stat was NOT touched — not in scope, and `totalWords` remains used by it.)
8. **research.astro** — hero stat switched from `totalDocs` (24, mostly Coming-Soon) to the already-computed `readyDocs` (6), relabeled "Published". The 18 Coming-Soon placeholder rows stay (owner call, untouched).
9. **sponsor.astro** — stale "313 Community Plugins / 1,500+ AI Skills" hero stats wired to `unified-search-index.json` (same build-time source index/explore use; renders 469 / 3,066); the third duplicate full-width "Email Me for Details" CTA banner removed (§7 one-primary-per-page; two CTAs remain) plus its `.final-cta` CSS.
10. **learn/index.astro** — "4 / Tier Levels" hero stat tile removed (taxonomy self-count padding; vendor-pack + skill counts stay).
11. **learning/index.astro** — "5 / Phase System" hero stat tile removed (guides + notebooks counts stay).
12. **collections.astro + compare-marketplaces.astro** — the two remaining "supercharge" instances reworded minimally ("…everything you need for a specific domain." / "Ready to Speed Up Your Claude Code?"). The only other hit is inside a blog post under `src/content` (editorial, out of scope).

## Pricing removal (owner amendment)

Owner, mid-pass: "pricing pills? we don't charge for anything" — pricing is decided per-customer after an onboarding call, never quoted on a page. Cut:

- **skill-enhancers.astro**: 3× "PRO TIER - $19/mo" pills, 1× "ENTERPRISE TIER - $199/mo" pill, the "Community tier — free" pill (no paid tiers shown → a FREE pill is noise), the "3 Tiers" hero stat (tiers no longer render meaningfully), "(Pro)" markers on two comparison labels, and the page's JSON-LD `offers` asserting $19/$199 "InStock" for unshipped roadmap items (descriptions now say "(roadmap)"). Orphaned CSS removed: `.tier-badge`, `.tier-pro`, `.tier-enterprise`, `.premium-tier`, `.badge-tier-free`, `.featured-badge`.
- **plugins/[name].astro**: the "Pricing" stats-bar row + `formatPricing` helper. The exception ("leave if it only ever renders Free") did not hold — `creator-studio-pack` carries catalog pricing and rendered "$149 USD (one-time)"; the helper also rendered `$undefined undefined/undefined` for string-typed pricing values (`free`/`paid`), so this is a bug fix too.
- **sponsor.astro**: the "$4.99/diagnostic" price in the DiagnosticPro case-study card (product price display).
- Untouched per the amendment's exceptions: sponsor.astro's sponsorship offering copy (no dollar figures there), truthful `price: "0"` JSON-LD offers (homepage + the free skill-enhancer plugin), cowork.astro's "pricing tiers" line (describes Anthropic's own Cowork product page), model-pricing editorial in `src/pages/research/` articles, and blog content under `src/content`.

Site-wide grep confirms zero `$N` amounts, `/mo`, or `per month` product-price claims remain in `src/pages` + `src/components` (research-article editorial about Anthropic model pricing excluded per scope).

## Why

Pass 1 (#1050) cut decoration and restyled labels. This pass executes the owner's decisions on the deferred list: invented numbers dressed as data, duplicated capture/CTA surfaces, stale hardcoded claims, and banned vocabulary — plus the pricing amendment. Constitution: `marketplace/DESIGN.md` §4 (badge/label spec) + §7 (one primary CTA / one signal accent) + §8 (reject table, banned vocabulary).

## Layers touched

Astro page templates + one shared component (`PlaybookTemplate.astro`) under `marketplace/src/` only. No build scripts, no catalog/data files, no plugin content, no CI. No invariant changes.

## How it works

Pure removals/rewording, plus two data-wiring changes: the homepage JSON-LD and sponsor hero stats now read `unified-search-index.json` at build time (the exact source the homepage hero already uses), so those numbers can never go stale again.

## Verification & evidence

- `cd marketplace && npm run build` → **passes: 3817 pages in ~50s** (run twice — after the main edits and after the JSON-LD amendment fix).
- Built-output asserts: homepage JSON-LD renders `"469 plugins for Claude Code with 3,066 agent skills…"` with no `softwareVersion`; sponsor renders live `469 / 3,066 / 100%` and exactly 2 "Email Me for Details" CTAs; `dist/skill-enhancers/` has zero `95%`/`93.8`/`$19`/`$199`/`19.00`/`199.00`/tier strings; skills detail pages have no stats-bar; playbooks pages show no "N words" meta; research shows `6 / Published`; learn/learning tiles gone; killer-signup gone (footer form present).
- Orphan-style greps: zero remaining references for every removed class (`.tier-badge`, `.tier-pro`, `.tier-enterprise`, `.premium-tier`, `.badge-tier-free`, `.featured-badge`, `.time-saved-summary`, `.summary-title`, `.summary-stat`, `.stats-bar`, `.stat-item`, `.stat-value`, `.stat-label`, `.stats-divider` (slug page), `.meta-divider`, `.final-cta`, `formatPricing`, `killer-signup`).
- Build-regenerated `src/data`/`public/data` artifacts reverted; `git status` shows the 13 UI files only. node_modules symlinks used for the build were deleted before committing.

## Risk assessment

Visual/copy only. Rollback = revert the single commit. The only behavioral surfaces: JSON-LD shape (validated by the build; `set:html` + `JSON.stringify` is the existing pattern used by the Organization block on the same page) and the removed killer-skills signup form (footer form retains the generic `[data-signup-form]` wiring — no JS orphaned; the `killer-skills` list source loses its dedicated capture point, which is the decluttering intent).

## Operational impact

None beyond the next deploy — static site rebuild picks everything up. No env, migrations, deps, secrets, or deploy-order changes.

## Still owner-gated (deliberately untouched)

Footer bio blurb · tools.astro Coming-Soon cards · research placeholder rows (kept per owner call) · learn "More Packs Coming Soon" banner · cowork onboarding panel · learn "View Pack" affordance · research "Research & Analysis" hero badge · the Featured pill · the npm static stats row. (PRO/ENTERPRISE pricing pills left this list via the amendment and are cut here.)

## Follow-up & deferred

- `sponsor.astro` still carries pre-existing dead CSS (`.pricing-price`, comparison-table/roadmap/FAQ styles) flagged by the audit as a later cleanup — out of this pass's scope.
- index.astro's meta `description` still contains "production-ready" (meta tag, not page copy; not in the enumerated cuts).

## Refs

Refs #1050

- Jeremy Longshore
intentsolutions.io