### PR TITLE
[skip auto-bump] docs(firebase): replace removed validation commands

### DIFF
--- a/plugins/community/jeremy-firebase/CLAUDE.md
+++ b/plugins/community/jeremy-firebase/CLAUDE.md
@@ -30,16 +30,19 @@ jeremy-firebase/
 cd plugins/community/jeremy-firebase/
 
 # Validate plugin structure
-../../scripts/validate-all-plugins.sh .
+python3 ../../../scripts/validate-skills-schema.py \
+  skills/firebase-vertex-ai/SKILL.md --marketplace
 
 # Add plugin to marketplace catalog
 # Edit .claude-plugin/marketplace.extended.json at repository root
 
 # Sync marketplace catalogs
-cd ../.. && pnpm run sync-marketplace
+cd ../../.. && pnpm run sync-marketplace
 
 # Validate changes
-./scripts/validate-all-plugins.sh plugins/community/jeremy-firebase/
+python3 scripts/validate-skills-schema.py \
+  plugins/community/jeremy-firebase/skills/firebase-vertex-ai/SKILL.md \
+  --marketplace
 ```
 
 ### Testing the Plugin
@@ -387,7 +390,8 @@ All examples should:
 
 ```bash
 # 1. Validate plugin structure
-../../scripts/validate-all-plugins.sh .
+python3 ../../../scripts/validate-skills-schema.py \
+  skills/firebase-vertex-ai/SKILL.md --marketplace
 
 # 2. Check for hardcoded secrets
 grep -r "AIza" . --exclude-dir=node_modules


### PR DESCRIPTION
## Type of Change

- [x] 📚 Documentation improvement

## Description

**Summary:** Replace three references to the removed `validate-all-plugins.sh` script with the authoritative `validate-skills-schema.py` validator, and fix traversal from the Firebase plugin directory to the repository root.

**Motivation:** The documented commands currently fail before validation starts. This intentionally does not edit the externally mirrored Mnemos files. The correction was found with the attest static instruction-binding scan.

**Related Issues:** N/A

## Checklist

- [x] My changes follow the project's style and conventions
- [x] I have performed a self-review of the change
- [x] Documentation has been updated
- [x] Code examples were tested and work
- [x] Links and paths were verified

## Testing Evidence

**Test Environment:** macOS; Python 3

**Test Commands Run:**

```bash
python3 scripts/validate-skills-schema.py \
  plugins/community/jeremy-firebase/skills/firebase-vertex-ai/SKILL.md \
  --marketplace
./scripts/quick-test.sh
```

**Test Results:** The scoped authoritative validator grades the skill A (97/100); the repository build/lint quick test completes; attest reports zero broken bindings in the modified Firebase guidance.

## Breaking Changes

- [x] No

## Performance Impact

- [x] No performance impact

## Security Considerations

Documentation-only command corrections; no runtime code, dependencies, permissions, or network behavior changed.

## Rollback Plan

Revert the single documentation commit.