### PR TITLE
fix(freshie): 2026-07-14 ops-review fix pass — P1 color-strip, wipe floor, phantom runs, populate-db integrity [skip auto-bump]

### DIFF
--- a/.github/workflows/promote-curated.yml
+++ b/.github/workflows/promote-curated.yml
@@ -21,12 +21,15 @@ name: Promote curated skills (skills.sh mirror)
 on:
   schedule:
     - cron: '0 6 * * 1' # Mondays 06:00 UTC
-  workflow_dispatch:
-    inputs:
-      rebuild_inventory:
-        description: 'Rebuild the Freshie inventory + grades.csv before promoting (slower, freshest grades). Off = promote from the committed grades.csv.'
-        type: boolean
-        default: false
+  # No inputs — a `rebuild_inventory` dispatch input used to live here and was
+  # structurally guaranteed to fail: freshie/inventory.sqlite is untracked
+  # (absent on every clean runner), rebuild-inventory.py by design scans into
+  # an EXISTING CMDB schema (it exits 1 when the DB is absent and creates no
+  # tables), and the runner has no dolt binary for dolt-sync (2026-07-14 ops
+  # review). Freshest grades come from running the freshie cycle on the dev
+  # box (CLAUDE.md § Freshie Inventory), which commits grades.csv — the
+  # committed CSV is what this workflow promotes from.
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -74,17 +77,8 @@ jobs:
       - name: Install root dev dependencies
         run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo"
 
-      # Optional: refresh grades from a full inventory run. Off by default — the
-      # committed grades.csv is the latest run's compact export and is enough to
-      # re-derive the mirror. (rebuild-inventory.py is heavier and writes the
-      # git-ignored inventory.sqlite + regenerates grades.csv via dolt-sync.)
-      - name: Rebuild inventory + grades (optional)
-        if: inputs.rebuild_inventory == true
-        run: |
-          python3 freshie/scripts/rebuild-inventory.py
-          python3 scripts/validate-skills-schema.py --marketplace --populate-db freshie/inventory.sqlite || true
-          python3 freshie/scripts/dolt-sync.py || true
-
+      # The mirror is re-derived from the COMMITTED freshie/grades.csv — see the
+      # `on:` comment for why CI cannot rebuild the inventory itself.
       - name: Rebuild skills/.curated/ mirror
         run: python3 freshie/scripts/promote-to-curated.py
 

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -117,6 +117,9 @@ jobs:
           python3 -m unittest tests.test_hms_readiness_classifier -v
           python3 -m unittest tests.test_enable_system_schemas -v
           python3 -m unittest tests.test_cluster_forensics -v
+          python3 -m unittest tests.test_populate_db_upsert -v
+          python3 -m unittest tests.test_promote_curated_floor -v
+          python3 -m unittest tests.test_rebuild_inventory_phantom -v
 
       # Reject PRs that reformat .claude-plugin/marketplace.extended.json beyond
       # the line budget implied by added/modified entries. Prevents prettier or

--- a/freshie/scripts/batch-remediate.py
+++ b/freshie/scripts/batch-remediate.py
@@ -34,18 +34,78 @@ DB_PATH = REPO_ROOT / "freshie" / "inventory.sqlite"
 PLUGINS_ROOT = REPO_ROOT / "plugins"
 SKILLS_ROOT = REPO_ROOT / "skills"  # legacy top-level numbered skill tree (dgpl)
 
