### PR TITLE
fix(dolt): public-export table allowlist + stub-badge and stale-badge integrity (ops review pass D) [skip auto-bump]

### DIFF
--- a/freshie/scripts/dolt-sync.py
+++ b/freshie/scripts/dolt-sync.py
@@ -19,7 +19,11 @@ What one sync does:
      `dolt reset --hard` + `dolt clean` (reset alone leaves never-committed
      tables behind).
   2. Snapshots the SQLite DB (VACUUM INTO a tmpfs copy) so every table export
-     reads one consistent point in time.
+     reads one consistent point in time. Gates table MEMBERSHIP against
+     EXPORT_ALLOWLIST (also in --dry-run): any table not deliberately
+     allowlisted is a hard failure — everything exported becomes permanent
+     public DoltHub history, so an unknown table (e.g. j-rig runtime tables
+     from pointing j-rig at the inventory DB) must never publish silently.
   3. Translates the schema (see translate rules below) and creates any table
      missing from the Dolt repo. Existing Dolt schemas are left alone — a
      schema-mismatch abort from `dolt table import -r` is a free parity gate;
@@ -42,9 +46,11 @@ What one sync does:
      history queries against Dolt are `WHERE run_id = N` / `AS OF 'run-N'`.
   7. Commits (`--skip-empty`), tags run-<N> (N = MAX(discovery_runs.id))
      only when the tag would sit on a commit that actually carries run N,