-# Fields that are no longer valid in agent frontmatter
-DEPRECATED_AGENT_FIELDS = frozenset(
+# Path to the canonical validator — the single source of truth for which agent
+# frontmatter fields are banned vs required (kernel-floor 8 + INVALID_AGENT_FIELDS).
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "validate-skills-schema.py"
+
+# Inline fallback used ONLY when the canonical validator cannot be imported
+# (e.g. pyyaml missing — the validator hard-exits at import without it).
+# Mirrors the validator's INVALID_AGENT_FIELDS as of schema 3.15.0.
+# NOTE: `color` is deliberately NOT here — it is one of the kernel-floor 8
+# REQUIRED agent fields (name, description, tools, model, color, version,
+# author, tags). A stale hand-rolled copy of this set used to carry it, and
+# --fix-agents stripped the required field from the entire A-grade agent
+# corpus (P1, 2026-07-14 ops review).
+_FALLBACK_REMOVABLE_AGENT_FIELDS = frozenset(
     [
         "capabilities",
         "expertise_level",
         "activation_priority",
         "activation_triggers",
-        "color",
         "type",
         "category",
+        "compatible-with",
+        "when_to_use",
     ]
 )
+
+
+def _load_removable_agent_fields() -> frozenset[str]:
+    """Derive the fields --fix-agents may remove FROM THE VALIDATOR, not a copy.
+
+    Removal set = the validator's INVALID_AGENT_FIELDS (hard errors at every
+    tier) union its DEPRECATED_AGENT_FIELDS (warn-level; empty today). The set
+    is cross-checked against the validator's AGENT_ALWAYS_REQUIRED (the
+    kernel-floor 8): if any "removable" field is also required, abort loudly
+    instead of mass-stripping a required field — the exact P1 this replaces
+    (a stale copy of this set carried `color` and --fix-agents removed it
+    from every agent it touched).
+
+    Falls back to the inline mirror above when the validator cannot be
+    imported. SystemExit is caught explicitly: the validator sys.exit(1)s at
+    import when pyyaml is missing, and SystemExit does not inherit Exception
+    (the 2026-07-13 promote-to-curated pyyaml incident class).
+    """
+    try:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("vss_for_batch_remediate", VALIDATOR_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except (Exception, SystemExit) as exc:
+        print(
+            f"WARNING: could not import the canonical validator ({exc!r}); "
+            "using the inline fallback agent-field set.",
+            file=sys.stderr,
+        )
+        return _FALLBACK_REMOVABLE_AGENT_FIELDS
+    removable = frozenset(mod.INVALID_AGENT_FIELDS) | frozenset(mod.DEPRECATED_AGENT_FIELDS)
+    required = frozenset(mod.AGENT_ALWAYS_REQUIRED)
+    overlap = removable & required
+    if overlap:
+        sys.exit(
+            "FATAL: the validator marks required agent field(s) "
+            f"{sorted(overlap)} as removable — refusing to run against an "
+            "inconsistent spec (a stale field set once stripped the required "
+            "`color` field from the whole corpus; see 2026-07-14 ops review)."
+        )
+    return removable
+
+
+# Fields --fix-agents removes from agent frontmatter. Kept under the historical
+# name (tests and docs reference it); the VALUE now derives from the canonical
+# validator so the two can never silently diverge again.
+DEPRECATED_AGENT_FIELDS = _load_removable_agent_fields()
 
 # Category directory → tags
 TAG_MAP: dict[str, list[str]] = {
@@ -500,10 +560,24 @@ def get_skills_missing_compatible_with(db: sqlite3.Connection) -> list[Path]:
     return [_skill_md_from_row(row[0]) for row in cur.fetchall()]
 
 
+def _agent_md_from_row(path_str: str) -> Path:
+    """Resolve an `agent_compliance.agent_path` DB value to an absolute file.
+
+    The DB stores repo-relative FILE paths (the validator normalizes them at
+    populate time). Left as-is, `Path(row).exists()` checks against the cwd, so
+    running --fix-agents from anywhere but the repo root counted every row as
+    'SKIP (not found)' and silently fixed nothing — the same bug class already
+    fixed for skills in _skill_md_from_row above."""
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    return p
+
+
 def get_agents_with_invalid_fields(db: sqlite3.Connection) -> list[Path]:
     cur = db.cursor()
     cur.execute("SELECT agent_path FROM agent_compliance WHERE has_invalid_fields = 1")
-    return [Path(row[0]) for row in cur.fetchall()]
+    return [_agent_md_from_row(row[0]) for row in cur.fetchall()]
 
 
 # ---------------------------------------------------------------------------
@@ -759,6 +833,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip DB lookup and use filesystem walk only.",
     )
+    parser.add_argument(
+        "--fs-fallback",
+        action="store_true",
+        help="Allow --fix-agents to fall back to a filesystem walk when the DB "
+        "is absent. Without the DB, the walk selects agents by pattern-matching "
+        "frontmatter text across the whole corpus, so the fallback is opt-in for "
+        "the destructive agent fixer (2026-07-14 ops review). --no-db counts as "
+        "the same explicit opt-in.",
+    )
     return parser
 
 
@@ -766,8 +849,14 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
 
-    # Resolve dry_run: write only when --execute is passed
-    dry_run = not args.execute
+    # --dry-run and --execute together are ambiguous — refuse rather than guess.
+    # (--dry-run used to be parsed but never read, so `--dry-run --execute`
+    # silently wrote files under a flag that says dry-run; 2026-07-14 ops review.)
+    if args.dry_run and args.execute:
+        parser.error("--dry-run and --execute are mutually exclusive")
+
+    # Resolve dry_run: write only when --execute is passed (and --dry-run is not).
+    dry_run = args.dry_run or not args.execute
 
     # Resolve which fixers to run
     fix_tags = args.fix_tags or args.all
@@ -786,6 +875,19 @@ def main() -> int:
     if use_db:
         db = _open_db()
         if db is None:
+            # The agent fixer is destructive at corpus scale: the filesystem walk
+            # selects agents by pattern-matching frontmatter text, and a fresh
+            # checkout never has the (untracked) DB — so require an explicit
+            # opt-in instead of silently degrading (2026-07-14 ops review P1).
+            if fix_agents and not args.fs_fallback:
+                parser.error(
+                    f"DB not found at {DB_PATH} and --fix-agents was requested. "
+                    "The filesystem-walk fallback selects agents by pattern-matching "
+                    "frontmatter across the whole corpus; pass --fs-fallback (or --no-db) "
+                    "to allow it explicitly, or build the DB first "
+                    "(freshie/scripts/rebuild-inventory.py, then "
+                    "validate-skills-schema.py --marketplace --populate-db)."
+                )
             print(f"WARNING: DB not found at {DB_PATH} — falling back to filesystem walk.\n")
             use_db = False
 

--- a/freshie/scripts/dolt-sync.py
+++ b/freshie/scripts/dolt-sync.py
@@ -637,6 +637,31 @@ def gate_json_checksums(conn: sqlite3.Connection, repo: Path,
     log(f"gate: per-row MD5 byte checksums OK on {len(JSON_CHECKSUM_COLUMNS)} JSON columns")
 
 
+def gate_run_completeness(conn: sqlite3.Connection, run_id: int) -> None:
+    """Refuse to export a phantom half-run into the append-only Dolt history.
+
+    rebuild-inventory writes the discovery_runs totals only as the LAST step of
+    a successful scan, so NULL totals on the newest run mean a crashed scan
+    left partial rows across the run-tagged tables. Exporting would freeze the
+    phantom into public Dolt history forever (2026-07-14 ops review); the
+    rebuild script now purges the phantom on its next default rerun."""
+    if not run_id:
+        return  # empty DB — nothing to judge (main already tags run-0 honestly)
+    try:
+        row = conn.execute(
+            "SELECT total_skills FROM discovery_runs WHERE id=?", (run_id,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return  # legacy schema without totals columns — cannot judge, do not block
+    if row is not None and row[0] is None:
+        raise SyncError(
+            f"discovery run {run_id} is incomplete (totals were never written — "
+            f"a crashed scan left a phantom half-run). Re-run "
+            f"freshie/scripts/rebuild-inventory.py (it purges the newest phantom "
+            f"and rescans) before syncing to Dolt."
+        )
+
+
 def gate_varchar_lengths(conn: sqlite3.Connection, guards: list[tuple[str, str]]) -> None:
     for table, col in guards:
         max_len = conn.execute(
@@ -931,6 +956,7 @@ def main() -> int:
                 f"JSON checks on {[f'{t}.{c}' for t, c in JSON_CHECKSUM_COLUMNS]}")
             return 0
 
+        gate_run_completeness(conn, run_id)
         gate_varchar_lengths(conn, guards)
         ensure_repo(repo)
 

--- a/freshie/scripts/promote-to-curated.py
+++ b/freshie/scripts/promote-to-curated.py
@@ -45,7 +45,10 @@ Modes
                      Writes `skills/.curated/MANIFEST.json` (the audit trail of what was
                      promoted and why). Needs the validator importable (local dev / the
                      weekly workflow after `pnpm install`); degrades to the recorded grade
-                     with a loud warning if it is not.
+                     with a loud warning if it is not. A wipe-floor guard refuses to touch
+                     the mirror when the fresh selection collapses (below 50% of the
+                     committed MANIFEST count or under 500 skills) — pass --force-floor
+                     for a deliberate mass-delisting.
   --check            CI drift gate. Reads the committed MANIFEST and verifies every promoted
                      copy is byte-identical to the current git-tracked source, with no orphan
                      or missing dirs. Deterministic, git-only — no validator, no sqlite, no
@@ -78,6 +81,21 @@ MANIFEST = CURATED_DIR / "MANIFEST.json"
 VALIDATOR = ROOT / "scripts" / "validate-skills-schema.py"
 
 PROMOTE_GRADES = {"A", "B"}
+
+# ── wipe-floor guards (build mode) ───────────────────────────────────────────
+# Every selection failure mode (empty/truncated grades.csv, validator API drift
+# making fresh_grade return None for everything) used to converge on wiping all
+# ~1,881 curated dirs and exiting 0 (2026-07-14 ops review). Before any rmtree,
+# the fresh selection must clear BOTH floors relative to the committed
+# MANIFEST count, or the build refuses and leaves the mirror untouched:
+#   - MIN_PROMOTED_ABSOLUTE: the corpus has sat at ~1,881 A/B skills since the
+#     mirror shipped; anything under 500 is not a plausible organic selection,
+#     it is an upstream failure.
+#   - MIN_PROMOTED_RATIO: a >50% single-run shrink is never routine grade
+#     movement — historical week-over-week drift is single-digit percent.
+# A deliberate mass-delisting passes --force-floor.
+MIN_PROMOTED_ABSOLUTE = 500
+MIN_PROMOTED_RATIO = 0.5
 
 
 # ── selection ────────────────────────────────────────────────────────────────
@@ -133,6 +151,19 @@ def load_validator():
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         return mod
+    except SystemExit as e:
+        # The validator hard-exits (sys.exit(1)) at import when a hard dep such
+        # as pyyaml is missing. SystemExit inherits BaseException, NOT Exception,
+        # so the generic handler below never saw it and the whole promoter died
+        # despite the documented degrade contract — the 2026-07-13 first-dispatch
+        # failure was patched in the workflow (`pip install pyyaml`), fixed here
+        # so the contract holds in every environment.
+        print(
+            f"⚠️  validator import hard-exited (exit={e.code}) — likely a missing "
+            "dependency such as pyyaml; falling back to recorded grades.",
+            file=sys.stderr,
+        )
+        return None
     except Exception as e:  # noqa: BLE001 — any failure ⇒ fall back to recorded grade
         print(f"⚠️  could not import validator ({e}); falling back to recorded grades.", file=sys.stderr)
         return None
@@ -194,7 +225,17 @@ def tracked_files(skill_dir: Path) -> List[str]:
 
 
 # ── build ────────────────────────────────────────────────────────────────────
-def build(validate: bool = True, quiet: bool = False) -> int:
+def _committed_manifest_count() -> Optional[int]:
+    """The promoted-skill count recorded by the last successful build, or None."""
+    if not MANIFEST.exists():
+        return None
+    try:
+        return int(json.loads(MANIFEST.read_text()).get("count"))
+    except (ValueError, TypeError, OSError, json.JSONDecodeError):
+        return None
+
+
+def build(validate: bool = True, quiet: bool = False, force_floor: bool = False) -> int:
     candidates = load_candidates(GRADES_CSV)
     if not quiet:
         print(f"selection: {len(candidates)} A/B plugin skills (own, source present)")
@@ -206,12 +247,9 @@ def build(validate: bool = True, quiet: bool = False) -> int:
     run_id = _run_id()
     assign_curated_names(candidates)
 
-    # Wipe and rebuild — deletions/downgrades propagate, like build-cowork-zips.mjs.
-    if CURATED_DIR.exists():
-        shutil.rmtree(CURATED_DIR)
-    CURATED_DIR.mkdir(parents=True)
-
-    promoted: List[Dict] = []
+    # Phase 1 — selection (no filesystem mutation): grade + enumerate BEFORE any
+    # wipe so a selection collapse is caught while the mirror is still intact.
+    keep: List[tuple] = []  # (candidate, fresh_grade, tracked_files)
     dropped_grade = 0
     dropped_empty = 0
     for c in candidates:
@@ -229,6 +267,47 @@ def build(validate: bool = True, quiet: bool = False) -> int:
             dropped_empty += 1
             continue  # nothing tracked to mirror
 
+        keep.append((c, fg, files))
+
+    # Phase 2 — wipe-floor gate: refuse to touch the mirror when the fresh
+    # selection is implausibly small (see MIN_PROMOTED_* rationale above).
+    if not force_floor:
+        problems: List[str] = []
+        if not candidates:
+            problems.append("grades.csv yielded ZERO candidates (empty/truncated export?)")
+        elif validate and not keep and dropped_grade == len(candidates):
+            problems.append(
+                "the in-process re-grade dropped 100% of candidates "
+                "(validator API drift or a broken kernel install?)"
+            )
+        prior = _committed_manifest_count()
+        if prior:
+            floor = max(MIN_PROMOTED_ABSOLUTE, int(prior * MIN_PROMOTED_RATIO))
+            if len(keep) < floor:
+                problems.append(
+                    f"fresh selection is {len(keep)} skills, below the floor of "
+                    f"{floor} (committed MANIFEST count {prior}; absolute floor "
+                    f"{MIN_PROMOTED_ABSOLUTE}, ratio {MIN_PROMOTED_RATIO})"
+                )
+        if problems:
+            for p in problems:
+                print(f"::error::refusing to rebuild skills/.curated/: {p}", file=sys.stderr)
+            print(
+                "skills/.curated/ left untouched. If this shrink is deliberate, "
+                "re-run with --force-floor.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Phase 3 — wipe and rebuild — deletions/downgrades propagate, like
+    # build-cowork-zips.mjs.
+    if CURATED_DIR.exists():
+        shutil.rmtree(CURATED_DIR)
+    CURATED_DIR.mkdir(parents=True)
+
+    promoted: List[Dict] = []
+    for c, fg, files in keep:
+        src_dir = ROOT / c["skill_path"]
         dest_dir = CURATED_DIR / c["curated_name"]
         for rel in files:
             dst = dest_dir / rel
@@ -367,11 +446,17 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Promote A/B plugin skills into skills/.curated/ for skills.sh.")
     ap.add_argument("--check", action="store_true", help="CI drift gate: exit 1 if the mirror is stale vs source.")
     ap.add_argument("--no-validate", action="store_true", help="Skip the in-process re-grade defense (build mode).")
+    ap.add_argument(
+        "--force-floor",
+        action="store_true",
+        help="Override the wipe-floor guard for a deliberate mass-delisting "
+        "(build mode; normally a selection below the floor refuses to wipe).",
+    )
     ap.add_argument("--quiet", action="store_true", help="Only print on error.")
     args = ap.parse_args()
     if args.check:
         return check(quiet=args.quiet)
-    return build(validate=not args.no_validate, quiet=args.quiet)
+    return build(validate=not args.no_validate, quiet=args.quiet, force_floor=args.force_floor)
 
 
 if __name__ == "__main__":

--- a/freshie/scripts/rebuild-inventory.py
+++ b/freshie/scripts/rebuild-inventory.py
@@ -363,6 +363,22 @@ def next_run_id(conn: sqlite3.Connection) -> int:
     return (row[0] or 0) + 1
 
 
+def find_phantom_runs(conn: sqlite3.Connection) -> list[int]:
+    """IDs of discovery runs whose totals were never written, oldest first.
+
+    The totals UPDATE is the LAST step of a successful scan (Step 15 in
+    run_scan), so a discovery_runs row with NULL total_skills means the process
+    died mid-scan and left a phantom half-run: partial rows in every table it
+    had reached, committed step by step. Left alone, the default rerun computes
+    MAX(id)+1, stacks a new run on top, and the phantom is exported permanently
+    into the append-only Dolt history (2026-07-14 ops review)."""
+    try:
+        rows = conn.execute("SELECT id FROM discovery_runs WHERE total_skills IS NULL ORDER BY id").fetchall()
+    except sqlite3.OperationalError:
+        return []  # exotic/legacy schema without totals columns — nothing to judge
+    return [row[0] for row in rows]
+
+
 # ---------------------------------------------------------------------------
 # Scanner — Group 1: Packs, Plugins, Skills
 # ---------------------------------------------------------------------------
@@ -2200,10 +2216,33 @@ def run_scan(args: argparse.Namespace) -> None:
         migrate_add_run_id(conn)
     print("  Done.")
 
-    # Step 2: Determine run_id
+    # Step 2: Determine run_id.
+    # Default rerun self-heals a crashed prior scan first: when the NEWEST run
+    # is a phantom (crashed before its totals were written — see
+    # find_phantom_runs), purge it and reuse its id, so a plain rerun cleans up
+    # after a crash instead of stacking a new run on top of half-populated
+    # tables (dolt-sync also refuses to export an incomplete newest run).
+    # Mid-history phantoms are reported but left alone — they are already
+    # frozen into Dolt history; purge one explicitly with --run-id N.
     if args.run_id:
         run_id = args.run_id
     else:
+        phantoms = find_phantom_runs(conn)
+        max_id_row = conn.execute("SELECT MAX(id) FROM discovery_runs").fetchone()
+        max_id = max_id_row[0] if max_id_row else None
+        for pid in phantoms:
+            if pid == max_id:
+                print(f"  WARNING: newest run_id={pid} is incomplete (crashed before totals were written).")
+                if dry_run:
+                    print(f"  (dry-run) would purge phantom run_id={pid} and reuse its id.")
+                else:
+                    purge_run(conn, pid)
+                    print(f"  Purged phantom run_id={pid}; its id will be reused.")
+            else:
+                print(
+                    f"  NOTE: run_id={pid} is an incomplete historical phantom — "
+                    f"leaving it in place; pass --run-id {pid} to purge and redo it explicitly."
+                )
         run_id = next_run_id(conn)
     print(f"\n[Step 2] Target run_id: {run_id}")
 

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -4564,6 +4564,11 @@ def populate_compliance_db(
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
 
+    # j-rig (better-sqlite3) writes the same file; Python's default busy
+    # timeout is 5s, which a concurrent write transaction can exceed —
+    # surfacing as 'database is locked'. Wait longer instead of failing.
+    c.execute("PRAGMA busy_timeout = 60000")
+
     # Resolve the current discovery run. Rows from older runs keep their
     # original run_id; fresh writes stamp the latest run so consumers can
     # filter WHERE run_id = (SELECT MAX(id) FROM discovery_runs).
@@ -4907,14 +4912,46 @@ def populate_compliance_db(
         gold_components = sum([1, has_prd, has_ard, has_refs, has_errors_md, has_examples_md, has_impl_md, has_config])
         gold_pct = int(100 * gold_components / 8)
 
+        # UPSERT, not INSERT OR REPLACE: REPLACE under UNIQUE(skill_path, run_id)
+        # is delete-then-insert, so any column absent from the list fell back to
+        # its default — silently NULLing the j-rig-owned jrig_* columns (paid
+        # behavioral-eval results) on every re-validation of the same run
+        # (2026-07-14 ops review). The DO UPDATE below rewrites only the
+        # validator-owned columns; jrig_passed / jrig_tier_blocked /
+        # jrig_baseline_delta are deliberately omitted so they survive.
         c.execute(
-            """INSERT OR REPLACE INTO skill_compliance
+            """INSERT INTO skill_compliance
             (skill_path, total_fields, anthropic_fields, enterprise_fields, missing_fields,
              has_references_dir, has_examples, has_scripts_dir, is_stub, stub_reasons,
              score, grade, error_count, warning_count, validated_at, source_modified_at, validator_version,
              has_prd, has_ard, has_errors_md, has_examples_md, has_implementation_md,
              reference_file_count, has_config_dir, gold_standard_pct, run_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(skill_path, run_id) DO UPDATE SET
+                total_fields=excluded.total_fields,
+                anthropic_fields=excluded.anthropic_fields,
+                enterprise_fields=excluded.enterprise_fields,
+                missing_fields=excluded.missing_fields,
+                has_references_dir=excluded.has_references_dir,
+                has_examples=excluded.has_examples,
+                has_scripts_dir=excluded.has_scripts_dir,
+                is_stub=excluded.is_stub,
+                stub_reasons=excluded.stub_reasons,
+                score=excluded.score,
+                grade=excluded.grade,
+                error_count=excluded.error_count,
+                warning_count=excluded.warning_count,
+                validated_at=excluded.validated_at,
+                source_modified_at=excluded.source_modified_at,
+                validator_version=excluded.validator_version,
+                has_prd=excluded.has_prd,
+                has_ard=excluded.has_ard,
+                has_errors_md=excluded.has_errors_md,
+                has_examples_md=excluded.has_examples_md,
+                has_implementation_md=excluded.has_implementation_md,
+                reference_file_count=excluded.reference_file_count,
+                has_config_dir=excluded.has_config_dir,
+                gold_standard_pct=excluded.gold_standard_pct""",
             (
                 skill_path,
                 total_fields,
@@ -5709,6 +5746,7 @@ def main() -> int:
                 print(f"✅ {rel} (plugin.json) - OK")
 
     # Populate compliance database if requested (after all validations complete)
+    populate_db_failed = False
     if args.populate_db:
         try:
             populate_compliance_db(
@@ -5722,6 +5760,12 @@ def main() -> int:
             import traceback
 
             traceback.print_exc()
+            # Do not swallow this: a failed populate used to leave the exit code
+            # untouched, so the freshie cycle continued to dolt-sync with zero
+            # fresh compliance rows and grades.csv silently regressed to the
+            # previous run (2026-07-14 ops review). The flag flips the exit code
+            # AFTER the full report below — validation semantics are unchanged.
+            populate_db_failed = True
 
     # === DEEP EVALUATION ENGINE ===
     if args.deep and skills:
@@ -5874,6 +5918,17 @@ def main() -> int:
     print(f"Needs Work (D+F): {d_f_count} ({d_f_pct:.1f}%)")
 
     print(f"{'=' * 70}")
+
+    # A requested --populate-db write that failed must fail the run. Placed after
+    # the full report so nothing above is hidden; only the exit code changes.
+    if populate_db_failed:
+        print(
+            "\n❌ --populate-db was requested but the compliance-DB write FAILED "
+            "(see traceback above) — exiting nonzero so the freshie cycle stops "
+            "instead of exporting stale grades.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.check_description_budget and total_description_chars >= TOTAL_DESCRIPTION_BUDGET_WARN:
         msg = (

--- a/tests/test_batch_remediate_compat.py
+++ b/tests/test_batch_remediate_compat.py
@@ -20,6 +20,7 @@ never touches the real repo or freshie/inventory.sqlite.
 
 import importlib.util
 import sqlite3
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -211,6 +212,164 @@ class DgplTagInferenceTests(unittest.TestCase):
 
     def test_unmapped_path_still_returns_none(self):
         self.assertIsNone(br._category_from_path(br.REPO_ROOT / "README.md"))
+
+
+AGENT_WITH_COLOR = """\
+---
+name: pinned-agent
+description: Pins that required agent fields survive remediation. Trigger with "pin".
+tools: Read
+model: sonnet
+color: blue
+version: 1.0.0
+author: Test <t@example.com>
+tags: [test]
+capabilities: [x, y]
+type: agent
+---
+# Body
+"""
+
+
+def _load_canonical_validator():
+    vpath = Path(__file__).resolve().parents[1] / "scripts" / "validate-skills-schema.py"
+    vspec = importlib.util.spec_from_file_location("vss_for_batch_remediate_tests", vpath)
+    mod = importlib.util.module_from_spec(vspec)
+    vspec.loader.exec_module(mod)
+    return mod
+
+
+class AgentRequiredFieldSurvivalTests(unittest.TestCase):
+    """P1 (2026-07-14 ops review): a stale hand-rolled DEPRECATED_AGENT_FIELDS
+    copy carried the REQUIRED `color` field (one of the kernel-floor 8), so
+    --fix-agents stripped it from every agent it touched. The set now derives
+    from the canonical validator and is cross-checked against
+    AGENT_ALWAYS_REQUIRED at load time."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.vss = _load_canonical_validator()
+
+    def test_color_is_not_removable(self):
+        self.assertNotIn("color", br.DEPRECATED_AGENT_FIELDS)
+
+    def test_no_removable_field_is_required_by_the_validator(self):
+        required = set(self.vss.AGENT_ALWAYS_REQUIRED)
+        self.assertEqual(set(br.DEPRECATED_AGENT_FIELDS) & required, set())
+        # The offline fallback set (used when the validator cannot be imported)
+        # must honor the same invariant.
+        self.assertEqual(set(br._FALLBACK_REMOVABLE_AGENT_FIELDS) & required, set())
+
+    def test_removal_set_matches_validator_banned_sets(self):
+        expected = set(self.vss.INVALID_AGENT_FIELDS) | set(self.vss.DEPRECATED_AGENT_FIELDS)
+        self.assertEqual(set(br.DEPRECATED_AGENT_FIELDS), expected)
+
+    def test_color_survives_remediation_and_banned_fields_are_removed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = Path(tmp) / "agents" / "pinned-agent.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text(AGENT_WITH_COLOR, encoding="utf-8")
+            changed, removed, err = br.remove_deprecated_agent_fields(agent, dry_run=False)
+            self.assertTrue(changed)
+            self.assertIsNone(err)
+            self.assertIn("capabilities", removed)
+            self.assertIn("type", removed)
+            self.assertNotIn("color", removed)
+            text = agent.read_text(encoding="utf-8")
+            self.assertIn("color: blue", text)  # REQUIRED field survives
+            self.assertNotIn("capabilities:", text)
+            self.assertNotIn("type: agent", text)
+
+
+class AgentDbPathResolutionTests(unittest.TestCase):
+    """P3 (2026-07-14 ops review): agent_compliance stores repo-relative FILE
+    paths, so without a REPO_ROOT join DB-mode --fix-agents silently no-ops
+    ('SKIP (not found)' for every row) from any cwd but the repo root — the
+    same bug class defect #4 fixed for skills."""
+
+    def test_agent_rows_resolve_against_repo_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            agent = root / "plugins" / "cat" / "p" / "agents" / "a.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text(AGENT_WITH_COLOR, encoding="utf-8")
+            conn = sqlite3.connect(":memory:")
+            conn.execute("CREATE TABLE agent_compliance (agent_path TEXT, has_invalid_fields INTEGER)")
+            conn.execute(
+                "INSERT INTO agent_compliance VALUES (?, 1)",
+                (str(agent.relative_to(root)),),
+            )
+            conn.commit()
+            orig_root = br.REPO_ROOT
+            br.REPO_ROOT = root
+            try:
+                paths = br.get_agents_with_invalid_fields(conn)
+            finally:
+                br.REPO_ROOT = orig_root
+                conn.close()
+            self.assertEqual(paths, [agent])
+            self.assertTrue(paths[0].is_file())
+
+
+class CliGuardrailTests(unittest.TestCase):
+    """2026-07-14 ops review: the --fix-agents filesystem-walk fallback must be
+    an explicit opt-in when the DB is absent; --dry-run/--execute together must
+    error; --dry-run must actually gate writes."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        plugins = root / "plugins"
+        self.agent = plugins / "cat" / "p" / "agents" / "a.md"
+        self.agent.parent.mkdir(parents=True)
+        self.agent.write_text(AGENT_WITH_COLOR, encoding="utf-8")
+        self._orig = {k: getattr(br, k) for k in ("REPO_ROOT", "PLUGINS_ROOT", "DB_PATH")}
+        br.REPO_ROOT = root
+        br.PLUGINS_ROOT = plugins
+        br.DB_PATH = root / "absent.sqlite"  # deliberately never created
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            setattr(br, k, v)
+        self._tmp.cleanup()
+
+    def _main(self, argv):
+        old_argv = sys.argv
+        sys.argv = ["batch-remediate.py"] + argv
+        try:
+            return br.main()
+        finally:
+            sys.argv = old_argv
+
+    def test_fix_agents_without_db_requires_explicit_fallback(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._main(["--fix-agents"])
+        self.assertEqual(cm.exception.code, 2)  # argparse error
+        self.assertEqual(self.agent.read_text(encoding="utf-8"), AGENT_WITH_COLOR)
+
+    def test_fs_fallback_flag_allows_the_walk_dry_run_default(self):
+        rc = self._main(["--fix-agents", "--fs-fallback"])
+        self.assertEqual(rc, 0)
+        # dry-run is the default: file untouched
+        self.assertEqual(self.agent.read_text(encoding="utf-8"), AGENT_WITH_COLOR)
+
+    def test_dry_run_and_execute_are_mutually_exclusive(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._main(["--all", "--dry-run", "--execute"])
+        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(self.agent.read_text(encoding="utf-8"), AGENT_WITH_COLOR)
+
+    def test_explicit_dry_run_gates_writes(self):
+        rc = self._main(["--fix-agents", "--fs-fallback", "--dry-run"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.agent.read_text(encoding="utf-8"), AGENT_WITH_COLOR)
+
+    def test_execute_with_fs_fallback_writes_but_keeps_color(self):
+        rc = self._main(["--fix-agents", "--fs-fallback", "--execute"])
+        self.assertEqual(rc, 0)
+        text = self.agent.read_text(encoding="utf-8")
+        self.assertIn("color: blue", text)
+        self.assertNotIn("capabilities:", text)
 
 
 class FilterByScopeTests(unittest.TestCase):

--- a/tests/test_dolt_sync.py
+++ b/tests/test_dolt_sync.py
@@ -244,5 +244,44 @@ class VarcharGuardTests(unittest.TestCase):
         conn.close()
 
 
+class RunCompletenessGateTests(unittest.TestCase):
+    """gate_run_completeness refuses to export a phantom half-run — a
+    discovery_runs row whose totals were never written means the scan crashed
+    mid-run, and exporting would freeze the phantom into the append-only Dolt
+    history (2026-07-14 ops review)."""
+
+    DDL = (
+        "CREATE TABLE discovery_runs (id INTEGER PRIMARY KEY, run_date TEXT, "
+        "commit_hash TEXT, total_packs INTEGER, total_plugins INTEGER, "
+        "total_skills INTEGER, total_files INTEGER, total_root_files INTEGER);"
+    )
+
+    def test_incomplete_newest_run_raises(self):
+        conn = fixture_conn(self.DDL + "INSERT INTO discovery_runs (id) VALUES (1);")
+        with self.assertRaises(dolt_sync.SyncError):
+            dolt_sync.gate_run_completeness(conn, 1)
+        conn.close()
+
+    def test_complete_run_passes(self):
+        conn = fixture_conn(
+            self.DDL + "INSERT INTO discovery_runs (id, total_skills) VALUES (1, 42);"
+        )
+        dolt_sync.gate_run_completeness(conn, 1)  # must not raise
+        conn.close()
+
+    def test_run_zero_passes(self):
+        conn = fixture_conn(self.DDL)
+        dolt_sync.gate_run_completeness(conn, 0)  # empty DB — nothing to judge
+        conn.close()
+
+    def test_legacy_schema_without_totals_does_not_block(self):
+        conn = fixture_conn(
+            "CREATE TABLE discovery_runs (id INTEGER PRIMARY KEY);"
+            "INSERT INTO discovery_runs (id) VALUES (1);"
+        )
+        dolt_sync.gate_run_completeness(conn, 1)  # cannot judge — do not block
+        conn.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_populate_db_upsert.py
+++ b/tests/test_populate_db_upsert.py
@@ -1,0 +1,97 @@
+"""Regression test for the --populate-db skill_compliance write (2026-07-14 ops
+review): INSERT OR REPLACE under UNIQUE(skill_path, run_id) is delete-then-insert,
+so the j-rig-owned jrig_* columns (paid behavioral-eval results, $2-5/skill) were
+silently NULLed every time the same discovery run was re-validated. The write is
+now an UPSERT whose DO UPDATE clause rewrites only validator-owned columns.
+
+Run: python3 -m unittest tests.test_populate_db_upsert -v
+
+Fully self-contained: tmp sqlite DB + tmp skill tree; never touches the real
+freshie/inventory.sqlite.
+"""
+
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate-skills-schema.py"
+_spec = importlib.util.spec_from_file_location("vss_populate_upsert_tests", SCRIPT)
+vss = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vss)
+
+SKILL = """\
+---
+name: upsert-pin
+description: Pins that j-rig columns survive re-population.
+---
+# Body
+"""
+
+
+class PopulateDbUpsertTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.db = root / "inv.sqlite"
+        conn = sqlite3.connect(self.db)
+        conn.execute(
+            "CREATE TABLE discovery_runs (id INTEGER PRIMARY KEY, run_date TEXT, "
+            "commit_hash TEXT, total_packs INTEGER, total_plugins INTEGER, "
+            "total_skills INTEGER, total_files INTEGER, total_root_files INTEGER)"
+        )
+        conn.execute("INSERT INTO discovery_runs (id) VALUES (1)")
+        conn.commit()
+        conn.close()
+        skill_dir = root / "plugins" / "cat" / "p" / "skills" / "upsert-pin"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL, encoding="utf-8")
+        self.result = {
+            "path": str(skill_dir / "SKILL.md"),
+            "score": 80,
+            "grade": "B",
+            "errors": 0,
+            "warnings": 1,
+        }
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _rows(self):
+        conn = sqlite3.connect(self.db)
+        rows = conn.execute(
+            "SELECT score, grade, jrig_passed, jrig_tier_blocked, jrig_baseline_delta "
+            "FROM skill_compliance"
+        ).fetchall()
+        conn.close()
+        return rows
+
+    def test_repopulate_preserves_jrig_columns_and_updates_validator_columns(self):
+        # First populate: fresh row, jrig columns default NULL.
+        vss.populate_compliance_db(str(self.db), [self.result])
+        rows = self._rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0], (80, "B", None, None, None))
+
+        # j-rig writes its behavioral-eval verdict into the same row.
+        conn = sqlite3.connect(self.db)
+        conn.execute(
+            "UPDATE skill_compliance SET jrig_passed=1, jrig_tier_blocked=0, jrig_baseline_delta=0.25"
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-populate the SAME run (e.g. after batch-remediate, to measure grade
+        # movement). Validator-owned columns must update; jrig_* must survive.
+        vss.populate_compliance_db(str(self.db), [dict(self.result, score=90, grade="A")])
+        rows = self._rows()
+        self.assertEqual(len(rows), 1)  # still one row per (skill_path, run_id)
+        score, grade, jrig_passed, jrig_tier_blocked, jrig_delta = rows[0]
+        self.assertEqual((score, grade), (90, "A"))
+        self.assertEqual((jrig_passed, jrig_tier_blocked), (1, 0))
+        self.assertAlmostEqual(jrig_delta, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_promote_curated_floor.py
+++ b/tests/test_promote_curated_floor.py
@@ -1,0 +1,111 @@
+"""Regression tests for freshie/scripts/promote-to-curated.py build-mode guards
+(2026-07-14 ops review):
+
+  1. Wipe floor — every selection failure mode (empty/truncated grades.csv,
+     validator API drift dropping 100% of candidates) used to converge on
+     wiping all ~1,881 skills/.curated/ dirs and exiting 0. build() now refuses
+     to touch the mirror when the fresh selection collapses; --force-floor is
+     the deliberate-shrink override.
+  2. Degrade contract — the validator sys.exit(1)s at import when pyyaml is
+     missing; SystemExit does not inherit Exception, so load_validator's
+     documented "fall back to recorded grades" never fired and the whole
+     promoter died (the 2026-07-13 CI incident, previously patched only in the
+     workflow).
+
+Run: python3 -m unittest tests.test_promote_curated_floor -v
+
+Fully self-contained: tmp tree, module globals monkeypatched; never touches the
+real skills/.curated/ mirror.
+"""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "freshie" / "scripts" / "promote-to-curated.py"
+_spec = importlib.util.spec_from_file_location("promote_to_curated_tests", SCRIPT)
+pc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pc)
+
+
+class WipeFloorTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        # Header-only grades.csv — the truncated-export failure mode.
+        self.grades = root / "grades.csv"
+        self.grades.write_text("skill_path,grade,score\n", encoding="utf-8")
+        # An existing mirror with one promoted dir + a committed MANIFEST.
+        self.curated = root / "skills" / ".curated"
+        self.survivor = self.curated / "existing-skill"
+        self.survivor.mkdir(parents=True)
+        (self.survivor / "SKILL.md").write_text("# existing\n", encoding="utf-8")
+        self.manifest = self.curated / "MANIFEST.json"
+        self.manifest.write_text(json.dumps({"count": 1881, "skills": []}), encoding="utf-8")
+
+        self._orig = {k: getattr(pc, k) for k in ("ROOT", "GRADES_CSV", "CURATED_DIR", "MANIFEST")}
+        pc.ROOT = root
+        pc.GRADES_CSV = self.grades
+        pc.CURATED_DIR = self.curated
+        pc.MANIFEST = self.manifest
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            setattr(pc, k, v)
+        self._tmp.cleanup()
+
+    def test_empty_selection_refuses_to_wipe(self):
+        rc = pc.build(validate=False, quiet=True)
+        self.assertEqual(rc, 1)
+        # Mirror and manifest untouched.
+        self.assertTrue((self.survivor / "SKILL.md").is_file())
+        self.assertEqual(json.loads(self.manifest.read_text())["count"], 1881)
+
+    def test_floor_triggers_below_ratio_of_committed_count(self):
+        # A selection well under 50% of the committed 1,881 (and under the
+        # absolute floor of 500) must also refuse — even when nonzero.
+        self.grades.write_text(
+            "skill_path,grade,score\nplugins/cat/p/skills/only-one,A,95\n",
+            encoding="utf-8",
+        )
+        # Source dir must exist for load_candidates to keep the row.
+        (pc.ROOT / "plugins" / "cat" / "p" / "skills" / "only-one").mkdir(parents=True)
+        rc = pc.build(validate=False, quiet=True)
+        self.assertEqual(rc, 1)
+        self.assertTrue((self.survivor / "SKILL.md").is_file())
+
+    def test_force_floor_allows_deliberate_shrink(self):
+        rc = pc.build(validate=False, quiet=True, force_floor=True)
+        self.assertEqual(rc, 0)
+        self.assertFalse(self.survivor.exists())
+        self.assertEqual(json.loads(self.manifest.read_text())["count"], 0)
+
+
+class ValidatorImportDegradeTests(unittest.TestCase):
+    def test_load_validator_degrades_on_systemexit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "fake-validator.py"
+            fake.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+            orig = pc.VALIDATOR
+            pc.VALIDATOR = fake
+            try:
+                self.assertIsNone(pc.load_validator())
+            finally:
+                pc.VALIDATOR = orig
+
+    def test_load_validator_degrades_on_plain_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "fake-validator.py"
+            fake.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+            orig = pc.VALIDATOR
+            pc.VALIDATOR = fake
+            try:
+                self.assertIsNone(pc.load_validator())
+            finally:
+                pc.VALIDATOR = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_rebuild_inventory_phantom.py
+++ b/tests/test_rebuild_inventory_phantom.py
@@ -1,0 +1,86 @@
+"""Regression tests for phantom half-run handling in
+freshie/scripts/rebuild-inventory.py (2026-07-14 ops review).
+
+A crash mid-scan leaves a discovery_runs row whose totals were never written
+(the totals UPDATE is the LAST step of a successful run) plus partial rows in
+every table the scan had reached. The default rerun used to compute MAX(id)+1
+and leave the phantom behind, where dolt-sync exported it permanently into the
+append-only Dolt history. find_phantom_runs() is the detector; run_scan purges
+the newest phantom and reuses its id.
+
+Run: python3 -m unittest tests.test_rebuild_inventory_phantom -v
+"""
+
+import importlib.util
+import sqlite3
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "freshie" / "scripts" / "rebuild-inventory.py"
+_spec = importlib.util.spec_from_file_location("rebuild_inventory_tests", SCRIPT)
+ri = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ri)
+
+
+def _db_with_phantom() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row  # matches open_db()
+    conn.execute(
+        "CREATE TABLE discovery_runs (id INTEGER PRIMARY KEY, run_date TEXT, "
+        "commit_hash TEXT, total_packs INTEGER, total_plugins INTEGER, "
+        "total_skills INTEGER, total_files INTEGER, total_root_files INTEGER)"
+    )
+    conn.execute("CREATE TABLE skills (id INTEGER PRIMARY KEY, run_id INTEGER)")
+    # Run 1 completed: totals written by Step 15.
+    conn.execute(
+        "INSERT INTO discovery_runs (id, run_date, total_packs, total_plugins, "
+        "total_skills, total_files, total_root_files) VALUES (1, '2026-01-01', 1, 1, 10, 100, 5)"
+    )
+    conn.execute("INSERT INTO skills (run_id) VALUES (1)")
+    # Run 2 crashed mid-scan: row inserted up front, totals never written.
+    conn.execute("INSERT INTO discovery_runs (id, run_date) VALUES (2, '2026-01-02')")
+    conn.execute("INSERT INTO skills (run_id) VALUES (2)")
+    conn.commit()
+    return conn
+
+
+class FindPhantomRunsTests(unittest.TestCase):
+    def test_detects_run_with_null_totals(self):
+        conn = _db_with_phantom()
+        self.assertEqual(ri.find_phantom_runs(conn), [2])
+        conn.close()
+
+    def test_no_phantoms_when_all_runs_complete(self):
+        conn = _db_with_phantom()
+        conn.execute("UPDATE discovery_runs SET total_skills = 7 WHERE id = 2")
+        self.assertEqual(ri.find_phantom_runs(conn), [])
+        conn.close()
+
+    def test_legacy_schema_without_totals_column_returns_empty(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("CREATE TABLE discovery_runs (id INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO discovery_runs (id) VALUES (1)")
+        self.assertEqual(ri.find_phantom_runs(conn), [])
+        conn.close()
+
+
+class PurgePhantomTests(unittest.TestCase):
+    def test_purge_run_removes_phantom_rows_and_keeps_complete_run(self):
+        conn = _db_with_phantom()
+        ri.purge_run(conn, 2)
+        runs = [row["id"] for row in conn.execute("SELECT id FROM discovery_runs").fetchall()]
+        self.assertEqual(runs, [1])
+        self.assertEqual(
+            conn.execute("SELECT COUNT(*) FROM skills WHERE run_id = 2").fetchone()[0], 0
+        )
+        self.assertEqual(
+            conn.execute("SELECT COUNT(*) FROM skills WHERE run_id = 1").fetchone()[0], 1
+        )
+        # The freed id is reused by the next default run.
+        self.assertEqual(ri.next_run_id(conn), 2)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
[skip auto-bump]

## What

Implements all 9 findings from the 2026-07-14 Freshie ops review (findings JSON: `review-freshie.json`, P1 verifier-CONFIRMED). Five commits, one per failure cluster:

| # | Finding | Fix |
|---|---------|-----|
| 1 | **P1 — `batch-remediate --fix-agents` strips the REQUIRED `color` field** (317/320 flagged agents were flagged solely for carrying it) | Removal set now **derives from the canonical validator** (`INVALID_AGENT_FIELDS ∪ DEPRECATED_AGENT_FIELDS`) with a load-time cross-check that aborts if any removable field is in `AGENT_ALWAYS_REQUIRED`; corrected inline fallback for validator-unimportable environments |
| 2 | Silent FS-walk fallback made the P1 reachable from any fresh checkout | `--fix-agents` with the DB absent now **errors** unless `--fs-fallback` (or `--no-db`) is passed |
| 3 | `promote-to-curated` wipe-and-succeed: every selection failure converged on deleting all ~1,881 curated dirs and exiting 0 | **Wipe floor**: build selects/re-grades *before* any `rmtree` and refuses (exit 1, mirror untouched) below `max(500, 50% × committed MANIFEST count)`, on zero candidates, or on a 100% re-grade drop; `--force-floor` overrides for deliberate shrinks |
| 4 | `load_validator`'s degrade contract couldn't catch the validator's `sys.exit(1)` (SystemExit ∉ Exception — the 2026-07-13 pyyaml incident class) | Explicit `except SystemExit` → degrade to recorded grades with the likely missing dep named |
| 5 | `--populate-db` failure swallowed → dolt-sync tags a run with zero fresh rows, grades.csv silently regresses | Populate failure now **exits 1** after the full report prints; `busy_timeout=60000` in the DB-writing path (j-rig shares the file) |
| 6 | `INSERT OR REPLACE` NULLs j-rig columns (paid behavioral-eval results) on every re-populate | `skill_compliance` write is now `INSERT … ON CONFLICT(skill_path, run_id) DO UPDATE` over **validator-owned columns only** — `jrig_*` survive |
| 7 | Crashed half-run leaves a phantom exported permanently into append-only Dolt history | `rebuild-inventory` default rerun purges the **newest** NULL-totals phantom and reuses its id (mid-history phantoms reported, left frozen); `dolt-sync` gains `gate_run_completeness` — `SyncError` before any pump when the newest run is incomplete |
| 8 | `promote-curated.yml` `rebuild_inventory` dispatch input guaranteed to fail (untracked DB, no schema-create, no dolt binary on runner) | Input + step **removed** with an explanatory comment — matches the script's dev-box-only design; the committed `grades.csv` is the CI-consumable export by design |
| 9 | DB-mode `--fix-agents` silently no-ops from any cwd ≠ repo root | Agent rows resolve against `REPO_ROOT` (same fix `_skill_md_from_row` already has); plus `--dry-run --execute` together now errors and `--dry-run` actually gates writes |

## Why + decision rationale

The P1 was live: `freshie/inventory.sqlite` is untracked, so the CLAUDE.md-documented cycle command on any fresh checkout fell back to the FS walk and would have stripped `color` (kernel-floor-required) from the entire 317-agent A-grade corpus, with the agent CI gate report-only. Chose *derive-from-validator* over *fix-the-copy* because a hand-rolled copy is exactly what drifted. Chose *select-then-wipe* over a post-wipe count check because the mirror must still be intact at refusal time. Chose the existing NULL-totals marker over a new `completed_at` column because a new `discovery_runs` column would trip dolt-sync's schema-mismatch parity gate and force `--recreate-tables`.

## Layer(s) touched

Freshie CMDB tooling (`freshie/scripts/{batch-remediate,promote-to-curated,rebuild-inventory,dolt-sync}.py`), the validator's `--populate-db` write path only (`scripts/validate-skills-schema.py` — **no rule code, no tier semantics, no kernel-shadow wiring touched**), two workflows (`promote-curated.yml` input removal; `validate-plugins.yml` unittest list +3). No invariant change to `ALWAYS_REQUIRED` / tier model / error-vs-warning semantics.

## Verification & evidence

- **Unit suites (all green, 67 tests across touched modules):** `tests/test_batch_remediate_compat.py` (+3 classes), new `tests/test_populate_db_upsert.py`, `tests/test_promote_curated_floor.py`, `tests/test_rebuild_inventory_phantom.py`, `tests/test_dolt_sync.py` (+`RunCompletenessGateTests`) — all wired into the blocking `Test in-repo Python suites` CI step.
- **Red/green, P1:** main's `remove_deprecated_agent_fields` → `removed=['capabilities', 'color']`, `color_survives=False`; this branch → `removed=['capabilities']`, `color_survives=True`.
- **Red/green, jrig NULLing:** identical populate→j-rig-update→re-populate flow yields `(90, 'A', None, None, None)` on main's validator, `(90, 'A', 1, 0, 0.25)` on this branch.
- **Floor demo (CLI, /tmp fixture):** header-only `grades.csv` + MANIFEST count 1881 → `exit 1`, mirror untouched, both floor errors printed; `--force-floor` → `exit 0`, count 0.
- **Phantom demo (copy of real DB + injected phantom run 10):** rebuild `--dry-run` prints `newest run_id=10 is incomplete … would purge and reuse` and flags historical run 3 as left-in-place; `gate_run_completeness` raises `SyncError` for run 10, passes complete run 9.
- **Populate exit-code:** full sweep with `--populate-db /nonexistent-dir/x.sqlite` prints the FAILED banner and exits 1; green sweep against a copy of the real DB wrote 3,677 skill rows.
- **Validator canary:** `--marketplace` full sweep before/after — `tail -3` identical; totals identical (4,403 files, 26.3% compliance, 7,994 errors); only diff is pre-existing `PYTHONHASHSEED` set-ordering noise in WARN/ERROR token lists.
- **Gates:** `promote-to-curated.py --check` green (1881 in sync); `ruff check`/`format --check` clean on gated files; both workflows `yaml.safe_load` OK; `tests/ci/test_path_routing.py` 35/35 (no `paths:` filter added).

## Risk assessment

- `--fix-agents` now also removes `compatible-with`/`when_to_use` (validator-banned); `when_to_use` trigger phrasing is not auto-folded into `description` — noted in the fixer docstring.
- A legitimate >50% curated delisting now requires `--force-floor` — intended friction.
- `ON CONFLICT` requires the composite UNIQUE — guaranteed by the existing issue-#660 migration + `CREATE TABLE` in the same function.
- The real DB's historical phantom (run 3, NULL totals since 2026-03-22) is deliberately left frozen; only the *newest* phantom is auto-purged.

## Operational impact

No deps, no migrations, no secrets. Operators: `--fix-agents` on a DB-less checkout needs `--fs-fallback`; a crashed inventory scan now self-heals on plain rerun; dolt-sync refuses phantom exports with an actionable message. `promote-curated.yml` loses its (never-workable) `rebuild_inventory` dispatch input.

## Follow-up & deferred

- Two pre-existing ruff findings in `freshie/scripts/rebuild-inventory.py` (unused `os` import, F541) — outside CI's ruff scope (`plugins/ scripts/`), left untouched per minimal-impact.
- The historical phantom run 3 in the local DB can be redone explicitly with `--run-id 3` if ever desired.

## Refs

2026-07-14 Freshie ops review (findings 1–9, P1 verifier-CONFIRMED).

- Jeremy Longshore
intentsolutions.io