-     then pushes main AND the tag (tags do not ride along on a branch push).
-     Push failure with valid creds exits non-zero and loud — a silently
-     unpushed Dolt repo is single-copy history on an OOM-prone box.
+     then pushes main AND the tag (tags do not ride along on a branch push)
+     — plus any older local tag a prior failed push stranded (reconciled
+     against the DoltHub API's dolt_tags, best-effort). Push failure with
+     valid creds exits non-zero and loud — a silently unpushed Dolt repo is
+     single-copy history on an OOM-prone box.
   8. Runs `dolt gc` under the same flock every GC_EVERY_N_SYNCS syncs or
      when the repo directory doubles since the last gc (no auto-GC runs on
      the import path in this Dolt build).
@@ -72,9 +78,12 @@ Restore path (DoltHub → local SQLite):
     sqlite3 new.sqlite ".import --csv skill_compliance.csv skill_compliance"
 
 Vocabulary: the DoltHub push is what makes the data durable and visible;
-it is not "backup" (borg on the VPS is backup). CI runners need a commit
-identity: `dolt config --global --add user.name ...` / user.email, or use
-`dolt push --user <name>` with DOLT_REMOTE_PASSWORD=<api token>.
+it is not "backup" (borg on the VPS is backup). Pushing requires DoltHub
+creds from `dolt login` (a creds keypair on the operator box) — this script
+implements NO env-var/CI credential path (no --user/DOLT_REMOTE_PASSWORD),
+by design: local is the sole writer and CI never pushes. Any environment
+that creates commits still needs a commit identity:
+`dolt config --global --add user.name ...` / user.email.
 
 Usage:
     python3 freshie/scripts/dolt-sync.py [--db PATH] [--no-push] [--dry-run]
@@ -119,6 +128,89 @@ DEFAULT_REPO = "freshie-inventory"
 CREDS_ENDPOINT = "doltremoteapi.dolthub.com:443"
 
 SKIP_TABLES = frozenset({"sqlite_sequence"})
+
+# ---------------------------------------------------------------------------
+# PUBLIC-EXPORT ALLOWLIST — every table this sync publishes to the PUBLIC
+# DoltHub database must be named here DELIBERATELY. This is a membership gate
+# in the same spirit as the BLOB hard-fail: an unknown table in
+# inventory.sqlite is a hard failure, never a silent publish. It exists
+# because j-rig's runtime tables leaked into the public run-9.1 push (51 rows
+# of LLM eval output) purely because nothing gated table membership.
+#
+# The set below is the intended CMDB system-of-record: the exact 51 tables of
+# run-8, the first Dolt sync (verified via `SHOW TABLES AS OF 'run-8'`) —
+# freshie/README.md § "Database design" describes the same 51-table model.
+#
+# Adding a table? Add it here in the same PR that introduces it, with a
+# reviewer confirming it is fit for PERMANENT PUBLIC history (Dolt history is
+# never rewritten). Tool-runtime tables (j-rig etc.) do NOT belong here —
+# route those tools through a /dev/shm scratch DB (scripts/run-jrig-eval.sh).
+EXPORT_ALLOWLIST = frozenset({
+    "agent_compliance",
+    "agent_files",
+    "anomalies",
+    "ci_workflows",
+    "command_files",
+    "content_signals",
+    "cross_references",
+    "discovery_runs",
+    "docs",
+    "duplicate_files",
+    "field_registry",
+    "forge_proofs",
+    "frontmatter_fields",
+    "frontmatter_shapes",
+    "frontmatter_values",
+    "marketplace_catalog",
+    "npm_discovery_runs",
+    "npm_dist_tags",
+    "npm_download_stats",
+    "npm_fetch_log",
+    "npm_package_dependencies",
+    "npm_packages",
+    "npm_publish_history_summary",
+    "npm_version_comparisons",
+    "npm_versions",
+    "pack_aggregates",
+    "pack_metadata",
+    "packs",
+    "planned_skills",
+    "plugin_companions",
+    "plugin_compliance",
+    "plugin_fields",
+    "plugin_shapes",
+    "plugin_templates",
+    "plugin_values",
+    "plugins",
+    "repo_package_sources",
+    "restructure_observations",
+    "root_files",
+    "root_skills_files",
+    "scripts",
+    "skill_compliance",
+    "skill_database_vendors",
+    "skill_files",
+    "skill_structure_shapes",
+    "skills",
+    "unique_extensions",
+    "unique_filenames",
+    "unique_subdirs",
+    "validator_checks",
+    "validators",
+})
+
+# j-rig's own runtime schema (created by `j-rig eval --db <path>`). These are
+# recognized specifically so the hard-fail message can say exactly how the
+# contamination happened and how to clean it up.
+JRIG_RUNTIME_TABLES = frozenset({
+    "artifacts",
+    "criterion_results",
+    "run_summaries",
+    "runs",
+    "skill_human_reviews",
+    "skill_usage_events",
+    "skill_versions",
+})
 
 TYPE_MAP = {
     "INTEGER": "BIGINT",
@@ -573,6 +665,43 @@ def pump_table_inserts(conn: sqlite3.Connection, repo: Path, table: str,
 # ---------------------------------------------------------------------------
 
 
+def gate_export_allowlist(tables) -> None:
+    """Hard-fail if the source DB carries any table not on EXPORT_ALLOWLIST.
+
+    Everything this sync exports becomes PERMANENT PUBLIC DoltHub history, so
+    table membership is a gate, not a discovery. Pure function over the table
+    names — unit-tested.
+    """
+    unexpected = sorted(set(tables) - EXPORT_ALLOWLIST)
+    if not unexpected:
+        log(f"gate: export allowlist OK ({len(set(tables))} tables, all allowlisted)")
+        return
+    jrig = [t for t in unexpected if t in JRIG_RUNTIME_TABLES]
+    other = [t for t in unexpected if t not in JRIG_RUNTIME_TABLES]
+    parts = [
+        f"{len(unexpected)} table(s) in the source DB are NOT on the public-export "
+        f"allowlist — refusing to publish them to public DoltHub history "
+        f"(which is never rewritten)."
+    ]
+    if jrig:
+        parts.append(
+            f"j-rig runtime tables: {jrig}. These mean j-rig was pointed at the "
+            f"inventory DB directly. Route evals through scripts/run-jrig-eval.sh "
+            f"(j-rig writes to a /dev/shm scratch DB; only the forge_proofs verdict "
+            f"row reaches the inventory), then drop the stray tables: "
+            + " ".join(
+                f"sqlite3 <db> 'DROP TABLE \"{t}\";'" for t in jrig
+            )
+        )
+    if other:
+        parts.append(
+            f"unrecognized tables: {other}. Either add each to EXPORT_ALLOWLIST "
+            f"deliberately (reviewer confirms it is fit for permanent public "
+            f"history) or drop it from the source DB."
+        )
+    raise SyncError(" ".join(parts))
+
+
 def gate_row_counts(conn: sqlite3.Connection, repo: Path, tables: list[str]) -> None:
     for t in tables:
         want = conn.execute(f'SELECT COUNT(*) FROM "{t}"').fetchone()[0]
@@ -608,8 +737,11 @@ def gate_real_checksums(conn: sqlite3.Connection, repo: Path,
 
 def gate_json_checksums(conn: sqlite3.Connection, repo: Path,
                         schema: dict[str, dict]) -> None:
+    checked: list[str] = []
+    skipped: list[str] = []
     for table, col in JSON_CHECKSUM_COLUMNS:
         if table not in schema:
+            skipped.append(f"{table}.{col}")
             continue
         pk_cols = [
             c[0] for c in sorted(
@@ -634,7 +766,16 @@ def gate_json_checksums(conn: sqlite3.Connection, repo: Path,
                 f"JSON byte checksum failed on {table}.{col}: "
                 f"{len(diff)} mismatched rows (sample PKs: {sample})"
             )
-    log(f"gate: per-row MD5 byte checksums OK on {len(JSON_CHECKSUM_COLUMNS)} JSON columns")
+        checked.append(f"{table}.{col}")
+    # Only claim OK for columns actually verified — a listed table missing
+    # from this database means byte verification did NOT run for it, and the
+    # log line is evidence an operator relies on.
+    for miss in skipped:
+        log(f"WARNING: JSON checksum column {miss} not present in this "
+            f"database — SKIPPED (no byte verification ran for it; update "
+            f"JSON_CHECKSUM_COLUMNS if the table was renamed)")
+    log(f"gate: per-row MD5 byte checksums OK on {len(checked)} JSON "
+        f"columns ({', '.join(checked) if checked else 'none checked'})")
 
 
 def gate_varchar_lengths(conn: sqlite3.Connection, guards: list[tuple[str, str]]) -> None:
@@ -654,22 +795,37 @@ def gate_varchar_lengths(conn: sqlite3.Connection, guards: list[tuple[str, str]]
 # ---------------------------------------------------------------------------
 
 
-def write_grades_export(conn: sqlite3.Connection, run_id: int) -> None:
+def write_grades_export(conn: sqlite3.Connection, run_id: int,
+                        csv_path: Path = GRADES_CSV,
+                        histogram_path: Path = GRADE_HISTOGRAM) -> None:
     # No run_id column in the CSV rows on purpose: it would change on every
     # row every sync, drowning the grade-movement diff this file exists to
     # tell. The current run_id lives in grade-histogram.json.
+    #
+    # Scoped to the CURRENT run only. The old latest-per-skill_path-across-
+    # all-runs query kept skills deleted from the repo alive forever as ghost
+    # rows (102 of them by run 9 — e.g. hyperflow's skills/amplify, gone from
+    # disk since run 7, still counted in the public histogram). grades.csv
+    # claims to be "current corpus grades"; only the current run's rows are.
     rows = conn.execute(
         """
-        SELECT s.skill_path, s.grade, s.score
-        FROM skill_compliance s
-        JOIN (
-            SELECT skill_path, MAX(run_id) AS mr
-            FROM skill_compliance GROUP BY skill_path
-        ) latest ON s.skill_path = latest.skill_path AND s.run_id = latest.mr
-        ORDER BY s.skill_path
-        """
+        SELECT skill_path, grade, score
+        FROM skill_compliance
+        WHERE run_id = ?
+        ORDER BY skill_path
+        """,
+        (run_id,),
     ).fetchall()
-    with open(GRADES_CSV, "w", newline="") as fh:
+    if not rows:
+        total = conn.execute("SELECT COUNT(*) FROM skill_compliance").fetchone()[0]
+        if total:
+            raise SyncError(
+                f"skill_compliance has no rows for run {run_id} but {total} rows "
+                f"overall — refusing to overwrite {csv_path.name} with an empty "
+                f"export. Run the validator --populate-db step for run {run_id} "
+                f"before syncing."
+            )
+    with open(csv_path, "w", newline="") as fh:
         writer = csv.writer(fh, lineterminator="\n")
         writer.writerow(["skill_path", "grade", "score"])
         writer.writerows(rows)
@@ -683,8 +839,8 @@ def write_grades_export(conn: sqlite3.Connection, run_id: int) -> None:
         "total": len(rows),
         "grades": {k: histogram[k] for k in sorted(histogram)},
     }
-    GRADE_HISTOGRAM.write_text(json.dumps(payload, indent=2) + "\n")
-    log(f"wrote {GRADES_CSV.name} ({len(rows)} skills) + {GRADE_HISTOGRAM.name}")
+    histogram_path.write_text(json.dumps(payload, indent=2) + "\n")
+    log(f"wrote {csv_path.name} ({len(rows)} skills) + {histogram_path.name}")
 
 
 # ---------------------------------------------------------------------------
@@ -720,7 +876,14 @@ def commit_and_tag(repo: Path, run_id: int, source_sha: str) -> tuple[bool, str 
             suffix += 1
             tag = f"{tag_base}.{suffix}"
         if suffix:
-            log(f"tag {tag_base} exists on an older commit — tagging {tag} instead")
+            log(f"WARNING: tag {tag_base} already exists on an older commit — "
+                f"tagging {tag} instead. This usually means one of: (a) a prior "
+                f"sync committed+tagged but its PUSH FAILED and was never "
+                f"retried — verify {tag_base} actually reached DoltHub "
+                f"(SELECT tag_name FROM dolt_tags via the DoltHub API) before "
+                f"trusting the public record; or (b) compliance was "
+                f"re-populated without a new discovery run. Do not treat this "
+                f"suffix as routine.")
         dolt(["tag", tag, "-m", msg], repo)
         return committed, tag
 
@@ -756,9 +919,10 @@ def check_creds() -> None:
     proc = run(["dolt", "creds", "check", "--endpoint", CREDS_ENDPOINT], check=False)
     if "Success" not in proc.stdout:
         raise PushError(
-            "dolt creds check failed — no valid DoltHub key. "
-            "Run `dolt creds ls` / `dolt login`, or in CI use "
-            "`dolt push --user <name>` with DOLT_REMOTE_PASSWORD=<api token>.\n"
+            "dolt creds check failed — no valid DoltHub key on this machine. "
+            "Run `dolt login` (inspect with `dolt creds ls`). Pushing is "
+            "operator-box-only: this script has no env-var/CI credential path, "
+            "by design — local is the sole writer and CI never pushes.\n"
             + proc.stdout + proc.stderr
         )
 
@@ -772,6 +936,28 @@ def check_repo_exists(org: str, repo_name: str) -> bool | None:
     if proc.returncode != 0 or not code.isdigit():
         return None
     return code == "200"
+
+
+def remote_tags(org: str, repo_name: str) -> set[str] | None:
+    """Best-effort DoltHub tag listing via the public SQL API.
+
+    Returns the set of tag names on the remote, or None when inconclusive
+    (network failure, unexpected payload). Used to reconcile local tags that a
+    prior failed push stranded — see push().
+    """
+    url = (f"https://www.dolthub.com/api/v1alpha1/{org}/{repo_name}/main"
+           f"?q=SELECT+tag_name+FROM+dolt_tags")
+    proc = run(["curl", "-s", "--max-time", "10", url], check=False)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return None
+    return {r["tag_name"] for r in rows if isinstance(r, dict) and r.get("tag_name")}
 
 
 def push(repo: Path, org: str, repo_name: str, tag: str | None) -> None:
@@ -793,12 +979,32 @@ def push(repo: Path, org: str, repo_name: str, tag: str | None) -> None:
     if exists is None:
         log("DoltHub existence probe inconclusive (network) — attempting push anyway")
 
+    tags_to_push: list[str] = [tag] if tag else []
+
+    # Retry-safety: a prior sync may have committed+tagged locally and then
+    # failed its push (exit 3). If the next inventory cycle runs before a
+    # manual retry, that run's tag would otherwise be stranded forever — the
+    # old code only ever pushed the CURRENT run's tag. Reconcile: push every
+    # local tag the remote is missing, not just this run's.
+    remote = remote_tags(org, repo_name)
+    if remote is None:
+        log("DoltHub tag listing inconclusive (network) — pushing only the "
+            "current run's tag; a previously-stranded tag (if any) stays "
+            "local until a sync with network access to the DoltHub API")
+    else:
+        local = {r[0] for r in dolt_csv_query(repo, "SELECT tag_name FROM dolt_tags")}
+        stranded = sorted(local - remote - set(tags_to_push))
+        if stranded:
+            log(f"WARNING: {len(stranded)} local tag(s) never reached DoltHub "
+                f"(a prior sync's push failed and was not retried): {stranded} "
+                f"— pushing them now")
+            tags_to_push.extend(stranded)
+
     refs = ["main"]
-    if tag:
-        # Tags do NOT ride along on a branch push; use the explicit refspec
-        # form so the tag lands as a tag (a bare name can label the transfer
-        # as a branch).
-        refs.append(f"refs/tags/{tag}:refs/tags/{tag}")
+    # Tags do NOT ride along on a branch push; use the explicit refspec
+    # form so the tag lands as a tag (a bare name can label the transfer
+    # as a branch).
+    refs.extend(f"refs/tags/{t}:refs/tags/{t}" for t in tags_to_push)
     for ref in refs:
         proc = dolt(["push", "origin", ref], repo, check=False)
         out = proc.stdout + proc.stderr
@@ -843,9 +1049,29 @@ def maybe_gc(repo: Path, state_path: Path, force: bool) -> None:
         or size_now > GC_SIZE_FACTOR * baseline
     )
     if due:
+        # The sql-server exclusion check ran at lock-acquisition time, but a
+        # `dolt sql-server` can have been started against this repo during the
+        # multi-minute sync — gc under a live server corrupts the working set.
+        # Re-check RIGHT BEFORE gc, and never fail the sync over gc: by this
+        # point commit+push already succeeded, so a gc problem is loud-skip,
+        # not exit-1 (which would misreport a successful, pushed sync).
+        try:
+            refuse_if_server_running(repo)
+        except SyncError as exc:
+            log(f"WARNING: skipping dolt gc — {exc} (the sync itself already "
+                f"succeeded; gc will be retried next sync)")
+            state_path.write_text(json.dumps(state) + "\n")
+            return
         log(f"running dolt gc (syncs_since_gc={state['syncs_since_gc']}, "
             f"size={size_now / 1e6:.0f}MB, baseline={baseline / 1e6:.0f}MB)")
-        dolt(["gc"], repo)
+        try:
+            dolt(["gc"], repo)
+        except subprocess.CalledProcessError as exc:
+            log(f"WARNING: dolt gc failed ({(exc.stderr or exc.stdout or '').strip()}) "
+                f"— the sync itself already succeeded and was pushed; gc will "
+                f"be retried next sync")
+            state_path.write_text(json.dumps(state) + "\n")
+            return
         state["syncs_since_gc"] = 0
         state["size_after_gc_bytes"] = dir_size_bytes(repo)
     state_path.write_text(json.dumps(state) + "\n")
@@ -903,6 +1129,9 @@ def main() -> int:
 
         schema = introspect_schema(conn)
         tables = sorted(schema)
+        # Membership gate FIRST (also in --dry-run): an unknown table must
+        # hard-fail before any DDL/plan output normalizes its presence.
+        gate_export_allowlist(tables)
         violations = scan_type_violations(conn, schema)
         widen = frozenset(violations)
         for (t, c), n in sorted(violations.items()):

--- a/marketplace/scripts/enrich-jrig-data.mjs
+++ b/marketplace/scripts/enrich-jrig-data.mjs
@@ -3,9 +3,11 @@
  * Enrich plugin metadata with JRig behavioral-eval results.
  *
  * Reads `forge_proofs` from `freshie/inventory.sqlite`, picks the
- * latest passing JRig verification per plugin, and writes the
- * results to `marketplace/src/data/jrig-data.json` as a flat map
- * keyed by plugin name. The detail-page Astro template
+ * LATEST real (non-stub) JRig verification per plugin — and includes
+ * it only if that latest eval passed, so a newer failing eval
+ * un-verifies — and writes the results to
+ * `marketplace/src/data/jrig-data.json` as a flat map keyed by
+ * plugin name. The detail-page Astro template
  * (`src/pages/plugins/[name].astro`) overlays this onto the
  * `plugin` prop at render time so the JRig-Verified badge lights
  * up on plugins with passing eval results — without polluting
@@ -138,10 +140,20 @@ function main() {
     return;
   }
 
-  // Pick the latest passing JRig verification per plugin. If a plugin has
-  // multiple verification_type rows (tier1, tier2, tier3-jrig), we surface
-  // the JRig behavioral row specifically — the badge represents JRig
-  // verification, not the lighter-weight static tiers.
+  // Pick the LATEST tier3-jrig row per plugin FIRST, then read its passed
+  // flag. The old query filtered `passed = 1` BEFORE picking latest, so a
+  // newer FAILING eval could never extinguish a stale verified entry — a
+  // regression caught by a re-eval left the badge lit forever. Ordering is
+  // deterministic: verified_at DESC, then run_id DESC (the live DB has three
+  // databricks-pack rows sharing one verified_at second), then id DESC.
+  //
+  // Stub rows are excluded outright: `--stub` runs (evidence JSON
+  // {"stub": true}, ground_truth: false) are pipeline plumbing, never
+  // ground truth — a stub row must not light OR extinguish a badge.
+  //
+  // If a plugin has multiple verification_type rows (tier1, tier2,
+  // tier3-jrig), we surface the JRig behavioral row specifically — the badge
+  // represents JRig verification, not the lighter-weight static tiers.
   const rows = querySqlite(
     dbPath,
     `SELECT plugin_name,
@@ -150,11 +162,27 @@ function main() {
             total_layers,
             baseline_delta,
             verified_at
-     FROM forge_proofs
-     WHERE verification_type = 'tier3-jrig'
-       AND passed = 1
-     GROUP BY plugin_name
-     HAVING MAX(verified_at)
+     FROM (
+       SELECT plugin_name,
+              passed,
+              layers_passed,
+              total_layers,
+              baseline_delta,
+              verified_at,
+              ROW_NUMBER() OVER (
+                PARTITION BY plugin_name
+                ORDER BY verified_at DESC, run_id DESC, id DESC
+              ) AS rn
+       FROM forge_proofs
+       WHERE verification_type = 'tier3-jrig'
+         AND CASE
+               WHEN evidence IS NULL THEN 1
+               WHEN json_valid(evidence)
+                 THEN COALESCE(json_extract(evidence, '$.stub'), 0) = 0
+               ELSE 1
+             END
+     )
+     WHERE rn = 1
      ORDER BY plugin_name`,
   );
 
@@ -164,15 +192,29 @@ function main() {
     return;
   }
 
+  let unverified = 0;
   for (const row of rows) {
     if (!row.plugin_name) continue;
+    if (row.passed !== 1) {
+      // The plugin's LATEST real eval failed/blocked — it gets no entry, so
+      // any previously-committed verified data for it is extinguished on
+      // this rebuild.
+      unverified += 1;
+      continue;
+    }
     data[row.plugin_name] = {
-      verified: row.passed === 1,
+      verified: true,
       layers_passed: row.layers_passed ?? null,
       total_layers: row.total_layers ?? 7,
       baseline_delta: row.baseline_delta ?? null,
       verified_at: row.verified_at ?? null,
     };
+  }
+  if (unverified > 0) {
+    warn(
+      `${unverified} plugin(s) have a FAILING latest tier3-jrig eval — ` +
+        'omitted from jrig-data.json (a newer failing eval un-verifies).',
+    );
   }
 
   fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');

--- a/scripts/run-jrig-eval.sh
+++ b/scripts/run-jrig-eval.sh
@@ -20,12 +20,22 @@
 #     [--run-id <int>] [--models <csv>] [--provider <name>] [--spec <path>] \
 #     [--scratch-db <path-under-/dev/shm>] [--stub]
 #
-# Defaults: --provider deepseek, --models deepseek-v4-flash,
-#           --run-id $(date +%s), scratch DB under /dev/shm.
+# Defaults: --provider deepseek, --models deepseek-v4-flash, scratch DB
+# under /dev/shm. --run-id defaults to the CURRENT discovery run
+# (MAX(id) FROM discovery_runs in --inventory-db): forge_proofs.run_id is
+# part of the recorder's UNIQUE(plugin_name, verification_type, run_id)
+# upsert key AND should be joinable to the discovery run the proof grades,
+# so the default must be stable across re-runs (the old $(date +%s) default
+# minted a new row per invocation, defeating the recorder's idempotency).
+# Pass --run-id explicitly to pin a different run.
 #
 # --stub runs the j-rig stub provider (J_RIG_ALLOW_STUB=1, no API key, no
-# spend) and passes --allow-stub to the recorder. Stub results are NOT ground
-# truth — only use against a scratch copy of the inventory DB.
+# spend) and passes --allow-stub to the recorder. Stub results are NOT
+# ground truth — so in stub mode --inventory-db is ENFORCED to be a scratch
+# copy under /dev/shm (symlinks resolved). A stub row in the real inventory
+# DB could surface as JRig-Verified badge data and gets published to public
+# DoltHub by dolt-sync. Copy first:
+#   cp freshie/inventory.sqlite /dev/shm/inventory-scratch.sqlite
 #
 # Env overrides:
 #   JRIG_BIN       — j-rig binary to use instead of `pnpm exec j-rig`
@@ -43,7 +53,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 skill_dir=""
 plugin=""
 inventory_db=""
-run_id="$(date +%s)"
+run_id=""  # resolved after the guards: defaults to the current discovery run
 models="deepseek-v4-flash"
 provider="deepseek"
 spec=""
@@ -70,9 +80,11 @@ done
 [ -n "$inventory_db" ] || die "--inventory-db is required"
 [ -d "$skill_dir" ] || die "--skill-dir does not exist: $skill_dir"
 [ -f "$inventory_db" ] || die "--inventory-db does not exist: $inventory_db"
-case "$run_id" in
-  ''|*[!0-9]*) die "--run-id must be a non-negative integer (got: $run_id)" ;;
-esac
+if [ -n "$run_id" ]; then
+  case "$run_id" in
+    *[!0-9]*) die "--run-id must be a non-negative integer (got: $run_id)" ;;
+  esac
+fi
 
 # Scratch workspace: everything transient lives under /dev/shm (tmpfs — no
 # plaintext or eval artifacts ever touch persistent disk) and dies with the
@@ -101,7 +113,33 @@ esac
 if [ "$scratch_db" = "$inventory_db" ]; then
   die "scratch DB and inventory DB must be different files"
 fi
+# --- STUB GUARD: stub verdicts must never reach the real inventory DB ------
+# --stub results carry ground_truth:false. The recorder marks them
+# (evidence.stub) but still writes a row — and forge_proofs in the real
+# inventory DB drives JRig-Verified badge data AND is published to public
+# DoltHub by dolt-sync. So in stub mode the --inventory-db itself must be a
+# scratch copy under /dev/shm (symlinks resolved to defeat aliasing).
+if [ "$stub" -eq 1 ]; then
+  inv_resolved="$(readlink -f "$inventory_db")"
+  case "$inv_resolved" in
+    /dev/shm/*) : ;;
+    *) die "--stub writes non-ground-truth rows; --inventory-db must be a scratch copy under /dev/shm (got: $inventory_db -> $inv_resolved). Copy it first: cp freshie/inventory.sqlite /dev/shm/inventory-scratch.sqlite — or drop --stub for a real eval." ;;
+  esac
+fi
 # ----------------------------------------------------------------------------
+
+# Resolve the default --run-id AFTER the guards: the current discovery run,
+# read from the inventory DB. Stable across re-runs → the recorder's upsert
+# is actually idempotent, and the proof row is joinable to the discovery run
+# it grades. (An epoch-seconds default minted a new forge_proofs row per
+# invocation and matched no discovery run.)
+if [ -z "$run_id" ]; then
+  run_id="$(sqlite3 "$inventory_db" 'SELECT COALESCE(MAX(id), 0) FROM discovery_runs;' 2>/dev/null || true)"
+  case "$run_id" in
+    ''|0|*[!0-9]*) die "could not resolve a default --run-id from $inventory_db (discovery_runs missing or empty) — pass --run-id <int> explicitly" ;;
+  esac
+  echo "[run-jrig-eval] --run-id defaulted to current discovery run: $run_id" >&2
+fi
 
 result_json="$scratch_dir/result.json"
 jrig_bin="${JRIG_BIN:-}"

--- a/tests/test_dolt_sync.py
+++ b/tests/test_dolt_sync.py
@@ -1,11 +1,17 @@
 """Unit tests for freshie/scripts/dolt-sync.py (schema translation, the
-(NULL,'') fallback SQL generation, and the VARCHAR length guard).
+(NULL,'') fallback SQL generation, the VARCHAR length guard, the
+public-export table allowlist, and the current-run grades export).
 
 Run: python3 -m unittest tests.test_dolt_sync -v
 
-Pure-function tests only — no dolt binary, no network, no repo state.
-The live round-trip (CSV canary, parity gates, push) is exercised by the
-sync itself on every run.
+Coverage honesty: these are pure-function tests only — no dolt binary, no
+network, no repo state. The commit/tag/push/gc state machine
+(commit_and_tag's crash-retry, tag-suffix, and head-message branches;
+push's stranded-tag reconciliation; maybe_gc) is NOT covered here, and the
+"the sync itself exercises it" framing only holds for the happy path — the
+rare branches (e.g. the run-9.1 tag-suffix event of 2026-07-13) run in
+production first. Treat any change to that state machine as untested until
+a dolt-backed round-trip test exists.
 """
 
 import importlib.util
@@ -226,6 +232,110 @@ class TypeViolationTests(unittest.TestCase):
         schema = dolt_sync.introspect_schema(conn)
         with self.assertRaises(dolt_sync.SyncError):
             dolt_sync.scan_type_violations(conn, schema)
+        conn.close()
+
+
+class ExportAllowlistTests(unittest.TestCase):
+    """Everything the sync exports becomes permanent PUBLIC DoltHub history —
+    table membership is a hard gate (j-rig's runtime tables leaked into the
+    public run-9.1 push because no such gate existed)."""
+
+    def test_allowlisted_tables_pass(self):
+        dolt_sync.gate_export_allowlist(["skill_compliance", "forge_proofs", "skills"])
+
+    def test_full_allowlist_passes(self):
+        dolt_sync.gate_export_allowlist(sorted(dolt_sync.EXPORT_ALLOWLIST))
+
+    def test_bogus_table_hard_fails_and_is_named(self):
+        with self.assertRaises(dolt_sync.SyncError) as ctx:
+            dolt_sync.gate_export_allowlist(["skill_compliance", "totally_bogus"])
+        self.assertIn("totally_bogus", str(ctx.exception))
+        self.assertIn("EXPORT_ALLOWLIST", str(ctx.exception))
+
+    def test_jrig_runtime_table_fails_with_scratch_db_guidance(self):
+        with self.assertRaises(dolt_sync.SyncError) as ctx:
+            dolt_sync.gate_export_allowlist(["skills", "criterion_results", "runs"])
+        msg = str(ctx.exception)
+        self.assertIn("criterion_results", msg)
+        self.assertIn("runs", msg)
+        self.assertIn("run-jrig-eval.sh", msg)
+        self.assertIn("DROP TABLE", msg)
+
+    def test_jrig_tables_are_never_allowlisted(self):
+        # The two sets must stay disjoint — allowlisting a j-rig runtime
+        # table would re-open the exact leak this gate exists to prevent.
+        self.assertEqual(
+            dolt_sync.JRIG_RUNTIME_TABLES & dolt_sync.EXPORT_ALLOWLIST, frozenset()
+        )
+
+    def test_empty_table_list_passes(self):
+        dolt_sync.gate_export_allowlist([])
+
+
+class GradesExportTests(unittest.TestCase):
+    """grades.csv must reflect the CURRENT run only — latest-per-skill across
+    all runs kept deleted skills alive as ghost rows (102 of them by run 9)."""
+
+    DDL = (
+        "CREATE TABLE skill_compliance ("
+        "  id INTEGER PRIMARY KEY, skill_path TEXT, grade TEXT,"
+        "  score REAL, run_id INTEGER);"
+    )
+
+    def export(self, conn, run_id, tmpdir):
+        import pathlib
+
+        csv_path = pathlib.Path(tmpdir) / "grades.csv"
+        hist_path = pathlib.Path(tmpdir) / "grade-histogram.json"
+        dolt_sync.write_grades_export(conn, run_id, csv_path, hist_path)
+        return csv_path.read_text(), hist_path.read_text()
+
+    def test_deleted_skill_is_not_a_ghost_row(self):
+        import json
+        import tempfile
+
+        conn = fixture_conn(self.DDL)
+        # run 1 graded two skills; 'plugins/gone' was deleted before run 2.
+        conn.executemany(
+            "INSERT INTO skill_compliance (skill_path, grade, score, run_id) VALUES (?,?,?,?)",
+            [
+                ("plugins/alive", "B", 80.0, 1),
+                ("plugins/gone", "B", 75.0, 1),
+                ("plugins/alive", "A", 92.0, 2),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_text, hist_text = self.export(conn, 2, tmpdir)
+        self.assertIn("plugins/alive,A,92.0", csv_text)
+        self.assertNotIn("plugins/gone", csv_text)
+        payload = json.loads(hist_text)
+        self.assertEqual(payload["run_id"], 2)
+        self.assertEqual(payload["total"], 1)
+        self.assertEqual(payload["grades"], {"A": 1})
+        conn.close()
+
+    def test_empty_current_run_refuses_to_wipe_export(self):
+        import tempfile
+
+        conn = fixture_conn(self.DDL)
+        conn.execute(
+            "INSERT INTO skill_compliance (skill_path, grade, score, run_id) "
+            "VALUES ('plugins/alive', 'B', 80.0, 1)"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(dolt_sync.SyncError):
+                self.export(conn, 2, tmpdir)
+        conn.close()
+
+    def test_fully_empty_table_writes_empty_export(self):
+        import json
+        import tempfile
+
+        conn = fixture_conn(self.DDL)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_text, hist_text = self.export(conn, 1, tmpdir)
+        self.assertEqual(csv_text.strip(), "skill_path,grade,score")
+        self.assertEqual(json.loads(hist_text)["total"], 0)
         conn.close()
 
 


### PR DESCRIPTION
## ⚠️ Already-leaked public tables — OWNER DECISION REQUIRED (not acted on here)

j-rig's runtime tables were published to the **public** DoltHub database `jeremylongshore/freshie-inventory` in the `run-9.1` push (2026-07-13): `artifacts`, `criterion_results` (**51 rows of LLM judge output**), `run_summaries`, `runs`, `skill_versions`, `skill_human_reviews`, `skill_usage_events`. Dolt history is never rewritten, so this PR **prevents future leaks only** — it deliberately does NOT touch the public DB.

**Recommendation:** the leaked content is low-sensitivity (judge verdicts about this repo's own public skills), but the tables are permanent cruft and future queries against them mislead. Cleanest option: **delete the DoltHub database and recreate it, then re-push from the local Dolt repo after dropping the 7 tables locally** (local is the sole writer, so nothing is lost — but the old run-8/run-9 clone URLs and web history reset). Alternative: leave-and-accept, documenting the 7 tables as dead. Either is defensible; deleting a public DB is one-way, so this stays Jeremy's call.

**Heads-up:** the next real sync will **hard-fail loudly** until the 7 j-rig tables are dropped from the local `freshie/inventory.sqlite` (the error message prints the exact `DROP TABLE` commands). That is the designed behavior, not a regression.

## What

Fixes the Dolt-layer findings from the 2026-07-14 ops review (pass D, bead `claude-k0h2`) in the four files this pass owns: `freshie/scripts/dolt-sync.py`, `marketplace/scripts/enrich-jrig-data.mjs`, `scripts/run-jrig-eval.sh`, `tests/test_dolt_sync.py`.

| # | Finding | Fix |
|---|---|---|
| P1 | Exporter publishes every SQLite table to public DoltHub, no gate; j-rig tables already leaked | `EXPORT_ALLOWLIST` (the exact 51-table run-8 CMDB set, verified via `SHOW TABLES AS OF 'run-8'`) + `gate_export_allowlist` — any non-allowlisted table hard-fails the sync, `--dry-run` included, with j-rig-specific cleanup guidance |
| P1 | `--stub` auto-passes `--allow-stub` while writing the REAL inventory DB → stub row could feed verified-badge data | Runner refuses `--stub` unless `--inventory-db` resolves (symlinks followed) under `/dev/shm`; belt-and-braces: enrich excludes `evidence.stub` rows outright |
| P2 | Badge can't be extinguished (`passed=1` filtered before latest-pick; tied timestamps nondeterministic) | Window function picks latest per plugin FIRST (`verified_at DESC, run_id DESC, id DESC`), THEN checks `passed` — a newer failing eval un-verifies; deterministic tiebreak |
| P2 | run-N tag stranded after a push failure; collision fallback silently masks it | `push()` reconciles local `dolt_tags` against the DoltHub API and pushes stranded tags (retry-safe); the `run-N.1` suffix fallback now logs a loud WARNING naming the unpushed-prior-run cause |
| P2 | Docstring/error advertise an unimplemented `dolt push --user` + `DOLT_REMOTE_PASSWORD` CI path | Docs-truth fix: creds-file (`dolt login`) only, no CI path — CI never pushes (`promote-curated.yml` runs it `\|\| true` with no creds; local is the sole writer). Chose docs-truth over implementing env-var creds because nothing needs CI push |
| P2 | 102 deleted skills persist as ghost rows in tracked `grades.csv` (histogram claims 3783 vs 3681 actually in run 9) | `write_grades_export` scoped to the CURRENT run; refuses to wipe the export if the current run has zero compliance rows |
| P3 | Checksum gate logs "OK on 3 JSON columns" even when tables were skipped | Logs only columns actually verified; per-column WARNING on skip |
| P3 | sql-server exclusion checked at lock time but `dolt gc` runs minutes later; gc failure exits 1 after a successful push | `maybe_gc` re-checks for a live server right before gc; gc problems loud-skip instead of failing an already-pushed sync |
| P3 | Runner's `--run-id` default `$(date +%s)` defeats the recorder's upsert idempotency | Defaults to the current discovery run (`MAX(id) FROM discovery_runs` in `--inventory-db`); explicit `--run-id` still honored |
| Test | Suite claims the live round-trip is "exercised on every run" | Honest docstring (commit/tag/push/gc state machine is NOT unit-covered) + 9 new tests (allowlist gate, current-run grades export) → 36 total |

## Why + decision rationale

Everything the exporter emits becomes permanent public history — membership must be a **gate**, not a discovery. Chose an explicit allowlist over a j-rig-prefix denylist because a denylist only blocks the leak we already know about; the allowlist makes every future table a deliberate, reviewed publish (mirrors the existing BLOB hard-fail philosophy).

## Layers touched / invariants

Dolt export layer (new membership invariant: `tables ⊆ EXPORT_ALLOWLIST`, and `JRIG_RUNTIME_TABLES ∩ EXPORT_ALLOWLIST = ∅` is pinned by a test); JRig proofs pipeline (new invariant: a `ground_truth:false` result can never produce verified-badge data end-to-end); tracked exports (`grades.csv` now = current run only — it will shrink by 102 ghost rows on the next sync, a real one-time diff).

## Verification & evidence (all offline — **no `dolt push` to the public remote was made**)

- `python3 -m unittest tests.test_dolt_sync` → **36 tests, OK**
- Hard-fail proof, bogus table (temp DB, `--dry-run`): exit 1 — `unrecognized tables: ['totally_bogus_table']. Either add each to EXPORT_ALLOWLIST deliberately … or drop it`
- Hard-fail proof, j-rig tables (temp DB): exit 1 with `Route evals through scripts/run-jrig-eval.sh … DROP TABLE "criterion_results" …`
- Hard-fail proof, **LIVE** inventory DB (`--dry-run`, read-only): exit 1 naming all 7 leaked tables
- Full offline sync (`--no-push`, temp Dolt dir): green end-to-end — allowlist gate OK, ghost row excluded from grades.csv, honest checksum log (`OK on 0 JSON columns (none checked)` + 3 skip WARNINGs), `run-2` tagged; re-populate run exercised the **loud** `run-2.1` collision WARNING
- Enrich fixture (temp `forge_proofs`): newer-failing row extinguishes a stale verified entry; equal-timestamp `run_id` tiebreak un-verifies; `evidence.stub` row never appears; output restored via `git checkout` after the test
- Runner: stub + non-/dev/shm inventory DB → refused; CI's exact-message assertion in `jrig-proofs-test.yml` still matches (guard order preserved — verified by re-running the workflow's own command); `--run-id` defaults to discovery run 9 from a fixture; `shellcheck` + `bash -n` clean
- `ruff check` clean; `node --test scripts/record-jrig-proofs.test.mjs` all pass (`ruff format --check` was already failing for these files on main; CI's format job scopes `plugins/ scripts/` only)

## Risk assessment & rollback

- **Designed breakage:** next real sync hard-fails until the operator drops the 7 j-rig tables locally (message prints the commands). Rollback: revert this PR — no data or public-DB state was changed.
- `grades.csv` −102 rows on next sync is intended honesty; `promote-to-curated.py` already tolerates it (independent source-dir check).
- Stranded-tag reconciliation is best-effort (DoltHub API); on network failure it degrades to exactly the old behavior, with a log line.

## Operational impact

None until the next inventory cycle. No new deps, no env vars, no schema change, no deploy-order concern. The badge UI itself was removed in #1046/#1050 — this fixes the **data** integrity so a re-surfaced badge can't lie.

## Follow-up & deferred (handing off)

- **Owner:** decide the already-leaked-tables question above (delete+recreate DoltHub DB vs leave-and-accept), then drop the 7 tables from local `inventory.sqlite`.
- **Docs pass (not this PR's files):** `CLAUDE.md:72-73` tells operators to point `j-rig eval --db` at `freshie/inventory.sqlite` — must route through `scripts/run-jrig-eval.sh` instead (this is how the leak happened); `freshie/README.md:207-210` still advertises the removed `dolt push --user`/`DOLT_REMOTE_PASSWORD` CI path; `freshie/README.md:117` test count (27 → 36); `freshie/README.md:21-24` says remote edits are "clobbered" when they actually cause a loud non-fast-forward exit-3.
- **Pass C:** none of `rebuild-inventory.py` / `promote-to-curated.py` / `batch-remediate.py` were touched.
- Deferred (from review, out of scope here): extracting `commit_and_tag`'s four-way branch into a pure function for unit coverage; auto-discovering JSON checksum candidate columns.

## Governance links / refs

Refs bead `claude-k0h2` (2026-07-14 ops review, pass D). Findings source: `~/.claude/jobs/febf243b/tmp/review-dolt.json`.

**Do not merge without the owner reading the leaked-tables section above.**